### PR TITLE
Ensure Dashboard page uses theme brushes

### DIFF
--- a/ToolManagementAppV2/Views/DashboardPage.xaml
+++ b/ToolManagementAppV2/Views/DashboardPage.xaml
@@ -2,7 +2,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       x:Class="ToolManagementAppV2.Views.DashboardPage"
       Background="{DynamicResource BackgroundBrush}">
-    <Grid>
+    <Grid Background="{DynamicResource CardBackgroundBrush}">
         <TextBlock Text="Dashboard" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="32" Foreground="{DynamicResource PrimaryTextBrush}"/>
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- Use app theme background and card colors on Dashboard page
- Keep text color aligned with theme brushes

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899b5ceb594832490cd622baf099acb