### PR TITLE
Add view model for printing labels

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/PrintLabelViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/PrintLabelViewModelTests.cs
@@ -1,0 +1,28 @@
+using System;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class PrintLabelViewModelTests
+    {
+        [Fact]
+        public void Constructor_InitializesDefaults()
+        {
+            var vm = new PrintLabelViewModel(() => { });
+            Assert.NotEmpty(vm.Templates);
+            Assert.Equal(vm.Templates[0], vm.SelectedTemplate);
+            Assert.False(vm.IncludeQr);
+            Assert.NotNull(vm.Items);
+        }
+
+        [Fact]
+        public void CloseCommand_InvokesAction()
+        {
+            bool closed = false;
+            var vm = new PrintLabelViewModel(() => closed = true);
+            vm.CloseCommand.Execute(null);
+            Assert.True(closed);
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/PrintLabelViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/PrintLabelViewModel.cs
@@ -1,0 +1,80 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Documents;
+using System.Windows.Controls;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Views;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class PrintLabelViewModel : ObservableObject
+    {
+        private readonly System.Action _closeAction;
+
+        public ObservableCollection<string> Templates { get; }
+
+        private string _selectedTemplate;
+        public string SelectedTemplate
+        {
+            get => _selectedTemplate;
+            set => SetProperty(ref _selectedTemplate, value);
+        }
+
+        private bool _includeQr;
+        public bool IncludeQr
+        {
+            get => _includeQr;
+            set => SetProperty(ref _includeQr, value);
+        }
+
+        public ObservableCollection<Tool> Items { get; }
+
+        public IRelayCommand PreviewCommand { get; }
+        public IRelayCommand PrintCommand { get; }
+        public IRelayCommand CloseCommand { get; }
+
+        public PrintLabelViewModel(System.Action closeAction)
+        {
+            _closeAction = closeAction;
+            Templates = new ObservableCollection<string> { "Standard", "Compact" };
+            _selectedTemplate = Templates.First();
+            Items = new ObservableCollection<Tool>();
+            PreviewCommand = new RelayCommand(Preview);
+            PrintCommand = new RelayCommand(Print);
+            CloseCommand = new RelayCommand(() => _closeAction?.Invoke());
+        }
+
+        private void Preview()
+        {
+            var doc = BuildDocument();
+            var preview = new PrintPreviewWindow();
+            preview.ShowPreview(doc, "Tool Labels", string.Empty);
+        }
+
+        private void Print()
+        {
+            var doc = BuildDocument();
+            var dlg = new PrintDialog();
+            if (dlg.ShowDialog() == true)
+                dlg.PrintDocument(((IDocumentPaginatorSource)doc).DocumentPaginator, "Tool Labels");
+        }
+
+        private FlowDocument BuildDocument()
+        {
+            var doc = new FlowDocument();
+            foreach (var t in Items)
+            {
+                var sp = new StackPanel { Orientation = Orientation.Vertical };
+                sp.Children.Add(new TextBlock { Text = t.ToolNumber });
+                sp.Children.Add(new TextBlock { Text = t.NameDescription });
+                sp.Children.Add(new TextBlock { Text = t.Location });
+                if (IncludeQr)
+                    sp.Children.Add(new TextBlock { Text = "[QR]" });
+                doc.Blocks.Add(new BlockUIContainer(sp));
+            }
+            return doc;
+        }
+    }
+}

--- a/ToolManagementAppV2/Views/PrintLabelWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PrintLabelWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
+using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2.Views
 {
@@ -22,6 +23,7 @@ namespace ToolManagementAppV2.Views
         public PrintLabelWindow()
         {
             InitializeComponent();
+            DataContext = new PrintLabelViewModel(() => Close());
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `PrintLabelViewModel` exposing templates, QR toggle, tool items, and preview/print commands
- wire `PrintLabelWindow` to new view model
- test default state and close command for print label view model

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689ad393c7f08324b466f287122d3a27