### PR TITLE
Enable virtualization for user and search lists

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/MapUserLoggingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/MapUserLoggingTests.cs
@@ -31,7 +31,7 @@ namespace ToolManagementAppV2.Tests
                 {
                     Console.SetOut(original);
                 }
-                Assert.NotEqual(string.Empty, sw.ToString());
+                Assert.Equal(string.Empty, sw.ToString());
             }
             finally
             {
@@ -60,7 +60,7 @@ namespace ToolManagementAppV2.Tests
                 {
                     Console.SetOut(original);
                 }
-                Assert.NotEqual(string.Empty, sw.ToString());
+                Assert.Equal(string.Empty, sw.ToString());
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Tests/SearchResultsTileTemplateTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/SearchResultsTileTemplateTests.cs
@@ -14,7 +14,7 @@ namespace ToolManagementAppV2.Tests.Tests
             var template = Assert.IsType<DataTemplate>(window.Resources["ToolTileTemplate"]);
             Assert.Same(template, window.SearchResultsList.ItemTemplate);
             var panel = window.SearchResultsList.ItemsPanel.LoadContent();
-            Assert.IsType<WrapPanel>(panel);
+            Assert.IsType<VirtualizingStackPanel>(panel);
             Assert.Equal(ScrollBarVisibility.Disabled, ScrollViewer.GetVerticalScrollBarVisibility(window.SearchResultsList));
             Assert.Equal(ScrollBarVisibility.Auto, ScrollViewer.GetHorizontalScrollBarVisibility(window.SearchResultsList));
         }

--- a/ToolManagementAppV2.Tests/ViewModels/AvatarSelectionTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/AvatarSelectionTests.cs
@@ -40,7 +40,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 var updated = userService.GetUserByID(added.UserID);
                 Assert.Equal(Path.Combine("Resources", "Avatars", "1.png"), updated.UserPhotoPath);
-                Assert.NotNull(updated.PhotoBitmap);
+                Assert.Null(updated.PhotoBitmap);
             }
             finally
             {

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -142,7 +142,7 @@
                       ItemTemplate="{StaticResource ToolTileTemplate}">
                                 <ListView.ItemsPanel>
                                     <ItemsPanelTemplate>
-                                        <WrapPanel/>
+                                        <VirtualizingStackPanel/>
                                     </ItemsPanelTemplate>
                                 </ListView.ItemsPanel>
                             </ListView>
@@ -398,7 +398,7 @@
 
                                 <StackPanel Orientation="Horizontal" Margin="5">
                                     <Border Width="100" Height="100" BorderBrush="Gray" BorderThickness="1">
-                                        <Image Source="{Binding SelectedUser.PhotoBitmap, ConverterParameter=User, Converter={StaticResource NullToDefaultImageConverter}}" Stretch="UniformToFill"/>
+                                        <Image Source="{Binding SelectedUser.UserPhotoPath, ConverterParameter=User, Converter={StaticResource NullToDefaultImageConverter}}" Stretch="UniformToFill"/>
                                     </Border>
                                     <Button Content="Change Photo" Command="{Binding UploadUserPhotoCommand}" Margin="10,0,0,0" VerticalAlignment="Center"/>
                                 </StackPanel>

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -168,7 +168,7 @@ namespace ToolManagementAppV2.Services.Users
 
         User MapUser(IDataRecord rdr)
         {
-            var u = new User
+            return new User
             {
                 UserID = Convert.ToInt32(rdr["UserID"]),
                 UserName = rdr["UserName"].ToString(),
@@ -179,43 +179,9 @@ namespace ToolManagementAppV2.Services.Users
                 Phone = rdr["Phone"]?.ToString(),
                 Mobile = rdr["Mobile"]?.ToString(),
                 Address = rdr["Address"]?.ToString(),
-                Role = rdr["Role"]?.ToString()
+                Role = rdr["Role"]?.ToString(),
+                PhotoBitmap = null
             };
-
-            try
-            {
-                if (!string.IsNullOrWhiteSpace(u.UserPhotoPath))
-                {
-                    Uri uri;
-                    if (u.UserPhotoPath.StartsWith("pack://"))
-                        uri = new Uri(u.UserPhotoPath, UriKind.Absolute);
-                    else
-                    {
-                        var full = PathHelper.GetAbsolutePath(u.UserPhotoPath);
-                        if (string.IsNullOrEmpty(full) || !File.Exists(full))
-                        {
-                            u.PhotoBitmap = null;
-                            return u;
-                        }
-                        uri = new Uri(full, UriKind.Absolute);
-                    }
-
-                    var bmp = new BitmapImage();
-                    bmp.BeginInit();
-                    bmp.UriSource = uri;
-                    bmp.CacheOption = BitmapCacheOption.OnLoad;
-                    bmp.CreateOptions = BitmapCreateOptions.IgnoreImageCache;
-                    bmp.EndInit();
-                    u.PhotoBitmap = bmp;
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex);
-                u.PhotoBitmap = null;
-            }
-
-            return u;
         }
     }
 }

--- a/ToolManagementAppV2/Views/LoginWindow.xaml
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml
@@ -66,7 +66,7 @@
                 </ListBox.ItemContainerStyle>
                 <ListBox.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center"/>
+                        <VirtualizingStackPanel Orientation="Vertical"/>
                     </ItemsPanelTemplate>
                 </ListBox.ItemsPanel>
                 <ListBox.ItemTemplate>
@@ -77,7 +77,7 @@
                                     Background="Transparent"
                                     BorderThickness="0">
                                 <StackPanel>
-                                    <Image Source="{Binding PhotoBitmap,
+                                    <Image Source="{Binding UserPhotoPath,
                                                    Converter={StaticResource NullToDefaultImageConverter},
                                                    ConverterParameter=User}"
                                            Width="80" Height="80" Stretch="Uniform"/>


### PR DESCRIPTION
## Summary
- swap WrapPanels for VirtualizingStackPanels in Login and Main windows
- defer loading of avatar images until items are realized
- simplify `UserService.MapUser` to avoid bitmap creation
- update unit tests for new behaviour

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e1cbdda2c8324a60a101c1b21e351