### PR TITLE
Ensure service methods propagate exceptions

### DIFF
--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -47,7 +47,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void RentTool_NoAvailability_DoesNotThrow()
+        public void RentTool_NoAvailability_Throws()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -64,8 +64,8 @@ namespace ToolManagementAppV2.Tests.Services
                 customerService.AddCustomer(new Customer { Company = "Acme" });
                 var cust = customerService.GetAllCustomers().First();
 
-                var ex = Record.Exception(() => rentalService.RentTool(addedTool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1)));
-                Assert.Null(ex);
+                Assert.Throws<InvalidOperationException>(() =>
+                    rentalService.RentTool(addedTool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1)));
                 Assert.Empty(rentalService.GetAllRentals());
             }
             finally
@@ -76,7 +76,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void RentTool_NoAvailability_DoesNotThrow_WithHelper()
+        public void RentTool_NoAvailability_Throws_WithHelper()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -93,8 +93,8 @@ namespace ToolManagementAppV2.Tests.Services
                 customerService.AddCustomer(new Customer { Company = "Beta" });
                 var cust = customerService.GetAllCustomers().First();
 
-                var ex = Record.Exception(() => rentalService.RentTool(addedTool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1)));
-                Assert.Null(ex);
+                Assert.Throws<InvalidOperationException>(() =>
+                    rentalService.RentTool(addedTool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1)));
                 Assert.Empty(rentalService.GetAllRentals());
             }
             finally
@@ -105,7 +105,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void ReturnTool_InvalidRentalID_DoesNotThrow()
+        public void ReturnTool_InvalidRentalID_Throws()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -114,8 +114,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var toolService = new ToolService(db);
                 IRentalService rentalService = new RentalService(db, toolService);
 
-                var ex = Record.Exception(() => rentalService.ReturnTool(1, DateTime.Today));
-                Assert.Null(ex);
+                Assert.Throws<InvalidOperationException>(() => rentalService.ReturnTool(1, DateTime.Today));
             }
             finally
             {
@@ -125,7 +124,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void ReturnTool_InvalidRentalID_DoesNotThrow_WithHelper()
+        public void ReturnTool_InvalidRentalID_Throws_WithHelper()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -134,8 +133,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var toolService = new ToolService(db);
                 IRentalService rentalService = new RentalService(db, toolService);
 
-                var ex = Record.Exception(() => rentalService.ReturnTool(1, DateTime.Today));
-                Assert.Null(ex);
+                Assert.Throws<InvalidOperationException>(() => rentalService.ReturnTool(1, DateTime.Today));
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -11,7 +11,7 @@ namespace ToolManagementAppV2.Tests.Services
     public class SettingsServiceTests
     {
         [Fact]
-        public void UpdateSettings_DoesNotThrowOnFailure()
+        public void UpdateSettings_ThrowsOnFailure()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -26,7 +26,7 @@ namespace ToolManagementAppV2.Tests.Services
                 }
 
                 var settings = new Dictionary<string, string> { ["Key1"] = "Value1" };
-                service.UpdateSettings(settings);
+                Assert.Throws<SQLiteException>(() => service.UpdateSettings(settings));
             }
             finally
             {

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -98,6 +98,7 @@ namespace ToolManagementAppV2.Services.Rentals
             {
                 Console.WriteLine(ex);
                 tx.Rollback();
+                throw;
             }
         }
 

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -71,7 +71,7 @@ namespace ToolManagementAppV2.Services.Settings
             {
                 tx.Rollback();
                 Console.WriteLine(ex);
-                return;
+                throw;
             }
         }
 


### PR DESCRIPTION
## Summary
- Prevent SettingsService.UpdateSettings from swallowing database errors by rethrowing exceptions
- Ensure RentalService transactions rethrow exceptions instead of logging and continuing
- Update service tests to expect exceptions when operations fail

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6898fc4af7e48324bbfce702323232e3