### PR TITLE
Bind customer search textbox to CustomerSearchTerm

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/CustomersPageBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CustomersPageBindingTests.cs
@@ -1,0 +1,42 @@
+using System.IO;
+using System.Windows.Controls;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Views;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Tests
+{
+    public class CustomersPageBindingTests
+    {
+        [Fact]
+        public void SearchBox_TwoWayBindsToCustomerSearchTerm()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var customerService = new CustomerService(db);
+                var vm = new RentalManagementViewModel(customerService);
+                var page = new CustomersPage { DataContext = vm };
+
+                var grid = (Grid)page.Content;
+                var border = (Border)grid.Children[0];
+                var stack = (StackPanel)border.Child;
+                var box = (TextBox)stack.Children[0];
+
+                box.Text = "Alpha";
+                Assert.Equal("Alpha", vm.CustomerSearchTerm);
+
+                vm.CustomerSearchTerm = "Beta";
+                Assert.Equal("Beta", box.Text);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/Views/CustomersPage.xaml
+++ b/ToolManagementAppV2/Views/CustomersPage.xaml
@@ -10,7 +10,7 @@
         </Grid.RowDefinitions>
         <Border Style="{StaticResource Card}">
             <StackPanel Orientation="Horizontal">
-                <TextBox Width="260" Text="{Binding CustomerSearch, UpdateSourceTrigger=PropertyChanged}"/>
+                <TextBox Width="260" Text="{Binding CustomerSearchTerm, UpdateSourceTrigger=PropertyChanged}"/>
                 <Button Style="{StaticResource PrimaryButton}" Content="Find" Command="{Binding SearchCustomersCommand}" Margin="8,0,0,0"/>
                 <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddCustomerCommand}" Margin="8,0,0,0"/>
             </StackPanel>


### PR DESCRIPTION
## Summary
- Bind CustomersPage search textbox to `CustomerSearchTerm`.
- Confirm RentalManagementViewModel's search command uses `CustomerSearchTerm`.

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689ae45d87fc8324a7759fc2f3b47c1a