### PR TITLE
Fix list refresh and binding issues

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/MainWindowRentalBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/MainWindowRentalBindingTests.cs
@@ -1,0 +1,21 @@
+using System.Windows.Controls;
+using System.Windows.Data;
+using ToolManagementAppV2;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Tests
+{
+    public class MainWindowRentalBindingTests
+    {
+        [Fact]
+        public void RentalsList_BindsToActiveRentalsCollection()
+        {
+            var window = new MainWindow();
+            var vm = Assert.IsType<MainViewModel>(window.DataContext);
+
+            Assert.True(BindingOperations.IsDataBound(window.RentalsList, ItemsControl.ItemsSourceProperty));
+            Assert.Same(vm.ActiveRentals, window.RentalsList.ItemsSource);
+        }
+    }
+}

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -356,7 +356,7 @@
                             <Button Content="Extend Rental" Command="{Binding ExtendRentalCommand}" Margin="5" />
                             <Button Content="Load Overdue Rentals" Command="{Binding LoadOverdueRentalsCommand}" Margin="5" />
                         </StackPanel>
-                        <ListView x:Name="RentalsList" ItemsSource="{Binding Rentals}" Grid.Row="2" Margin="10">
+                        <ListView x:Name="RentalsList" ItemsSource="{Binding ActiveRentals}" Grid.Row="2" Margin="10">
                             <ListView.View>
                                 <GridView>
                                     <GridViewColumn Header="Rental ID" DisplayMemberBinding="{Binding RentalID}" Width="100" />

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -281,42 +281,8 @@ namespace ToolManagementAppV2
         {
             try
             {
-                var users = _userService.GetAllUsers();
-                foreach (var u in users)
-                {
-                    if (!string.IsNullOrWhiteSpace(u.UserPhotoPath))
-                    {
-                        try
-                        {
-                            Uri uri;
-                            if (u.UserPhotoPath.StartsWith("pack://"))
-                            {
-                                uri = new Uri(u.UserPhotoPath, UriKind.Absolute);
-                            }
-                            else
-                            {
-                                var fullPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, u.UserPhotoPath);
-                                if (!File.Exists(fullPath)) continue;
-                                uri = new Uri($"file:///{fullPath.Replace("\\", "/")}", UriKind.Absolute);
-                            }
-
-                            var bmp = new BitmapImage();
-                            bmp.BeginInit();
-                            bmp.CacheOption = BitmapCacheOption.OnLoad;
-                            bmp.CreateOptions = BitmapCreateOptions.IgnoreImageCache;
-                            bmp.UriSource = uri;
-                            bmp.EndInit();
-                            u.PhotoBitmap = bmp;
-                        }
-                        catch (Exception ex)
-                        {
-                            Console.WriteLine(ex);
-                            u.PhotoBitmap = null;
-                        }
-                    }
-                }
-                UserList.ItemsSource = users;
-                UserList.Items.Refresh();
+                if (DataContext is MainViewModel vm)
+                    vm.LoadUsers();
             }
             catch (Exception ex)
             {
@@ -477,7 +443,8 @@ namespace ToolManagementAppV2
         {
             try
             {
-                CustomerList.ItemsSource = _customerService.GetAllCustomers();
+                if (DataContext is MainViewModel vm)
+                    vm.LoadCustomers();
             }
             catch (Exception ex)
             {
@@ -489,7 +456,8 @@ namespace ToolManagementAppV2
         {
             try
             {
-                RentalsList.ItemsSource = _rentalService.GetActiveRentals();
+                if (DataContext is MainViewModel vm)
+                    vm.LoadActiveRentals();
             }
             catch (Exception ex)
             {
@@ -520,9 +488,8 @@ namespace ToolManagementAppV2
                 var txt = CustomerSearchInput.Text;
                 if (DataContext is MainViewModel vm)
                 {
-                    CustomerList.ItemsSource = string.IsNullOrWhiteSpace(txt)
-                        ? vm.SearchCustomers(string.Empty)
-                        : vm.SearchCustomers(txt);
+                    vm.CustomerSearchTerm = txt;
+                    vm.SearchCustomersCommand.Execute(null);
                 }
             }
             catch (Exception ex)
@@ -733,7 +700,10 @@ namespace ToolManagementAppV2
                 case "Search Tools":
                 case "Tool Management":
                     if (DataContext is MainViewModel vm)
+                    {
                         vm.LoadTools();
+                        vm.SearchCommand.Execute(null);
+                    }
                     break;
                 case "Customers":
                     RefreshCustomerList();


### PR DESCRIPTION
## Summary
- bind rentals list to ActiveRentals collection
- refresh viewmodel collections when switching tabs
- update search handling for customers
- add regression test for rentals list binding

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb56292788324b63337db5ebe000c