### PR TITLE
Fix invalid DialogResult usage

### DIFF
--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -20,7 +20,9 @@ namespace ToolManagementAppV2
                 if (login.DialogResult != true)
                     mainWindow.Close();
             };
-            login.Show();
+            // Display the login window modally so that DialogResult can be set
+            // without throwing an InvalidOperationException when the user logs in.
+            login.ShowDialog();
         }
     }
 }


### PR DESCRIPTION
## Summary
- show the login window using `ShowDialog` so it can set `DialogResult` safely

## Testing
- `dotnet test` *(fails: `command not found: dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_687e9e3b19b4832493a2858ee8144b3a