### PR TITLE
Add rental flow command and rename tool creation command

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
@@ -19,7 +21,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
-                var vm = new ToolManagementViewModel(toolService);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw" });
                 vm.SearchTerm = "Ham";
@@ -42,7 +46,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
-                var vm = new ToolManagementViewModel(toolService);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Cordless Drill" });
                 vm.SearchTerm = string.Empty;
@@ -58,14 +64,16 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void AddToolCommand_PersistsNewToolValues()
+        public void NewToolCommand_PersistsNewToolValues()
         {
             var dbPath = Path.GetTempFileName();
             try
             {
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
-                var vm = new ToolManagementViewModel(toolService);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
                 vm.NewTool.ToolNumber = "TN1";
                 vm.NewTool.NameDescription = "Hammer";
                 vm.NewTool.PartNumber = "PN1";
@@ -74,7 +82,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 vm.NewTool.QuantityOnHand = 5;
                 vm.NewTool.Supplier = "ABC";
                 vm.NewTool.Notes = "Note";
-                vm.AddToolCommand.Execute(null);
+                vm.NewToolCommand.Execute(null);
                 var tools = toolService.GetAllTools();
                 Assert.Single(tools);
                 var tool = tools.First();
@@ -102,7 +110,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
-                var vm = new ToolManagementViewModel(toolService);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
                 var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer" };
                 toolService.AddTool(tool);
                 vm.LoadTools();
@@ -128,7 +138,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
-                var vm = new ToolManagementViewModel(toolService);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
                 var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer" };
                 toolService.AddTool(tool);
                 vm.LoadTools();
@@ -136,6 +148,33 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 vm.DeleteToolCommand.Execute(null);
                 Assert.Empty(toolService.GetAllTools());
                 Assert.Empty(vm.Tools);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void OpenRentalsCommand_CanExecuteDependsOnSelectedTool()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+
+                Assert.False(vm.OpenRentalsCommand.CanExecute(null));
+
+                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
+                vm.LoadTools();
+                vm.SelectedTool = vm.Tools.First();
+
+                Assert.True(vm.OpenRentalsCommand.CanExecute(null));
             }
             finally
             {

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -98,7 +98,7 @@ namespace ToolManagementAppV2.ViewModels
                              IFileDialogService fileDialogService,
                              ActivityLogService activityLogService)
         {
-            ToolManagement = new ToolManagementViewModel(toolService);
+            ToolManagement = new ToolManagementViewModel(toolService, customerService, rentalService);
             UserManagement = new UserManagementViewModel(userService, fileDialogService);
             RentalManagement = new RentalManagementViewModel(customerService);
             Rentals = new RentalViewModel(rentalService);

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -6,12 +6,16 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Extensions;
+using ToolManagementAppV2.ViewModels.Rental;
+using ToolManagementAppV2.Views;
 
 namespace ToolManagementAppV2.ViewModels
 {
     public class ToolManagementViewModel : ObservableObject
     {
         private readonly IToolService _toolService;
+        private readonly ICustomerService _customerService;
+        private readonly IRentalService _rentalService;
 
         public ObservableCollection<ToolModel> Tools { get; } = new();
         public ObservableCollection<ToolModel> SearchResults { get; } = new();
@@ -36,13 +40,18 @@ namespace ToolManagementAppV2.ViewModels
         public ToolModel SelectedTool
         {
             get => _selectedTool;
-            set => SetProperty(ref _selectedTool, value);
+            set
+            {
+                if (SetProperty(ref _selectedTool, value))
+                    ((RelayCommand)OpenRentalsCommand).NotifyCanExecuteChanged();
+            }
         }
 
         public IRelayCommand SearchCommand { get; }
-        public IRelayCommand AddToolCommand { get; }
+        public IRelayCommand NewToolCommand { get; }
         public IRelayCommand UpdateToolCommand { get; }
         public IRelayCommand DeleteToolCommand { get; }
+        public IRelayCommand OpenRentalsCommand { get; }
 
         // Writable for TwoWay binding from XAML. Mirrors SearchTerm and triggers search.
         private string _searchText = string.Empty;
@@ -59,13 +68,18 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        public ToolManagementViewModel(IToolService toolService)
+        public ToolManagementViewModel(IToolService toolService,
+                                       ICustomerService customerService,
+                                       IRentalService rentalService)
         {
             _toolService = toolService;
+            _customerService = customerService;
+            _rentalService = rentalService;
             SearchCommand = new RelayCommand(SearchTools);
-            AddToolCommand = new RelayCommand(AddTool);
+            NewToolCommand = new RelayCommand(AddTool);
             UpdateToolCommand = new RelayCommand(UpdateTool);
             DeleteToolCommand = new RelayCommand(DeleteTool);
+            OpenRentalsCommand = new RelayCommand(OpenRentals, () => SelectedTool != null);
         }
 
         public void LoadTools()
@@ -110,6 +124,26 @@ namespace ToolManagementAppV2.ViewModels
             LoadTools();
             SearchTools();
             SelectedTool = null;
+        }
+
+        void OpenRentals()
+        {
+            if (SelectedTool == null) return;
+
+            var customers = _customerService.GetAllCustomers();
+            var vm = new RentToolPopupViewModel(SelectedTool, customers);
+            var win = new RentToolPopupWindow { DataContext = vm };
+            vm.RequestClose += (_, _) => win.Close();
+            win.ShowDialog();
+
+            if (vm.SelectedCustomerResult != null)
+            {
+                _rentalService.RentTool(SelectedTool.ToolID,
+                    vm.SelectedCustomerResult.CustomerID,
+                    DateTime.Today,
+                    vm.SelectedDueDateResult);
+                LoadTools();
+            }
         }
 
         void CategorizeTools(IEnumerable<ToolModel> tools)


### PR DESCRIPTION
## Summary
- expose `NewToolCommand` and add `OpenRentalsCommand` to `ToolManagementViewModel`
- wire `ToolManagementViewModel` with customer and rental services and update main viewmodel
- extend tests for tool management to cover new command

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ae458bfa88324bf030b2485f06c9c