### PR TITLE
Fix search tab preload

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/SearchTabPreloadTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/SearchTabPreloadTests.cs
@@ -1,0 +1,16 @@
+using Xunit;
+using System.Windows.Controls;
+using System.Linq;
+
+namespace ToolManagementAppV2.Tests.Tests
+{
+    public class SearchTabPreloadTests
+    {
+        [Fact]
+        public void SearchResultsList_IsLoadedOnStartup()
+        {
+            var window = new ToolManagementAppV2.MainWindow();
+            Assert.True(window.SearchResultsList.IsLoaded);
+        }
+    }
+}

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -8,7 +8,8 @@
         Height="750"
         Width="1600"
         WindowStartupLocation="CenterScreen"
-        SizeChanged="MainWindow_SizeChanged">
+        SizeChanged="MainWindow_SizeChanged"
+        Loaded="Window_Loaded">
     <DockPanel Margin="10">
         <!-- Global Resources -->
         <DockPanel.Resources>

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -74,6 +74,22 @@ namespace ToolManagementAppV2
             }
         }
 
+        void Window_Loaded(object s, RoutedEventArgs e)
+            => PreloadSearchTab();
+
+        void PreloadSearchTab()
+        {
+            var searchTab = MyTabControl.Items.OfType<TabItem>().FirstOrDefault(t => t.Header!.ToString() == "Tool Search");
+            if (searchTab == null)
+                return;
+
+            var current = MyTabControl.SelectedItem;
+            MyTabControl.SelectedItem = searchTab;
+            searchTab.UpdateLayout();
+            MyTabControl.UpdateLayout();
+            MyTabControl.SelectedItem = current;
+        }
+
         // ---------- Printing ----------
         void PrintInventoryReport_Click(object s, RoutedEventArgs e)
             => PrintReport(_reportService.GenerateInventoryReport(), "Inventory Report");


### PR DESCRIPTION
## Summary
- load the search tab as soon as the window opens so search results appear instantly
- add a unit test verifying the search list is loaded at startup

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbbd14f3883249fb018894c79d90e