### PR TITLE
Add report selection with data results

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Windows.Documents;
+using System.Linq;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
@@ -76,7 +76,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void ReportsViewModel_GenerateSummaryReport_SetsDocument()
+        public void ReportsViewModel_RunReport_PopulatesResults()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -84,8 +84,10 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var db = new DatabaseService(dbPath);
                 var reportService = new ReportService(new StubToolService(), new StubRentalService(), new ActivityLogService(db), new StubCustomerService(), new StubUserService());
                 var vm = new ReportsViewModel(reportService);
-                vm.GenerateSummaryReportCommand.Execute(null);
-                Assert.NotNull(vm.CurrentReport);
+                vm.SelectedReport = vm.ReportTypes.First();
+                vm.RunReportCommand.Execute(null);
+                Assert.NotNull(vm.ReportResults);
+                Assert.True(vm.ReportResults.Rows.Count > 0);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/ViewModels/ReportsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ReportsViewModelTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Data;
+using System.IO;
+using System.Linq;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class ReportsViewModelTests
+    {
+        [Fact]
+        public void ReportsViewModel_ReportsPage_Binding_Wiring()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var userService = new UserService(db);
+                var rentalService = new RentalService(db, toolService);
+                var activityService = new ActivityLogService(db);
+                var reportService = new ReportService(toolService, rentalService, activityService, customerService, userService);
+
+                var tool = new Tool { ToolNumber = "T1", QuantityOnHand = 1 };
+                toolService.AddTool(tool);
+
+                var customer = new Customer { Company = "C1" };
+                customerService.AddCustomer(customer);
+                var cust = customerService.GetAllCustomers().First();
+
+                rentalService.RentTool(tool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+
+                var user = new User { UserName = "user" };
+                userService.AddUser(user);
+
+                var vm = new ReportsViewModel(reportService);
+
+                Assert.False(vm.RunReportCommand.CanExecute(null));
+
+                vm.SelectedReport = "Summary";
+                Assert.True(vm.RunReportCommand.CanExecute(null));
+
+                vm.RunReportCommand.Execute(null);
+                Assert.NotNull(vm.ReportResults);
+                Assert.Contains("Total Tools: 1",
+                    vm.ReportResults.Rows.Cast<DataRow>().Select(r => r[0]?.ToString()));
+
+                vm.SelectedReport = null;
+                Assert.False(vm.RunReportCommand.CanExecute(null));
+
+                vm.SelectedReport = "Inventory";
+                Assert.True(vm.RunReportCommand.CanExecute(null));
+
+                vm.RunReportCommand.Execute(null);
+                Assert.Contains("Tool ID:",
+                    vm.ReportResults.Rows.Cast<DataRow>().Select(r => r[0]?.ToString()));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/ReportsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ReportsViewModel.cs
@@ -1,5 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System.Collections.ObjectModel;
+using System.Data;
+using System.Linq;
 using System.Windows.Documents;
 using ToolManagementAppV2.Services.Tools;
 
@@ -9,21 +12,87 @@ namespace ToolManagementAppV2.ViewModels
     {
         private readonly ReportService _reportService;
 
-        private FlowDocument _currentReport;
-        public FlowDocument CurrentReport
+        public ObservableCollection<string> ReportTypes { get; }
+
+        private string _selectedReport;
+        public string SelectedReport
         {
-            get => _currentReport;
-            set => SetProperty(ref _currentReport, value);
+            get => _selectedReport;
+            set
+            {
+                if (SetProperty(ref _selectedReport, value))
+                {
+                    RunReportCommand.NotifyCanExecuteChanged();
+                }
+            }
         }
 
-        public IRelayCommand GenerateSummaryReportCommand { get; }
-        public IRelayCommand GenerateActivityLogReportCommand { get; }
+        private DataTable _reportResults;
+        public DataTable ReportResults
+        {
+            get => _reportResults;
+            set => SetProperty(ref _reportResults, value);
+        }
+
+        public IRelayCommand RunReportCommand { get; }
 
         public ReportsViewModel(ReportService reportService)
         {
             _reportService = reportService;
-            GenerateSummaryReportCommand = new RelayCommand(() => CurrentReport = _reportService.GenerateSummaryReport());
-            GenerateActivityLogReportCommand = new RelayCommand(() => CurrentReport = _reportService.GenerateActivityLogReport());
+
+            ReportTypes = new ObservableCollection<string>
+            {
+                "Summary",
+                "Inventory",
+                "Activity Log",
+                "Customers",
+                "Users",
+                "Active Rentals",
+                "Full Rental History"
+            };
+
+            RunReportCommand = new RelayCommand(RunReport, CanRunReport);
+        }
+
+        private bool CanRunReport() => !string.IsNullOrEmpty(SelectedReport);
+
+        private void RunReport()
+        {
+            FlowDocument doc = SelectedReport switch
+            {
+                "Summary" => _reportService.GenerateSummaryReport(),
+                "Inventory" => _reportService.GenerateInventoryReport(),
+                "Activity Log" => _reportService.GenerateActivityLogReport(),
+                "Customers" => _reportService.GenerateCustomerReport(),
+                "Users" => _reportService.GenerateUserReport(),
+                "Active Rentals" => _reportService.GenerateRentalReport(true),
+                "Full Rental History" => _reportService.GenerateRentalReport(false),
+                _ => null
+            };
+
+            ReportResults = ConvertToTable(doc);
+        }
+
+        private static DataTable ConvertToTable(FlowDocument doc)
+        {
+            var table = new DataTable();
+            table.Columns.Add("Line");
+
+            if (doc == null)
+                return table;
+
+            var paragraphs = doc.Blocks
+                .OfType<Paragraph>()
+                .Skip(1) // Skip header
+                .Select(p => new TextRange(p.ContentStart, p.ContentEnd).Text.Trim())
+                .Where(t => !string.IsNullOrWhiteSpace(t));
+
+            foreach (var line in paragraphs)
+            {
+                table.Rows.Add(line);
+            }
+
+            return table;
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace report view model with selectable report types and results table
- update tests for new report execution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ae46f69408324b5ba915f25a784ec