### PR TITLE
Add customer dialog for rental management

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/RentalManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/RentalManagementViewModelTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
 
@@ -11,20 +12,25 @@ namespace ToolManagementAppV2.Tests.ViewModels
     public class RentalManagementViewModelTests
     {
         [Fact]
-        public void AddCustomerCommand_PersistsNewCustomerValues()
+        public void AddCustomerCommand_UsesDialogValues()
         {
             var dbPath = Path.GetTempFileName();
             try
             {
                 var db = new DatabaseService(dbPath);
                 ICustomerService customerService = new CustomerService(db);
-                var vm = new RentalManagementViewModel(customerService);
-                vm.NewCustomerName = "ACME";
-                vm.NewCustomerEmail = "a@b.com";
-                vm.NewCustomerContact = "John";
-                vm.NewCustomerPhone = "123";
-                vm.NewCustomerMobile = "456";
-                vm.NewCustomerAddress = "Addr";
+                var vm = new RentalManagementViewModel(customerService)
+                {
+                    AddCustomerDialog = () => new CustomerModel
+                    {
+                        Company = "ACME",
+                        Email = "a@b.com",
+                        Contact = "John",
+                        Phone = "123",
+                        Mobile = "456",
+                        Address = "Addr"
+                    }
+                };
                 vm.AddCustomerCommand.Execute(null);
                 var customers = customerService.GetAllCustomers();
                 Assert.Single(customers);
@@ -35,12 +41,29 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 Assert.Equal("123", c.Phone);
                 Assert.Equal("456", c.Mobile);
                 Assert.Equal("Addr", c.Address);
-                Assert.True(string.IsNullOrEmpty(vm.NewCustomerName));
-                Assert.True(string.IsNullOrEmpty(vm.NewCustomerEmail));
-                Assert.True(string.IsNullOrEmpty(vm.NewCustomerContact));
-                Assert.True(string.IsNullOrEmpty(vm.NewCustomerPhone));
-                Assert.True(string.IsNullOrEmpty(vm.NewCustomerMobile));
-                Assert.True(string.IsNullOrEmpty(vm.NewCustomerAddress));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void AddCustomerCommand_CancelledDialog_DoesNotAdd()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                ICustomerService customerService = new CustomerService(db);
+                var vm = new RentalManagementViewModel(customerService)
+                {
+                    AddCustomerDialog = () => null
+                };
+                vm.AddCustomerCommand.Execute(null);
+                var customers = customerService.GetAllCustomers();
+                Assert.Empty(customers);
             }
             finally
             {

--- a/ToolManagementAppV2/ViewModels/CustomerEditViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/CustomerEditViewModel.cs
@@ -1,0 +1,22 @@
+// ViewModels/CustomerEditViewModel.cs
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class CustomerEditViewModel : ObservableObject
+    {
+        public CustomerModel Customer { get; }
+
+        public IRelayCommand SaveCommand { get; }
+        public IRelayCommand CancelCommand { get; }
+
+        public CustomerEditViewModel(CustomerModel customer, Action onSave, Action onCancel)
+        {
+            Customer = customer;
+            SaveCommand = new RelayCommand(onSave);
+            CancelCommand = new RelayCommand(onCancel);
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/RentalManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/RentalManagementViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Extensions;
+using ToolManagementAppV2.Views;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -72,9 +73,13 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand SearchCustomersCommand { get; }
         public IRelayCommand DeleteCustomerCommand { get; }
 
+        public Func<CustomerModel?> AddCustomerDialog { get; set; }
+
         public RentalManagementViewModel(ICustomerService customerService)
         {
+        
             _customerService = customerService;
+            AddCustomerDialog = DefaultAddCustomerDialog;
             AddCustomerCommand = new RelayCommand(AddCustomer);
             UpdateCustomerCommand = new RelayCommand(UpdateCustomer, () => SelectedCustomer != null);
             SearchCustomersCommand = new RelayCommand(SearchCustomers);
@@ -89,15 +94,10 @@ namespace ToolManagementAppV2.ViewModels
 
         void AddCustomer()
         {
-            _customerService.AddCustomer(new CustomerModel
-            {
-                Company = NewCustomerName,
-                Email = NewCustomerEmail,
-                Contact = NewCustomerContact,
-                Phone = NewCustomerPhone,
-                Mobile = NewCustomerMobile,
-                Address = NewCustomerAddress
-            });
+            var customer = AddCustomerDialog?.Invoke();
+            if (customer == null) return;
+
+            _customerService.AddCustomer(customer);
             LoadCustomers();
             NewCustomerName = string.Empty;
             NewCustomerEmail = string.Empty;
@@ -105,6 +105,17 @@ namespace ToolManagementAppV2.ViewModels
             NewCustomerPhone = string.Empty;
             NewCustomerMobile = string.Empty;
             NewCustomerAddress = string.Empty;
+        }
+
+        CustomerModel? DefaultAddCustomerDialog()
+        {
+            var customer = new CustomerModel();
+            CustomerEditWindow win = null!;
+            win = new CustomerEditWindow(customer,
+                onSave: () => win.DialogResult = true,
+                onCancel: () => win.DialogResult = false);
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
+            try { return win.ShowDialog() == true ? customer : null; } catch { return null; }
         }
 
         void UpdateCustomer()

--- a/ToolManagementAppV2/Views/CustomerEditWindow.xaml
+++ b/ToolManagementAppV2/Views/CustomerEditWindow.xaml
@@ -1,0 +1,51 @@
+<!-- Views/CustomerEditWindow.xaml -->
+<Window x:Class="ToolManagementAppV2.Views.CustomerEditWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Customer" Width="520" Height="420" WindowStartupLocation="CenterOwner"
+        Background="{StaticResource BackgroundBrush}">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="120"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Company" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Customer.Company, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Contact" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Customer.Contact, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Email" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Customer.Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Phone" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Customer.Phone, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Mobile" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Customer.Mobile, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Address" VerticalAlignment="Center" Margin="0,0,8,0"/>
+            <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Customer.Address, UpdateSourceTrigger=PropertyChanged}"/>
+        </Grid>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Style="{StaticResource PrimaryButton}" Content="Save" Command="{Binding SaveCommand}" Margin="0,0,8,0"/>
+            <Button Style="{StaticResource PrimaryButton}" Content="Cancel" Command="{Binding CancelCommand}"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/ToolManagementAppV2/Views/CustomerEditWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/CustomerEditWindow.xaml.cs
@@ -1,0 +1,17 @@
+// Views/CustomerEditWindow.xaml.cs
+using System;
+using System.Windows;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.ViewModels;
+
+namespace ToolManagementAppV2.Views
+{
+    public partial class CustomerEditWindow : Window
+    {
+        public CustomerEditWindow(CustomerModel customer, Action onSave, Action onCancel)
+        {
+            InitializeComponent();
+            DataContext = new CustomerEditViewModel(customer, onSave, onCancel);
+        }
+    }
+}

--- a/ToolManagementAppV2/Views/CustomersPage.xaml
+++ b/ToolManagementAppV2/Views/CustomersPage.xaml
@@ -12,7 +12,7 @@
             <StackPanel Orientation="Horizontal">
                 <TextBox Width="260" Text="{Binding CustomerSearchTerm, UpdateSourceTrigger=PropertyChanged}"/>
                 <Button Style="{StaticResource PrimaryButton}" Content="Find" Command="{Binding SearchCustomersCommand}" Margin="8,0,0,0"/>
-                <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddCustomerCommand}" Margin="8,0,0,0"/>
+                <Button Style="{StaticResource PrimaryButton}" Content="Add Customer" Command="{Binding AddCustomerCommand}" Margin="8,0,0,0"/>
             </StackPanel>
         </Border>
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">


### PR DESCRIPTION
## Summary
- add CustomerEditWindow and view model for entering new customer details
- trigger dialog from Customers page and RentalManagementViewModel using configurable delegate
- test RentalManagementViewModel AddCustomer dialog workflow

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689afdcc5fb083249fc88b379a7790c6