### PR TITLE
Implement ConvertBack in NonEmptyStringToBoolConverter

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/NonEmptyStringToBoolConverterTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NonEmptyStringToBoolConverterTests.cs
@@ -1,0 +1,34 @@
+using System.Globalization;
+using System.Windows.Data;
+using ToolManagementAppV2.Utilities.Converters;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests
+{
+    public class NonEmptyStringToBoolConverterTests
+    {
+        [Fact]
+        public void ConvertBack_True_ReturnsEmptyString()
+        {
+            var converter = new NonEmptyStringToBoolConverter();
+            var result = converter.ConvertBack(true, typeof(string), null, CultureInfo.InvariantCulture);
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void ConvertBack_False_ReturnsNull()
+        {
+            var converter = new NonEmptyStringToBoolConverter();
+            var result = converter.ConvertBack(false, typeof(string), null, CultureInfo.InvariantCulture);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ConvertBack_InvalidInput_ReturnsBindingDoNothing()
+        {
+            var converter = new NonEmptyStringToBoolConverter();
+            var result = converter.ConvertBack(42, typeof(string), null, CultureInfo.InvariantCulture);
+            Assert.Equal(Binding.DoNothing, result);
+        }
+    }
+}

--- a/ToolManagementAppV2/Utilities/Converters/NonEmptyStringToBoolConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/NonEmptyStringToBoolConverter.cs
@@ -10,7 +10,21 @@ namespace ToolManagementAppV2.Utilities.Converters
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
             !string.IsNullOrEmpty(value as string);
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
-            throw new NotImplementedException();
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            try
+            {
+                if (value is bool b)
+                    return b ? string.Empty : null;
+
+                if (value is string s)
+                    return s;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+            return Binding.DoNothing;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- finish `NonEmptyStringToBoolConverter` by providing a full `ConvertBack` implementation
- add unit tests for the converter

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf0c7ced48324bf6f469199096d65