### PR TITLE
Fix quantity sync and login flow

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolCheckOutTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolCheckOutTests.cs
@@ -1,0 +1,57 @@
+using System.IO;
+using System.Linq;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Interfaces;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Services
+{
+    public class ToolCheckOutTests
+    {
+        [Fact]
+        public void ToggleCheckOut_NoQuantity_DoesNothing()
+        {
+            var db = Path.GetTempFileName();
+            try
+            {
+                var service = new ToolService(new DatabaseService(db));
+                service.AddTool(new Tool { ToolNumber = "T1", QuantityOnHand = 0 });
+                var tool = service.GetAllTools().First();
+                service.ToggleToolCheckOutStatus(tool.ToolID, "u");
+                var updated = service.GetToolByID(tool.ToolID);
+                Assert.False(updated.IsCheckedOut);
+                Assert.Equal(0, updated.QuantityOnHand);
+            }
+            finally
+            {
+                if (File.Exists(db)) File.Delete(db);
+            }
+        }
+
+        [Fact]
+        public void ToggleCheckOut_UpdatesQuantity()
+        {
+            var db = Path.GetTempFileName();
+            try
+            {
+                IToolService svc = new ToolService(new DatabaseService(db));
+                svc.AddTool(new Tool { ToolNumber = "T2", QuantityOnHand = 1 });
+                var tool = svc.GetAllTools().First();
+                svc.ToggleToolCheckOutStatus(tool.ToolID, "u");
+                var outTool = svc.GetToolByID(tool.ToolID);
+                Assert.True(outTool.IsCheckedOut);
+                Assert.Equal(0, outTool.QuantityOnHand);
+                svc.ToggleToolCheckOutStatus(tool.ToolID, "u");
+                var back = svc.GetToolByID(tool.ToolID);
+                Assert.False(back.IsCheckedOut);
+                Assert.Equal(1, back.QuantityOnHand);
+            }
+            finally
+            {
+                if (File.Exists(db)) File.Delete(db);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2.Tests/Tests/ZeroToDisabledConverterTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ZeroToDisabledConverterTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Globalization;
+using ToolManagementAppV2.Utilities.Converters;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests
+{
+    public class ZeroToDisabledConverterTests
+    {
+        [Fact]
+        public void Convert_Positive_ReturnsTrue()
+        {
+            var c = new ZeroToDisabledConverter();
+            Assert.True((bool)c.Convert(5, typeof(bool), null, CultureInfo.InvariantCulture));
+        }
+
+        [Fact]
+        public void Convert_ZeroOrNegative_ReturnsFalse()
+        {
+            var c = new ZeroToDisabledConverter();
+            Assert.False((bool)c.Convert(0, typeof(bool), null, CultureInfo.InvariantCulture));
+            Assert.False((bool)c.Convert(-1, typeof(bool), null, CultureInfo.InvariantCulture));
+        }
+
+        [Fact]
+        public void Convert_InvalidInput_ReturnsFalse()
+        {
+            var c = new ZeroToDisabledConverter();
+            Assert.False((bool)c.Convert("bad", typeof(bool), null, CultureInfo.InvariantCulture));
+        }
+
+        [Fact]
+        public void ConvertBack_Throws()
+        {
+            var c = new ZeroToDisabledConverter();
+            Assert.Throws<NotImplementedException>(() => c.ConvertBack(true, typeof(int), null, CultureInfo.InvariantCulture));
+        }
+    }
+}

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -5,18 +5,25 @@ namespace ToolManagementAppV2
 {
     public partial class App : System.Windows.Application
     {
-        protected override void OnStartup(StartupEventArgs e)
+        protected override async void OnStartup(StartupEventArgs e)
         {
-            // Prevent shutdown when the login window closes
             ShutdownMode = ShutdownMode.OnExplicitShutdown;
             base.OnStartup(e);
 
-            LoginWindow login = new LoginWindow();
-            bool? loginResult = login.ShowDialog();
+            var login = new LoginWindow();
+            login.Show();
 
-            if (loginResult == true)
+            var tcs = new System.Threading.Tasks.TaskCompletionSource<bool>();
+            void Handler(object s, System.EventArgs args)
             {
-                // Switch shutdown mode now that we are creating the main window
+                tcs.TrySetResult(login.DialogResult == true);
+                login.Closed -= Handler;
+            }
+            login.Closed += Handler;
+            bool result = await tcs.Task;
+
+            if (result)
+            {
                 ShutdownMode = ShutdownMode.OnMainWindowClose;
                 MainWindow mainWindow = new MainWindow();
                 Current.MainWindow = mainWindow;

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -16,10 +16,12 @@
             <local:CheckOutStatusConverter x:Key="CheckOutStatusConverter"/>
             <local:NullToDefaultImageConverter x:Key="NullToDefaultImageConverter"/>
             <local:InverseBooleanConverter x:Key="InverseBooleanConverter"/>
+            <local:ZeroToDisabledConverter x:Key="ZeroToDisabledConverter"/>
             <DataTemplate x:Key="CheckOutButtonTemplate">
                 <Button Content="{Binding IsCheckedOut, Converter={StaticResource CheckOutStatusConverter}}"
                 Click="CheckOutButton_Click"
-                CommandParameter="{Binding ToolID}" />
+                CommandParameter="{Binding ToolID}"
+                IsEnabled="{Binding QuantityOnHand, Converter={StaticResource ZeroToDisabledConverter}}" />
             </DataTemplate>
             <Style x:Key="ToolImageTooltipStyle" TargetType="Image">
                 <Setter Property="ToolTip">
@@ -120,7 +122,10 @@
                                 <xctk:WatermarkTextBox x:Name="SearchInput" Width="400" Margin="5" Watermark="Search Tools..." TextChanged="SearchInput_TextChanged" />
                                 <Button Content="Print Search" Click="PrintSearchResults_Click" Width="150" Margin="5"/>
                                 <Button Content="Print My Tools" Click="PrintMyCheckedOutTools_Click" Width="150" Margin="5"/>
-                                <Button Content="Rent Tool" Command="{Binding RentToolCommand}" Width="150" Margin="5"/>
+                                <Button Content="Rent Tool"
+                                        Command="{Binding RentToolCommand}"
+                                        Width="150" Margin="5"
+                                        IsEnabled="{Binding SelectedTool.QuantityOnHand, Converter={StaticResource ZeroToDisabledConverter}}"/>
                                 <Button Content="Rental History" Command="{Binding ViewRentalHistoryCommand}" Width="150" Margin="5"/>
                             </StackPanel>
                         </GroupBox>

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -50,11 +50,21 @@ namespace ToolManagementAppV2
 
             try
             {
-                ((MainViewModel)DataContext).LoadTools();
-                RefreshUserList();
-                RefreshCustomerList();
-                RefreshRentalList();
-                LoadSettings();
+                Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    try
+                    {
+                        ((MainViewModel)DataContext).LoadTools();
+                        RefreshUserList();
+                        RefreshCustomerList();
+                        RefreshRentalList();
+                        LoadSettings();
+                    }
+                    catch (Exception ex)
+                    {
+                        ShowError("Initialization Error", ex);
+                    }
+                }));
             }
             catch (Exception ex)
             {

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -46,7 +46,12 @@ namespace ToolManagementAppV2.Services.Rentals
                     });
 
                 tx.Commit();
-                _toolService.UpdateToolQuantities(toolID, 1, true);
+                var tool = _toolService.GetToolByID(toolID);
+                if (tool != null)
+                {
+                    tool.QuantityOnHand--;
+                    _toolService.UpdateTool(tool);
+                }
             }
             catch (Exception ex)
             {
@@ -79,7 +84,12 @@ namespace ToolManagementAppV2.Services.Rentals
                     });
 
                 tx.Commit();
-                _toolService.UpdateToolQuantities(toolID, 1, true);
+                var tool = _toolService.GetToolByID(toolID);
+                if (tool != null)
+                {
+                    tool.QuantityOnHand--;
+                    _toolService.UpdateTool(tool);
+                }
             }
             catch (Exception ex)
             {
@@ -112,7 +122,12 @@ namespace ToolManagementAppV2.Services.Rentals
                     throw new InvalidOperationException("Return operation failed.");
 
                 tx.Commit();
-                _toolService.UpdateToolQuantities(toolID, 1, false);
+                var tool = _toolService.GetToolByID(toolID);
+                if (tool != null)
+                {
+                    tool.QuantityOnHand++;
+                    _toolService.UpdateTool(tool);
+                }
             }
             catch (Exception ex)
             {
@@ -144,7 +159,12 @@ namespace ToolManagementAppV2.Services.Rentals
                     });
 
                 tx.Commit();
-                _toolService.UpdateToolQuantities(toolID, 1, false);
+                var tool = _toolService.GetToolByID(toolID);
+                if (tool != null)
+                {
+                    tool.QuantityOnHand++;
+                    _toolService.UpdateTool(tool);
+                }
             }
             catch (Exception ex)
             {

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -165,27 +165,34 @@ namespace ToolManagementAppV2.Services.Tools
         public void ToggleToolCheckOutStatus(string toolID, string currentUser)
         {
             using var conn = _dbService.CreateConnection();
-            var result = SqliteHelper.ExecuteScalar(conn,
-                "SELECT IsCheckedOut FROM Tools WHERE ToolID=@ID",
-                   new[] { new SQLiteParameter("@ID", toolID) });
-    
-            if (result == null)
+            var record = SqliteHelper.ExecuteReader(conn,
+                "SELECT IsCheckedOut, AvailableQuantity FROM Tools WHERE ToolID=@ID",
+                new[] { new SQLiteParameter("@ID", toolID) },
+                r => new { Out = Convert.ToInt32(r["IsCheckedOut"]) == 1, Qty = Convert.ToInt32(r["AvailableQuantity"]) }).FirstOrDefault();
+
+            if (record == null)
                 throw new InvalidOperationException($"Tool {toolID} not found.");
-    
-            var isOut = Convert.ToInt32(result) == 1;
-            var newStatus = isOut ? 0 : 1;
-            var time = isOut ? (object)DBNull.Value : DateTime.Now;
-            var by = isOut ? (object)DBNull.Value : currentUser;
+
+            if (!record.Out && record.Qty <= 0)
+                return;
+
+            var newStatus = record.Out ? 0 : 1;
+            var time = record.Out ? (object)DBNull.Value : DateTime.Now;
+            var by = record.Out ? (object)DBNull.Value : currentUser;
+            var qtyChange = record.Out ? 1 : -1;
+
             SqliteHelper.ExecuteNonQuery(conn, @"
                 UPDATE Tools SET
                   IsCheckedOut = @Out,
                   CheckedOutBy = @By,
-                  CheckedOutTime = @Time
+                  CheckedOutTime = @Time,
+                  AvailableQuantity = AvailableQuantity + @Q
                 WHERE ToolID = @ID", new[]
             {
                 new SQLiteParameter("@Out", newStatus),
                 new SQLiteParameter("@By", by),
                 new SQLiteParameter("@Time", time),
+                new SQLiteParameter("@Q", qtyChange),
                 new SQLiteParameter("@ID", toolID)
             });
             _cache = null;

--- a/ToolManagementAppV2/Utilities/Converters/ZeroToDisabledConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/ZeroToDisabledConverter.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace ToolManagementAppV2.Utilities.Converters
+{
+    public class ZeroToDisabledConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value is int qty && qty > 0;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- async login startup
- load data after window shown
- update checkout/rental quantity logic
- disable actions when quantity is zero
- add converter and unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cc34510d08324aebb27e56607145b