### PR TITLE
Add console logging for RentalService errors

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ConsoleLoggingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ConsoleLoggingTests.cs
@@ -7,6 +7,9 @@ using System.Windows.Controls;
 using ToolManagementAppV2;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Utilities.Converters;
 using ToolManagementAppV2.Utilities.Helpers;
 using ToolManagementAppV2.Models.Domain;
@@ -116,6 +119,108 @@ namespace ToolManagementAppV2.Tests
                 var original = Console.Out;
                 Console.SetOut(sw);
                 Assert.Throws<IOException>(() => db.BackupDatabase("invalid|path.db"));
+                Console.SetOut(original);
+                Assert.NotEqual(string.Empty, sw.ToString());
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void RentTool_LogsException()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+
+                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 0 });
+                var tool = toolService.GetAllTools().First();
+                customerService.AddCustomer(new Customer { Company = "Acme" });
+                var cust = customerService.GetAllCustomers().First();
+
+                var sw = new StringWriter();
+                var original = Console.Out;
+                Console.SetOut(sw);
+                rentalService.RentTool(tool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                Console.SetOut(original);
+                Assert.NotEqual(string.Empty, sw.ToString());
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void RentToolWithTransaction_LogsException()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+
+                toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Wrench", QuantityOnHand = 0 });
+                var tool = toolService.GetAllTools().First();
+                customerService.AddCustomer(new Customer { Company = "Beta" });
+                var cust = customerService.GetAllCustomers().First();
+
+                var sw = new StringWriter();
+                var original = Console.Out;
+                Console.SetOut(sw);
+                rentalService.RentToolWithTransaction(tool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                Console.SetOut(original);
+                Assert.NotEqual(string.Empty, sw.ToString());
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void ReturnTool_LogsException()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var rentalService = new RentalService(db);
+
+                var sw = new StringWriter();
+                var original = Console.Out;
+                Console.SetOut(sw);
+                rentalService.ReturnTool(1, DateTime.Today);
+                Console.SetOut(original);
+                Assert.NotEqual(string.Empty, sw.ToString());
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void ReturnToolWithTransaction_LogsException()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var rentalService = new RentalService(db);
+
+                var sw = new StringWriter();
+                var original = Console.Out;
+                Console.SetOut(sw);
+                rentalService.ReturnToolWithTransaction(1, DateTime.Today);
                 Console.SetOut(original);
                 Assert.NotEqual(string.Empty, sw.ToString());
             }

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -50,7 +50,7 @@ namespace ToolManagementAppV2.Services.Rentals
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.Message);
+                Console.WriteLine(ex);
                 tx.Rollback();
                 return;
             }
@@ -87,7 +87,7 @@ namespace ToolManagementAppV2.Services.Rentals
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.Message);
+                Console.WriteLine(ex);
                 tx.Rollback();
                 return;
             }
@@ -119,7 +119,7 @@ namespace ToolManagementAppV2.Services.Rentals
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.Message);
+                Console.WriteLine(ex);
                 tx.Rollback();
                 return;
             }
@@ -155,7 +155,7 @@ namespace ToolManagementAppV2.Services.Rentals
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.Message);
+                Console.WriteLine(ex);
                 tx.Rollback();
                 return;
             }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -528,6 +528,7 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (Exception ex)
             {
+                Console.WriteLine(ex);
                 ShowWarning($"Rental failed: {ex.Message}");
                 return;
             }


### PR DESCRIPTION
## Summary
- log full exceptions instead of messages in `RentalService`
- log exceptions in `MainViewModel.RentSelectedTool`
- add tests confirming RentalService writes to console

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684bfd335630832482036f96fa1fd729