### PR TITLE
Add reset password command and tests

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/PasswordPromptViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/PasswordPromptViewModelTests.cs
@@ -1,4 +1,6 @@
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.ViewModels
@@ -10,7 +12,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             bool success = false;
             string? error = null;
-            var vm = new PasswordPromptViewModel(() => success = true, () => { }, m => error = m)
+            var vm = new PasswordPromptViewModel(new StubDialogService(), () => success = true, () => { }, m => error = m)
             {
                 ValidatePassword = p => p == "secret"
             };
@@ -27,7 +29,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             bool success = false;
             string? error = null;
-            var vm = new PasswordPromptViewModel(() => success = true, () => { }, m => error = m)
+            var vm = new PasswordPromptViewModel(new StubDialogService(), () => success = true, () => { }, m => error = m)
             {
                 ValidatePassword = p => p == "secret"
             };
@@ -38,5 +40,47 @@ namespace ToolManagementAppV2.Tests.ViewModels
             Assert.False(success);
             Assert.Equal("Incorrect password. Please try again.", error);
         }
+
+        [Fact]
+        public void ResetPasswordCommand_ShowsInfo_ForNonAdmin()
+        {
+            var dialog = new StubDialogService();
+            bool success = false;
+            var vm = new PasswordPromptViewModel(dialog, () => success = true, () => { }, _ => { })
+            {
+                SelectedUser = new User { IsAdmin = false }
+            };
+
+            vm.ResetPasswordCommand.Execute(null);
+
+            Assert.True(dialog.InfoShown);
+            Assert.False(success);
+            Assert.False(vm.IsPasswordResetRequested);
+        }
+
+        [Fact]
+        public void ResetPasswordCommand_SetsFlag_WhenConfirmed()
+        {
+            var dialog = new StubDialogService { ConfirmationResult = true };
+            bool success = false;
+            var vm = new PasswordPromptViewModel(dialog, () => success = true, () => { }, _ => { })
+            {
+                SelectedUser = new User { IsAdmin = true }
+            };
+
+            vm.ResetPasswordCommand.Execute(null);
+
+            Assert.True(success);
+            Assert.True(vm.IsPasswordResetRequested);
+        }
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public bool InfoShown { get; private set; }
+        public bool ConfirmationResult { get; set; }
+
+        public void ShowInfo(string message, string title) => InfoShown = true;
+        public bool ShowConfirmation(string message, string title) => ConfirmationResult;
     }
 }

--- a/ToolManagementAppV2/ViewModels/PasswordPromptViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/PasswordPromptViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
+using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 
 namespace ToolManagementAppV2.ViewModels
@@ -14,19 +15,23 @@ namespace ToolManagementAppV2.ViewModels
 
         public IRelayCommand OkCommand { get; }
         public IRelayCommand CancelCommand { get; }
+        public IRelayCommand ResetPasswordCommand { get; }
 
         private readonly Action _onSuccess;
         private readonly Action _onCancel;
         private readonly Action<string> _showError;
+        readonly IDialogService _dialogService;
 
-        public PasswordPromptViewModel(Action onSuccess, Action onCancel, Action<string> showError)
+        public PasswordPromptViewModel(IDialogService dialogService, Action onSuccess, Action onCancel, Action<string> showError)
         {
+            _dialogService = dialogService;
             _onSuccess = onSuccess;
             _onCancel = onCancel;
             _showError = showError;
 
             OkCommand = new RelayCommand(OnOk);
             CancelCommand = new RelayCommand(() => _onCancel());
+            ResetPasswordCommand = new RelayCommand(OnResetPassword);
         }
 
         private void OnOk()
@@ -39,6 +44,25 @@ namespace ToolManagementAppV2.ViewModels
             }
 
             _showError("Incorrect password. Please try again.");
+        }
+
+        void OnResetPassword()
+        {
+            if (SelectedUser?.IsAdmin != true)
+            {
+                _dialogService.ShowInfo(
+                    "Password recovery is only available for admin users.",
+                    "Not Allowed");
+                return;
+            }
+
+            if (!_dialogService.ShowConfirmation(
+                "You have entered the wrong password multiple times. Reset to default and change it after login?",
+                "Reset Password"))
+                return;
+
+            IsPasswordResetRequested = true;
+            _onSuccess();
         }
     }
 }

--- a/ToolManagementAppV2/Views/PasswordPromptWindow.xaml
+++ b/ToolManagementAppV2/Views/PasswordPromptWindow.xaml
@@ -6,6 +6,24 @@
         Width="520" Height="260"
         WindowStartupLocation="CenterScreen"
         Background="{StaticResource BackgroundBrush}">
+    <Window.Resources>
+        <Style x:Key="LinkButton" TargetType="Button">
+            <Setter Property="Foreground" Value="{StaticResource ForegroundMutedBrush}"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <ContentPresenter TextBlock.TextDecorations="Underline"
+                                          TextElement.Foreground="{TemplateBinding Foreground}"/>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
     <Grid Margin="14">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -37,15 +55,13 @@
             </Grid>
         </Border>
 
-        <TextBlock x:Name="ForgotPasswordTextBlock"
-                   Grid.Row="2"
-                   Text="Forgot password? Click here to reset."
-                   Foreground="{StaticResource ForegroundMutedBrush}"
-                   Margin="2,6,0,0"
-                   TextWrapping="Wrap"
-                   Visibility="Collapsed"
-                   Cursor="Hand"
-                   MouseLeftButtonUp="ForgotPasswordTextBlock_MouseLeftButtonUp"/>
+        <Button x:Name="ForgotPasswordButton"
+                Grid.Row="2"
+                Content="Forgot password? Click here to reset."
+                Margin="2,6,0,0"
+                Visibility="Collapsed"
+                Style="{StaticResource LinkButton}"
+                Command="{Binding ResetPasswordCommand}"/>
 
         <TextBlock x:Name="ErrorTextBlock"
                    Grid.Row="3"

--- a/ToolManagementAppV2/Views/PasswordPromptWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PasswordPromptWindow.xaml.cs
@@ -1,7 +1,6 @@
 ﻿// Views/PasswordPromptWindow.xaml.cs
 using System;
 using System.Windows;
-using System.Windows.Input;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services;
@@ -13,7 +12,6 @@ namespace ToolManagementAppV2.Views
     {
         private const int MaxAttempts = 2;
         private int _attemptCount;
-        readonly IDialogService _dialogService;
 
         public PasswordPromptViewModel VM => (PasswordPromptViewModel)DataContext;
         public string EnteredPassword => VM.EnteredPassword;
@@ -36,8 +34,8 @@ namespace ToolManagementAppV2.Views
         public PasswordPromptWindow(IDialogService dialogService)
         {
             InitializeComponent();
-            _dialogService = dialogService;
             DataContext = new PasswordPromptViewModel(
+                dialogService,
                 () => { DialogResult = true; },
                 () => { DialogResult = false; },
                 ShowError);
@@ -67,30 +65,12 @@ namespace ToolManagementAppV2.Views
             ErrorTextBlock.Text = message;
             ErrorTextBlock.Visibility = Visibility.Visible;
 
-            ForgotPasswordTextBlock.Visibility = _attemptCount >= MaxAttempts
+            ForgotPasswordButton.Visibility = _attemptCount >= MaxAttempts
                 ? Visibility.Visible
                 : Visibility.Collapsed;
 
             PasswordBox.Clear();
             PasswordBox.Focus();
-        }
-
-        private void ForgotPasswordTextBlock_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
-        {
-            if (SelectedUser?.IsAdmin != true)
-            {
-                _dialogService.ShowInfo(
-                    "Password recovery is only available for admin users.",
-                    "Not Allowed");
-                return;
-            }
-
-            if (!_dialogService.ShowConfirmation(
-                "You have entered the wrong password multiple times. Reset to default and change it after login?",
-                "Reset Password")) return;
-
-            IsPasswordResetRequested = true;
-            DialogResult = true;
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace forgotten password text with a link-styled button bound to a new reset command
- move password reset logic into `PasswordPromptViewModel`
- test reset flow for non-admin and confirmed reset scenarios

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b1bec3024832486b1079aa1464697