### PR TITLE
Ensure PasswordPromptWindow handles Enter and Escape

### DIFF
--- a/ToolManagementAppV2/Views/PasswordPromptWindow.xaml
+++ b/ToolManagementAppV2/Views/PasswordPromptWindow.xaml
@@ -56,12 +56,14 @@
         <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Style="{StaticResource PrimaryButton}"
                     Content="Cancel"
-                    Command="{Binding CancelCommand}"/>
+                    Command="{Binding CancelCommand}"
+                    IsCancel="True"/>
             <Button Style="{StaticResource PrimaryButton}"
                     Content="OK"
                     Margin="8,0,0,0"
                     Command="{Binding OkCommand}"
-                    CommandParameter="{Binding ElementName=PasswordBox, Path=Password}"/>
+                    CommandParameter="{Binding ElementName=PasswordBox, Path=Password}"
+                    IsDefault="True"/>
         </StackPanel>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- Allow Escape key to cancel password prompt
- Allow Enter key to confirm password prompt

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b114e0c88832491117f3a382f4393