### PR TITLE
Fix tab alignment and add test

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/TabPlacementBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/TabPlacementBindingTests.cs
@@ -17,6 +17,7 @@ namespace ToolManagementAppV2.Tests.Tests
 
             Assert.Equal(Dock.Right, window.MyTabControl.TabStripPlacement);
             Assert.Equal(Dock.Right, DockPanel.GetDock(window.TabPlacementThumb));
+            Assert.Equal(Dock.Right, DockPanel.GetDock(window.MyTabControl));
         }
     }
 }

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -85,8 +85,8 @@
                     <Thumb x:Name="TabPlacementThumb" Width="10" Height="10" Cursor="SizeAll"
                            DragDelta="TabPlacementThumb_DragDelta"
                            DockPanel.Dock="{Binding TabPlacement}" />
-                    <TabControl x:Name="MyTabControl" Margin="5" SelectionChanged="MyTabControl_SelectionChanged"
-                                TabStripPlacement="{Binding TabPlacement}">
+                    <TabControl x:Name="MyTabControl" Margin="0" SelectionChanged="MyTabControl_SelectionChanged"
+                                TabStripPlacement="{Binding TabPlacement}" DockPanel.Dock="{Binding TabPlacement}">
                 <TabItem Header="Dashboard">
                     <Grid Margin="10">
                         <Grid.RowDefinitions>


### PR DESCRIPTION
## Summary
- align TabControl with window edge and sync docking
- verify DockPanel.Dock of TabControl in unit test

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68809798772c83248f31b44ec00d61bf