### PR TITLE
Add dashboard view model with statistics

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/DashboardViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/DashboardViewModelTests.cs
@@ -1,0 +1,60 @@
+using System.IO;
+using CommunityToolkit.Mvvm.Input;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class DashboardViewModelTests
+    {
+        [Fact]
+        public void Constructor_LoadsStatsAndActivity_AndCommandsExecute()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+                activityLogService.LogAction(1, "user", "action");
+
+                bool newTool = false, rentals = false, import = false;
+
+                var vm = new DashboardViewModel(
+                    toolService,
+                    rentalService,
+                    customerService,
+                    userService,
+                    activityLogService,
+                    new RelayCommand(() => newTool = true),
+                    new RelayCommand(() => rentals = true),
+                    new RelayCommand(() => import = true));
+
+                Assert.NotEmpty(vm.StatCards);
+                Assert.NotEmpty(vm.RecentActivity);
+
+                vm.NewToolCommand.Execute(null);
+                vm.OpenRentalsCommand.Execute(null);
+                vm.OpenImportExportCommand.Execute(null);
+
+                Assert.True(newTool);
+                Assert.True(rentals);
+                Assert.True(import);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2.Tests/ViewModels/DashboardViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/DashboardViewModelTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using CommunityToolkit.Mvvm.Input;
 using ToolManagementAppV2.Interfaces;
@@ -49,6 +50,49 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 Assert.True(newTool);
                 Assert.True(rentals);
                 Assert.True(import);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Theory]
+        [InlineData("toolService")]
+        [InlineData("rentalService")]
+        [InlineData("customerService")]
+        [InlineData("userService")]
+        [InlineData("activityLogService")]
+        [InlineData("openManageToolsCommand")]
+        [InlineData("openRentalsCommand")]
+        [InlineData("openImportExportCommand")]
+        public void Constructor_ThrowsArgumentNull(string nullParam)
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+                IRelayCommand manageCmd = new RelayCommand(() => { });
+                IRelayCommand rentalsCmd = new RelayCommand(() => { });
+                IRelayCommand importCmd = new RelayCommand(() => { });
+
+                var ex = Assert.Throws<ArgumentNullException>(() => new DashboardViewModel(
+                    nullParam == "toolService" ? null : toolService,
+                    nullParam == "rentalService" ? null : rentalService,
+                    nullParam == "customerService" ? null : customerService,
+                    nullParam == "userService" ? null : userService,
+                    nullParam == "activityLogService" ? null : activityLogService,
+                    nullParam == "openManageToolsCommand" ? null : manageCmd,
+                    nullParam == "openRentalsCommand" ? null : rentalsCmd,
+                    nullParam == "openImportExportCommand" ? null : importCmd));
+
+                Assert.Equal(nullParam, ex.ParamName);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -61,7 +61,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
                 vm.OpenDashboardCommand.Execute(null);
 
-                Assert.IsType<DashboardPage>(vm.CurrentPage);
+                var page = Assert.IsType<DashboardPage>(vm.CurrentPage);
+                Assert.IsType<DashboardViewModel>(page.DataContext);
             }
             finally
             {

--- a/ToolManagementAppV2/Models/StatCard.cs
+++ b/ToolManagementAppV2/Models/StatCard.cs
@@ -1,0 +1,22 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace ToolManagementAppV2.Models
+{
+    public class StatCard : ObservableObject
+    {
+        string _title = string.Empty;
+        string _value = string.Empty;
+
+        public string Title
+        {
+            get => _title;
+            set => SetProperty(ref _title, value);
+        }
+
+        public string Value
+        {
+            get => _value;
+            set => SetProperty(ref _value, value);
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
@@ -1,0 +1,100 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System;
+using System.Collections.ObjectModel;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Users;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class DashboardViewModel : ObservableObject
+    {
+        readonly IToolService _toolService;
+        readonly IRentalService _rentalService;
+        readonly ICustomerService _customerService;
+        readonly IUserService _userService;
+        readonly ActivityLogService _activityLogService;
+        readonly IRelayCommand _openManageToolsCommand;
+        readonly IRelayCommand _openRentalsCommand;
+        readonly IRelayCommand _openImportExportCommand;
+
+        public ObservableCollection<StatCard> StatCards { get; } = new();
+        public ObservableCollection<ActivityLog> RecentActivity { get; } = new();
+
+        public IRelayCommand NewToolCommand { get; }
+        public IRelayCommand OpenRentalsCommand { get; }
+        public IRelayCommand OpenImportExportCommand { get; }
+
+        public DashboardViewModel(IToolService toolService,
+                                  IRentalService rentalService,
+                                  ICustomerService customerService,
+                                  IUserService userService,
+                                  ActivityLogService activityLogService,
+                                  IRelayCommand openManageToolsCommand,
+                                  IRelayCommand openRentalsCommand,
+                                  IRelayCommand openImportExportCommand)
+        {
+            _toolService = toolService;
+            _rentalService = rentalService;
+            _customerService = customerService;
+            _userService = userService;
+            _activityLogService = activityLogService;
+            _openManageToolsCommand = openManageToolsCommand;
+            _openRentalsCommand = openRentalsCommand;
+            _openImportExportCommand = openImportExportCommand;
+
+            NewToolCommand = new RelayCommand(() =>
+            {
+                try { _openManageToolsCommand?.Execute(null); }
+                catch (Exception ex) { Console.WriteLine(ex); }
+            });
+
+            OpenRentalsCommand = new RelayCommand(() =>
+            {
+                try { _openRentalsCommand?.Execute(null); }
+                catch (Exception ex) { Console.WriteLine(ex); }
+            });
+
+            OpenImportExportCommand = new RelayCommand(() =>
+            {
+                try { _openImportExportCommand?.Execute(null); }
+                catch (Exception ex) { Console.WriteLine(ex); }
+            });
+
+            LoadStats();
+            LoadRecentActivity();
+        }
+
+        void LoadStats()
+        {
+            try
+            {
+                StatCards.Clear();
+                StatCards.Add(new StatCard { Title = "Total Tools", Value = _toolService.GetAllTools().Count.ToString() });
+                StatCards.Add(new StatCard { Title = "Active Rentals", Value = _rentalService.GetActiveRentals().Count.ToString() });
+                StatCards.Add(new StatCard { Title = "Total Customers", Value = _customerService.GetAllCustomers().Count.ToString() });
+                StatCards.Add(new StatCard { Title = "Total Users", Value = _userService.GetAllUsers().Count.ToString() });
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+        }
+
+        void LoadRecentActivity()
+        {
+            try
+            {
+                RecentActivity.Clear();
+                foreach (var log in _activityLogService.GetRecentLogs(10))
+                    RecentActivity.Add(log);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
@@ -36,30 +36,30 @@ namespace ToolManagementAppV2.ViewModels
                                   IRelayCommand openRentalsCommand,
                                   IRelayCommand openImportExportCommand)
         {
-            _toolService = toolService;
-            _rentalService = rentalService;
-            _customerService = customerService;
-            _userService = userService;
-            _activityLogService = activityLogService;
-            _openManageToolsCommand = openManageToolsCommand;
-            _openRentalsCommand = openRentalsCommand;
-            _openImportExportCommand = openImportExportCommand;
+            _toolService = toolService ?? throw new ArgumentNullException(nameof(toolService));
+            _rentalService = rentalService ?? throw new ArgumentNullException(nameof(rentalService));
+            _customerService = customerService ?? throw new ArgumentNullException(nameof(customerService));
+            _userService = userService ?? throw new ArgumentNullException(nameof(userService));
+            _activityLogService = activityLogService ?? throw new ArgumentNullException(nameof(activityLogService));
+            _openManageToolsCommand = openManageToolsCommand ?? throw new ArgumentNullException(nameof(openManageToolsCommand));
+            _openRentalsCommand = openRentalsCommand ?? throw new ArgumentNullException(nameof(openRentalsCommand));
+            _openImportExportCommand = openImportExportCommand ?? throw new ArgumentNullException(nameof(openImportExportCommand));
 
             NewToolCommand = new RelayCommand(() =>
             {
-                try { _openManageToolsCommand?.Execute(null); }
+                try { _openManageToolsCommand.Execute(null); }
                 catch (Exception ex) { Console.WriteLine(ex); }
             });
 
             OpenRentalsCommand = new RelayCommand(() =>
             {
-                try { _openRentalsCommand?.Execute(null); }
+                try { _openRentalsCommand.Execute(null); }
                 catch (Exception ex) { Console.WriteLine(ex); }
             });
 
             OpenImportExportCommand = new RelayCommand(() =>
             {
-                try { _openImportExportCommand?.Execute(null); }
+                try { _openImportExportCommand.Execute(null); }
                 catch (Exception ex) { Console.WriteLine(ex); }
             });
 

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -18,6 +18,12 @@ namespace ToolManagementAppV2.ViewModels
 {
     public class MainViewModel : ObservableObject
     {
+        readonly IToolService _toolService;
+        readonly IUserService _userService;
+        readonly ICustomerService _customerService;
+        readonly IRentalService _rentalService;
+        readonly ActivityLogService _activityLogService;
+
         public ToolManagementViewModel ToolManagement { get; }
         public UserManagementViewModel UserManagement { get; }
         public RentalManagementViewModel RentalManagement { get; }
@@ -98,18 +104,25 @@ namespace ToolManagementAppV2.ViewModels
                              IFileDialogService fileDialogService,
                              ActivityLogService activityLogService)
         {
-            ToolManagement = new ToolManagementViewModel(toolService);
-            UserManagement = new UserManagementViewModel(userService, fileDialogService);
-            RentalManagement = new RentalManagementViewModel(customerService);
-            Rentals = new RentalViewModel(rentalService);
-            ManageRentals = new ManageRentalsViewModel(rentalService);
-            ImportExport = new ImportExportViewModel(toolService, customerService, fileDialogService);
-            Reports = new ReportsViewModel(new ReportService(toolService, rentalService, activityLogService, customerService, userService));
-            ActivityLogs = new ActivityLogsViewModel(activityLogService);
+            _toolService = toolService;
+            _userService = userService;
+            _customerService = customerService;
+            _rentalService = rentalService;
+            _activityLogService = activityLogService;
+
+            ToolManagement = new ToolManagementViewModel(_toolService);
+            UserManagement = new UserManagementViewModel(_userService, fileDialogService);
+            RentalManagement = new RentalManagementViewModel(_customerService);
+            Rentals = new RentalViewModel(_rentalService);
+            ManageRentals = new ManageRentalsViewModel(_rentalService);
+            ImportExport = new ImportExportViewModel(_toolService, _customerService, fileDialogService);
+            Reports = new ReportsViewModel(new ReportService(_toolService, _rentalService, _activityLogService, _customerService, _userService));
+            ActivityLogs = new ActivityLogsViewModel(_activityLogService);
 
             OpenDashboardCommand = new RelayCommand(() =>
             {
-                var page = new DashboardPage { Title = "Dashboard" };
+                var vm = new DashboardViewModel(_toolService, _rentalService, _customerService, _userService, _activityLogService, OpenManageToolsCommand, OpenRentalsCommand, OpenImportExportCommand);
+                var page = new DashboardPage { DataContext = vm, Title = "Dashboard" };
                 CurrentPage = page;
             });
 


### PR DESCRIPTION
## Summary
- implement `DashboardViewModel` with stat cards, recent activity and quick-action commands
- inject services into `MainViewModel` and bind dashboard page to a new `DashboardViewModel`
- add unit tests for dashboard view model and navigation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ae467860483248c489e57f348d5c0