### PR TITLE
Improve search tile layout

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/SearchResultsTileTemplateTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/SearchResultsTileTemplateTests.cs
@@ -15,6 +15,8 @@ namespace ToolManagementAppV2.Tests.Tests
             Assert.Same(template, window.SearchResultsList.ItemTemplate);
             var panel = window.SearchResultsList.ItemsPanel.LoadContent();
             Assert.IsType<WrapPanel>(panel);
+            Assert.Equal(ScrollBarVisibility.Disabled, ScrollViewer.GetVerticalScrollBarVisibility(window.SearchResultsList));
+            Assert.Equal(ScrollBarVisibility.Auto, ScrollViewer.GetHorizontalScrollBarVisibility(window.SearchResultsList));
         }
     }
 }

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -30,9 +30,13 @@
                 </Setter>
             </Style>
             <DataTemplate x:Key="ToolTileTemplate">
-                <StackPanel Orientation="Vertical" Width="200" Margin="10">
+                <StackPanel Orientation="Vertical"
+                            Width="{Binding DataContext.SearchTileWidth, RelativeSource={RelativeSource AncestorType=Window}}"
+                            Margin="10">
                     <Image Source="{Binding ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=Tool}"
-                           Width="180" Height="180" Stretch="Uniform" Style="{StaticResource ToolImageTooltipStyle}"/>
+                           Width="{Binding DataContext.SearchTileWidth, RelativeSource={RelativeSource AncestorType=Window}}"
+                           Height="{Binding DataContext.SearchTileWidth, RelativeSource={RelativeSource AncestorType=Window}}"
+                           Stretch="Uniform" Style="{StaticResource ToolImageTooltipStyle}"/>
                     <ContentControl Margin="0,5,0,0" Content="{Binding}" ContentTemplate="{StaticResource CheckOutButtonTemplate}"/>
                     <TextBlock Text="{Binding ToolNumber}" FontWeight="Bold" Margin="0,5,0,0" />
                     <TextBlock Text="{Binding NameDescription}" TextWrapping="Wrap"/>
@@ -123,7 +127,11 @@
                             <ListView x:Name="SearchResultsList"
                       ItemsSource="{Binding SearchResults}"
                       SelectedItem="{Binding SelectedTool, Mode=TwoWay}"
-                      ScrollViewer.VerticalScrollBarVisibility="Auto"
+                      ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                      ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                      Loaded="SearchResultsList_Loaded"
+                      SizeChanged="SearchResultsList_SizeChanged"
+                      PreviewMouseWheel="SearchResultsList_PreviewMouseWheel"
                       ItemTemplate="{StaticResource ToolTileTemplate}">
                                 <ListView.ItemsPanel>
                                     <ItemsPanelTemplate>

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -682,6 +682,46 @@ namespace ToolManagementAppV2
                 _printer.PrintTools(vm.CheckedOutTools, "My Checked-Out Tools", vm.CurrentUserName);
         }
 
+        ScrollViewer _searchScrollViewer;
+
+        void SearchResultsList_Loaded(object s, RoutedEventArgs e)
+        {
+            _searchScrollViewer = FindVisualChild<ScrollViewer>(SearchResultsList);
+        }
+
+        void SearchResultsList_SizeChanged(object s, SizeChangedEventArgs e)
+        {
+            if (DataContext is MainViewModel vm)
+            {
+                var width = e.NewSize.Width;
+                var itemWidth = Math.Clamp(width / 5 - 20, 120, 300);
+                vm.SearchTileWidth = itemWidth;
+            }
+        }
+
+        void SearchResultsList_PreviewMouseWheel(object s, MouseWheelEventArgs e)
+        {
+            if (_searchScrollViewer != null)
+            {
+                _searchScrollViewer.ScrollToHorizontalOffset(_searchScrollViewer.HorizontalOffset - e.Delta);
+                e.Handled = true;
+            }
+        }
+
+        static T FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                if (child is T t)
+                    return t;
+                var result = FindVisualChild<T>(child);
+                if (result != null)
+                    return result;
+            }
+            return null;
+        }
+
         public void MyTabControl_SelectionChanged(object s, SelectionChangedEventArgs e)
         {
             // Only respond when the tab selection actually changes.

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -34,6 +34,13 @@ namespace ToolManagementAppV2.ViewModels
         public ObservableCollection<ToolModel> Tools { get; } = new();
         public ObservableCollection<ToolModel> SearchResults { get; } = new();
         public ObservableCollection<ToolModel> CheckedOutTools { get; } = new();
+
+        double _searchTileWidth = 200;
+        public double SearchTileWidth
+        {
+            get => _searchTileWidth;
+            set => SetProperty(ref _searchTileWidth, value);
+        }
         ToolModel _selectedTool;
         public ToolModel SelectedTool
         {


### PR DESCRIPTION
## Summary
- adjust search result tiles to size with window
- enable horizontal scrolling with mouse wheel
- expose `SearchTileWidth` in `MainViewModel`
- test for horizontal scroll setup

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ca196d9148324941629633bac2f41