### PR TITLE
Add customer search

### DIFF
--- a/ToolManagementAppV2.Tests/Services/CustomerServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/CustomerServiceTests.cs
@@ -1,0 +1,56 @@
+using System.IO;
+using System.Linq;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Customers;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Services
+{
+    public class CustomerServiceTests
+    {
+        [Fact]
+        public void SearchCustomers_WithNull_ReturnsAllCustomers()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var service = new CustomerService(dbService);
+
+                service.AddCustomer(new Customer { Company = "Acme", Contact = "J" });
+
+                var results = service.SearchCustomers(null);
+                Assert.Single(results);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void GetCustomerByID_ReturnsCustomer()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var service = new CustomerService(dbService);
+
+                service.AddCustomer(new Customer { Company = "Acme", Contact = "John" });
+                var cust = service.GetAllCustomers().First();
+
+                var fetched = service.GetCustomerByID(cust.CustomerID);
+                Assert.NotNull(fetched);
+                Assert.Equal(cust.CustomerID, fetched.CustomerID);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -289,7 +289,11 @@
                             <ColumnDefinition Width="350" />
                             <ColumnDefinition />
                         </Grid.ColumnDefinitions>
-                        <GroupBox Header="Customer Details" Grid.Column="0" Margin="5">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <GroupBox Header="Customer Details" Grid.Column="0" Grid.Row="0" Margin="5">
                             <StackPanel>
                                 <xctk:WatermarkTextBox x:Name="CustomerNameInput" Watermark="Name" Margin="5" />
                                 <xctk:WatermarkTextBox x:Name="CustomerEmailInput" Watermark="Email" Margin="5" />
@@ -304,7 +308,10 @@
                                 </StackPanel>
                             </StackPanel>
                         </GroupBox>
-                        <ListView x:Name="CustomerList" Grid.Column="1" ItemsSource="{Binding Customers}" Margin="5">
+                        <xctk:WatermarkTextBox x:Name="CustomerSearchInput" Grid.Column="1" Grid.Row="0"
+                                              Margin="5" Width="300"
+                                              Watermark="Search Customers..." TextChanged="CustomerSearchInput_TextChanged" />
+                        <ListView x:Name="CustomerList" Grid.Column="1" Grid.Row="1" ItemsSource="{Binding Customers}" Margin="5">
                             <ListView.View>
                                 <GridView>
                                     <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Company}" Width="150" />

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -624,6 +624,24 @@ namespace ToolManagementAppV2
             }
         }
 
+        void CustomerSearchInput_TextChanged(object s, TextChangedEventArgs e)
+        {
+            try
+            {
+                var txt = CustomerSearchInput.Text;
+                if (DataContext is MainViewModel vm)
+                {
+                    CustomerList.ItemsSource = string.IsNullOrWhiteSpace(txt)
+                        ? vm.SearchCustomers(string.Empty)
+                        : vm.SearchCustomers(txt);
+                }
+            }
+            catch (Exception ex)
+            {
+                ShowError("Error performing customer search", ex);
+            }
+        }
+
         void UpdateHeaderLogo()
         {
             try

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -131,6 +131,7 @@ namespace ToolManagementAppV2.ViewModels
         }
 
         public string SearchTerm { get; set; }
+        public string CustomerSearchTerm { get; set; }
         public bool IsLastAdmin =>
             SelectedUser != null &&
             SelectedUser.IsAdmin &&
@@ -141,6 +142,7 @@ namespace ToolManagementAppV2.ViewModels
         public string ConfirmPassword { get; set; }
 
         public IRelayCommand SearchCommand { get; }
+        public IRelayCommand SearchCustomersCommand { get; }
         public IRelayCommand AddToolCommand { get; }
         public IRelayCommand UpdateToolCommand { get; }
         public IRelayCommand ImportToolsCommand { get; }
@@ -178,9 +180,10 @@ namespace ToolManagementAppV2.ViewModels
             _userService = userService;
             _customerService = customerService;
             _rentalService = rentalService;
-            _settingsService = settingsService;
+           _settingsService = settingsService;
 
-            SearchCommand = new RelayCommand(SearchTools);
+           SearchCommand = new RelayCommand(SearchTools);
+            SearchCustomersCommand = new RelayCommand(SearchCustomers);
             AddToolCommand = new RelayCommand(AddTool);
             UpdateToolCommand = new RelayCommand(UpdateTool, () => SelectedTool != null);
             ImportToolsCommand = new RelayCommand(ImportTools);
@@ -463,6 +466,20 @@ namespace ToolManagementAppV2.ViewModels
         {
             _customerService.DeleteCustomer(SelectedCustomer.CustomerID);
             LoadCustomers();
+        }
+
+        public CustomerModel GetCustomerByID(int customerID)
+            => _customerService.GetCustomerByID(customerID);
+
+        public List<CustomerModel> SearchCustomers(string searchTerm)
+            => _customerService.SearchCustomers(searchTerm);
+
+        void SearchCustomers()
+        {
+            var results = string.IsNullOrWhiteSpace(CustomerSearchTerm)
+                ? _customerService.GetAllCustomers()
+                : _customerService.SearchCustomers(CustomerSearchTerm);
+            Customers.ReplaceRange(results);
         }
 
         void RentSelectedTool()


### PR DESCRIPTION
## Summary
- expose GetCustomerByID and SearchCustomers via MainViewModel
- add search box for customers in MainWindow
- handle customer search in code behind
- add unit tests for CustomerService

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684bbd0307688324bf16238c697ac7fd