### PR TITLE
Add adaptive layout and tile animations

### DIFF
--- a/ToolManagementAppV2/Views/ToolSearchPage.xaml
+++ b/ToolManagementAppV2/Views/ToolSearchPage.xaml
@@ -1,69 +1,126 @@
 <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      x:Class="ToolManagementAppV2.Views.ToolSearchPage">
+      x:Class="ToolManagementAppV2.Views.ToolSearchPage"
+      Loaded="Page_Loaded"
+      SizeChanged="Page_SizeChanged">
     <Page.Resources>
+        <!-- Card template with adaptive visuals and subtle animations -->
         <DataTemplate x:Key="ToolCardTemplate">
-            <Border Width="200" Height="300" Margin="5" Background="Gray" Cursor="Hand">
-                <Border.RenderTransform>
-                    <ScaleTransform ScaleX="1" ScaleY="1" />
-                </Border.RenderTransform>
-                <Border.Style>
-                    <Style TargetType="Border">
-                        <Setter Property="RenderTransformOrigin" Value="0.5,0.5"/>
-                        <Style.Triggers>
-                            <Trigger Property="IsMouseOver" Value="True">
-                                <Setter Property="RenderTransform">
-                                    <Setter.Value>
-                                        <ScaleTransform ScaleX="1.05" ScaleY="1.05" />
-                                    </Setter.Value>
-                                </Setter>
-                            </Trigger>
-                        </Style.Triggers>
-                    </Style>
-                </Border.Style>
+            <Grid Margin="5"
+                  Background="Gray"
+                  Cursor="Hand"
+                  Focusable="True"
+                  Opacity="0">
+                <Grid.RenderTransform>
+                    <ScaleTransform x:Name="TileScale" ScaleX="1" ScaleY="1"/>
+                </Grid.RenderTransform>
+                <Grid.Triggers>
+                    <!-- Fade and scale when loaded -->
+                    <EventTrigger RoutedEvent="FrameworkElement.Loaded">
+                        <BeginStoryboard>
+                            <Storyboard>
+                                <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                                 From="0" To="1" Duration="0:0:0.3"/>
+                                <DoubleAnimation Storyboard.TargetProperty="RenderTransform.(ScaleTransform.ScaleX)"
+                                                 From="0.9" To="1" Duration="0:0:0.3"/>
+                                <DoubleAnimation Storyboard.TargetProperty="RenderTransform.(ScaleTransform.ScaleY)"
+                                                 From="0.9" To="1" Duration="0:0:0.3"/>
+                            </Storyboard>
+                        </BeginStoryboard>
+                    </EventTrigger>
+                    <!-- Scale when tile gains focus -->
+                    <EventTrigger RoutedEvent="UIElement.GotFocus">
+                        <BeginStoryboard>
+                            <Storyboard>
+                                <DoubleAnimation Storyboard.TargetProperty="RenderTransform.(ScaleTransform.ScaleX)"
+                                                 To="1.05" Duration="0:0:0.1"/>
+                                <DoubleAnimation Storyboard.TargetProperty="RenderTransform.(ScaleTransform.ScaleY)"
+                                                 To="1.05" Duration="0:0:0.1"/>
+                            </Storyboard>
+                        </BeginStoryboard>
+                    </EventTrigger>
+                    <EventTrigger RoutedEvent="UIElement.LostFocus">
+                        <BeginStoryboard>
+                            <Storyboard>
+                                <DoubleAnimation Storyboard.TargetProperty="RenderTransform.(ScaleTransform.ScaleX)"
+                                                 To="1" Duration="0:0:0.1"/>
+                                <DoubleAnimation Storyboard.TargetProperty="RenderTransform.(ScaleTransform.ScaleY)"
+                                                 To="1" Duration="0:0:0.1"/>
+                            </Storyboard>
+                        </BeginStoryboard>
+                    </EventTrigger>
+                </Grid.Triggers>
                 <Grid>
                     <Image Source="{Binding ToolImagePath}" Stretch="UniformToFill"/>
                     <Border Background="#80000000" VerticalAlignment="Bottom" Height="40">
-                        <TextBlock Text="{Binding NameDescription}" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                        <TextBlock Text="{Binding NameDescription}"
+                                   Foreground="White"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   TextWrapping="Wrap"/>
                     </Border>
                 </Grid>
-            </Border>
+            </Grid>
         </DataTemplate>
+
+        <!-- Styles used for responsive tile sizing -->
+        <Style x:Key="NarrowTileStyle" TargetType="ContentPresenter">
+            <Setter Property="Width" Value="150"/>
+            <Setter Property="Height" Value="220"/>
+        </Style>
+        <Style x:Key="WideTileStyle" TargetType="ContentPresenter">
+            <Setter Property="Width" Value="200"/>
+            <Setter Property="Height" Value="300"/>
+        </Style>
     </Page.Resources>
+
+    <VisualStateManager.VisualStateGroups>
+        <!-- Adjust tile size and typography based on available width -->
+        <VisualStateGroup x:Name="WidthStates">
+            <VisualState x:Name="Narrow">
+                <VisualState.Setters>
+                    <Setter Target="HandToolsList.ItemContainerStyle" Value="{StaticResource NarrowTileStyle}"/>
+                    <Setter Target="PowerToolsList.ItemContainerStyle" Value="{StaticResource NarrowTileStyle}"/>
+                    <Setter Target="HandHeader.FontSize" Value="18"/>
+                    <Setter Target="PowerHeader.FontSize" Value="18"/>
+                </VisualState.Setters>
+            </VisualState>
+            <VisualState x:Name="Wide">
+                <VisualState.Setters>
+                    <Setter Target="HandToolsList.ItemContainerStyle" Value="{StaticResource WideTileStyle}"/>
+                    <Setter Target="PowerToolsList.ItemContainerStyle" Value="{StaticResource WideTileStyle}"/>
+                    <Setter Target="HandHeader.FontSize" Value="24"/>
+                    <Setter Target="PowerHeader.FontSize" Value="24"/>
+                </VisualState.Setters>
+            </VisualState>
+        </VisualStateGroup>
+    </VisualStateManager.VisualStateGroups>
+
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel>
-            <TextBlock Text="Hand Tools" FontSize="24" Margin="10,0,10,5"/>
-            <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled" CanContentScroll="True">
-                <ItemsControl ItemsSource="{Binding HandTools}"
-                              VirtualizingStackPanel.IsVirtualizing="True"
-                              VirtualizingStackPanel.VirtualizationMode="Recycling"
-                              ScrollViewer.CanContentScroll="True">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <VirtualizingStackPanel Orientation="Horizontal"/>
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <StaticResource ResourceKey="ToolCardTemplate"/>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </ScrollViewer>
-            <TextBlock Text="Power Tools" FontSize="24" Margin="10,20,10,5"/>
-            <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled" CanContentScroll="True">
-                <ItemsControl ItemsSource="{Binding PowerTools}"
-                              VirtualizingStackPanel.IsVirtualizing="True"
-                              VirtualizingStackPanel.VirtualizationMode="Recycling"
-                              ScrollViewer.CanContentScroll="True">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <VirtualizingStackPanel Orientation="Horizontal"/>
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <StaticResource ResourceKey="ToolCardTemplate"/>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </ScrollViewer>
+            <TextBlock x:Name="HandHeader" Text="Hand Tools" FontSize="24" Margin="10,0,10,5"/>
+            <ItemsControl x:Name="HandToolsList" ItemsSource="{Binding HandTools}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <StaticResource ResourceKey="ToolCardTemplate"/>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+
+            <TextBlock x:Name="PowerHeader" Text="Power Tools" FontSize="24" Margin="10,20,10,5"/>
+            <ItemsControl x:Name="PowerToolsList" ItemsSource="{Binding PowerTools}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <StaticResource ResourceKey="ToolCardTemplate"/>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/ToolManagementAppV2/Views/ToolSearchPage.xaml.cs
+++ b/ToolManagementAppV2/Views/ToolSearchPage.xaml.cs
@@ -1,3 +1,4 @@
+using System.Windows;
 using System.Windows.Controls;
 
 namespace ToolManagementAppV2.Views
@@ -7,6 +8,16 @@ namespace ToolManagementAppV2.Views
         public ToolSearchPage()
         {
             InitializeComponent();
+        }
+
+        private void Page_Loaded(object sender, RoutedEventArgs e) => UpdateState();
+
+        private void Page_SizeChanged(object sender, SizeChangedEventArgs e) => UpdateState();
+
+        private void UpdateState()
+        {
+            string state = ActualWidth < 800 ? "Narrow" : "Wide";
+            VisualStateManager.GoToState(this, state, true);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Use VisualState setters to swap item container styles, adjusting tile dimensions for narrow and wide screens
- Define reusable styles for tile sizing instead of animating non-existent WrapPanel properties

## Testing
- `apt-get update` *(fails: repository not signed)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68984cdac4448324a923dfbecc2e601f