### PR TITLE
Add caching to NullToDefaultImageConverter

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/NullToDefaultImageConverterTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NullToDefaultImageConverterTests.cs
@@ -38,6 +38,16 @@ namespace ToolManagementAppV2.Tests
         }
 
         [Fact]
+        public void Convert_SamePath_ReturnsCachedInstance()
+        {
+            var converter = new NullToDefaultImageConverter();
+            var path = "Assets/Avatars/2.png";
+            var bmp1 = Assert.IsType<BitmapImage>(converter.Convert(path, typeof(BitmapImage), null, CultureInfo.InvariantCulture));
+            var bmp2 = Assert.IsType<BitmapImage>(converter.Convert(path, typeof(BitmapImage), null, CultureInfo.InvariantCulture));
+            Assert.Same(bmp1, bmp2);
+        }
+
+        [Fact]
         public void ConvertBack_BitmapImage_ReturnsUriString()
         {
             var converter = new NullToDefaultImageConverter();

--- a/ToolManagementAppV2/Utilities/Converters/NullToDefaultImageConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/NullToDefaultImageConverter.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Media.Imaging;
 using System.IO;
+using System.Collections.Generic;
 
 namespace ToolManagementAppV2.Utilities.Converters
 {
@@ -12,6 +13,8 @@ namespace ToolManagementAppV2.Utilities.Converters
         private static BitmapImage _defaultUser;
         private static BitmapImage _defaultTool;
         private static BitmapImage _defaultLogo;
+        private static readonly Dictionary<string, BitmapImage> _imageCache =
+            new Dictionary<string, BitmapImage>(StringComparer.OrdinalIgnoreCase);
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
@@ -29,12 +32,16 @@ namespace ToolManagementAppV2.Utilities.Converters
 
                     if (!string.IsNullOrEmpty(absPath))
                     {
+                        if (_imageCache.TryGetValue(absPath, out var cached))
+                            return cached;
+
                         var image = new BitmapImage();
                         image.BeginInit();
                         image.CacheOption = BitmapCacheOption.OnLoad;
                         image.UriSource = new Uri(absPath, UriKind.Absolute);
                         image.EndInit();
                         image.Freeze();
+                        _imageCache[absPath] = image;
                         return image;
                     }
                 }


### PR DESCRIPTION
## Summary
- store loaded images in a static cache in `NullToDefaultImageConverter`
- return cached image instances when the same path is provided
- add unit test covering the caching behaviour

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c90531d688324b45789b14de1907f