### PR TITLE
Bind customer input fields to VM

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
@@ -75,5 +75,89 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void AddCustomerCommand_AddsCustomerAndClearsFields()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+                ISettingsService settingsService = new SettingsService(db);
+
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, settingsService);
+
+                vm.NewCustomerName = "Acme";
+                vm.NewCustomerEmail = "info@acme.com";
+                vm.NewCustomerContact = "John";
+                vm.NewCustomerPhone = "111";
+                vm.NewCustomerMobile = "222";
+                vm.NewCustomerAddress = "Addr";
+
+                vm.AddCustomerCommand.Execute(null);
+
+                Assert.Single(vm.Customers);
+                var added = vm.Customers.First();
+                Assert.Equal("Acme", added.Company);
+                Assert.Equal(string.Empty, vm.NewCustomerName);
+                Assert.Equal(string.Empty, vm.NewCustomerEmail);
+                Assert.Equal(string.Empty, vm.NewCustomerContact);
+                Assert.Equal(string.Empty, vm.NewCustomerPhone);
+                Assert.Equal(string.Empty, vm.NewCustomerMobile);
+                Assert.Equal(string.Empty, vm.NewCustomerAddress);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void UpdateCustomerCommand_UpdatesSelectedCustomerFromBoundFields()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+                ISettingsService settingsService = new SettingsService(db);
+
+                customerService.AddCustomer(new Customer { Company = "Old" });
+                var existing = customerService.GetAllCustomers().First();
+
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, settingsService);
+                vm.SelectedCustomer = vm.Customers.First();
+
+                vm.NewCustomerName = "New";
+                vm.NewCustomerEmail = "new@a.com";
+                vm.NewCustomerContact = "Bob";
+                vm.NewCustomerPhone = "123";
+                vm.NewCustomerMobile = "456";
+                vm.NewCustomerAddress = "Addr2";
+
+                vm.UpdateCustomerCommand.Execute(null);
+
+                var updated = customerService.GetCustomerByID(existing.CustomerID);
+                Assert.Equal("New", updated.Company);
+                Assert.Equal("new@a.com", updated.Email);
+                Assert.Equal("Bob", updated.Contact);
+                Assert.Equal("123", updated.Phone);
+                Assert.Equal("456", updated.Mobile);
+                Assert.Equal("Addr2", updated.Address);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -296,12 +296,30 @@
                         </Grid.RowDefinitions>
                         <GroupBox Header="Customer Details" Grid.Column="0" Grid.Row="0" Margin="5">
                             <StackPanel>
-                                <xctk:WatermarkTextBox x:Name="CustomerNameInput" Watermark="Name" Margin="5" />
-                                <xctk:WatermarkTextBox x:Name="CustomerEmailInput" Watermark="Email" Margin="5" />
-                                <xctk:WatermarkTextBox x:Name="CustomerContactInput" Watermark="Customer Contact" Margin="5" />
-                                <xctk:WatermarkTextBox x:Name="CustomerPhoneInput" Watermark="Phone" Margin="5" />
-                                <xctk:WatermarkTextBox x:Name="CustomerMobileInput" Watermark="Mobile" Margin="5" />
-                                <xctk:WatermarkTextBox x:Name="CustomerAddressInput" Watermark="Address" Margin="5" />
+                                <xctk:WatermarkTextBox x:Name="CustomerNameInput"
+                                                        Watermark="Name"
+                                                        Text="{Binding NewCustomerName, UpdateSourceTrigger=PropertyChanged}"
+                                                        Margin="5" />
+                                <xctk:WatermarkTextBox x:Name="CustomerEmailInput"
+                                                        Watermark="Email"
+                                                        Text="{Binding NewCustomerEmail, UpdateSourceTrigger=PropertyChanged}"
+                                                        Margin="5" />
+                                <xctk:WatermarkTextBox x:Name="CustomerContactInput"
+                                                        Watermark="Customer Contact"
+                                                        Text="{Binding NewCustomerContact, UpdateSourceTrigger=PropertyChanged}"
+                                                        Margin="5" />
+                                <xctk:WatermarkTextBox x:Name="CustomerPhoneInput"
+                                                        Watermark="Phone"
+                                                        Text="{Binding NewCustomerPhone, UpdateSourceTrigger=PropertyChanged}"
+                                                        Margin="5" />
+                                <xctk:WatermarkTextBox x:Name="CustomerMobileInput"
+                                                        Watermark="Mobile"
+                                                        Text="{Binding NewCustomerMobile, UpdateSourceTrigger=PropertyChanged}"
+                                                        Margin="5" />
+                                <xctk:WatermarkTextBox x:Name="CustomerAddressInput"
+                                                        Watermark="Address"
+                                                        Text="{Binding NewCustomerAddress, UpdateSourceTrigger=PropertyChanged}"
+                                                        Margin="5" />
                                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                                     <Button Content="Add" Command="{Binding AddCustomerCommand}" Margin="5" />
                                     <Button Content="Update" Command="{Binding UpdateCustomerCommand}" Margin="5" />
@@ -312,7 +330,7 @@
                         <xctk:WatermarkTextBox x:Name="CustomerSearchInput" Grid.Column="1" Grid.Row="0"
                                               Margin="5" Width="300"
                                               Watermark="Search Customers..." TextChanged="CustomerSearchInput_TextChanged" />
-                        <ListView x:Name="CustomerList" Grid.Column="1" Grid.Row="1" ItemsSource="{Binding Customers}" Margin="5">
+                        <ListView x:Name="CustomerList" Grid.Column="1" Grid.Row="1" ItemsSource="{Binding Customers}" SelectedItem="{Binding SelectedCustomer, Mode=TwoWay}" Margin="5">
                             <ListView.View>
                                 <GridView>
                                     <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Company}" Width="150" />

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -443,10 +443,25 @@ namespace ToolManagementAppV2.ViewModels
                 Address = NewCustomerAddress
             });
             LoadCustomers();
+            NewCustomerName = string.Empty;
+            NewCustomerEmail = string.Empty;
+            NewCustomerContact = string.Empty;
+            NewCustomerPhone = string.Empty;
+            NewCustomerMobile = string.Empty;
+            NewCustomerAddress = string.Empty;
         }
 
         void UpdateCustomer()
         {
+            if (SelectedCustomer == null) return;
+
+            SelectedCustomer.Company = NewCustomerName;
+            SelectedCustomer.Email = NewCustomerEmail;
+            SelectedCustomer.Contact = NewCustomerContact;
+            SelectedCustomer.Phone = NewCustomerPhone;
+            SelectedCustomer.Mobile = NewCustomerMobile;
+            SelectedCustomer.Address = NewCustomerAddress;
+
             _customerService.UpdateCustomer(SelectedCustomer);
             LoadCustomers();
         }


### PR DESCRIPTION
## Summary
- bind customer detail input boxes to `NewCustomer*` properties
- select a customer in the list via `SelectedCustomer` binding
- clear new customer fields after adding
- update selected customer with bound field values
- add unit tests for adding and updating customers

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684faf5c6d5c8324abf4bf08c453c638