### PR TITLE
Add detailed rental info

### DIFF
--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -193,5 +193,43 @@ namespace ToolManagementAppV2.Tests.Services
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void GetActiveRentals_ReturnsCustomerAndToolDetails()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+
+                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, Location = "A1", ToolImagePath = "path" };
+                toolService.AddTool(tool);
+                var addedTool = toolService.GetAllTools().First();
+
+                var customer = new Customer { Company = "Acme", Contact = "Bob", Email = "b@c.com", Phone = "111", Mobile = "222", Address = "Addr" };
+                customerService.AddCustomer(customer);
+                var addedCust = customerService.GetAllCustomers().First();
+
+                rentalService.RentTool(addedTool.ToolID, addedCust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+
+                var rentals = rentalService.GetActiveRentals();
+                var r = rentals.First();
+                Assert.Equal("A1", r.ToolLocation);
+                Assert.Equal("path", r.ToolImagePath);
+                Assert.Equal("Bob", r.CustomerContact);
+                Assert.Equal("b@c.com", r.CustomerEmail);
+                Assert.Equal("111", r.CustomerPhone);
+                Assert.Equal("222", r.CustomerMobile);
+                Assert.Equal("Addr", r.CustomerAddress);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -311,7 +311,20 @@
                                 <GridView>
                                     <GridViewColumn Header="Rental ID" DisplayMemberBinding="{Binding RentalID}" Width="80"/>
                                     <GridViewColumn Header="Tool" DisplayMemberBinding="{Binding ToolNumber}" Width="120"/>
+                                    <GridViewColumn Header="Image" Width="100">
+                                        <GridViewColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <Image Source="{Binding ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=Tool}" Width="50" Height="50" Stretch="Uniform" Style="{StaticResource ToolImageTooltipStyle}"/>
+                                            </DataTemplate>
+                                        </GridViewColumn.CellTemplate>
+                                    </GridViewColumn>
+                                    <GridViewColumn Header="Location" DisplayMemberBinding="{Binding ToolLocation}" Width="100"/>
                                     <GridViewColumn Header="Customer" DisplayMemberBinding="{Binding CustomerName}" Width="150"/>
+                                    <GridViewColumn Header="Contact" DisplayMemberBinding="{Binding CustomerContact}" Width="120"/>
+                                    <GridViewColumn Header="Email" DisplayMemberBinding="{Binding CustomerEmail}" Width="150"/>
+                                    <GridViewColumn Header="Phone" DisplayMemberBinding="{Binding CustomerPhone}" Width="120"/>
+                                    <GridViewColumn Header="Mobile" DisplayMemberBinding="{Binding CustomerMobile}" Width="120"/>
+                                    <GridViewColumn Header="Address" DisplayMemberBinding="{Binding CustomerAddress}" Width="200"/>
                                     <GridViewColumn Header="Rental Date" DisplayMemberBinding="{Binding RentalDate, StringFormat=\{0:yyyy-MM-dd\}}" Width="120"/>
                                     <GridViewColumn Header="Due Date" DisplayMemberBinding="{Binding DueDate, StringFormat=\{0:yyyy-MM-dd\}}" Width="120"/>
                                     <GridViewColumn Header="Return Date" DisplayMemberBinding="{Binding ReturnDate, StringFormat=\{0:yyyy-MM-dd\}}" Width="120"/>

--- a/ToolManagementAppV2/Models/Domain/Rental.cs
+++ b/ToolManagementAppV2/Models/Domain/Rental.cs
@@ -66,5 +66,54 @@ namespace ToolManagementAppV2.Models.Domain
             get => _customerName;
             set => SetProperty(ref _customerName, value);
         }
+
+        private string _customerContact = string.Empty;
+        public string CustomerContact
+        {
+            get => _customerContact;
+            set => SetProperty(ref _customerContact, value);
+        }
+
+        private string _customerEmail = string.Empty;
+        public string CustomerEmail
+        {
+            get => _customerEmail;
+            set => SetProperty(ref _customerEmail, value);
+        }
+
+        private string _customerPhone = string.Empty;
+        public string CustomerPhone
+        {
+            get => _customerPhone;
+            set => SetProperty(ref _customerPhone, value);
+        }
+
+        private string _customerMobile = string.Empty;
+        public string CustomerMobile
+        {
+            get => _customerMobile;
+            set => SetProperty(ref _customerMobile, value);
+        }
+
+        private string _customerAddress = string.Empty;
+        public string CustomerAddress
+        {
+            get => _customerAddress;
+            set => SetProperty(ref _customerAddress, value);
+        }
+
+        private string _toolImagePath = string.Empty;
+        public string ToolImagePath
+        {
+            get => _toolImagePath;
+            set => SetProperty(ref _toolImagePath, value);
+        }
+
+        private string _toolLocation = string.Empty;
+        public string ToolLocation
+        {
+            get => _toolLocation;
+            set => SetProperty(ref _toolLocation, value);
+        }
     }
 }

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -176,9 +176,20 @@ namespace ToolManagementAppV2.Services.Rentals
                 throw new InvalidOperationException("Unable to extend rental. Rental not found or already returned.");
         }
 
-        const string BaseSelect = @"SELECT r.*, t.ToolNumber, t.NameDescription, c.Company FROM Rentals r
-                                    JOIN Tools t ON r.ToolID = t.ToolID
-                                    JOIN Customers c ON r.CustomerID = c.CustomerID";
+        const string BaseSelect = @"SELECT r.*,
+                                    t.ToolNumber,
+                                    t.NameDescription,
+                                    t.Location AS ToolLocation,
+                                    t.ToolImagePath,
+                                    c.Company,
+                                    c.Contact,
+                                    c.Email,
+                                    c.Phone,
+                                    c.Mobile,
+                                    c.Address
+                                 FROM Rentals r
+                                 JOIN Tools t ON r.ToolID = t.ToolID
+                                 JOIN Customers c ON r.CustomerID = c.CustomerID";
 
         public List<Rental> GetActiveRentals()
         {
@@ -227,7 +238,14 @@ namespace ToolManagementAppV2.Services.Rentals
             ReturnDate = r["ReturnDate"] is DBNull ? null : Convert.ToDateTime(r["ReturnDate"]),
             Status = r["Status"].ToString(),
             ToolNumber = r["ToolNumber"].ToString(),
-            CustomerName = r["Company"].ToString()
+            CustomerName = r["Company"].ToString(),
+            CustomerContact = r["Contact"].ToString(),
+            CustomerEmail = r["Email"].ToString(),
+            CustomerPhone = r["Phone"].ToString(),
+            CustomerMobile = r["Mobile"].ToString(),
+            CustomerAddress = r["Address"].ToString(),
+            ToolImagePath = r["ToolImagePath"].ToString(),
+            ToolLocation = r["ToolLocation"].ToString()
         };
     }
 }


### PR DESCRIPTION
## Summary
- expand `Rental` model with customer and tool details
- include these fields in `RentalService` queries
- display tool image, location, and full customer info in rentals tab
- test rental service returns new details

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68799952f9e8832481c26c9da386e701