### PR TITLE
Add tool rental history view

### DIFF
--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using System.Linq;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Tools;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Services
+{
+    public class RentalServiceTests
+    {
+        [Fact]
+        public void GetRentalHistoryForTool_ReturnsHistory()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+
+                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 5 };
+                toolService.AddTool(tool);
+                var addedTool = toolService.GetAllTools().First();
+
+                var cust = new Customer { Company = "Acme" };
+                customerService.AddCustomer(cust);
+                var addedCust = customerService.GetAllCustomers().First();
+
+                rentalService.RentTool(addedTool.ToolID, addedCust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentTool(addedTool.ToolID, addedCust.CustomerID, DateTime.Today.AddDays(2), DateTime.Today.AddDays(3));
+
+                var history = rentalService.GetRentalHistoryForTool(addedTool.ToolID);
+                Assert.Equal(2, history.Count);
+                Assert.True(history[0].RentalDate > history[1].RentalDate);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -80,6 +80,11 @@
                                 Height="20"
                                 Width="150"
                                 Margin="10,0"/>
+                                <Button Content="View Rental History"
+                                Command="{Binding ViewRentalHistoryCommand}"
+                                Height="20"
+                                Width="150"
+                                Margin="10,0"/>
 
                             </StackPanel>
                         </StackPanel>

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -37,7 +37,10 @@ namespace ToolManagementAppV2.ViewModels
             set
             {
                 if (SetProperty(ref _selectedTool, value))
+                {
                     ((RelayCommand)RentToolCommand).NotifyCanExecuteChanged();
+                    ((RelayCommand)ViewRentalHistoryCommand).NotifyCanExecuteChanged();
+                }
             }
         }
 
@@ -159,6 +162,7 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand LoadOverdueRentalsCommand { get; }
         public IRelayCommand ReturnToolCommand { get; }
         public IRelayCommand ExtendRentalCommand { get; }
+        public IRelayCommand ViewRentalHistoryCommand { get; }
 
         public MainViewModel(
             ToolService toolService,
@@ -199,6 +203,7 @@ namespace ToolManagementAppV2.ViewModels
             LoadOverdueRentalsCommand = new RelayCommand(LoadOverdueRentals);
             ReturnToolCommand = new RelayCommand(ReturnSelectedRental, () => SelectedRental != null);
             ExtendRentalCommand = new RelayCommand(ExtendSelectedRental, () => SelectedRental != null);
+            ViewRentalHistoryCommand = new RelayCommand(ShowRentalHistoryForSelectedTool, () => SelectedTool != null);
 
             InitializeData();
             _refreshTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(2) };
@@ -532,6 +537,16 @@ namespace ToolManagementAppV2.ViewModels
             _rentalService.ExtendRental(SelectedRental.RentalID, NewDueDate);
             LoadActiveRentals();
             LoadOverdueRentals();
+        }
+
+        void ShowRentalHistoryForSelectedTool()
+        {
+            if (SelectedTool == null) return;
+
+            var history = _rentalService.GetRentalHistoryForTool(SelectedTool.ToolID);
+            var vm = new RentalHistoryViewModel(SelectedTool, history);
+            var win = new RentalHistoryWindow { DataContext = vm };
+            win.ShowDialog();
         }
 
         bool ShowFileDialog(string filter, out string path)

--- a/ToolManagementAppV2/ViewModels/RentalHistoryViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/RentalHistoryViewModel.cs
@@ -1,0 +1,19 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using ToolManagementAppV2.Models.Domain;
+
+namespace ToolManagementAppV2.ViewModels.Rental
+{
+    public class RentalHistoryViewModel : ObservableObject
+    {
+        public ObservableCollection<RentalModel> History { get; }
+        public string ToolDisplayName { get; }
+
+        public RentalHistoryViewModel(ToolModel tool, IEnumerable<RentalModel> history)
+        {
+            ToolDisplayName = $"{tool.ToolNumber} - {tool.NameDescription}";
+            History = new ObservableCollection<RentalModel>(history);
+        }
+    }
+}

--- a/ToolManagementAppV2/Views/RentalHistoryWindow.xaml
+++ b/ToolManagementAppV2/Views/RentalHistoryWindow.xaml
@@ -1,0 +1,22 @@
+<Window x:Class="ToolManagementAppV2.Views.RentalHistoryWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Rental History" Height="350" Width="650" WindowStartupLocation="CenterOwner">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <TextBlock Text="{Binding ToolDisplayName}" FontWeight="Bold" FontSize="16" Margin="0,0,0,10"/>
+        <DataGrid ItemsSource="{Binding History}" AutoGenerateColumns="False" Grid.Row="1">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Rental ID" Binding="{Binding RentalID}" Width="*"/>
+                <DataGridTextColumn Header="Customer ID" Binding="{Binding CustomerID}" Width="*"/>
+                <DataGridTextColumn Header="Rental Date" Binding="{Binding RentalDate, StringFormat={}{0:yyyy-MM-dd}}" Width="*"/>
+                <DataGridTextColumn Header="Due Date" Binding="{Binding DueDate, StringFormat={}{0:yyyy-MM-dd}}" Width="*"/>
+                <DataGridTextColumn Header="Return Date" Binding="{Binding ReturnDate, StringFormat={}{0:yyyy-MM-dd}}" Width="*"/>
+                <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="*"/>
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
+</Window>

--- a/ToolManagementAppV2/Views/RentalHistoryWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/RentalHistoryWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace ToolManagementAppV2.Views
+{
+    public partial class RentalHistoryWindow : Window
+    {
+        public RentalHistoryWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `RentalHistoryViewModel` for showing rental history of a tool
- create `RentalHistoryWindow` UI
- expose `ViewRentalHistoryCommand` in `MainViewModel`
- show a "View Rental History" button in the main window
- test retrieval of rental history from `RentalService`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4bc348e083249bfe21a4f7474b12