### PR TITLE
Update search behavior and tests

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
@@ -1,0 +1,79 @@
+using System.IO;
+using System.Linq;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class MainViewModelTests
+    {
+        [Fact]
+        public void SearchCommand_FiltersToolsBySearchTerm()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+                ISettingsService settingsService = new SettingsService(db);
+
+                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
+                toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw" });
+
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, settingsService);
+
+                vm.SearchTerm = "Ham";
+                vm.SearchCommand.Execute(null);
+
+                Assert.Single(vm.SearchResults);
+                Assert.Equal("Hammer", vm.SearchResults.First().NameDescription);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void SearchCommand_EmptyTerm_ReturnsAllTools()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+                ISettingsService settingsService = new SettingsService(db);
+
+                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
+                toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw" });
+
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, settingsService);
+
+                vm.SearchTerm = string.Empty;
+                vm.SearchCommand.Execute(null);
+
+                Assert.Equal(2, vm.SearchResults.Count);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -45,6 +45,8 @@ namespace ToolManagementAppV2
             _printer = new Printer(_settingsService);
             _reportService = new ReportService(_toolService, _rentalService, _activityLogService, _customerService, _userService);
 
+            DataContext = new MainViewModel(_toolService, _userService, _customerService, _rentalService, _settingsService);
+
             try
             {
                 RefreshToolList();
@@ -58,7 +60,6 @@ namespace ToolManagementAppV2
                 ShowError("Initialization Error", ex);
             }
 
-            DataContext = new MainViewModel(_toolService, _userService, _customerService, _rentalService, _settingsService);
             RestrictTabsForNonAdmin();
         }
 
@@ -470,9 +471,11 @@ namespace ToolManagementAppV2
         {
             try
             {
-                var tools = _toolService.GetAllTools();
-                ToolsList.ItemsSource = tools;
-                SearchResultsList.ItemsSource = tools;
+                if (DataContext is MainViewModel vm)
+                {
+                    vm.LoadTools();
+                    vm.SearchCommand.Execute(null);
+                }
             }
             catch (Exception ex)
             {
@@ -509,10 +512,11 @@ namespace ToolManagementAppV2
         {
             try
             {
-                var txt = SearchInput.Text;
-                SearchResultsList.ItemsSource = string.IsNullOrWhiteSpace(txt)
-                    ? _toolService.GetAllTools()
-                    : _toolService.SearchTools(txt);
+                if (DataContext is MainViewModel vm)
+                {
+                    vm.SearchTerm = SearchInput.Text;
+                    vm.SearchCommand.Execute(null);
+                }
             }
             catch (Exception ex)
             {

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -230,7 +230,7 @@ namespace ToolManagementAppV2.ViewModels
             LoadOverdueRentals();
         }
 
-        void LoadTools()
+        public void LoadTools()
         {
             Tools.ReplaceRange(_toolService.GetAllTools());
         }


### PR DESCRIPTION
## Summary
- set DataContext earlier in MainWindow
- use MainViewModel methods in RefreshToolList and search event
- expose `LoadTools` publicly
- add MainViewModel unit tests for searching

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fa64bb38083248153661c88c64611