### PR TITLE
Skip invalid CSV rows for tools

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.IO;
+using ToolManagementAppV2.Utilities.IO;
+using Xunit;
+
+public class CsvImportTests
+{
+    [Fact]
+    public void LoadToolsFromCsv_SkipsRowsMissingToolNumber()
+    {
+        var csv = string.Join('\n',
+            "ToolNumber,NameDescription,AvailableQuantity",
+            ",Hammer,5",
+            "T1,Screwdriver,2");
+        var path = Path.GetTempFileName();
+        File.WriteAllText(path, csv);
+
+        var map = new Dictionary<string, string>
+        {
+            { "ToolNumber", "ToolNumber" },
+            { "NameDescription", "NameDescription" },
+            { "AvailableQuantity", "AvailableQuantity" }
+        };
+
+        var tools = CsvHelperUtil.LoadToolsFromCsv(path, map, out var invalid);
+
+        Assert.Single(tools);
+        Assert.Contains(2, invalid);
+    }
+}
+

--- a/ToolManagementAppV2.Tests/ToolManagementAppV2.Tests.csproj
+++ b/ToolManagementAppV2.Tests/ToolManagementAppV2.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Test.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ToolManagementAppV2\ToolManagementAppV2.csproj" />
+  </ItemGroup>
+</Project>
+

--- a/ToolManagementAppV2.sln
+++ b/ToolManagementAppV2.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.12.35707.178 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToolManagementAppV2", "ToolManagementAppV2\ToolManagementAppV2.csproj", "{D7C90C3C-2641-4E33-87A2-8778E278A369}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToolManagementAppV2.Tests", "ToolManagementAppV2.Tests\ToolManagementAppV2.Tests.csproj", "{DA332D39-AF9A-4F53-90F9-E359C0A85F23}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -13,9 +15,13 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D7C90C3C-2641-4E33-87A2-8778E278A369}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D7C90C3C-2641-4E33-87A2-8778E278A369}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D7C90C3C-2641-4E33-87A2-8778E278A369}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D7C90C3C-2641-4E33-87A2-8778E278A369}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {D7C90C3C-2641-4E33-87A2-8778E278A369}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {D7C90C3C-2641-4E33-87A2-8778E278A369}.Release|Any CPU.Build.0 = Release|Any CPU
+                {DA332D39-AF9A-4F53-90F9-E359C0A85F23}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {DA332D39-AF9A-4F53-90F9-E359C0A85F23}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {DA332D39-AF9A-4F53-90F9-E359C0A85F23}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {DA332D39-AF9A-4F53-90F9-E359C0A85F23}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/ToolManagementAppV2/Interfaces/IToolService.cs
+++ b/ToolManagementAppV2/Interfaces/IToolService.cs
@@ -15,7 +15,7 @@ namespace ToolManagementAppV2.Interfaces
         void ToggleToolCheckOutStatus(string toolID, string currentUser);
         List<ToolModel> GetToolsCheckedOutBy(string userName);
         void UpdateToolImage(string toolID, string imagePath);
-        void ImportToolsFromCsv(string filePath, IDictionary<string, string> map);
+        List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map);
         void ExportToolsToCsv(string filePath);
     }
 }

--- a/ToolManagementAppV2/Services/Core/CsvHelper.cs
+++ b/ToolManagementAppV2/Services/Core/CsvHelper.cs
@@ -10,9 +10,10 @@ namespace ToolManagementAppV2.Utilities.IO
 {
     public static class CsvHelperUtil
     {
-        public static List<ToolModel> LoadToolsFromCsv(string filePath, IDictionary<string, string> map)
+        public static List<ToolModel> LoadToolsFromCsv(string filePath, IDictionary<string, string> map, out List<int> invalidRows)
         {
             var list = new List<ToolModel>();
+            invalidRows = new List<int>();
             using var parser = new TextFieldParser(filePath);
             parser.SetDelimiters(",");
             parser.HasFieldsEnclosedInQuotes = true;
@@ -20,12 +21,21 @@ namespace ToolManagementAppV2.Utilities.IO
             if (parser.EndOfData) return list;
             var headers = parser.ReadFields();
 
+            var row = 1; // header already read
             while (!parser.EndOfData)
             {
+                row++;
                 var cols = parser.ReadFields();
+                var toolNumber = GetMapped(cols, headers, map, "ToolNumber");
+                if (string.IsNullOrWhiteSpace(toolNumber))
+                {
+                    invalidRows.Add(row);
+                    continue;
+                }
+
                 list.Add(new ToolModel
                 {
-                    ToolNumber = GetMapped(cols, headers, map, "ToolNumber"),
+                    ToolNumber = toolNumber,
                     NameDescription = GetMapped(cols, headers, map, "NameDescription"),
                     Location = GetMapped(cols, headers, map, "Location"),
                     Brand = GetMapped(cols, headers, map, "Brand"),

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -166,14 +166,15 @@ public class ToolService
                 new SQLiteParameter("@ID", toolID)
             });
 
-    public void ImportToolsFromCsv(string filePath, IDictionary<string, string> map)
+    public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map)
     {
-        var tools = CsvHelperUtil.LoadToolsFromCsv(filePath, map);
+        var tools = CsvHelperUtil.LoadToolsFromCsv(filePath, map, out var invalidRows);
         foreach (var tool in tools)
         {
             if (!ToolExists(tool.ToolNumber))
                 AddTool(tool);
         }
+        return invalidRows;
     }
 
     public void ExportToolsToCsv(string filePath)

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -261,9 +261,13 @@ namespace ToolManagementAppV2.ViewModels
             var headers = lines[0].Split(',').Select(h => h.Trim());
             var fields = new[] { "ToolNumber", "NameDescription", "Location", "Brand", "PartNumber", "Supplier", "PurchasedDate", "Notes", "AvailableQuantity" };
             if (!ShowMappingWindow(headers, fields, out var map)) return;
-            _toolService.ImportToolsFromCsv(path, map);
+            var invalid = _toolService.ImportToolsFromCsv(path, map);
             LoadTools();
-            ShowInfo($"{lines.Length - 1} tools imported successfully.");
+            var importedCount = (lines.Length - 1) - invalid.Count;
+            var msg = $"{importedCount} tools imported successfully.";
+            if (invalid.Count > 0)
+                msg += $" {invalid.Count} rows skipped.";
+            ShowInfo(msg);
 
             LoadTools();
             LoadCheckedOutTools();


### PR DESCRIPTION
## Summary
- skip tools missing ToolNumber when importing from CSV
- return skipped row numbers from the import API
- show skipped row count in the UI
- add a small unit test for CsvHelperUtil

## Testing
- `dotnet test ToolManagementAppV2.Tests/ToolManagementAppV2.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaf7a9ab8832480422a6e20640f77