### PR TITLE
Fix MapUser logging

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/MapUserLoggingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/MapUserLoggingTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Users;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests
+{
+    public class MapUserLoggingTests
+    {
+        [Fact]
+        public void GetAllUsers_InvalidPackPath_LogsException()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var service = new UserService(db);
+                service.AddUser(new User { UserName = "u", Password = "p", UserPhotoPath = "pack://application:,,,/Resources/NoImage.png" });
+
+                var sw = new StringWriter();
+                var original = Console.Out;
+                Console.SetOut(sw);
+                try
+                {
+                    service.GetAllUsers();
+                }
+                finally
+                {
+                    Console.SetOut(original);
+                }
+                Assert.NotEqual(string.Empty, sw.ToString());
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void GetAllUsers_InvalidFilePath_LogsException()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var service = new UserService(db);
+                service.AddUser(new User { UserName = "u", Password = "p", UserPhotoPath = "invalid|path.png" });
+
+                var sw = new StringWriter();
+                var original = Console.Out;
+                Console.SetOut(sw);
+                try
+                {
+                    service.GetAllUsers();
+                }
+                finally
+                {
+                    Console.SetOut(original);
+                }
+                Assert.NotEqual(string.Empty, sw.ToString());
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.SQLite;
+﻿using System;
+using System.Data.SQLite;
 using System.IO;
 using System.Windows.Media.Imaging;
 using System.Data;
@@ -192,8 +193,9 @@ namespace ToolManagementAppV2.Services.Users
                     u.PhotoBitmap = bmp;
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                Console.WriteLine(ex);
                 u.PhotoBitmap = null;
             }
 


### PR DESCRIPTION
## Summary
- write invalid photo path exceptions to console
- test console output from MapUser on invalid photo paths

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bfd15c15083248cf810fbfc915c24