### PR TITLE
Add scanner status view model

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    class FakeScannerService : IScannerService
+    {
+        public int CallCount { get; private set; }
+
+        public IEnumerable<ScannerDevice> GetScannerDevices()
+        {
+            CallCount++;
+            return new[]
+            {
+                new ScannerDevice { Name = "A", Ip = "1.1.1.1", Status = "Online", LastSeen = DateTime.Now }
+            };
+        }
+    }
+
+    public class ScannerStatusViewModelTests
+    {
+        [Fact]
+        public void RefreshCommand_PopulatesDevices()
+        {
+            var svc = new FakeScannerService();
+            var vm = new ScannerStatusViewModel(svc);
+            vm.RefreshCommand.Execute(null);
+            Assert.Single(vm.Devices);
+            Assert.Equal(1, svc.CallCount);
+        }
+
+        [Fact]
+        public void AutoRefresh_TogglesTimer()
+        {
+            var svc = new FakeScannerService();
+            var vm = new ScannerStatusViewModel(svc);
+            vm.AutoRefresh = true;
+            Assert.True(vm.IsTimerRunning);
+            vm.AutoRefresh = false;
+            Assert.False(vm.IsTimerRunning);
+        }
+    }
+}

--- a/ToolManagementAppV2/Interfaces/IScannerService.cs
+++ b/ToolManagementAppV2/Interfaces/IScannerService.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using ToolManagementAppV2.Models;
+
+namespace ToolManagementAppV2.Interfaces
+{
+    public interface IScannerService
+    {
+        IEnumerable<ScannerDevice> GetScannerDevices();
+    }
+}

--- a/ToolManagementAppV2/Models/ScannerDevice.cs
+++ b/ToolManagementAppV2/Models/ScannerDevice.cs
@@ -1,0 +1,37 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace ToolManagementAppV2.Models
+{
+    public class ScannerDevice : ObservableObject
+    {
+        string _name = string.Empty;
+        string _ip = string.Empty;
+        string _status = string.Empty;
+        DateTime _lastSeen;
+
+        public string Name
+        {
+            get => _name;
+            set => SetProperty(ref _name, value);
+        }
+
+        public string Ip
+        {
+            get => _ip;
+            set => SetProperty(ref _ip, value);
+        }
+
+        public string Status
+        {
+            get => _status;
+            set => SetProperty(ref _status, value);
+        }
+
+        public DateTime LastSeen
+        {
+            get => _lastSeen;
+            set => SetProperty(ref _lastSeen, value);
+        }
+    }
+}

--- a/ToolManagementAppV2/Services/Devices/ScannerService.cs
+++ b/ToolManagementAppV2/Services/Devices/ScannerService.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Net.NetworkInformation;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models;
+
+namespace ToolManagementAppV2.Services.Devices
+{
+    public class ScannerService : IScannerService
+    {
+        static readonly string[] IpAddresses = new[]
+        {
+            "192.168.1.10",
+            "192.168.1.11"
+        };
+
+        public IEnumerable<ScannerDevice> GetScannerDevices()
+        {
+            var list = new List<ScannerDevice>();
+            foreach (var ip in IpAddresses)
+            {
+                var device = new ScannerDevice
+                {
+                    Name = $"Scanner {ip}",
+                    Ip = ip,
+                    LastSeen = DateTime.Now
+                };
+                try
+                {
+                    using var ping = new Ping();
+                    var reply = ping.Send(ip, 1000);
+                    device.Status = reply.Status == IPStatus.Success ? "Online" : "Offline";
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex);
+                    device.Status = "Error";
+                }
+                list.Add(device);
+            }
+            return list;
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/ScannerStatusViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ScannerStatusViewModel.cs
@@ -1,0 +1,51 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System;
+using System.Collections.ObjectModel;
+using System.Windows.Threading;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class ScannerStatusViewModel : ObservableObject
+    {
+        readonly IScannerService _service;
+        readonly DispatcherTimer _timer;
+
+        public ObservableCollection<ScannerDevice> Devices { get; } = new();
+
+        bool _autoRefresh;
+        public bool AutoRefresh
+        {
+            get => _autoRefresh;
+            set
+            {
+                if (SetProperty(ref _autoRefresh, value))
+                {
+                    if (value) _timer.Start();
+                    else _timer.Stop();
+                }
+            }
+        }
+
+        public IRelayCommand RefreshCommand { get; }
+
+        internal bool IsTimerRunning => _timer.IsEnabled;
+
+        public ScannerStatusViewModel(IScannerService service)
+        {
+            _service = service;
+            RefreshCommand = new RelayCommand(Refresh);
+            _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
+            _timer.Tick += (s, e) => Refresh();
+        }
+
+        void Refresh()
+        {
+            Devices.Clear();
+            foreach (var d in _service.GetScannerDevices())
+                Devices.Add(d);
+        }
+    }
+}

--- a/ToolManagementAppV2/Views/ScannerStatusWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ScannerStatusWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,6 +11,8 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
+using ToolManagementAppV2.Services.Devices;
+using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2.Views
 {
@@ -22,6 +24,7 @@ namespace ToolManagementAppV2.Views
         public ScannerStatusWindow()
         {
             InitializeComponent();
+            DataContext = new ScannerStatusViewModel(new ScannerService());
         }
     }
 }


### PR DESCRIPTION
## Summary
- add view model and service to query scanner devices with refresh and auto-refresh support
- bind ScannerStatusWindow to new ScannerStatusViewModel
- test scanner status view model behavior

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ad8d6a61483249e24d5dfd44ba840