### PR TITLE
Implement converter logic and tests

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/CheckOutStatusConverterTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CheckOutStatusConverterTests.cs
@@ -1,0 +1,34 @@
+using System.Globalization;
+using System.Windows.Data;
+using ToolManagementAppV2.Utilities.Converters;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests
+{
+    public class CheckOutStatusConverterTests
+    {
+        [Fact]
+        public void ConvertBack_CheckIn_ReturnsTrue()
+        {
+            var converter = new CheckOutStatusConverter();
+            var result = converter.ConvertBack("Check In", typeof(bool), null, CultureInfo.InvariantCulture);
+            Assert.True((bool)result);
+        }
+
+        [Fact]
+        public void ConvertBack_CheckOut_ReturnsFalse()
+        {
+            var converter = new CheckOutStatusConverter();
+            var result = converter.ConvertBack("Check Out", typeof(bool), null, CultureInfo.InvariantCulture);
+            Assert.False((bool)result);
+        }
+
+        [Fact]
+        public void ConvertBack_InvalidInput_ReturnsBindingDoNothing()
+        {
+            var converter = new CheckOutStatusConverter();
+            var result = converter.ConvertBack(42, typeof(bool), null, CultureInfo.InvariantCulture);
+            Assert.Equal(Binding.DoNothing, result);
+        }
+    }
+}

--- a/ToolManagementAppV2/Utilities/Converters/CheckOutStatusConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/CheckOutStatusConverter.cs
@@ -13,7 +13,21 @@ namespace ToolManagementAppV2.Utilities.Converters
         }
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            try
+            {
+                if (value is string status)
+                {
+                    if (status == "Check In")
+                        return true;
+                    if (status == "Check Out")
+                        return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+            return Binding.DoNothing;
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement ConvertBack logic for `CheckOutStatusConverter`
- test CheckOutStatusConverter for expected conversions

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf2fdc8a88324b576fc442a943d3c