### PR TITLE
Handle empty salt during password verification

### DIFF
--- a/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
@@ -70,4 +70,33 @@ public class UserAuthenticationTests
                 File.Delete(dbPath);
         }
     }
+
+    [Fact]
+    public void AuthenticateUser_EmptySalt_ReturnsNull()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService);
+
+            var user = new User { UserName = "emptysalt", Password = "secret", IsAdmin = false };
+            userService.AddUser(user);
+
+            using (var conn = dbService.CreateConnection())
+            using (var cmd = new SQLiteCommand("UPDATE Users SET Salt='' WHERE UserID=@ID", conn))
+            {
+                cmd.Parameters.AddWithValue("@ID", user.UserID);
+                cmd.ExecuteNonQuery();
+            }
+
+            var auth = userService.AuthenticateUser("emptysalt", "secret");
+            Assert.Null(auth);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
 }

--- a/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
@@ -37,6 +37,9 @@ namespace ToolManagementAppV2.Utilities.Helpers
 
         public static bool VerifyPassword(string password, string salt, string hash)
         {
+            if (string.IsNullOrEmpty(salt))
+                return false;
+
             var computed = HashPassword(password, salt);
             return computed == hash;
         }


### PR DESCRIPTION
## Summary
- Avoid hashing when salt is null or empty, returning false instead
- Add regression test ensuring authentication fails gracefully with empty salt

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b1adcc8dc8324a7a18b39866b4bed