### PR TITLE
Trigger tool search from global command

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -1,4 +1,6 @@
 using System.IO;
+using System.Linq;
+using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Services.Users;
@@ -168,6 +170,40 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 var page = Assert.IsType<ManageRentalsPage>(vm.CurrentPage);
                 Assert.IsType<ManageRentalsViewModel>(page.DataContext);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void GlobalSearchCommand_NavigatesAndExecutesSearch()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+
+                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
+                toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw" });
+
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
+                vm.GlobalSearchText = "Ham";
+
+                vm.GlobalSearchCommand.Execute(null);
+
+                var page = Assert.IsType<ToolSearchPage>(vm.CurrentPage);
+                Assert.Equal("Ham", vm.ToolManagement.SearchText);
+                Assert.Empty(vm.GlobalSearchText);
+                Assert.Single(vm.ToolManagement.SearchResults);
+                Assert.Equal("Hammer", vm.ToolManagement.SearchResults.First().NameDescription);
             }
             finally
             {

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -176,9 +176,10 @@ namespace ToolManagementAppV2.ViewModels
 
             GlobalSearchCommand = new RelayCommand(() =>
             {
+                ToolManagement.SearchText = GlobalSearchText;
                 OpenSearchToolsCommand.Execute(null);
-                // If needed, trigger ToolManagement.SearchCommand here once you wire GlobalSearchText -> VM
-                // ToolManagement.SearchCommand?.Execute(null);
+                ToolManagement.SearchCommand?.Execute(null);
+                GlobalSearchText = string.Empty;
             });
 
             ExitCommand = new RelayCommand(() =>


### PR DESCRIPTION
## Summary
- wire `GlobalSearchCommand` to transfer text to tool search, navigate, run the search, and clear the global text box
- add unit test for global search navigation and execution

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, preventing .NET installation)*

------
https://chatgpt.com/codex/tasks/task_e_689ae473c62c8324af04f3ba714d023b