### PR TITLE
Add confirm dialog view model and bind to window

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ConfirmDialogViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ConfirmDialogViewModelTests.cs
@@ -1,0 +1,30 @@
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class ConfirmDialogViewModelTests
+    {
+        [Fact]
+        public void OkCommand_SetsDialogResultTrue()
+        {
+            bool? result = null;
+            var vm = new ConfirmDialogViewModel("message", r => result = r);
+
+            vm.OkCommand.Execute(null);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void CancelCommand_SetsDialogResultFalse()
+        {
+            bool? result = true;
+            var vm = new ConfirmDialogViewModel("message", r => result = r);
+
+            vm.CancelCommand.Execute(null);
+
+            Assert.False(result);
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/ConfirmDialogViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ConfirmDialogViewModel.cs
@@ -1,0 +1,21 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class ConfirmDialogViewModel : ObservableObject
+    {
+        public string Message { get; }
+
+        public IRelayCommand OkCommand { get; }
+        public IRelayCommand CancelCommand { get; }
+
+        public ConfirmDialogViewModel(string message, Action<bool?> close)
+        {
+            Message = message;
+            OkCommand = new RelayCommand(() => close(true));
+            CancelCommand = new RelayCommand(() => close(false));
+        }
+    }
+}

--- a/ToolManagementAppV2/Views/ConfirmDialogWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ConfirmDialogWindow.xaml.cs
@@ -1,16 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2.Views
 {
@@ -19,9 +8,12 @@ namespace ToolManagementAppV2.Views
     /// </summary>
     public partial class ConfirmDialogWindow : Window
     {
-        public ConfirmDialogWindow()
+        public ConfirmDialogWindow(string message)
         {
             InitializeComponent();
+            DataContext = new ConfirmDialogViewModel(message, result => DialogResult = result);
         }
+
+        public ConfirmDialogWindow() : this(string.Empty) { }
     }
 }


### PR DESCRIPTION
## Summary
- implement `ConfirmDialogViewModel` with message and dialog result commands
- bind `ConfirmDialogWindow` to view model and update commands to close dialog
- cover confirm dialog commands with unit tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden; repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ad67f0fb4832484d84be7e16dddc2