### PR TITLE
Add ConvertBack logic to image converter

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/NullToDefaultImageConverterTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NullToDefaultImageConverterTests.cs
@@ -1,0 +1,38 @@
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media.Imaging;
+using ToolManagementAppV2.Utilities.Converters;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests
+{
+    public class NullToDefaultImageConverterTests
+    {
+        [Fact]
+        public void ConvertBack_BitmapImage_ReturnsUriString()
+        {
+            var converter = new NullToDefaultImageConverter();
+            var uri = "pack://application:,,,/Resources/DefaultUserPhoto.png";
+            var bmp = new BitmapImage(new Uri(uri));
+            var result = converter.ConvertBack(bmp, typeof(string), null, CultureInfo.InvariantCulture);
+            Assert.Equal(uri, result);
+        }
+
+        [Fact]
+        public void ConvertBack_String_ReturnsSameString()
+        {
+            var converter = new NullToDefaultImageConverter();
+            var path = "image.png";
+            var result = converter.ConvertBack(path, typeof(string), null, CultureInfo.InvariantCulture);
+            Assert.Equal(path, result);
+        }
+
+        [Fact]
+        public void ConvertBack_InvalidInput_ReturnsBindingDoNothing()
+        {
+            var converter = new NullToDefaultImageConverter();
+            var result = converter.ConvertBack(42, typeof(string), null, CultureInfo.InvariantCulture);
+            Assert.Equal(Binding.DoNothing, result);
+        }
+    }
+}

--- a/ToolManagementAppV2/Utilities/Converters/NullToDefaultImageConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/NullToDefaultImageConverter.cs
@@ -80,7 +80,20 @@ namespace ToolManagementAppV2.Utilities.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            try
+            {
+                if (value is BitmapImage bmp)
+                    return bmp.UriSource?.OriginalString;
+
+                if (value is string path)
+                    return path;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+
+            return Binding.DoNothing;
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement ConvertBack in NullToDefaultImageConverter
- test ConvertBack logic

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf2ff74c88324a0904e1d5101ad28