### PR TITLE
Lazy load data on first tab visit

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/MainWindowTabBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/MainWindowTabBindingTests.cs
@@ -20,7 +20,7 @@ namespace ToolManagementAppV2.Tests.Tests
             Assert.Same(vm.Tools, window.ToolsList.ItemsSource);
 
             var tabControl = window.MyTabControl;
-            var searchTab = tabControl.Items.OfType<TabItem>().First(t => t.Header!.ToString() == "Search Tools");
+            var searchTab = tabControl.Items.OfType<TabItem>().First(t => t.Header!.ToString() == "Tool Search");
             var toolsTab = tabControl.Items.OfType<TabItem>().First(t => t.Header!.ToString() == "Tool Management");
 
             tabControl.SelectedItem = searchTab;

--- a/ToolManagementAppV2.Tests/Tests/SearchTabPreloadTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/SearchTabPreloadTests.cs
@@ -7,9 +7,15 @@ namespace ToolManagementAppV2.Tests.Tests
     public class SearchTabPreloadTests
     {
         [Fact]
-        public void SearchResultsList_IsLoadedOnStartup()
+        public void SearchResultsList_LoadsWhenTabOpened()
         {
             var window = new ToolManagementAppV2.MainWindow();
+            Assert.False(window.SearchResultsList.IsLoaded);
+
+            var searchTab = window.MyTabControl.Items.OfType<TabItem>().First(t => t.Header!.ToString() == "Tool Search");
+            window.MyTabControl.SelectedItem = searchTab;
+            window.MyTabControl_SelectionChanged(window.MyTabControl, new SelectionChangedEventArgs(TabControl.SelectionChangedEvent, null, null));
+
             Assert.True(window.SearchResultsList.IsLoaded);
         }
     }

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -66,19 +66,7 @@ namespace ToolManagementAppV2
         }
 
         void Window_Loaded(object s, RoutedEventArgs e)
-            => PreloadSearchTab();
-
-        void PreloadSearchTab()
         {
-            var searchTab = MyTabControl.Items.OfType<TabItem>().FirstOrDefault(t => t.Header!.ToString() == "Tool Search");
-            if (searchTab == null)
-                return;
-
-            var current = MyTabControl.SelectedItem;
-            MyTabControl.SelectedItem = searchTab;
-            searchTab.UpdateLayout();
-            MyTabControl.UpdateLayout();
-            MyTabControl.SelectedItem = current;
         }
 
         // ---------- Printing ----------
@@ -758,36 +746,55 @@ namespace ToolManagementAppV2
 
             switch (tab.Header)
             {
-                case "Search Tools":
+                case "Tool Search":
                     if (DataContext is MainViewModel vmSearch)
                     {
-                        vmSearch.LoadTools();
-                        vmSearch.SearchCommand.Execute(null);
+                        if (!vmSearch.ToolsLoaded)
+                        {
+                            vmSearch.LoadTools();
+                            vmSearch.SearchCommand.Execute(null);
+                        }
+                        vmSearch.LoadCheckedOutTools();
                         vmSearch.StartAutoRefresh();
                     }
                     break;
                 case "Tool Management":
                     if (DataContext is MainViewModel vmManage)
                     {
-                        vmManage.LoadTools();
-                        vmManage.SearchCommand.Execute(null);
+                        if (!vmManage.ToolsLoaded)
+                        {
+                            vmManage.LoadTools();
+                            vmManage.SearchCommand.Execute(null);
+                        }
                         vmManage.StopAutoRefresh();
                     }
                     break;
                 case "Customers":
-                    RefreshCustomerList();
                     if (DataContext is MainViewModel vmCust)
+                    {
+                        if (!vmCust.CustomersLoaded)
+                            vmCust.LoadCustomers();
                         vmCust.StartAutoRefresh();
+                    }
                     break;
                 case "Rentals":
-                    RefreshRentalList();
                     if (DataContext is MainViewModel vmRent)
+                    {
+                        if (!vmRent.RentalsLoaded)
+                        {
+                            vmRent.LoadActiveRentals();
+                            vmRent.LoadOverdueRentals();
+                        }
                         vmRent.StartAutoRefresh();
+                    }
                     break;
                 case "Users":
-                    RefreshUserList();
                     if (DataContext is MainViewModel vmUser)
+                    {
+                        if (!vmUser.UsersLoaded)
+                            vmUser.LoadUsers();
                         vmUser.StartAutoRefresh();
+                    }
                     break;
                 case "Settings":
                     LoadSettings();
@@ -820,24 +827,12 @@ namespace ToolManagementAppV2
         {
             try
             {
-                var toolsTask = Task.Run(() => _toolService.GetAllTools());
-                var usersTask = Task.Run(() => _userService.GetAllUsers());
-                var customersTask = Task.Run(() => _customerService.GetAllCustomers());
-                var rentalsTask = Task.Run(() => _rentalService.GetActiveRentals());
                 var settingsTask = Task.Run(() => _settingsService.GetAllSettings());
 
-                await Task.WhenAll(toolsTask, usersTask, customersTask, rentalsTask, settingsTask);
+                await settingsTask;
 
                 await Dispatcher.InvokeAsync(() =>
                 {
-                    if (DataContext is MainViewModel vm)
-                    {
-                        vm.Tools.ReplaceRange(toolsTask.Result);
-                        vm.SearchCommand.Execute(null);
-                        vm.Users.ReplaceRange(usersTask.Result);
-                        vm.Customers.ReplaceRange(customersTask.Result);
-                        vm.ActiveRentals.ReplaceRange(rentalsTask.Result);
-                    }
                     ApplySettings(settingsTask.Result);
                 });
             }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -53,6 +53,11 @@ namespace ToolManagementAppV2.ViewModels
         public ObservableCollection<ToolModel> SearchResults { get; } = new();
         public ObservableCollection<ToolModel> CheckedOutTools { get; } = new();
 
+        public bool ToolsLoaded { get; private set; }
+        public bool UsersLoaded { get; private set; }
+        public bool CustomersLoaded { get; private set; }
+        public bool RentalsLoaded { get; private set; }
+
         double _searchTileWidth = 200;
         public double SearchTileWidth
         {
@@ -327,20 +332,12 @@ namespace ToolManagementAppV2.ViewModels
             InitializeData();
             _refreshTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(2) };
             _refreshTimer.Tick += (_, __) => { LoadTools(); LoadCheckedOutTools(); };
-            IsAutoRefreshEnabled = true;
+            IsAutoRefreshEnabled = false;
         }
 
         void InitializeData()
         {
-            LoadTools();
-            SearchTools();
-            LoadCheckedOutTools();
-            LoadUsers();
             LoadCurrentUser();
-            LoadCustomers();
-            LoadActiveRentals();
-            LoadOverdueRentals();
-            UpdateSummaries();
         }
 
         public void LoadTools()
@@ -349,6 +346,7 @@ namespace ToolManagementAppV2.ViewModels
             Tools.ReplaceRange(_toolService.GetAllTools());
             if (!string.IsNullOrEmpty(selectedId))
                 SelectedTool = Tools.FirstOrDefault(t => t.ToolID == selectedId);
+            ToolsLoaded = true;
             UpdateSummaries();
         }
 
@@ -434,6 +432,7 @@ namespace ToolManagementAppV2.ViewModels
             Users.ReplaceRange(_userService.GetAllUsers());
             SelectedUser = Users.FirstOrDefault();
             OnPropertyChanged(nameof(IsLastAdmin));
+            UsersLoaded = true;
         }
 
         void LoadCurrentUser()
@@ -500,8 +499,6 @@ namespace ToolManagementAppV2.ViewModels
                     CurrentUserPhoto = bmp;
                 }
             }
-
-            LoadCheckedOutTools();
         }
 
         void ChooseProfilePic() => UploadPhotoForUser((UserModel)System.Windows.Application.Current.Properties["CurrentUser"]);
@@ -551,6 +548,7 @@ namespace ToolManagementAppV2.ViewModels
         public void LoadCustomers()
         {
             Customers.ReplaceRange(_customerService.GetAllCustomers());
+            CustomersLoaded = true;
             UpdateSummaries();
         }
 
@@ -702,12 +700,14 @@ namespace ToolManagementAppV2.ViewModels
         {
             ActiveRentals.ReplaceRange(_rentalService.GetActiveRentals());
             SelectedRental = null;
+            RentalsLoaded = true;
             UpdateSummaries();
         }
 
         void LoadOverdueRentals()
         {
             OverdueRentals.ReplaceRange(_rentalService.GetOverdueRentals());
+            RentalsLoaded = true;
             UpdateSummaries();
         }
 


### PR DESCRIPTION
## Summary
- defer loading of tools, users, customers and rentals until their tab is opened
- remove the `PreloadSearchTab` helper and update tab change logic
- adjust MainViewModel initialization and add flags tracking whether data was loaded
- update tests for new behaviour

## Testing
- `dotnet test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e23196a90832495b218449e9fe425