### PR TITLE
Refactor login to MVVM with command-based user selection

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class LoginViewModelTests
+    {
+        [Fact]
+        public void SelectUserCommand_SetsCurrentUser()
+        {
+            if (Application.Current == null)
+                new Application();
+
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var userService = new UserService(dbService);
+                userService.AddUser(new User { UserName = "user", Password = "newpassword", IsAdmin = false });
+
+                var vm = new LoginViewModel(dbPath);
+                bool success = false;
+                vm.LoginSucceeded += (_, __) => success = true;
+
+                vm.SelectUserCommand.Execute(vm.Users.First());
+
+                Assert.True(success);
+                var current = Application.Current.Properties["CurrentUser"] as User;
+                Assert.NotNull(current);
+                Assert.Equal("user", current.UserName);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+                Application.Current.Properties.Remove("CurrentUser");
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -1,0 +1,156 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media.Imaging;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Utilities.Extensions;
+using ToolManagementAppV2.Utilities.Helpers;
+using ToolManagementAppV2.Views;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class LoginViewModel : ObservableObject
+    {
+        readonly IUserService _userService;
+        readonly ISettingsService _settingsService;
+
+        public ObservableCollection<User> Users { get; } = new();
+
+        User _selectedUser;
+        public User SelectedUser
+        {
+            get => _selectedUser;
+            set => SetProperty(ref _selectedUser, value);
+        }
+
+        public BitmapImage CompanyLogo { get; }
+        public string WindowTitle { get; }
+
+        public ICommand SelectUserCommand { get; }
+
+        public event EventHandler? LoginSucceeded;
+
+        public LoginViewModel(string? dbPath = null)
+        {
+            dbPath ??= Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db");
+            var dbService = new DatabaseService(dbPath);
+            _settingsService = new SettingsService(dbService);
+            _userService = new UserService(dbService);
+
+            CompanyLogo = LoadLogo();
+            WindowTitle = GetWindowTitle();
+
+            SelectUserCommand = new RelayCommand<User>(OnUserSelected);
+
+            LoadUsers();
+        }
+
+        BitmapImage LoadLogo()
+        {
+            var logoPath = _settingsService.GetSetting("CompanyLogoPath");
+            Uri logoUri;
+            if (!string.IsNullOrWhiteSpace(logoPath))
+            {
+                var full = PathHelper.GetAbsolutePath(logoPath);
+                logoUri = !string.IsNullOrEmpty(full) && File.Exists(full)
+                    ? new Uri(full)
+                    : new Uri("pack://application:,,,/Resources/DefaultLogo.png");
+            }
+            else
+            {
+                logoUri = new Uri("pack://application:,,,/Resources/DefaultLogo.png");
+            }
+
+            var bitmap = new BitmapImage();
+            bitmap.BeginInit();
+            bitmap.UriSource = logoUri;
+            bitmap.CacheOption = BitmapCacheOption.OnLoad;
+            bitmap.EndInit();
+            bitmap.Freeze();
+            return bitmap;
+        }
+
+        string GetWindowTitle()
+        {
+            var appName = _settingsService.GetSetting("ApplicationName");
+            return !string.IsNullOrWhiteSpace(appName)
+                ? $"{appName} – Login"
+                : "Tool Inventory Management – Login";
+        }
+
+        void LoadUsers()
+        {
+            var users = _userService.GetAllUsers();
+            if (users.Count == 0)
+            {
+                MessageBox.Show(
+                    "No users exist. A default admin account will be created (username: admin, password: admin).",
+                    "Setup", MessageBoxButton.OK, MessageBoxImage.Information);
+
+                var admin = new User { UserName = "admin", Password = "admin", IsAdmin = true };
+                _userService.AddUser(admin);
+                users = _userService.GetAllUsers();
+            }
+
+            Users.ReplaceRange(users);
+        }
+
+        void OnUserSelected(User user)
+        {
+            if (user == null) return;
+
+            if (user.IsAdmin && string.IsNullOrWhiteSpace(user.Password))
+            {
+                _userService.ChangeUserPassword(user.UserID, "admin");
+                user.Password = SecurityHelper.ComputeSha256Hash("admin");
+            }
+
+            var defaultHash = SecurityHelper.ComputeSha256Hash("newpassword");
+            if (!user.IsAdmin &&
+                (string.IsNullOrWhiteSpace(user.Password) ||
+                 user.Password.Equals(defaultHash, StringComparison.OrdinalIgnoreCase)))
+            {
+                Application.Current.Properties["CurrentUser"] = user;
+                LoginSucceeded?.Invoke(this, EventArgs.Empty);
+                return;
+            }
+
+            var passwordValidated = false;
+            while (!passwordValidated)
+            {
+                var prompt = new PasswordPromptWindow
+                {
+                    SelectedUser = user,
+                    ValidatePassword = pwd => _userService.AuthenticateUser(user.UserName, pwd) != null
+                };
+
+                if (prompt.ShowDialog() != true) return;
+
+                if (prompt.IsPasswordResetRequested)
+                {
+                    _userService.ChangeUserPassword(user.UserID, "admin");
+                    user.Password = SecurityHelper.ComputeSha256Hash("admin");
+                    LoadUsers();
+                    MessageBox.Show("Password has been reset to default. Please enter the new password to login.",
+                        "Password Reset", MessageBoxButton.OK, MessageBoxImage.Information);
+                    continue;
+                }
+
+                var credential = _userService.AuthenticateUser(user.UserName, prompt.EnteredPassword);
+                if (credential != null)
+                {
+                    Application.Current.Properties["CurrentUser"] = credential;
+                    LoginSucceeded?.Invoke(this, EventArgs.Empty);
+                    passwordValidated = true;
+                }
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/Views/LoginWindow.xaml
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:ToolManagementAppV2.Utilities.Converters"
-        Title="Tool Inventory Management – Login"
+        Title="{Binding WindowTitle}"
         Height="750" Width="1600"
         WindowState="Maximized"
         WindowStartupLocation="CenterScreen"
@@ -31,9 +31,9 @@
 
                 <!-- Header -->
                 <StackPanel Grid.Row="0" HorizontalAlignment="Center" Margin="0,0,0,20">
-                    <Image x:Name="LoginLogo" Width="80" Height="80" Margin="0,0,0,10"/>
-                    <TextBlock x:Name="HeaderTitle"
-                               Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}"
+                    <Image Width="80" Height="80" Margin="0,0,0,10"
+                           Source="{Binding CompanyLogo}"/>
+                    <TextBlock Text="{Binding WindowTitle}"
                                FontWeight="Bold"
                                FontSize="24"
                                Foreground="{DynamicResource PrimaryTextBrush}"
@@ -47,7 +47,7 @@
                 </StackPanel>
 
                 <!-- User avatars -->
-                    <ListBox x:Name="UsersListBox"
+                    <ListBox
                          Grid.Row="1"
                          HorizontalAlignment="Center"
                          BorderThickness="0"
@@ -55,7 +55,9 @@
                          HorizontalContentAlignment="Center"
                          ScrollViewer.HorizontalScrollBarVisibility="Auto"
                          ScrollViewer.VerticalScrollBarVisibility="Disabled"
-                         MaxHeight="400">
+                         MaxHeight="400"
+                         ItemsSource="{Binding Users}"
+                         SelectedItem="{Binding SelectedUser}">
                     <ListBox.ItemContainerStyle>
                         <Style TargetType="ListBoxItem">
                             <Setter Property="Background" Value="Transparent"/>
@@ -93,8 +95,9 @@
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <StackPanel Width="120" Margin="5">
-                                <Button Click="UserButton_Click"
-                                        Tag="{Binding}"
+                                <Button
+                                        Command="{Binding DataContext.SelectUserCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                        CommandParameter="{Binding}"
                                         Background="Transparent"
                                         BorderThickness="0"
                                         FocusVisualStyle="{StaticResource DefaultFocusVisual}">

--- a/ToolManagementAppV2/Views/LoginWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml.cs
@@ -1,122 +1,17 @@
-﻿using System.IO;
+using System;
 using System.Windows;
-using System.Windows.Media.Imaging;
-using ToolManagementAppV2.Models.Domain;
-using ToolManagementAppV2.Services.Users;
-using ToolManagementAppV2.Services.Settings;
-using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Utilities.Helpers;
-using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2
 {
     public partial class LoginWindow : Window
     {
-        readonly IUserService _userService;
-
         public LoginWindow()
         {
             InitializeComponent();
-
-            var dbPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db");
-            var dbService = new DatabaseService(dbPath);
-            var settings = new SettingsService(dbService);
-
-            var logoPath = settings.GetSetting("CompanyLogoPath");
-            Uri logoUri;
-            if (!string.IsNullOrWhiteSpace(logoPath))
-            {
-                var full = Utilities.Helpers.PathHelper.GetAbsolutePath(logoPath);
-                logoUri = !string.IsNullOrEmpty(full) && File.Exists(full)
-                    ? new Uri(full)
-                    : new Uri("pack://application:,,,/Resources/DefaultLogo.png");
-            }
-            else
-            {
-                logoUri = new Uri("pack://application:,,,/Resources/DefaultLogo.png");
-            }
-            var bitmap = new BitmapImage();
-            bitmap.BeginInit();
-            bitmap.UriSource = logoUri;
-            bitmap.CacheOption = BitmapCacheOption.OnLoad;
-            bitmap.EndInit();
-            bitmap.Freeze();
-            LoginLogo.Source = bitmap;
-
-            var appName = settings.GetSetting("ApplicationName");
-            Title = !string.IsNullOrWhiteSpace(appName)
-                    ? $"{appName} – Login"
-                    : Title;
-
-            _userService = new UserService(dbService);
-            LoadUsers();
-        }
-
-        void LoadUsers()
-        {
-            var users = _userService.GetAllUsers();
-            if (users.Count == 0)
-            {
-                System.Windows.MessageBox.Show(
-                    "No users exist. A default admin account will be created (username: admin, password: admin).",
-                    "Setup", MessageBoxButton.OK, MessageBoxImage.Information);
-
-                var admin = new User { UserName = "admin", Password = "admin", IsAdmin = true };
-                _userService.AddUser(admin);
-                users = _userService.GetAllUsers();
-            }
-
-            UsersListBox.ItemsSource = users;
-        }
-
-        void UserButton_Click(object sender, RoutedEventArgs e)
-        {
-            if (!(sender is FrameworkElement fe && fe.Tag is User user)) return;
-
-            if (user.IsAdmin && string.IsNullOrWhiteSpace(user.Password))
-            {
-                _userService.ChangeUserPassword(user.UserID, "admin");
-                user.Password = SecurityHelper.ComputeSha256Hash("admin");
-            }
-
-            var defaultHash = SecurityHelper.ComputeSha256Hash("newpassword");
-            if (!user.IsAdmin &&
-                (string.IsNullOrWhiteSpace(user.Password) ||
-                 user.Password.Equals(defaultHash, StringComparison.OrdinalIgnoreCase)))
-            {
-                App.Current.Properties["CurrentUser"] = user;
-                DialogResult = true;
-                return;
-            }
-
-            var passwordValidated = false;
-            while (!passwordValidated)
-            {
-                var prompt = new PasswordPromptWindow
-                {
-                    SelectedUser = user,
-                    ValidatePassword = pwd => _userService.AuthenticateUser(user.UserName, pwd) != null
-                };
-
-                if (prompt.ShowDialog() != true) return;
-
-                if (prompt.IsPasswordResetRequested)
-                {
-                    _userService.ChangeUserPassword(user.UserID, "admin");
-                    user.Password = SecurityHelper.ComputeSha256Hash("admin");
-                    LoadUsers();
-                    System.Windows.MessageBox.Show("Password has been reset to default. Please enter the new password to login.", "Password Reset", MessageBoxButton.OK, MessageBoxImage.Information);
-                    continue;
-                }
-
-                var credential = _userService.AuthenticateUser(user.UserName, prompt.EnteredPassword);
-                if (credential != null)
-                {
-                    App.Current.Properties["CurrentUser"] = credential;
-                    DialogResult = true;
-                    passwordValidated = true;
-                }
-            }
+            var vm = new LoginViewModel();
+            vm.LoginSucceeded += (_, __) => DialogResult = true;
+            DataContext = vm;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Introduce `LoginViewModel` with user list, selection, and command-driven authentication
- Bind `LoginWindow` to the new view model and remove click handlers
- Add unit test covering `LoginViewModel` login flow

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6898623d5ae08324b46b99e6da74536e