### PR TITLE
Fix access modifiers for rental loading

### DIFF
--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -350,7 +350,7 @@ namespace ToolManagementAppV2.ViewModels
             UpdateSummaries();
         }
 
-        void LoadCheckedOutTools()
+        public void LoadCheckedOutTools()
         {
             if (!string.IsNullOrWhiteSpace(CurrentUserName))
                 CheckedOutTools.ReplaceRange(_toolService.GetToolsCheckedOutBy(CurrentUserName));
@@ -704,7 +704,7 @@ namespace ToolManagementAppV2.ViewModels
             UpdateSummaries();
         }
 
-        void LoadOverdueRentals()
+        public void LoadOverdueRentals()
         {
             OverdueRentals.ReplaceRange(_rentalService.GetOverdueRentals());
             RentalsLoaded = true;


### PR DESCRIPTION
## Summary
- make `LoadCheckedOutTools` and `LoadOverdueRentals` public so MainWindow can access them

## Testing
- `dotnet test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e9b887d9883249c578e8fe870efcc