### PR TITLE
Modernize login layout with dark theme

### DIFF
--- a/ToolManagementAppV2/Resources/Styles.xaml
+++ b/ToolManagementAppV2/Resources/Styles.xaml
@@ -1,10 +1,57 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Theme Colors and Fonts -->
+    <Color x:Key="BackgroundColor">#FF121212</Color>
+    <!-- Application-wide dark background brush providing consistent contrast and easier maintenance -->
+    <SolidColorBrush x:Key="BackgroundBrush" Color="{StaticResource BackgroundColor}"/>
+    <Color x:Key="CardBackgroundColor">#AA1E1E1E</Color>
+    <!-- Semi-transparent surface for overlay cards; central resource ensures readable, maintainable theming -->
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}"/>
+    <!-- Primary accent color for interactive controls; high contrast and centralization aid accessibility and maintenance -->
+    <SolidColorBrush x:Key="AccentBrush" Color="#FF3A8FB7"/>
+    <SolidColorBrush x:Key="ForegroundBrush" Color="White"/>
+    <FontFamily x:Key="AppFont">Segoe UI</FontFamily>
+
+    <!-- Reusable focus visual style providing clear keyboard cues; defined once for accessibility and maintainability -->
+    <Style x:Key="DefaultFocusVisual" TargetType="Control">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Stroke="{StaticResource AccentBrush}" StrokeThickness="2" Margin="2" StrokeDashArray="1 2"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Base Button Style -->
     <Style TargetType="Button">
         <Setter Property="Margin" Value="5"/>
         <Setter Property="Padding" Value="10,4"/>
+        <Setter Property="FontFamily" Value="{StaticResource AppFont}"/>
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
+        <Setter Property="Background" Value="{StaticResource AccentBrush}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
     </Style>
+
+    <!-- Base TextBox Style with Validation -->
     <Style TargetType="TextBox">
         <Setter Property="Margin" Value="5"/>
+        <Setter Property="FontFamily" Value="{StaticResource AppFont}"/>
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
+        <Setter Property="Background" Value="#22FFFFFF"/>
+        <Setter Property="Validation.ErrorTemplate">
+            <Setter.Value>
+                <ControlTemplate>
+                    <DockPanel LastChildFill="True">
+                        <Border BorderBrush="Red" BorderThickness="1">
+                            <AdornedElementPlaceholder/>
+                        </Border>
+                    </DockPanel>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
     </Style>
+
 </ResourceDictionary>

--- a/ToolManagementAppV2/Views/LoginWindow.xaml
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="ToolManagementAppV2.LoginWindow"
+<Window x:Class="ToolManagementAppV2.LoginWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:ToolManagementAppV2.Utilities.Converters"
@@ -6,97 +6,118 @@
         Height="750" Width="1600"
         WindowState="Maximized"
         WindowStartupLocation="CenterScreen"
-        Background="White">
+        Background="{StaticResource BackgroundBrush}">
     <Window.Resources>
         <local:NullToDefaultImageConverter x:Key="NullToDefaultImageConverter"/>
-        <local:BooleanToAdminConverter    x:Key="BooleanToAdminConverter"/>
+        <local:BooleanToAdminConverter x:Key="BooleanToAdminConverter"/>
     </Window.Resources>
 
-    <DockPanel>
+    <Grid>
+        <!-- Full-bleed background image -->
+        <Image Source="pack://application:,,,/Resources/DefaultToolImage.png"
+               Stretch="UniformToFill"/>
 
-        <!-- HEADER -->
-        <Border DockPanel.Dock="Top" Background="#DDD" Padding="10">
-            <DockPanel>
-                <Image x:Name="LoginLogo" Width="50" Height="50" Margin="10"/>
-                <TextBlock x:Name="HeaderTitle"
-                           Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}"
-                           FontWeight="Bold"
-                           FontSize="20"
-                           VerticalAlignment="Center"
-                           Margin="10,0,0,0"/>
-            </DockPanel>
+        <!-- Translucent centered login card -->
+        <Border Background="{StaticResource CardBackgroundBrush}"
+                Padding="40"
+                CornerRadius="10"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- Header -->
+                <StackPanel Grid.Row="0" HorizontalAlignment="Center" Margin="0,0,0,20">
+                    <Image x:Name="LoginLogo" Width="80" Height="80" Margin="0,0,0,10"/>
+                    <TextBlock x:Name="HeaderTitle"
+                               Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}"
+                               FontWeight="Bold"
+                               FontSize="24"
+                               Foreground="{StaticResource ForegroundBrush}"
+                               HorizontalAlignment="Center"/>
+                    <TextBlock Text="Select User to Login:"
+                               FontSize="16"
+                               FontWeight="SemiBold"
+                               Margin="0,20,0,0"
+                               Foreground="{StaticResource ForegroundBrush}"
+                               HorizontalAlignment="Center"/>
+                </StackPanel>
+
+                <!-- User avatars -->
+                <ListBox x:Name="UsersListBox"
+                         Grid.Row="1"
+                         HorizontalAlignment="Center"
+                         BorderThickness="0"
+                         Background="Transparent"
+                         HorizontalContentAlignment="Center"
+                         ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
+                         MaxHeight="400">
+                    <ListBox.ItemContainerStyle>
+                        <Style TargetType="ListBoxItem">
+                            <Setter Property="Background" Value="Transparent"/>
+                            <Setter Property="BorderThickness" Value="0"/>
+                            <Setter Property="Margin" Value="10"/>
+                            <Setter Property="Padding" Value="0"/>
+                            <Setter Property="RenderTransformOrigin" Value="0.5,0.5"/>
+                            <Setter Property="RenderTransform">
+                                <Setter.Value>
+                                    <ScaleTransform ScaleX="0.8" ScaleY="0.8"/>
+                                </Setter.Value>
+                            </Setter>
+                            <Style.Triggers>
+                                <EventTrigger RoutedEvent="Loaded">
+                                    <BeginStoryboard>
+                                        <Storyboard>
+                                            <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                                             From="0" To="1" Duration="0:0:0.3"/>
+                                            <DoubleAnimation Storyboard.TargetProperty="RenderTransform.(ScaleTransform.ScaleX)"
+                                                             From="0.8" To="1" Duration="0:0:0.3"/>
+                                            <DoubleAnimation Storyboard.TargetProperty="RenderTransform.(ScaleTransform.ScaleY)"
+                                                             From="0.8" To="1" Duration="0:0:0.3"/>
+                                        </Storyboard>
+                                    </BeginStoryboard>
+                                </EventTrigger>
+                            </Style.Triggers>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+                        </Style>
+                    </ListBox.ItemContainerStyle>
+                    <ListBox.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <WrapPanel HorizontalAlignment="Center"/>
+                        </ItemsPanelTemplate>
+                    </ListBox.ItemsPanel>
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Width="120" Margin="5">
+                                <Button Click="UserButton_Click"
+                                        Tag="{Binding}"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        FocusVisualStyle="{StaticResource DefaultFocusVisual}">
+                                    <StackPanel>
+                                        <Image Source="{Binding UserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=User}"
+                                               Width="80" Height="80" Stretch="UniformToFill"/>
+                                        <TextBlock Text="{Binding UserName}"
+                                                   TextAlignment="Center"
+                                                   Margin="0,5,0,0"
+                                                   FontWeight="SemiBold"
+                                                   Foreground="{StaticResource ForegroundBrush}"/>
+                                        <TextBlock Text="{Binding IsAdmin, Converter={StaticResource BooleanToAdminConverter}}"
+                                                   FontSize="10"
+                                                   Foreground="Red"
+                                                   TextAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Grid>
         </Border>
-
-        <!-- CONTENT -->
-        <Grid Margin="10">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
-
-            <TextBlock Text="Select User to Login:"
-                       FontSize="16"
-                       FontWeight="SemiBold"
-                       Margin="0,0,0,10"
-                       HorizontalAlignment="Center"
-                       Grid.Row="0"/>
-
-            <ListBox x:Name="UsersListBox"
-                     Grid.Row="1"
-                     HorizontalAlignment="Center"
-                     BorderThickness="0"
-                     Background="Transparent"
-                     HorizontalContentAlignment="Center"
-                     ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                     ScrollViewer.VerticalScrollBarVisibility="Disabled"
-                     MaxHeight="350">
-                <ListBox.ItemContainerStyle>
-                    <Style TargetType="ListBoxItem">
-                        <Setter Property="Background" Value="Transparent"/>
-                        <Setter Property="BorderThickness" Value="0"/>
-                        <Setter Property="Padding" Value="0"/>
-                        <Setter Property="Margin" Value="0"/>
-                        <Setter Property="Template">
-                            <Setter.Value>
-                                <ControlTemplate TargetType="ListBoxItem">
-                                    <ContentPresenter/>
-                                </ControlTemplate>
-                            </Setter.Value>
-                        </Setter>
-                    </Style>
-                </ListBox.ItemContainerStyle>
-                <ListBox.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <VirtualizingStackPanel Orientation="Horizontal"/>
-                    </ItemsPanelTemplate>
-                </ListBox.ItemsPanel>
-                <ListBox.ItemTemplate>
-                    <DataTemplate>
-                        <StackPanel Width="120" Margin="5">
-                            <Button Click="UserButton_Click"
-                                    Tag="{Binding}"
-                                    Background="Transparent"
-                                    BorderThickness="0">
-                                <StackPanel>
-                                    <Image Source="{Binding UserPhotoPath,
-                                                   Converter={StaticResource NullToDefaultImageConverter},
-                                                   ConverterParameter=User}"
-                                           Width="80" Height="80" Stretch="Uniform"/>
-                                    <TextBlock Text="{Binding UserName}"
-                                               TextAlignment="Center"
-                                               Margin="0,5,0,0"
-                                               FontWeight="SemiBold"/>
-                                    <TextBlock Text="{Binding IsAdmin,
-                                                   Converter={StaticResource BooleanToAdminConverter}}"
-                                               FontSize="10"
-                                               Foreground="Red"
-                                               TextAlignment="Center"/>
-                                </StackPanel>
-                            </Button>
-                        </StackPanel>
-                    </DataTemplate>
-                </ListBox.ItemTemplate>
-            </ListBox>
-        </Grid>
-    </DockPanel>
+    </Grid>
 </Window>
+


### PR DESCRIPTION
## Summary
- Replace DockPanel-based login window with dark-themed full-bleed background and centered translucent card
- Use wrap layout and fade/scale transitions for avatar selection
- Add global theme resources for fonts, colors, focus visuals, and validation templates
- Document theme brushes and focus visuals to clarify accessibility and maintainability

## Testing
- `dotnet test` *(fails: command not found; dotnet SDK unavailable)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68984561f13c832495354b1a7843dce2