### PR TITLE
Fix orientation of lists

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/LoginWindowLayoutTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/LoginWindowLayoutTests.cs
@@ -1,0 +1,20 @@
+using System.Windows.Controls;
+using ToolManagementAppV2;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Tests
+{
+    public class LoginWindowLayoutTests
+    {
+        [Fact]
+        public void UsersListBox_UsesHorizontalStackPanel()
+        {
+            var window = new LoginWindow();
+            var panel = window.UsersListBox.ItemsPanel.LoadContent();
+            var stackPanel = Assert.IsType<VirtualizingStackPanel>(panel);
+            Assert.Equal(Orientation.Horizontal, stackPanel.Orientation);
+            Assert.Equal(ScrollBarVisibility.Auto, ScrollViewer.GetHorizontalScrollBarVisibility(window.UsersListBox));
+            Assert.Equal(ScrollBarVisibility.Disabled, ScrollViewer.GetVerticalScrollBarVisibility(window.UsersListBox));
+        }
+    }
+}

--- a/ToolManagementAppV2.Tests/Tests/SearchResultsTileTemplateTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/SearchResultsTileTemplateTests.cs
@@ -14,7 +14,8 @@ namespace ToolManagementAppV2.Tests.Tests
             var template = Assert.IsType<DataTemplate>(window.Resources["ToolTileTemplate"]);
             Assert.Same(template, window.SearchResultsList.ItemTemplate);
             var panel = window.SearchResultsList.ItemsPanel.LoadContent();
-            Assert.IsType<VirtualizingStackPanel>(panel);
+            var stackPanel = Assert.IsType<VirtualizingStackPanel>(panel);
+            Assert.Equal(Orientation.Horizontal, stackPanel.Orientation);
             Assert.Equal(ScrollBarVisibility.Disabled, ScrollViewer.GetVerticalScrollBarVisibility(window.SearchResultsList));
             Assert.Equal(ScrollBarVisibility.Auto, ScrollViewer.GetHorizontalScrollBarVisibility(window.SearchResultsList));
         }

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -142,7 +142,7 @@
                       ItemTemplate="{StaticResource ToolTileTemplate}">
                                 <ListView.ItemsPanel>
                                     <ItemsPanelTemplate>
-                                        <VirtualizingStackPanel/>
+                                        <VirtualizingStackPanel Orientation="Horizontal"/>
                                     </ItemsPanelTemplate>
                                 </ListView.ItemsPanel>
                             </ListView>

--- a/ToolManagementAppV2/Views/LoginWindow.xaml
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml
@@ -46,8 +46,8 @@
                      BorderThickness="0"
                      Background="Transparent"
                      HorizontalContentAlignment="Center"
-                     ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                     ScrollViewer.VerticalScrollBarVisibility="Auto"
+                     ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                     ScrollViewer.VerticalScrollBarVisibility="Disabled"
                      MaxHeight="350">
                 <ListBox.ItemContainerStyle>
                     <Style TargetType="ListBoxItem">
@@ -66,7 +66,7 @@
                 </ListBox.ItemContainerStyle>
                 <ListBox.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <VirtualizingStackPanel Orientation="Vertical"/>
+                        <VirtualizingStackPanel Orientation="Horizontal"/>
                     </ItemsPanelTemplate>
                 </ListBox.ItemsPanel>
                 <ListBox.ItemTemplate>


### PR DESCRIPTION
## Summary
- show login users horizontally
- display search results horizontally
- check list orientations in tests

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ea11dcdcc8324b053c8f363adac3d