### PR TITLE
Introduce salted password hashing and migrate legacy hashes

### DIFF
--- a/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using System.Data.SQLite;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
@@ -23,10 +24,45 @@ public class UserAuthenticationTests
             var added = userService.GetAllUsers().First();
 
             Assert.NotEqual("secret", added.Password);
-            Assert.Equal(SecurityHelper.ComputeSha256Hash("secret"), added.Password);
+            Assert.False(SecurityHelper.IsSha256Hash(added.Password));
+            Assert.False(string.IsNullOrWhiteSpace(added.Salt));
+            Assert.True(SecurityHelper.VerifyPassword("secret", added.Salt, added.Password));
 
             var auth = userService.AuthenticateUser("test", "secret");
             Assert.NotNull(auth);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public void AuthenticateUser_UpgradesLegacyHash()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService);
+
+            var legacy = SecurityHelper.ComputeSha256HashLegacy("secret");
+            using (var conn = dbService.CreateConnection())
+            using (var cmd = new SQLiteCommand("INSERT INTO Users (UserName, Password, IsAdmin) VALUES (@u,@p,0);", conn))
+            {
+                cmd.Parameters.AddWithValue("@u", "legacy");
+                cmd.Parameters.AddWithValue("@p", legacy);
+                cmd.ExecuteNonQuery();
+            }
+
+            var auth = userService.AuthenticateUser("legacy", "secret");
+            Assert.NotNull(auth);
+
+            var updated = userService.GetAllUsers().First(u => u.UserName == "legacy");
+            Assert.False(SecurityHelper.IsSha256Hash(updated.Password));
+            Assert.False(string.IsNullOrWhiteSpace(updated.Salt));
+            Assert.True(SecurityHelper.VerifyPassword("secret", updated.Salt, updated.Password));
         }
         finally
         {

--- a/ToolManagementAppV2/Models/Domain/User.cs
+++ b/ToolManagementAppV2/Models/Domain/User.cs
@@ -13,6 +13,9 @@ namespace ToolManagementAppV2.Models.Domain
         private string _password;
         public string Password { get => _password; set => SetProperty(ref _password, value); }
 
+        private string _salt;
+        public string Salt { get => _salt; set => SetProperty(ref _salt, value); }
+
         private string _userPhotoPath;
         public string UserPhotoPath { get => _userPhotoPath; set => SetProperty(ref _userPhotoPath, value); }
 

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -35,6 +35,7 @@ namespace ToolManagementAppV2.Services.Core
             EnsureColumn("Tools", "CheckedOutTime", "DATETIME");
             EnsureColumn("Tools", "Keywords", "TEXT");
             EnsureColumn("Users", "Password", "TEXT");
+            EnsureColumn("Users", "Salt", "TEXT");
             EnsureColumn("Users", "Email", "TEXT");
             EnsureColumn("Users", "Phone", "TEXT");
             EnsureColumn("Users", "Mobile", "TEXT");
@@ -66,7 +67,14 @@ namespace ToolManagementAppV2.Services.Core
                     UserID INTEGER PRIMARY KEY AUTOINCREMENT,
                     UserName TEXT NOT NULL,
                     UserPhotoPath TEXT,
-                    IsAdmin INTEGER NOT NULL DEFAULT 0
+                    Password TEXT,
+                    Salt TEXT,
+                    IsAdmin INTEGER NOT NULL DEFAULT 0,
+                    Email TEXT,
+                    Phone TEXT,
+                    Mobile TEXT,
+                    Address TEXT,
+                    Role TEXT
                 );
                 CREATE TABLE IF NOT EXISTS Customers (
                     CustomerID INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -38,8 +38,25 @@ namespace ToolManagementAppV2.Services.Users
                 new[] { new SQLiteParameter("@UserName", userName) }, MapUser);
             var u = users.FirstOrDefault();
             if (u == null) return null;
-            var hashed = SecurityHelper.ComputeSha256Hash(password ?? string.Empty);
-            return u.Password == hashed ? u : null;
+
+            if (string.IsNullOrWhiteSpace(u.Salt) && SecurityHelper.IsSha256Hash(u.Password))
+            {
+                var legacy = SecurityHelper.ComputeSha256HashLegacy(password ?? string.Empty);
+                if (u.Password != legacy) return null;
+                var upgraded = SecurityHelper.HashPassword(password ?? string.Empty, out var salt);
+                var p = new[]
+                {
+                    new SQLiteParameter("@Pwd", upgraded),
+                    new SQLiteParameter("@Salt", salt),
+                    new SQLiteParameter("@ID", u.UserID)
+                };
+                SqliteHelper.ExecuteNonQuery(conn, "UPDATE Users SET Password=@Pwd, Salt=@Salt WHERE UserID=@ID", p);
+                u.Password = upgraded;
+                u.Salt = salt;
+                return u;
+            }
+
+            return SecurityHelper.VerifyPassword(password ?? string.Empty, u.Salt, u.Password) ? u : null;
         }
 
         public User GetCurrentUser()
@@ -53,24 +70,34 @@ namespace ToolManagementAppV2.Services.Users
         {
             const string sql = @"
                 INSERT INTO Users
-                  (UserName, Password, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role)
+                  (UserName, Password, Salt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role)
                 VALUES
-                  (@UserName,@Password,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role);
+                  (@UserName,@Password,@Salt,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role);
                 SELECT last_insert_rowid();";
 
             using var conn = _dbService.CreateConnection();
             using var cmd = new SQLiteCommand(sql, conn);
 
-            var hashed = string.IsNullOrWhiteSpace(user.Password)
-                ? string.Empty
-                : SecurityHelper.IsSha256Hash(user.Password)
-                    ? user.Password
-                    : SecurityHelper.ComputeSha256Hash(user.Password);
+            string hashed = string.Empty;
+            string salt = string.Empty;
+            if (!string.IsNullOrWhiteSpace(user.Password))
+            {
+                if (!string.IsNullOrWhiteSpace(user.Salt))
+                {
+                    hashed = user.Password;
+                    salt = user.Salt;
+                }
+                else
+                {
+                    hashed = SecurityHelper.HashPassword(user.Password, out salt);
+                }
+            }
 
             cmd.Parameters.AddRange(new[]
             {
                 new SQLiteParameter("@UserName", user.UserName),
                 new SQLiteParameter("@Password", hashed),
+                new SQLiteParameter("@Salt",     salt),
                 new SQLiteParameter("@Photo",    (object)user.UserPhotoPath ?? DBNull.Value),
                 new SQLiteParameter("@Admin",    user.IsAdmin ? 1 : 0),
                 new SQLiteParameter("@Email",    (object)user.Email ?? DBNull.Value),
@@ -81,6 +108,7 @@ namespace ToolManagementAppV2.Services.Users
             });
             user.UserID = Convert.ToInt32(cmd.ExecuteScalar());
             user.Password = hashed;
+            user.Salt = salt;
         }
 
         public void UpdateUser(User user)
@@ -89,6 +117,7 @@ namespace ToolManagementAppV2.Services.Users
                 UPDATE Users SET
                   UserName      = @UserName,
                   Password      = @Password,
+                  Salt          = @Salt,
                   UserPhotoPath = @Photo,
                   IsAdmin       = @Admin,
                   Email         = @Email,
@@ -98,17 +127,19 @@ namespace ToolManagementAppV2.Services.Users
                   Role          = @Role
                 WHERE UserID = @UserID";
 
-            var hashed = string.IsNullOrWhiteSpace(user.Password)
-                ? string.Empty
-                : SecurityHelper.IsSha256Hash(user.Password)
-                    ? user.Password
-                    : SecurityHelper.ComputeSha256Hash(user.Password);
+            string hashed = user.Password;
+            string salt = user.Salt;
+            if (!string.IsNullOrWhiteSpace(user.Password) && string.IsNullOrWhiteSpace(user.Salt))
+            {
+                hashed = SecurityHelper.HashPassword(user.Password, out salt);
+            }
 
             var p = new[]
             {
                 new SQLiteParameter("@UserID",   user.UserID),
                 new SQLiteParameter("@UserName", user.UserName),
                 new SQLiteParameter("@Password", hashed),
+                new SQLiteParameter("@Salt",     salt),
                 new SQLiteParameter("@Photo",    (object)user.UserPhotoPath ?? DBNull.Value),
                 new SQLiteParameter("@Admin",    user.IsAdmin ? 1 : 0),
                 new SQLiteParameter("@Email",    (object)user.Email ?? DBNull.Value),
@@ -121,20 +152,23 @@ namespace ToolManagementAppV2.Services.Users
             using var conn = _dbService.CreateConnection();
             SqliteHelper.ExecuteNonQuery(conn, sql, p);
             user.Password = hashed;
+            user.Salt = salt;
         }
 
         public void ChangeUserPassword(int userID, string newPassword)
         {
-            var sql = "UPDATE Users SET Password=@Pwd WHERE UserID=@ID";
-            var hashed = string.IsNullOrWhiteSpace(newPassword)
-                ? string.Empty
-                : SecurityHelper.IsSha256Hash(newPassword)
-                    ? newPassword
-                    : SecurityHelper.ComputeSha256Hash(newPassword);
+            var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt WHERE UserID=@ID";
+            string hashed = string.Empty;
+            string salt = string.Empty;
+            if (!string.IsNullOrWhiteSpace(newPassword))
+            {
+                hashed = SecurityHelper.HashPassword(newPassword, out salt);
+            }
 
             var p = new[]
             {
                 new SQLiteParameter("@Pwd", hashed),
+                new SQLiteParameter("@Salt", salt),
                 new SQLiteParameter("@ID",  userID)
             };
             using var conn = _dbService.CreateConnection();
@@ -171,6 +205,7 @@ namespace ToolManagementAppV2.Services.Users
                 UserID = Convert.ToInt32(rdr["UserID"]),
                 UserName = rdr["UserName"].ToString(),
                 Password = rdr["Password"].ToString(),
+                Salt = rdr["Salt"]?.ToString(),
                 UserPhotoPath = rdr["UserPhotoPath"]?.ToString(),
                 IsAdmin = Convert.ToInt32(rdr["IsAdmin"]) == 1,
                 Email = rdr["Email"]?.ToString(),

--- a/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
@@ -1,10 +1,12 @@
-﻿using System.Security.Cryptography;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace ToolManagementAppV2.Utilities.Helpers
 {
     public static class SecurityHelper
     {
+        const int Iterations = 100_000;
+
         public static bool IsSha256Hash(string input)
         {
             if (string.IsNullOrWhiteSpace(input) || input.Length != 64)
@@ -18,18 +20,38 @@ namespace ToolManagementAppV2.Utilities.Helpers
             return true;
         }
 
-        public static string ComputeSha256Hash(string rawData)
+        public static string HashPassword(string password, out string salt)
         {
-            using (SHA256 sha256Hash = SHA256.Create())
+            var saltBytes = new byte[16];
+            RandomNumberGenerator.Fill(saltBytes);
+            salt = Convert.ToBase64String(saltBytes);
+            return HashPassword(password, salt);
+        }
+
+        public static string HashPassword(string password, string salt)
+        {
+            var saltBytes = Convert.FromBase64String(salt);
+            using var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, Iterations, HashAlgorithmName.SHA256);
+            return Convert.ToBase64String(pbkdf2.GetBytes(32));
+        }
+
+        public static bool VerifyPassword(string password, string salt, string hash)
+        {
+            var computed = HashPassword(password, salt);
+            return computed == hash;
+        }
+
+        // Legacy support for migrating existing SHA256 hashes
+        public static string ComputeSha256HashLegacy(string rawData)
+        {
+            using var sha256Hash = SHA256.Create();
+            var bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(rawData));
+            var builder = new StringBuilder();
+            foreach (var b in bytes)
             {
-                byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(rawData));
-                StringBuilder builder = new StringBuilder();
-                foreach (byte b in bytes)
-                {
-                    builder.Append(b.ToString("x2")); // lowercase hex
-                }
-                return builder.ToString();
+                builder.Append(b.ToString("x2"));
             }
+            return builder.ToString();
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -135,13 +135,14 @@ namespace ToolManagementAppV2.ViewModels
             if (user.IsAdmin && string.IsNullOrWhiteSpace(user.Password))
             {
                 _userService.ChangeUserPassword(user.UserID, "admin");
-                user.Password = SecurityHelper.ComputeSha256Hash("admin");
+                var refreshed = _userService.GetUserByID(user.UserID);
+                user.Password = refreshed.Password;
+                user.Salt = refreshed.Salt;
             }
 
-            var defaultHash = SecurityHelper.ComputeSha256Hash("newpassword");
             if (!user.IsAdmin &&
                 (string.IsNullOrWhiteSpace(user.Password) ||
-                 user.Password.Equals(defaultHash, StringComparison.OrdinalIgnoreCase)))
+                 SecurityHelper.VerifyPassword("newpassword", user.Salt, user.Password)))
             {
                 Application.Current.Properties["CurrentUser"] = user;
                 LoginSucceeded?.Invoke(this, EventArgs.Empty);
@@ -162,7 +163,9 @@ namespace ToolManagementAppV2.ViewModels
                 if (prompt.IsPasswordResetRequested)
                 {
                     _userService.ChangeUserPassword(user.UserID, "admin");
-                    user.Password = SecurityHelper.ComputeSha256Hash("admin");
+                    var refreshed = _userService.GetUserByID(user.UserID);
+                    user.Password = refreshed.Password;
+                    user.Salt = refreshed.Salt;
                     LoadUsers();
                     MessageBox.Show("Password has been reset to default. Please enter the new password to login.",
                         "Password Reset", MessageBoxButton.OK, MessageBoxImage.Information);


### PR DESCRIPTION
## Summary
- replace unsalted SHA256 hashing with PBKDF2-based hash and per-user salt
- persist salt in Users table and handle migration of legacy hashes
- update authentication, password change logic, and related tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68998c9545ac8324a0743cb07fda45de