### PR TITLE
Fix rentals UI and concurrency

### DIFF
--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -275,17 +275,14 @@
                             <StackPanel Orientation="Vertical" Margin="5">
 
                                 <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                                    <xctk:WatermarkTextBox x:Name="ToolIDForRentalInput" Watermark="Tool ID" Width="150" Margin="5"/>
-                                    <xctk:WatermarkTextBox x:Name="CustomerIDForRentalInput" Watermark="Customer ID" Width="150" Margin="5"/>
-                                    <xctk:WatermarkTextBox x:Name="DueDateInput" Watermark="Due Date (YYYY-MM-DD)" Width="150" Margin="5"/>
                                     <Button Content="Rent Tool" Command="{Binding RentToolCommand}" Width="120" Margin="5"/>
                                     <Button Content="Return Tool" Command="{Binding ReturnToolCommand}" Width="120" Margin="5"/>
                                     <Button Content="Print Receipt" Click="PrintRentalReceipt_Click" Width="120" Margin="5"/>
                                 </StackPanel>
 
                                 <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                                    <xctk:WatermarkTextBox x:Name="RentalIDInput" Watermark="Rental ID" Width="120" Margin="5"/>
-                                    <xctk:WatermarkTextBox x:Name="NewDueDateInput" Watermark="New Due Date (YYYY-MM-DD)" Width="150" Margin="5"/>
+                                    <xctk:WatermarkTextBox x:Name="RentalIDInput" Watermark="Rental ID" Width="120" Margin="5" IsReadOnly="True" Text="{Binding SelectedRental.RentalID}"/>
+                                    <DatePicker x:Name="NewDueDateInput" SelectedDate="{Binding NewDueDate, Mode=TwoWay}" Width="150" Margin="5"/>
                                     <Button Content="Extend Rental" Command="{Binding ExtendRentalCommand}" Width="150" Margin="5"/>
                                     <Button Content="Overdue Rentals" Command="{Binding LoadOverdueRentalsCommand}" Width="150" Margin="5"/>
                                 </StackPanel>
@@ -293,12 +290,12 @@
                             </StackPanel>
                         </GroupBox>
 
-                        <ListView x:Name="RentalsList" ItemsSource="{Binding ActiveRentals}" Grid.Row="1">
+                        <ListView x:Name="RentalsList" ItemsSource="{Binding ActiveRentals}" SelectedItem="{Binding SelectedRental, Mode=TwoWay}" Grid.Row="1">
                             <ListView.View>
                                 <GridView>
                                     <GridViewColumn Header="Rental ID" DisplayMemberBinding="{Binding RentalID}" Width="80"/>
-                                    <GridViewColumn Header="Tool ID" DisplayMemberBinding="{Binding ToolID}" Width="80"/>
-                                    <GridViewColumn Header="Customer ID" DisplayMemberBinding="{Binding CustomerID}" Width="80"/>
+                                    <GridViewColumn Header="Tool" DisplayMemberBinding="{Binding ToolNumber}" Width="120"/>
+                                    <GridViewColumn Header="Customer" DisplayMemberBinding="{Binding CustomerName}" Width="150"/>
                                     <GridViewColumn Header="Rental Date" DisplayMemberBinding="{Binding RentalDate, StringFormat=\{0:yyyy-MM-dd\}}" Width="120"/>
                                     <GridViewColumn Header="Due Date" DisplayMemberBinding="{Binding DueDate, StringFormat=\{0:yyyy-MM-dd\}}" Width="120"/>
                                     <GridViewColumn Header="Return Date" DisplayMemberBinding="{Binding ReturnDate, StringFormat=\{0:yyyy-MM-dd\}}" Width="120"/>

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -604,8 +604,8 @@ namespace ToolManagementAppV2
             var details = new Paragraph();
             void AddLine(string text) => details.Inlines.Add(new Run(text + "\n"));
             AddLine($"Rental ID: {r.RentalID}");
-            AddLine($"Tool ID: {r.ToolID}");
-            AddLine($"Customer ID: {r.CustomerID}");
+            AddLine($"Tool: {r.ToolNumber}");
+            AddLine($"Customer: {r.CustomerName}");
             AddLine($"Rental Date: {r.RentalDate:yyyy-MM-dd}");
             AddLine($"Due Date: {r.DueDate:yyyy-MM-dd}");
             if (r.ReturnDate.HasValue)

--- a/ToolManagementAppV2/Models/Domain/Rental.cs
+++ b/ToolManagementAppV2/Models/Domain/Rental.cs
@@ -52,5 +52,19 @@ namespace ToolManagementAppV2.Models.Domain
             get => _status;
             set => SetProperty(ref _status, value);
         }
+
+        private string _toolNumber = string.Empty;
+        public string ToolNumber
+        {
+            get => _toolNumber;
+            set => SetProperty(ref _toolNumber, value);
+        }
+
+        private string _customerName = string.Empty;
+        public string CustomerName
+        {
+            get => _customerName;
+            set => SetProperty(ref _customerName, value);
+        }
     }
 }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -96,7 +96,12 @@ namespace ToolManagementAppV2.ViewModels
             set => SetProperty(ref _selectedRental, value);
         }
 
-        public DateTime NewDueDate { get; set; } = DateTime.Today.AddDays(7);
+        DateTime _newDueDate = DateTime.Today.AddDays(7);
+        public DateTime NewDueDate
+        {
+            get => _newDueDate;
+            set => SetProperty(ref _newDueDate, value);
+        }
 
         string _currentUserName;
         public string CurrentUserName


### PR DESCRIPTION
## Summary
- display tool and customer names in rentals grid
- use selected rental for operations and edit due date with DatePicker
- add ToolNumber and CustomerName fields to Rental model
- join tool and customer tables in RentalService queries
- use pooled connections in ActivityLogService
- update receipt printout to include names

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684fcc7863048324980deccf9b59c66c