### PR TITLE
Add user activity fields and disambiguate file dialog

### DIFF
--- a/ToolManagementAppV2.Tests/Services/UserActiveTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserActiveTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using System.Linq;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Interfaces;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Services
+{
+    public class UserActiveTests
+    {
+        [Fact]
+        public void AddUser_SetsCreatedAtAndIsActive()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IUserService userService = new UserService(db);
+                var user = new User { UserName = "u", Password = "p" };
+                userService.AddUser(user);
+                var added = userService.GetAllUsers().First();
+                Assert.True(added.IsActive);
+                Assert.True((DateTime.UtcNow - added.CreatedAt).TotalMinutes < 5);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void UpdateUser_PersistsIsActive()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IUserService userService = new UserService(db);
+                var user = new User { UserName = "u", Password = "p" };
+                userService.AddUser(user);
+                var added = userService.GetAllUsers().First();
+                added.IsActive = false;
+                userService.UpdateUser(added);
+                var updated = userService.GetUserByID(added.UserID);
+                Assert.False(updated.IsActive);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/Models/Domain/User.cs
+++ b/ToolManagementAppV2/Models/Domain/User.cs
@@ -1,4 +1,5 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ToolManagementAppV2.Models.Domain
 {
@@ -22,7 +23,6 @@ namespace ToolManagementAppV2.Models.Domain
         private bool _isAdmin;
         public bool IsAdmin { get => _isAdmin; set => SetProperty(ref _isAdmin, value); }
 
-
         private string _email;
         public string Email { get => _email; set => SetProperty(ref _email, value); }
 
@@ -37,5 +37,11 @@ namespace ToolManagementAppV2.Models.Domain
 
         private string _role;
         public string Role { get => _role; set => SetProperty(ref _role, value); }
+
+        private bool _isActive = true;
+        public bool IsActive { get => _isActive; set => SetProperty(ref _isActive, value); }
+
+        private DateTime _createdAt;
+        public DateTime CreatedAt { get => _createdAt; set => SetProperty(ref _createdAt, value); }
     }
 }

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -41,6 +41,8 @@ namespace ToolManagementAppV2.Services.Core
             EnsureColumn("Users", "Mobile", "TEXT");
             EnsureColumn("Users", "Address", "TEXT");
             EnsureColumn("Users", "Role", "TEXT");
+            EnsureColumn("Users", "IsActive", "INTEGER");
+            EnsureColumn("Users", "CreatedAt", "DATETIME");
         }
 
         void InitializeDatabase()
@@ -74,7 +76,9 @@ namespace ToolManagementAppV2.Services.Core
                     Phone TEXT,
                     Mobile TEXT,
                     Address TEXT,
-                    Role TEXT
+                    Role TEXT,
+                    IsActive INTEGER NOT NULL DEFAULT 1,
+                    CreatedAt DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
                 );
                 CREATE TABLE IF NOT EXISTS Customers (
                     CustomerID INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/ToolManagementAppV2/Services/Core/FileDialogService.cs
+++ b/ToolManagementAppV2/Services/Core/FileDialogService.cs
@@ -16,7 +16,7 @@ namespace ToolManagementAppV2.Services.Core
 
         public string? SaveFile(string filter)
         {
-            var dlg = new SaveFileDialog
+            var dlg = new Microsoft.Win32.SaveFileDialog
             {
                 Filter = filter
             };

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -70,9 +70,9 @@ namespace ToolManagementAppV2.Services.Users
         {
             const string sql = @"
                 INSERT INTO Users
-                  (UserName, Password, Salt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role)
+                  (UserName, Password, Salt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt)
                 VALUES
-                  (@UserName,@Password,@Salt,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role);
+                  (@UserName,@Password,@Salt,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role,@IsActive,@CreatedAt);
                 SELECT last_insert_rowid();";
 
             using var conn = _dbService.CreateConnection();
@@ -93,6 +93,8 @@ namespace ToolManagementAppV2.Services.Users
                 }
             }
 
+            if (user.CreatedAt == default)
+                user.CreatedAt = DateTime.UtcNow;
             cmd.Parameters.AddRange(new[]
             {
                 new SQLiteParameter("@UserName", user.UserName),
@@ -104,7 +106,9 @@ namespace ToolManagementAppV2.Services.Users
                 new SQLiteParameter("@Phone",    (object)user.Phone ?? DBNull.Value),
                 new SQLiteParameter("@Mobile",   (object)user.Mobile ?? DBNull.Value),
                 new SQLiteParameter("@Address",  (object)user.Address ?? DBNull.Value),
-                new SQLiteParameter("@Role",     (object)user.Role ?? DBNull.Value)
+                new SQLiteParameter("@Role",     (object)user.Role ?? DBNull.Value),
+                new SQLiteParameter("@IsActive", user.IsActive ? 1 : 0),
+                new SQLiteParameter("@CreatedAt", user.CreatedAt)
             });
             user.UserID = Convert.ToInt32(cmd.ExecuteScalar());
             user.Password = hashed;
@@ -124,7 +128,8 @@ namespace ToolManagementAppV2.Services.Users
                   Phone         = @Phone,
                   Mobile        = @Mobile,
                   Address       = @Address,
-                  Role          = @Role
+                  Role          = @Role,
+                  IsActive      = @IsActive
                 WHERE UserID = @UserID";
 
             string hashed = user.Password;
@@ -146,7 +151,8 @@ namespace ToolManagementAppV2.Services.Users
                 new SQLiteParameter("@Phone",    (object)user.Phone ?? DBNull.Value),
                 new SQLiteParameter("@Mobile",   (object)user.Mobile ?? DBNull.Value),
                 new SQLiteParameter("@Address",  (object)user.Address ?? DBNull.Value),
-                new SQLiteParameter("@Role",     (object)user.Role ?? DBNull.Value)
+                new SQLiteParameter("@Role",     (object)user.Role ?? DBNull.Value),
+                new SQLiteParameter("@IsActive", user.IsActive ? 1 : 0)
             };
 
             using var conn = _dbService.CreateConnection();
@@ -213,6 +219,8 @@ namespace ToolManagementAppV2.Services.Users
                 Mobile = rdr["Mobile"]?.ToString(),
                 Address = rdr["Address"]?.ToString(),
                 Role = rdr["Role"]?.ToString(),
+                IsActive = Convert.ToInt32(rdr["IsActive"]) == 1,
+                CreatedAt = rdr["CreatedAt"] == DBNull.Value ? DateTime.MinValue : Convert.ToDateTime(rdr["CreatedAt"])
             };
         }
     }


### PR DESCRIPTION
## Summary
- support `IsActive` and `CreatedAt` on `User` records
- update SQLite schema and service mappings for new fields
- fix `SaveFileDialog` ambiguity
- add tests for user active state and creation timestamp

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689afaea20508324b1b40db5db12c5a5