### PR TITLE
Add user creation and password reset commands

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -95,9 +95,55 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 vm.LoadUsers();
                 Assert.False(vm.UpdateUserCommand.CanExecute(null));
                 Assert.False(vm.DeleteUserCommand.CanExecute(null));
+                Assert.False(vm.ResetPasswordCommand.CanExecute(null));
                 vm.SelectedUser = vm.Users.First();
                 Assert.True(vm.UpdateUserCommand.CanExecute(null));
                 Assert.True(vm.DeleteUserCommand.CanExecute(null));
+                Assert.True(vm.ResetPasswordCommand.CanExecute(null));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void AddUserCommand_AddsUser()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IUserService userService = new UserService(db);
+                var vm = new UserManagementViewModel(userService, new StubFileDialogService());
+                vm.AddUserCommand.Execute(null);
+                Assert.Single(vm.Users);
+                Assert.Single(userService.GetAllUsers());
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void ResetPasswordCommand_ChangesPassword()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IUserService userService = new UserService(db);
+                var vm = new UserManagementViewModel(userService, new StubFileDialogService());
+                userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                vm.LoadUsers();
+                vm.SelectedUser = vm.Users.First();
+                var oldPwd = vm.SelectedUser.Password;
+                vm.ResetPasswordCommand.Execute(null);
+                var updated = userService.GetAllUsers().First();
+                Assert.NotEqual(oldPwd, updated.Password);
             }
             finally
             {

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -23,6 +23,7 @@ namespace ToolManagementAppV2.ViewModels
                 {
                     ((RelayCommand)UpdateUserCommand).NotifyCanExecuteChanged();
                     ((RelayCommand)DeleteUserCommand).NotifyCanExecuteChanged();
+                    ((RelayCommand)ResetPasswordCommand).NotifyCanExecuteChanged();
                 }
             }
         }
@@ -31,6 +32,8 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand UploadUserPhotoCommand { get; }
         public IRelayCommand UpdateUserCommand { get; }
         public IRelayCommand DeleteUserCommand { get; }
+        public IRelayCommand AddUserCommand { get; }
+        public IRelayCommand ResetPasswordCommand { get; }
 
         public UserManagementViewModel(IUserService userService, IFileDialogService fileDialogService)
         {
@@ -40,6 +43,8 @@ namespace ToolManagementAppV2.ViewModels
             UploadUserPhotoCommand = new RelayCommand(UploadUserPhoto);
             UpdateUserCommand = new RelayCommand(UpdateUser, () => SelectedUser != null);
             DeleteUserCommand = new RelayCommand(DeleteUser, () => SelectedUser != null);
+            AddUserCommand = new RelayCommand(AddUser);
+            ResetPasswordCommand = new RelayCommand(ResetPassword, () => SelectedUser != null);
         }
 
         public void LoadUsers()
@@ -73,6 +78,38 @@ namespace ToolManagementAppV2.ViewModels
                 Users.Remove(SelectedUser);
                 SelectedUser = null;
             }
+        }
+
+        public void AddUser()
+        {
+            var newUser = new UserModel { UserName = $"user{Users.Count + 1}" };
+
+            if (System.Windows.Application.Current != null)
+            {
+                try
+                {
+                    var prompt = new Views.PasswordPromptWindow { SelectedUser = newUser };
+                    if (prompt.ShowDialog() == true)
+                        newUser.Password = prompt.EnteredPassword;
+                }
+                catch
+                {
+                    // Ignore UI errors in non-interactive environments
+                }
+            }
+
+            _userService.AddUser(newUser);
+            Users.Add(newUser);
+            SelectedUser = newUser;
+        }
+
+        public void ResetPassword()
+        {
+            if (SelectedUser == null) return;
+            _userService.ChangeUserPassword(SelectedUser.UserID, "admin");
+            var refreshed = _userService.GetUserByID(SelectedUser.UserID);
+            SelectedUser.Password = refreshed.Password;
+            SelectedUser.Salt = refreshed.Salt;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `AddUserCommand` and `ResetPasswordCommand` to `UserManagementViewModel`
- Implement handlers to create users via dialog and reset selected user's password
- Expand unit tests to cover new commands and command enablement

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689acdc94e708324891972b829c16f3c