### PR TITLE
Add indexes for common search columns

### DIFF
--- a/ToolManagementAppV2.Tests/Services/DatabaseIndexTests.cs
+++ b/ToolManagementAppV2.Tests/Services/DatabaseIndexTests.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using ToolManagementAppV2.Services.Core;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Services
+{
+    public class DatabaseIndexTests
+    {
+        [Fact]
+        public void InitializeDatabase_CreatesIndexes()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                Assert.True(SqliteHelper.IndexExists(db.ConnectionString, "idx_Tools_ToolNumber"));
+                Assert.True(SqliteHelper.IndexExists(db.ConnectionString, "idx_Users_UserName"));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -1,5 +1,6 @@
-﻿using System.Data.SQLite;
+using System.Data.SQLite;
 using System.IO;
+using System;
 
 namespace ToolManagementAppV2.Services.Core
 {
@@ -101,6 +102,9 @@ namespace ToolManagementAppV2.Services.Core
                 );";
             using var cmd = new SQLiteCommand(sql, conn);
             cmd.ExecuteNonQuery();
+
+            EnsureIndex(conn, "Tools", "ToolNumber");
+            EnsureIndex(conn, "Users", "UserName");
         }
 
         void EnsureColumn(string table, string column, string type)
@@ -117,6 +121,29 @@ namespace ToolManagementAppV2.Services.Core
                 if (ex.Message.Contains("duplicate column name", StringComparison.OrdinalIgnoreCase))
                 {
                     // Column already exists due to a race condition; safe to ignore
+                }
+                else
+                {
+                    Console.WriteLine(ex);
+                    throw;
+                }
+            }
+        }
+
+        void EnsureIndex(SQLiteConnection conn, string table, string column)
+        {
+            var indexName = $"idx_{table}_{column}";
+            if (SqliteHelper.IndexExists(conn, indexName)) return;
+            try
+            {
+                using var cmd = new SQLiteCommand($"CREATE INDEX {indexName} ON {table}({column})", conn);
+                cmd.ExecuteNonQuery();
+            }
+            catch (SQLiteException ex)
+            {
+                if (ex.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Index already exists due to a race condition; safe to ignore
                 }
                 else
                 {

--- a/ToolManagementAppV2/Services/Core/SqliteHelper.cs
+++ b/ToolManagementAppV2/Services/Core/SqliteHelper.cs
@@ -81,5 +81,20 @@ namespace ToolManagementAppV2.Services.Core
                     return true;
             return false;
         }
+
+        public static bool IndexExists(string connStr, string indexName)
+        {
+            using var conn = new SQLiteConnection(connStr);
+            conn.Open();
+            return IndexExists(conn, indexName);
+        }
+
+        public static bool IndexExists(SQLiteConnection conn, string indexName)
+        {
+            using var cmd = new SQLiteCommand("SELECT name FROM sqlite_master WHERE type='index' AND name=@name", conn);
+            cmd.Parameters.AddWithValue("@name", indexName);
+            using var rdr = cmd.ExecuteReader();
+            return rdr.Read();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend database initialization to create indexes
- provide helper methods to check for existing indexes
- verify index creation with new unit test

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e20d7e56083249b142f3db82da1e2