### PR TITLE
Fix admin management and password reset

### DIFF
--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -14,7 +14,6 @@
             <local:CheckOutStatusConverter x:Key="CheckOutStatusConverter"/>
             <local:NullToDefaultImageConverter x:Key="NullToDefaultImageConverter"/>
             <local:InverseBooleanConverter x:Key="InverseBooleanConverter"/>
-            <local:NonEmptyStringToBoolConverter x:Key="NonEmptyStringToBoolConverter"/>
             <DataTemplate x:Key="CheckOutButtonTemplate">
                 <Button Content="{Binding IsCheckedOut, Converter={StaticResource CheckOutStatusConverter}}"
                 Click="CheckOutButton_Click"
@@ -430,8 +429,8 @@
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="5">
                                 <TextBlock Text="Is Admin:" Width="100" VerticalAlignment="Center"/>
-                                <CheckBox IsChecked="{Binding SelectedUser.IsAdmin, Mode=TwoWay}" 
-              IsEnabled="{Binding UserPassword, Converter={StaticResource NonEmptyStringToBoolConverter}, UpdateSourceTrigger=PropertyChanged}" />
+                                <CheckBox IsChecked="{Binding SelectedUser.IsAdmin, Mode=TwoWay}"
+              IsEnabled="{Binding IsLastAdmin, Converter={StaticResource InverseBooleanConverter}}" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="10">
                                 <Button Content="New User" Click="NewUserButton_Click" Width="100" Margin="5"/>

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -343,6 +343,14 @@ namespace ToolManagementAppV2
             if (DataContext is MainViewModel vm && vm.SelectedUser != null)
             {
                 var u = vm.SelectedUser;
+
+                if (!u.IsAdmin && vm.Users.Count(x => x.IsAdmin && x != u) == 0)
+                {
+                    ShowMessage("Save Failed", "At least one admin user must remain.", MessageBoxImage.Warning);
+                    u.IsAdmin = true;
+                    return;
+                }
+
                 if (u.UserID > 0) _userService.UpdateUser(u);
                 else _userService.AddUser(u);
 

--- a/ToolManagementAppV2/Views/LoginWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml.cs
@@ -79,7 +79,7 @@ namespace ToolManagementAppV2
             if (user.IsAdmin && string.IsNullOrWhiteSpace(user.Password))
             {
                 _userService.ChangeUserPassword(user.UserID, "admin");
-                user.Password = "admin";
+                user.Password = SecurityHelper.ComputeSha256Hash("admin");
             }
 
             // Non-admin default-password skip
@@ -101,9 +101,16 @@ namespace ToolManagementAppV2
 
             if (prompt.ShowDialog() != true) return;
 
-            var credential = prompt.IsPasswordResetRequested
-                ? _userService.AuthenticateUser(user.UserName, "admin")
-                : _userService.AuthenticateUser(user.UserName, prompt.EnteredPassword);
+            if (prompt.IsPasswordResetRequested)
+            {
+                _userService.ChangeUserPassword(user.UserID, "admin");
+                user.Password = SecurityHelper.ComputeSha256Hash("admin");
+                LoadUsers();
+            }
+
+            var credential = _userService.AuthenticateUser(
+                user.UserName,
+                prompt.IsPasswordResetRequested ? "admin" : prompt.EnteredPassword);
 
             if (credential != null)
             {

--- a/ToolManagementAppV2/Views/PasswordPromptWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PasswordPromptWindow.xaml.cs
@@ -82,11 +82,7 @@ namespace ToolManagementAppV2
             if (result != MessageBoxResult.Yes) return;
 
             IsPasswordResetRequested = true;
-            _attemptCount = 0;
-            ErrorTextBlock.Visibility = Visibility.Collapsed;
-            ForgotPasswordTextBlock.Visibility = Visibility.Collapsed;
-            PasswordBox.Clear();
-            PasswordBox.Focus();
+            DialogResult = true;
         }
     }
 }


### PR DESCRIPTION
## Summary
- prevent removing the last admin when saving changes
- always hash password when auto-setting admin default password
- ensure reset password replaces stored hash
- reload user list after a password reset so login works with the new default password
- close the password prompt automatically when resetting

## Testing
- ❌ `dotnet test --no-build` *(failed to run: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd4d174308324a3e62c21c1aa59c6