### PR TITLE
feat: add rentals view model and navigation

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -7,6 +7,7 @@ using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
+using ToolManagementAppV2.Services.Rentals;
 
 namespace ToolManagementAppV2.Tests.ViewModels
 {
@@ -25,8 +26,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var toolService = new ToolService(db);
                 var userService = new UserService(db);
                 var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService);
 
                 bool raised = false;
                 vm.PropertyChanged += (s, e) =>

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -6,6 +6,7 @@ using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Views;
+using ToolManagementAppV2.Services.Rentals;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.ViewModels
@@ -22,12 +23,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 IUserService userService = new UserService(db);
                 ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService);
 
                 Assert.NotNull(vm.ToolManagement);
                 Assert.NotNull(vm.UserManagement);
                 Assert.NotNull(vm.RentalManagement);
+                Assert.NotNull(vm.Rentals);
             }
             finally
             {
@@ -46,8 +49,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 IUserService userService = new UserService(db);
                 ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService);
                 vm.OpenDashboardCommand.Execute(null);
 
                 Assert.IsType<DashboardPage>(vm.CurrentPage);

--- a/ToolManagementAppV2.Tests/ViewModels/RentalViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/RentalViewModelTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using System.Linq;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+using ToolManagementAppV2.Models.Domain;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class RentalViewModelTests
+    {
+        [Fact]
+        public void LoadRentals_PopulatesActiveAndOverdue()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+
+                // seed tool and customer
+                var tool1 = new Tool { ToolID = "T1", ToolNumber = "T1" };
+                var tool2 = new Tool { ToolID = "T2", ToolNumber = "T2" };
+                toolService.AddTool(tool1);
+                toolService.AddTool(tool2);
+                var customer = new Customer { Company = "C1" };
+                customerService.AddCustomer(customer);
+                var cust = customerService.GetAllCustomers().First();
+
+                // create one active rental and one overdue rental
+                rentalService.RentTool("T1", cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentTool("T2", cust.CustomerID, DateTime.Today.AddDays(-10), DateTime.Today.AddDays(-5));
+
+                var vm = new RentalViewModel(rentalService);
+                vm.LoadRentals();
+
+                Assert.Single(vm.ActiveRentals);
+                Assert.Single(vm.OverdueRentals);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -5,6 +5,7 @@ using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2
@@ -19,7 +20,8 @@ namespace ToolManagementAppV2
             var toolService = new ToolService(db);
             var customerService = new CustomerService(db);
             var userService = new UserService(db);
-            DataContext = new MainViewModel(toolService, userService, customerService);
+            var rentalService = new RentalService(db);
+            DataContext = new MainViewModel(toolService, userService, customerService, rentalService);
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -13,6 +13,7 @@ namespace ToolManagementAppV2.ViewModels
         public ToolManagementViewModel ToolManagement { get; }
         public UserManagementViewModel UserManagement { get; }
         public RentalManagementViewModel RentalManagement { get; }
+        public RentalViewModel Rentals { get; }
 
         Page _currentPage;
         public Page CurrentPage
@@ -37,11 +38,12 @@ namespace ToolManagementAppV2.ViewModels
 
         public void RefreshCurrentUser() => OnPropertyChanged(nameof(IsCurrentUserAdmin));
 
-        public MainViewModel(IToolService toolService, IUserService userService, ICustomerService customerService)
+        public MainViewModel(IToolService toolService, IUserService userService, ICustomerService customerService, IRentalService rentalService)
         {
             ToolManagement = new ToolManagementViewModel(toolService);
             UserManagement = new UserManagementViewModel(userService);
             RentalManagement = new RentalManagementViewModel(customerService);
+            Rentals = new RentalViewModel(rentalService);
 
             OpenDashboardCommand = new RelayCommand(() => CurrentPage = new DashboardPage());
             OpenSearchToolsCommand = new RelayCommand(() =>
@@ -56,8 +58,8 @@ namespace ToolManagementAppV2.ViewModels
             });
             OpenRentalsCommand = new RelayCommand(() =>
             {
-                RentalManagement.LoadCustomers();
-                CurrentPage = new RentalsPage { DataContext = RentalManagement };
+                Rentals.LoadRentals();
+                CurrentPage = new RentalsPage { DataContext = Rentals };
             });
             OpenCustomersCommand = new RelayCommand(() =>
             {

--- a/ToolManagementAppV2/ViewModels/RentalViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/RentalViewModel.cs
@@ -1,21 +1,94 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System;
+using System.Collections.ObjectModel;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Utilities.Extensions;
+using ToolManagementAppV2.Views;
+using ToolManagementAppV2.ViewModels.Rental;
 
 namespace ToolManagementAppV2.ViewModels
 {
-    internal class RentalViewModel : ObservableObject
+    /// <summary>
+    /// View model backing the RentalsPage. Exposes active and overdue rentals
+    /// along with commands for returning, extending and viewing history of the
+    /// selected rental.
+    /// </summary>
+    public class RentalViewModel : ObservableObject
     {
-        private RentalModel _rental;
-        public RentalModel Rental
+        private readonly IRentalService _rentalService;
+
+        public ObservableCollection<RentalModel> ActiveRentals { get; } = new();
+        public ObservableCollection<RentalModel> OverdueRentals { get; } = new();
+
+        private RentalModel _selectedRental;
+        public RentalModel SelectedRental
         {
-            get => _rental;
-            set => SetProperty(ref _rental, value);
+            get => _selectedRental;
+            set
+            {
+                if (SetProperty(ref _selectedRental, value))
+                {
+                    ((RelayCommand)ReturnToolCommand).NotifyCanExecuteChanged();
+                    ((RelayCommand)ExtendRentalCommand).NotifyCanExecuteChanged();
+                    ((RelayCommand)ViewSelectedRentalHistoryCommand).NotifyCanExecuteChanged();
+                }
+            }
         }
 
-        public RentalViewModel(RentalModel rental)
+        public IRelayCommand ReturnToolCommand { get; }
+        public IRelayCommand ExtendRentalCommand { get; }
+        public IRelayCommand ViewSelectedRentalHistoryCommand { get; }
+
+        public RentalViewModel(IRentalService rentalService)
         {
-            _rental = rental;
+            _rentalService = rentalService;
+            ReturnToolCommand = new RelayCommand(ReturnTool, () => SelectedRental != null);
+            ExtendRentalCommand = new RelayCommand(ExtendRental, () => SelectedRental != null);
+            ViewSelectedRentalHistoryCommand = new RelayCommand(ViewHistory, () => SelectedRental != null);
         }
 
-        public string StatusSummary => $"{_rental.Status} (Due: {_rental.DueDate:yyyy-MM-dd})";
+        /// <summary>Loads active and overdue rentals from the service.</summary>
+        public void LoadRentals()
+        {
+            ActiveRentals.ReplaceRange(_rentalService.GetActiveRentals());
+            OverdueRentals.ReplaceRange(_rentalService.GetOverdueRentals());
+        }
+
+        void ReturnTool()
+        {
+            if (SelectedRental == null)
+                return;
+
+            _rentalService.ReturnTool(SelectedRental.RentalID, DateTime.Today);
+            LoadRentals();
+        }
+
+        void ExtendRental()
+        {
+            if (SelectedRental == null)
+                return;
+
+            var newDueDate = SelectedRental.DueDate.AddDays(7);
+            _rentalService.ExtendRental(SelectedRental.RentalID, newDueDate);
+            LoadRentals();
+        }
+
+        void ViewHistory()
+        {
+            if (SelectedRental == null)
+                return;
+
+            var history = _rentalService.GetRentalHistoryForTool(SelectedRental.ToolID);
+            var tool = new ToolModel
+            {
+                ToolID = SelectedRental.ToolID,
+                ToolNumber = SelectedRental.ToolNumber,
+                NameDescription = SelectedRental.ToolNumber
+            };
+            var vm = new RentalHistoryViewModel(tool, history);
+            var win = new RentalHistoryWindow { DataContext = vm, Title = $"Rental History - {tool.ToolNumber}" };
+            win.ShowDialog();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add RentalViewModel exposing rental collections and actions
- hook RentalsPage navigation to RentalViewModel and load rentals
- wire up rental service in MainWindow and view model
- add tests for RentalViewModel and update navigation tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68999bfbdd9c83248caa4ddc666a7f3d