### PR TITLE
Avatar selection and customer bindings

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/AvatarSelectionTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/AvatarSelectionTests.cs
@@ -1,0 +1,51 @@
+using System.IO;
+using System.Linq;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Interfaces;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class AvatarSelectionTests
+    {
+        [Fact]
+        public void ApplyAvatar_StoresRelativePath()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+                ISettingsService settingsService = new SettingsService(db);
+
+                var user = new User { UserName = "u", Password = "p" };
+                userService.AddUser(user);
+                var added = userService.GetAllUsers().First();
+
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, settingsService);
+                var avatar = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "Avatars", "1.png");
+
+                vm.ApplyAvatar(added, avatar);
+
+                var updated = userService.GetUserByID(added.UserID);
+                Assert.Equal(Path.Combine("Resources", "Avatars", "1.png"), updated.UserPhotoPath);
+                Assert.NotNull(updated.PhotoBitmap);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
@@ -120,5 +120,95 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void AddCustomerCommand_PersistsNewCustomerValues()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+                ISettingsService settingsService = new SettingsService(db);
+
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, settingsService);
+
+                vm.NewCustomerName = "ACME";
+                vm.NewCustomerEmail = "a@b.com";
+                vm.NewCustomerContact = "John";
+                vm.NewCustomerPhone = "123";
+                vm.NewCustomerMobile = "456";
+                vm.NewCustomerAddress = "Addr";
+
+                vm.AddCustomerCommand.Execute(null);
+
+                var customers = customerService.GetAllCustomers();
+                Assert.Single(customers);
+                var c = customers.First();
+                Assert.Equal("ACME", c.Company);
+                Assert.Equal("a@b.com", c.Email);
+                Assert.Equal("John", c.Contact);
+                Assert.Equal("123", c.Phone);
+                Assert.Equal("456", c.Mobile);
+                Assert.Equal("Addr", c.Address);
+
+                Assert.True(string.IsNullOrEmpty(vm.NewCustomerName));
+                Assert.True(string.IsNullOrEmpty(vm.NewCustomerEmail));
+                Assert.True(string.IsNullOrEmpty(vm.NewCustomerContact));
+                Assert.True(string.IsNullOrEmpty(vm.NewCustomerPhone));
+                Assert.True(string.IsNullOrEmpty(vm.NewCustomerMobile));
+                Assert.True(string.IsNullOrEmpty(vm.NewCustomerAddress));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void UpdateCustomerCommand_UpdatesSelectedCustomer()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+                ISettingsService settingsService = new SettingsService(db);
+
+                customerService.AddCustomer(new Customer { Company = "Old" });
+                var existing = customerService.GetAllCustomers().First();
+
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, settingsService);
+                vm.SelectedCustomer = existing;
+                vm.NewCustomerName = "New";
+                vm.NewCustomerEmail = "e@e.com";
+                vm.NewCustomerContact = "Bob";
+                vm.NewCustomerPhone = "9";
+                vm.NewCustomerMobile = "8";
+                vm.NewCustomerAddress = "Addr";
+
+                vm.UpdateCustomerCommand.Execute(null);
+
+                var updated = customerService.GetCustomerByID(existing.CustomerID);
+                Assert.Equal("New", updated.Company);
+                Assert.Equal("e@e.com", updated.Email);
+                Assert.Equal("Bob", updated.Contact);
+                Assert.Equal("9", updated.Phone);
+                Assert.Equal("8", updated.Mobile);
+                Assert.Equal("Addr", updated.Address);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/ToolManagementAppV2/AssemblyInfo.cs
+++ b/ToolManagementAppV2/AssemblyInfo.cs
@@ -1,4 +1,7 @@
 using System.Windows;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ToolManagementAppV2.Tests")]
 
 [assembly: ThemeInfo(
     ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -297,12 +297,18 @@
                         </Grid.RowDefinitions>
                         <GroupBox Header="Customer Details" Grid.Column="0" Grid.Row="0" Margin="5">
                             <StackPanel>
-                                <xctk:WatermarkTextBox x:Name="CustomerNameInput" Watermark="Name" Margin="5" />
-                                <xctk:WatermarkTextBox x:Name="CustomerEmailInput" Watermark="Email" Margin="5" />
-                                <xctk:WatermarkTextBox x:Name="CustomerContactInput" Watermark="Customer Contact" Margin="5" />
-                                <xctk:WatermarkTextBox x:Name="CustomerPhoneInput" Watermark="Phone" Margin="5" />
-                                <xctk:WatermarkTextBox x:Name="CustomerMobileInput" Watermark="Mobile" Margin="5" />
-                                <xctk:WatermarkTextBox x:Name="CustomerAddressInput" Watermark="Address" Margin="5" />
+                                <xctk:WatermarkTextBox x:Name="CustomerNameInput" Watermark="Name" Margin="5"
+                                                         Text="{Binding NewCustomerName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                <xctk:WatermarkTextBox x:Name="CustomerEmailInput" Watermark="Email" Margin="5"
+                                                         Text="{Binding NewCustomerEmail, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                <xctk:WatermarkTextBox x:Name="CustomerContactInput" Watermark="Customer Contact" Margin="5"
+                                                         Text="{Binding NewCustomerContact, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                <xctk:WatermarkTextBox x:Name="CustomerPhoneInput" Watermark="Phone" Margin="5"
+                                                         Text="{Binding NewCustomerPhone, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                <xctk:WatermarkTextBox x:Name="CustomerMobileInput" Watermark="Mobile" Margin="5"
+                                                         Text="{Binding NewCustomerMobile, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                <xctk:WatermarkTextBox x:Name="CustomerAddressInput" Watermark="Address" Margin="5"
+                                                         Text="{Binding NewCustomerAddress, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                                     <Button Content="Add" Command="{Binding AddCustomerCommand}" Margin="5" />
                                     <Button Content="Update" Command="{Binding UpdateCustomerCommand}" Margin="5" />
@@ -313,7 +319,7 @@
                         <xctk:WatermarkTextBox x:Name="CustomerSearchInput" Grid.Column="1" Grid.Row="0"
                                               Margin="5" Width="300"
                                               Watermark="Search Customers..." TextChanged="CustomerSearchInput_TextChanged" />
-                        <ListView x:Name="CustomerList" Grid.Column="1" Grid.Row="1" ItemsSource="{Binding Customers}" Margin="5">
+                        <ListView x:Name="CustomerList" Grid.Column="1" Grid.Row="1" ItemsSource="{Binding Customers}" SelectedItem="{Binding SelectedCustomer, Mode=TwoWay}" SelectionChanged="CustomerList_SelectionChanged" Margin="5">
                             <ListView.View>
                                 <GridView>
                                     <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Company}" Width="150" />

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -152,14 +152,15 @@ namespace ToolManagementAppV2
 
         void CustomerList_SelectionChanged(object s, SelectionChangedEventArgs e)
         {
-            if (CustomerList.SelectedItem is Customer c)
+            if (DataContext is MainViewModel vm && CustomerList.SelectedItem is Customer c)
             {
-                CustomerNameInput.Text = c.Company;
-                CustomerEmailInput.Text = c.Email;
-                CustomerContactInput.Text = c.Contact;
-                CustomerPhoneInput.Text = c.Phone;
-                CustomerMobileInput.Text = c.Mobile;
-                CustomerAddressInput.Text = c.Address;
+                vm.SelectedCustomer = c;
+                vm.NewCustomerName = c.Company;
+                vm.NewCustomerEmail = c.Email;
+                vm.NewCustomerContact = c.Contact;
+                vm.NewCustomerPhone = c.Phone;
+                vm.NewCustomerMobile = c.Mobile;
+                vm.NewCustomerAddress = c.Address;
             }
         }
 


### PR DESCRIPTION
## Summary
- hook up avatar selection window and update photo logic
- clear add customer fields and bind inputs
- update customer update logic
- expose ApplyAvatar for testing and allow internals visible to tests
- fix customer list selection bindings
- add tests for avatar paths and customer add/update

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb261d01083249ffa3e51f81d5e79