### PR TITLE
Wrap CSV imports in transactions

### DIFF
--- a/ToolManagementAppV2.Tests/Services/CustomerServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/CustomerServiceTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Data.SQLite;
 using System.IO;
 using System.Linq;
 using ToolManagementAppV2.Models.Domain;
@@ -72,6 +74,37 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 if (File.Exists(dbPath))
                     File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void ImportCustomersFromCsv_PartialFailure_RollsBack()
+        {
+            var dbPath = Path.GetTempFileName();
+            var csvPath = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(csvPath, "Company,Contact,Phone\nAcme,John,1\nAcme,Jane,2");
+                var dbService = new DatabaseService(dbPath);
+                using (var conn = dbService.CreateConnection())
+                {
+                    SqliteHelper.ExecuteNonQuery(conn, "CREATE UNIQUE INDEX idx_customers_company ON Customers(Company)", null);
+                }
+                var service = new CustomerService(dbService);
+                var map = new Dictionary<string, string>
+                {
+                    {"Company", "Company"},
+                    {"Contact", "Contact"},
+                    {"Phone", "Phone"}
+                };
+
+                Assert.Throws<SQLiteException>(() => service.ImportCustomersFromCsv(csvPath, map));
+                Assert.Empty(service.GetAllCustomers());
+            }
+            finally
+            {
+                if (File.Exists(csvPath)) File.Delete(csvPath);
+                if (File.Exists(dbPath)) File.Delete(dbPath);
             }
         }
     }

--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data.SQLite;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
@@ -145,6 +146,31 @@ namespace ToolManagementAppV2.Tests.Services
             }
             finally
             {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void ImportToolsFromCsv_PartialFailure_RollsBack()
+        {
+            var dbPath = Path.GetTempFileName();
+            var csvPath = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(csvPath, "ToolNumber\nT1\nT1");
+                var dbService = new DatabaseService(dbPath);
+                var service = new ToolService(dbService);
+                var map = new Dictionary<string, string>
+                {
+                    {"ToolNumber", "ToolNumber"}
+                };
+
+                Assert.Throws<SQLiteException>(() => service.ImportToolsFromCsv(csvPath, map));
+                Assert.Empty(service.GetAllTools());
+            }
+            finally
+            {
+                if (File.Exists(csvPath)) File.Delete(csvPath);
                 if (File.Exists(dbPath)) File.Delete(dbPath);
             }
         }

--- a/ToolManagementAppV2/Services/Customers/CustomerService.cs
+++ b/ToolManagementAppV2/Services/Customers/CustomerService.cs
@@ -22,14 +22,25 @@ namespace ToolManagementAppV2.Services.Customers
         public void ImportCustomersFromCsv(string filePath, IDictionary<string, string> map)
         {
             var customers = CsvHelperUtil.LoadCustomersFromCsv(filePath, map);
-            foreach (var c in customers)
+            using var conn = _dbService.CreateConnection();
+            using var tran = conn.BeginTransaction();
+            try
             {
-                if (string.IsNullOrWhiteSpace(c.Company)) continue;
-                if (string.IsNullOrWhiteSpace(c.Contact)) continue;
-                if (string.IsNullOrWhiteSpace(c.Phone) && string.IsNullOrWhiteSpace(c.Mobile)) continue;
+                foreach (var c in customers)
+                {
+                    if (string.IsNullOrWhiteSpace(c.Company)) continue;
+                    if (string.IsNullOrWhiteSpace(c.Contact)) continue;
+                    if (string.IsNullOrWhiteSpace(c.Phone) && string.IsNullOrWhiteSpace(c.Mobile)) continue;
 
-                if (!CustomerExists(c.Contact, c.Phone, c.Mobile))
-                    AddCustomer(c);
+                    if (!CustomerExists(c.Contact, c.Phone, c.Mobile))
+                        InsertCustomer(conn, tran, c);
+                }
+                tran.Commit();
+            }
+            catch
+            {
+                tran.Rollback();
+                throw;
             }
         }
 
@@ -68,6 +79,12 @@ namespace ToolManagementAppV2.Services.Customers
 
         public void AddCustomer(CustomerModel customer)
         {
+            using var conn = _dbService.CreateConnection();
+            InsertCustomer(conn, null, customer);
+        }
+
+        void InsertCustomer(SQLiteConnection conn, SQLiteTransaction? tran, CustomerModel customer)
+        {
             const string sql = @"
         INSERT INTO Customers (Company, Email, Contact, Phone, Mobile, Address)
         VALUES (@Company, @Email, @Contact, @Phone, @Mobile, @Address);
@@ -83,8 +100,7 @@ namespace ToolManagementAppV2.Services.Customers
                 new SQLiteParameter("@Address", customer.Address ?? string.Empty)
             };
 
-            using var conn = _dbService.CreateConnection();
-            using var cmd = new SQLiteCommand(sql, conn);
+            using var cmd = new SQLiteCommand(sql, conn, tran);
             cmd.Parameters.AddRange(p);
             customer.CustomerID = Convert.ToInt32(cmd.ExecuteScalar());
         }

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -74,24 +74,8 @@ namespace ToolManagementAppV2.Services.Tools
         {
             if (ToolExists(tool.ToolNumber))
                 throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
-            var p = new[]
-            {
-                new SQLiteParameter("@ToolNumber", tool.ToolNumber),
-                new SQLiteParameter("@Desc", (object)tool.NameDescription ?? DBNull.Value),
-                new SQLiteParameter("@Loc", tool.Location),
-                new SQLiteParameter("@Brand", tool.Brand),
-                new SQLiteParameter("@PN", tool.PartNumber),
-                new SQLiteParameter("@Sup", (object)tool.Supplier ?? DBNull.Value),
-                new SQLiteParameter("@PD", (object)tool.PurchasedDate ?? DBNull.Value),
-                new SQLiteParameter("@Notes", (object)tool.Notes ?? DBNull.Value),
-                new SQLiteParameter("@Keywords", (object)tool.Keywords ?? DBNull.Value),
-                new SQLiteParameter("@Avail", tool.QuantityOnHand),
-                new SQLiteParameter("@Rent", tool.RentedQuantity)
-            };
             using var conn = _dbService.CreateConnection();
-            var result = SqliteHelper.ExecuteScalar(conn, UpsertToolCsv, p);
-            if (result != null)
-                tool.ToolID = result.ToString();
+            InsertTool(conn, null, tool);
             _cache = null;
         }
     
@@ -225,12 +209,47 @@ namespace ToolManagementAppV2.Services.Tools
         public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map)
         {
             var tools = CsvHelperUtil.LoadToolsFromCsv(filePath, map, out var invalidRows);
-            foreach (var tool in tools)
+            using var conn = _dbService.CreateConnection();
+            using var tran = conn.BeginTransaction();
+            try
             {
-                if (!ToolExists(tool.ToolNumber))
-                    AddTool(tool);
+                foreach (var tool in tools)
+                {
+                    if (!ToolExists(tool.ToolNumber))
+                        InsertTool(conn, tran, tool);
+                }
+                tran.Commit();
+                _cache = null;
+                return invalidRows;
             }
-            return invalidRows;
+            catch
+            {
+                tran.Rollback();
+                throw;
+            }
+        }
+
+        void InsertTool(SQLiteConnection conn, SQLiteTransaction? tran, ToolModel tool)
+        {
+            var p = new[]
+            {
+                new SQLiteParameter("@ToolNumber", tool.ToolNumber),
+                new SQLiteParameter("@Desc", (object)tool.NameDescription ?? DBNull.Value),
+                new SQLiteParameter("@Loc", tool.Location),
+                new SQLiteParameter("@Brand", tool.Brand),
+                new SQLiteParameter("@PN", tool.PartNumber),
+                new SQLiteParameter("@Sup", (object)tool.Supplier ?? DBNull.Value),
+                new SQLiteParameter("@PD", (object)tool.PurchasedDate ?? DBNull.Value),
+                new SQLiteParameter("@Notes", (object)tool.Notes ?? DBNull.Value),
+                new SQLiteParameter("@Keywords", (object)tool.Keywords ?? DBNull.Value),
+                new SQLiteParameter("@Avail", tool.QuantityOnHand),
+                new SQLiteParameter("@Rent", tool.RentedQuantity)
+            };
+            using var cmd = new SQLiteCommand(UpsertToolCsv, conn, tran);
+            cmd.Parameters.AddRange(p);
+            var result = cmd.ExecuteScalar();
+            if (result != null)
+                tool.ToolID = result.ToString();
         }
     
         public void ExportToolsToCsv(string filePath)


### PR DESCRIPTION
## Summary
- wrap customer CSV import in a single transaction and rollback on failure
- wrap tool CSV import in a single transaction and rollback on failure
- add tests proving partial CSV import failures roll back all inserts

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden while attempting to install .NET)*

------
https://chatgpt.com/codex/tasks/task_e_6899154be1348324b25d16afb5398579