### PR TITLE
Implement unique ToolNumber enforcement

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -71,6 +71,27 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
+        public void AddTool_DuplicateToolNumber_Throws()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                IToolService service = new ToolService(dbService);
+
+                service.AddTool(new Tool { ToolNumber = "T1" });
+
+                var dup = new Tool { ToolNumber = "T1" };
+                Assert.Throws<InvalidOperationException>(() => service.AddTool(dup));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public void ImportToolImages_UpdatesImagePathsAndReportsIssues()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -103,7 +103,7 @@ namespace ToolManagementAppV2.Services.Core
             using var cmd = new SQLiteCommand(sql, conn);
             cmd.ExecuteNonQuery();
 
-            EnsureIndex(conn, "Tools", "ToolNumber");
+            EnsureIndex(conn, "Tools", "ToolNumber", true);
             EnsureIndex(conn, "Users", "UserName");
         }
 
@@ -130,13 +130,14 @@ namespace ToolManagementAppV2.Services.Core
             }
         }
 
-        void EnsureIndex(SQLiteConnection conn, string table, string column)
+        void EnsureIndex(SQLiteConnection conn, string table, string column, bool unique = false)
         {
             var indexName = $"idx_{table}_{column}";
             if (SqliteHelper.IndexExists(conn, indexName)) return;
             try
             {
-                using var cmd = new SQLiteCommand($"CREATE INDEX {indexName} ON {table}({column})", conn);
+                var uniqueSql = unique ? "UNIQUE" : string.Empty;
+                using var cmd = new SQLiteCommand($"CREATE {uniqueSql} INDEX {indexName} ON {table}({column})", conn);
                 cmd.ExecuteNonQuery();
             }
             catch (SQLiteException ex)

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -72,6 +72,8 @@ namespace ToolManagementAppV2.Services.Tools
     
         public void AddTool(ToolModel tool)
         {
+            if (ToolExists(tool.ToolNumber))
+                throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
             var p = new[]
             {
                 new SQLiteParameter("@ToolNumber", tool.ToolNumber),
@@ -95,6 +97,9 @@ namespace ToolManagementAppV2.Services.Tools
     
         public void UpdateTool(ToolModel tool)
         {
+            var dup = GetAllTools().Any(t => t.ToolNumber == tool.ToolNumber && t.ToolID != tool.ToolID);
+            if (dup)
+                throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
             const string sql = @"
                 UPDATE Tools SET
                   ToolNumber = @ToolNumber,


### PR DESCRIPTION
## Summary
- ensure unique index on ToolNumber
- check duplicate ToolNumber on add/update
- test duplicate ToolNumber handling

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687efc4bd1dc832482c8fa0bc024f22b