### PR TITLE
Use virtualizing stack panels for tool search list rendering

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
@@ -20,6 +20,7 @@ namespace ToolManagementAppV2.Tests.Tests
             Assert.Equal(ScrollBarVisibility.Auto, ScrollViewer.GetHorizontalScrollBarVisibility(page.HandToolsList));
             Assert.Equal(ScrollBarVisibility.Disabled, ScrollViewer.GetVerticalScrollBarVisibility(page.HandToolsList));
             Assert.True(VirtualizingStackPanel.GetIsVirtualizing(page.HandToolsList));
+            Assert.IsType<Grid>(page.HandToolsList.ItemTemplate.LoadContent());
 
             var powerPanel = page.PowerToolsList.ItemsPanel.LoadContent();
             var powerStack = Assert.IsType<VirtualizingStackPanel>(powerPanel);
@@ -30,19 +31,33 @@ namespace ToolManagementAppV2.Tests.Tests
         }
 
         [Fact]
-        public void HandToolsList_VirtualizesLargeCollections()
+        public void ToolLists_VirtualizeLargeCollections()
         {
             var page = new ToolSearchPage();
             page.HandToolsList.ItemsSource = Enumerable.Range(0, 1000)
                 .Select(i => new Tool { ToolID = i.ToString(), NameDescription = $"Tool {i}" })
+                .ToList();
+            page.PowerToolsList.ItemsSource = Enumerable.Range(0, 1000)
+                .Select(i => new Tool { ToolID = i.ToString(), NameDescription = $"Power {i}" })
                 .ToList();
 
             page.HandToolsList.Measure(new Size(800, 300));
             page.HandToolsList.Arrange(new Rect(0, 0, 800, 300));
             page.HandToolsList.UpdateLayout();
 
+            page.PowerToolsList.Measure(new Size(800, 300));
+            page.PowerToolsList.Arrange(new Rect(0, 0, 800, 300));
+            page.PowerToolsList.UpdateLayout();
+
             Assert.NotNull(page.HandToolsList.ItemContainerGenerator.ContainerFromIndex(0));
             Assert.Null(page.HandToolsList.ItemContainerGenerator.ContainerFromIndex(999));
+            Assert.NotNull(page.PowerToolsList.ItemContainerGenerator.ContainerFromIndex(0));
+            Assert.Null(page.PowerToolsList.ItemContainerGenerator.ContainerFromIndex(999));
+
+            var handFirst = (FrameworkElement)page.HandToolsList.ItemContainerGenerator.ContainerFromIndex(0);
+            var powerFirst = (FrameworkElement)page.PowerToolsList.ItemContainerGenerator.ContainerFromIndex(0);
+            Assert.True(handFirst.ActualWidth > 0 && handFirst.ActualHeight > 0);
+            Assert.True(powerFirst.ActualWidth > 0 && powerFirst.ActualHeight > 0);
         }
     }
 }

--- a/ToolManagementAppV2/Views/ToolSearchPage.xaml
+++ b/ToolManagementAppV2/Views/ToolSearchPage.xaml
@@ -103,7 +103,10 @@
             <TextBlock x:Name="HandHeader" Text="Hand Tools" FontSize="24" Margin="10,0,10,5"/>
             <ItemsControl x:Name="HandToolsList" ItemsSource="{Binding HandTools}"
                           ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                          ScrollViewer.VerticalScrollBarVisibility="Disabled">
+                          ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                          ScrollViewer.CanContentScroll="True"
+                          VirtualizingStackPanel.IsVirtualizing="True"
+                          VirtualizingStackPanel.VirtualizationMode="Recycling">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
                         <VirtualizingStackPanel Orientation="Horizontal"/>
@@ -117,7 +120,10 @@
             <TextBlock x:Name="PowerHeader" Text="Power Tools" FontSize="24" Margin="10,20,10,5"/>
             <ItemsControl x:Name="PowerToolsList" ItemsSource="{Binding PowerTools}"
                           ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                          ScrollViewer.VerticalScrollBarVisibility="Disabled">
+                          ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                          ScrollViewer.CanContentScroll="True"
+                          VirtualizingStackPanel.IsVirtualizing="True"
+                          VirtualizingStackPanel.VirtualizationMode="Recycling">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
                         <VirtualizingStackPanel Orientation="Horizontal"/>


### PR DESCRIPTION
## Summary
- Enable virtualization in `ToolSearchPage` hand and power tool lists by configuring `VirtualizingStackPanel`
- Add tests populating large tool collections to verify virtualization, horizontal scrolling and card layout

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899b5c95bd0832493d0d8caa1362a01