### PR TITLE
Fix ToolList binding refresh

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/MainWindowTabBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/MainWindowTabBindingTests.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using System.Windows.Controls;
+using System.Windows.Data;
+using ToolManagementAppV2;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Tests
+{
+    public class MainWindowTabBindingTests
+    {
+        [StaFact]
+        public void SwitchingTabs_DoesNotBreakToolsListBinding()
+        {
+            var window = new MainWindow();
+            var vm = Assert.IsType<MainViewModel>(window.DataContext);
+
+            // ToolsList should be bound to the Tools collection
+            Assert.True(BindingOperations.IsDataBound(window.ToolsList, ItemsControl.ItemsSourceProperty));
+            Assert.Same(vm.Tools, window.ToolsList.ItemsSource);
+
+            var tabControl = window.MyTabControl;
+            var searchTab = tabControl.Items.OfType<TabItem>().First(t => t.Header!.ToString() == "Search Tools");
+            var toolsTab = tabControl.Items.OfType<TabItem>().First(t => t.Header!.ToString() == "Tool Management");
+
+            tabControl.SelectedItem = searchTab;
+            window.MyTabControl_SelectionChanged(tabControl, new SelectionChangedEventArgs(TabControl.SelectionChangedEvent, null, null));
+
+            tabControl.SelectedItem = toolsTab;
+            window.MyTabControl_SelectionChanged(tabControl, new SelectionChangedEventArgs(TabControl.SelectionChangedEvent, null, null));
+
+            Assert.True(BindingOperations.IsDataBound(window.ToolsList, ItemsControl.ItemsSourceProperty));
+            Assert.Same(vm.Tools, window.ToolsList.ItemsSource);
+        }
+    }
+}

--- a/ToolManagementAppV2.Tests/Tests/MainWindowTabBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/MainWindowTabBindingTests.cs
@@ -9,7 +9,7 @@ namespace ToolManagementAppV2.Tests.Tests
 {
     public class MainWindowTabBindingTests
     {
-        [StaFact]
+        [Fact]
         public void SwitchingTabs_DoesNotBreakToolsListBinding()
         {
             var window = new MainWindow();

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -45,9 +45,11 @@ namespace ToolManagementAppV2
             _printer = new Printer(_settingsService);
             _reportService = new ReportService(_toolService, _rentalService, _activityLogService, _customerService, _userService);
 
+            DataContext = new MainViewModel(_toolService, _userService, _customerService, _rentalService, _settingsService);
+
             try
             {
-                RefreshToolList();
+                ((MainViewModel)DataContext).LoadTools();
                 RefreshUserList();
                 RefreshCustomerList();
                 RefreshRentalList();
@@ -58,7 +60,6 @@ namespace ToolManagementAppV2
                 ShowError("Initialization Error", ex);
             }
 
-            DataContext = new MainViewModel(_toolService, _userService, _customerService, _rentalService, _settingsService);
             RestrictTabsForNonAdmin();
         }
 
@@ -470,9 +471,8 @@ namespace ToolManagementAppV2
         {
             try
             {
-                var tools = _toolService.GetAllTools();
-                ToolsList.ItemsSource = tools;
-                SearchResultsList.ItemsSource = tools;
+                if (DataContext is MainViewModel vm)
+                    vm.LoadTools();
             }
             catch (Exception ex)
             {
@@ -739,7 +739,8 @@ namespace ToolManagementAppV2
             {
                 case "Search Tools":
                 case "Tool Management":
-                    RefreshToolList();
+                    if (DataContext is MainViewModel vm)
+                        vm.LoadTools();
                     break;
                 case "Customers":
                     RefreshCustomerList();

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -230,7 +230,7 @@ namespace ToolManagementAppV2.ViewModels
             LoadOverdueRentals();
         }
 
-        void LoadTools()
+        public void LoadTools()
         {
             Tools.ReplaceRange(_toolService.GetAllTools());
         }


### PR DESCRIPTION
## Summary
- populate tool list using MainViewModel
- avoid breaking binding when refreshing tools
- update tab selection logic to use the view model
- add regression test for ToolsList binding

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fa64e7df8832496d0dc55f1998409