### PR TITLE
Bind pages to view models and trigger data loading

### DIFF
--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -37,15 +37,39 @@ namespace ToolManagementAppV2.ViewModels
             RentalManagement = new RentalManagementViewModel(customerService);
 
             OpenDashboardCommand = new RelayCommand(() => CurrentPage = new DashboardPage());
-            OpenSearchToolsCommand = new RelayCommand(() => CurrentPage = new ToolSearchPage());
-            OpenManageToolsCommand = new RelayCommand(() => CurrentPage = new ManageToolsPage());
-            OpenRentalsCommand = new RelayCommand(() => CurrentPage = new RentalsPage());
-            OpenCustomersCommand = new RelayCommand(() => CurrentPage = new CustomersPage());
-            OpenUsersCommand = new RelayCommand(() => CurrentPage = new UsersPage());
-            OpenSettingsCommand = new RelayCommand(() => CurrentPage = new SettingsPage());
-            OpenImportExportCommand = new RelayCommand(() => CurrentPage = new ImportExportPage());
-            OpenActivityLogsCommand = new RelayCommand(() => CurrentPage = new ActivityLogsPage());
-            OpenReportsCommand = new RelayCommand(() => CurrentPage = new ReportsPage());
+            OpenSearchToolsCommand = new RelayCommand(() =>
+            {
+                ToolManagement.LoadTools();
+                CurrentPage = new ToolSearchPage { DataContext = ToolManagement };
+            });
+            OpenManageToolsCommand = new RelayCommand(() =>
+            {
+                ToolManagement.LoadTools();
+                CurrentPage = new ManageToolsPage { DataContext = ToolManagement };
+            });
+            OpenRentalsCommand = new RelayCommand(() =>
+            {
+                RentalManagement.LoadCustomers();
+                CurrentPage = new RentalsPage { DataContext = RentalManagement };
+            });
+            OpenCustomersCommand = new RelayCommand(() =>
+            {
+                RentalManagement.LoadCustomers();
+                CurrentPage = new CustomersPage { DataContext = RentalManagement };
+            });
+            OpenUsersCommand = new RelayCommand(() =>
+            {
+                UserManagement.LoadUsers();
+                CurrentPage = new UsersPage { DataContext = UserManagement };
+            });
+            OpenSettingsCommand = new RelayCommand(() =>
+                CurrentPage = new SettingsPage { DataContext = new SettingsViewModel() });
+            OpenImportExportCommand = new RelayCommand(() =>
+                CurrentPage = new ImportExportPage());
+            OpenActivityLogsCommand = new RelayCommand(() =>
+                CurrentPage = new ActivityLogsPage());
+            OpenReportsCommand = new RelayCommand(() =>
+                CurrentPage = new ReportsPage());
         }
     }
 }


### PR DESCRIPTION
## Summary
- Assign view models as DataContext when navigating to pages from `MainViewModel`
- Load tools, users, or customers during navigation to ensure data is current
- Instantiate settings view model for settings page navigation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6899914a3d1883248d63feffb9d82542