### PR TITLE
Ensure tool search navigation initializes data

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -1,4 +1,12 @@
+using System.IO;
 using ToolManagementAppV2;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Views;
 using Xunit;
@@ -17,5 +25,38 @@ namespace ToolManagementAppV2.Tests.Tests
 
             Assert.IsType<ToolSearchPage>(vm.CurrentPage);
         }
+
+        [Fact]
+        public void OpenSearchToolsCommand_LoadsToolsAndSetsDataContext()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
+
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService());
+                vm.OpenSearchToolsCommand.Execute(null);
+
+                var page = Assert.IsType<ToolSearchPage>(vm.CurrentPage);
+                Assert.Same(vm.ToolManagement, page.DataContext);
+                Assert.Same(vm.ToolManagement.HandTools, page.HandToolsList.ItemsSource);
+                Assert.NotEmpty(vm.ToolManagement.HandTools);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
+}
+
+class StubFileDialogService : IFileDialogService
+{
+    public string OpenFile(string filter) => null;
 }


### PR DESCRIPTION
## Summary
- add regression test verifying that navigating to tool search loads tool data and binds the page to the ToolManagement view model

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6899a0851ed483248aaa76f530cd9211