### PR TITLE
Fix admin selection and password reset

### DIFF
--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -14,7 +14,6 @@
             <local:CheckOutStatusConverter x:Key="CheckOutStatusConverter"/>
             <local:NullToDefaultImageConverter x:Key="NullToDefaultImageConverter"/>
             <local:InverseBooleanConverter x:Key="InverseBooleanConverter"/>
-            <local:NonEmptyStringToBoolConverter x:Key="NonEmptyStringToBoolConverter"/>
             <DataTemplate x:Key="CheckOutButtonTemplate">
                 <Button Content="{Binding IsCheckedOut, Converter={StaticResource CheckOutStatusConverter}}"
                 Click="CheckOutButton_Click"
@@ -430,8 +429,8 @@
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="5">
                                 <TextBlock Text="Is Admin:" Width="100" VerticalAlignment="Center"/>
-                                <CheckBox IsChecked="{Binding SelectedUser.IsAdmin, Mode=TwoWay}" 
-              IsEnabled="{Binding UserPassword, Converter={StaticResource NonEmptyStringToBoolConverter}, UpdateSourceTrigger=PropertyChanged}" />
+                                <CheckBox IsChecked="{Binding SelectedUser.IsAdmin, Mode=TwoWay}"
+              IsEnabled="{Binding IsLastAdmin, Converter={StaticResource InverseBooleanConverter}}" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="10">
                                 <Button Content="New User" Click="NewUserButton_Click" Width="100" Margin="5"/>

--- a/ToolManagementAppV2/Views/LoginWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml.cs
@@ -101,9 +101,15 @@ namespace ToolManagementAppV2
 
             if (prompt.ShowDialog() != true) return;
 
-            var credential = prompt.IsPasswordResetRequested
-                ? _userService.AuthenticateUser(user.UserName, "admin")
-                : _userService.AuthenticateUser(user.UserName, prompt.EnteredPassword);
+            if (prompt.IsPasswordResetRequested)
+            {
+                _userService.ChangeUserPassword(user.UserID, "admin");
+                user.Password = SecurityHelper.ComputeSha256Hash("admin");
+            }
+
+            var credential = _userService.AuthenticateUser(
+                user.UserName,
+                prompt.IsPasswordResetRequested ? "admin" : prompt.EnteredPassword);
 
             if (credential != null)
             {


### PR DESCRIPTION
## Summary
- allow setting admin status without requiring a password
- prevent unchecking the last admin
- reset password to `admin` when the user opts to reset from the password prompt

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd4d174308324a3e62c21c1aa59c6