### PR TITLE
Populate customer edit fields from selection

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/RentalManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/RentalManagementViewModelTests.cs
@@ -50,6 +50,41 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public void SelectedCustomer_PopulatesNewCustomerFields()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                ICustomerService customerService = new CustomerService(db);
+                customerService.AddCustomer(new ToolManagementAppV2.Models.Domain.Customer
+                {
+                    Company = "ACME",
+                    Email = "a@b.com",
+                    Contact = "John",
+                    Phone = "123",
+                    Mobile = "456",
+                    Address = "Addr"
+                });
+                var existing = customerService.GetAllCustomers().First();
+                var vm = new RentalManagementViewModel(customerService);
+                vm.SelectedCustomer = existing;
+
+                Assert.Equal("ACME", vm.NewCustomerName);
+                Assert.Equal("a@b.com", vm.NewCustomerEmail);
+                Assert.Equal("John", vm.NewCustomerContact);
+                Assert.Equal("123", vm.NewCustomerPhone);
+                Assert.Equal("456", vm.NewCustomerMobile);
+                Assert.Equal("Addr", vm.NewCustomerAddress);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public void UpdateCustomerCommand_UpdatesSelectedCustomer()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2/ViewModels/RentalManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/RentalManagementViewModel.cs
@@ -24,6 +24,25 @@ namespace ToolManagementAppV2.ViewModels
                 {
                     ((RelayCommand)UpdateCustomerCommand).NotifyCanExecuteChanged();
                     ((RelayCommand)DeleteCustomerCommand).NotifyCanExecuteChanged();
+
+                    if (value != null)
+                    {
+                        NewCustomerName = value.Company;
+                        NewCustomerEmail = value.Email;
+                        NewCustomerContact = value.Contact;
+                        NewCustomerPhone = value.Phone;
+                        NewCustomerMobile = value.Mobile;
+                        NewCustomerAddress = value.Address;
+                    }
+                    else
+                    {
+                        NewCustomerName = string.Empty;
+                        NewCustomerEmail = string.Empty;
+                        NewCustomerContact = string.Empty;
+                        NewCustomerPhone = string.Empty;
+                        NewCustomerMobile = string.Empty;
+                        NewCustomerAddress = string.Empty;
+                    }
                 }
             }
         }
@@ -91,15 +110,18 @@ namespace ToolManagementAppV2.ViewModels
         void UpdateCustomer()
         {
             if (SelectedCustomer == null) return;
+            var updated = new CustomerModel
+            {
+                CustomerID = SelectedCustomer.CustomerID,
+                Company = NewCustomerName,
+                Email = NewCustomerEmail,
+                Contact = NewCustomerContact,
+                Phone = NewCustomerPhone,
+                Mobile = NewCustomerMobile,
+                Address = NewCustomerAddress
+            };
 
-            SelectedCustomer.Company = NewCustomerName;
-            SelectedCustomer.Email = NewCustomerEmail;
-            SelectedCustomer.Contact = NewCustomerContact;
-            SelectedCustomer.Phone = NewCustomerPhone;
-            SelectedCustomer.Mobile = NewCustomerMobile;
-            SelectedCustomer.Address = NewCustomerAddress;
-
-            _customerService.UpdateCustomer(SelectedCustomer);
+            _customerService.UpdateCustomer(updated);
             LoadCustomers();
         }
 


### PR DESCRIPTION
## Summary
- Sync new customer form fields whenever a customer is selected
- Update customer update routine to use the bound form values
- Add unit test to ensure selected customer details populate the form

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899a8756db88324ad0661287ae76bae