### PR TITLE
Remove unused SearchTileWidth property

### DIFF
--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -62,13 +62,6 @@ namespace ToolManagementAppV2.ViewModels
         public bool CustomersLoaded { get; private set; }
         public bool RentalsLoaded { get; private set; }
 
-        double _searchTileWidth = 200;
-        public double SearchTileWidth
-        {
-            get => _searchTileWidth;
-            set => SetProperty(ref _searchTileWidth, value);
-        }
-
         Page _currentPage;
         public Page CurrentPage
         {


### PR DESCRIPTION
## Summary
- drop SearchTileWidth field and property from MainViewModel

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68985ad102948324aa0d1f0d746ce8d0