### PR TITLE
refactor: use commands for rent tool popup

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/RentToolPopupViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/RentToolPopupViewModelTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Linq;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.ViewModels.Rental;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class RentToolPopupViewModelTests
+    {
+        [Fact]
+        public void CheckOutCommand_SetsResultsAndRaisesClose()
+        {
+            var tool = new ToolModel();
+            var customer = new CustomerModel { CustomerID = 1, Company = "ACME" };
+            var vm = new RentToolPopupViewModel(tool, new[] { customer })
+            {
+                SelectedCustomer = customer,
+                SelectedDueDate = DateTime.Today.AddDays(3)
+            };
+
+            bool closed = false;
+            vm.RequestClose += (_, __) => closed = true;
+
+            vm.CheckOutCommand.Execute(null);
+
+            Assert.True(closed);
+            Assert.Equal(customer, vm.SelectedCustomerResult);
+            Assert.Equal(vm.SelectedDueDate, vm.SelectedDueDateResult);
+        }
+    }
+}
+

--- a/ToolManagementAppV2/ViewModels/RentToolPopupViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/RentToolPopupViewModel.cs
@@ -1,4 +1,5 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
 using ToolManagementAppV2.Models.Domain;
@@ -8,23 +9,34 @@ namespace ToolManagementAppV2.ViewModels.Rental
     public class RentToolPopupViewModel : ObservableObject
     {
         public ObservableCollection<CustomerModel> Customers { get; }
-        public CustomerModel SelectedCustomer { get; set; }
+        public CustomerModel? SelectedCustomer { get; set; }
         public DateTime SelectedDueDate { get; set; } = DateTime.Today.AddDays(7);
-        public event EventHandler RequestClose;
+        public event EventHandler? RequestClose;
 
-        public CustomerModel SelectedCustomerResult { get; private set; }
+        public CustomerModel? SelectedCustomerResult { get; private set; }
         public DateTime SelectedDueDateResult { get; private set; }
+
+        public IRelayCommand CheckOutCommand { get; }
+        public IRelayCommand CancelCommand { get; }
 
         public RentToolPopupViewModel(ToolModel tool, IEnumerable<CustomerModel> customers)
         {
             Customers = new ObservableCollection<CustomerModel>(customers);
+            CheckOutCommand = new RelayCommand(Confirm);
+            CancelCommand = new RelayCommand(Cancel);
         }
 
-        public void Confirm()
+        void Confirm()
         {
             SelectedCustomerResult = SelectedCustomer;
             SelectedDueDateResult = SelectedDueDate;
             RequestClose?.Invoke(this, EventArgs.Empty);
         }
+
+        void Cancel()
+        {
+            RequestClose?.Invoke(this, EventArgs.Empty);
+        }
     }
 }
+

--- a/ToolManagementAppV2/Views/RentToolPopup.xaml
+++ b/ToolManagementAppV2/Views/RentToolPopup.xaml
@@ -35,8 +35,8 @@
             <DatePicker SelectedDate="{Binding SelectedDueDate}" Grid.Row="1" Grid.Column="1" FontSize="16" Margin="0,0,0,10"/>
 
             <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
-                <Button Content="Cancel" Click="Cancel_Click" Width="150" Height="40" FontSize="16" Margin="5"/>
-                <Button Content="Confirm" Click="Confirm_Click" Width="150" Height="40" FontSize="16" Margin="5"/>
+                <Button Content="Cancel" Command="{Binding CancelCommand}" Width="150" Height="40" FontSize="16" Margin="5"/>
+                <Button Content="Confirm" Command="{Binding CheckOutCommand}" Width="150" Height="40" FontSize="16" Margin="5"/>
             </StackPanel>
         </Grid>
 

--- a/ToolManagementAppV2/Views/RentToolPopup.xaml.cs
+++ b/ToolManagementAppV2/Views/RentToolPopup.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows;
+using System.Windows;
 
 namespace ToolManagementAppV2.Views
 {
@@ -8,16 +8,6 @@ namespace ToolManagementAppV2.Views
         {
             InitializeComponent();
         }
-
-        private void Confirm_Click(object sender, RoutedEventArgs e)
-        {
-            if (DataContext is ViewModels.Rental.RentToolPopupViewModel vm)
-                vm.Confirm();
-        }
-
-        private void Cancel_Click(object sender, RoutedEventArgs e)
-        {
-            Close();
-        }
     }
 }
+


### PR DESCRIPTION
## Summary
- replace RentToolPopup button events with MVVM commands
- add ViewModel commands for checkout and cancel
- cover checkout command with unit test

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68984adf2bd08324ba65a8a35e97828a