### PR TITLE
Refactor tool search view with categorized poster layout

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
@@ -71,6 +71,34 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public void SearchCommand_SortsResultsIntoCategories()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db, toolService);
+                ISettingsService settingsService = new SettingsService(db);
+                ActivityLogService logService = new ActivityLogService(db);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, settingsService, logService);
+                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
+                toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Cordless Drill" });
+                vm.SearchTerm = string.Empty;
+                vm.SearchCommand.Execute(null);
+                Assert.Single(vm.HandTools);
+                Assert.Single(vm.PowerTools);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public void AddToolCommand_PersistsNewToolValues()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System;
 using System.Windows;
+using System.Linq;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using ToolManagementAppV2.Models.Domain;
@@ -52,6 +53,8 @@ namespace ToolManagementAppV2.ViewModels
 
         public ObservableCollection<ToolModel> Tools { get; } = new();
         public ObservableCollection<ToolModel> SearchResults { get; } = new();
+        public ObservableCollection<ToolModel> HandTools { get; } = new();
+        public ObservableCollection<ToolModel> PowerTools { get; } = new();
         public ObservableCollection<ToolModel> CheckedOutTools { get; } = new();
 
         public bool ToolsLoaded { get; private set; }
@@ -371,10 +374,12 @@ namespace ToolManagementAppV2.ViewModels
         public void LoadTools()
         {
             var selectedId = SelectedTool?.ToolID;
-            Tools.ReplaceRange(_toolService.GetAllTools());
+            var allTools = _toolService.GetAllTools();
+            Tools.ReplaceRange(allTools);
             if (!string.IsNullOrEmpty(selectedId))
                 SelectedTool = Tools.FirstOrDefault(t => t.ToolID == selectedId);
             ToolsLoaded = true;
+            CategorizeTools(allTools);
             UpdateSummaries();
         }
 
@@ -392,7 +397,20 @@ namespace ToolManagementAppV2.ViewModels
                 ? _toolService.GetAllTools()
                 : _toolService.SearchTools(SearchTerm);
             SearchResults.ReplaceRange(results);
+            CategorizeTools(results);
         }
+
+        void CategorizeTools(IEnumerable<ToolModel> tools)
+        {
+            HandTools.ReplaceRange(tools.Where(t => !IsPowerTool(t)));
+            PowerTools.ReplaceRange(tools.Where(IsPowerTool));
+        }
+
+        static bool IsPowerTool(ToolModel tool) =>
+            tool?.NameDescription?.Contains("power", StringComparison.OrdinalIgnoreCase) == true ||
+            tool?.NameDescription?.Contains("cordless", StringComparison.OrdinalIgnoreCase) == true ||
+            tool?.NameDescription?.Contains("electric", StringComparison.OrdinalIgnoreCase) == true ||
+            tool?.NameDescription?.Contains("drill", StringComparison.OrdinalIgnoreCase) == true;
 
         void AddTool()
         {

--- a/ToolManagementAppV2/Views/ToolSearchPage.xaml
+++ b/ToolManagementAppV2/Views/ToolSearchPage.xaml
@@ -1,7 +1,69 @@
 <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       x:Class="ToolManagementAppV2.Views.ToolSearchPage">
-    <Grid>
-        <TextBlock Text="Tool Search" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="32"/>
-    </Grid>
+    <Page.Resources>
+        <DataTemplate x:Key="ToolCardTemplate">
+            <Border Width="200" Height="300" Margin="5" Background="Gray" Cursor="Hand">
+                <Border.RenderTransform>
+                    <ScaleTransform ScaleX="1" ScaleY="1" />
+                </Border.RenderTransform>
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="RenderTransformOrigin" Value="0.5,0.5"/>
+                        <Style.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="RenderTransform">
+                                    <Setter.Value>
+                                        <ScaleTransform ScaleX="1.05" ScaleY="1.05" />
+                                    </Setter.Value>
+                                </Setter>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+                <Grid>
+                    <Image Source="{Binding ToolImagePath}" Stretch="UniformToFill"/>
+                    <Border Background="#80000000" VerticalAlignment="Bottom" Height="40">
+                        <TextBlock Text="{Binding NameDescription}" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                    </Border>
+                </Grid>
+            </Border>
+        </DataTemplate>
+    </Page.Resources>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel>
+            <TextBlock Text="Hand Tools" FontSize="24" Margin="10,0,10,5"/>
+            <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled" CanContentScroll="True">
+                <ItemsControl ItemsSource="{Binding HandTools}"
+                              VirtualizingStackPanel.IsVirtualizing="True"
+                              VirtualizingStackPanel.VirtualizationMode="Recycling"
+                              ScrollViewer.CanContentScroll="True">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel Orientation="Horizontal"/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <StaticResource ResourceKey="ToolCardTemplate"/>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+            <TextBlock Text="Power Tools" FontSize="24" Margin="10,20,10,5"/>
+            <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled" CanContentScroll="True">
+                <ItemsControl ItemsSource="{Binding PowerTools}"
+                              VirtualizingStackPanel.IsVirtualizing="True"
+                              VirtualizingStackPanel.VirtualizationMode="Recycling"
+                              ScrollViewer.CanContentScroll="True">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel Orientation="Horizontal"/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <StaticResource ResourceKey="ToolCardTemplate"/>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </StackPanel>
+    </ScrollViewer>
 </Page>


### PR DESCRIPTION
## Summary
- Display tool search results in poster-style cards grouped by Hand Tools and Power Tools categories.
- Add category collections to `MainViewModel` and categorize tools during load and search.
- Include unit test for category population.

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689843f43ad88324a53634093f930993