### PR TITLE
Replace rental footer buttons with context menu

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ManageRentalsPageMenuTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ManageRentalsPageMenuTests.cs
@@ -1,0 +1,69 @@
+using System.IO;
+using System.Linq;
+using System.Windows.Controls;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Views;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Tests
+{
+    public class ManageRentalsPageMenuTests
+    {
+        [Fact]
+        public void ContextMenu_BindsToViewModelCommands()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var rentalService = new RentalService(db);
+                var vm = new ManageRentalsViewModel(rentalService);
+                var page = new ManageRentalsPage { DataContext = vm };
+
+                var grid = (Grid)page.Content;
+                var border = (Border)grid.Children[1];
+                var dataGrid = (DataGrid)border.Child;
+                var menu = dataGrid.ContextMenu;
+                var items = menu.Items.OfType<MenuItem>().ToArray();
+
+                Assert.Equal(vm.CheckInCommand, items[0].Command);
+                Assert.Equal(vm.ExtendCommand, items[1].Command);
+                Assert.Equal(vm.OpenHistoryCommand, items[2].Command);
+                Assert.Equal(vm.PrintRentalCommand, items[3].Command);
+                Assert.Equal(vm.DeleteRentalCommand, items[4].Command);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void Toolbar_CheckInButton_BindsToCheckInCommand()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var rentalService = new RentalService(db);
+                var vm = new ManageRentalsViewModel(rentalService);
+                var page = new ManageRentalsPage { DataContext = vm };
+
+                var grid = (Grid)page.Content;
+                var stack = (StackPanel)grid.Children[0];
+                var toolbar = (ToolBar)stack.Children[1];
+                var button = (Button)toolbar.Items[0];
+
+                Assert.Equal(vm.CheckInCommand, button.Command);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/Views/ManageRentalsPage.xaml
+++ b/ToolManagementAppV2/Views/ManageRentalsPage.xaml
@@ -9,50 +9,47 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <Border Style="{StaticResource Card}">
-            <StackPanel Orientation="Horizontal">
-                <TextBox Width="260" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"/>
-                <DatePicker SelectedDate="{Binding FilterFrom}" Margin="8,0,0,0"/>
-                <DatePicker SelectedDate="{Binding FilterTo}" Margin="8,0,0,0"/>
-                <ComboBox Width="180" ItemsSource="{Binding StatusOptions}" SelectedItem="{Binding SelectedStatus}" Margin="8,0,0,0"/>
-                <Button Style="{StaticResource PrimaryButton}" Content="Filter" Command="{Binding ApplyFilterCommand}" Margin="8,0,0,0"/>
-                <Button Style="{StaticResource PrimaryButton}" Content="Clear" Command="{Binding ClearFilterCommand}" Margin="8,0,0,0"/>
-            </StackPanel>
-        </Border>
-
-        <Grid Grid.Row="1">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-
-            <Border Style="{StaticResource Card}" Padding="0">
-                <DataGrid ItemsSource="{Binding Rentals}"
-                          SelectedItem="{Binding SelectedRental}"
-                          IsReadOnly="True"
-                          AutoGenerateColumns="False">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Rental #" Binding="{Binding RentalId}" Width="120"/>
-                        <DataGridTextColumn Header="Tool #" Binding="{Binding ToolNumber}" Width="120"/>
-                        <DataGridTextColumn Header="Tool" Binding="{Binding ToolName}" Width="*"/>
-                        <DataGridTextColumn Header="Customer" Binding="{Binding CustomerName}" Width="220"/>
-                        <DataGridTextColumn Header="Out" Binding="{Binding DateOut, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180"/>
-                        <DataGridTextColumn Header="Due" Binding="{Binding DueDate, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180"/>
-                        <DataGridTextColumn Header="Returned" Binding="{Binding DateReturned, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180"/>
-                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="140"/>
-                    </DataGrid.Columns>
-                </DataGrid>
-            </Border>
-
-            <Border Grid.Row="1" Background="{StaticResource BackgroundBrush}" BorderBrush="{StaticResource BorderBrushBase}" BorderThickness="1,1,0,0" Padding="12">
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Check In" Command="{Binding CheckInCommand}"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Extend" Command="{Binding ExtendCommand}" Margin="8,0,0,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="History" Command="{Binding OpenHistoryCommand}" Margin="8,0,0,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Print" Command="{Binding PrintRentalCommand}" Margin="8,0,0,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Delete" Command="{Binding DeleteRentalCommand}" Margin="8,0,0,0"/>
+        <StackPanel>
+            <Border Style="{StaticResource Card}">
+                <StackPanel Orientation="Horizontal">
+                    <TextBox Width="260" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"/>
+                    <DatePicker SelectedDate="{Binding FilterFrom}" Margin="8,0,0,0"/>
+                    <DatePicker SelectedDate="{Binding FilterTo}" Margin="8,0,0,0"/>
+                    <ComboBox Width="180" ItemsSource="{Binding StatusOptions}" SelectedItem="{Binding SelectedStatus}" Margin="8,0,0,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Filter" Command="{Binding ApplyFilterCommand}" Margin="8,0,0,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Clear" Command="{Binding ClearFilterCommand}" Margin="8,0,0,0"/>
                 </StackPanel>
             </Border>
-        </Grid>
+            <ToolBar HorizontalAlignment="Right">
+                <Button Style="{StaticResource PrimaryButton}" Content="Check In" Command="{Binding CheckInCommand}"/>
+            </ToolBar>
+        </StackPanel>
+
+        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
+            <DataGrid ItemsSource="{Binding Rentals}"
+                      SelectedItem="{Binding SelectedRental}"
+                      IsReadOnly="True"
+                      AutoGenerateColumns="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Rental #" Binding="{Binding RentalId}" Width="120"/>
+                    <DataGridTextColumn Header="Tool #" Binding="{Binding ToolNumber}" Width="120"/>
+                    <DataGridTextColumn Header="Tool" Binding="{Binding ToolName}" Width="*"/>
+                    <DataGridTextColumn Header="Customer" Binding="{Binding CustomerName}" Width="220"/>
+                    <DataGridTextColumn Header="Out" Binding="{Binding DateOut, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180"/>
+                    <DataGridTextColumn Header="Due" Binding="{Binding DueDate, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180"/>
+                    <DataGridTextColumn Header="Returned" Binding="{Binding DateReturned, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180"/>
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="140"/>
+                </DataGrid.Columns>
+                <DataGrid.ContextMenu>
+                    <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                        <MenuItem Header="Check In" Command="{Binding CheckInCommand}"/>
+                        <MenuItem Header="Extend" Command="{Binding ExtendCommand}"/>
+                        <MenuItem Header="History" Command="{Binding OpenHistoryCommand}"/>
+                        <MenuItem Header="Print" Command="{Binding PrintRentalCommand}"/>
+                        <MenuItem Header="Delete" Command="{Binding DeleteRentalCommand}"/>
+                    </ContextMenu>
+                </DataGrid.ContextMenu>
+            </DataGrid>
+        </Border>
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- replace ManageRentalsPage footer buttons with a DataGrid context menu
- surface Check In command in a small toolbar
- add tests ensuring context menu and toolbar are bound to the existing commands

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689b086e8e688324be3237d7ab84cec1