### PR TITLE
Handle update settings errors gracefully

### DIFF
--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Data.SQLite;
+using System.IO;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Settings;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Services
+{
+    public class SettingsServiceTests
+    {
+        [Fact]
+        public void UpdateSettings_DoesNotThrowOnFailure()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var service = new SettingsService(dbService);
+
+                using (var conn = new SQLiteConnection(dbService.ConnectionString))
+                {
+                    conn.Open();
+                    using var cmd = new SQLiteCommand("DROP TABLE Settings", conn);
+                    cmd.ExecuteNonQuery();
+                }
+
+                var settings = new Dictionary<string, string> { ["Key1"] = "Value1" };
+                service.UpdateSettings(settings);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data.SQLite;
+using System;
 using ToolManagementAppV2.Services.Core;
 
 namespace ToolManagementAppV2.Services.Settings
@@ -65,10 +66,11 @@ namespace ToolManagementAppV2.Services.Settings
                 }
                 tx.Commit();
             }
-            catch
+            catch (Exception ex)
             {
                 tx.Rollback();
-                throw;
+                Console.WriteLine(ex);
+                return;
             }
         }
 


### PR DESCRIPTION
## Summary
- log `UpdateSettings` exceptions and exit without rethrowing
- test that `UpdateSettings` swallows exceptions

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf301be2c832492c7499ec9a9a16f