### PR TITLE
Add rentals filter popup

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ManageRentalsPageMenuTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ManageRentalsPageMenuTests.cs
@@ -66,7 +66,7 @@ namespace ToolManagementAppV2.Tests.Tests
         }
 
         [Fact]
-        public void Toolbar_FilterButton_BindsToToggleFilterPanelCommand()
+        public void Toolbar_FilterButton_BindsToOpenFilterWindowCommand()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -80,7 +80,7 @@ namespace ToolManagementAppV2.Tests.Tests
                 var toolbar = (ToolBar)grid.Children[0];
                 var button = (Button)toolbar.Items[0];
 
-                Assert.Equal(vm.ToggleFilterPanelCommand, button.Command);
+                Assert.Equal(vm.OpenFilterWindowCommand, button.Command);
             }
             finally
             {

--- a/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
@@ -72,16 +72,9 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        private bool _isFilterPanelVisible;
-        public bool IsFilterPanelVisible
-        {
-            get => _isFilterPanelVisible;
-            set => SetProperty(ref _isFilterPanelVisible, value);
-        }
-
         public IRelayCommand ApplyFilterCommand { get; }
         public IRelayCommand ClearFilterCommand { get; }
-        public IRelayCommand ToggleFilterPanelCommand { get; }
+        public IRelayCommand OpenFilterWindowCommand { get; }
         public IRelayCommand CheckInCommand { get; }
         public IRelayCommand ExtendCommand { get; }
         public IRelayCommand OpenHistoryCommand { get; }
@@ -94,7 +87,7 @@ namespace ToolManagementAppV2.ViewModels
 
             ApplyFilterCommand = new RelayCommand(ApplyFilter);
             ClearFilterCommand = new RelayCommand(ClearFilter);
-            ToggleFilterPanelCommand = new RelayCommand(() => IsFilterPanelVisible = !IsFilterPanelVisible);
+            OpenFilterWindowCommand = new RelayCommand(OpenFilterWindow);
             CheckInCommand = new RelayCommand(CheckIn, () => SelectedRental != null);
             ExtendCommand = new RelayCommand(Extend, () => SelectedRental != null);
             OpenHistoryCommand = new RelayCommand(OpenHistory, () => SelectedRental != null);
@@ -129,7 +122,6 @@ namespace ToolManagementAppV2.ViewModels
                 filtered = filtered.Where(r => string.Equals(r.Status, SelectedStatus, StringComparison.OrdinalIgnoreCase));
 
             Rentals.ReplaceRange(filtered);
-            IsFilterPanelVisible = false;
         }
 
         void ClearFilter()
@@ -139,7 +131,13 @@ namespace ToolManagementAppV2.ViewModels
             FilterTo = null;
             SelectedStatus = StatusOptions.First();
             Rentals.ReplaceRange(_allRentals);
-            IsFilterPanelVisible = false;
+        }
+
+        void OpenFilterWindow()
+        {
+            var win = new RentalsFilterWindow { DataContext = this };
+            try { win.Owner = Application.Current?.MainWindow; } catch { }
+            try { win.ShowDialog(); } catch { }
         }
 
         void CheckIn()

--- a/ToolManagementAppV2/Views/ManageRentalsPage.xaml
+++ b/ToolManagementAppV2/Views/ManageRentalsPage.xaml
@@ -10,7 +10,7 @@
         </Grid.RowDefinitions>
 
         <ToolBar HorizontalAlignment="Right">
-            <Button Style="{StaticResource PrimaryButton}" Content="Filter" Command="{Binding ToggleFilterPanelCommand}"/>
+            <Button Style="{StaticResource PrimaryButton}" Content="Filter" Command="{Binding OpenFilterWindowCommand}"/>
             <Button Style="{StaticResource PrimaryButton}" Content="Check In" Command="{Binding CheckInCommand}" Margin="8,0,0,0"/>
         </ToolBar>
 
@@ -41,26 +41,6 @@
             </DataGrid>
         </Border>
 
-        <Border Grid.RowSpan="2"
-                Background="#80000000"
-                Visibility="{Binding IsFilterPanelVisible, Converter={StaticResource BoolToVis}}">
-            <Border Width="600"
-                    Style="{StaticResource Card}"
-                    Padding="12"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center">
-                <StackPanel>
-                    <TextBox Width="260" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"/>
-                    <DatePicker SelectedDate="{Binding FilterFrom}" Margin="0,8,0,0"/>
-                    <DatePicker SelectedDate="{Binding FilterTo}" Margin="0,8,0,0"/>
-                    <ComboBox Width="180" ItemsSource="{Binding StatusOptions}" SelectedItem="{Binding SelectedStatus}" Margin="0,8,0,0"/>
-                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
-                        <Button Style="{StaticResource PrimaryButton}" Content="Filter" Command="{Binding ApplyFilterCommand}"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Clear" Command="{Binding ClearFilterCommand}" Margin="8,0,0,0"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Close" Command="{Binding ToggleFilterPanelCommand}" Margin="8,0,0,0"/>
-                    </StackPanel>
-                </StackPanel>
-            </Border>
-        </Border>
+        <!-- Filter overlay removed; filtering handled by RentalsFilterWindow -->
     </Grid>
 </Page>

--- a/ToolManagementAppV2/Views/RentalsFilterWindow.xaml
+++ b/ToolManagementAppV2/Views/RentalsFilterWindow.xaml
@@ -1,0 +1,26 @@
+<!-- Views/RentalsFilterWindow.xaml -->
+<Window x:Class="ToolManagementAppV2.Views.RentalsFilterWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Filter Rentals"
+        Width="420" Height="260"
+        WindowStartupLocation="CenterOwner"
+        Background="{StaticResource BackgroundBrush}">
+    <Grid Margin="14">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <StackPanel>
+            <TextBox Width="260" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"/>
+            <DatePicker SelectedDate="{Binding FilterFrom}" Margin="0,8,0,0"/>
+            <DatePicker SelectedDate="{Binding FilterTo}" Margin="0,8,0,0"/>
+            <ComboBox Width="180" ItemsSource="{Binding StatusOptions}" SelectedItem="{Binding SelectedStatus}" Margin="0,8,0,0"/>
+        </StackPanel>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+            <Button Style="{StaticResource PrimaryButton}" Content="Apply" Command="{Binding ApplyFilterCommand}"/>
+            <Button Style="{StaticResource PrimaryButton}" Content="Clear" Command="{Binding ClearFilterCommand}" Margin="8,0,0,0"/>
+            <Button Style="{StaticResource PrimaryButton}" Content="Close" Click="OnClose" Margin="8,0,0,0"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/ToolManagementAppV2/Views/RentalsFilterWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/RentalsFilterWindow.xaml.cs
@@ -1,0 +1,17 @@
+using System.Windows;
+
+namespace ToolManagementAppV2.Views
+{
+    /// <summary>
+    /// Interaction logic for RentalsFilterWindow.xaml
+    /// </summary>
+    public partial class RentalsFilterWindow : Window
+    {
+        public RentalsFilterWindow()
+        {
+            InitializeComponent();
+        }
+
+        void OnClose(object sender, RoutedEventArgs e) => Close();
+    }
+}


### PR DESCRIPTION
## Summary
- add a RentalsFilterWindow dialog for search text, date range, and status filtering
- launch filter dialog via new OpenFilterWindowCommand and remove inline panel
- update ManageRentalsPage and tests to use the popup

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b179a8ca0832495d1e81330f57c75