### PR TITLE
Fix login window dialog handling

### DIFF
--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -5,24 +5,15 @@ namespace ToolManagementAppV2
 {
     public partial class App : System.Windows.Application
     {
-        protected override async void OnStartup(StartupEventArgs e)
+        protected override void OnStartup(StartupEventArgs e)
         {
             ShutdownMode = ShutdownMode.OnExplicitShutdown;
             base.OnStartup(e);
 
             var login = new LoginWindow();
-            login.Show();
+            bool? result = login.ShowDialog();
 
-            var tcs = new System.Threading.Tasks.TaskCompletionSource<bool>();
-            void Handler(object s, System.EventArgs args)
-            {
-                tcs.TrySetResult(login.DialogResult == true);
-                login.Closed -= Handler;
-            }
-            login.Closed += Handler;
-            bool result = await tcs.Task;
-
-            if (result)
+            if (result == true)
             {
                 ShutdownMode = ShutdownMode.OnMainWindowClose;
                 MainWindow mainWindow = new MainWindow();


### PR DESCRIPTION
## Summary
- show `LoginWindow` as a modal dialog when application starts

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e074c2c008324925823e2ecbee257