### PR TITLE
Implement BooleanToAdminConverter ConvertBack with tests

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/BooleanToAdminConverterTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/BooleanToAdminConverterTests.cs
@@ -1,0 +1,66 @@
+using System.Globalization;
+using System.Windows.Data;
+using ToolManagementAppV2.Utilities.Converters;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests
+{
+    public class BooleanToAdminConverterTests
+    {
+        [Fact]
+        public void Convert_True_ReturnsAdmin()
+        {
+            var converter = new BooleanToAdminConverter();
+            var result = converter.Convert(true, typeof(string), null, CultureInfo.InvariantCulture);
+            Assert.Equal("Admin", result);
+        }
+
+        [Fact]
+        public void Convert_False_ReturnsEmptyString()
+        {
+            var converter = new BooleanToAdminConverter();
+            var result = converter.Convert(false, typeof(string), null, CultureInfo.InvariantCulture);
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void Convert_InvalidInput_ReturnsBindingDoNothing()
+        {
+            var converter = new BooleanToAdminConverter();
+            var result = converter.Convert(5, typeof(string), null, CultureInfo.InvariantCulture);
+            Assert.Equal(Binding.DoNothing, result);
+        }
+
+        [Fact]
+        public void ConvertBack_AdminString_ReturnsTrue()
+        {
+            var converter = new BooleanToAdminConverter();
+            var result = converter.ConvertBack("Admin", typeof(bool), null, CultureInfo.InvariantCulture);
+            Assert.True((bool)result);
+        }
+
+        [Fact]
+        public void ConvertBack_True_ReturnsTrue()
+        {
+            var converter = new BooleanToAdminConverter();
+            var result = converter.ConvertBack(true, typeof(bool), null, CultureInfo.InvariantCulture);
+            Assert.True((bool)result);
+        }
+
+        [Fact]
+        public void ConvertBack_OtherString_ReturnsFalse()
+        {
+            var converter = new BooleanToAdminConverter();
+            var result = converter.ConvertBack("User", typeof(bool), null, CultureInfo.InvariantCulture);
+            Assert.False((bool)result);
+        }
+
+        [Fact]
+        public void ConvertBack_InvalidInput_ReturnsBindingDoNothing()
+        {
+            var converter = new BooleanToAdminConverter();
+            var result = converter.ConvertBack(42, typeof(bool), null, CultureInfo.InvariantCulture);
+            Assert.Equal(Binding.DoNothing, result);
+        }
+    }
+}

--- a/ToolManagementAppV2/Utilities/Converters/BooleanToAdminConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/BooleanToAdminConverter.cs
@@ -9,13 +9,33 @@ namespace ToolManagementAppV2.Utilities.Converters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is bool isAdmin && isAdmin)
-                return "Admin";
-            return string.Empty;
+            try
+            {
+                if (value is bool isAdmin)
+                    return isAdmin ? "Admin" : string.Empty;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+            return Binding.DoNothing;
         }
+
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            try
+            {
+                if (value is bool b)
+                    return b;
+
+                if (value is string s)
+                    return string.Equals(s, "Admin", StringComparison.OrdinalIgnoreCase);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+            return value is string or bool ? false : Binding.DoNothing;
         }
     }
 }


### PR DESCRIPTION
## Summary
- return "Admin" for admins in BooleanToAdminConverter
- implement ConvertBack to read "Admin" or true as true
- add BooleanToAdminConverter unit tests

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf300c8608324884a6fc26f6a6256