### PR TITLE
Fix Windows Forms reference

### DIFF
--- a/ToolManagementAppV2/ToolManagementAppV2.csproj
+++ b/ToolManagementAppV2/ToolManagementAppV2.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- allow the WPF project to reference System.Windows.Forms

## Testing
- `dotnet test` *(fails: `command not found: dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_687c86c6bd9483248723d384ac08ea23