### PR TITLE
Switch MainWindow buttons to commands

### DIFF
--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -134,7 +134,7 @@
                                 </GridView>
                             </ListView.View>
                         </ListView>
-                        <Button Content="Choose Profile Picture" Click="ChooseUserProfilePicButton_Click" Width="150" Height="20" HorizontalAlignment="Right" VerticalAlignment="Top" Grid.RowSpan="2" />
+                        <Button Content="Choose Profile Picture" Command="{Binding ChooseProfilePicCommand}" Width="150" Height="20" HorizontalAlignment="Right" VerticalAlignment="Top" Grid.RowSpan="2" />
                         <!-- Display tools checked out by the current user -->
                         <GroupBox Header="My Checked-Out Tools" Grid.Row="2" Margin="10">
                             <ListView x:Name="CheckedOutToolsList" ItemContainerStyle="{StaticResource ToolImageTooltipStyle}" ItemsSource="{Binding CheckedOutTools}" SelectedItem="{Binding SelectedTool, Mode=TwoWay}">
@@ -229,9 +229,9 @@
                                 </Grid>
 
                                 <StackPanel Grid.Row="10" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-                                    <Button Content="Add" Click="AddButton_Click" Margin="5"/>
-                                    <Button Content="Update" Click="UpdateButton_Click" Margin="5"/>
-                                    <Button Content="Delete" Click="DeleteButton_Click" Margin="5"/>
+                                    <Button Content="Add" Command="{Binding AddToolCommand}" Margin="5"/>
+                                    <Button Content="Update" Command="{Binding UpdateToolCommand}" Margin="5"/>
+                                    <Button Content="Delete" Command="{Binding DeleteToolCommand}" Margin="5"/>
                                     <Button Content="Add/Change Tool Image" Click="ChangeToolImage_Click" Margin="5"/>
                                 </StackPanel>
                             </Grid>
@@ -303,9 +303,9 @@
                                 <xctk:WatermarkTextBox x:Name="CustomerMobileInput" Watermark="Mobile" Margin="5" />
                                 <xctk:WatermarkTextBox x:Name="CustomerAddressInput" Watermark="Address" Margin="5" />
                                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                    <Button Content="Add" Click="AddCustomerButton_Click" Margin="5" />
-                                    <Button Content="Update" Click="UpdateCustomerButton_Click" Margin="5" />
-                                    <Button Content="Delete" Click="DeleteCustomerButton_Click" Margin="5" />
+                                    <Button Content="Add" Command="{Binding AddCustomerCommand}" Margin="5" />
+                                    <Button Content="Update" Command="{Binding UpdateCustomerCommand}" Margin="5" />
+                                    <Button Content="Delete" Command="{Binding DeleteCustomerCommand}" Margin="5" />
                                 </StackPanel>
                             </StackPanel>
                         </GroupBox>
@@ -339,15 +339,15 @@
                             <xctk:WatermarkTextBox x:Name="ToolIDForRentalInput" Watermark="Tool ID" Margin="5" Width="200" />
                             <xctk:WatermarkTextBox x:Name="CustomerIDForRentalInput" Watermark="Customer ID" Margin="5" Width="200" />
                             <xctk:WatermarkTextBox x:Name="DueDateInput" Watermark="Due Date (YYYY-MM-DD)" Margin="5" Width="200" />
-                            <Button Content="Rent Tool" Click="RentToolButton_Click" Margin="5" />
-                            <Button Content="Return Tool" Click="ReturnToolButton_Click" Margin="5" />
+                            <Button Content="Rent Tool" Command="{Binding RentToolCommand}" Margin="5" />
+                            <Button Content="Return Tool" Command="{Binding ReturnToolCommand}" Margin="5" />
                             <Button Content="Print Receipt" Click="PrintRentalReceipt_Click" Margin="5" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="10" Grid.Row="1">
                             <xctk:WatermarkTextBox x:Name="RentalIDInput" Watermark="Rental ID" Margin="5" Width="100" />
                             <xctk:WatermarkTextBox x:Name="NewDueDateInput" Watermark="New Due Date (YYYY-MM-DD)" Margin="5" Width="200" />
-                            <Button Content="Extend Rental" Click="ExtendRentalButton_Click" Margin="5" />
-                            <Button Content="Load Overdue Rentals" Click="LoadOverdueRentals_Click" Margin="5" />
+                            <Button Content="Extend Rental" Command="{Binding ExtendRentalCommand}" Margin="5" />
+                            <Button Content="Load Overdue Rentals" Command="{Binding LoadOverdueRentalsCommand}" Margin="5" />
                         </StackPanel>
                         <ListView x:Name="RentalsList" ItemsSource="{Binding Rentals}" Grid.Row="2" Margin="10">
                             <ListView.View>
@@ -397,7 +397,7 @@
                                     <Image Source="{Binding SelectedUser.PhotoBitmap, ConverterParameter=User, Converter={StaticResource NullToDefaultImageConverter}}" 
                  Stretch="UniformToFill"/>
                                 </Border>
-                                <Button Content="Change Photo" Click="UploadUserPhotoButton_Click" Margin="10,0,0,0" VerticalAlignment="Center"/>
+                                <Button Content="Change Photo" Command="{Binding UploadUserPhotoCommand}" Margin="10,0,0,0" VerticalAlignment="Center"/>
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="5">
                                 <TextBlock Text="User Name:" Width="100" VerticalAlignment="Center"/>

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -118,78 +118,7 @@ namespace ToolManagementAppV2
             RefreshToolList();
         }
 
-        void AddButton_Click(object s, RoutedEventArgs e)
-        {
-            var toolNumber = ToolNumberInput.Text.Trim();
-            if (string.IsNullOrEmpty(toolNumber))
-            {
-                ShowMessage("Validation Error", "Tool Number is required.", MessageBoxImage.Warning);
-                return;
-            }
 
-            if (_toolService.GetAllTools().Any(x => x.ToolNumber.Equals(toolNumber, StringComparison.OrdinalIgnoreCase)))
-            {
-                ShowMessage("Duplicate Tool Number", "A tool with this Tool Number already exists.", MessageBoxImage.Warning);
-                return;
-            }
-
-            var tool = new Tool
-            {
-                ToolNumber = toolNumber,
-                NameDescription = ToolNameInput.Text.Trim(),
-                PartNumber = PartNumberInput.Text.Trim(),
-                Brand = BrandInput.Text.Trim(),
-                Location = LocationInput.Text.Trim(),
-                QuantityOnHand = int.TryParse(QuantityInput.Text, out var q) ? q : 0,
-                Supplier = SupplierInput.Text.Trim(),
-                PurchasedDate = DateTime.TryParse(PurchasedInput.Text, out var d) ? d : (DateTime?)null,
-                Notes = NotesInput.Text.Trim()
-            };
-
-            _toolService.AddTool(tool);
-            RefreshToolList();
-            ClearToolInputs();
-        }
-
-
-        void UpdateButton_Click(object s, RoutedEventArgs e)
-        {
-            if (!(ToolsList.SelectedItem is Tool t)) return;
-            t.ToolNumber = ToolNumberInput.Text.Trim();
-            t.NameDescription = ToolNameInput.Text.Trim();
-            t.PartNumber = PartNumberInput.Text.Trim();
-            t.Brand = BrandInput.Text.Trim();
-            t.Location = LocationInput.Text.Trim();
-            t.QuantityOnHand = int.TryParse(QuantityInput.Text, out var q) ? q : t.QuantityOnHand;
-            t.Supplier = SupplierInput.Text.Trim();
-            t.PurchasedDate = DateTime.TryParse(PurchasedInput.Text, out var d) ? d : t.PurchasedDate;
-            t.Notes = NotesInput.Text.Trim();
-            _toolService.UpdateTool(t);
-            RefreshToolList();
-            ClearToolInputs();
-        }
-
-        void ClearToolInputs()
-        {
-            ToolNumberInput.Text = "";
-            ToolNameInput.Text = "";
-            PartNumberInput.Text = "";
-            BrandInput.Text = "";
-            LocationInput.Text = "";
-            QuantityInput.Text = "";
-            SupplierInput.Text = "";
-            PurchasedInput.Text = "";
-            NotesInput.Text = "";
-        }
-
-        void DeleteButton_Click(object s, RoutedEventArgs e)
-        {
-            if (ToolsList.SelectedItem is Tool t)
-            {
-                _toolService.DeleteTool(t.ToolID);
-                RefreshToolList();
-            }
-        }
 
         void ChangeToolImage_Click(object s, RoutedEventArgs e)
         {
@@ -233,42 +162,6 @@ namespace ToolManagementAppV2
 
 
         // ---------- Customer & Rental ----------
-        void AddCustomerButton_Click(object s, RoutedEventArgs e)
-        {
-            var c = new Customer
-            {
-                Company = CustomerNameInput.Text.Trim(),
-                Email = CustomerEmailInput.Text.Trim(),
-                Contact = CustomerContactInput.Text.Trim(),
-                Phone = CustomerPhoneInput.Text.Trim(),
-                Mobile = CustomerMobileInput.Text.Trim(),
-                Address = CustomerAddressInput.Text.Trim()
-            };
-            _customerService.AddCustomer(c);
-            RefreshCustomerList();
-        }
-
-        void UpdateCustomerButton_Click(object s, RoutedEventArgs e)
-        {
-            if (!(CustomerList.SelectedItem is Customer c)) return;
-            c.Company = CustomerNameInput.Text.Trim();
-            c.Email = CustomerEmailInput.Text.Trim();
-            c.Contact = CustomerContactInput.Text.Trim();
-            c.Phone = CustomerPhoneInput.Text.Trim();
-            c.Mobile = CustomerMobileInput.Text.Trim();
-            c.Address = CustomerAddressInput.Text.Trim();
-            _customerService.UpdateCustomer(c);
-            RefreshCustomerList();
-        }
-
-        void DeleteCustomerButton_Click(object s, RoutedEventArgs e)
-        {
-            if (CustomerList.SelectedItem is Customer c)
-            {
-                _customerService.DeleteCustomer(c.CustomerID);
-                RefreshCustomerList();
-            }
-        }
 
         void CustomerList_SelectionChanged(object s, SelectionChangedEventArgs e)
         {
@@ -283,48 +176,6 @@ namespace ToolManagementAppV2
             }
         }
 
-        void RentToolButton_Click(object s, RoutedEventArgs e)
-        {
-            if (ToolsList.SelectedItem is Tool t && CustomerList.SelectedItem is Customer c)
-            {
-                try
-                {
-                    var now = DateTime.Now;
-                    _rentalService.RentTool(t.ToolID, c.CustomerID, now, now.AddDays(7));
-                    var user = _userService.GetCurrentUser();
-                    _activityLogService.LogAction(user.UserID, user.UserName, $"Rented tool {t.ToolID} to customer {c.CustomerID}");
-                    RefreshRentalList();
-                    RefreshToolList();
-                }
-                catch (InvalidOperationException ex)
-                {
-                    ShowMessage("Rental Error", ex.Message, MessageBoxImage.Warning);
-                }
-                catch (Exception ex)
-                {
-                    ShowError("Error renting tool", ex);
-                }
-            }
-        }
-
-        void ReturnToolButton_Click(object s, RoutedEventArgs e)
-        {
-            if (RentalsList.SelectedItem is Rental r)
-            {
-                try
-                {
-                    _rentalService.ReturnTool(r.RentalID, DateTime.Now);
-                    var user = _userService.GetCurrentUser();
-                    _activityLogService.LogAction(user.UserID, user.UserName, $"Returned rental {r.RentalID}");
-                    RefreshRentalList();
-                    RefreshToolList();
-                }
-                catch (Exception ex)
-                {
-                    ShowError("Error returning tool", ex);
-                }
-            }
-        }
 
         // ---------- User Management ----------
         void NewUserButton_Click(object s, RoutedEventArgs e)
@@ -392,23 +243,6 @@ namespace ToolManagementAppV2
         }
 
 
-        void UploadUserPhotoButton_Click(object s, RoutedEventArgs e)
-        {
-            if (DataContext is MainViewModel vm && vm.SelectedUser is User u)
-            {
-                var dlg = new AvatarSelectionWindow();
-                if (dlg.ShowDialog() == true) ApplyAvatar(u, dlg.SelectedAvatarPath);
-            }
-        }
-
-        void ChooseUserProfilePicButton_Click(object s, RoutedEventArgs e)
-        {
-            if (App.Current.Properties["CurrentUser"] is User u)
-            {
-                var dlg = new AvatarSelectionWindow();
-                if (dlg.ShowDialog() == true) ApplyAvatar(u, dlg.SelectedAvatarPath);
-            }
-        }
 
         void ApplyAvatar(User u, string path)
         {
@@ -790,38 +624,6 @@ namespace ToolManagementAppV2
         }
 
 
-        void LoadOverdueRentals_Click(object s, RoutedEventArgs e)
-        {
-            try
-            {
-                var overdue = _rentalService.GetOverdueRentals();
-                var msg = string.Join(Environment.NewLine, overdue.Select(r =>
-                    $"RentalID: {r.RentalID}, ToolID: {r.ToolID}, Due: {r.DueDate:yyyy-MM-dd}"));
-                ShowMessage("Overdue Rentals", msg, MessageBoxImage.Information);
-            }
-            catch (Exception ex)
-            {
-                ShowError("Error loading overdue rentals", ex);
-            }
-        }
-
-        void ExtendRentalButton_Click(object s, RoutedEventArgs e)
-        {
-            try
-            {
-                if (int.TryParse(RentalIDInput.Text, out var id) && DateTime.TryParse(NewDueDateInput.Text, out var due))
-                {
-                    _rentalService.ExtendRental(id, due);
-                    ShowMessage("Success", "Rental extended.", MessageBoxImage.Information);
-                    RefreshRentalList();
-                }
-                else ShowMessage("Error", "Invalid input.", MessageBoxImage.Error);
-            }
-            catch (Exception ex)
-            {
-                ShowError("Error extending rental", ex);
-            }
-        }
 
         void PrintRentalReceipt_Click(object s, RoutedEventArgs e)
         {


### PR DESCRIPTION
## Summary
- bind tool management and customer management buttons to commands
- drop redundant event handler methods

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f13bb39448324bcdcd284bf5e1a13