### PR TITLE
Add admin visibility flag and refresh logic

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -1,0 +1,60 @@
+using System.IO;
+using System.Windows;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class MainViewModelCurrentUserTests
+    {
+        [Fact]
+        public void RefreshCurrentUser_RaisesPropertyChanged()
+        {
+            if (Application.Current == null)
+                new Application();
+
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var userService = new UserService(db);
+                var customerService = new CustomerService(db);
+
+                var vm = new MainViewModel(toolService, userService, customerService);
+
+                bool raised = false;
+                vm.PropertyChanged += (s, e) =>
+                {
+                    if (e.PropertyName == nameof(MainViewModel.IsCurrentUserAdmin))
+                        raised = true;
+                };
+
+                Application.Current.Properties["CurrentUser"] = new User { UserName = "admin", IsAdmin = true };
+                vm.RefreshCurrentUser();
+
+                Assert.True(raised);
+                Assert.True(vm.IsCurrentUserAdmin);
+
+                raised = false;
+                Application.Current.Properties["CurrentUser"] = new User { UserName = "user", IsAdmin = false };
+                vm.RefreshCurrentUser();
+
+                Assert.True(raised);
+                Assert.False(vm.IsCurrentUserAdmin);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+                Application.Current.Properties.Remove("CurrentUser");
+            }
+        }
+    }
+}
+

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -1,7 +1,9 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System.Windows;
 using System.Windows.Controls;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Views;
 
 namespace ToolManagementAppV2.ViewModels
@@ -29,6 +31,11 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand OpenImportExportCommand { get; }
         public IRelayCommand OpenActivityLogsCommand { get; }
         public IRelayCommand OpenReportsCommand { get; }
+
+        public bool IsCurrentUserAdmin =>
+            Application.Current.Properties["CurrentUser"] is User u && u.IsAdmin;
+
+        public void RefreshCurrentUser() => OnPropertyChanged(nameof(IsCurrentUserAdmin));
 
         public MainViewModel(IToolService toolService, IUserService userService, ICustomerService customerService)
         {

--- a/ToolManagementAppV2/Views/LoginWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml.cs
@@ -10,7 +10,12 @@ namespace ToolManagementAppV2
         {
             InitializeComponent();
             var vm = new LoginViewModel();
-            vm.LoginSucceeded += (_, __) => DialogResult = true;
+            vm.LoginSucceeded += (_, __) =>
+            {
+                if (Application.Current.MainWindow?.DataContext is MainViewModel main)
+                    main.RefreshCurrentUser();
+                DialogResult = true;
+            };
             DataContext = vm;
         }
     }


### PR DESCRIPTION
## Summary
- expose `IsCurrentUserAdmin` on `MainViewModel` to drive admin-only button visibility
- notify `MainViewModel` when login succeeds so visibility updates on user changes
- add unit test covering admin flag refresh

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_6899928669988324bcf7d2106dcfb499