### PR TITLE
Add tool details window and command

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -236,5 +236,61 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void ViewDetailsCommand_InvokesDialog()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer" };
+                toolService.AddTool(tool);
+                vm.LoadTools();
+                vm.SelectedTool = vm.Tools.First();
+                bool called = false;
+                Tool? passed = null;
+                vm.ViewDetailsDialog = t => { called = true; passed = t; };
+                vm.ViewDetailsCommand.Execute(null);
+                Assert.True(called);
+                Assert.Equal(vm.SelectedTool, passed);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void ViewDetailsCommand_CanExecuteDependsOnSelectedTool()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+
+                Assert.False(vm.ViewDetailsCommand.CanExecute(null));
+
+                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
+                vm.LoadTools();
+                vm.SelectedTool = vm.Tools.First();
+
+                Assert.True(vm.ViewDetailsCommand.CanExecute(null));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/ToolManagementAppV2/ViewModels/ToolDetailsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolDetailsViewModel.cs
@@ -1,0 +1,20 @@
+// ViewModels/ToolDetailsViewModel.cs
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class ToolDetailsViewModel : ObservableObject
+    {
+        public ToolModel Tool { get; }
+
+        public IRelayCommand CloseCommand { get; }
+
+        public ToolDetailsViewModel(ToolModel tool, Action onClose)
+        {
+            Tool = tool;
+            CloseCommand = new RelayCommand(onClose);
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -52,6 +52,7 @@ namespace ToolManagementAppV2.ViewModels
                 {
                     ((RelayCommand)OpenRentalsCommand).NotifyCanExecuteChanged();
                     ((RelayCommand)EditToolCommand).NotifyCanExecuteChanged();
+                    ((RelayCommand)ViewDetailsCommand).NotifyCanExecuteChanged();
                 }
             }
         }
@@ -79,8 +80,10 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand EditToolCommand { get; }
         public IRelayCommand DeleteToolCommand { get; }
         public IRelayCommand OpenRentalsCommand { get; }
+        public IRelayCommand ViewDetailsCommand { get; }
 
         public Func<ToolModel, ToolModel?> EditToolDialog { get; set; }
+        public Action<ToolModel>? ViewDetailsDialog { get; set; }
 
         // Writable for TwoWay binding from XAML. Mirrors SearchTerm and triggers search.
         private string _searchText = string.Empty;
@@ -108,7 +111,9 @@ namespace ToolManagementAppV2.ViewModels
             EditToolCommand = new RelayCommand(EditTool, () => SelectedTool != null);
             DeleteToolCommand = new RelayCommand(DeleteTool);
             OpenRentalsCommand = new RelayCommand(OpenRentals, () => SelectedTool != null);
+            ViewDetailsCommand = new RelayCommand(ViewDetails, () => SelectedTool != null);
             EditToolDialog = DefaultEditToolDialog;
+            ViewDetailsDialog = DefaultViewDetailsDialog;
         }
 
         public void LoadTools()
@@ -175,6 +180,12 @@ namespace ToolManagementAppV2.ViewModels
             SelectedTool = Tools.FirstOrDefault(t => t.ToolID == updated.ToolID);
         }
 
+        void ViewDetails()
+        {
+            if (SelectedTool == null) return;
+            ViewDetailsDialog?.Invoke(SelectedTool);
+        }
+
         void DeleteTool()
         {
             if (SelectedTool == null) return;
@@ -235,6 +246,14 @@ namespace ToolManagementAppV2.ViewModels
                 onCancel: () => win.DialogResult = false);
             try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
             try { return win.ShowDialog() == true ? tool : null; } catch { return null; }
+        }
+
+        void DefaultViewDetailsDialog(ToolModel tool)
+        {
+            ToolDetailsWindow win = null!;
+            win = new ToolDetailsWindow(tool);
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
+            try { win.ShowDialog(); } catch { }
         }
     }
 }

--- a/ToolManagementAppV2/Views/ManageToolsPage.xaml
+++ b/ToolManagementAppV2/Views/ManageToolsPage.xaml
@@ -4,16 +4,12 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       Background="{StaticResource BackgroundBrush}">
     <Grid Margin="8">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="2*"/>
-            <ColumnDefinition Width="3*"/>
-        </Grid.ColumnDefinitions>
-
-        <Border Style="{StaticResource Card}" Margin="0,0,8,0">
+        <Border Style="{StaticResource Card}">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
                 <TextBlock Text="Tools" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,8"/>
@@ -43,62 +39,10 @@
                         </GridView>
                     </ListView.View>
                 </ListView>
-            </Grid>
-        </Border>
-
-        <Border Grid.Column="1" Style="{StaticResource Card}">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-
-                <TextBlock Text="Tool Details" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,8"/>
-
-                <Grid Grid.Row="1">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="180"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Tool Number" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-                    <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding SelectedTool.ToolNumber}" Margin="8,4"/>
-
-                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-                    <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedTool.NameDescription}" Margin="8,4"/>
-
-                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Brand" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-                    <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SelectedTool.Brand}" Margin="8,4"/>
-
-                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Location" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-                    <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedTool.Location}" Margin="8,4"/>
-
-                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Part #" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-                    <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding SelectedTool.PartNumber}" Margin="8,4"/>
-
-                    <TextBlock Grid.Row="5" Grid.Column="0" Text="Supplier" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-                    <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding SelectedTool.Supplier}" Margin="8,4"/>
-
-                    <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Vertical" Margin="0,8,0,0">
-                        <TextBlock Text="Notes" Foreground="{StaticResource ForegroundMutedBrush}"/>
-                        <ScrollViewer Height="90" VerticalScrollBarVisibility="Auto">
-                            <TextBlock Text="{Binding SelectedTool.Notes}" TextWrapping="Wrap"/>
-                        </ScrollViewer>
-                    </StackPanel>
-                </Grid>
 
                 <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
                     <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditToolCommand}"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="View Details" Command="{Binding ViewDetailsCommand}" Margin="8,0,0,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="New" Command="{Binding NewToolCommand}" Margin="8,0,0,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Delete" Command="{Binding DeleteToolCommand}" Margin="8,0,0,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Rent" Command="{Binding OpenRentalsCommand}" Margin="8,0,0,0"/>

--- a/ToolManagementAppV2/Views/ToolDetailsWindow.xaml
+++ b/ToolManagementAppV2/Views/ToolDetailsWindow.xaml
@@ -1,0 +1,58 @@
+<!-- Views/ToolDetailsWindow.xaml -->
+<Window x:Class="ToolManagementAppV2.Views.ToolDetailsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Tool Details" Width="520" Height="420" WindowStartupLocation="CenterOwner"
+        Background="{StaticResource BackgroundBrush}">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="180"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Tool Number" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Tool.ToolNumber}" Margin="8,4"/>
+
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Tool.NameDescription}" Margin="8,4"/>
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Brand" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Tool.Brand}" Margin="8,4"/>
+
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Location" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Tool.Location}" Margin="8,4"/>
+
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Part #" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Tool.PartNumber}" Margin="8,4"/>
+
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Supplier" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding Tool.Supplier}" Margin="8,4"/>
+
+            <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Vertical" Margin="0,8,0,0">
+                <TextBlock Text="Notes" Foreground="{StaticResource ForegroundMutedBrush}"/>
+                <ScrollViewer Height="90" VerticalScrollBarVisibility="Auto">
+                    <TextBlock Text="{Binding Tool.Notes}" TextWrapping="Wrap"/>
+                </ScrollViewer>
+            </StackPanel>
+        </Grid>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Style="{StaticResource PrimaryButton}" Content="Close" Command="{Binding CloseCommand}"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/ToolManagementAppV2/Views/ToolDetailsWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ToolDetailsWindow.xaml.cs
@@ -1,0 +1,15 @@
+// Views/ToolDetailsWindow.xaml.cs
+using System.Windows;
+using ToolManagementAppV2.ViewModels;
+
+namespace ToolManagementAppV2.Views
+{
+    public partial class ToolDetailsWindow : Window
+    {
+        public ToolDetailsWindow(ToolModel tool)
+        {
+            InitializeComponent();
+            DataContext = new ToolDetailsViewModel(tool, () => Close());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- remove inline details panel and show tools only list on ManageToolsPage
- add View Details action and supporting ToolDetailsWindow/command to display selected tool info
- cover ViewDetails command with unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b134f085c83249285726dc8c63b41