### PR TITLE
Use command CanExecute for user actions

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -96,10 +96,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 Assert.False(vm.UpdateUserCommand.CanExecute(null));
                 Assert.False(vm.DeleteUserCommand.CanExecute(null));
                 Assert.False(vm.ResetPasswordCommand.CanExecute(null));
+                Assert.False(vm.EditUserCommand.CanExecute(null));
                 vm.SelectedUser = vm.Users.First();
                 Assert.True(vm.UpdateUserCommand.CanExecute(null));
                 Assert.True(vm.DeleteUserCommand.CanExecute(null));
                 Assert.True(vm.ResetPasswordCommand.CanExecute(null));
+                Assert.True(vm.EditUserCommand.CanExecute(null));
             }
             finally
             {

--- a/ToolManagementAppV2/Utilities/Converters/NullToBooleanConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/NullToBooleanConverter.cs
@@ -1,0 +1,27 @@
+// NullToBooleanConverter.cs
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace ToolManagementAppV2.Utilities.Converters
+{
+    public class NullToBooleanConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            => value != null;
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            try
+            {
+                if (value is bool b)
+                    return b ? new object() : null;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+            return Binding.DoNothing;
+        }
+    }
+}

--- a/ToolManagementAppV2/Utilities/Converters/NullToBooleanConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/NullToBooleanConverter.cs
@@ -5,11 +5,25 @@ using System.Windows.Data;
 
 namespace ToolManagementAppV2.Utilities.Converters
 {
+    /// <summary>
+    /// Converts <c>null</c> values to <c>false</c> and non-<c>null</c> values to
+    /// <c>true</c>, typically for bindings like <c>IsEnabled</c> that expect a
+    /// boolean.
+    /// </summary>
     public class NullToBooleanConverter : IValueConverter
     {
+        /// <summary>
+        /// Returns <c>true</c> if <paramref name="value"/> is not <c>null</c>;
+        /// otherwise returns <c>false</c>.
+        /// </summary>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
             => value != null;
 
+        /// <summary>
+        /// Converts a boolean back to an object placeholder when <c>true</c>, or
+        /// <c>null</c> when <c>false</c>. Returns <see cref="Binding.DoNothing"/>
+        /// for non-boolean inputs.
+        /// </summary>
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             try

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -37,6 +37,7 @@ namespace ToolManagementAppV2.ViewModels
                     ((RelayCommand)UpdateUserCommand).NotifyCanExecuteChanged();
                     ((RelayCommand)DeleteUserCommand).NotifyCanExecuteChanged();
                     ((RelayCommand)ResetPasswordCommand).NotifyCanExecuteChanged();
+                    ((RelayCommand)EditUserCommand).NotifyCanExecuteChanged();
                 }
             }
         }

--- a/ToolManagementAppV2/Views/UsersPage.xaml
+++ b/ToolManagementAppV2/Views/UsersPage.xaml
@@ -19,14 +19,14 @@
             <DockPanel LastChildFill="False">
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
                     <Button Style="{StaticResource PrimaryButton}" Content="Add User" Command="{Binding AddUserCommand}" Margin="0,0,8,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Edit User" Command="{Binding EditUserCommand}" Margin="0,0,8,0" IsEnabled="{Binding SelectedUser}"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Edit User" Command="{Binding EditUserCommand}" Margin="0,0,8,0"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
                     <TextBox Width="260" Text="{Binding UserSearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Search" Command="{Binding SearchUsersCommand}" Margin="0,0,8,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Clear" Command="{Binding ClearUserSearchCommand}" Margin="0,0,8,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Reset Password" Command="{Binding ResetPasswordCommand}" Margin="0,0,8,0" IsEnabled="{Binding SelectedUser}"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Delete User" Command="{Binding DeleteUserCommand}" IsEnabled="{Binding SelectedUser}"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Reset Password" Command="{Binding ResetPasswordCommand}" Margin="0,0,8,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Delete User" Command="{Binding DeleteUserCommand}"/>
                 </StackPanel>
             </DockPanel>
         </Border>


### PR DESCRIPTION
## Summary
- Remove `IsEnabled` bindings from UsersPage buttons to rely on command `CanExecute`
- Notify `EditUserCommand` when `SelectedUser` changes and add optional `NullToBooleanConverter`
- Extend tests to ensure commands enable only when a user is selected

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://apt.llvm.org/noble llvm-toolchain-noble-20 InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b0137fca08324b2bcfa3f5ec9d93d