### PR TITLE
Add rental search and creation commands to RentalViewModel

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/RentalViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/RentalViewModelTests.cs
@@ -49,5 +49,46 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void SearchRentals_FiltersByToolNumber()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+
+                var tool1 = new Tool { ToolID = "T1", ToolNumber = "T1" };
+                var tool2 = new Tool { ToolID = "T2", ToolNumber = "T2" };
+                toolService.AddTool(tool1);
+                toolService.AddTool(tool2);
+                var customer = new Customer { Company = "C1" };
+                customerService.AddCustomer(customer);
+                var cust = customerService.GetAllCustomers().First();
+
+                rentalService.RentTool("T1", cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentTool("T2", cust.CustomerID, DateTime.Today.AddDays(-10), DateTime.Today.AddDays(-5));
+
+                var vm = new RentalViewModel(rentalService);
+
+                vm.RentalSearch = "T1";
+                vm.SearchRentalsCommand.Execute(null);
+                Assert.Single(vm.ActiveRentals);
+                Assert.Empty(vm.OverdueRentals);
+
+                vm.RentalSearch = "T2";
+                vm.SearchRentalsCommand.Execute(null);
+                Assert.Single(vm.OverdueRentals);
+                Assert.Empty(vm.ActiveRentals);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/ToolManagementAppV2/ViewModels/RentalViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/RentalViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Extensions;
 using ToolManagementAppV2.Views;
@@ -21,6 +22,13 @@ namespace ToolManagementAppV2.ViewModels
         public ObservableCollection<RentalModel> ActiveRentals { get; } = new();
         public ObservableCollection<RentalModel> OverdueRentals { get; } = new();
 
+        private string _rentalSearch = string.Empty;
+        public string RentalSearch
+        {
+            get => _rentalSearch;
+            set => SetProperty(ref _rentalSearch, value);
+        }
+
         private RentalModel _selectedRental;
         public RentalModel SelectedRental
         {
@@ -39,6 +47,8 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand ReturnToolCommand { get; }
         public IRelayCommand ExtendRentalCommand { get; }
         public IRelayCommand ViewSelectedRentalHistoryCommand { get; }
+        public IRelayCommand SearchRentalsCommand { get; }
+        public IRelayCommand NewRentalCommand { get; }
 
         public RentalViewModel(IRentalService rentalService)
         {
@@ -46,6 +56,8 @@ namespace ToolManagementAppV2.ViewModels
             ReturnToolCommand = new RelayCommand(ReturnTool, () => SelectedRental != null);
             ExtendRentalCommand = new RelayCommand(ExtendRental, () => SelectedRental != null);
             ViewSelectedRentalHistoryCommand = new RelayCommand(ViewHistory, () => SelectedRental != null);
+            SearchRentalsCommand = new RelayCommand(SearchRentals);
+            NewRentalCommand = new RelayCommand(NewRental);
         }
 
         /// <summary>Loads active and overdue rentals from the service.</summary>
@@ -53,6 +65,30 @@ namespace ToolManagementAppV2.ViewModels
         {
             ActiveRentals.ReplaceRange(_rentalService.GetActiveRentals());
             OverdueRentals.ReplaceRange(_rentalService.GetOverdueRentals());
+        }
+
+        void SearchRentals()
+        {
+            var all = _rentalService.GetAllRentals();
+            if (!string.IsNullOrWhiteSpace(RentalSearch))
+            {
+                var term = RentalSearch.Trim();
+                all = all.Where(r =>
+                    (r.ToolNumber?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    (r.CustomerName?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false))
+                    .ToList();
+            }
+
+            ActiveRentals.ReplaceRange(all.Where(r => r.Status == "Rented" && r.DueDate >= DateTime.Today));
+            OverdueRentals.ReplaceRange(all.Where(r => r.Status == "Rented" && r.DueDate < DateTime.Today));
+        }
+
+        void NewRental()
+        {
+            var vm = new RentToolPopupViewModel(null, Enumerable.Empty<CustomerModel>());
+            var win = new RentToolPopupWindow { DataContext = vm, Title = "New Rental" };
+            win.ShowDialog();
+            LoadRentals();
         }
 
         void ReturnTool()


### PR DESCRIPTION
## Summary
- enable text search over rentals and refresh listings via `IRentalService`
- wire up command to start new rental flow and refresh list after completion
- cover rental search filtering with unit tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden when attempting to install .NET SDK)*

------
https://chatgpt.com/codex/tasks/task_e_689acf3b9c30832497d7d6d52741c1b1