### PR TITLE
Add ToolImagePath support to tool insertion

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -73,6 +73,37 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
+        public void AddTool_WithImagePath_PersistsPath()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                IToolService service = new ToolService(dbService);
+
+                var tool = new Tool
+                {
+                    ToolNumber = "TIMG",
+                    NameDescription = "With Image",
+                    Location = "Loc",
+                    Brand = "Brand",
+                    PartNumber = "PN",
+                    ToolImagePath = "Images/test.jpg"
+                };
+
+                service.AddTool(tool);
+                var stored = service.GetAllTools().Single();
+
+                Assert.Equal("Images/test.jpg", stored.ToolImagePath);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public void AddTool_DuplicateToolNumber_Throws()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -20,8 +20,8 @@ namespace ToolManagementAppV2.Services.Tools
         const string AllToolsSql = "SELECT * FROM Tools";
         const string UpsertToolCsv = @"
             INSERT INTO Tools
-              (ToolNumber, NameDescription, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity, RentedQuantity, IsCheckedOut)
-            VALUES (@ToolNumber,@Desc,@Loc,@Brand,@PN,@Sup,@PD,@Notes,@Keywords,@Avail,@Rent,0);
+              (ToolNumber, NameDescription, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity, RentedQuantity, ToolImagePath, IsCheckedOut)
+            VALUES (@ToolNumber,@Desc,@Loc,@Brand,@PN,@Sup,@PD,@Notes,@Keywords,@Avail,@Rent,@Img,0);
             SELECT last_insert_rowid();";
     
         public ToolService(DatabaseService dbService)
@@ -248,7 +248,8 @@ namespace ToolManagementAppV2.Services.Tools
                 new SQLiteParameter("@Notes", (object)tool.Notes ?? DBNull.Value),
                 new SQLiteParameter("@Keywords", (object)tool.Keywords ?? DBNull.Value),
                 new SQLiteParameter("@Avail", tool.QuantityOnHand),
-                new SQLiteParameter("@Rent", tool.RentedQuantity)
+                new SQLiteParameter("@Rent", tool.RentedQuantity),
+                new SQLiteParameter("@Img", (object)tool.ToolImagePath ?? DBNull.Value)
             };
             using var cmd = new SQLiteCommand(UpsertToolCsv, conn, tran);
             cmd.Parameters.AddRange(p);


### PR DESCRIPTION
## Summary
- store tool image paths during CSV and single tool inserts
- cover image path insertion with new unit test

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b225b618883249660b142b913f096