### PR TITLE
Fix image importer selector

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Collections.Generic;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
@@ -88,7 +89,7 @@ namespace ToolManagementAppV2.Tests.Services
                 File.WriteAllText(Path.Combine(imgDir, "T2.jpg"), string.Empty);
                 File.WriteAllText(Path.Combine(imgDir, "X.jpg"), string.Empty);
 
-                var result = svc.ImportToolImages(imgDir, t => t.ToolNumber);
+                var result = svc.ImportToolImages(imgDir, t => new[] { t.ToolNumber });
 
                 var all = svc.GetAllTools();
                 var t2 = all.First(t => t.ToolNumber == "T2");

--- a/ToolManagementAppV2.Tests/ViewModels/ImportToolPicturesCommandTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportToolPicturesCommandTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Collections.Generic;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Customers;
@@ -18,7 +19,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public bool ImportCalled { get; private set; }
         public TestToolService(DatabaseService db) : base(db) { }
-        public override ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, string> keySelector)
+        public override ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector)
         {
             ImportCalled = true;
             return new ImageImportResult();
@@ -35,7 +36,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         protected override bool ShowFolderDialog(out string folder) { folder = _folder; return true; }
-        protected override bool ShowImageImportOptions(out Func<ToolModel, string> selector) { selector = t => t.ToolNumber; return true; }
+        protected override bool ShowImageImportOptions(out Func<ToolModel, IEnumerable<string>> selector) { selector = t => new[] { t.ToolNumber }; return true; }
         protected override void ShowInfo(string msg) { }
     }
 

--- a/ToolManagementAppV2/Interfaces/IToolService.cs
+++ b/ToolManagementAppV2/Interfaces/IToolService.cs
@@ -19,7 +19,7 @@ namespace ToolManagementAppV2.Interfaces
         void UpdateToolImage(string toolID, string imagePath);
         List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map);
         void ExportToolsToCsv(string filePath);
-        ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, string> keySelector);
+        ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector);
         void UpdateToolQuantities(string toolID, int qtyChange, bool isRental);
     }
 }

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -234,16 +234,28 @@ namespace ToolManagementAppV2.Services.Tools
             CsvHelperUtil.ExportToolsToCsv(filePath, tools);
         }
 
-        public virtual ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, string> keySelector)
+        public virtual ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector)
         {
             var result = new ImageImportResult();
             if (string.IsNullOrWhiteSpace(folderPath) || keySelector == null)
                 return result;
 
             var tools = GetAllTools();
-            var groups = tools
-                .GroupBy(t => (keySelector(t) ?? string.Empty).ToUpperInvariant())
-                .ToDictionary(g => g.Key, g => g.ToList());
+            var groups = new Dictionary<string, List<ToolModel>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var tool in tools)
+            {
+                var keys = keySelector(tool);
+                if (keys == null) continue;
+                foreach (var key in keys)
+                {
+                    var k = (key ?? string.Empty).Trim().ToUpperInvariant();
+                    if (string.IsNullOrEmpty(k))
+                        continue;
+                    if (!groups.TryGetValue(k, out var list))
+                        groups[k] = list = new List<ToolModel>();
+                    list.Add(tool);
+                }
+            }
 
             var destDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images");
             Directory.CreateDirectory(destDir);

--- a/ToolManagementAppV2/ViewModels/ImageImportMappingViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImageImportMappingViewModel.cs
@@ -16,15 +16,18 @@ namespace ToolManagementAppV2.ViewModels
         bool _useNameDescription;
         public bool UseNameDescription { get => _useNameDescription; set => SetProperty(ref _useNameDescription, value); }
 
-        public Func<ToolModel, string> BuildSelector()
+        public Func<ToolModel, IEnumerable<string>> BuildSelector()
         {
             return t =>
             {
-                var parts = new List<string>();
-                if (UseToolNumber) parts.Add(t.ToolNumber);
-                if (UsePartNumber) parts.Add(t.PartNumber);
-                if (UseNameDescription) parts.Add(t.NameDescription);
-                return string.Join("_", parts).Trim().ToUpperInvariant();
+                var keys = new List<string>();
+                if (UseToolNumber && !string.IsNullOrWhiteSpace(t.ToolNumber))
+                    keys.Add(t.ToolNumber.Trim().ToUpperInvariant());
+                if (UsePartNumber && !string.IsNullOrWhiteSpace(t.PartNumber))
+                    keys.Add(t.PartNumber.Trim().ToUpperInvariant());
+                if (UseNameDescription && !string.IsNullOrWhiteSpace(t.NameDescription))
+                    keys.Add(t.NameDescription.Trim().ToUpperInvariant());
+                return keys;
             };
         }
     }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -2,6 +2,7 @@
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Win32;
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.IO;
 using System;
 using System.Windows;
@@ -809,7 +810,7 @@ namespace ToolManagementAppV2.ViewModels
             return false;
         }
 
-        protected virtual bool ShowImageImportOptions(out Func<ToolModel, string> selector)
+        protected virtual bool ShowImageImportOptions(out Func<ToolModel, IEnumerable<string>> selector)
         {
             var win = new ImageImportMappingWindow();
             if (win.ShowDialog() == true)


### PR DESCRIPTION
## Summary
- allow tool image import to match on multiple fields individually
- update mapping UI ViewModel to build selector returning multiple keys
- adjust `ToolService.ImportToolImages` to accept multiple keys
- change interface and command tests for new delegate type

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687efba399748324a8895d0e125463db