### PR TITLE
Call RefreshCurrentUser after login

### DIFF
--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -1,5 +1,6 @@
 ﻿// App.xaml.cs – Use OnExplicitShutdown while showing the login window, then switch after login
 using System.Windows;
+using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2
 {
@@ -13,12 +14,16 @@ namespace ToolManagementAppV2
             var mainWindow = new MainWindow();
             Current.MainWindow = mainWindow;
             mainWindow.Show();
+            if (mainWindow.DataContext is MainViewModel vmStartup)
+                vmStartup.RefreshCurrentUser();
 
             var login = new LoginWindow { Owner = mainWindow };
             login.Closed += (s, args) =>
             {
                 if (login.DialogResult != true)
                     mainWindow.Close();
+                else if (mainWindow.DataContext is MainViewModel vm)
+                    vm.RefreshCurrentUser();
             };
             // Display the login window modally so that DialogResult can be set
             // without throwing an InvalidOperationException when the user logs in.

--- a/ToolManagementAppV2/Views/LoginWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Windows;
 using ToolManagementAppV2.ViewModels;
 
@@ -10,12 +9,7 @@ namespace ToolManagementAppV2
         {
             InitializeComponent();
             var vm = new LoginViewModel();
-            vm.LoginSucceeded += (_, __) =>
-            {
-                if (Application.Current.MainWindow?.DataContext is MainViewModel main)
-                    main.RefreshCurrentUser();
-                DialogResult = true;
-            };
+            vm.LoginSucceeded += (_, __) => DialogResult = true;
             DataContext = vm;
         }
     }


### PR DESCRIPTION
## Summary
- Remove MainWindow lookup from LoginWindow and rely solely on DialogResult after successful login
- Trigger RefreshCurrentUser from App startup and after login window closes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6899ac5146608324aefdb40ea7f3bdea