### PR TITLE
Fix ActivityLog mapping for NULL UserID

### DIFF
--- a/ToolManagementAppV2/Services/Users/ActivityLogService.cs
+++ b/ToolManagementAppV2/Services/Users/ActivityLogService.cs
@@ -47,13 +47,21 @@ namespace ToolManagementAppV2.Services.Users
             SqliteHelper.ExecuteNonQuery(_connString, sql, p);
         }
 
-        ActivityLog MapLog(IDataRecord r) => new()
+        ActivityLog MapLog(IDataRecord r)
         {
-            LogID = Convert.ToInt32(r["LogID"]),
-            UserID = Convert.ToInt32(r["UserID"]),
-            UserName = r["UserName"].ToString(),
-            Action = r["Action"].ToString(),
-            Timestamp = Convert.ToDateTime(r["Timestamp"])
-        };
+            var log = new ActivityLog
+            {
+                LogID = Convert.ToInt32(r["LogID"]),
+                UserName = r["UserName"].ToString(),
+                Action = r["Action"].ToString(),
+                Timestamp = Convert.ToDateTime(r["Timestamp"])
+            };
+
+            log.UserID = r["UserID"] == DBNull.Value
+                ? 0
+                : Convert.ToInt32(r["UserID"]);
+
+            return log;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- prevent exceptions when reading logs with NULL `UserID`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7571ad4c8324a751e1d6ab936910