### PR TITLE
Add rental history view model test

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/RentalHistoryViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/RentalHistoryViewModelTests.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Linq;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.ViewModels.Rental;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class RentalHistoryViewModelTests
+    {
+        [Fact]
+        public void Constructor_SetsDisplayNameAndHistory()
+        {
+            var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer" };
+            var rentals = new List<Rental>
+            {
+                new Rental { RentalID = 1, ToolID = tool.ToolID, CustomerID = 1 },
+                new Rental { RentalID = 2, ToolID = tool.ToolID, CustomerID = 2 }
+            };
+
+            var vm = new RentalHistoryViewModel(tool, rentals);
+
+            Assert.Equal("T1 - Hammer", vm.ToolDisplayName);
+            Assert.Equal(2, vm.History.Count);
+            Assert.Equal(rentals.First().RentalID, vm.History[0].RentalID);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `RentalHistoryViewModelTests` covering rental history view model

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bbd00dd108324a75ee4012de31ed9