### PR TITLE
Fix tool edit refresh

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
@@ -327,5 +327,33 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void StartAndStopAutoRefresh_ToggleProperty()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
+                ISettingsService settingsService = new SettingsService(db);
+                ActivityLogService logService = new ActivityLogService(db);
+
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, settingsService, logService);
+                Assert.True(vm.IsAutoRefreshEnabled);
+                vm.StopAutoRefresh();
+                Assert.False(vm.IsAutoRefreshEnabled);
+                vm.StartAutoRefresh();
+                Assert.True(vm.IsAutoRefreshEnabled);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -768,27 +768,49 @@ namespace ToolManagementAppV2
             switch (tab.Header)
             {
                 case "Search Tools":
-                case "Tool Management":
-                    if (DataContext is MainViewModel vm)
+                    if (DataContext is MainViewModel vmSearch)
                     {
-                        vm.LoadTools();
-                        vm.SearchCommand.Execute(null);
+                        vmSearch.LoadTools();
+                        vmSearch.SearchCommand.Execute(null);
+                        vmSearch.StartAutoRefresh();
+                    }
+                    break;
+                case "Tool Management":
+                    if (DataContext is MainViewModel vmManage)
+                    {
+                        vmManage.LoadTools();
+                        vmManage.SearchCommand.Execute(null);
+                        vmManage.StopAutoRefresh();
                     }
                     break;
                 case "Customers":
                     RefreshCustomerList();
+                    if (DataContext is MainViewModel vmCust)
+                        vmCust.StartAutoRefresh();
                     break;
                 case "Rentals":
                     RefreshRentalList();
+                    if (DataContext is MainViewModel vmRent)
+                        vmRent.StartAutoRefresh();
                     break;
                 case "Users":
                     RefreshUserList();
+                    if (DataContext is MainViewModel vmUser)
+                        vmUser.StartAutoRefresh();
                     break;
                 case "Settings":
                     LoadSettings();
+                    if (DataContext is MainViewModel vmSet)
+                        vmSet.StartAutoRefresh();
                     break;
                 case "Activity Logs":
                     RefreshLogsButton_Click(s, e);
+                    if (DataContext is MainViewModel vmLog)
+                        vmLog.StartAutoRefresh();
+                    break;
+                case "Dashboard":
+                    if (DataContext is MainViewModel vmDash)
+                        vmDash.StartAutoRefresh();
                     break;
             }
         }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -24,6 +24,24 @@ namespace ToolManagementAppV2.ViewModels
     public class MainViewModel : ObservableObject
     {
         readonly DispatcherTimer _refreshTimer;
+        bool _isAutoRefreshEnabled;
+        public bool IsAutoRefreshEnabled
+        {
+            get => _isAutoRefreshEnabled;
+            private set
+            {
+                if (SetProperty(ref _isAutoRefreshEnabled, value))
+                {
+                    if (value)
+                        _refreshTimer.Start();
+                    else
+                        _refreshTimer.Stop();
+                }
+            }
+        }
+
+        public void StartAutoRefresh() => IsAutoRefreshEnabled = true;
+        public void StopAutoRefresh() => IsAutoRefreshEnabled = false;
         readonly IToolService _toolService;
         readonly IUserService _userService;
         readonly ICustomerService _customerService;
@@ -309,7 +327,7 @@ namespace ToolManagementAppV2.ViewModels
             InitializeData();
             _refreshTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(2) };
             _refreshTimer.Tick += (_, __) => { LoadTools(); LoadCheckedOutTools(); };
-            _refreshTimer.Start();
+            IsAutoRefreshEnabled = true;
         }
 
         void InitializeData()


### PR DESCRIPTION
## Summary
- stop auto refresh when editing tools
- restart auto refresh when switching away
- expose refresh state on `MainViewModel`
- test start/stop refresh toggles property

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cc19d6ef48324a24021d8e11075ad