### PR TITLE
Add converter Convert tests

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/NonEmptyStringToBoolConverterTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NonEmptyStringToBoolConverterTests.cs
@@ -8,6 +8,30 @@ namespace ToolManagementAppV2.Tests
     public class NonEmptyStringToBoolConverterTests
     {
         [Fact]
+        public void Convert_NonEmptyString_ReturnsTrue()
+        {
+            var converter = new NonEmptyStringToBoolConverter();
+            var result = converter.Convert("text", typeof(bool), null, CultureInfo.InvariantCulture);
+            Assert.True((bool)result);
+        }
+
+        [Fact]
+        public void Convert_EmptyOrNull_ReturnsFalse()
+        {
+            var converter = new NonEmptyStringToBoolConverter();
+            Assert.False((bool)converter.Convert(string.Empty, typeof(bool), null, CultureInfo.InvariantCulture));
+            Assert.False((bool)converter.Convert(null, typeof(bool), null, CultureInfo.InvariantCulture));
+        }
+
+        [Fact]
+        public void Convert_InvalidInput_ReturnsFalse()
+        {
+            var converter = new NonEmptyStringToBoolConverter();
+            var result = converter.Convert(42, typeof(bool), null, CultureInfo.InvariantCulture);
+            Assert.False((bool)result);
+        }
+
+        [Fact]
         public void ConvertBack_True_ReturnsEmptyString()
         {
             var converter = new NonEmptyStringToBoolConverter();

--- a/ToolManagementAppV2.Tests/Tests/NullToDefaultImageConverterTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NullToDefaultImageConverterTests.cs
@@ -3,12 +3,40 @@ using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Media.Imaging;
 using ToolManagementAppV2.Utilities.Converters;
+using ToolManagementAppV2.Utilities.Helpers;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests
 {
     public class NullToDefaultImageConverterTests
     {
+        [Fact]
+        public void Convert_Null_ReturnsDefaultUser()
+        {
+            var converter = new NullToDefaultImageConverter();
+            var result = converter.Convert(null, typeof(BitmapImage), null, CultureInfo.InvariantCulture);
+            var bmp = Assert.IsType<BitmapImage>(result);
+            Assert.Equal("pack://application:,,,/Resources/DefaultUserPhoto.png", bmp.UriSource.OriginalString);
+        }
+
+        [Fact]
+        public void Convert_ValidPath_ReturnsBitmapImage()
+        {
+            var converter = new NullToDefaultImageConverter();
+            var path = "Assets/Avatars/1.png";
+            var bmp = Assert.IsType<BitmapImage>(converter.Convert(path, typeof(BitmapImage), null, CultureInfo.InvariantCulture));
+            Assert.Equal(PathHelper.GetAbsolutePath(path), bmp.UriSource.OriginalString);
+        }
+
+        [Fact]
+        public void Convert_InvalidPath_ReturnsDefaultUser()
+        {
+            var converter = new NullToDefaultImageConverter();
+            var result = converter.Convert("invalid|path.png", typeof(BitmapImage), null, CultureInfo.InvariantCulture);
+            var bmp = Assert.IsType<BitmapImage>(result);
+            Assert.Equal("pack://application:,,,/Resources/DefaultUserPhoto.png", bmp.UriSource.OriginalString);
+        }
+
         [Fact]
         public void ConvertBack_BitmapImage_ReturnsUriString()
         {


### PR DESCRIPTION
## Summary
- test `NullToDefaultImageConverter.Convert` for null, valid paths, and invalid paths
- test `NonEmptyStringToBoolConverter.Convert` handling strings and invalid inputs

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0ae4c87c832488a72fab32810116