### PR TITLE
Add path validation helper and update usages

### DIFF
--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -624,7 +624,7 @@ namespace ToolManagementAppV2
                 if (!string.IsNullOrWhiteSpace(logoPath))
                 {
                     var fullPath = Utilities.Helpers.PathHelper.GetAbsolutePath(logoPath);
-                    if (File.Exists(fullPath))
+                    if (!string.IsNullOrEmpty(fullPath) && File.Exists(fullPath))
                     {
                         using (var stream = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read))
                         {
@@ -663,7 +663,7 @@ namespace ToolManagementAppV2
                 if (!string.IsNullOrWhiteSpace(logoPath))
                 {
                     var fullPath = Utilities.Helpers.PathHelper.GetAbsolutePath(logoPath);
-                    if (File.Exists(fullPath))
+                    if (!string.IsNullOrEmpty(fullPath) && File.Exists(fullPath))
                     {
                         using (var stream = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read))
                         {

--- a/ToolManagementAppV2/Services/Tools/Printer.cs
+++ b/ToolManagementAppV2/Services/Tools/Printer.cs
@@ -54,7 +54,7 @@ namespace ToolManagementAppV2.Services.Tools
                 return null;
 
             var full = Utilities.Helpers.PathHelper.GetAbsolutePath(path);
-            return File.Exists(full) ? full : null;
+            return !string.IsNullOrEmpty(full) && File.Exists(full) ? full : null;
         }
 
         private FlowDocument BuildDocument(List<ToolModel> tools, string title, string logoPath)
@@ -181,6 +181,8 @@ namespace ToolManagementAppV2.Services.Tools
         private Border CreateOptimizedImage(string path)
         {
             var full = Utilities.Helpers.PathHelper.GetAbsolutePath(path);
+            if (string.IsNullOrEmpty(full))
+                return new Border { Width = 120, Height = 120, CornerRadius = new CornerRadius(10) };
 
             var bmp = new BitmapImage();
             bmp.BeginInit();
@@ -206,7 +208,7 @@ namespace ToolManagementAppV2.Services.Tools
                 return;
 
             var full = Utilities.Helpers.PathHelper.GetAbsolutePath(logoPath);
-            if (!File.Exists(full))
+            if (string.IsNullOrEmpty(full) || !File.Exists(full))
                 return;
             var bmp = new BitmapImage();
             bmp.BeginInit();

--- a/ToolManagementAppV2/Utilities/Converters/NullToDefaultImageConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/NullToDefaultImageConverter.cs
@@ -23,17 +23,20 @@ namespace ToolManagementAppV2.Utilities.Converters
             {
                 try
                 {
-                    var absPath = path;
-                    if (!Uri.IsWellFormedUriString(path, UriKind.Absolute))
-                        absPath = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, path));
+                    var absPath = Uri.IsWellFormedUriString(path, UriKind.Absolute)
+                        ? path
+                        : Helpers.PathHelper.GetAbsolutePath(path);
 
-                    var image = new BitmapImage();
-                    image.BeginInit();
-                    image.CacheOption = BitmapCacheOption.OnLoad;
-                    image.UriSource = new Uri(absPath, UriKind.Absolute);
-                    image.EndInit();
-                    image.Freeze();
-                    return image;
+                    if (!string.IsNullOrEmpty(absPath))
+                    {
+                        var image = new BitmapImage();
+                        image.BeginInit();
+                        image.CacheOption = BitmapCacheOption.OnLoad;
+                        image.UriSource = new Uri(absPath, UriKind.Absolute);
+                        image.EndInit();
+                        image.Freeze();
+                        return image;
+                    }
                 }
                 catch
                 {

--- a/ToolManagementAppV2/Utilities/Helpers/PathHelper.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/PathHelper.cs
@@ -5,15 +5,35 @@ namespace ToolManagementAppV2.Utilities.Helpers
 {
     public static class PathHelper
     {
-        public static string GetAbsolutePath(string path)
+        /// <summary>
+        /// Resolves <paramref name="path"/> against the application's base directory
+        /// and ensures the resulting absolute path stays within that directory.
+        /// </summary>
+        /// <param name="path">Relative or absolute path.</param>
+        /// <returns>The validated absolute path, or <c>null</c> if validation fails.</returns>
+        public static string? GetAbsolutePath(string? path)
         {
             if (string.IsNullOrWhiteSpace(path))
-                return path;
+                return null;
 
-            if (!Path.IsPathRooted(path))
-                path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, path);
+            try
+            {
+                var baseDir = Path.GetFullPath(AppDomain.CurrentDomain.BaseDirectory);
+                var combined = Path.IsPathRooted(path)
+                    ? path
+                    : Path.Combine(baseDir, path);
 
-            return Path.GetFullPath(path);
+                var fullPath = Path.GetFullPath(combined);
+
+                if (!fullPath.StartsWith(baseDir, StringComparison.OrdinalIgnoreCase))
+                    return null;
+
+                return fullPath;
+            }
+            catch
+            {
+                return null;
+            }
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -107,7 +107,7 @@ namespace ToolManagementAppV2.ViewModels
                     if (!string.IsNullOrEmpty(path))
                     {
                         var full = Utilities.Helpers.PathHelper.GetAbsolutePath(path);
-                        uri = File.Exists(full)
+                        uri = !string.IsNullOrEmpty(full) && File.Exists(full)
                             ? new Uri(full, UriKind.Absolute)
                             : new Uri("pack://application:,,,/Resources/DefaultLogo.png", UriKind.Absolute);
                     }

--- a/ToolManagementAppV2/Views/LoginWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml.cs
@@ -27,7 +27,7 @@ namespace ToolManagementAppV2
             if (!string.IsNullOrWhiteSpace(logoPath))
             {
                 var full = Utilities.Helpers.PathHelper.GetAbsolutePath(logoPath);
-                logoUri = File.Exists(full)
+                logoUri = !string.IsNullOrEmpty(full) && File.Exists(full)
                     ? new Uri(full)
                     : new Uri("pack://application:,,,/Resources/DefaultLogo.png");
             }

--- a/ToolManagementAppV2/Views/PrintPreviewWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PrintPreviewWindow.xaml.cs
@@ -31,7 +31,7 @@ namespace ToolManagementAppV2.Views
             if (!string.IsNullOrWhiteSpace(_logoPath))
             {
                 var full = Utilities.Helpers.PathHelper.GetAbsolutePath(_logoPath);
-                logoUri = File.Exists(full)
+                logoUri = !string.IsNullOrEmpty(full) && File.Exists(full)
                     ? new Uri(full, UriKind.Absolute)
                     : new Uri("pack://application:,,,/Resources/DefaultLogo.png");
             }


### PR DESCRIPTION
## Summary
- ensure helper resolves paths and validates they remain under the app base directory
- handle invalid paths in callers

## Testing
- `dotnet build ToolManagementAppV2/ToolManagementAppV2.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaf7ccef88324a52ac57ee8bc16f7