### PR TITLE
Add console logging and tests

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ConsoleLoggingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ConsoleLoggingTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Windows.Controls;
+using ToolManagementAppV2;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Utilities.Converters;
+using ToolManagementAppV2.Utilities.Helpers;
+using ToolManagementAppV2.Models.Domain;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests
+{
+    public class ConsoleLoggingTests
+    {
+        [Fact]
+        public void PathHelper_InvalidPath_LogsException()
+        {
+            var sw = new StringWriter();
+            var original = Console.Out;
+            Console.SetOut(sw);
+            try
+            {
+                var result = PathHelper.GetAbsolutePath("invalid|path");
+                Assert.Null(result);
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
+            Assert.NotEqual(string.Empty, sw.ToString());
+        }
+
+        [Fact]
+        public void NullToDefaultImageConverter_InvalidResource_LogsException()
+        {
+            var converter = new NullToDefaultImageConverter();
+            var method = typeof(NullToDefaultImageConverter).GetMethod("LoadFromResource", BindingFlags.NonPublic | BindingFlags.Instance);
+            var sw = new StringWriter();
+            var original = Console.Out;
+            Console.SetOut(sw);
+            try
+            {
+                method.Invoke(converter, new object[] { "NoSuchFile.png" });
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
+            Assert.NotEqual(string.Empty, sw.ToString());
+        }
+
+        [Fact]
+        public void ShowError_LogsException()
+        {
+            var window = (MainWindow)FormatterServices.GetUninitializedObject(typeof(MainWindow));
+            var method = typeof(MainWindow).GetMethod("ShowError", BindingFlags.NonPublic | BindingFlags.Instance);
+            var sw = new StringWriter();
+            var original = Console.Out;
+            Console.SetOut(sw);
+            try
+            {
+                method.Invoke(window, new object[] { "Error", new Exception("fail") });
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
+            Assert.Contains("fail", sw.ToString());
+        }
+
+        [Fact]
+        public void RefreshUserList_InvalidPhoto_LogsException()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var userService = new UserService(db);
+                userService.AddUser(new User { UserName = "u", Password = "p", UserPhotoPath = "pack://application:,,,/Resources/NoFile.png" });
+                var window = (MainWindow)FormatterServices.GetUninitializedObject(typeof(MainWindow));
+                var list = new ListView();
+                typeof(MainWindow).GetField("_userService", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(window, userService);
+                typeof(MainWindow).GetField("UserList", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(window, list);
+
+                var sw = new StringWriter();
+                var original = Console.Out;
+                Console.SetOut(sw);
+                try
+                {
+                    typeof(MainWindow).GetMethod("RefreshUserList", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(window, null);
+                }
+                finally
+                {
+                    Console.SetOut(original);
+                }
+                Assert.NotEqual(string.Empty, sw.ToString());
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void BackupDatabase_LogsException()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var sw = new StringWriter();
+                var original = Console.Out;
+                Console.SetOut(sw);
+                Assert.Throws<IOException>(() => db.BackupDatabase("invalid|path.db"));
+                Console.SetOut(original);
+                Assert.NotEqual(string.Empty, sw.ToString());
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -485,7 +485,11 @@ namespace ToolManagementAppV2
                             bmp.EndInit();
                             u.PhotoBitmap = bmp;
                         }
-                        catch { u.PhotoBitmap = null; }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine(ex);
+                            u.PhotoBitmap = null;
+                        }
                     }
                 }
                 UserList.ItemsSource = users;
@@ -957,6 +961,9 @@ namespace ToolManagementAppV2
             => MessageBox.Show(msg, title, MessageBoxButton.OK, icon);
 
         void ShowError(string title, Exception ex)
-            => MessageBox.Show(ex.Message, title, MessageBoxButton.OK, MessageBoxImage.Error);
+        {
+            Console.WriteLine(ex);
+            MessageBox.Show(ex.Message, title, MessageBoxButton.OK, MessageBoxImage.Error);
+        }
     }
 }

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -128,6 +128,7 @@ namespace ToolManagementAppV2.Services.Core
             }
             catch (Exception ex)
             {
+                Console.WriteLine(ex);
                 throw new IOException("Failed to backup database.", ex);
             }
         }

--- a/ToolManagementAppV2/Utilities/Converters/NullToDefaultImageConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/NullToDefaultImageConverter.cs
@@ -38,8 +38,9 @@ namespace ToolManagementAppV2.Utilities.Converters
                         return image;
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
+                    Console.WriteLine(ex);
                     // fall-through to default
                 }
             }
@@ -72,8 +73,9 @@ namespace ToolManagementAppV2.Utilities.Converters
                 var uri = new Uri($"pack://application:,,,/Resources/{fileName}", UriKind.Absolute);
                 return new BitmapImage(uri);
             }
-            catch
+            catch (Exception ex)
             {
+                Console.WriteLine(ex);
                 return new BitmapImage(); // empty fallback
             }
         }

--- a/ToolManagementAppV2/Utilities/Helpers/PathHelper.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/PathHelper.cs
@@ -30,8 +30,9 @@ namespace ToolManagementAppV2.Utilities.Helpers
 
                 return fullPath;
             }
-            catch
+            catch (Exception ex)
             {
+                Console.WriteLine(ex);
                 return null;
             }
         }


### PR DESCRIPTION
## Summary
- log exceptions in converters, helpers, and services
- log suppressed exceptions in `MainWindow`
- new unit tests capture console output

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf838cd1083249f425c535e67a9bf