### PR TITLE
Add company logo management to settings

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -10,7 +10,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void Constructor_InitializesThemeDefaults()
         {
-            var vm = new SettingsViewModel();
+            var vm = new SettingsViewModel(new StubFileDialogService(), new StubSettingsService());
             Assert.Contains("Light", vm.ThemeOptions);
             Assert.Equal("Light", vm.Theme);
         }
@@ -21,7 +21,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
             try
             {
-                var vm = new SettingsViewModel { ConnectionString = path };
+                var vm = new SettingsViewModel(new StubFileDialogService(), new StubSettingsService()) { ConnectionString = path };
                 vm.TestDbCommand.Execute(null);
                 Assert.True(File.Exists(path));
             }
@@ -30,6 +30,51 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 if (File.Exists(path)) File.Delete(path);
             }
         }
+        [Fact]
+        public void BrowseCompanyLogoCommand_SetsPath()
+        {
+            var fileDialog = new StubFileDialogService { OpenPath = "logo.png" };
+            var vm = new SettingsViewModel(fileDialog, new StubSettingsService());
+            vm.BrowseCompanyLogoCommand.Execute(null);
+            Assert.Equal("logo.png", vm.CompanyLogoPath);
+        }
+
+        [Fact]
+        public void SaveCompanyLogoCommand_PersistsPath()
+        {
+            var settings = new StubSettingsService();
+            var vm = new SettingsViewModel(new StubFileDialogService(), settings)
+            {
+                CompanyLogoPath = "logo.png"
+            };
+            vm.SaveCompanyLogoCommand.Execute(null);
+            Assert.Equal("CompanyLogoPath", settings.SavedKey);
+            Assert.Equal("logo.png", settings.SavedValue);
+        }
+    }
+
+    class StubFileDialogService : ToolManagementAppV2.Interfaces.IFileDialogService
+    {
+        public string OpenPath { get; set; } = string.Empty;
+        public string? OpenFile(string filter) => OpenPath;
+        public string? SaveFile(string filter) => null;
+    }
+
+    class StubSettingsService : ToolManagementAppV2.Interfaces.ISettingsService
+    {
+        public string SavedKey { get; private set; }
+        public string SavedValue { get; private set; }
+
+        public void SaveSetting(string key, string value)
+        {
+            SavedKey = key;
+            SavedValue = value;
+        }
+
+        public string GetSetting(string key) => string.Empty;
+        public Dictionary<string, string> GetAllSettings() => new();
+        public void UpdateSettings(Dictionary<string, string> settings) { }
+        public void DeleteSetting(string key) { }
     }
 }
 

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsWindowViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsWindowViewModelTests.cs
@@ -9,7 +9,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void Constructor_CreatesSettingsPageAndUsesProvidedViewModel()
         {
-            var settingsVm = new SettingsViewModel();
+            var settingsVm = new SettingsViewModel(new StubFileDialogService(), new StubSettingsService());
             var vm = new SettingsWindowViewModel(settingsVm, () => { });
             Assert.NotNull(vm.SettingsPageContent);
             Assert.Same(settingsVm, vm.SettingsViewModel);
@@ -19,12 +19,27 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void Commands_InvokeProvidedActions()
         {
             bool saved = false, closed = false;
-            var vm = new SettingsWindowViewModel(new SettingsViewModel(), () => closed = true, () => saved = true);
+            var vm = new SettingsWindowViewModel(new SettingsViewModel(new StubFileDialogService(), new StubSettingsService()), () => closed = true, () => saved = true);
             vm.SaveSettingsCommand.Execute(null);
             vm.CloseCommand.Execute(null);
             Assert.True(saved);
             Assert.True(closed);
         }
+    }
+
+    class StubFileDialogService : ToolManagementAppV2.Interfaces.IFileDialogService
+    {
+        public string? OpenFile(string filter) => null;
+        public string? SaveFile(string filter) => null;
+    }
+
+    class StubSettingsService : ToolManagementAppV2.Interfaces.ISettingsService
+    {
+        public void SaveSetting(string key, string value) { }
+        public string GetSetting(string key) => string.Empty;
+        public Dictionary<string, string> GetAllSettings() => new();
+        public void UpdateSettings(Dictionary<string, string> settings) { }
+        public void DeleteSetting(string key) { }
     }
 }
 

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -1,6 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -9,6 +11,7 @@ using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.ViewModels.Rental;
@@ -163,7 +166,13 @@ namespace ToolManagementAppV2.ViewModels
 
             OpenSettingsCommand = new RelayCommand(() =>
             {
-                var page = new SettingsPage { DataContext = new SettingsViewModel(), Title = "Settings" };
+                var db = new DatabaseService(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db"));
+                var settingsService = new SettingsService(db);
+                var page = new SettingsPage
+                {
+                    DataContext = new SettingsViewModel(fileDialogService, settingsService),
+                    Title = "Settings"
+                };
                 CurrentPage = page;
             });
 

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -1,17 +1,26 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System.Collections.ObjectModel;
+using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Services.Core;
 
 namespace ToolManagementAppV2.ViewModels
 {
     internal class SettingsViewModel : ObservableObject
     {
-        public SettingsViewModel()
+        readonly IFileDialogService _fileDialog;
+        readonly ISettingsService _settingsService;
+
+        public SettingsViewModel(IFileDialogService fileDialog, ISettingsService settingsService)
         {
+            _fileDialog = fileDialog;
+            _settingsService = settingsService;
+
             ThemeOptions = new ObservableCollection<string> { "Light", "Dark" };
             _theme = ThemeOptions[0];
             TestDbCommand = new RelayCommand(TestDbConnection);
+            BrowseCompanyLogoCommand = new RelayCommand(BrowseCompanyLogo);
+            SaveCompanyLogoCommand = new RelayCommand(SaveCompanyLogo);
         }
 
         private string _applicationName;
@@ -52,11 +61,26 @@ namespace ToolManagementAppV2.ViewModels
         public ObservableCollection<string> ThemeOptions { get; }
 
         public IRelayCommand TestDbCommand { get; }
+        public IRelayCommand BrowseCompanyLogoCommand { get; }
+        public IRelayCommand SaveCompanyLogoCommand { get; }
 
         void TestDbConnection()
         {
             var db = new DatabaseService(ConnectionString);
             using var conn = db.CreateConnection();
+        }
+
+        void BrowseCompanyLogo()
+        {
+            var path = _fileDialog.OpenFile("Image Files|*.png;*.jpg;*.jpeg;*.bmp");
+            if (!string.IsNullOrWhiteSpace(path))
+                CompanyLogoPath = path;
+        }
+
+        void SaveCompanyLogo()
+        {
+            if (!string.IsNullOrWhiteSpace(CompanyLogoPath))
+                _settingsService.SaveSetting("CompanyLogoPath", CompanyLogoPath);
         }
     }
 }

--- a/ToolManagementAppV2/Views/SettingsWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/SettingsWindow.xaml.cs
@@ -1,16 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+using System.Collections.Generic;
+using System.IO;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2.Views
@@ -23,8 +16,27 @@ namespace ToolManagementAppV2.Views
         public SettingsWindow()
         {
             InitializeComponent();
-            var settingsVm = new SettingsViewModel();
-            DataContext = new SettingsWindowViewModel(settingsVm, () => Close());
+
+            var db = new DatabaseService(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db"));
+            var settingsService = new SettingsService(db);
+            var fileDialog = new FileDialogService();
+            var settingsVm = new SettingsViewModel(fileDialog, settingsService);
+
+            DataContext = new SettingsWindowViewModel(
+                settingsVm,
+                () => Close(),
+                () =>
+                {
+                    var dict = new Dictionary<string, string>
+                    {
+                        ["ApplicationName"] = settingsVm.ApplicationName ?? string.Empty,
+                        ["CompanyLogoPath"] = settingsVm.CompanyLogoPath ?? string.Empty,
+                        ["DefaultRentalDuration"] = settingsVm.DefaultRentalDuration.ToString(),
+                        ["ConnectionString"] = settingsVm.ConnectionString ?? string.Empty,
+                        ["Theme"] = settingsVm.Theme ?? string.Empty
+                    };
+                    settingsService.UpdateSettings(dict);
+                });
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow browsing and saving the company logo in `SettingsViewModel`
- persist SettingsWindow values through `ISettingsService`
- wire MainViewModel and window to provide required services

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689af98c800c8324924881273f845b2a