### PR TITLE
Implement dark-themed layouts for management pages

### DIFF
--- a/ToolManagementAppV2/Views/CustomersPage.xaml
+++ b/ToolManagementAppV2/Views/CustomersPage.xaml
@@ -1,7 +1,55 @@
 <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      x:Class="ToolManagementAppV2.Views.CustomersPage">
-    <Grid>
-        <TextBlock Text="Customers" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="32"/>
+      x:Class="ToolManagementAppV2.Views.CustomersPage"
+      Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="3*"/>
+        </Grid.ColumnDefinitions>
+
+        <Border Background="{DynamicResource CardBackgroundBrush}"
+                Padding="10" Margin="0,0,10,0">
+            <StackPanel>
+                <TextBlock Text="Customers" FontSize="24"/>
+                <StackPanel Orientation="Horizontal">
+                    <TextBox Width="200" Text="{Binding CustomerSearchTerm, UpdateSourceTrigger=PropertyChanged}"/>
+                    <Button Content="Search" Command="{Binding SearchCustomersCommand}"/>
+                </StackPanel>
+                <ListView ItemsSource="{Binding Customers}"
+                          SelectedItem="{Binding SelectedCustomer}"
+                          Background="{DynamicResource CardBackgroundBrush}"
+                          Foreground="{DynamicResource PrimaryTextBrush}">
+                    <ListView.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </ListView.ItemsPanel>
+                    <ListView.View>
+                        <GridView>
+                            <GridViewColumn Header="Company" DisplayMemberBinding="{Binding Company}"/>
+                            <GridViewColumn Header="Email" DisplayMemberBinding="{Binding Email}"/>
+                        </GridView>
+                    </ListView.View>
+                </ListView>
+            </StackPanel>
+        </Border>
+
+        <Border Grid.Column="1" Background="{DynamicResource CardBackgroundBrush}" Padding="10">
+            <StackPanel>
+                <TextBlock Text="Customer Details" FontSize="24"/>
+                <TextBox Text="{Binding NewCustomerName}"/>
+                <TextBox Text="{Binding NewCustomerEmail}"/>
+                <TextBox Text="{Binding NewCustomerContact}"/>
+                <TextBox Text="{Binding NewCustomerPhone}"/>
+                <TextBox Text="{Binding NewCustomerMobile}"/>
+                <TextBox Text="{Binding NewCustomerAddress}"/>
+                <StackPanel Orientation="Horizontal">
+                    <Button Content="Add" Command="{Binding AddCustomerCommand}"/>
+                    <Button Content="Update" Command="{Binding UpdateCustomerCommand}"/>
+                    <Button Content="Delete" Command="{Binding DeleteCustomerCommand}"/>
+                </StackPanel>
+            </StackPanel>
+        </Border>
     </Grid>
 </Page>

--- a/ToolManagementAppV2/Views/CustomersPage.xaml
+++ b/ToolManagementAppV2/Views/CustomersPage.xaml
@@ -11,10 +11,16 @@
         <Border Background="{DynamicResource CardBackgroundBrush}"
                 Padding="10" Margin="0,0,10,0">
             <StackPanel>
-                <TextBlock Text="Customers" FontSize="24"/>
+                <TextBlock Text="Customers" FontSize="24" Foreground="{DynamicResource PrimaryTextBrush}"/>
                 <StackPanel Orientation="Horizontal">
-                    <TextBox Width="200" Text="{Binding CustomerSearchTerm, UpdateSourceTrigger=PropertyChanged}"/>
-                    <Button Content="Search" Command="{Binding SearchCustomersCommand}"/>
+                    <TextBox Width="200" Text="{Binding CustomerSearchTerm, UpdateSourceTrigger=PropertyChanged}"
+                             Foreground="{DynamicResource PrimaryTextBrush}"
+                             Background="{DynamicResource CardBackgroundBrush}"
+                             BorderBrush="{DynamicResource PrimaryTextBrush}"/>
+                    <Button Content="Search" Command="{Binding SearchCustomersCommand}"
+                            Foreground="{DynamicResource PrimaryTextBrush}"
+                            Background="{DynamicResource AccentBrush}"
+                            BorderBrush="{DynamicResource AccentBrush}"/>
                 </StackPanel>
                 <ListView ItemsSource="{Binding Customers}"
                           SelectedItem="{Binding SelectedCustomer}"
@@ -37,17 +43,44 @@
 
         <Border Grid.Column="1" Background="{DynamicResource CardBackgroundBrush}" Padding="10">
             <StackPanel>
-                <TextBlock Text="Customer Details" FontSize="24"/>
-                <TextBox Text="{Binding NewCustomerName}"/>
-                <TextBox Text="{Binding NewCustomerEmail}"/>
-                <TextBox Text="{Binding NewCustomerContact}"/>
-                <TextBox Text="{Binding NewCustomerPhone}"/>
-                <TextBox Text="{Binding NewCustomerMobile}"/>
-                <TextBox Text="{Binding NewCustomerAddress}"/>
+                <TextBlock Text="Customer Details" FontSize="24" Foreground="{DynamicResource PrimaryTextBrush}"/>
+                <TextBox Text="{Binding NewCustomerName}"
+                         Foreground="{DynamicResource PrimaryTextBrush}"
+                         Background="{DynamicResource CardBackgroundBrush}"
+                         BorderBrush="{DynamicResource PrimaryTextBrush}"/>
+                <TextBox Text="{Binding NewCustomerEmail}"
+                         Foreground="{DynamicResource PrimaryTextBrush}"
+                         Background="{DynamicResource CardBackgroundBrush}"
+                         BorderBrush="{DynamicResource PrimaryTextBrush}"/>
+                <TextBox Text="{Binding NewCustomerContact}"
+                         Foreground="{DynamicResource PrimaryTextBrush}"
+                         Background="{DynamicResource CardBackgroundBrush}"
+                         BorderBrush="{DynamicResource PrimaryTextBrush}"/>
+                <TextBox Text="{Binding NewCustomerPhone}"
+                         Foreground="{DynamicResource PrimaryTextBrush}"
+                         Background="{DynamicResource CardBackgroundBrush}"
+                         BorderBrush="{DynamicResource PrimaryTextBrush}"/>
+                <TextBox Text="{Binding NewCustomerMobile}"
+                         Foreground="{DynamicResource PrimaryTextBrush}"
+                         Background="{DynamicResource CardBackgroundBrush}"
+                         BorderBrush="{DynamicResource PrimaryTextBrush}"/>
+                <TextBox Text="{Binding NewCustomerAddress}"
+                         Foreground="{DynamicResource PrimaryTextBrush}"
+                         Background="{DynamicResource CardBackgroundBrush}"
+                         BorderBrush="{DynamicResource PrimaryTextBrush}"/>
                 <StackPanel Orientation="Horizontal">
-                    <Button Content="Add" Command="{Binding AddCustomerCommand}"/>
-                    <Button Content="Update" Command="{Binding UpdateCustomerCommand}"/>
-                    <Button Content="Delete" Command="{Binding DeleteCustomerCommand}"/>
+                    <Button Content="Add" Command="{Binding AddCustomerCommand}"
+                            Foreground="{DynamicResource PrimaryTextBrush}"
+                            Background="{DynamicResource AccentBrush}"
+                            BorderBrush="{DynamicResource AccentBrush}"/>
+                    <Button Content="Update" Command="{Binding UpdateCustomerCommand}"
+                            Foreground="{DynamicResource PrimaryTextBrush}"
+                            Background="{DynamicResource AccentBrush}"
+                            BorderBrush="{DynamicResource AccentBrush}"/>
+                    <Button Content="Delete" Command="{Binding DeleteCustomerCommand}"
+                            Foreground="{DynamicResource PrimaryTextBrush}"
+                            Background="{DynamicResource AccentBrush}"
+                            BorderBrush="{DynamicResource AccentBrush}"/>
                 </StackPanel>
             </StackPanel>
         </Border>

--- a/ToolManagementAppV2/Views/ManageToolsPage.xaml
+++ b/ToolManagementAppV2/Views/ManageToolsPage.xaml
@@ -1,7 +1,48 @@
 <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      x:Class="ToolManagementAppV2.Views.ManageToolsPage">
-    <Grid>
-        <TextBlock Text="Manage Tools" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="32"/>
+      x:Class="ToolManagementAppV2.Views.ManageToolsPage"
+      Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="3*"/>
+        </Grid.ColumnDefinitions>
+
+        <Border Background="{DynamicResource CardBackgroundBrush}"
+                Padding="10" Margin="0,0,10,0">
+            <StackPanel>
+                <TextBlock Text="Tools" FontSize="24"/>
+                <ListView ItemsSource="{Binding Tools}" SelectedItem="{Binding SelectedTool}"
+                          Background="{DynamicResource CardBackgroundBrush}"
+                          Foreground="{DynamicResource PrimaryTextBrush}">
+                    <ListView.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </ListView.ItemsPanel>
+                    <ListView.View>
+                        <GridView>
+                            <GridViewColumn Header="Number" DisplayMemberBinding="{Binding ToolNumber}"/>
+                            <GridViewColumn Header="Name" DisplayMemberBinding="{Binding NameDescription}"/>
+                        </GridView>
+                    </ListView.View>
+                </ListView>
+            </StackPanel>
+        </Border>
+
+        <Border Grid.Column="1" Background="{DynamicResource CardBackgroundBrush}" Padding="10">
+            <StackPanel>
+                <TextBlock Text="Tool Details" FontSize="24"/>
+                <TextBox Text="{Binding NewTool.ToolNumber}"/>
+                <TextBox Text="{Binding NewTool.NameDescription}"/>
+                <TextBox Text="{Binding NewTool.Location}"/>
+                <TextBox Text="{Binding NewTool.Brand}"/>
+                <StackPanel Orientation="Horizontal">
+                    <Button Content="Add" Command="{Binding AddToolCommand}"/>
+                    <Button Content="Update" Command="{Binding UpdateToolCommand}"/>
+                    <Button Content="Delete" Command="{Binding DeleteToolCommand}"/>
+                </StackPanel>
+            </StackPanel>
+        </Border>
     </Grid>
 </Page>

--- a/ToolManagementAppV2/Views/ManageToolsPage.xaml
+++ b/ToolManagementAppV2/Views/ManageToolsPage.xaml
@@ -11,7 +11,7 @@
         <Border Background="{DynamicResource CardBackgroundBrush}"
                 Padding="10" Margin="0,0,10,0">
             <StackPanel>
-                <TextBlock Text="Tools" FontSize="24"/>
+                <TextBlock Text="Tools" FontSize="24" Foreground="{DynamicResource PrimaryTextBrush}"/>
                 <ListView ItemsSource="{Binding Tools}" SelectedItem="{Binding SelectedTool}"
                           Background="{DynamicResource CardBackgroundBrush}"
                           Foreground="{DynamicResource PrimaryTextBrush}">
@@ -32,15 +32,36 @@
 
         <Border Grid.Column="1" Background="{DynamicResource CardBackgroundBrush}" Padding="10">
             <StackPanel>
-                <TextBlock Text="Tool Details" FontSize="24"/>
-                <TextBox Text="{Binding NewTool.ToolNumber}"/>
-                <TextBox Text="{Binding NewTool.NameDescription}"/>
-                <TextBox Text="{Binding NewTool.Location}"/>
-                <TextBox Text="{Binding NewTool.Brand}"/>
+                <TextBlock Text="Tool Details" FontSize="24" Foreground="{DynamicResource PrimaryTextBrush}"/>
+                <TextBox Text="{Binding NewTool.ToolNumber}"
+                         Foreground="{DynamicResource PrimaryTextBrush}"
+                         Background="{DynamicResource CardBackgroundBrush}"
+                         BorderBrush="{DynamicResource PrimaryTextBrush}"/>
+                <TextBox Text="{Binding NewTool.NameDescription}"
+                         Foreground="{DynamicResource PrimaryTextBrush}"
+                         Background="{DynamicResource CardBackgroundBrush}"
+                         BorderBrush="{DynamicResource PrimaryTextBrush}"/>
+                <TextBox Text="{Binding NewTool.Location}"
+                         Foreground="{DynamicResource PrimaryTextBrush}"
+                         Background="{DynamicResource CardBackgroundBrush}"
+                         BorderBrush="{DynamicResource PrimaryTextBrush}"/>
+                <TextBox Text="{Binding NewTool.Brand}"
+                         Foreground="{DynamicResource PrimaryTextBrush}"
+                         Background="{DynamicResource CardBackgroundBrush}"
+                         BorderBrush="{DynamicResource PrimaryTextBrush}"/>
                 <StackPanel Orientation="Horizontal">
-                    <Button Content="Add" Command="{Binding AddToolCommand}"/>
-                    <Button Content="Update" Command="{Binding UpdateToolCommand}"/>
-                    <Button Content="Delete" Command="{Binding DeleteToolCommand}"/>
+                    <Button Content="Add" Command="{Binding AddToolCommand}"
+                            Foreground="{DynamicResource PrimaryTextBrush}"
+                            Background="{DynamicResource AccentBrush}"
+                            BorderBrush="{DynamicResource AccentBrush}"/>
+                    <Button Content="Update" Command="{Binding UpdateToolCommand}"
+                            Foreground="{DynamicResource PrimaryTextBrush}"
+                            Background="{DynamicResource AccentBrush}"
+                            BorderBrush="{DynamicResource AccentBrush}"/>
+                    <Button Content="Delete" Command="{Binding DeleteToolCommand}"
+                            Foreground="{DynamicResource PrimaryTextBrush}"
+                            Background="{DynamicResource AccentBrush}"
+                            BorderBrush="{DynamicResource AccentBrush}"/>
                 </StackPanel>
             </StackPanel>
         </Border>

--- a/ToolManagementAppV2/Views/RentalsPage.xaml
+++ b/ToolManagementAppV2/Views/RentalsPage.xaml
@@ -6,7 +6,7 @@
         <StackPanel Margin="10">
             <Border Background="{DynamicResource CardBackgroundBrush}" Padding="10">
                 <StackPanel>
-                    <TextBlock Text="Active Rentals" FontSize="24"/>
+                    <TextBlock Text="Active Rentals" FontSize="24" Foreground="{DynamicResource PrimaryTextBrush}"/>
                     <ListView ItemsSource="{Binding ActiveRentals}"
                               SelectedItem="{Binding SelectedRental}"
                               Background="{DynamicResource CardBackgroundBrush}"
@@ -29,7 +29,7 @@
 
             <Border Background="{DynamicResource CardBackgroundBrush}" Padding="10" Margin="0,10,0,0">
                 <StackPanel>
-                    <TextBlock Text="Overdue Rentals" FontSize="24"/>
+                    <TextBlock Text="Overdue Rentals" FontSize="24" Foreground="{DynamicResource PrimaryTextBrush}"/>
                     <ListView ItemsSource="{Binding OverdueRentals}"
                               SelectedItem="{Binding SelectedRental}"
                               Background="{DynamicResource CardBackgroundBrush}"
@@ -51,9 +51,18 @@
             </Border>
 
             <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                <Button Content="Return" Command="{Binding ReturnToolCommand}"/>
-                <Button Content="Extend" Command="{Binding ExtendRentalCommand}"/>
-                <Button Content="History" Command="{Binding ViewSelectedRentalHistoryCommand}"/>
+                <Button Content="Return" Command="{Binding ReturnToolCommand}"
+                        Foreground="{DynamicResource PrimaryTextBrush}"
+                        Background="{DynamicResource AccentBrush}"
+                        BorderBrush="{DynamicResource AccentBrush}"/>
+                <Button Content="Extend" Command="{Binding ExtendRentalCommand}"
+                        Foreground="{DynamicResource PrimaryTextBrush}"
+                        Background="{DynamicResource AccentBrush}"
+                        BorderBrush="{DynamicResource AccentBrush}"/>
+                <Button Content="History" Command="{Binding ViewSelectedRentalHistoryCommand}"
+                        Foreground="{DynamicResource PrimaryTextBrush}"
+                        Background="{DynamicResource AccentBrush}"
+                        BorderBrush="{DynamicResource AccentBrush}"/>
             </StackPanel>
         </StackPanel>
     </ScrollViewer>

--- a/ToolManagementAppV2/Views/RentalsPage.xaml
+++ b/ToolManagementAppV2/Views/RentalsPage.xaml
@@ -1,7 +1,60 @@
 <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      x:Class="ToolManagementAppV2.Views.RentalsPage">
-    <Grid>
-        <TextBlock Text="Rentals" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="32"/>
-    </Grid>
+      x:Class="ToolManagementAppV2.Views.RentalsPage"
+      Background="{DynamicResource BackgroundBrush}">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="10">
+            <Border Background="{DynamicResource CardBackgroundBrush}" Padding="10">
+                <StackPanel>
+                    <TextBlock Text="Active Rentals" FontSize="24"/>
+                    <ListView ItemsSource="{Binding ActiveRentals}"
+                              SelectedItem="{Binding SelectedRental}"
+                              Background="{DynamicResource CardBackgroundBrush}"
+                              Foreground="{DynamicResource PrimaryTextBrush}">
+                        <ListView.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel/>
+                            </ItemsPanelTemplate>
+                        </ListView.ItemsPanel>
+                        <ListView.View>
+                            <GridView>
+                                <GridViewColumn Header="Tool" DisplayMemberBinding="{Binding ToolNumber}"/>
+                                <GridViewColumn Header="Customer" DisplayMemberBinding="{Binding CustomerName}"/>
+                                <GridViewColumn Header="Due" DisplayMemberBinding="{Binding DueDate, StringFormat={}{0:yyyy-MM-dd}}"/>
+                            </GridView>
+                        </ListView.View>
+                    </ListView>
+                </StackPanel>
+            </Border>
+
+            <Border Background="{DynamicResource CardBackgroundBrush}" Padding="10" Margin="0,10,0,0">
+                <StackPanel>
+                    <TextBlock Text="Overdue Rentals" FontSize="24"/>
+                    <ListView ItemsSource="{Binding OverdueRentals}"
+                              SelectedItem="{Binding SelectedRental}"
+                              Background="{DynamicResource CardBackgroundBrush}"
+                              Foreground="{DynamicResource PrimaryTextBrush}">
+                        <ListView.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel/>
+                            </ItemsPanelTemplate>
+                        </ListView.ItemsPanel>
+                        <ListView.View>
+                            <GridView>
+                                <GridViewColumn Header="Tool" DisplayMemberBinding="{Binding ToolNumber}"/>
+                                <GridViewColumn Header="Customer" DisplayMemberBinding="{Binding CustomerName}"/>
+                                <GridViewColumn Header="Status" DisplayMemberBinding="{Binding Status}"/>
+                            </GridView>
+                        </ListView.View>
+                    </ListView>
+                </StackPanel>
+            </Border>
+
+            <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                <Button Content="Return" Command="{Binding ReturnToolCommand}"/>
+                <Button Content="Extend" Command="{Binding ExtendRentalCommand}"/>
+                <Button Content="History" Command="{Binding ViewSelectedRentalHistoryCommand}"/>
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
 </Page>

--- a/ToolManagementAppV2/Views/UsersPage.xaml
+++ b/ToolManagementAppV2/Views/UsersPage.xaml
@@ -11,7 +11,7 @@
         <Border Background="{DynamicResource CardBackgroundBrush}"
                 Padding="10" Margin="0,0,10,0">
             <StackPanel>
-                <TextBlock Text="Users" FontSize="24"/>
+                <TextBlock Text="Users" FontSize="24" Foreground="{DynamicResource PrimaryTextBrush}"/>
                 <ListView ItemsSource="{Binding Users}" SelectedItem="{Binding SelectedUser}"
                           Background="{DynamicResource CardBackgroundBrush}"
                           Foreground="{DynamicResource PrimaryTextBrush}">
@@ -32,12 +32,24 @@
 
         <Border Grid.Column="1" Background="{DynamicResource CardBackgroundBrush}" Padding="10">
             <StackPanel>
-                <TextBlock Text="User Details" FontSize="24"/>
+                <TextBlock Text="User Details" FontSize="24" Foreground="{DynamicResource PrimaryTextBrush}"/>
                 <Image Source="{Binding SelectedUser.PhotoBitmap}" Height="100" Width="100" Margin="0,0,0,10"/>
-                <TextBox Text="{Binding SelectedUser.UserName}"/>
-                <TextBox Text="{Binding SelectedUser.Email}"/>
-                <TextBox Text="{Binding SelectedUser.Phone}"/>
-                <Button Content="Upload Photo" Command="{Binding UploadUserPhotoCommand}"/>
+                <TextBox Text="{Binding SelectedUser.UserName}"
+                         Foreground="{DynamicResource PrimaryTextBrush}"
+                         Background="{DynamicResource CardBackgroundBrush}"
+                         BorderBrush="{DynamicResource PrimaryTextBrush}"/>
+                <TextBox Text="{Binding SelectedUser.Email}"
+                         Foreground="{DynamicResource PrimaryTextBrush}"
+                         Background="{DynamicResource CardBackgroundBrush}"
+                         BorderBrush="{DynamicResource PrimaryTextBrush}"/>
+                <TextBox Text="{Binding SelectedUser.Phone}"
+                         Foreground="{DynamicResource PrimaryTextBrush}"
+                         Background="{DynamicResource CardBackgroundBrush}"
+                         BorderBrush="{DynamicResource PrimaryTextBrush}"/>
+                <Button Content="Upload Photo" Command="{Binding UploadUserPhotoCommand}"
+                        Foreground="{DynamicResource PrimaryTextBrush}"
+                        Background="{DynamicResource AccentBrush}"
+                        BorderBrush="{DynamicResource AccentBrush}"/>
             </StackPanel>
         </Border>
     </Grid>

--- a/ToolManagementAppV2/Views/UsersPage.xaml
+++ b/ToolManagementAppV2/Views/UsersPage.xaml
@@ -1,7 +1,44 @@
 <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      x:Class="ToolManagementAppV2.Views.UsersPage">
-    <Grid>
-        <TextBlock Text="Users" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="32"/>
+      x:Class="ToolManagementAppV2.Views.UsersPage"
+      Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="3*"/>
+        </Grid.ColumnDefinitions>
+
+        <Border Background="{DynamicResource CardBackgroundBrush}"
+                Padding="10" Margin="0,0,10,0">
+            <StackPanel>
+                <TextBlock Text="Users" FontSize="24"/>
+                <ListView ItemsSource="{Binding Users}" SelectedItem="{Binding SelectedUser}"
+                          Background="{DynamicResource CardBackgroundBrush}"
+                          Foreground="{DynamicResource PrimaryTextBrush}">
+                    <ListView.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </ListView.ItemsPanel>
+                    <ListView.View>
+                        <GridView>
+                            <GridViewColumn Header="User" DisplayMemberBinding="{Binding UserName}"/>
+                            <GridViewColumn Header="Role" DisplayMemberBinding="{Binding Role}"/>
+                        </GridView>
+                    </ListView.View>
+                </ListView>
+            </StackPanel>
+        </Border>
+
+        <Border Grid.Column="1" Background="{DynamicResource CardBackgroundBrush}" Padding="10">
+            <StackPanel>
+                <TextBlock Text="User Details" FontSize="24"/>
+                <Image Source="{Binding SelectedUser.PhotoBitmap}" Height="100" Width="100" Margin="0,0,0,10"/>
+                <TextBox Text="{Binding SelectedUser.UserName}"/>
+                <TextBox Text="{Binding SelectedUser.Email}"/>
+                <TextBox Text="{Binding SelectedUser.Phone}"/>
+                <Button Content="Upload Photo" Command="{Binding UploadUserPhotoCommand}"/>
+            </StackPanel>
+        </Border>
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- Apply dark theme background to Customers, ManageTools, Rentals, and Users pages.
- Replace placeholder content with MVVM-bound layouts using CardBackgroundBrush, PrimaryTextBrush, and virtualized lists.
- Add details and actions for managing customers, tools, rentals, and users.

## Testing
- `dotnet test` *(fails: `dotnet` command not found; network restrictions prevented installing .NET SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6898695beda88324b617471c7d5b12a2