### PR TITLE
Fix security issue loading user photos

### DIFF
--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -184,13 +184,13 @@ namespace ToolManagementAppV2.Services.Users
                     }
                     else
                     {
-                        var full = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, u.UserPhotoPath);
-                        if (!File.Exists(full))
+                        var full = PathHelper.GetAbsolutePath(u.UserPhotoPath);
+                        if (string.IsNullOrEmpty(full) || !File.Exists(full))
                         {
                             u.PhotoBitmap = null;
                             return u;
                         }
-                        uri = new Uri($"file:///{full.Replace("\\", "/")}", UriKind.Absolute);
+                        uri = new Uri(full, UriKind.Absolute);
                     }
 
                     var bmp = new BitmapImage();


### PR DESCRIPTION
## Summary
- secure user photo loading with `PathHelper`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bcf8c33108324b0b1b3aefffd2ab6