### PR TITLE
Remove unused user management toolbar actions

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -36,29 +36,6 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void DeleteUserCommand_RemovesUser()
-        {
-            var dbPath = Path.GetTempFileName();
-            try
-            {
-                var db = new DatabaseService(dbPath);
-                IUserService userService = new UserService(db);
-                var vm = new UserManagementViewModel(userService, new StubFileDialogService());
-                userService.AddUser(new User { UserName = "user1", Password = "pw" });
-                vm.LoadUsers();
-                vm.SelectedUser = vm.Users.First();
-                vm.DeleteUserCommand.Execute(null);
-                Assert.Empty(userService.GetAllUsers());
-                Assert.Empty(vm.Users);
-            }
-            finally
-            {
-                if (File.Exists(dbPath))
-                    File.Delete(dbPath);
-            }
-        }
-
-        [Fact]
         public void UploadUserPhotoCommand_SetsPhotoPathAndPersists()
         {
             var dbPath = Path.GetTempFileName();
@@ -94,13 +71,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
                 vm.LoadUsers();
                 Assert.False(vm.UpdateUserCommand.CanExecute(null));
-                Assert.False(vm.DeleteUserCommand.CanExecute(null));
-                Assert.False(vm.ResetPasswordCommand.CanExecute(null));
                 Assert.False(vm.EditUserCommand.CanExecute(null));
                 vm.SelectedUser = vm.Users.First();
                 Assert.True(vm.UpdateUserCommand.CanExecute(null));
-                Assert.True(vm.DeleteUserCommand.CanExecute(null));
-                Assert.True(vm.ResetPasswordCommand.CanExecute(null));
                 Assert.True(vm.EditUserCommand.CanExecute(null));
             }
             finally
@@ -131,7 +104,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void ResetPasswordCommand_ChangesPassword()
+        public void ResetPasswordFromRowCommand_ChangesPassword()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -141,9 +114,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var vm = new UserManagementViewModel(userService, new StubFileDialogService());
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
                 vm.LoadUsers();
-                vm.SelectedUser = vm.Users.First();
-                var oldPwd = vm.SelectedUser.Password;
-                vm.ResetPasswordCommand.Execute(null);
+                var user = vm.Users.First();
+                var oldPwd = user.Password;
+                vm.ResetPasswordFromRowCommand.Execute(user);
                 var updated = userService.GetAllUsers().First();
                 Assert.NotEqual(oldPwd, updated.Password);
             }

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -36,8 +36,6 @@ namespace ToolManagementAppV2.ViewModels
                 if (SetProperty(ref _selectedUser, value))
                 {
                     ((RelayCommand)UpdateUserCommand).NotifyCanExecuteChanged();
-                    ((RelayCommand)DeleteUserCommand).NotifyCanExecuteChanged();
-                    ((RelayCommand)ResetPasswordCommand).NotifyCanExecuteChanged();
                     ((RelayCommand)EditUserCommand).NotifyCanExecuteChanged();
                 }
             }
@@ -46,9 +44,7 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand LoadUsersCommand { get; }
         public IRelayCommand UploadUserPhotoCommand { get; }
         public IRelayCommand UpdateUserCommand { get; }
-        public IRelayCommand DeleteUserCommand { get; }
         public IRelayCommand AddUserCommand { get; }
-        public IRelayCommand ResetPasswordCommand { get; }
 
         public IRelayCommand SearchUsersCommand { get; }
         public IRelayCommand ClearUserSearchCommand { get; }
@@ -65,9 +61,7 @@ namespace ToolManagementAppV2.ViewModels
             LoadUsersCommand = new RelayCommand(LoadUsers);
             UploadUserPhotoCommand = new RelayCommand(UploadUserPhoto);
             UpdateUserCommand = new RelayCommand(UpdateUser, () => SelectedUser != null);
-            DeleteUserCommand = new RelayCommand(DeleteSelectedUser, () => SelectedUser != null);
             AddUserCommand = new RelayCommand(AddUser);
-            ResetPasswordCommand = new RelayCommand(ResetPassword, () => SelectedUser != null);
 
             SearchUsersCommand = new RelayCommand(SearchUsers);
             ClearUserSearchCommand = new RelayCommand(ClearUserSearch);
@@ -101,12 +95,6 @@ namespace ToolManagementAppV2.ViewModels
             _userService.UpdateUser(SelectedUser);
         }
 
-        void DeleteSelectedUser()
-        {
-            if (SelectedUser == null) return;
-            DeleteUser(SelectedUser);
-        }
-
         public void AddUser()
         {
             var newUser = new UserModel { UserName = $"user{Users.Count + 1}" };
@@ -129,12 +117,6 @@ namespace ToolManagementAppV2.ViewModels
             _allUsers.Add(newUser);
             Users.Add(newUser);
             SelectedUser = newUser;
-        }
-
-        void ResetPassword()
-        {
-            if (SelectedUser == null) return;
-            ResetPasswordFor(SelectedUser);
         }
 
         void SearchUsers()

--- a/ToolManagementAppV2/Views/UsersPage.xaml
+++ b/ToolManagementAppV2/Views/UsersPage.xaml
@@ -25,8 +25,6 @@
                     <TextBox Width="260" Text="{Binding UserSearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Search" Command="{Binding SearchUsersCommand}" Margin="0,0,8,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Clear" Command="{Binding ClearUserSearchCommand}" Margin="0,0,8,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Reset Password" Command="{Binding ResetPasswordCommand}" Margin="0,0,8,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Delete User" Command="{Binding DeleteUserCommand}"/>
                 </StackPanel>
             </DockPanel>
         </Border>


### PR DESCRIPTION
## Summary
- remove Reset Password/Delete buttons from UsersPage toolbar to simplify layout
- drop unused commands from UserManagementViewModel and rely on row-level actions
- update unit tests for new command structure

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b1bfa92e08324bc452a67b08ca5c7