### PR TITLE
Add image import

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
@@ -37,6 +38,40 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 if (File.Exists(dbPath))
                     File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void ImportToolImages_UpdatesImagePathsAndReportsIssues()
+        {
+            var dbPath = Path.GetTempFileName();
+            var imgDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(imgDir);
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService svc = new ToolService(db);
+                svc.AddTool(new Tool { ToolNumber = "T1", NameDescription = "A" });
+                svc.AddTool(new Tool { ToolNumber = "T2", NameDescription = "B" });
+                svc.AddTool(new Tool { ToolNumber = "T1", NameDescription = "C" });
+
+                File.WriteAllText(Path.Combine(imgDir, "T1.jpg"), string.Empty);
+                File.WriteAllText(Path.Combine(imgDir, "T2.jpg"), string.Empty);
+                File.WriteAllText(Path.Combine(imgDir, "X.jpg"), string.Empty);
+
+                var result = svc.ImportToolImages(imgDir, t => t.ToolNumber);
+
+                var all = svc.GetAllTools();
+                var t2 = all.First(t => t.ToolNumber == "T2");
+                Assert.NotNull(t2.ToolImagePath);
+                Assert.Single(result.ConflictingFiles);
+                Assert.Single(result.UnmatchedFiles);
+                Assert.Equal(1, result.ImportedCount);
+            }
+            finally
+            {
+                if (Directory.Exists(imgDir)) Directory.Delete(imgDir, true);
+                if (File.Exists(dbPath)) File.Delete(dbPath);
             }
         }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/ImportToolPicturesCommandTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportToolPicturesCommandTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+using System.Linq;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    class TestToolService : ToolService
+    {
+        public bool ImportCalled { get; private set; }
+        public TestToolService(DatabaseService db) : base(db) { }
+        public override ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, string> keySelector)
+        {
+            ImportCalled = true;
+            return new ImageImportResult();
+        }
+    }
+
+    class TestMainViewModel : MainViewModel
+    {
+        readonly string _folder;
+        public TestMainViewModel(IToolService t, IUserService u, ICustomerService c, IRentalService r, ISettingsService s, ActivityLogService a, string folder)
+            : base(t, u, c, r, s, a)
+        {
+            _folder = folder;
+        }
+
+        protected override bool ShowFolderDialog(out string folder) { folder = _folder; return true; }
+        protected override bool ShowImageImportOptions(out Func<ToolModel, string> selector) { selector = t => t.ToolNumber; return true; }
+        protected override void ShowInfo(string msg) { }
+    }
+
+    public class ImportToolPicturesCommandTests
+    {
+        [Fact]
+        public void CommandCallsService()
+        {
+            var dbPath = Path.GetTempFileName();
+            var imgDir = Path.GetTempPath();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new TestToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService custService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+                ISettingsService settingsService = new SettingsService(db);
+                ActivityLogService logService = new ActivityLogService(db);
+                var vm = new TestMainViewModel(toolService, userService, custService, rentalService, settingsService, logService, imgDir);
+                vm.ImportToolPicturesCommand.Execute(null);
+                Assert.True(toolService.ImportCalled);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/Interfaces/IToolService.cs
+++ b/ToolManagementAppV2/Interfaces/IToolService.cs
@@ -1,4 +1,6 @@
+using System;
 ﻿using System.Collections.Generic;
+using ToolManagementAppV2.Models.ImportExport;
 using ToolManagementAppV2.Models;
 
 
@@ -17,5 +19,6 @@ namespace ToolManagementAppV2.Interfaces
         void UpdateToolImage(string toolID, string imagePath);
         List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map);
         void ExportToolsToCsv(string filePath);
+        ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, string> keySelector);
     }
 }

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -504,6 +504,7 @@
                                 <StackPanel Orientation="Horizontal" Margin="5">
                                     <Button Content="Import Tools" Command="{Binding ImportToolsCommand}" Width="150" Margin="5"/>
                                     <Button Content="Export Tools" Command="{Binding ExportToolsCommand}" Width="150" Margin="5"/>
+                                    <Button Content="Import Tool Pictures" Command="{Binding ImportToolPicturesCommand}" Width="150" Margin="5"/>
                                 </StackPanel>
 
                                 <TextBlock Text="Customers" FontWeight="Bold" Margin="10,10,5,5"/>

--- a/ToolManagementAppV2/Models/DTOs/ImageImportResult.cs
+++ b/ToolManagementAppV2/Models/DTOs/ImageImportResult.cs
@@ -1,0 +1,9 @@
+namespace ToolManagementAppV2.Models.ImportExport
+{
+    public class ImageImportResult
+    {
+        public int ImportedCount { get; set; }
+        public List<string> UnmatchedFiles { get; } = new();
+        public List<string> ConflictingFiles { get; } = new();
+    }
+}

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -1,6 +1,9 @@
 ﻿using System.Data.SQLite;
+using System;
+using System.IO;
 using System.Data;
 using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Utilities.IO;
 using ToolManagementAppV2.Models.ImportExport;
 using ToolManagementAppV2.Interfaces;
@@ -210,6 +213,56 @@ namespace ToolManagementAppV2.Services.Tools
         {
             var tools = GetAllTools();
             CsvHelperUtil.ExportToolsToCsv(filePath, tools);
+        }
+
+        public virtual ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, string> keySelector)
+        {
+            var result = new ImageImportResult();
+            if (string.IsNullOrWhiteSpace(folderPath) || keySelector == null)
+                return result;
+
+            var tools = GetAllTools();
+            var groups = tools
+                .GroupBy(t => (keySelector(t) ?? string.Empty).ToUpperInvariant())
+                .ToDictionary(g => g.Key, g => g.ToList());
+
+            var destDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images");
+            Directory.CreateDirectory(destDir);
+
+            var supported = new HashSet<string>(new[] { ".png", ".jpg", ".jpeg", ".bmp", ".gif" }, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var file in Directory.EnumerateFiles(folderPath))
+            {
+                var ext = Path.GetExtension(file);
+                if (!supported.Contains(ext))
+                    continue;
+
+                var name = Path.GetFileNameWithoutExtension(file).ToUpperInvariant();
+                if (!groups.TryGetValue(name, out var list) || list.Count == 0)
+                {
+                    result.UnmatchedFiles.Add(file);
+                    continue;
+                }
+                if (list.Count > 1)
+                {
+                    result.ConflictingFiles.Add(file);
+                    continue;
+                }
+                var tool = list[0];
+                if (!string.IsNullOrEmpty(tool.ToolImagePath))
+                {
+                    result.ConflictingFiles.Add(file);
+                    continue;
+                }
+                var dest = Path.Combine(destDir, Path.GetFileName(file));
+                if (!File.Exists(dest))
+                    File.Copy(file, dest, true);
+                var relative = $"Images/{Path.GetFileName(dest)}";
+                UpdateToolImage(tool.ToolID, relative);
+                result.ImportedCount++;
+            }
+
+            return result;
         }
     
         private bool ToolExists(string toolNumber)

--- a/ToolManagementAppV2/ViewModels/ImageImportMappingViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImageImportMappingViewModel.cs
@@ -1,0 +1,31 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+using System.Collections.Generic;
+using ToolManagementAppV2.Models.Domain;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class ImageImportMappingViewModel : ObservableObject
+    {
+        bool _useToolNumber = true;
+        public bool UseToolNumber { get => _useToolNumber; set => SetProperty(ref _useToolNumber, value); }
+
+        bool _usePartNumber;
+        public bool UsePartNumber { get => _usePartNumber; set => SetProperty(ref _usePartNumber, value); }
+
+        bool _useNameDescription;
+        public bool UseNameDescription { get => _useNameDescription; set => SetProperty(ref _useNameDescription, value); }
+
+        public Func<ToolModel, string> BuildSelector()
+        {
+            return t =>
+            {
+                var parts = new List<string>();
+                if (UseToolNumber) parts.Add(t.ToolNumber);
+                if (UsePartNumber) parts.Add(t.PartNumber);
+                if (UseNameDescription) parts.Add(t.NameDescription);
+                return string.Join("_", parts).Trim().ToUpperInvariant();
+            };
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -3,7 +3,9 @@ using CommunityToolkit.Mvvm.Input;
 using Microsoft.Win32;
 using System.Collections.ObjectModel;
 using System.IO;
+using System;
 using System.Windows;
+using System.Windows.Forms;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using ToolManagementAppV2.Models.Domain;
@@ -213,6 +215,7 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand UpdateToolCommand { get; }
         public IRelayCommand ImportToolsCommand { get; }
         public IRelayCommand ExportToolsCommand { get; }
+        public IRelayCommand ImportToolPicturesCommand { get; }
         public IRelayCommand DeleteToolCommand { get; }
         public IRelayCommand LoadUsersCommand { get; }
         public IRelayCommand ChooseProfilePicCommand { get; }
@@ -266,6 +269,7 @@ namespace ToolManagementAppV2.ViewModels
             UpdateToolCommand = new RelayCommand(UpdateTool, () => SelectedTool != null);
             ImportToolsCommand = new RelayCommand(ImportTools);
             ExportToolsCommand = new RelayCommand(ExportTools);
+            ImportToolPicturesCommand = new RelayCommand(ImportToolPictures);
             DeleteToolCommand = new RelayCommand(DeleteTool, () => SelectedTool != null);
 
             LoadUsersCommand = new RelayCommand(LoadUsers);
@@ -375,6 +379,20 @@ namespace ToolManagementAppV2.ViewModels
             if (!ShowSaveDialog("tools_export.csv", out var path)) return;
             _toolService.ExportToolsToCsv(path);
             ShowInfo("Tools exported successfully.");
+        }
+
+        void ImportToolPictures()
+        {
+            if (!ShowFolderDialog(out var folder)) return;
+            if (!ShowImageImportOptions(out var selector)) return;
+            var result = _toolService.ImportToolImages(folder, selector);
+            var msg = $"{result.ImportedCount} images imported.";
+            if (result.ConflictingFiles.Count > 0)
+                msg += $" {result.ConflictingFiles.Count} conflicts.";
+            if (result.UnmatchedFiles.Count > 0)
+                msg += $" {result.UnmatchedFiles.Count} unmatched.";
+            ShowInfo(msg);
+            LoadTools();
         }
 
         void DeleteTool()
@@ -725,21 +743,21 @@ namespace ToolManagementAppV2.ViewModels
             win.ShowDialog();
         }
 
-        bool ShowFileDialog(string filter, out string path)
+        protected virtual bool ShowFileDialog(string filter, out string path)
         {
             var dlg = new OpenFileDialog { Filter = filter };
             if (dlg.ShowDialog() == true) { path = dlg.FileName; return true; }
             path = null; return false;
         }
 
-        bool ShowSaveDialog(string defaultName, out string path)
+        protected virtual bool ShowSaveDialog(string defaultName, out string path)
         {
             var dlg = new SaveFileDialog { Filter = "CSV Files|*.csv", FileName = defaultName };
             if (dlg.ShowDialog() == true) { path = dlg.FileName; return true; }
             path = null; return false;
         }
 
-        bool ShowMappingWindow(IEnumerable<string> headers, IEnumerable<string> fields, out Dictionary<string, string> map)
+        protected virtual bool ShowMappingWindow(IEnumerable<string> headers, IEnumerable<string> fields, out Dictionary<string, string> map)
         {
             var win = new ImportMappingWindow(headers, fields);
             if (win.ShowDialog() == true)
@@ -751,7 +769,31 @@ namespace ToolManagementAppV2.ViewModels
             return false;
         }
 
-        void ShowInfo(string msg) => MessageBox.Show(msg, "Info", MessageBoxButton.OK, MessageBoxImage.Information);
-        void ShowWarning(string msg) => MessageBox.Show(msg, "Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
+        protected virtual bool ShowFolderDialog(out string folder)
+        {
+            using var dlg = new System.Windows.Forms.FolderBrowserDialog();
+            if (dlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            {
+                folder = dlg.SelectedPath;
+                return true;
+            }
+            folder = null;
+            return false;
+        }
+
+        protected virtual bool ShowImageImportOptions(out Func<ToolModel, string> selector)
+        {
+            var win = new ImageImportMappingWindow();
+            if (win.ShowDialog() == true)
+            {
+                selector = win.VM.BuildSelector();
+                return true;
+            }
+            selector = null;
+            return false;
+        }
+
+        protected virtual void ShowInfo(string msg) => MessageBox.Show(msg, "Info", MessageBoxButton.OK, MessageBoxImage.Information);
+        protected virtual void ShowWarning(string msg) => MessageBox.Show(msg, "Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
     }
 }

--- a/ToolManagementAppV2/Views/ImageImportMappingWindow.xaml
+++ b/ToolManagementAppV2/Views/ImageImportMappingWindow.xaml
@@ -1,0 +1,21 @@
+<Window x:Class="ToolManagementAppV2.Views.ImageImportMappingWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Tool Inventory Management – Import Tool Pictures"
+        Height="200" Width="600"
+        WindowStartupLocation="CenterScreen">
+    <DockPanel Margin="10">
+        <StackPanel>
+            <TextBlock Text="Match images by:" FontWeight="Bold" Margin="0,0,0,5"/>
+            <StackPanel Orientation="Horizontal">
+                <CheckBox Content="ToolNumber" IsChecked="{Binding UseToolNumber}" Margin="5"/>
+                <CheckBox Content="PartNumber" IsChecked="{Binding UsePartNumber}" Margin="5"/>
+                <CheckBox Content="NameDescription" IsChecked="{Binding UseNameDescription}" Margin="5"/>
+            </StackPanel>
+        </StackPanel>
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+            <Button Content="OK" Width="150" Margin="10" Click="Ok_Click"/>
+            <Button Content="Cancel" Width="150" Margin="10" Click="Cancel_Click"/>
+        </StackPanel>
+    </DockPanel>
+</Window>

--- a/ToolManagementAppV2/Views/ImageImportMappingWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ImageImportMappingWindow.xaml.cs
@@ -1,0 +1,28 @@
+using System.Windows;
+using ToolManagementAppV2.ViewModels;
+
+namespace ToolManagementAppV2.Views
+{
+    public partial class ImageImportMappingWindow : Window
+    {
+        public ImageImportMappingWindow()
+        {
+            InitializeComponent();
+            DataContext = new ImageImportMappingViewModel();
+        }
+
+        public ImageImportMappingViewModel VM => (ImageImportMappingViewModel)DataContext;
+
+        private void Ok_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            Close();
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow importing tool pictures from the UI
- support selecting matching fields to map image file names
- implement image importing logic in tool service
- show import options in a dedicated window
- test image importing logic and command execution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c80d4f92c8324a28cd63e8b8eadd5