### PR TITLE
Hash passwords on user operations

### DIFF
--- a/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using System.Linq;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Utilities.Helpers;
+using Xunit;
+
+public class UserAuthenticationTests
+{
+    [Fact]
+    public void AuthenticateUser_HashesPassword()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            var userService = new UserService(dbService);
+
+            var user = new User { UserName = "test", Password = "secret", IsAdmin = false };
+            userService.AddUser(user);
+            var added = userService.GetAllUsers().First();
+
+            Assert.NotEqual("secret", added.Password);
+            Assert.Equal(SecurityHelper.ComputeSha256Hash("secret"), added.Password);
+
+            var auth = userService.AuthenticateUser("test", "secret");
+            Assert.NotNull(auth);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+}

--- a/ToolManagementAppV2/Views/LoginWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml.cs
@@ -83,9 +83,10 @@ namespace ToolManagementAppV2
             }
 
             // Non-admin default-password skip
+            var defaultHash = SecurityHelper.ComputeSha256Hash("newpassword");
             if (!user.IsAdmin &&
                 (string.IsNullOrWhiteSpace(user.Password) ||
-                 user.Password.Equals("newpassword", StringComparison.OrdinalIgnoreCase)))
+                 user.Password.Equals(defaultHash, StringComparison.OrdinalIgnoreCase)))
             {
                 App.Current.Properties["CurrentUser"] = user;
                 DialogResult = true;


### PR DESCRIPTION
## Summary
- hash passwords when adding, updating or changing a user
- verify hash on authentication
- update login logic to recognize hashed default password
- add a unit test for authentication with hashed credentials

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bbd050c208324b8a9c799ebabae8f