### PR TITLE
Fix search results resizing

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/SearchResultsResizeTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/SearchResultsResizeTests.cs
@@ -1,0 +1,22 @@
+using System.Windows;
+using ToolManagementAppV2;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Tests
+{
+    public class SearchResultsResizeTests
+    {
+        [Fact]
+        public void SearchResultsList_SizeChanged_UpdatesTileWidth()
+        {
+            var window = new MainWindow();
+            var vm = Assert.IsType<MainViewModel>(window.DataContext);
+
+            var args = new SizeChangedEventArgs(FrameworkElement.SizeChangedEvent, new Size(0, 0), new Size(1000, 0));
+            window.SearchResultsList_SizeChanged(window.SearchResultsList, args);
+
+            Assert.Equal(180, vm.SearchTileWidth);
+        }
+    }
+}

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -7,7 +7,8 @@
         Title="Tool Inventory Management"
         Height="750"
         Width="1600"
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen"
+        SizeChanged="MainWindow_SizeChanged">
     <DockPanel Margin="10">
         <!-- Global Resources -->
         <DockPanel.Resources>

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -708,6 +708,19 @@ namespace ToolManagementAppV2
             }
         }
 
+        void MainWindow_SizeChanged(object s, SizeChangedEventArgs e)
+        {
+            if (DataContext is MainViewModel vm && SearchResultsList != null)
+            {
+                var width = SearchResultsList.ActualWidth;
+                if (width > 0)
+                {
+                    var itemWidth = Math.Clamp(width / 5 - 20, 120, 300);
+                    vm.SearchTileWidth = itemWidth;
+                }
+            }
+        }
+
         static T FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
         {
             for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)


### PR DESCRIPTION
## Summary
- update MainWindow to handle window resizing
- recalc tool tile width when window size changes
- test search results resizing logic

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687caa504bc8832483149b8fe7176ef8