### PR TITLE
Use shared SQLite connections

### DIFF
--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -19,9 +19,8 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 ISettingsService service = new SettingsService(dbService);
 
-                using (var conn = new SQLiteConnection(dbService.ConnectionString))
+                using (var conn = dbService.CreateConnection())
                 {
-                    conn.Open();
                     using var cmd = new SQLiteCommand("DROP TABLE Settings", conn);
                     cmd.ExecuteNonQuery();
                 }

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -9,16 +9,19 @@ namespace ToolManagementAppV2.Services.Rentals
     public class RentalService : IRentalService
     {
         readonly string _connString;
+        readonly DatabaseService _dbService;
 
-        public RentalService(DatabaseService dbService) =>
+        public RentalService(DatabaseService dbService)
+        {
+            _dbService = dbService;
             _connString = dbService.ConnectionString;
+        }
 
         // toolID is passed as a string even though the underlying column is INTEGER
         // to keep consistency with ToolModel.ToolID
         public void RentTool(string toolID, int customerID, DateTime rentalDate, DateTime dueDate)
         {
-            using var conn = new SQLiteConnection(_connString);
-            conn.Open();
+            using var conn = _dbService.CreateConnection();
             using var tx = conn.BeginTransaction();
 
             try
@@ -59,8 +62,7 @@ namespace ToolManagementAppV2.Services.Rentals
 
         public void RentToolWithTransaction(string toolID, int customerID, DateTime rentalDate, DateTime dueDate)
         {
-            using var conn = new SQLiteConnection(_connString);
-            conn.Open();
+            using var conn = _dbService.CreateConnection();
             using var tx = conn.BeginTransaction();
             try
             {
@@ -96,8 +98,7 @@ namespace ToolManagementAppV2.Services.Rentals
 
         public void ReturnTool(int rentalID, DateTime returnDate)
         {
-            using var conn = new SQLiteConnection(_connString);
-            conn.Open();
+            using var conn = _dbService.CreateConnection();
             using var tx = conn.BeginTransaction();
             try
             {
@@ -128,8 +129,7 @@ namespace ToolManagementAppV2.Services.Rentals
 
         public void ReturnToolWithTransaction(int rentalID, DateTime returnDate)
         {
-            using var conn = new SQLiteConnection(_connString);
-            conn.Open();
+            using var conn = _dbService.CreateConnection();
             using var tx = conn.BeginTransaction();
             try
             {

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -13,9 +13,13 @@ namespace ToolManagementAppV2.Services.Users
     public class UserService : IUserService
     {
         readonly string _connString;
+        readonly DatabaseService _dbService;
 
-        public UserService(DatabaseService dbService) =>
+        public UserService(DatabaseService dbService)
+        {
+            _dbService = dbService;
             _connString = dbService.ConnectionString;
+        }
 
         public List<User> GetAllUsers() =>
             SqliteHelper.ExecuteReader(_connString, "SELECT * FROM Users", null, MapUser);
@@ -51,8 +55,7 @@ namespace ToolManagementAppV2.Services.Users
                   (@UserName,@Password,@Photo,@Admin,@Email,@Phone,@Address,@Role);
                 SELECT last_insert_rowid();";
 
-            using var conn = new SQLiteConnection(_connString);
-            conn.Open();
+            using var conn = _dbService.CreateConnection();
             using var cmd = new SQLiteCommand(sql, conn);
 
             var hashed = string.IsNullOrWhiteSpace(user.Password)


### PR DESCRIPTION
## Summary
- add `DatabaseService.CreateConnection` to centralize SQLite initialization
- open all service connections via the new factory method
- run WAL and busy timeout PRAGMAs when a connection is opened
- update test to use the new connection helper

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcdc9a1c48324a307034d30513354