### PR TITLE
feat: centralize dialog windows

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -6,6 +6,7 @@ using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Interfaces;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.ViewModels
@@ -25,7 +26,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var userService = new UserService(dbService);
                 userService.AddUser(new User { UserName = "user", Password = "newpassword", IsAdmin = false });
 
-                var vm = new LoginViewModel(dbPath);
+                var vm = new LoginViewModel(new StubDialogService(), dbPath);
                 bool success = false;
                 vm.LoginSucceeded += (_, __) => success = true;
 
@@ -42,5 +43,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 Application.Current.Properties.Remove("CurrentUser");
             }
         }
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => true;
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Interfaces;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.ViewModels
@@ -11,7 +12,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void Constructor_InitializesThemeDefaults()
         {
-            var vm = new SettingsViewModel(new StubFileDialogService(), new StubSettingsService());
+            var vm = new SettingsViewModel(new StubFileDialogService(), new StubSettingsService(), new StubDialogService());
             Assert.Contains("Light", vm.ThemeOptions);
             Assert.Equal("Light", vm.Theme);
         }
@@ -22,7 +23,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
             try
             {
-                var vm = new SettingsViewModel(new StubFileDialogService(), new StubSettingsService()) { ConnectionString = path };
+                var vm = new SettingsViewModel(new StubFileDialogService(), new StubSettingsService(), new StubDialogService()) { ConnectionString = path };
                 var success = vm.TestDbConnection(out var message);
                 Assert.True(success);
                 Assert.Equal("Connection successful.", message);
@@ -37,7 +38,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void TestDbConnection_InvalidPath_ReturnsErrorMessage()
         {
-            var vm = new SettingsViewModel(new StubFileDialogService(), new StubSettingsService())
+            var vm = new SettingsViewModel(new StubFileDialogService(), new StubSettingsService(), new StubDialogService())
             {
                 ConnectionString = "/nonexistent/path/db.sqlite"
             };
@@ -49,7 +50,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void BrowseCompanyLogoCommand_SetsPath()
         {
             var fileDialog = new StubFileDialogService { OpenPath = "logo.png" };
-            var vm = new SettingsViewModel(fileDialog, new StubSettingsService());
+            var vm = new SettingsViewModel(fileDialog, new StubSettingsService(), new StubDialogService());
             vm.BrowseCompanyLogoCommand.Execute(null);
             Assert.Equal("logo.png", vm.CompanyLogoPath);
         }
@@ -58,7 +59,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void SaveCompanyLogoCommand_PersistsPath()
         {
             var settings = new StubSettingsService();
-            var vm = new SettingsViewModel(new StubFileDialogService(), settings)
+            var vm = new SettingsViewModel(new StubFileDialogService(), settings, new StubDialogService())
             {
                 CompanyLogoPath = "logo.png"
             };
@@ -90,6 +91,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Dictionary<string, string> GetAllSettings() => new();
         public void UpdateSettings(Dictionary<string, string> settings) { }
         public void DeleteSetting(string key) { }
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => true;
     }
 }
 

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsWindowViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsWindowViewModelTests.cs
@@ -1,5 +1,6 @@
 using System;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Interfaces;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.ViewModels
@@ -9,7 +10,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void Constructor_CreatesSettingsPageAndUsesProvidedViewModel()
         {
-            var settingsVm = new SettingsViewModel(new StubFileDialogService(), new StubSettingsService());
+            var settingsVm = new SettingsViewModel(new StubFileDialogService(), new StubSettingsService(), new StubDialogService());
             var vm = new SettingsWindowViewModel(settingsVm, () => { });
             Assert.NotNull(vm.SettingsPageContent);
             Assert.Same(settingsVm, vm.SettingsViewModel);
@@ -19,7 +20,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void Commands_InvokeProvidedActions()
         {
             bool saved = false, closed = false;
-            var vm = new SettingsWindowViewModel(new SettingsViewModel(new StubFileDialogService(), new StubSettingsService()), () => closed = true, () => saved = true);
+            var vm = new SettingsWindowViewModel(new SettingsViewModel(new StubFileDialogService(), new StubSettingsService(), new StubDialogService()), () => closed = true, () => saved = true);
             vm.SaveSettingsCommand.Execute(null);
             vm.CloseCommand.Execute(null);
             Assert.True(saved);
@@ -40,6 +41,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Dictionary<string, string> GetAllSettings() => new();
         public void UpdateSettings(Dictionary<string, string> settings) { }
         public void DeleteSetting(string key) { }
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => true;
     }
 }
 

--- a/ToolManagementAppV2/Interfaces/IDialogService.cs
+++ b/ToolManagementAppV2/Interfaces/IDialogService.cs
@@ -1,0 +1,8 @@
+namespace ToolManagementAppV2.Interfaces
+{
+    public interface IDialogService
+    {
+        void ShowInfo(string message, string title);
+        bool ShowConfirmation(string message, string title);
+    }
+}

--- a/ToolManagementAppV2/Services/DialogService.cs
+++ b/ToolManagementAppV2/Services/DialogService.cs
@@ -1,0 +1,20 @@
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Views;
+
+namespace ToolManagementAppV2.Services
+{
+    public class DialogService : IDialogService
+    {
+        public void ShowInfo(string message, string title)
+        {
+            var dialog = new InfoDialogWindow(message) { Title = title };
+            dialog.ShowDialog();
+        }
+
+        public bool ShowConfirmation(string message, string title)
+        {
+            var dialog = new ConfirmDialogWindow(message) { Title = title };
+            return dialog.ShowDialog() == true;
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/InfoDialogViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/InfoDialogViewModel.cs
@@ -1,0 +1,18 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class InfoDialogViewModel : ObservableObject
+    {
+        public string Message { get; }
+        public IRelayCommand OkCommand { get; }
+
+        public InfoDialogViewModel(string message, Action close)
+        {
+            Message = message;
+            OkCommand = new RelayCommand(close);
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -29,6 +29,7 @@ namespace ToolManagementAppV2.ViewModels
     {
         readonly IUserService _userService;
         readonly ISettingsService _settingsService;
+        readonly IDialogService _dialogService;
 
         public ObservableCollection<User> Users { get; } = new();
 
@@ -55,12 +56,13 @@ namespace ToolManagementAppV2.ViewModels
         /// </summary>
         public event EventHandler? LoginSucceeded;
 
-        public LoginViewModel(string? dbPath = null)
+        public LoginViewModel(IDialogService dialogService, string? dbPath = null)
         {
             dbPath ??= Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db");
             var dbService = new DatabaseService(dbPath);
             _settingsService = new SettingsService(dbService);
             _userService = new UserService(dbService);
+            _dialogService = dialogService;
 
             CompanyLogo = LoadLogo();
             WindowTitle = GetWindowTitle();
@@ -108,9 +110,9 @@ namespace ToolManagementAppV2.ViewModels
             var users = _userService.GetAllUsers();
             if (users.Count == 0)
             {
-                System.Windows.MessageBox.Show(
+                _dialogService.ShowInfo(
                     "No users exist. A default admin account will be created (username: admin, password: admin).",
-                    "Setup", MessageBoxButton.OK, MessageBoxImage.Information);
+                    "Setup");
 
                 var admin = new User { UserName = "admin", Password = "admin", IsAdmin = true };
                 _userService.AddUser(admin);
@@ -153,7 +155,7 @@ namespace ToolManagementAppV2.ViewModels
             var passwordValidated = false;
             while (!passwordValidated)
             {
-                var prompt = new PasswordPromptWindow
+                var prompt = new PasswordPromptWindow(_dialogService)
                 {
                     SelectedUser = user,
                     ValidatePassword = pwd => _userService.AuthenticateUser(user.UserName, pwd) != null
@@ -168,8 +170,8 @@ namespace ToolManagementAppV2.ViewModels
                     user.Password = refreshed.Password;
                     user.Salt = refreshed.Salt;
                     LoadUsers();
-                    System.Windows.MessageBox.Show("Password has been reset to default. Please enter the new password to login.",
-                        "Password Reset", MessageBoxButton.OK, MessageBoxImage.Information);
+                    _dialogService.ShowInfo("Password has been reset to default. Please enter the new password to login.",
+                        "Password Reset");
                     continue;
                 }
 

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -9,6 +9,7 @@ using System.Windows.Controls;
 using System.Windows.Documents;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Settings;
@@ -170,7 +171,7 @@ namespace ToolManagementAppV2.ViewModels
                 var settingsService = new SettingsService(db);
                 var page = new SettingsPage
                 {
-                    DataContext = new SettingsViewModel(fileDialogService, settingsService),
+                    DataContext = new SettingsViewModel(fileDialogService, settingsService, new DialogService()),
                     Title = "Settings"
                 };
                 CurrentPage = page;
@@ -246,7 +247,7 @@ namespace ToolManagementAppV2.ViewModels
 
             OpenPasswordPromptWindowCommand = new RelayCommand(() =>
             {
-                var win = new PasswordPromptWindow { SelectedUser = System.Windows.Application.Current.Properties["CurrentUser"] as User };
+                var win = new PasswordPromptWindow(new DialogService()) { SelectedUser = System.Windows.Application.Current.Properties["CurrentUser"] as User };
                 win.ShowDialog();
             });
 

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -11,21 +11,20 @@ namespace ToolManagementAppV2.ViewModels
     {
         readonly IFileDialogService _fileDialog;
         readonly ISettingsService _settingsService;
+        readonly IDialogService _dialogService;
 
-        public SettingsViewModel(IFileDialogService fileDialog, ISettingsService settingsService)
+        public SettingsViewModel(IFileDialogService fileDialog, ISettingsService settingsService, IDialogService dialogService)
         {
             _fileDialog = fileDialog;
             _settingsService = settingsService;
+            _dialogService = dialogService;
 
             ThemeOptions = new ObservableCollection<string> { "Light", "Dark" };
             _theme = ThemeOptions[0];
             TestDbCommand = new RelayCommand(() =>
             {
                 var success = TestDbConnection(out var message);
-                System.Windows.MessageBox.Show(message,
-                    "Database Connection",
-                    System.Windows.MessageBoxButton.OK,
-                    success ? System.Windows.MessageBoxImage.Information : System.Windows.MessageBoxImage.Error);
+                _dialogService.ShowInfo(message, "Database Connection");
             });
             BrowseCompanyLogoCommand = new RelayCommand(BrowseCompanyLogo);
             SaveCompanyLogoCommand = new RelayCommand(SaveCompanyLogo);

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Extensions;
 using ToolManagementAppV2.Views;
+using ToolManagementAppV2.Services;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -114,7 +115,7 @@ namespace ToolManagementAppV2.ViewModels
             {
                 try
                 {
-                    var prompt = new Views.PasswordPromptWindow { SelectedUser = newUser };
+                    var prompt = new Views.PasswordPromptWindow(new DialogService()) { SelectedUser = newUser };
                     if (prompt.ShowDialog() == true)
                         newUser.Password = prompt.EnteredPassword;
                 }

--- a/ToolManagementAppV2/Views/InfoDialogWindow.xaml
+++ b/ToolManagementAppV2/Views/InfoDialogWindow.xaml
@@ -1,0 +1,21 @@
+<!-- Views/InfoDialogWindow.xaml -->
+<Window x:Class="ToolManagementAppV2.Views.InfoDialogWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Information"
+        Width="480" Height="220"
+        WindowStartupLocation="CenterScreen"
+        Background="{StaticResource BackgroundBrush}">
+    <Grid Margin="14">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Border Style="{StaticResource Card}">
+            <TextBlock Text="{Binding Message}" FontSize="16" TextWrapping="Wrap"/>
+        </Border>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Style="{StaticResource PrimaryButton}" Content="OK" Command="{Binding OkCommand}"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/ToolManagementAppV2/Views/InfoDialogWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/InfoDialogWindow.xaml.cs
@@ -1,0 +1,19 @@
+using System.Windows;
+using ToolManagementAppV2.ViewModels;
+
+namespace ToolManagementAppV2.Views
+{
+    /// <summary>
+    /// Interaction logic for InfoDialogWindow.xaml
+    /// </summary>
+    public partial class InfoDialogWindow : Window
+    {
+        public InfoDialogWindow(string message)
+        {
+            InitializeComponent();
+            DataContext = new InfoDialogViewModel(message, () => DialogResult = true);
+        }
+
+        public InfoDialogWindow() : this(string.Empty) { }
+    }
+}

--- a/ToolManagementAppV2/Views/LoginWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Windows;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Services;
 
 namespace ToolManagementAppV2
 {
@@ -13,7 +14,7 @@ namespace ToolManagementAppV2
 
             if (DataContext is not LoginViewModel vm)
             {
-                vm = new LoginViewModel();
+                vm = new LoginViewModel(new DialogService());
                 DataContext = vm;
             }
 

--- a/ToolManagementAppV2/Views/PasswordPromptWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PasswordPromptWindow.xaml.cs
@@ -2,7 +2,9 @@
 using System;
 using System.Windows;
 using System.Windows.Input;
+using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services;
 using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2.Views
@@ -11,6 +13,7 @@ namespace ToolManagementAppV2.Views
     {
         private const int MaxAttempts = 2;
         private int _attemptCount;
+        readonly IDialogService _dialogService;
 
         public PasswordPromptViewModel VM => (PasswordPromptViewModel)DataContext;
         public string EnteredPassword => VM.EnteredPassword;
@@ -30,15 +33,18 @@ namespace ToolManagementAppV2.Views
             set => VM.SelectedUser = value;
         }
 
-        public PasswordPromptWindow()
+        public PasswordPromptWindow(IDialogService dialogService)
         {
             InitializeComponent();
+            _dialogService = dialogService;
             DataContext = new PasswordPromptViewModel(
                 () => { DialogResult = true; },
                 () => { DialogResult = false; },
                 ShowError);
             Loaded += OnLoaded;
         }
+
+        public PasswordPromptWindow() : this(new DialogService()) { }
 
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
@@ -68,23 +74,15 @@ namespace ToolManagementAppV2.Views
         {
             if (SelectedUser?.IsAdmin != true)
             {
-                System.Windows.MessageBox.Show(
+                _dialogService.ShowInfo(
                     "Password recovery is only available for admin users.",
-                    "Not Allowed",
-                    MessageBoxButton.OK,
-                    MessageBoxImage.Warning
-                );
+                    "Not Allowed");
                 return;
             }
 
-            var result = System.Windows.MessageBox.Show(
+            if (!_dialogService.ShowConfirmation(
                 "You have entered the wrong password multiple times. Reset to default and change it after login?",
-                "Reset Password",
-                MessageBoxButton.YesNo,
-                MessageBoxImage.Question
-            );
-
-            if (result != MessageBoxResult.Yes) return;
+                "Reset Password")) return;
 
             IsPasswordResetRequested = true;
             DialogResult = true;

--- a/ToolManagementAppV2/Views/SettingsWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/SettingsWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Services;
 using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2.Views
@@ -20,7 +21,8 @@ namespace ToolManagementAppV2.Views
             var db = new DatabaseService(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db"));
             var settingsService = new SettingsService(db);
             var fileDialog = new FileDialogService();
-            var settingsVm = new SettingsViewModel(fileDialog, settingsService);
+            var dialog = new DialogService();
+            var settingsVm = new SettingsViewModel(fileDialog, settingsService, dialog);
 
             DataContext = new SettingsWindowViewModel(
                 settingsVm,


### PR DESCRIPTION
## Summary
- add IDialogService and DialogService with themed info and confirmation dialogs
- inject dialog service into login, settings, and password prompt workflows
- replace direct MessageBox usages

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b0f0aaec48324a22712e27bcf2115