### PR TITLE
Handle database test feedback

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Collections.Generic;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
 
@@ -16,19 +17,33 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void TestDbCommand_CreatesDatabaseFile()
+        public void TestDbConnection_CreatesDatabaseFile()
         {
             var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
             try
             {
                 var vm = new SettingsViewModel(new StubFileDialogService(), new StubSettingsService()) { ConnectionString = path };
-                vm.TestDbCommand.Execute(null);
+                var success = vm.TestDbConnection(out var message);
+                Assert.True(success);
+                Assert.Equal("Connection successful.", message);
                 Assert.True(File.Exists(path));
             }
             finally
             {
                 if (File.Exists(path)) File.Delete(path);
             }
+        }
+
+        [Fact]
+        public void TestDbConnection_InvalidPath_ReturnsErrorMessage()
+        {
+            var vm = new SettingsViewModel(new StubFileDialogService(), new StubSettingsService())
+            {
+                ConnectionString = "/nonexistent/path/db.sqlite"
+            };
+            var success = vm.TestDbConnection(out var message);
+            Assert.False(success);
+            Assert.Contains("Connection failed", message);
         }
         [Fact]
         public void BrowseCompanyLogoCommand_SetsPath()

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System;
 using System.Collections.ObjectModel;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Services.Core;
@@ -18,7 +19,14 @@ namespace ToolManagementAppV2.ViewModels
 
             ThemeOptions = new ObservableCollection<string> { "Light", "Dark" };
             _theme = ThemeOptions[0];
-            TestDbCommand = new RelayCommand(TestDbConnection);
+            TestDbCommand = new RelayCommand(() =>
+            {
+                var success = TestDbConnection(out var message);
+                System.Windows.MessageBox.Show(message,
+                    "Database Connection",
+                    System.Windows.MessageBoxButton.OK,
+                    success ? System.Windows.MessageBoxImage.Information : System.Windows.MessageBoxImage.Error);
+            });
             BrowseCompanyLogoCommand = new RelayCommand(BrowseCompanyLogo);
             SaveCompanyLogoCommand = new RelayCommand(SaveCompanyLogo);
         }
@@ -64,10 +72,20 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand BrowseCompanyLogoCommand { get; }
         public IRelayCommand SaveCompanyLogoCommand { get; }
 
-        void TestDbConnection()
+        internal bool TestDbConnection(out string message)
         {
-            var db = new DatabaseService(ConnectionString);
-            using var conn = db.CreateConnection();
+            try
+            {
+                var db = new DatabaseService(ConnectionString);
+                using var conn = db.CreateConnection();
+                message = "Connection successful.";
+                return true;
+            }
+            catch (Exception ex)
+            {
+                message = $"Connection failed: {ex.Message}";
+                return false;
+            }
         }
 
         void BrowseCompanyLogo()


### PR DESCRIPTION
## Summary
- Add status messaging to SettingsViewModel database test and show result to user
- Expand unit tests for database connection success and failure

## Testing
- `dotnet test` *(fails: bash: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689b03aebe10832481858ad2fa5ba3b0