### PR TITLE
Ensure tab switches refresh UI

### DIFF
--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -61,7 +61,7 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <TabControl x:Name="MyTabControl" Margin="5" Grid.Row="0">
+            <TabControl x:Name="MyTabControl" Margin="5" Grid.Row="0" SelectionChanged="MyTabControl_SelectionChanged">
                 <!-- Search Tools Tab -->
                 <TabItem Header="Search Tools">
                     <Grid Margin="5">

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -840,6 +840,35 @@ namespace ToolManagementAppV2
                 _printer.PrintTools(vm.CheckedOutTools, "My Checked-Out Tools", vm.CurrentUserName);
         }
 
+        void MyTabControl_SelectionChanged(object s, SelectionChangedEventArgs e)
+        {
+            if (!(MyTabControl.SelectedItem is TabItem tab))
+                return;
+
+            switch (tab.Header)
+            {
+                case "Search Tools":
+                case "Tool Management":
+                    RefreshToolList();
+                    break;
+                case "Customers":
+                    RefreshCustomerList();
+                    break;
+                case "Rentals":
+                    RefreshRentalList();
+                    break;
+                case "Users":
+                    RefreshUserList();
+                    break;
+                case "Settings":
+                    LoadSettings();
+                    break;
+                case "Activity Logs":
+                    RefreshLogsButton_Click(s, e);
+                    break;
+            }
+        }
+
         // ---------- Helpers ----------
         void ShowMessage(string title, string msg, MessageBoxImage icon)
             => MessageBox.Show(msg, title, MessageBoxButton.OK, icon);


### PR DESCRIPTION
## Summary
- refresh lists when switching tabs
- hook up tab selection changed event

## Testing
- `dotnet test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac1381cc48324b46d9a609c61f633