### PR TITLE
Add update and delete controls for user management

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -81,6 +81,30 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void CommandsDisabledWhenNoUserSelected()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IUserService userService = new UserService(db);
+                var vm = new UserManagementViewModel(userService, new StubFileDialogService());
+                userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                vm.LoadUsers();
+                Assert.False(vm.UpdateUserCommand.CanExecute(null));
+                Assert.False(vm.DeleteUserCommand.CanExecute(null));
+                vm.SelectedUser = vm.Users.First();
+                Assert.True(vm.UpdateUserCommand.CanExecute(null));
+                Assert.True(vm.DeleteUserCommand.CanExecute(null));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 }
 

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -17,7 +17,14 @@ namespace ToolManagementAppV2.ViewModels
         public UserModel SelectedUser
         {
             get => _selectedUser;
-            set => SetProperty(ref _selectedUser, value);
+            set
+            {
+                if (SetProperty(ref _selectedUser, value))
+                {
+                    ((RelayCommand)UpdateUserCommand).NotifyCanExecuteChanged();
+                    ((RelayCommand)DeleteUserCommand).NotifyCanExecuteChanged();
+                }
+            }
         }
 
         public IRelayCommand LoadUsersCommand { get; }
@@ -31,8 +38,8 @@ namespace ToolManagementAppV2.ViewModels
             _fileDialogService = fileDialogService;
             LoadUsersCommand = new RelayCommand(LoadUsers);
             UploadUserPhotoCommand = new RelayCommand(UploadUserPhoto);
-            UpdateUserCommand = new RelayCommand(UpdateUser);
-            DeleteUserCommand = new RelayCommand(DeleteUser);
+            UpdateUserCommand = new RelayCommand(UpdateUser, () => SelectedUser != null);
+            DeleteUserCommand = new RelayCommand(DeleteUser, () => SelectedUser != null);
         }
 
         public void LoadUsers()

--- a/ToolManagementAppV2/Views/UsersPage.xaml
+++ b/ToolManagementAppV2/Views/UsersPage.xaml
@@ -46,14 +46,24 @@
                          Foreground="{DynamicResource PrimaryTextBrush}"
                          Background="{DynamicResource CardBackgroundBrush}"
                          BorderBrush="{DynamicResource PrimaryTextBrush}"/>
-                <TextBox Text="{Binding SelectedUser.Phone}"
-                         Foreground="{DynamicResource PrimaryTextBrush}"
-                         Background="{DynamicResource CardBackgroundBrush}"
-                         BorderBrush="{DynamicResource PrimaryTextBrush}"/>
+                  <TextBox Text="{Binding SelectedUser.Phone}"
+                           Foreground="{DynamicResource PrimaryTextBrush}"
+                           Background="{DynamicResource CardBackgroundBrush}"
+                           BorderBrush="{DynamicResource PrimaryTextBrush}"/>
                 <Button Content="Upload Photo" Command="{Binding UploadUserPhotoCommand}"
                         Foreground="{DynamicResource PrimaryTextBrush}"
                         Background="{DynamicResource AccentBrush}"
                         BorderBrush="{DynamicResource AccentBrush}"/>
+                <StackPanel Orientation="Horizontal">
+                    <Button Content="Update" Command="{Binding UpdateUserCommand}"
+                            Foreground="{DynamicResource PrimaryTextBrush}"
+                            Background="{DynamicResource AccentBrush}"
+                            BorderBrush="{DynamicResource AccentBrush}"/>
+                    <Button Content="Delete" Command="{Binding DeleteUserCommand}"
+                            Foreground="{DynamicResource PrimaryTextBrush}"
+                            Background="{DynamicResource AccentBrush}"
+                            BorderBrush="{DynamicResource AccentBrush}"/>
+                </StackPanel>
             </StackPanel>
         </Border>
     </Grid>


### PR DESCRIPTION
## Summary
- add Update and Delete buttons on Users page bound to view model commands
- gate user Update/Delete commands on selection and notify when selection changes
- test that Update/Delete commands are disabled without a selected user

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899aa661ec88324bdbf3ba3384b3dac