### PR TITLE
Make customer and rental loader methods public

### DIFF
--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -425,7 +425,7 @@ namespace ToolManagementAppV2.ViewModels
 
 
 
-        void LoadCustomers()
+        public void LoadCustomers()
         {
             Customers.ReplaceRange(_customerService.GetAllCustomers());
         }
@@ -557,7 +557,7 @@ namespace ToolManagementAppV2.ViewModels
 
 
 
-        void LoadActiveRentals()
+        public void LoadActiveRentals()
         {
             ActiveRentals.ReplaceRange(_rentalService.GetActiveRentals());
             SelectedRental = null;


### PR DESCRIPTION
## Summary
- expose `LoadCustomers` and `LoadActiveRentals` as public methods

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb77b3cd483249bad8483ce212935