### PR TITLE
Bind RentalsFilterWindow close to view-model command

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
@@ -95,5 +95,23 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void CloseCommand_DoesNotThrowWithoutWindow()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var rentalService = new RentalService(db);
+                var vm = new ManageRentalsViewModel(rentalService);
+                vm.CloseCommand.Execute(null);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
@@ -75,6 +75,7 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand ApplyFilterCommand { get; }
         public IRelayCommand ClearFilterCommand { get; }
         public IRelayCommand OpenFilterWindowCommand { get; }
+        public IRelayCommand CloseCommand { get; }
         public IRelayCommand CheckInCommand { get; }
         public IRelayCommand ExtendCommand { get; }
         public IRelayCommand OpenHistoryCommand { get; }
@@ -88,6 +89,7 @@ namespace ToolManagementAppV2.ViewModels
             ApplyFilterCommand = new RelayCommand(ApplyFilter);
             ClearFilterCommand = new RelayCommand(ClearFilter);
             OpenFilterWindowCommand = new RelayCommand(OpenFilterWindow);
+            CloseCommand = new RelayCommand(CloseFilterWindow);
             CheckInCommand = new RelayCommand(CheckIn, () => SelectedRental != null);
             ExtendCommand = new RelayCommand(Extend, () => SelectedRental != null);
             OpenHistoryCommand = new RelayCommand(OpenHistory, () => SelectedRental != null);
@@ -138,6 +140,15 @@ namespace ToolManagementAppV2.ViewModels
             var win = new RentalsFilterWindow { DataContext = this };
             try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
             try { win.ShowDialog(); } catch { }
+        }
+
+        void CloseFilterWindow()
+        {
+            if (System.Windows.Application.Current == null) return;
+            var window = System.Windows.Application.Current.Windows
+                .OfType<Window>()
+                .FirstOrDefault(w => w.DataContext == this);
+            window?.Close();
         }
 
         void CheckIn()

--- a/ToolManagementAppV2/Views/RentalsFilterWindow.xaml
+++ b/ToolManagementAppV2/Views/RentalsFilterWindow.xaml
@@ -20,7 +20,7 @@
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
             <Button Style="{StaticResource PrimaryButton}" Content="Apply" Command="{Binding ApplyFilterCommand}"/>
             <Button Style="{StaticResource PrimaryButton}" Content="Clear" Command="{Binding ClearFilterCommand}" Margin="8,0,0,0"/>
-            <Button Style="{StaticResource PrimaryButton}" Content="Close" Click="OnClose" Margin="8,0,0,0"/>
+            <Button Style="{StaticResource PrimaryButton}" Content="Close" Command="{Binding CloseCommand}" Margin="8,0,0,0"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/ToolManagementAppV2/Views/RentalsFilterWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/RentalsFilterWindow.xaml.cs
@@ -11,7 +11,5 @@ namespace ToolManagementAppV2.Views
         {
             InitializeComponent();
         }
-
-        void OnClose(object sender, RoutedEventArgs e) => Close();
     }
 }


### PR DESCRIPTION
## Summary
- Bind RentalsFilterWindow Close button to new CloseCommand
- Remove code-behind click handler and add view-model-based closing logic
- Add unit test for CloseCommand

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689b1be415c0832490f0b14e2112cce4