### PR TITLE
Add draggable tab placement

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/TabPlacementBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/TabPlacementBindingTests.cs
@@ -1,0 +1,21 @@
+using System.Windows.Controls;
+using ToolManagementAppV2;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Tests
+{
+    public class TabPlacementBindingTests
+    {
+        [Fact]
+        public void ChangingTabPlacement_UpdatesTabStripPlacement()
+        {
+            var window = new MainWindow();
+            var vm = Assert.IsType<MainViewModel>(window.DataContext);
+
+            vm.TabPlacement = Dock.Right;
+
+            Assert.Equal(Dock.Right, window.MyTabControl.TabStripPlacement);
+        }
+    }
+}

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -80,7 +80,13 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <TabControl x:Name="MyTabControl" Margin="5" Grid.Row="0" SelectionChanged="MyTabControl_SelectionChanged">
+            <Grid Grid.Row="0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Thumb x:Name="TabPlacementThumb" Height="10" Cursor="SizeAll" DragDelta="TabPlacementThumb_DragDelta" />
+                <TabControl x:Name="MyTabControl" Margin="5" Grid.Row="1" SelectionChanged="MyTabControl_SelectionChanged" TabStripPlacement="{Binding TabPlacement}">
                 <TabItem Header="Dashboard">
                     <Grid Margin="10">
                         <Grid.RowDefinitions>
@@ -580,6 +586,7 @@
 
 
             </TabControl>
+            </Grid>
 
             <!-- Status Bar -->
             <StatusBar Grid.Row="1" Height="25" Background="LightGray">

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Windows.Controls.Primitives;
 using System.Linq;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Customers;
@@ -666,6 +667,21 @@ namespace ToolManagementAppV2
                 {
                     var itemWidth = Math.Clamp(width / 5 - 20, 120, 300);
                     vm.SearchTileWidth = itemWidth;
+                }
+            }
+        }
+
+        void TabPlacementThumb_DragDelta(object s, System.Windows.Controls.Primitives.DragDeltaEventArgs e)
+        {
+            if (DataContext is MainViewModel vm)
+            {
+                if (Math.Abs(e.HorizontalChange) > Math.Abs(e.VerticalChange))
+                {
+                    vm.TabPlacement = e.HorizontalChange > 0 ? Dock.Right : Dock.Left;
+                }
+                else
+                {
+                    vm.TabPlacement = e.VerticalChange > 0 ? Dock.Bottom : Dock.Top;
                 }
             }
         }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -65,6 +65,13 @@ namespace ToolManagementAppV2.ViewModels
             get => _searchTileWidth;
             set => SetProperty(ref _searchTileWidth, value);
         }
+
+        Dock _tabPlacement = Dock.Top;
+        public Dock TabPlacement
+        {
+            get => _tabPlacement;
+            set => SetProperty(ref _tabPlacement, value);
+        }
         ToolModel _selectedTool;
         public ToolModel SelectedTool
         {


### PR DESCRIPTION
## Summary
- add `TabPlacement` to `MainViewModel`
- bind `TabControl.TabStripPlacement` to `TabPlacement`
- add drag handle thumb and update placement via drag
- test that updating the view model updates the tab strip placement

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68805d6733308324a221a10d631ef472