### PR TITLE
Enable virtualization for tool listings

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/LoginWindowLayoutTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/LoginWindowLayoutTests.cs
@@ -1,4 +1,7 @@
+using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
+using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2;
 using Xunit;
 
@@ -15,6 +18,23 @@ namespace ToolManagementAppV2.Tests.Tests
             Assert.Equal(Orientation.Horizontal, stackPanel.Orientation);
             Assert.Equal(ScrollBarVisibility.Auto, ScrollViewer.GetHorizontalScrollBarVisibility(window.UsersListBox));
             Assert.Equal(ScrollBarVisibility.Disabled, ScrollViewer.GetVerticalScrollBarVisibility(window.UsersListBox));
+            Assert.True(VirtualizingStackPanel.GetIsVirtualizing(window.UsersListBox));
+        }
+
+        [Fact]
+        public void UsersListBox_VirtualizesLargeCollections()
+        {
+            var window = new LoginWindow();
+            window.UsersListBox.ItemsSource = Enumerable.Range(0, 1000)
+                .Select(i => new User { UserID = i, UserName = $"User {i}" })
+                .ToList();
+
+            window.UsersListBox.Measure(new Size(800, 200));
+            window.UsersListBox.Arrange(new Rect(0, 0, 800, 200));
+            window.UsersListBox.UpdateLayout();
+
+            Assert.NotNull(window.UsersListBox.ItemContainerGenerator.ContainerFromIndex(0));
+            Assert.Null(window.UsersListBox.ItemContainerGenerator.ContainerFromIndex(999));
         }
     }
 }

--- a/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Views;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Tests
+{
+    public class ToolSearchPageLayoutTests
+    {
+        [Fact]
+        public void ToolLists_UseHorizontalVirtualizingStackPanel()
+        {
+            var page = new ToolSearchPage();
+
+            var handPanel = page.HandToolsList.ItemsPanel.LoadContent();
+            var handStack = Assert.IsType<VirtualizingStackPanel>(handPanel);
+            Assert.Equal(Orientation.Horizontal, handStack.Orientation);
+            Assert.Equal(ScrollBarVisibility.Auto, ScrollViewer.GetHorizontalScrollBarVisibility(page.HandToolsList));
+            Assert.Equal(ScrollBarVisibility.Disabled, ScrollViewer.GetVerticalScrollBarVisibility(page.HandToolsList));
+            Assert.True(VirtualizingStackPanel.GetIsVirtualizing(page.HandToolsList));
+
+            var powerPanel = page.PowerToolsList.ItemsPanel.LoadContent();
+            var powerStack = Assert.IsType<VirtualizingStackPanel>(powerPanel);
+            Assert.Equal(Orientation.Horizontal, powerStack.Orientation);
+            Assert.Equal(ScrollBarVisibility.Auto, ScrollViewer.GetHorizontalScrollBarVisibility(page.PowerToolsList));
+            Assert.Equal(ScrollBarVisibility.Disabled, ScrollViewer.GetVerticalScrollBarVisibility(page.PowerToolsList));
+            Assert.True(VirtualizingStackPanel.GetIsVirtualizing(page.PowerToolsList));
+        }
+
+        [Fact]
+        public void HandToolsList_VirtualizesLargeCollections()
+        {
+            var page = new ToolSearchPage();
+            page.HandToolsList.ItemsSource = Enumerable.Range(0, 1000)
+                .Select(i => new Tool { ToolID = i.ToString(), NameDescription = $"Tool {i}" })
+                .ToList();
+
+            page.HandToolsList.Measure(new Size(800, 300));
+            page.HandToolsList.Arrange(new Rect(0, 0, 800, 300));
+            page.HandToolsList.UpdateLayout();
+
+            Assert.NotNull(page.HandToolsList.ItemContainerGenerator.ContainerFromIndex(0));
+            Assert.Null(page.HandToolsList.ItemContainerGenerator.ContainerFromIndex(999));
+        }
+    }
+}

--- a/ToolManagementAppV2.Tests/ToolManagementAppV2.Tests.csproj
+++ b/ToolManagementAppV2.Tests/ToolManagementAppV2.Tests.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
-		<IsPackable>false</IsPackable>
-		<Nullable>enable</Nullable>
-	</PropertyGroup>
+        <PropertyGroup>
+                <TargetFramework>net8.0-windows</TargetFramework>
+                <IsPackable>false</IsPackable>
+                <Nullable>enable</Nullable>
+                <UseWPF>true</UseWPF>
+        </PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />

--- a/ToolManagementAppV2/Views/LoginWindow.xaml
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml
@@ -47,14 +47,14 @@
                 </StackPanel>
 
                 <!-- User avatars -->
-                <ListBox x:Name="UsersListBox"
+                    <ListBox x:Name="UsersListBox"
                          Grid.Row="1"
                          HorizontalAlignment="Center"
                          BorderThickness="0"
                          Background="Transparent"
                          HorizontalContentAlignment="Center"
-                         ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                         ScrollViewer.VerticalScrollBarVisibility="Auto"
+                         ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                         ScrollViewer.VerticalScrollBarVisibility="Disabled"
                          MaxHeight="400">
                     <ListBox.ItemContainerStyle>
                         <Style TargetType="ListBoxItem">
@@ -87,7 +87,7 @@
                     </ListBox.ItemContainerStyle>
                     <ListBox.ItemsPanel>
                         <ItemsPanelTemplate>
-                            <WrapPanel HorizontalAlignment="Center"/>
+                            <VirtualizingStackPanel Orientation="Horizontal"/>
                         </ItemsPanelTemplate>
                     </ListBox.ItemsPanel>
                     <ListBox.ItemTemplate>

--- a/ToolManagementAppV2/Views/ToolSearchPage.xaml
+++ b/ToolManagementAppV2/Views/ToolSearchPage.xaml
@@ -97,13 +97,16 @@
         </VisualStateGroup>
     </VisualStateManager.VisualStateGroups>
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
+    <ScrollViewer VerticalScrollBarVisibility="Auto"
+                  HorizontalScrollBarVisibility="Auto">
         <StackPanel>
             <TextBlock x:Name="HandHeader" Text="Hand Tools" FontSize="24" Margin="10,0,10,5"/>
-            <ItemsControl x:Name="HandToolsList" ItemsSource="{Binding HandTools}">
+            <ItemsControl x:Name="HandToolsList" ItemsSource="{Binding HandTools}"
+                          ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                          ScrollViewer.VerticalScrollBarVisibility="Disabled">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <WrapPanel/>
+                        <VirtualizingStackPanel Orientation="Horizontal"/>
                     </ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>
@@ -112,10 +115,12 @@
             </ItemsControl>
 
             <TextBlock x:Name="PowerHeader" Text="Power Tools" FontSize="24" Margin="10,20,10,5"/>
-            <ItemsControl x:Name="PowerToolsList" ItemsSource="{Binding PowerTools}">
+            <ItemsControl x:Name="PowerToolsList" ItemsSource="{Binding PowerTools}"
+                          ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                          ScrollViewer.VerticalScrollBarVisibility="Disabled">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <WrapPanel/>
+                        <VirtualizingStackPanel Orientation="Horizontal"/>
                     </ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>


### PR DESCRIPTION
## Summary
- replace WrapPanel panels with VirtualizingStackPanel to enable virtualization
- enable horizontal scrolling on user and tool lists
- add UI tests validating virtualization and scrolling for large user and tool collections
- configure test project for WPF-based UI tests

## Testing
- `dotnet test` *(command not found: dotnet)*
- `apt-get update` *(403 Forbidden: repository not signed)*
- `wget https://dot.net/v1/dotnet-install.sh` *(proxy forbids SSL connection)*

------
https://chatgpt.com/codex/tasks/task_e_68985cccd0388324b436cea3fb6ed295