### PR TITLE
Add docking for tab placement

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/TabPlacementBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/TabPlacementBindingTests.cs
@@ -16,6 +16,7 @@ namespace ToolManagementAppV2.Tests.Tests
             vm.TabPlacement = Dock.Right;
 
             Assert.Equal(Dock.Right, window.MyTabControl.TabStripPlacement);
+            Assert.Equal(Dock.Right, DockPanel.GetDock(window.TabPlacementThumb));
         }
     }
 }

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -81,12 +81,12 @@
             </Grid.RowDefinitions>
 
             <Grid Grid.Row="0">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <Thumb x:Name="TabPlacementThumb" Height="10" Cursor="SizeAll" DragDelta="TabPlacementThumb_DragDelta" />
-                <TabControl x:Name="MyTabControl" Margin="5" Grid.Row="1" SelectionChanged="MyTabControl_SelectionChanged" TabStripPlacement="{Binding TabPlacement}">
+                <DockPanel x:Name="TabDockPanel" LastChildFill="True">
+                    <Thumb x:Name="TabPlacementThumb" Width="10" Height="10" Cursor="SizeAll"
+                           DragDelta="TabPlacementThumb_DragDelta"
+                           DockPanel.Dock="{Binding TabPlacement}" />
+                    <TabControl x:Name="MyTabControl" Margin="5" SelectionChanged="MyTabControl_SelectionChanged"
+                                TabStripPlacement="{Binding TabPlacement}">
                 <TabItem Header="Dashboard">
                     <Grid Margin="10">
                         <Grid.RowDefinitions>
@@ -586,6 +586,7 @@
 
 
             </TabControl>
+                </DockPanel>
             </Grid>
 
             <!-- Status Bar -->


### PR DESCRIPTION
## Summary
- dock the main tab control to any screen edge
- test tab thumb dock binding

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688085a94d908324b83a9693cb7f6c87