### PR TITLE
Make domain models observable

### DIFF
--- a/ToolManagementAppV2/Models/Domain/ActivityLog.cs
+++ b/ToolManagementAppV2/Models/Domain/ActivityLog.cs
@@ -1,11 +1,42 @@
-﻿namespace ToolManagementAppV2.Models.Domain
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace ToolManagementAppV2.Models.Domain
 {
-    public class ActivityLog
+    public class ActivityLog : ObservableObject
     {
-        public int LogID { get; set; }
-        public int UserID { get; set; }
-        public string UserName { get; set; }
-        public string Action { get; set; }
-        public DateTime Timestamp { get; set; }
+        private int _logID;
+        public int LogID
+        {
+            get => _logID;
+            set => SetProperty(ref _logID, value);
+        }
+
+        private int _userID;
+        public int UserID
+        {
+            get => _userID;
+            set => SetProperty(ref _userID, value);
+        }
+
+        private string _userName = string.Empty;
+        public string UserName
+        {
+            get => _userName;
+            set => SetProperty(ref _userName, value);
+        }
+
+        private string _action = string.Empty;
+        public string Action
+        {
+            get => _action;
+            set => SetProperty(ref _action, value);
+        }
+
+        private DateTime _timestamp;
+        public DateTime Timestamp
+        {
+            get => _timestamp;
+            set => SetProperty(ref _timestamp, value);
+        }
     }
 }

--- a/ToolManagementAppV2/Models/Domain/Customer.cs
+++ b/ToolManagementAppV2/Models/Domain/Customer.cs
@@ -1,13 +1,56 @@
-﻿namespace ToolManagementAppV2.Models.Domain
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace ToolManagementAppV2.Models.Domain
 {
-    public class Customer
+    public class Customer : ObservableObject
     {
-        public int CustomerID { get; set; }
-        public string Company { get; set; }
-        public string Contact { get; set; }
-        public string Email { get; set; }
-        public string Phone { get; set; }
-        public string Mobile { get; set; }
-        public string Address { get; set; }
+        private int _customerID;
+        public int CustomerID
+        {
+            get => _customerID;
+            set => SetProperty(ref _customerID, value);
+        }
+
+        private string _company = string.Empty;
+        public string Company
+        {
+            get => _company;
+            set => SetProperty(ref _company, value);
+        }
+
+        private string _contact = string.Empty;
+        public string Contact
+        {
+            get => _contact;
+            set => SetProperty(ref _contact, value);
+        }
+
+        private string _email = string.Empty;
+        public string Email
+        {
+            get => _email;
+            set => SetProperty(ref _email, value);
+        }
+
+        private string _phone = string.Empty;
+        public string Phone
+        {
+            get => _phone;
+            set => SetProperty(ref _phone, value);
+        }
+
+        private string _mobile = string.Empty;
+        public string Mobile
+        {
+            get => _mobile;
+            set => SetProperty(ref _mobile, value);
+        }
+
+        private string _address = string.Empty;
+        public string Address
+        {
+            get => _address;
+            set => SetProperty(ref _address, value);
+        }
     }
 }

--- a/ToolManagementAppV2/Models/Domain/Rental.cs
+++ b/ToolManagementAppV2/Models/Domain/Rental.cs
@@ -1,15 +1,56 @@
-﻿namespace ToolManagementAppV2.Models.Domain
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace ToolManagementAppV2.Models.Domain
 {
-    public class Rental
+    public class Rental : ObservableObject
     {
-        public int RentalID { get; set; }
-        // Stored as INTEGER in the database but exposed as a string for
-        // consistency with ToolModel.ToolID and service signatures.
-        public string ToolID { get; set; }
-        public int CustomerID { get; set; }
-        public DateTime RentalDate { get; set; }
-        public DateTime DueDate { get; set; }
-        public DateTime? ReturnDate { get; set; } // Nullable to indicate if returned or not
-        public string? Status { get; set; }
+        private int _rentalID;
+        public int RentalID
+        {
+            get => _rentalID;
+            set => SetProperty(ref _rentalID, value);
+        }
+
+        private string _toolID = string.Empty;
+        public string ToolID
+        {
+            get => _toolID;
+            set => SetProperty(ref _toolID, value);
+        }
+
+        private int _customerID;
+        public int CustomerID
+        {
+            get => _customerID;
+            set => SetProperty(ref _customerID, value);
+        }
+
+        private DateTime _rentalDate;
+        public DateTime RentalDate
+        {
+            get => _rentalDate;
+            set => SetProperty(ref _rentalDate, value);
+        }
+
+        private DateTime _dueDate;
+        public DateTime DueDate
+        {
+            get => _dueDate;
+            set => SetProperty(ref _dueDate, value);
+        }
+
+        private DateTime? _returnDate;
+        public DateTime? ReturnDate
+        {
+            get => _returnDate;
+            set => SetProperty(ref _returnDate, value);
+        }
+
+        private string? _status;
+        public string? Status
+        {
+            get => _status;
+            set => SetProperty(ref _status, value);
+        }
     }
 }

--- a/ToolManagementAppV2/Models/Domain/Tool.cs
+++ b/ToolManagementAppV2/Models/Domain/Tool.cs
@@ -1,25 +1,135 @@
-﻿namespace ToolManagementAppV2.Models.Domain
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace ToolManagementAppV2.Models.Domain
 {
-    public class Tool
+    public class Tool : ObservableObject
     {
-        public string ToolID { get; set; } = string.Empty;
-        public string ToolNumber { get; set; } = string.Empty;
-        public string PartNumber { get; set; } = string.Empty;
-        public string NameDescription { get; set; } = string.Empty;
-        public string Brand { get; set; } = string.Empty;
-        public string Location { get; set; } = string.Empty;
-        public int QuantityOnHand { get; set; }
-        public int RentedQuantity { get; set; }
-        public string Supplier { get; set; } = string.Empty;
-        public DateTime? PurchasedDate { get; set; }
-        public string Notes { get; set; } = string.Empty;
-        public string Keywords { get; set; } = string.Empty;
-        public bool IsCheckedOut { get; set; }
-        public string CheckedOutBy { get; set; } = string.Empty;
-        public DateTime? CheckedOutTime { get; set; }
-        public string ToolImagePath { get; set; } = string.Empty;
+        private string _toolID = string.Empty;
+        public string ToolID
+        {
+            get => _toolID;
+            set => SetProperty(ref _toolID, value);
+        }
+
+        private string _toolNumber = string.Empty;
+        public string ToolNumber
+        {
+            get => _toolNumber;
+            set => SetProperty(ref _toolNumber, value);
+        }
+
+        private string _partNumber = string.Empty;
+        public string PartNumber
+        {
+            get => _partNumber;
+            set => SetProperty(ref _partNumber, value);
+        }
+
+        private string _nameDescription = string.Empty;
+        public string NameDescription
+        {
+            get => _nameDescription;
+            set => SetProperty(ref _nameDescription, value);
+        }
+
+        private string _brand = string.Empty;
+        public string Brand
+        {
+            get => _brand;
+            set => SetProperty(ref _brand, value);
+        }
+
+        private string _location = string.Empty;
+        public string Location
+        {
+            get => _location;
+            set => SetProperty(ref _location, value);
+        }
+
+        private int _quantityOnHand;
+        public int QuantityOnHand
+        {
+            get => _quantityOnHand;
+            set
+            {
+                if (SetProperty(ref _quantityOnHand, value))
+                {
+                    OnPropertyChanged(nameof(OnHand));
+                }
+            }
+        }
+
+        private int _rentedQuantity;
+        public int RentedQuantity
+        {
+            get => _rentedQuantity;
+            set => SetProperty(ref _rentedQuantity, value);
+        }
+
+        private string _supplier = string.Empty;
+        public string Supplier
+        {
+            get => _supplier;
+            set => SetProperty(ref _supplier, value);
+        }
+
+        private DateTime? _purchasedDate;
+        public DateTime? PurchasedDate
+        {
+            get => _purchasedDate;
+            set
+            {
+                if (SetProperty(ref _purchasedDate, value))
+                {
+                    OnPropertyChanged(nameof(Purchased));
+                }
+            }
+        }
+
+        private string _notes = string.Empty;
+        public string Notes
+        {
+            get => _notes;
+            set => SetProperty(ref _notes, value);
+        }
+
+        private string _keywords = string.Empty;
+        public string Keywords
+        {
+            get => _keywords;
+            set => SetProperty(ref _keywords, value);
+        }
+
+        private bool _isCheckedOut;
+        public bool IsCheckedOut
+        {
+            get => _isCheckedOut;
+            set => SetProperty(ref _isCheckedOut, value);
+        }
+
+        private string _checkedOutBy = string.Empty;
+        public string CheckedOutBy
+        {
+            get => _checkedOutBy;
+            set => SetProperty(ref _checkedOutBy, value);
+        }
+
+        private DateTime? _checkedOutTime;
+        public DateTime? CheckedOutTime
+        {
+            get => _checkedOutTime;
+            set => SetProperty(ref _checkedOutTime, value);
+        }
+
+        private string _toolImagePath = string.Empty;
+        public string ToolImagePath
+        {
+            get => _toolImagePath;
+            set => SetProperty(ref _toolImagePath, value);
+        }
 
         public int OnHand => QuantityOnHand;
-        public string Purchased => PurchasedDate?.ToString("yyyy-MM-dd") ?? "";
+
+        public string Purchased => PurchasedDate?.ToString("yyyy-MM-dd") ?? string.Empty;
     }
 }


### PR DESCRIPTION
## Summary
- implement ObservableObject for domain models Tool, Customer, Rental, and ActivityLog
- convert properties to backing fields and use `SetProperty`
- keep SettingItem and User as-is

## Testing
- `dotnet test ToolManagementAppV2.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bedee91b0832486792c04946c08cd