### PR TITLE
Add user photo upload and management commands

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -28,7 +28,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService());
 
                 bool raised = false;
                 vm.PropertyChanged += (s, e) =>
@@ -58,5 +58,10 @@ namespace ToolManagementAppV2.Tests.ViewModels
             }
         }
     }
+}
+
+class StubFileDialogService : ToolManagementAppV2.Interfaces.IFileDialogService
+{
+    public string OpenFile(string filter) => null;
 }
 

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -25,7 +25,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService());
 
                 Assert.NotNull(vm.ToolManagement);
                 Assert.NotNull(vm.UserManagement);
@@ -51,7 +51,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService());
                 vm.OpenDashboardCommand.Execute(null);
 
                 Assert.IsType<DashboardPage>(vm.CurrentPage);
@@ -63,4 +63,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
             }
         }
     }
+}
+
+class StubFileDialogService : ToolManagementAppV2.Interfaces.IFileDialogService
+{
+    public string OpenFile(string filter) => null;
 }

--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -1,0 +1,91 @@
+using System.IO;
+using System.Linq;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class UserManagementViewModelTests
+    {
+        [Fact]
+        public void UpdateUserCommand_PersistsChanges()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IUserService userService = new UserService(db);
+                var vm = new UserManagementViewModel(userService, new StubFileDialogService());
+                userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                vm.LoadUsers();
+                vm.SelectedUser = vm.Users.First();
+                vm.SelectedUser.Email = "test@example.com";
+                vm.UpdateUserCommand.Execute(null);
+                var updated = userService.GetAllUsers().First();
+                Assert.Equal("test@example.com", updated.Email);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void DeleteUserCommand_RemovesUser()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IUserService userService = new UserService(db);
+                var vm = new UserManagementViewModel(userService, new StubFileDialogService());
+                userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                vm.LoadUsers();
+                vm.SelectedUser = vm.Users.First();
+                vm.DeleteUserCommand.Execute(null);
+                Assert.Empty(userService.GetAllUsers());
+                Assert.Empty(vm.Users);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void UploadUserPhotoCommand_SetsPhotoPathAndPersists()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IUserService userService = new UserService(db);
+                var fileSvc = new StubFileDialogService { FileToReturn = "path/to/image.png" };
+                var vm = new UserManagementViewModel(userService, fileSvc);
+                userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                vm.LoadUsers();
+                vm.SelectedUser = vm.Users.First();
+                vm.UploadUserPhotoCommand.Execute(null);
+                var updated = userService.GetAllUsers().First();
+                Assert.Equal("path/to/image.png", updated.UserPhotoPath);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}
+
+class StubFileDialogService : IFileDialogService
+{
+    public string FileToReturn { get; set; }
+    public string OpenFile(string filter) => FileToReturn;
+}

--- a/ToolManagementAppV2/Interfaces/IFileDialogService.cs
+++ b/ToolManagementAppV2/Interfaces/IFileDialogService.cs
@@ -1,0 +1,7 @@
+namespace ToolManagementAppV2.Interfaces
+{
+    public interface IFileDialogService
+    {
+        string OpenFile(string filter);
+    }
+}

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -21,7 +21,8 @@ namespace ToolManagementAppV2
             var customerService = new CustomerService(db);
             var userService = new UserService(db);
             var rentalService = new RentalService(db);
-            DataContext = new MainViewModel(toolService, userService, customerService, rentalService);
+            var fileDialogService = new FileDialogService();
+            DataContext = new MainViewModel(toolService, userService, customerService, rentalService, fileDialogService);
         }
     }
 }

--- a/ToolManagementAppV2/Services/Core/FileDialogService.cs
+++ b/ToolManagementAppV2/Services/Core/FileDialogService.cs
@@ -1,0 +1,17 @@
+using Microsoft.Win32;
+using ToolManagementAppV2.Interfaces;
+
+namespace ToolManagementAppV2.Services.Core
+{
+    public class FileDialogService : IFileDialogService
+    {
+        public string OpenFile(string filter)
+        {
+            var dlg = new OpenFileDialog
+            {
+                Filter = filter
+            };
+            return dlg.ShowDialog() == true ? dlg.FileName : null;
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -38,10 +38,10 @@ namespace ToolManagementAppV2.ViewModels
 
         public void RefreshCurrentUser() => OnPropertyChanged(nameof(IsCurrentUserAdmin));
 
-        public MainViewModel(IToolService toolService, IUserService userService, ICustomerService customerService, IRentalService rentalService)
+        public MainViewModel(IToolService toolService, IUserService userService, ICustomerService customerService, IRentalService rentalService, IFileDialogService fileDialogService)
         {
             ToolManagement = new ToolManagementViewModel(toolService);
-            UserManagement = new UserManagementViewModel(userService);
+            UserManagement = new UserManagementViewModel(userService, fileDialogService);
             RentalManagement = new RentalManagementViewModel(customerService);
             Rentals = new RentalViewModel(rentalService);
 

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -9,6 +9,7 @@ namespace ToolManagementAppV2.ViewModels
     public class UserManagementViewModel : ObservableObject
     {
         private readonly IUserService _userService;
+        private readonly IFileDialogService _fileDialogService;
 
         public ObservableCollection<UserModel> Users { get; } = new();
 
@@ -20,17 +21,51 @@ namespace ToolManagementAppV2.ViewModels
         }
 
         public IRelayCommand LoadUsersCommand { get; }
+        public IRelayCommand UploadUserPhotoCommand { get; }
+        public IRelayCommand UpdateUserCommand { get; }
+        public IRelayCommand DeleteUserCommand { get; }
 
-        public UserManagementViewModel(IUserService userService)
+        public UserManagementViewModel(IUserService userService, IFileDialogService fileDialogService)
         {
             _userService = userService;
+            _fileDialogService = fileDialogService;
             LoadUsersCommand = new RelayCommand(LoadUsers);
+            UploadUserPhotoCommand = new RelayCommand(UploadUserPhoto);
+            UpdateUserCommand = new RelayCommand(UpdateUser);
+            DeleteUserCommand = new RelayCommand(DeleteUser);
         }
 
         public void LoadUsers()
         {
             var all = _userService.GetAllUsers();
             Users.ReplaceRange(all);
+        }
+
+        public void UploadUserPhoto()
+        {
+            if (SelectedUser == null) return;
+            var path = _fileDialogService.OpenFile("Image Files|*.png;*.jpg;*.jpeg;*.bmp|All Files|*.*");
+            if (!string.IsNullOrEmpty(path))
+            {
+                SelectedUser.UserPhotoPath = path;
+                _userService.UpdateUser(SelectedUser);
+            }
+        }
+
+        public void UpdateUser()
+        {
+            if (SelectedUser == null) return;
+            _userService.UpdateUser(SelectedUser);
+        }
+
+        public void DeleteUser()
+        {
+            if (SelectedUser == null) return;
+            if (_userService.TryDeleteUser(SelectedUser.UserID))
+            {
+                Users.Remove(SelectedUser);
+                SelectedUser = null;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend UserManagementViewModel with commands to upload photos, update details and delete accounts
- introduce FileDialogService and inject via MainViewModel and MainWindow
- add unit tests for new user management commands

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68999e50c7d88324b59b2c9ed5ec71fc