### PR TITLE
Fix avatar editing and window state

### DIFF
--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -8,6 +8,7 @@
         Height="750"
         Width="1600"
         WindowStartupLocation="CenterScreen"
+        WindowState="Maximized"
         SizeChanged="MainWindow_SizeChanged"
         Loaded="Window_Loaded">
     <DockPanel Margin="10">

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -98,8 +98,11 @@ namespace ToolManagementAppV2.ViewModels
             get => _selectedUser;
             set
             {
-                SetProperty(ref _selectedUser, value);
-                OnPropertyChanged(nameof(IsLastAdmin));
+                if (SetProperty(ref _selectedUser, value))
+                {
+                    OnPropertyChanged(nameof(IsLastAdmin));
+                    ((RelayCommand)UploadUserPhotoCommand).NotifyCanExecuteChanged();
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- enable avatar upload button when selecting users
- open main window maximized

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687efc766bfc832494cc406ca4b64a2b