### PR TITLE
Fix tool cache invalidation and selection

### DIFF
--- a/ToolManagementAppV2.Tests/Services/InterfaceReferenceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/InterfaceReferenceTests.cs
@@ -21,7 +21,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var db = new DatabaseService(dbPath);
                 IToolService toolSvc = new ToolService(db);
                 ICustomerService custSvc = new CustomerService(db);
-                IRentalService rentalSvc = new RentalService(db);
+                IRentalService rentalSvc = new RentalService(db, toolSvc);
                 IUserService userSvc = new UserService(db);
                 ISettingsService settingsSvc = new SettingsService(db);
 

--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -22,7 +22,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
 
                 var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 5 };
                 toolService.AddTool(tool);
@@ -55,7 +55,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
 
                 var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 0 };
                 toolService.AddTool(tool);
@@ -84,7 +84,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
 
                 var tool = new Tool { ToolNumber = "T2", NameDescription = "Wrench", QuantityOnHand = 0 };
                 toolService.AddTool(tool);
@@ -111,7 +111,7 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
 
                 var ex = Record.Exception(() => rentalService.ReturnTool(1, DateTime.Today));
                 Assert.Null(ex);
@@ -130,7 +130,7 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
 
                 var ex = Record.Exception(() => rentalService.ReturnToolWithTransaction(1, DateTime.Today));
                 Assert.Null(ex);
@@ -149,7 +149,7 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var rentalService = new RentalService(db);
+                var rentalService = new RentalService(db, toolService);
 
                 Assert.Throws<InvalidOperationException>(() =>
                     rentalService.ExtendRental(1, DateTime.Today.AddDays(1)));
@@ -170,7 +170,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var db = new DatabaseService(dbPath);
                 var toolService = new ToolService(db);
                 var customerService = new CustomerService(db);
-                var rentalService = new RentalService(db);
+                var rentalService = new RentalService(db, toolService);
 
                 var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 };
                 toolService.AddTool(tool);
@@ -203,7 +203,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var db = new DatabaseService(dbPath);
                 var toolService = new ToolService(db);
                 var customerService = new CustomerService(db);
-                var rentalService = new RentalService(db);
+                var rentalService = new RentalService(db, toolService);
 
                 var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, Location = "A1", ToolImagePath = "path" };
                 toolService.AddTool(tool);
@@ -224,6 +224,43 @@ namespace ToolManagementAppV2.Tests.Services
                 Assert.Equal("111", r.CustomerPhone);
                 Assert.Equal("222", r.CustomerMobile);
                 Assert.Equal("Addr", r.CustomerAddress);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void RentAndReturnTool_UpdatesQuantities()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db, toolService);
+
+                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
+                var tool = toolService.GetAllTools().First();
+
+                customerService.AddCustomer(new Customer { Company = "Acme" });
+                var cust = customerService.GetAllCustomers().First();
+
+                rentalService.RentTool(tool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+
+                var rented = toolService.GetToolByID(tool.ToolID);
+                Assert.Equal(0, rented.QuantityOnHand);
+                Assert.Equal(1, rented.RentedQuantity);
+
+                var rental = rentalService.GetAllRentals().First();
+                rentalService.ReturnTool(rental.RentalID, DateTime.Today);
+
+                var returned = toolService.GetToolByID(tool.ToolID);
+                Assert.Equal(1, returned.QuantityOnHand);
+                Assert.Equal(0, returned.RentedQuantity);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Tests/ConsoleLoggingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ConsoleLoggingTests.cs
@@ -139,7 +139,7 @@ namespace ToolManagementAppV2.Tests
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
 
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 0 });
                 var tool = toolService.GetAllTools().First();
@@ -168,7 +168,7 @@ namespace ToolManagementAppV2.Tests
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
 
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Wrench", QuantityOnHand = 0 });
                 var tool = toolService.GetAllTools().First();
@@ -195,7 +195,7 @@ namespace ToolManagementAppV2.Tests
             try
             {
                 var db = new DatabaseService(dbPath);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
 
                 var sw = new StringWriter();
                 var original = Console.Out;
@@ -217,7 +217,7 @@ namespace ToolManagementAppV2.Tests
             try
             {
                 var db = new DatabaseService(dbPath);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
 
                 var sw = new StringWriter();
                 var original = Console.Out;

--- a/ToolManagementAppV2.Tests/ViewModels/AvatarSelectionTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/AvatarSelectionTests.cs
@@ -26,7 +26,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 IUserService userService = new UserService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
                 ISettingsService settingsService = new SettingsService(db);
 
                 var user = new User { UserName = "u", Password = "p" };

--- a/ToolManagementAppV2.Tests/ViewModels/ImportToolPicturesCommandTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportToolPicturesCommandTests.cs
@@ -52,7 +52,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var toolService = new TestToolService(db);
                 IUserService userService = new UserService(db);
                 ICustomerService custService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
                 ISettingsService settingsService = new SettingsService(db);
                 ActivityLogService logService = new ActivityLogService(db);
                 var vm = new TestMainViewModel(toolService, userService, custService, rentalService, settingsService, logService, imgDir);

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
@@ -25,7 +25,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 IUserService userService = new UserService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
                 ISettingsService settingsService = new SettingsService(db);
                 ActivityLogService logService = new ActivityLogService(db);
                 var vm = new MainViewModel(toolService, userService, customerService, rentalService, settingsService, logService);
@@ -53,7 +53,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 IUserService userService = new UserService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
                 ISettingsService settingsService = new SettingsService(db);
                 ActivityLogService logService = new ActivityLogService(db);
                 var vm = new MainViewModel(toolService, userService, customerService, rentalService, settingsService, logService);
@@ -80,7 +80,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 IUserService userService = new UserService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
                 ISettingsService settingsService = new SettingsService(db);
                 ActivityLogService logService = new ActivityLogService(db);
                 var vm = new MainViewModel(toolService, userService, customerService, rentalService, settingsService, logService);
@@ -122,7 +122,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 IUserService userService = new UserService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
                 ISettingsService settingsService = new SettingsService(db);
                 ActivityLogService logService = new ActivityLogService(db);
                 var vm = new MainViewModel(toolService, userService, customerService, rentalService, settingsService, logService);
@@ -166,7 +166,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 IUserService userService = new UserService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
                 ISettingsService settingsService = new SettingsService(db);
                 customerService.AddCustomer(new Customer { Company = "Old" });
                 var existing = customerService.GetAllCustomers().First();
@@ -205,7 +205,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 IUserService userService = new UserService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
                 ISettingsService settingsService = new SettingsService(db);
                 ActivityLogService logService = new ActivityLogService(db);
                 toolService.AddTool(new Tool { ToolNumber = "TN1", NameDescription = "Hammer", QuantityOnHand = 1 });
@@ -238,7 +238,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 IUserService userService = new UserService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
                 ISettingsService settingsService = new SettingsService(db);
                 ActivityLogService logService = new ActivityLogService(db);
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
@@ -275,7 +275,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 IUserService userService = new UserService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
                 ISettingsService settingsService = new SettingsService(db);
                 ActivityLogService logService = new ActivityLogService(db);
                 toolService.AddTool(new Tool { ToolNumber = "TN1", NameDescription = "Hammer", QuantityOnHand = 1 });
@@ -289,6 +289,37 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 Assert.True(vm.ViewSelectedCustomerHistoryCommand.CanExecute(null));
                 var history = rentalService.GetRentalHistoryForCustomer(cust.CustomerID);
                 Assert.NotEmpty(history);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void LoadTools_PreservesSelectedTool()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
+                ISettingsService settingsService = new SettingsService(db);
+                ActivityLogService logService = new ActivityLogService(db);
+
+                toolService.AddTool(new Tool { ToolNumber = "T1" });
+                toolService.AddTool(new Tool { ToolNumber = "T2" });
+
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, settingsService, logService);
+                vm.LoadTools();
+                vm.SelectedTool = vm.Tools.First();
+                var id = vm.SelectedTool.ToolID;
+                vm.LoadTools();
+                Assert.Equal(id, vm.SelectedTool.ToolID);
             }
             finally
             {

--- a/ToolManagementAppV2/Interfaces/IToolService.cs
+++ b/ToolManagementAppV2/Interfaces/IToolService.cs
@@ -20,5 +20,6 @@ namespace ToolManagementAppV2.Interfaces
         List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map);
         void ExportToolsToCsv(string filePath);
         ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, string> keySelector);
+        void UpdateToolQuantities(string toolID, int qtyChange, bool isRental);
     }
 }

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -38,7 +38,7 @@ namespace ToolManagementAppV2
             _db = new DatabaseService(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db"));
             _toolService = new ToolService(_db);
             _customerService = new CustomerService(_db);
-            _rentalService = new RentalService(_db);
+            _rentalService = new RentalService(_db, _toolService);
             _userService = new UserService(_db);
             _settingsService = new SettingsService(_db);
             _activityLogService = new ActivityLogService(_db);

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -9,10 +9,12 @@ namespace ToolManagementAppV2.Services.Rentals
     public class RentalService : IRentalService
     {
         readonly DatabaseService _dbService;
+        readonly IToolService _toolService;
 
-        public RentalService(DatabaseService dbService)
+        public RentalService(DatabaseService dbService, IToolService toolService)
         {
             _dbService = dbService;
+            _toolService = toolService;
         }
 
         // toolID is passed as a string even though the underlying column is INTEGER
@@ -43,12 +45,8 @@ namespace ToolManagementAppV2.Services.Rentals
                         new SQLiteParameter("@DueDate", dueDate)
                     });
 
-                SqliteHelper.ExecuteNonQuery(conn, tx,
-                    "UPDATE Tools SET AvailableQuantity = AvailableQuantity - 1, " +
-                    "RentedQuantity = RentedQuantity + 1 WHERE ToolID = @ToolID",
-                    new[] { new SQLiteParameter("@ToolID", toolID) });
-
                 tx.Commit();
+                _toolService.UpdateToolQuantities(toolID, 1, true);
             }
             catch (Exception ex)
             {
@@ -80,11 +78,8 @@ namespace ToolManagementAppV2.Services.Rentals
                         new SQLiteParameter("@DueDate", dueDate)
                     });
 
-                SqliteHelper.ExecuteNonQuery(conn, tx,
-                    "UPDATE Tools SET AvailableQuantity = AvailableQuantity - 1, RentedQuantity = RentedQuantity + 1 WHERE ToolID = @ToolID",
-                    new[] { new SQLiteParameter("@ToolID", toolID) });
-
                 tx.Commit();
+                _toolService.UpdateToolQuantities(toolID, 1, true);
             }
             catch (Exception ex)
             {
@@ -108,14 +103,16 @@ namespace ToolManagementAppV2.Services.Rentals
                         new SQLiteParameter("@RentalID", rentalID)
                     });
 
-                var toolRows = SqliteHelper.ExecuteNonQuery(conn, tx,
-                    "UPDATE Tools SET AvailableQuantity=AvailableQuantity+1, RentedQuantity=RentedQuantity-1 WHERE ToolID=(SELECT ToolID FROM Rentals WHERE RentalID=@RentalID)",
-                    new[] { new SQLiteParameter("@RentalID", rentalID) });
+                var cmd = new SQLiteCommand("SELECT ToolID FROM Rentals WHERE RentalID=@RentalID", conn, tx);
+                cmd.Parameters.AddWithValue("@RentalID", rentalID);
+                var toolIdObj = cmd.ExecuteScalar();
+                var toolID = toolIdObj?.ToString();
 
-                if (rentalRows == 0 || toolRows == 0)
+                if (rentalRows == 0 || string.IsNullOrEmpty(toolID))
                     throw new InvalidOperationException("Return operation failed.");
 
                 tx.Commit();
+                _toolService.UpdateToolQuantities(toolID, 1, false);
             }
             catch (Exception ex)
             {
@@ -146,11 +143,8 @@ namespace ToolManagementAppV2.Services.Rentals
                         new SQLiteParameter("@RentalID", rentalID)
                     });
 
-                SqliteHelper.ExecuteNonQuery(conn, tx,
-                    "UPDATE Tools SET AvailableQuantity=AvailableQuantity+1,RentedQuantity=RentedQuantity-1 WHERE ToolID=@ToolID",
-                    new[] { new SQLiteParameter("@ToolID", toolID) });
-
                 tx.Commit();
+                _toolService.UpdateToolQuantities(toolID, 1, false);
             }
             catch (Exception ex)
             {

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -327,7 +327,10 @@ namespace ToolManagementAppV2.ViewModels
 
         public void LoadTools()
         {
+            var selectedId = SelectedTool?.ToolID;
             Tools.ReplaceRange(_toolService.GetAllTools());
+            if (!string.IsNullOrEmpty(selectedId))
+                SelectedTool = Tools.FirstOrDefault(t => t.ToolID == selectedId);
             UpdateSummaries();
         }
 


### PR DESCRIPTION
## Summary
- expose `UpdateToolQuantities` on `IToolService`
- use the new interface in `RentalService`
- keep the selected tool when the tool list refreshes
- update constructors and tests for new dependency
- add unit tests covering quantity updates and selection

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ca34b348083249f7c22271089162e