### PR TITLE
Replace code-behind clicks with MVVM commands

### DIFF
--- a/ToolManagementAppV2/ViewModels/AvatarSelectionViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/AvatarSelectionViewModel.cs
@@ -1,0 +1,34 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class AvatarSelectionViewModel : ObservableObject
+    {
+        public ObservableCollection<Uri> Avatars { get; }
+
+        private string _selectedAvatarPath = string.Empty;
+        public string SelectedAvatarPath
+        {
+            get => _selectedAvatarPath;
+            private set => SetProperty(ref _selectedAvatarPath, value);
+        }
+
+        public IRelayCommand<Uri> SelectAvatarCommand { get; }
+
+        public AvatarSelectionViewModel(IEnumerable<Uri> avatars, Action onSelected)
+        {
+            Avatars = new ObservableCollection<Uri>(avatars ?? Array.Empty<Uri>());
+            SelectAvatarCommand = new RelayCommand<Uri>(uri =>
+            {
+                if (uri == null) return;
+                SelectedAvatarPath = uri.LocalPath;
+                onSelected();
+            });
+        }
+    }
+}
+

--- a/ToolManagementAppV2/ViewModels/ImageImportMappingViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImageImportMappingViewModel.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.Generic;
 using ToolManagementAppV2.Models.Domain;
@@ -15,6 +16,15 @@ namespace ToolManagementAppV2.ViewModels
 
         bool _useNameDescription;
         public bool UseNameDescription { get => _useNameDescription; set => SetProperty(ref _useNameDescription, value); }
+
+        public IRelayCommand OkCommand { get; }
+        public IRelayCommand CancelCommand { get; }
+
+        public ImageImportMappingViewModel(Action onOk, Action onCancel)
+        {
+            OkCommand = new RelayCommand(onOk);
+            CancelCommand = new RelayCommand(onCancel);
+        }
 
         public Func<ToolModel, IEnumerable<string>> BuildSelector()
         {

--- a/ToolManagementAppV2/ViewModels/ImportMappingViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportMappingViewModel.cs
@@ -1,5 +1,9 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.Linq;
+using System;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -28,7 +32,14 @@ namespace ToolManagementAppV2.ViewModels
         public IReadOnlyList<string> ColumnHeaders { get; }
         public ObservableCollection<FieldMapping> Mappings { get; }
 
-        public ImportMappingViewModel(IEnumerable<string> headers, IEnumerable<string> properties)
+        public IRelayCommand OkCommand { get; }
+        public IRelayCommand CancelCommand { get; }
+
+        public ImportMappingViewModel(
+            IEnumerable<string> headers,
+            IEnumerable<string> properties,
+            Action onOk,
+            Action onCancel)
         {
             var headerList = (headers ?? Enumerable.Empty<string>()).ToList();
             ColumnHeaders = headerList;
@@ -37,6 +48,15 @@ namespace ToolManagementAppV2.ViewModels
                 (properties ?? Enumerable.Empty<string>())
                     .Select(prop => new FieldMapping(prop, ColumnHeaders))
             );
+
+            OkCommand = new RelayCommand(() =>
+            {
+                if (Mappings.Any(m => string.IsNullOrEmpty(m.SelectedColumn)))
+                    return;
+                onOk();
+            });
+
+            CancelCommand = new RelayCommand(onCancel);
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -261,7 +261,7 @@ namespace ToolManagementAppV2.ViewModels
 
             OpenImageImportMappingWindowCommand = new RelayCommand(() =>
             {
-                var win = new ImageImportMappingWindow { DataContext = new ImageImportMappingViewModel() };
+                var win = new ImageImportMappingWindow();
                 win.ShowDialog();
             });
 

--- a/ToolManagementAppV2/ViewModels/PasswordPromptViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/PasswordPromptViewModel.cs
@@ -1,0 +1,46 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System;
+using ToolManagementAppV2.Models.Domain;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class PasswordPromptViewModel : ObservableObject
+    {
+        public string EnteredPassword { get; private set; } = string.Empty;
+        public bool IsPasswordResetRequested { get; set; }
+        public Func<string, bool> ValidatePassword { get; set; } = _ => true;
+        public User? SelectedUser { get; set; }
+
+        public IRelayCommand<string> OkCommand { get; }
+        public IRelayCommand CancelCommand { get; }
+
+        private readonly Action _onSuccess;
+        private readonly Action _onCancel;
+        private readonly Action<string> _showError;
+
+        public PasswordPromptViewModel(Action onSuccess, Action onCancel, Action<string> showError)
+        {
+            _onSuccess = onSuccess;
+            _onCancel = onCancel;
+            _showError = showError;
+
+            OkCommand = new RelayCommand<string>(OnOk);
+            CancelCommand = new RelayCommand(() => _onCancel());
+        }
+
+        private void OnOk(string? password)
+        {
+            var pwd = password ?? string.Empty;
+            if (ValidatePassword?.Invoke(pwd) == true)
+            {
+                EnteredPassword = pwd;
+                _onSuccess();
+                return;
+            }
+
+            _showError("Incorrect password. Please try again.");
+        }
+    }
+}
+

--- a/ToolManagementAppV2/ViewModels/PrintPreviewViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/PrintPreviewViewModel.cs
@@ -1,0 +1,21 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class PrintPreviewViewModel : ObservableObject
+    {
+        public IRelayCommand PageSetupCommand { get; }
+        public IRelayCommand PrintCommand { get; }
+        public IRelayCommand CloseCommand { get; }
+
+        public PrintPreviewViewModel(Action onPageSetup, Action onPrint, Action onClose)
+        {
+            PageSetupCommand = new RelayCommand(onPageSetup);
+            PrintCommand = new RelayCommand(onPrint);
+            CloseCommand = new RelayCommand(onClose);
+        }
+    }
+}
+

--- a/ToolManagementAppV2/Views/AvatarSelectionWindow.xaml
+++ b/ToolManagementAppV2/Views/AvatarSelectionWindow.xaml
@@ -25,8 +25,8 @@
             </ListBox.ItemsPanel>
             <ListBox.ItemTemplate>
                 <DataTemplate>
-                    <Button Click="AvatarButton_Click"
-                            Tag="{Binding}"
+                    <Button Command="{Binding DataContext.SelectAvatarCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                            CommandParameter="{Binding}"
                             Background="Transparent"
                             BorderThickness="0"
                             Margin="5">

--- a/ToolManagementAppV2/Views/AvatarSelectionWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/AvatarSelectionWindow.xaml.cs
@@ -1,16 +1,19 @@
-﻿using System.IO;
+using System;
+using System.IO;
+using System.Linq;
 using System.Windows;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.ViewModels;
 
 
 namespace ToolManagementAppV2.Views
 {
     public partial class AvatarSelectionWindow : Window
     {
-        public string SelectedAvatarPath { get; private set; }
-        public Uri[] Avatars { get; private set; } = Array.Empty<Uri>();
+        public AvatarSelectionViewModel VM => (AvatarSelectionViewModel)DataContext;
+        public string SelectedAvatarPath => VM.SelectedAvatarPath;
 
         public AvatarSelectionWindow()
         {
@@ -24,22 +27,14 @@ namespace ToolManagementAppV2.Views
                 Title = $"{appName} – Select Avatar";
 
             var avatarDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "Avatars");
+            var avatars = Array.Empty<Uri>();
             if (Directory.Exists(avatarDir))
-                Avatars = Directory
+                avatars = Directory
                     .EnumerateFiles(avatarDir, "*.png")
                     .Select(path => new Uri(path, UriKind.Absolute))
                     .ToArray();
 
-            DataContext = this;
-        }
-
-        private void AvatarButton_Click(object sender, RoutedEventArgs e)
-        {
-            if (sender is FrameworkElement fe && fe.Tag is Uri uri)
-            {
-                SelectedAvatarPath = uri.LocalPath;
-                DialogResult = true;
-            }
+            DataContext = new AvatarSelectionViewModel(avatars, () => DialogResult = true);
         }
     }
 }

--- a/ToolManagementAppV2/Views/ImageImportMappingWindow.xaml
+++ b/ToolManagementAppV2/Views/ImageImportMappingWindow.xaml
@@ -19,8 +19,15 @@
         </Border>
 
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Style="{StaticResource PrimaryButton}" Content="OK" Width="140" Click="Ok_Click"/>
-            <Button Style="{StaticResource PrimaryButton}" Content="Cancel" Width="140" Margin="8,0,0,0" Click="Cancel_Click"/>
+            <Button Style="{StaticResource PrimaryButton}"
+                    Content="OK"
+                    Width="140"
+                    Command="{Binding OkCommand}"/>
+            <Button Style="{StaticResource PrimaryButton}"
+                    Content="Cancel"
+                    Width="140"
+                    Margin="8,0,0,0"
+                    Command="{Binding CancelCommand}"/>
         </StackPanel>
     </DockPanel>
 </Window>

--- a/ToolManagementAppV2/Views/ImageImportMappingWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ImageImportMappingWindow.xaml.cs
@@ -8,21 +8,11 @@ namespace ToolManagementAppV2.Views
         public ImageImportMappingWindow()
         {
             InitializeComponent();
-            DataContext = new ImageImportMappingViewModel();
+            DataContext = new ImageImportMappingViewModel(
+                () => { DialogResult = true; Close(); },
+                () => { DialogResult = false; Close(); });
         }
 
         public ImageImportMappingViewModel VM => (ImageImportMappingViewModel)DataContext;
-
-        private void Ok_Click(object sender, RoutedEventArgs e)
-        {
-            DialogResult = true;
-            Close();
-        }
-
-        private void Cancel_Click(object sender, RoutedEventArgs e)
-        {
-            DialogResult = false;
-            Close();
-        }
     }
 }

--- a/ToolManagementAppV2/Views/ImportMappingWindow.xaml
+++ b/ToolManagementAppV2/Views/ImportMappingWindow.xaml
@@ -39,8 +39,15 @@
         </Border>
 
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Style="{StaticResource PrimaryButton}" Content="OK" Width="140" Click="Ok_Click"/>
-            <Button Style="{StaticResource PrimaryButton}" Content="Cancel" Width="140" Margin="8,0,0,0" Click="Cancel_Click"/>
+            <Button Style="{StaticResource PrimaryButton}"
+                    Content="OK"
+                    Width="140"
+                    Command="{Binding OkCommand}"/>
+            <Button Style="{StaticResource PrimaryButton}"
+                    Content="Cancel"
+                    Width="140"
+                    Margin="8,0,0,0"
+                    Command="{Binding CancelCommand}"/>
         </StackPanel>
     </DockPanel>
 </Window>

--- a/ToolManagementAppV2/Views/ImportMappingWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ImportMappingWindow.xaml.cs
@@ -12,23 +12,13 @@ namespace ToolManagementAppV2.Views
         public ImportMappingWindow(IEnumerable<string> headers, IEnumerable<string> propertyNames)
         {
             InitializeComponent();
-            DataContext = new ImportMappingViewModel(headers, propertyNames);
+            DataContext = new ImportMappingViewModel(
+                headers,
+                propertyNames,
+                () => { DialogResult = true; Close(); },
+                () => { DialogResult = false; Close(); });
         }
 
         public ImportMappingViewModel VM => (ImportMappingViewModel)DataContext;
-
-        private void Ok_Click(object sender, RoutedEventArgs e)
-        {
-            if (VM.Mappings.Any(m => string.IsNullOrEmpty(m.SelectedColumn)))
-                return;
-            DialogResult = true;
-            Close();
-        }
-
-        private void Cancel_Click(object sender, RoutedEventArgs e)
-        {
-            DialogResult = false;
-            Close();
-        }
     }
 }

--- a/ToolManagementAppV2/Views/PasswordPromptWindow.xaml
+++ b/ToolManagementAppV2/Views/PasswordPromptWindow.xaml
@@ -54,8 +54,14 @@
                    TextWrapping="Wrap"/>
 
         <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
-            <Button Style="{StaticResource PrimaryButton}" Content="Cancel" Click="Cancel_Click"/>
-            <Button Style="{StaticResource PrimaryButton}" Content="OK" Margin="8,0,0,0" Click="OK_Click"/>
+            <Button Style="{StaticResource PrimaryButton}"
+                    Content="Cancel"
+                    Command="{Binding CancelCommand}"/>
+            <Button Style="{StaticResource PrimaryButton}"
+                    Content="OK"
+                    Margin="8,0,0,0"
+                    Command="{Binding OkCommand}"
+                    CommandParameter="{Binding ElementName=PasswordBox, Path=Password}"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/ToolManagementAppV2/Views/PasswordPromptWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PasswordPromptWindow.xaml.cs
@@ -3,6 +3,7 @@ using System;
 using System.Windows;
 using System.Windows.Input;
 using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2.Views
 {
@@ -11,14 +12,31 @@ namespace ToolManagementAppV2.Views
         private const int MaxAttempts = 2;
         private int _attemptCount;
 
-        public string EnteredPassword { get; private set; } = string.Empty;
-        public bool IsPasswordResetRequested { get; private set; }
-        public Func<string, bool> ValidatePassword { get; set; } = _ => true;
-        public User? SelectedUser { get; set; }
+        public PasswordPromptViewModel VM => (PasswordPromptViewModel)DataContext;
+        public string EnteredPassword => VM.EnteredPassword;
+        public bool IsPasswordResetRequested
+        {
+            get => VM.IsPasswordResetRequested;
+            set => VM.IsPasswordResetRequested = value;
+        }
+        public Func<string, bool> ValidatePassword
+        {
+            get => VM.ValidatePassword;
+            set => VM.ValidatePassword = value;
+        }
+        public User? SelectedUser
+        {
+            get => VM.SelectedUser;
+            set => VM.SelectedUser = value;
+        }
 
         public PasswordPromptWindow()
         {
             InitializeComponent();
+            DataContext = new PasswordPromptViewModel(
+                () => { DialogResult = true; },
+                () => { DialogResult = false; },
+                ShowError);
             Loaded += OnLoaded;
         }
 
@@ -30,24 +48,6 @@ namespace ToolManagementAppV2.Views
                 PromptTextBlock.Text = "Please enter your password:";
 
             PasswordBox.Focus();
-        }
-
-        private void OK_Click(object sender, RoutedEventArgs e)
-        {
-            var pwd = PasswordBox.Password;
-            if (ValidatePassword?.Invoke(pwd) == true)
-            {
-                EnteredPassword = pwd;
-                DialogResult = true;
-                return;
-            }
-
-            ShowError("Incorrect password. Please try again.");
-        }
-
-        private void Cancel_Click(object sender, RoutedEventArgs e)
-        {
-            DialogResult = false;
         }
 
         private void ShowError(string message)

--- a/ToolManagementAppV2/Views/PrintPreviewWindow.xaml
+++ b/ToolManagementAppV2/Views/PrintPreviewWindow.xaml
@@ -25,9 +25,17 @@
                                VerticalAlignment="Center"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Page Setup" Click="PageSetup_Click"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Print" Margin="8,0,0,0" Click="Print_Click"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Close" Margin="8,0,0,0" Click="Close_Click"/>
+                    <Button Style="{StaticResource PrimaryButton}"
+                            Content="Page Setup"
+                            Command="{Binding PageSetupCommand}"/>
+                    <Button Style="{StaticResource PrimaryButton}"
+                            Content="Print"
+                            Margin="8,0,0,0"
+                            Command="{Binding PrintCommand}"/>
+                    <Button Style="{StaticResource PrimaryButton}"
+                            Content="Close"
+                            Margin="8,0,0,0"
+                            Command="{Binding CloseCommand}"/>
                 </StackPanel>
             </DockPanel>
         </Border>

--- a/ToolManagementAppV2/Views/PrintPreviewWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PrintPreviewWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Media.Imaging;
 using System.Windows.Controls; // WPF PrintDialog
+using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2.Views
 {
@@ -16,6 +17,7 @@ namespace ToolManagementAppV2.Views
         public PrintPreviewWindow()
         {
             InitializeComponent();
+            DataContext = new PrintPreviewViewModel(OnPageSetup, OnPrint, Close);
         }
 
         public void ShowPreview(FlowDocument document, string title, string logoPath)
@@ -52,24 +54,19 @@ namespace ToolManagementAppV2.Views
             return new Uri("pack://application:,,,/Resources/DefaultLogo.png");
         }
 
-        private void PageSetup_Click(object sender, RoutedEventArgs e)
+        private void OnPageSetup()
         {
             DocViewer.FitToWidth();
         }
 
-        private void Print_Click(object sender, RoutedEventArgs e)
+        private void OnPrint()
         {
             if (_document == null) return;
             var dlg = new System.Windows.Controls.PrintDialog();
-            if (dlg.ShowDialog() == true) // ✅ Correct nullable bool check
+            if (dlg.ShowDialog() == true)
             {
                 dlg.PrintDocument(((IDocumentPaginatorSource)_document).DocumentPaginator, _title);
             }
-        }
-
-        private void Close_Click(object sender, RoutedEventArgs e)
-        {
-            Close();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove Click handlers from PasswordPrompt, ImportMapping, ImageImportMapping, PrintPreview and AvatarSelection windows
- Implement ICommand properties in new or existing view models to handle each button interaction
- Set window DataContexts to the view models providing commands and clean up code-behind

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(403 Forbidden: unable to install dotnet SDK)*

------
https://chatgpt.com/codex/tasks/task_e_689b0c554c5c8324937343dc8bab708d