### PR TITLE
Add tool and customer CSV import/export commands

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -36,12 +36,43 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void ImportExportViewModel_ExportCommand_InvokesService()
+        public void ImportExportViewModel_ImportToolsCommand_InvokesService()
         {
             var toolService = new StubToolService();
-            var vm = new ImportExportViewModel(toolService, new StubFileDialogService());
-            vm.ExportCommand.Execute(null);
+            var customerService = new StubCustomerService();
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
+            vm.ImportToolsCommand.Execute(null);
+            Assert.True(toolService.ImportCalled);
+        }
+
+        [Fact]
+        public void ImportExportViewModel_ExportToolsCommand_InvokesService()
+        {
+            var toolService = new StubToolService();
+            var customerService = new StubCustomerService();
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
+            vm.ExportToolsCommand.Execute(null);
             Assert.True(toolService.ExportCalled);
+        }
+
+        [Fact]
+        public void ImportExportViewModel_ImportCustomersCommand_InvokesService()
+        {
+            var toolService = new StubToolService();
+            var customerService = new StubCustomerService();
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
+            vm.ImportCustomersCommand.Execute(null);
+            Assert.True(customerService.ImportCalled);
+        }
+
+        [Fact]
+        public void ImportExportViewModel_ExportCustomersCommand_InvokesService()
+        {
+            var toolService = new StubToolService();
+            var customerService = new StubCustomerService();
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
+            vm.ExportCustomersCommand.Execute(null);
+            Assert.True(customerService.ExportCalled);
         }
 
         [Fact]
@@ -70,9 +101,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
     class StubToolService : IToolService
     {
+        public bool ImportCalled { get; private set; }
         public bool ExportCalled { get; private set; }
+        public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map)
+        {
+            ImportCalled = true;
+            return new();
+        }
         public void ExportToolsToCsv(string filePath) => ExportCalled = true;
-        public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => new();
         public List<ToolModel> GetAllTools() => new();
         public void AddTool(ToolModel tool) => throw new System.NotImplementedException();
         public void UpdateTool(ToolModel tool) => throw new System.NotImplementedException();
@@ -100,14 +136,16 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
     class StubCustomerService : ICustomerService
     {
+        public bool ImportCalled { get; private set; }
+        public bool ExportCalled { get; private set; }
+        public void ImportCustomersFromCsv(string filePath, IDictionary<string, string> map) => ImportCalled = true;
+        public void ExportCustomersToCsv(string filePath) => ExportCalled = true;
         public void AddCustomer(Customer customer) => throw new System.NotImplementedException();
         public void UpdateCustomer(Customer customer) => throw new System.NotImplementedException();
         public void DeleteCustomer(int customerID) => throw new System.NotImplementedException();
         public Customer GetCustomerByID(int customerID) => throw new System.NotImplementedException();
         public List<Customer> GetAllCustomers() => new();
         public List<Customer> SearchCustomers(string searchTerm) => new();
-        public void ImportCustomersFromCsv(string filePath, IDictionary<string, string> map) => throw new System.NotImplementedException();
-        public void ExportCustomersToCsv(string filePath) => throw new System.NotImplementedException();
     }
 
     class StubUserService : IUserService

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -8,17 +8,25 @@ namespace ToolManagementAppV2.ViewModels
     public class ImportExportViewModel : ObservableObject
     {
         private readonly IToolService _toolService;
+        private readonly ICustomerService _customerService;
         private readonly IFileDialogService _fileDialogService;
 
-        public IRelayCommand ImportCommand { get; }
-        public IRelayCommand ExportCommand { get; }
+        public IRelayCommand ImportToolsCommand { get; }
+        public IRelayCommand ExportToolsCommand { get; }
+        public IRelayCommand ImportCustomersCommand { get; }
+        public IRelayCommand ExportCustomersCommand { get; }
 
-        public ImportExportViewModel(IToolService toolService, IFileDialogService fileDialogService)
+        public ImportExportViewModel(IToolService toolService,
+                                     ICustomerService customerService,
+                                     IFileDialogService fileDialogService)
         {
             _toolService = toolService;
+            _customerService = customerService;
             _fileDialogService = fileDialogService;
-            ImportCommand = new RelayCommand(ImportTools);
-            ExportCommand = new RelayCommand(ExportTools);
+            ImportToolsCommand = new RelayCommand(ImportTools);
+            ExportToolsCommand = new RelayCommand(ExportTools);
+            ImportCustomersCommand = new RelayCommand(ImportCustomers);
+            ExportCustomersCommand = new RelayCommand(ExportCustomers);
         }
 
         void ImportTools()
@@ -33,6 +41,20 @@ namespace ToolManagementAppV2.ViewModels
             var path = _fileDialogService.OpenFile("CSV Files|*.csv");
             if (!string.IsNullOrEmpty(path))
                 _toolService.ExportToolsToCsv(path);
+        }
+
+        void ImportCustomers()
+        {
+            var path = _fileDialogService.OpenFile("CSV Files|*.csv");
+            if (!string.IsNullOrEmpty(path))
+                _customerService.ImportCustomersFromCsv(path, new Dictionary<string, string>());
+        }
+
+        void ExportCustomers()
+        {
+            var path = _fileDialogService.OpenFile("CSV Files|*.csv");
+            if (!string.IsNullOrEmpty(path))
+                _customerService.ExportCustomersToCsv(path);
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -101,7 +101,7 @@ namespace ToolManagementAppV2.ViewModels
             UserManagement = new UserManagementViewModel(userService, fileDialogService);
             RentalManagement = new RentalManagementViewModel(customerService);
             Rentals = new RentalViewModel(rentalService);
-            ImportExport = new ImportExportViewModel(toolService, fileDialogService);
+            ImportExport = new ImportExportViewModel(toolService, customerService, fileDialogService);
             Reports = new ReportsViewModel(new ReportService(toolService, rentalService, activityLogService, customerService, userService));
             ActivityLogs = new ActivityLogsViewModel(activityLogService);
 


### PR DESCRIPTION
## Summary
- Add ImportTools, ExportTools, ImportCustomers, and ExportCustomers commands in `ImportExportViewModel`
- Wire commands to `IToolService` and `ICustomerService`
- Update tests to cover new import/export commands and constructor

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689ad09a0d108324a78dab09041ff576