### PR TITLE
Add rental history filtering and CSV export

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/RentalHistoryViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/RentalHistoryViewModelTests.cs
@@ -1,5 +1,6 @@
+using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.IO;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.ViewModels.Rental;
 using Xunit;
@@ -9,20 +10,47 @@ namespace ToolManagementAppV2.Tests.ViewModels
     public class RentalHistoryViewModelTests
     {
         [Fact]
-        public void Constructor_SetsDisplayNameAndHistory()
+        public void SearchCommand_FiltersHistory()
         {
-            var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer" };
-            var rentals = new List<Rental>
+            var history = new List<Rental>
             {
-                new Rental { RentalID = 1, ToolID = tool.ToolID, CustomerID = 1 },
-                new Rental { RentalID = 2, ToolID = tool.ToolID, CustomerID = 2 }
+                new Rental { RentalID = 1, ToolNumber = "T1", CustomerName = "Alice", Status = "Rented", RentalDate=DateTime.Today, DueDate=DateTime.Today },
+                new Rental { RentalID = 2, ToolNumber = "T2", CustomerName = "Bob", Status = "Returned", RentalDate=DateTime.Today, DueDate=DateTime.Today }
             };
+            var vm = new RentalHistoryViewModel(null, history);
 
-            var vm = new RentalHistoryViewModel(tool, rentals);
+            vm.SearchText = "T1";
+            vm.SearchCommand.Execute(null);
 
-            Assert.Equal("T1 - Hammer", vm.ToolDisplayName);
-            Assert.Equal(2, vm.History.Count);
-            Assert.Equal(rentals.First().RentalID, vm.History[0].RentalID);
+            Assert.Single(vm.History);
+            Assert.Equal(1, vm.History[0].RentalID);
+        }
+
+        [Fact]
+        public void ExportCsvCommand_CreatesFile()
+        {
+            var history = new List<Rental>
+            {
+                new Rental { RentalID = 1, ToolNumber = "T1", CustomerName = "Alice", Status = "Rented", RentalDate=DateTime.Today, DueDate=DateTime.Today }
+            };
+            var vm = new RentalHistoryViewModel(null, history);
+
+            var original = Environment.CurrentDirectory;
+            var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDir);
+            Environment.CurrentDirectory = tempDir;
+            try
+            {
+                vm.ExportCsvCommand.Execute(null);
+                var expected = Path.Combine(tempDir, "rental_history.csv");
+                Assert.True(File.Exists(expected));
+            }
+            finally
+            {
+                Environment.CurrentDirectory = original;
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -189,7 +189,7 @@ namespace ToolManagementAppV2.ViewModels
             {
                 // Constructor requires (Tool tool, IEnumerable<Rental> history)
                 var vm = new RentalHistoryViewModel(null, Enumerable.Empty<Models.Domain.Rental>());
-                var win = new RentalHistoryWindow { DataContext = vm };
+                var win = new RentalHistoryWindow(vm);
                 win.ShowDialog();
             });
 

--- a/ToolManagementAppV2/ViewModels/RentalHistoryViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/RentalHistoryViewModel.cs
@@ -1,15 +1,42 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
+using System.Text;
+using System.Windows;
+using Microsoft.Win32;
 using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.ViewModels.Rental
 {
     public class RentalHistoryViewModel : ObservableObject
     {
+        private readonly List<RentalModel> _allHistory;
+
         public ObservableCollection<RentalModel> History { get; }
         public string ToolDisplayName { get; }
+
+        private string _searchText = string.Empty;
+        public string SearchText
+        {
+            get => _searchText;
+            set => SetProperty(ref _searchText, value);
+        }
+
+        private RentalModel _selectedEntry;
+        public RentalModel SelectedEntry
+        {
+            get => _selectedEntry;
+            set => SetProperty(ref _selectedEntry, value);
+        }
+
+        public IRelayCommand SearchCommand { get; }
+        public IRelayCommand ExportCsvCommand { get; }
+        public IRelayCommand CloseCommand { get; }
 
         public RentalHistoryViewModel(ToolModel? tool, IEnumerable<RentalModel>? history)
         {
@@ -17,7 +44,81 @@ namespace ToolManagementAppV2.ViewModels.Rental
                 ? $"{tool.ToolNumber} - {tool.NameDescription}"
                 : "Rental History";
 
-            History = new ObservableCollection<RentalModel>(history ?? Enumerable.Empty<RentalModel>());
+            _allHistory = (history ?? Enumerable.Empty<RentalModel>()).ToList();
+            History = new ObservableCollection<RentalModel>(_allHistory);
+
+            SearchCommand = new RelayCommand(ExecuteSearch);
+            ExportCsvCommand = new RelayCommand(ExportCsv);
+            CloseCommand = new RelayCommand(CloseWindow);
+        }
+
+        void ExecuteSearch()
+        {
+            var term = string.IsNullOrWhiteSpace(SearchText) ? string.Empty : SearchText.Trim();
+            IEnumerable<RentalModel> results = _allHistory;
+            if (!string.IsNullOrEmpty(term))
+            {
+                results = _allHistory.Where(r =>
+                    r.RentalID.ToString().Contains(term, StringComparison.OrdinalIgnoreCase) ||
+                    (r.ToolNumber?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    (r.CustomerName?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    (r.Status?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false));
+            }
+
+            History.ReplaceRange(results);
+        }
+
+        void ExportCsv()
+        {
+            string? path = null;
+
+            if (Application.Current != null)
+            {
+                try
+                {
+                    var dlg = new SaveFileDialog
+                    {
+                        Filter = "CSV Files|*.csv",
+                        FileName = "rental_history.csv"
+                    };
+                    if (dlg.ShowDialog() == true)
+                        path = dlg.FileName;
+                }
+                catch
+                {
+                    // ignore dialog errors in non-interactive environments
+                }
+            }
+
+            path ??= Path.Combine(Environment.CurrentDirectory, "rental_history.csv");
+
+            var sb = new StringBuilder();
+            sb.AppendLine("RentalID,ToolNumber,CustomerName,RentalDate,DueDate,ReturnDate,Status");
+            foreach (var r in History)
+            {
+                sb.AppendLine(string.Join(',',
+                    r.RentalID,
+                    Escape(r.ToolNumber),
+                    Escape(r.CustomerName),
+                    r.RentalDate.ToString("o"),
+                    r.DueDate.ToString("o"),
+                    r.ReturnDate?.ToString("o") ?? string.Empty,
+                    Escape(r.Status)));
+            }
+
+            File.WriteAllText(path, sb.ToString());
+        }
+
+        static string Escape(string? value) =>
+            value?.Replace("\"", "\"\"") ?? string.Empty;
+
+        void CloseWindow()
+        {
+            if (Application.Current == null) return;
+            var window = Application.Current.Windows
+                .OfType<Window>()
+                .FirstOrDefault(w => w.DataContext == this);
+            window?.Close();
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/RentalViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/RentalViewModel.cs
@@ -123,7 +123,7 @@ namespace ToolManagementAppV2.ViewModels
                 NameDescription = SelectedRental.ToolNumber
             };
             var vm = new RentalHistoryViewModel(tool, history);
-            var win = new RentalHistoryWindow { DataContext = vm, Title = $"Rental History - {tool.ToolNumber}" };
+            var win = new RentalHistoryWindow(vm) { Title = $"Rental History - {tool.ToolNumber}" };
             win.ShowDialog();
         }
     }

--- a/ToolManagementAppV2/Views/RentalHistoryWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/RentalHistoryWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using ToolManagementAppV2.ViewModels.Rental;
 
 namespace ToolManagementAppV2.Views
 {
@@ -7,6 +8,11 @@ namespace ToolManagementAppV2.Views
         public RentalHistoryWindow()
         {
             InitializeComponent();
+        }
+
+        public RentalHistoryWindow(RentalHistoryViewModel viewModel) : this()
+        {
+            DataContext = viewModel;
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow searching and CSV export of rental history entries
- wire rental history window to set its own DataContext on creation
- cover rental history behaviors with new unit tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ad1f8978c8324b299c7ce5765a917