### PR TITLE
Add exception handling to RentalService

### DIFF
--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -44,5 +44,101 @@ namespace ToolManagementAppV2.Tests.Services
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void RentTool_NoAvailability_DoesNotThrow()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+
+                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 0 };
+                toolService.AddTool(tool);
+                var addedTool = toolService.GetAllTools().First();
+
+                customerService.AddCustomer(new Customer { Company = "Acme" });
+                var cust = customerService.GetAllCustomers().First();
+
+                var ex = Record.Exception(() => rentalService.RentTool(addedTool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1)));
+                Assert.Null(ex);
+                Assert.Empty(rentalService.GetAllRentals());
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void RentToolWithTransaction_NoAvailability_DoesNotThrow()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+
+                var tool = new Tool { ToolNumber = "T2", NameDescription = "Wrench", QuantityOnHand = 0 };
+                toolService.AddTool(tool);
+                var addedTool = toolService.GetAllTools().First();
+
+                customerService.AddCustomer(new Customer { Company = "Beta" });
+                var cust = customerService.GetAllCustomers().First();
+
+                var ex = Record.Exception(() => rentalService.RentToolWithTransaction(addedTool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1)));
+                Assert.Null(ex);
+                Assert.Empty(rentalService.GetAllRentals());
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void ReturnTool_InvalidRentalID_DoesNotThrow()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var rentalService = new RentalService(db);
+
+                var ex = Record.Exception(() => rentalService.ReturnTool(1, DateTime.Today));
+                Assert.Null(ex);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void ReturnToolWithTransaction_InvalidRentalID_DoesNotThrow()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var rentalService = new RentalService(db);
+
+                var ex = Record.Exception(() => rentalService.ReturnToolWithTransaction(1, DateTime.Today));
+                Assert.Null(ex);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -48,10 +48,11 @@ namespace ToolManagementAppV2.Services.Rentals
 
                 tx.Commit();
             }
-            catch
+            catch (Exception ex)
             {
+                Console.WriteLine(ex.Message);
                 tx.Rollback();
-                throw;
+                return;
             }
         }
 
@@ -84,10 +85,11 @@ namespace ToolManagementAppV2.Services.Rentals
 
                 tx.Commit();
             }
-            catch
+            catch (Exception ex)
             {
+                Console.WriteLine(ex.Message);
                 tx.Rollback();
-                throw;
+                return;
             }
         }
 
@@ -115,10 +117,11 @@ namespace ToolManagementAppV2.Services.Rentals
 
                 tx.Commit();
             }
-            catch
+            catch (Exception ex)
             {
+                Console.WriteLine(ex.Message);
                 tx.Rollback();
-                throw;
+                return;
             }
         }
 
@@ -150,10 +153,11 @@ namespace ToolManagementAppV2.Services.Rentals
 
                 tx.Commit();
             }
-            catch
+            catch (Exception ex)
             {
+                Console.WriteLine(ex.Message);
                 tx.Rollback();
-                throw;
+                return;
             }
         }
 


### PR DESCRIPTION
## Summary
- log rental errors and rollback without rethrowing
- verify rental operations don't throw when failures occur

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf303777c8324a42a670335a4bfb8