### PR TITLE
Implement MVVM layouts for auxiliary pages

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -37,9 +37,10 @@ namespace ToolManagementAppV2.Tests.Tests
                 IUserService userService = new UserService(db);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService());
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
                 vm.OpenSearchToolsCommand.Execute(null);
 
                 var page = Assert.IsType<ToolSearchPage>(vm.CurrentPage);

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -9,6 +9,7 @@ using ToolManagementAppV2.ViewModels;
 using Xunit;
 using ToolManagementAppV2.Services.Rentals;
 
+
 namespace ToolManagementAppV2.Tests.ViewModels
 {
     public class MainViewModelCurrentUserTests
@@ -27,8 +28,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var userService = new UserService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService());
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
 
                 bool raised = false;
                 vm.PropertyChanged += (s, e) =>
@@ -64,4 +66,3 @@ class StubFileDialogService : ToolManagementAppV2.Interfaces.IFileDialogService
 {
     public string OpenFile(string filter) => null;
 }
-

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -9,6 +9,7 @@ using ToolManagementAppV2.Views;
 using ToolManagementAppV2.Services.Rentals;
 using Xunit;
 
+
 namespace ToolManagementAppV2.Tests.ViewModels
 {
     public class MainViewModelNavigationTests
@@ -24,13 +25,17 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IUserService userService = new UserService(db);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService());
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
 
                 Assert.NotNull(vm.ToolManagement);
                 Assert.NotNull(vm.UserManagement);
                 Assert.NotNull(vm.RentalManagement);
                 Assert.NotNull(vm.Rentals);
+                Assert.NotNull(vm.ImportExport);
+                Assert.NotNull(vm.ActivityLogs);
+                Assert.NotNull(vm.Reports);
             }
             finally
             {
@@ -50,11 +55,92 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IUserService userService = new UserService(db);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService());
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
                 vm.OpenDashboardCommand.Execute(null);
 
                 Assert.IsType<DashboardPage>(vm.CurrentPage);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void OpenImportExportCommand_SetsDataContext()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
+                vm.OpenImportExportCommand.Execute(null);
+
+                var page = Assert.IsType<ImportExportPage>(vm.CurrentPage);
+                Assert.IsType<ImportExportViewModel>(page.DataContext);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void OpenActivityLogsCommand_LoadsLogs()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var activityLogService = new ActivityLogService(db);
+                activityLogService.LogAction(1, "user", "action");
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
+                vm.OpenActivityLogsCommand.Execute(null);
+
+                var page = Assert.IsType<ActivityLogsPage>(vm.CurrentPage);
+                var logsVm = Assert.IsType<ActivityLogsViewModel>(page.DataContext);
+                Assert.NotEmpty(logsVm.Logs);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void OpenReportsCommand_SetsDataContext()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var activityLogService = new ActivityLogService(db);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
+                vm.OpenReportsCommand.Execute(null);
+
+                var page = Assert.IsType<ReportsPage>(vm.CurrentPage);
+                Assert.IsType<ReportsViewModel>(page.DataContext);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Windows.Documents;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class NewPageViewModelTests
+    {
+        [Fact]
+        public void ActivityLogsViewModel_LoadsLogs()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var service = new ActivityLogService(db);
+                service.LogAction(1, "user", "action");
+                var vm = new ActivityLogsViewModel(service);
+                vm.LoadLogs();
+                Assert.NotEmpty(vm.Logs);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void ImportExportViewModel_ExportCommand_InvokesService()
+        {
+            var toolService = new StubToolService();
+            var vm = new ImportExportViewModel(toolService, new StubFileDialogService());
+            vm.ExportCommand.Execute(null);
+            Assert.True(toolService.ExportCalled);
+        }
+
+        [Fact]
+        public void ReportsViewModel_GenerateSummaryReport_SetsDocument()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var reportService = new ReportService(new StubToolService(), new StubRentalService(), new ActivityLogService(db), new StubCustomerService(), new StubUserService());
+                var vm = new ReportsViewModel(reportService);
+                vm.GenerateSummaryReportCommand.Execute(null);
+                Assert.NotNull(vm.CurrentReport);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+    }
+
+    class StubFileDialogService : IFileDialogService
+    {
+        public string OpenFile(string filter) => "path.csv";
+    }
+
+    class StubToolService : IToolService
+    {
+        public bool ExportCalled { get; private set; }
+        public void ExportToolsToCsv(string filePath) => ExportCalled = true;
+        public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => new();
+        public List<ToolModel> GetAllTools() => new();
+        public void AddTool(ToolModel tool) => throw new System.NotImplementedException();
+        public void UpdateTool(ToolModel tool) => throw new System.NotImplementedException();
+        public void DeleteTool(string toolID) => throw new System.NotImplementedException();
+        public ToolModel GetToolByID(string toolID) => throw new System.NotImplementedException();
+        public List<ToolModel> SearchTools(string? searchText) => new();
+        public void ToggleToolCheckOutStatus(string toolID, string currentUser) => throw new System.NotImplementedException();
+        public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
+        public void UpdateToolImage(string toolID, string imagePath) => throw new System.NotImplementedException();
+        public ImageImportResult ImportToolImages(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector) => new();
+        public void UpdateToolQuantities(string toolID, int qtyChange, bool isRental) => throw new System.NotImplementedException();
+    }
+
+    class StubRentalService : IRentalService
+    {
+        public void RentTool(string toolID, int customerID, System.DateTime rentalDate, System.DateTime dueDate) => throw new System.NotImplementedException();
+        public void ReturnTool(int rentalID, System.DateTime returnDate) => throw new System.NotImplementedException();
+        public void ExtendRental(int rentalID, System.DateTime newDueDate) => throw new System.NotImplementedException();
+        public List<Rental> GetActiveRentals() => new();
+        public List<Rental> GetOverdueRentals() => new();
+        public List<Rental> GetAllRentals() => new();
+        public List<Rental> GetRentalHistoryForTool(string toolID) => new();
+        public List<Rental> GetRentalHistoryForCustomer(int customerID) => new();
+    }
+
+    class StubCustomerService : ICustomerService
+    {
+        public void AddCustomer(Customer customer) => throw new System.NotImplementedException();
+        public void UpdateCustomer(Customer customer) => throw new System.NotImplementedException();
+        public void DeleteCustomer(int customerID) => throw new System.NotImplementedException();
+        public Customer GetCustomerByID(int customerID) => throw new System.NotImplementedException();
+        public List<Customer> GetAllCustomers() => new();
+        public List<Customer> SearchCustomers(string searchTerm) => new();
+        public void ImportCustomersFromCsv(string filePath, IDictionary<string, string> map) => throw new System.NotImplementedException();
+        public void ExportCustomersToCsv(string filePath) => throw new System.NotImplementedException();
+    }
+
+    class StubUserService : IUserService
+    {
+        public List<User> GetAllUsers() => new();
+        public User GetUserByID(int userID) => throw new System.NotImplementedException();
+        public User AuthenticateUser(string userName, string password) => throw new System.NotImplementedException();
+        public User GetCurrentUser() => throw new System.NotImplementedException();
+        public void AddUser(User user) => throw new System.NotImplementedException();
+        public void UpdateUser(User user) => throw new System.NotImplementedException();
+        public bool TryDeleteUser(int userID) => throw new System.NotImplementedException();
+        public bool DeleteUser(int userID) => throw new System.NotImplementedException();
+        public void ChangeUserPassword(int userID, string newPassword) => throw new System.NotImplementedException();
+    }
+}

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -21,8 +21,9 @@ namespace ToolManagementAppV2
             var customerService = new CustomerService(db);
             var userService = new UserService(db);
             var rentalService = new RentalService(db);
+            var activityLogService = new ActivityLogService(db);
             var fileDialogService = new FileDialogService();
-            DataContext = new MainViewModel(toolService, userService, customerService, rentalService, fileDialogService);
+            DataContext = new MainViewModel(toolService, userService, customerService, rentalService, fileDialogService, activityLogService);
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/ActivityLogsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ActivityLogsViewModel.cs
@@ -1,0 +1,30 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Collections.ObjectModel;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Users;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class ActivityLogsViewModel : ObservableObject
+    {
+        private readonly ActivityLogService _service;
+
+        public ObservableCollection<ActivityLog> Logs { get; } = new();
+
+        public IRelayCommand RefreshCommand { get; }
+
+        public ActivityLogsViewModel(ActivityLogService service)
+        {
+            _service = service;
+            RefreshCommand = new RelayCommand(LoadLogs);
+        }
+
+        public void LoadLogs()
+        {
+            Logs.Clear();
+            foreach (var log in _service.GetRecentLogs())
+                Logs.Add(log);
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -1,0 +1,38 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Collections.Generic;
+using ToolManagementAppV2.Interfaces;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class ImportExportViewModel : ObservableObject
+    {
+        private readonly IToolService _toolService;
+        private readonly IFileDialogService _fileDialogService;
+
+        public IRelayCommand ImportCommand { get; }
+        public IRelayCommand ExportCommand { get; }
+
+        public ImportExportViewModel(IToolService toolService, IFileDialogService fileDialogService)
+        {
+            _toolService = toolService;
+            _fileDialogService = fileDialogService;
+            ImportCommand = new RelayCommand(ImportTools);
+            ExportCommand = new RelayCommand(ExportTools);
+        }
+
+        void ImportTools()
+        {
+            var path = _fileDialogService.OpenFile("CSV Files|*.csv");
+            if (!string.IsNullOrEmpty(path))
+                _toolService.ImportToolsFromCsv(path, new Dictionary<string, string>());
+        }
+
+        void ExportTools()
+        {
+            var path = _fileDialogService.OpenFile("CSV Files|*.csv");
+            if (!string.IsNullOrEmpty(path))
+                _toolService.ExportToolsToCsv(path);
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -5,6 +5,8 @@ using System.Windows.Controls;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Views;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Services.Tools;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -14,6 +16,9 @@ namespace ToolManagementAppV2.ViewModels
         public UserManagementViewModel UserManagement { get; }
         public RentalManagementViewModel RentalManagement { get; }
         public RentalViewModel Rentals { get; }
+        public ImportExportViewModel ImportExport { get; }
+        public ActivityLogsViewModel ActivityLogs { get; }
+        public ReportsViewModel Reports { get; }
 
         Page _currentPage;
         public Page CurrentPage
@@ -38,12 +43,15 @@ namespace ToolManagementAppV2.ViewModels
 
         public void RefreshCurrentUser() => OnPropertyChanged(nameof(IsCurrentUserAdmin));
 
-        public MainViewModel(IToolService toolService, IUserService userService, ICustomerService customerService, IRentalService rentalService, IFileDialogService fileDialogService)
+        public MainViewModel(IToolService toolService, IUserService userService, ICustomerService customerService, IRentalService rentalService, IFileDialogService fileDialogService, ActivityLogService activityLogService)
         {
             ToolManagement = new ToolManagementViewModel(toolService);
             UserManagement = new UserManagementViewModel(userService, fileDialogService);
             RentalManagement = new RentalManagementViewModel(customerService);
             Rentals = new RentalViewModel(rentalService);
+            ImportExport = new ImportExportViewModel(toolService, fileDialogService);
+            ActivityLogs = new ActivityLogsViewModel(activityLogService);
+            Reports = new ReportsViewModel(new ReportService(toolService, rentalService, activityLogService, customerService, userService));
 
             OpenDashboardCommand = new RelayCommand(() => CurrentPage = new DashboardPage());
             OpenSearchToolsCommand = new RelayCommand(() =>
@@ -74,11 +82,14 @@ namespace ToolManagementAppV2.ViewModels
             OpenSettingsCommand = new RelayCommand(() =>
                 CurrentPage = new SettingsPage { DataContext = new SettingsViewModel() });
             OpenImportExportCommand = new RelayCommand(() =>
-                CurrentPage = new ImportExportPage());
+                CurrentPage = new ImportExportPage { DataContext = ImportExport });
             OpenActivityLogsCommand = new RelayCommand(() =>
-                CurrentPage = new ActivityLogsPage());
+            {
+                ActivityLogs.LoadLogs();
+                CurrentPage = new ActivityLogsPage { DataContext = ActivityLogs };
+            });
             OpenReportsCommand = new RelayCommand(() =>
-                CurrentPage = new ReportsPage());
+                CurrentPage = new ReportsPage { DataContext = Reports });
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/ReportsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ReportsViewModel.cs
@@ -1,0 +1,29 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Windows.Documents;
+using ToolManagementAppV2.Services.Tools;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class ReportsViewModel : ObservableObject
+    {
+        private readonly ReportService _reportService;
+
+        private FlowDocument _currentReport;
+        public FlowDocument CurrentReport
+        {
+            get => _currentReport;
+            set => SetProperty(ref _currentReport, value);
+        }
+
+        public IRelayCommand GenerateSummaryReportCommand { get; }
+        public IRelayCommand GenerateActivityLogReportCommand { get; }
+
+        public ReportsViewModel(ReportService reportService)
+        {
+            _reportService = reportService;
+            GenerateSummaryReportCommand = new RelayCommand(() => CurrentReport = _reportService.GenerateSummaryReport());
+            GenerateActivityLogReportCommand = new RelayCommand(() => CurrentReport = _reportService.GenerateActivityLogReport());
+        }
+    }
+}

--- a/ToolManagementAppV2/Views/ActivityLogsPage.xaml
+++ b/ToolManagementAppV2/Views/ActivityLogsPage.xaml
@@ -1,7 +1,18 @@
 <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      x:Class="ToolManagementAppV2.Views.ActivityLogsPage">
-    <Grid>
-        <TextBlock Text="Activity Logs" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="32"/>
+      x:Class="ToolManagementAppV2.Views.ActivityLogsPage"
+      Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="10">
+        <DataGrid ItemsSource="{Binding Logs}"
+                  AutoGenerateColumns="False"
+                  CanUserAddRows="False"
+                  Background="{DynamicResource CardBackgroundBrush}"
+                  Foreground="{DynamicResource PrimaryTextBrush}">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="User" Binding="{Binding UserName}"/>
+                <DataGridTextColumn Header="Action" Binding="{Binding Action}"/>
+                <DataGridTextColumn Header="Timestamp" Binding="{Binding Timestamp}"/>
+            </DataGrid.Columns>
+        </DataGrid>
     </Grid>
 </Page>

--- a/ToolManagementAppV2/Views/ImportExportPage.xaml
+++ b/ToolManagementAppV2/Views/ImportExportPage.xaml
@@ -1,7 +1,15 @@
 <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      x:Class="ToolManagementAppV2.Views.ImportExportPage">
-    <Grid>
-        <TextBlock Text="Import/Export" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="32"/>
-    </Grid>
+      x:Class="ToolManagementAppV2.Views.ImportExportPage"
+      Background="{DynamicResource BackgroundBrush}">
+    <StackPanel Margin="20" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <Button Content="Import Tools" Command="{Binding ImportCommand}"
+                Width="150" Margin="0,0,0,10"
+                Background="{DynamicResource CardBackgroundBrush}"
+                Foreground="{DynamicResource PrimaryTextBrush}"/>
+        <Button Content="Export Tools" Command="{Binding ExportCommand}"
+                Width="150"
+                Background="{DynamicResource CardBackgroundBrush}"
+                Foreground="{DynamicResource PrimaryTextBrush}"/>
+    </StackPanel>
 </Page>

--- a/ToolManagementAppV2/Views/ReportsPage.xaml
+++ b/ToolManagementAppV2/Views/ReportsPage.xaml
@@ -1,7 +1,24 @@
 <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      x:Class="ToolManagementAppV2.Views.ReportsPage">
-    <Grid>
-        <TextBlock Text="Reports" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="32"/>
+      x:Class="ToolManagementAppV2.Views.ReportsPage"
+      Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+            <Button Content="Summary" Command="{Binding GenerateSummaryReportCommand}"
+                    Margin="0,0,10,0" Width="120"
+                    Background="{DynamicResource CardBackgroundBrush}"
+                    Foreground="{DynamicResource PrimaryTextBrush}"/>
+            <Button Content="Activity Logs" Command="{Binding GenerateActivityLogReportCommand}"
+                    Width="120"
+                    Background="{DynamicResource CardBackgroundBrush}"
+                    Foreground="{DynamicResource PrimaryTextBrush}"/>
+        </StackPanel>
+        <FlowDocumentScrollViewer Grid.Row="1" Document="{Binding CurrentReport}"
+                                   Foreground="{DynamicResource PrimaryTextBrush}"
+                                   Background="{DynamicResource CardBackgroundBrush}"/>
     </Grid>
 </Page>

--- a/ToolManagementAppV2/Views/SettingsPage.xaml
+++ b/ToolManagementAppV2/Views/SettingsPage.xaml
@@ -1,7 +1,28 @@
 <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      x:Class="ToolManagementAppV2.Views.SettingsPage">
-    <Grid>
-        <TextBlock Text="Settings" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="32"/>
+      x:Class="ToolManagementAppV2.Views.SettingsPage"
+      Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <TextBlock Text="Application Name:" Grid.Row="0" Grid.Column="0" Margin="0,0,10,10"
+                   Foreground="{DynamicResource PrimaryTextBrush}" VerticalAlignment="Center"/>
+        <TextBox Text="{Binding ApplicationName}" Grid.Row="0" Grid.Column="1" Margin="0,0,0,10"
+                 Background="{DynamicResource CardBackgroundBrush}" Foreground="{DynamicResource PrimaryTextBrush}"/>
+        <TextBlock Text="Company Logo:" Grid.Row="1" Grid.Column="0" Margin="0,0,10,10"
+                   Foreground="{DynamicResource PrimaryTextBrush}" VerticalAlignment="Center"/>
+        <TextBox Text="{Binding CompanyLogoPath}" Grid.Row="1" Grid.Column="1" Margin="0,0,0,10"
+                 Background="{DynamicResource CardBackgroundBrush}" Foreground="{DynamicResource PrimaryTextBrush}"/>
+        <TextBlock Text="Default Rental Duration:" Grid.Row="2" Grid.Column="0" Margin="0,0,10,0"
+                   Foreground="{DynamicResource PrimaryTextBrush}" VerticalAlignment="Center"/>
+        <TextBox Text="{Binding DefaultRentalDuration}" Grid.Row="2" Grid.Column="1"
+                 Background="{DynamicResource CardBackgroundBrush}" Foreground="{DynamicResource PrimaryTextBrush}"/>
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- Replace placeholder content in Activity Logs, Import/Export, Reports, and Settings pages with MVVM-bound layouts using dark theme resources.
- Introduce view models for new pages and update MainViewModel navigation to supply data contexts.
- Expand unit tests to cover navigation and view model behaviors.

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6899a39e311c8324a3570bcc1e7db665