### PR TITLE
Handle cancelled password prompt

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -178,6 +178,26 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void AddUserCommand_CancelledPrompt_DoesNotAddUser()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IUserService userService = new UserService(db);
+                var vm = new CancelPromptUserManagementViewModel(userService, new StubFileDialogService());
+                vm.AddUserCommand.Execute(null);
+                Assert.Empty(vm.Users);
+                Assert.Empty(userService.GetAllUsers());
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 }
 
@@ -186,4 +206,16 @@ class StubFileDialogService : IFileDialogService
     public string FileToReturn { get; set; }
     public string OpenFile(string filter) => FileToReturn;
     public string SaveFile(string filter) => FileToReturn;
+}
+
+class CancelPromptUserManagementViewModel : UserManagementViewModel
+{
+    public CancelPromptUserManagementViewModel(IUserService userService, IFileDialogService fileDialogService)
+        : base(userService, fileDialogService) { }
+
+    protected override bool TryPromptForPassword(UserModel newUser, out string password)
+    {
+        password = null;
+        return false;
+    }
 }

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Extensions;
+using ToolManagementAppV2.Utilities.Helpers;
 using ToolManagementAppV2.Views;
 using ToolManagementAppV2.Services;
 
@@ -99,13 +100,43 @@ namespace ToolManagementAppV2.ViewModels
         {
             var newUser = new UserModel { UserName = $"user{Users.Count + 1}" };
 
+            if (!TryPromptForPassword(newUser, out var entered))
+                return;
+
+            // If the user leaves the prompt blank, assign a hashed "changeme" password
+            // so the account is initialized with a known placeholder that must be changed.
+            if (string.IsNullOrWhiteSpace(entered))
+            {
+                const string defaultPwd = "changeme";
+                newUser.Password = SecurityHelper.HashPassword(defaultPwd, out var salt);
+                newUser.Salt = salt;
+            }
+            else
+            {
+                newUser.Password = entered;
+            }
+
+            _userService.AddUser(newUser);
+            _allUsers.Add(newUser);
+            Users.Add(newUser);
+            SelectedUser = newUser;
+        }
+
+        protected virtual bool TryPromptForPassword(UserModel newUser, out string password)
+        {
+            password = null;
+
             if (System.Windows.Application.Current != null)
             {
                 try
                 {
-                    var prompt = new Views.PasswordPromptWindow(new DialogService()) { SelectedUser = newUser };
+                    var prompt = new PasswordPromptWindow(new DialogService()) { SelectedUser = newUser };
                     if (prompt.ShowDialog() == true)
-                        newUser.Password = prompt.EnteredPassword;
+                    {
+                        password = prompt.EnteredPassword;
+                        return true;
+                    }
+                    return false;
                 }
                 catch
                 {
@@ -113,10 +144,7 @@ namespace ToolManagementAppV2.ViewModels
                 }
             }
 
-            _userService.AddUser(newUser);
-            _allUsers.Add(newUser);
-            Users.Add(newUser);
-            SelectedUser = newUser;
+            return true;
         }
 
         void SearchUsers()


### PR DESCRIPTION
## Summary
- Skip user creation when the password prompt is cancelled
- Hash a default "changeme" password when no password is entered
- Document the hashed default password behavior
- Add regression test for cancelled password prompt

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures missing, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b1d434dec8324a7e730d361c21f82