### PR TITLE
Switch CsvHelperUtilTests to xUnit

### DIFF
--- a/ToolManagementAppV2.Tests/CsvHelperUtilTests.cs
+++ b/ToolManagementAppV2.Tests/CsvHelperUtilTests.cs
@@ -1,13 +1,12 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using System.Collections.Generic;
 using ToolManagementAppV2.Utilities.IO;
 
 namespace ToolManagementAppV2.Tests
 {
-    [TestClass]
     public class CsvHelperUtilTests
     {
-        [TestMethod]
+        [Fact]
         public void GetMapped_IgnoresHeaderCase()
         {
             var headers = new[] { "toolnumber", "location" };
@@ -22,11 +21,11 @@ namespace ToolManagementAppV2.Tests
                 .GetMethod("GetMapped", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
                 .Invoke(null, new object[] { row, headers, map, "Location" });
 
-            Assert.AreEqual("123", number);
-            Assert.AreEqual("Loc", location);
+            Assert.Equal("123", number);
+            Assert.Equal("Loc", location);
         }
 
-        [TestMethod]
+        [Fact]
         public void GetMapped_IgnoresHeaderCase_Reversed()
         {
             var headers = new[] { "TOOLNUMBER", "LOCATION" };
@@ -41,8 +40,8 @@ namespace ToolManagementAppV2.Tests
                 .GetMethod("GetMapped", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
                 .Invoke(null, new object[] { row, headers, map, "Location" });
 
-            Assert.AreEqual("321", number);
-            Assert.AreEqual("Loc", location);
+            Assert.Equal("321", number);
+            Assert.Equal("Loc", location);
         }
     }
 }


### PR DESCRIPTION
## Summary
- convert `CsvHelperUtilTests` to use xUnit
- remove MSTest dependency from the test file

## Testing
- `dotnet test ToolManagementAppV2.Tests/ToolManagementAppV2.Tests.csproj --no-build --verbosity normal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684abe440b28832490b71b4f67646e13