### PR TITLE
Define columns for activity log grid

### DIFF
--- a/ToolManagementAppV2/Views/ActivityLogsPage.xaml
+++ b/ToolManagementAppV2/Views/ActivityLogsPage.xaml
@@ -16,7 +16,19 @@
         </Border>
 
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
-            <DataGrid ItemsSource="{Binding Logs}" IsReadOnly="True" AutoGenerateColumns="True"/>
+            <DataGrid ItemsSource="{Binding Logs}" IsReadOnly="True" AutoGenerateColumns="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Timestamp"
+                                         Binding="{Binding Timestamp, StringFormat={}{0:yyyy-MM-dd HH:mm}}"
+                                         Width="180"/>
+                    <DataGridTextColumn Header="User"
+                                         Binding="{Binding UserName}"
+                                         Width="160"/>
+                    <DataGridTextColumn Header="Action"
+                                         Binding="{Binding Action}"
+                                         Width="*"/>
+                </DataGrid.Columns>
+            </DataGrid>
         </Border>
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- Declare explicit Timestamp, User, and Action columns for activity log DataGrid
- Disable automatic column generation to show only relevant log fields

## Testing
- `dotnet test` *(fails: command not found; dotnet SDK unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_689b18a2f3848324a4b63b47e4cf0918