### PR TITLE
Bind password prompt to view model

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/PasswordPromptViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/PasswordPromptViewModelTests.cs
@@ -1,0 +1,42 @@
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class PasswordPromptViewModelTests
+    {
+        [Fact]
+        public void OkCommand_Succeeds_WhenPasswordValid()
+        {
+            bool success = false;
+            string? error = null;
+            var vm = new PasswordPromptViewModel(() => success = true, () => { }, m => error = m)
+            {
+                ValidatePassword = p => p == "secret"
+            };
+            vm.EnteredPassword = "secret";
+
+            vm.OkCommand.Execute(null);
+
+            Assert.True(success);
+            Assert.Null(error);
+        }
+
+        [Fact]
+        public void OkCommand_ShowsError_WhenPasswordInvalid()
+        {
+            bool success = false;
+            string? error = null;
+            var vm = new PasswordPromptViewModel(() => success = true, () => { }, m => error = m)
+            {
+                ValidatePassword = p => p == "secret"
+            };
+            vm.EnteredPassword = "wrong";
+
+            vm.OkCommand.Execute(null);
+
+            Assert.False(success);
+            Assert.Equal("Incorrect password. Please try again.", error);
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/PasswordPromptViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/PasswordPromptViewModel.cs
@@ -7,12 +7,12 @@ namespace ToolManagementAppV2.ViewModels
 {
     public class PasswordPromptViewModel : ObservableObject
     {
-        public string EnteredPassword { get; private set; } = string.Empty;
+        public string EnteredPassword { get; set; } = string.Empty;
         public bool IsPasswordResetRequested { get; set; }
         public Func<string, bool> ValidatePassword { get; set; } = _ => true;
         public User? SelectedUser { get; set; }
 
-        public IRelayCommand<string> OkCommand { get; }
+        public IRelayCommand OkCommand { get; }
         public IRelayCommand CancelCommand { get; }
 
         private readonly Action _onSuccess;
@@ -25,16 +25,15 @@ namespace ToolManagementAppV2.ViewModels
             _onCancel = onCancel;
             _showError = showError;
 
-            OkCommand = new RelayCommand<string>(OnOk);
+            OkCommand = new RelayCommand(OnOk);
             CancelCommand = new RelayCommand(() => _onCancel());
         }
 
-        private void OnOk(string? password)
+        private void OnOk()
         {
-            var pwd = password ?? string.Empty;
+            var pwd = EnteredPassword ?? string.Empty;
             if (ValidatePassword?.Invoke(pwd) == true)
             {
-                EnteredPassword = pwd;
                 _onSuccess();
                 return;
             }

--- a/ToolManagementAppV2/Views/PasswordPromptWindow.xaml
+++ b/ToolManagementAppV2/Views/PasswordPromptWindow.xaml
@@ -32,7 +32,8 @@
                 <PasswordBox x:Name="PasswordBox"
                              Grid.Column="1"
                              PasswordChar="•"
-                             Margin="8,0,0,0"/>
+                             Margin="8,0,0,0"
+                             PasswordChanged="PasswordBox_PasswordChanged"/>
             </Grid>
         </Border>
 
@@ -62,7 +63,6 @@
                     Content="OK"
                     Margin="8,0,0,0"
                     Command="{Binding OkCommand}"
-                    CommandParameter="{Binding ElementName=PasswordBox, Path=Password}"
                     IsDefault="True"/>
         </StackPanel>
     </Grid>

--- a/ToolManagementAppV2/Views/PasswordPromptWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PasswordPromptWindow.xaml.cs
@@ -56,6 +56,11 @@ namespace ToolManagementAppV2.Views
             PasswordBox.Focus();
         }
 
+        private void PasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
+        {
+            VM.EnteredPassword = PasswordBox.Password;
+        }
+
         private void ShowError(string message)
         {
             _attemptCount++;


### PR DESCRIPTION
## Summary
- Bind password box directly to the view model and remove command parameter.
- Update password prompt view model to validate the stored password and expose a parameterless OK command.
- Add unit tests covering password prompt success and failure scenarios.

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b1636f8308324848f17cce69aa2c6