### PR TITLE
Add ExtendRental error handling tests

### DIFF
--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -140,5 +140,57 @@ namespace ToolManagementAppV2.Tests.Services
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void ExtendRental_InvalidRentalID_Throws()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var rentalService = new RentalService(db);
+
+                Assert.Throws<InvalidOperationException>(() =>
+                    rentalService.ExtendRental(1, DateTime.Today.AddDays(1)));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void ExtendRental_ReturnedRental_Throws()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+
+                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 };
+                toolService.AddTool(tool);
+                var addedTool = toolService.GetAllTools().First();
+
+                customerService.AddCustomer(new Customer { Company = "Acme" });
+                var cust = customerService.GetAllCustomers().First();
+
+                rentalService.RentTool(addedTool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                var rental = rentalService.GetAllRentals().First();
+
+                rentalService.ReturnTool(rental.RentalID, DateTime.Today);
+
+                Assert.Throws<InvalidOperationException>(() =>
+                    rentalService.ExtendRental(rental.RentalID, DateTime.Today.AddDays(2)));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add unit tests for RentalService.ExtendRental

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0ae5c4dc8324938c4cda84265e4e