### PR TITLE
Integrate tool queries into view model

### DIFF
--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -136,27 +136,29 @@
                             </ListView.View>
                         </ListView>
                         <Button Content="Choose Profile Picture" Click="ChooseUserProfilePicButton_Click" Width="150" Height="20" HorizontalAlignment="Right" VerticalAlignment="Top" Grid.RowSpan="2" />
-                        <!-- In MainWindow.xaml, update the Checked Out Tools ListView -->
-                        <ListView x:Name="CheckedOutToolsList" ItemContainerStyle="{StaticResource ToolImageTooltipStyle}" ItemsSource="{Binding CheckedOutTools}" SelectedItem="{Binding SelectedTool, Mode=TwoWay}" Margin="10" Grid.Row="2">
-                            <ListView.View>
-                                <GridView>
-                                    <GridViewColumn Header="Action" Width="80">
-                                        <GridViewColumn.CellTemplate>
-                                            <DataTemplate>
-                                                <Button Content="{Binding IsCheckedOut, Converter={StaticResource CheckOutStatusConverter}}" 
-                                Click="CheckOutButton_Click" 
+                        <!-- Display tools checked out by the current user -->
+                        <GroupBox Header="My Checked-Out Tools" Grid.Row="2" Margin="10">
+                            <ListView x:Name="CheckedOutToolsList" ItemContainerStyle="{StaticResource ToolImageTooltipStyle}" ItemsSource="{Binding CheckedOutTools}" SelectedItem="{Binding SelectedTool, Mode=TwoWay}">
+                                <ListView.View>
+                                    <GridView>
+                                        <GridViewColumn Header="Action" Width="80">
+                                            <GridViewColumn.CellTemplate>
+                                                <DataTemplate>
+                                                    <Button Content="{Binding IsCheckedOut, Converter={StaticResource CheckOutStatusConverter}}"
+                                Click="CheckOutButton_Click"
                                 CommandParameter="{Binding ToolID}" />
-                                            </DataTemplate>
-                                        </GridViewColumn.CellTemplate>
-                                    </GridViewColumn>
-                                    <GridViewColumn Header="Tool ID" DisplayMemberBinding="{Binding ToolID}" Width="60" />
-                                    <GridViewColumn Header="Name" DisplayMemberBinding="{Binding NameDescription}" Width="380" />
-                                    <GridViewColumn Header="Checked Out By" DisplayMemberBinding="{Binding CheckedOutBy}" Width="150" />
-                                    <GridViewColumn Header="Checked Out Time" DisplayMemberBinding="{Binding CheckedOutTime, StringFormat=\{0:G\}}" Width="150" />
-                                    <GridViewColumn Header="Location" DisplayMemberBinding="{Binding Location}" Width="100" />
-                                </GridView>
-                            </ListView.View>
-                        </ListView>
+                                                </DataTemplate>
+                                            </GridViewColumn.CellTemplate>
+                                        </GridViewColumn>
+                                        <GridViewColumn Header="Tool ID" DisplayMemberBinding="{Binding ToolID}" Width="60" />
+                                        <GridViewColumn Header="Name" DisplayMemberBinding="{Binding NameDescription}" Width="380" />
+                                        <GridViewColumn Header="Checked Out By" DisplayMemberBinding="{Binding CheckedOutBy}" Width="150" />
+                                        <GridViewColumn Header="Checked Out Time" DisplayMemberBinding="{Binding CheckedOutTime, StringFormat=\{0:G\}}" Width="150" />
+                                        <GridViewColumn Header="Location" DisplayMemberBinding="{Binding Location}" Width="100" />
+                                    </GridView>
+                                </ListView.View>
+                            </ListView>
+                        </GroupBox>
 
                     </Grid>
                 </TabItem>

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -36,7 +36,11 @@ namespace ToolManagementAppV2.ViewModels
             get => _selectedTool;
             set
             {
-                if (SetProperty(ref _selectedTool, value))
+                ToolModel updated = value;
+                if (value != null)
+                    updated = _toolService.GetToolByID(value.ToolID);
+
+                if (SetProperty(ref _selectedTool, updated))
                 {
                     ((RelayCommand)RentToolCommand).NotifyCanExecuteChanged();
                     ((RelayCommand)ViewRentalHistoryCommand).NotifyCanExecuteChanged();
@@ -229,7 +233,10 @@ namespace ToolManagementAppV2.ViewModels
 
         void LoadCheckedOutTools()
         {
-            CheckedOutTools.ReplaceRange(_toolService.GetAllTools().Where(t => t.IsCheckedOut));
+            if (!string.IsNullOrWhiteSpace(CurrentUserName))
+                CheckedOutTools.ReplaceRange(_toolService.GetToolsCheckedOutBy(CurrentUserName));
+            else
+                CheckedOutTools.ReplaceRange(_toolService.GetAllTools().Where(t => t.IsCheckedOut));
         }
 
         void SearchTools()
@@ -364,6 +371,8 @@ namespace ToolManagementAppV2.ViewModels
                     CurrentUserPhoto = bmp;
                 }
             }
+
+            LoadCheckedOutTools();
         }
 
         void ChooseProfilePic() => UploadPhotoForUser((UserModel)Application.Current.Properties["CurrentUser"]);


### PR DESCRIPTION
## Summary
- integrate `ToolService.GetToolByID` for SelectedTool updates
- show checked-out tools for the current user using `GetToolsCheckedOutBy`
- reload checked out tools when current user loads
- display a header for the checked-out tools list

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bbd03a2488324a9a80906921ed88f