### PR TITLE
Add tool editing dialog

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -126,7 +126,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void UpdateToolCommand_UpdatesExistingTool()
+        public void EditToolCommand_UpdatesExistingTool_WhenDialogReturnsTool()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -140,11 +140,42 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 toolService.AddTool(tool);
                 vm.LoadTools();
                 vm.SelectedTool = vm.Tools.First();
-                vm.SelectedTool.NameDescription = "Updated Hammer";
-                vm.UpdateToolCommand.Execute(null);
+                vm.EditToolDialog = t =>
+                {
+                    t.NameDescription = "Updated Hammer";
+                    return t;
+                };
+                vm.EditToolCommand.Execute(null);
                 var updated = toolService.GetAllTools().First();
                 Assert.Equal("Updated Hammer", updated.NameDescription);
                 Assert.Equal("Updated Hammer", vm.Tools.First().NameDescription);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void EditToolCommand_DoesNothing_WhenDialogReturnsNull()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer" };
+                toolService.AddTool(tool);
+                vm.LoadTools();
+                vm.SelectedTool = vm.Tools.First();
+                vm.EditToolDialog = _ => null;
+                vm.EditToolCommand.Execute(null);
+                var unchanged = toolService.GetAllTools().First();
+                Assert.Equal("Hammer", unchanged.NameDescription);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Views/ToolEditWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ToolEditWindowTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Views;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Views
+{
+    public class ToolEditWindowTests
+    {
+        [Fact]
+        public void Constructor_SetsDataContext_And_CallsCallbacks()
+        {
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var tool = new Tool();
+                    ToolEditWindow? window = null;
+                    bool closed = false;
+
+                    Action onSave = () => window?.Close();
+                    Action onCancel = () => window?.Close();
+
+                    window = new ToolEditWindow(tool, onSave, onCancel);
+                    window.Closed += (_, __) => closed = true;
+
+                    Assert.IsType<ToolEditViewModel>(window.DataContext);
+                    var vm = (ToolEditViewModel)window.DataContext;
+                    Assert.Equal(tool, vm.Tool);
+
+                    vm.SaveCommand.Execute(null);
+
+                    Assert.True(closed);
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+            {
+                throw threadException;
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/ToolEditViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolEditViewModel.cs
@@ -1,0 +1,22 @@
+// ViewModels/ToolEditViewModel.cs
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class ToolEditViewModel : ObservableObject
+    {
+        public ToolModel Tool { get; }
+
+        public IRelayCommand SaveCommand { get; }
+        public IRelayCommand CancelCommand { get; }
+
+        public ToolEditViewModel(ToolModel tool, Action onSave, Action onCancel)
+        {
+            Tool = tool;
+            SaveCommand = new RelayCommand(onSave);
+            CancelCommand = new RelayCommand(onCancel);
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -49,7 +49,10 @@ namespace ToolManagementAppV2.ViewModels
             set
             {
                 if (SetProperty(ref _selectedTool, value))
+                {
                     ((RelayCommand)OpenRentalsCommand).NotifyCanExecuteChanged();
+                    ((RelayCommand)EditToolCommand).NotifyCanExecuteChanged();
+                }
             }
         }
 
@@ -73,9 +76,11 @@ namespace ToolManagementAppV2.ViewModels
 
         public IRelayCommand SearchCommand { get; }
         public IRelayCommand NewToolCommand { get; }
-        public IRelayCommand UpdateToolCommand { get; }
+        public IRelayCommand EditToolCommand { get; }
         public IRelayCommand DeleteToolCommand { get; }
         public IRelayCommand OpenRentalsCommand { get; }
+
+        public Func<ToolModel, ToolModel?> EditToolDialog { get; set; }
 
         // Writable for TwoWay binding from XAML. Mirrors SearchTerm and triggers search.
         private string _searchText = string.Empty;
@@ -100,10 +105,10 @@ namespace ToolManagementAppV2.ViewModels
             SearchCommand = new RelayCommand(FilterTools);
             NewToolCommand = new RelayCommand(AddTool);
             _customerService = customerService;
-
-            UpdateToolCommand = new RelayCommand(UpdateTool);
+            EditToolCommand = new RelayCommand(EditTool, () => SelectedTool != null);
             DeleteToolCommand = new RelayCommand(DeleteTool);
             OpenRentalsCommand = new RelayCommand(OpenRentals, () => SelectedTool != null);
+            EditToolDialog = DefaultEditToolDialog;
         }
 
         public void LoadTools()
@@ -144,13 +149,30 @@ namespace ToolManagementAppV2.ViewModels
             NewTool = new ToolModel();
         }
 
-        void UpdateTool()
+        void EditTool()
         {
             if (SelectedTool == null) return;
-            _toolService.UpdateTool(SelectedTool);
+
+            var clone = new ToolModel
+            {
+                ToolID = SelectedTool.ToolID,
+                ToolNumber = SelectedTool.ToolNumber,
+                PartNumber = SelectedTool.PartNumber,
+                NameDescription = SelectedTool.NameDescription,
+                Brand = SelectedTool.Brand,
+                Location = SelectedTool.Location,
+                QuantityOnHand = SelectedTool.QuantityOnHand,
+                Supplier = SelectedTool.Supplier,
+                Notes = SelectedTool.Notes
+            };
+
+            var updated = EditToolDialog?.Invoke(clone);
+            if (updated == null) return;
+
+            _toolService.UpdateTool(updated);
             LoadTools();
             FilterTools();
-            SelectedTool = null;
+            SelectedTool = Tools.FirstOrDefault(t => t.ToolID == updated.ToolID);
         }
 
         void DeleteTool()
@@ -203,6 +225,16 @@ namespace ToolManagementAppV2.ViewModels
                                    .ToList();
             categories.Insert(0, "All");
             Categories.ReplaceRange(categories);
+        }
+
+        ToolModel? DefaultEditToolDialog(ToolModel tool)
+        {
+            ToolEditWindow win = null!;
+            win = new ToolEditWindow(tool,
+                onSave: () => win.DialogResult = true,
+                onCancel: () => win.DialogResult = false);
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
+            try { return win.ShowDialog() == true ? tool : null; } catch { return null; }
         }
     }
 }

--- a/ToolManagementAppV2/Views/ManageToolsPage.xaml
+++ b/ToolManagementAppV2/Views/ManageToolsPage.xaml
@@ -72,31 +72,33 @@
                     </Grid.ColumnDefinitions>
 
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="Tool Number" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-                    <TextBox   Grid.Row="0" Grid.Column="1" Text="{Binding SelectedTool.ToolNumber, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="8,4"/>
+                    <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding SelectedTool.ToolNumber}" Margin="8,4"/>
 
                     <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-                    <TextBox   Grid.Row="1" Grid.Column="1" Text="{Binding SelectedTool.NameDescription, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="8,4"/>
+                    <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedTool.NameDescription}" Margin="8,4"/>
 
                     <TextBlock Grid.Row="2" Grid.Column="0" Text="Brand" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-                    <TextBox   Grid.Row="2" Grid.Column="1" Text="{Binding SelectedTool.Brand, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="8,4"/>
+                    <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SelectedTool.Brand}" Margin="8,4"/>
 
                     <TextBlock Grid.Row="3" Grid.Column="0" Text="Location" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-                    <TextBox   Grid.Row="3" Grid.Column="1" Text="{Binding SelectedTool.Location, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="8,4"/>
+                    <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedTool.Location}" Margin="8,4"/>
 
                     <TextBlock Grid.Row="4" Grid.Column="0" Text="Part #" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-                    <TextBox   Grid.Row="4" Grid.Column="1" Text="{Binding SelectedTool.PartNumber, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="8,4"/>
+                    <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding SelectedTool.PartNumber}" Margin="8,4"/>
 
                     <TextBlock Grid.Row="5" Grid.Column="0" Text="Supplier" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-                    <TextBox   Grid.Row="5" Grid.Column="1" Text="{Binding SelectedTool.Supplier, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="8,4"/>
+                    <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding SelectedTool.Supplier}" Margin="8,4"/>
 
                     <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Vertical" Margin="0,8,0,0">
                         <TextBlock Text="Notes" Foreground="{StaticResource ForegroundMutedBrush}"/>
-                        <TextBox Text="{Binding SelectedTool.Notes, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="90" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" />
+                        <ScrollViewer Height="90" VerticalScrollBarVisibility="Auto">
+                            <TextBlock Text="{Binding SelectedTool.Notes}" TextWrapping="Wrap"/>
+                        </ScrollViewer>
                     </StackPanel>
                 </Grid>
 
                 <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Update" Command="{Binding UpdateToolCommand}"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditToolCommand}"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="New" Command="{Binding NewToolCommand}" Margin="8,0,0,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Delete" Command="{Binding DeleteToolCommand}" Margin="8,0,0,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Rent" Command="{Binding OpenRentalsCommand}" Margin="8,0,0,0"/>

--- a/ToolManagementAppV2/Views/ToolEditWindow.xaml
+++ b/ToolManagementAppV2/Views/ToolEditWindow.xaml
@@ -1,0 +1,57 @@
+<!-- Views/ToolEditWindow.xaml -->
+<Window x:Class="ToolManagementAppV2.Views.ToolEditWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Tool" Width="520" Height="420" WindowStartupLocation="CenterOwner"
+        Background="{StaticResource BackgroundBrush}">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="120"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Tool Number" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Tool.ToolNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Tool.NameDescription, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Brand" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Tool.Brand, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Location" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Tool.Location, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Part #" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Tool.PartNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Supplier" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Tool.Supplier, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+
+            <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Vertical">
+                <TextBlock Text="Notes" Margin="0,0,0,4"/>
+                <TextBox Text="{Binding Tool.Notes, UpdateSourceTrigger=PropertyChanged}" Height="90" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+            </StackPanel>
+        </Grid>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Style="{StaticResource PrimaryButton}" Content="Save" Command="{Binding SaveCommand}" Margin="0,0,8,0"/>
+            <Button Style="{StaticResource PrimaryButton}" Content="Cancel" Command="{Binding CancelCommand}"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/ToolManagementAppV2/Views/ToolEditWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ToolEditWindow.xaml.cs
@@ -1,0 +1,17 @@
+// Views/ToolEditWindow.xaml.cs
+using System;
+using System.Windows;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.ViewModels;
+
+namespace ToolManagementAppV2.Views
+{
+    public partial class ToolEditWindow : Window
+    {
+        public ToolEditWindow(ToolModel tool, Action onSave, Action onCancel)
+        {
+            InitializeComponent();
+            DataContext = new ToolEditViewModel(tool, onSave, onCancel);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ToolEditWindow` for editing tool details
- open dialog from Tools management page via new `Edit` button
- wire up `ToolManagementViewModel` to launch dialog and handle save/cancel
- add tests for dialog workflow

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689b05f1f9308324a7d53222d155a683