### PR TITLE
Add refresh for activity logs and load logs on init

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ActivityLogsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ActivityLogsViewModelTests.cs
@@ -1,0 +1,53 @@
+using System.IO;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class ActivityLogsViewModelTests
+    {
+        [Fact]
+        public void Constructor_LoadsLogs()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var service = new ActivityLogService(db);
+                service.LogAction(1, "user", "action");
+                var vm = new ActivityLogsViewModel(service);
+                Assert.Single(vm.Logs);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void RefreshCommand_ReloadsLogs()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var service = new ActivityLogService(db);
+                service.LogAction(1, "user", "first");
+                var vm = new ActivityLogsViewModel(service);
+                Assert.Single(vm.Logs);
+                service.LogAction(1, "user", "second");
+                Assert.Single(vm.Logs);
+                vm.RefreshCommand.Execute(null);
+                Assert.Equal(2, vm.Logs.Count);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/ActivityLogsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ActivityLogsViewModel.cs
@@ -18,6 +18,7 @@ namespace ToolManagementAppV2.ViewModels
         {
             _service = service;
             RefreshCommand = new RelayCommand(LoadLogs);
+            LoadLogs();
         }
 
         public void LoadLogs()

--- a/ToolManagementAppV2/Views/ActivityLogsPage.xaml
+++ b/ToolManagementAppV2/Views/ActivityLogsPage.xaml
@@ -4,7 +4,18 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       Background="{StaticResource BackgroundBrush}">
     <Grid Margin="8">
-        <Border Style="{StaticResource Card}" Padding="0">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <Border Style="{StaticResource Card}" Padding="12">
+            <Button Style="{StaticResource PrimaryButton}"
+                    Content="Refresh"
+                    Command="{Binding RefreshCommand}"/>
+        </Border>
+
+        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
             <DataGrid ItemsSource="{Binding Logs}" IsReadOnly="True" AutoGenerateColumns="True"/>
         </Border>
     </Grid>


### PR DESCRIPTION
## Summary
- Add Refresh button toolbar to activity logs page
- Load logs in ActivityLogsViewModel constructor
- Test automatic load and refresh behaviors

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ae46adaa083249e25eda4a7963e54