### PR TITLE
feat: add import/export logs

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -60,4 +60,5 @@ namespace ToolManagementAppV2.Tests.Tests
 class StubFileDialogService : IFileDialogService
 {
     public string OpenFile(string filter) => null;
+    public string SaveFile(string filter) => null;
 }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -65,4 +65,5 @@ namespace ToolManagementAppV2.Tests.ViewModels
 class StubFileDialogService : ToolManagementAppV2.Interfaces.IFileDialogService
 {
     public string OpenFile(string filter) => null;
+    public string SaveFile(string filter) => null;
 }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -218,4 +218,5 @@ namespace ToolManagementAppV2.Tests.ViewModels
 class StubFileDialogService : ToolManagementAppV2.Interfaces.IFileDialogService
 {
     public string OpenFile(string filter) => null;
+    public string SaveFile(string filter) => null;
 }

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -36,43 +36,95 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void ImportExportViewModel_ImportToolsCommand_InvokesService()
+        public void ImportExportViewModel_ImportToolsCommand_LogsSuccess()
         {
             var toolService = new StubToolService();
             var customerService = new StubCustomerService();
             var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
             vm.ImportToolsCommand.Execute(null);
             Assert.True(toolService.ImportCalled);
+            Assert.Single(vm.ImportExportLogs);
+            Assert.StartsWith("Successfully imported tools", vm.ImportExportLogs[0]);
         }
 
         [Fact]
-        public void ImportExportViewModel_ExportToolsCommand_InvokesService()
+        public void ImportExportViewModel_ExportToolsCommand_LogsSuccess()
         {
             var toolService = new StubToolService();
             var customerService = new StubCustomerService();
             var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
             vm.ExportToolsCommand.Execute(null);
             Assert.True(toolService.ExportCalled);
+            Assert.Single(vm.ImportExportLogs);
+            Assert.StartsWith("Successfully exported tools", vm.ImportExportLogs[0]);
         }
 
         [Fact]
-        public void ImportExportViewModel_ImportCustomersCommand_InvokesService()
+        public void ImportExportViewModel_ImportCustomersCommand_LogsSuccess()
         {
             var toolService = new StubToolService();
             var customerService = new StubCustomerService();
             var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
             vm.ImportCustomersCommand.Execute(null);
             Assert.True(customerService.ImportCalled);
+            Assert.Single(vm.ImportExportLogs);
+            Assert.StartsWith("Successfully imported customers", vm.ImportExportLogs[0]);
         }
 
         [Fact]
-        public void ImportExportViewModel_ExportCustomersCommand_InvokesService()
+        public void ImportExportViewModel_ExportCustomersCommand_LogsSuccess()
         {
             var toolService = new StubToolService();
             var customerService = new StubCustomerService();
             var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
             vm.ExportCustomersCommand.Execute(null);
             Assert.True(customerService.ExportCalled);
+            Assert.Single(vm.ImportExportLogs);
+            Assert.StartsWith("Successfully exported customers", vm.ImportExportLogs[0]);
+        }
+
+        [Fact]
+        public void ImportExportViewModel_ImportToolsCommand_LogsFailure()
+        {
+            var toolService = new FailToolService();
+            var customerService = new StubCustomerService();
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
+            vm.ImportToolsCommand.Execute(null);
+            Assert.Single(vm.ImportExportLogs);
+            Assert.StartsWith("Failed to import tools", vm.ImportExportLogs[0]);
+        }
+
+        [Fact]
+        public void ImportExportViewModel_ExportToolsCommand_LogsFailure()
+        {
+            var toolService = new FailToolService();
+            var customerService = new StubCustomerService();
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
+            vm.ExportToolsCommand.Execute(null);
+            Assert.Single(vm.ImportExportLogs);
+            Assert.StartsWith("Failed to export tools", vm.ImportExportLogs[0]);
+        }
+
+        [Fact]
+        public void ImportExportViewModel_ImportCustomersCommand_LogsFailure()
+        {
+            var toolService = new StubToolService();
+            var customerService = new FailCustomerService();
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
+            vm.ImportCustomersCommand.Execute(null);
+            Assert.Single(vm.ImportExportLogs);
+            Assert.StartsWith("Failed to import customers", vm.ImportExportLogs[0]);
+        }
+
+        [Fact]
+        public void ImportExportViewModel_ExportCustomersCommand_LogsFailure()
+        {
+            var toolService = new StubToolService();
+            var customerService = new FailCustomerService();
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
+            vm.ExportCustomersCommand.Execute(null);
+            Assert.Single(vm.ImportExportLogs);
+            Assert.StartsWith("Failed to export customers", vm.ImportExportLogs[0]);
         }
 
         [Fact]
@@ -124,6 +176,23 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void UpdateToolQuantities(string toolID, int qtyChange, bool isRental) => throw new System.NotImplementedException();
     }
 
+    class FailToolService : IToolService
+    {
+        public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => throw new System.Exception("fail");
+        public void ExportToolsToCsv(string filePath) => throw new System.Exception("fail");
+        public List<ToolModel> GetAllTools() => new();
+        public void AddTool(ToolModel tool) => throw new System.NotImplementedException();
+        public void UpdateTool(ToolModel tool) => throw new System.NotImplementedException();
+        public void DeleteTool(string toolID) => throw new System.NotImplementedException();
+        public ToolModel GetToolByID(string toolID) => throw new System.NotImplementedException();
+        public List<ToolModel> SearchTools(string? searchText) => new();
+        public void ToggleToolCheckOutStatus(string toolID, string currentUser) => throw new System.NotImplementedException();
+        public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
+        public void UpdateToolImage(string toolID, string imagePath) => throw new System.NotImplementedException();
+        public ImageImportResult ImportToolImages(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector) => new();
+        public void UpdateToolQuantities(string toolID, int qtyChange, bool isRental) => throw new System.NotImplementedException();
+    }
+
     class StubRentalService : IRentalService
     {
         public void RentTool(string toolID, int customerID, System.DateTime rentalDate, System.DateTime dueDate) => throw new System.NotImplementedException();
@@ -142,6 +211,18 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public bool ExportCalled { get; private set; }
         public void ImportCustomersFromCsv(string filePath, IDictionary<string, string> map) => ImportCalled = true;
         public void ExportCustomersToCsv(string filePath) => ExportCalled = true;
+        public void AddCustomer(Customer customer) => throw new System.NotImplementedException();
+        public void UpdateCustomer(Customer customer) => throw new System.NotImplementedException();
+        public void DeleteCustomer(int customerID) => throw new System.NotImplementedException();
+        public Customer GetCustomerByID(int customerID) => throw new System.NotImplementedException();
+        public List<Customer> GetAllCustomers() => new();
+        public List<Customer> SearchCustomers(string searchTerm) => new();
+    }
+
+    class FailCustomerService : ICustomerService
+    {
+        public void ImportCustomersFromCsv(string filePath, IDictionary<string, string> map) => throw new System.Exception("fail");
+        public void ExportCustomersToCsv(string filePath) => throw new System.Exception("fail");
         public void AddCustomer(Customer customer) => throw new System.NotImplementedException();
         public void UpdateCustomer(Customer customer) => throw new System.NotImplementedException();
         public void DeleteCustomer(int customerID) => throw new System.NotImplementedException();

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -151,6 +151,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     class StubFileDialogService : IFileDialogService
     {
         public string OpenFile(string filter) => "path.csv";
+        public string SaveFile(string filter) => "path.csv";
     }
 
     class StubToolService : IToolService

--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -210,4 +210,5 @@ class StubFileDialogService : IFileDialogService
 {
     public string FileToReturn { get; set; }
     public string OpenFile(string filter) => FileToReturn;
+    public string SaveFile(string filter) => FileToReturn;
 }

--- a/ToolManagementAppV2/Interfaces/IFileDialogService.cs
+++ b/ToolManagementAppV2/Interfaces/IFileDialogService.cs
@@ -3,5 +3,6 @@ namespace ToolManagementAppV2.Interfaces
     public interface IFileDialogService
     {
         string? OpenFile(string filter);
+        string? SaveFile(string filter);
     }
 }

--- a/ToolManagementAppV2/Services/Core/FileDialogService.cs
+++ b/ToolManagementAppV2/Services/Core/FileDialogService.cs
@@ -13,5 +13,14 @@ namespace ToolManagementAppV2.Services.Core
             };
             return dlg.ShowDialog() == true ? dlg.FileName : null;
         }
+
+        public string? SaveFile(string filter)
+        {
+            var dlg = new SaveFileDialog
+            {
+                Filter = filter
+            };
+            return dlg.ShowDialog() == true ? dlg.FileName : null;
+        }
     }
 }

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -50,7 +50,7 @@ namespace ToolManagementAppV2.ViewModels
 
         void ExportTools()
         {
-            var path = _fileDialogService.OpenFile("CSV Files|*.csv");
+            var path = _fileDialogService.SaveFile("CSV Files|*.csv");
             if (string.IsNullOrEmpty(path)) return;
             try
             {
@@ -80,7 +80,7 @@ namespace ToolManagementAppV2.ViewModels
 
         void ExportCustomers()
         {
-            var path = _fileDialogService.OpenFile("CSV Files|*.csv");
+            var path = _fileDialogService.SaveFile("CSV Files|*.csv");
             if (string.IsNullOrEmpty(path)) return;
             try
             {

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -1,6 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System;
 using ToolManagementAppV2.Interfaces;
 
 namespace ToolManagementAppV2.ViewModels
@@ -15,6 +17,8 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand ExportToolsCommand { get; }
         public IRelayCommand ImportCustomersCommand { get; }
         public IRelayCommand ExportCustomersCommand { get; }
+
+        public ObservableCollection<string> ImportExportLogs { get; } = new();
 
         public ImportExportViewModel(IToolService toolService,
                                      ICustomerService customerService,
@@ -32,29 +36,61 @@ namespace ToolManagementAppV2.ViewModels
         void ImportTools()
         {
             var path = _fileDialogService.OpenFile("CSV Files|*.csv");
-            if (!string.IsNullOrEmpty(path))
+            if (string.IsNullOrEmpty(path)) return;
+            try
+            {
                 _toolService.ImportToolsFromCsv(path, new Dictionary<string, string>());
+                ImportExportLogs.Add($"Successfully imported tools from {path}.");
+            }
+            catch (Exception ex)
+            {
+                ImportExportLogs.Add($"Failed to import tools from {path}: {ex.Message}");
+            }
         }
 
         void ExportTools()
         {
             var path = _fileDialogService.OpenFile("CSV Files|*.csv");
-            if (!string.IsNullOrEmpty(path))
+            if (string.IsNullOrEmpty(path)) return;
+            try
+            {
                 _toolService.ExportToolsToCsv(path);
+                ImportExportLogs.Add($"Successfully exported tools to {path}.");
+            }
+            catch (Exception ex)
+            {
+                ImportExportLogs.Add($"Failed to export tools to {path}: {ex.Message}");
+            }
         }
 
         void ImportCustomers()
         {
             var path = _fileDialogService.OpenFile("CSV Files|*.csv");
-            if (!string.IsNullOrEmpty(path))
+            if (string.IsNullOrEmpty(path)) return;
+            try
+            {
                 _customerService.ImportCustomersFromCsv(path, new Dictionary<string, string>());
+                ImportExportLogs.Add($"Successfully imported customers from {path}.");
+            }
+            catch (Exception ex)
+            {
+                ImportExportLogs.Add($"Failed to import customers from {path}: {ex.Message}");
+            }
         }
 
         void ExportCustomers()
         {
             var path = _fileDialogService.OpenFile("CSV Files|*.csv");
-            if (!string.IsNullOrEmpty(path))
+            if (string.IsNullOrEmpty(path)) return;
+            try
+            {
                 _customerService.ExportCustomersToCsv(path);
+                ImportExportLogs.Add($"Successfully exported customers to {path}.");
+            }
+            catch (Exception ex)
+            {
+                ImportExportLogs.Add($"Failed to export customers to {path}: {ex.Message}");
+            }
         }
     }
 }

--- a/ToolManagementAppV2/Views/ImportExportPage.xaml
+++ b/ToolManagementAppV2/Views/ImportExportPage.xaml
@@ -17,7 +17,11 @@
             </WrapPanel>
         </Border>
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
-            <DataGrid ItemsSource="{Binding ImportExportLogs}" IsReadOnly="True" AutoGenerateColumns="True"/>
+            <DataGrid ItemsSource="{Binding ImportExportLogs}" IsReadOnly="True" AutoGenerateColumns="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Message" Binding="{Binding}" />
+                </DataGrid.Columns>
+            </DataGrid>
         </Border>
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- track import/export actions with a log collection
- show log entries in Import/Export page
- cover success and failure scenarios in view model tests

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689af6fbad588324b0096c8521c198c6