### PR TITLE
Add transaction to ReturnTool

### DIFF
--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -69,21 +69,33 @@ namespace ToolManagementAppV2.Services.Rentals
 
         public void ReturnTool(int rentalID, DateTime returnDate)
         {
-            const string sql = @"
-                UPDATE Rentals
-                   SET ReturnDate = @ReturnDate, Status = 'Returned'
-                 WHERE RentalID = @RentalID;
-                UPDATE Tools
-                   SET AvailableQuantity = AvailableQuantity + 1,
-                       RentedQuantity   = RentedQuantity - 1
-                 WHERE ToolID =
-                   (SELECT ToolID FROM Rentals WHERE RentalID=@RentalID)";
-            var p = new[]
+            using var conn = new SQLiteConnection(_connString);
+            conn.Open();
+            using var tx = conn.BeginTransaction();
+            try
             {
-                new SQLiteParameter("@RentalID", rentalID),
-                new SQLiteParameter("@ReturnDate", returnDate)
-            };
-            SqliteHelper.ExecuteNonQuery(_connString, sql, p);
+                var rentalRows = SqliteHelper.ExecuteNonQuery(conn, tx,
+                    "UPDATE Rentals SET ReturnDate=@ReturnDate, Status='Returned' WHERE RentalID=@RentalID",
+                    new[]
+                    {
+                        new SQLiteParameter("@ReturnDate", returnDate),
+                        new SQLiteParameter("@RentalID", rentalID)
+                    });
+
+                var toolRows = SqliteHelper.ExecuteNonQuery(conn, tx,
+                    "UPDATE Tools SET AvailableQuantity=AvailableQuantity+1, RentedQuantity=RentedQuantity-1 WHERE ToolID=(SELECT ToolID FROM Rentals WHERE RentalID=@RentalID)",
+                    new[] { new SQLiteParameter("@RentalID", rentalID) });
+
+                if (rentalRows == 0 || toolRows == 0)
+                    throw new InvalidOperationException("Return operation failed.");
+
+                tx.Commit();
+            }
+            catch
+            {
+                tx.Rollback();
+                throw;
+            }
         }
 
         public void ReturnToolWithTransaction(int rentalID, DateTime returnDate)


### PR DESCRIPTION
## Summary
- update `ReturnTool` to use an explicit transaction
- ensure rental and tool updates both succeed

## Testing
- `dotnet build ToolManagementAppV2/ToolManagementAppV2.csproj -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaf7035308324aadbcece5afe638b