### PR TITLE
Preserve tool image path when editing tools

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -136,7 +136,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
-                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer" };
+                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", ToolImagePath = "img1.png" };
                 toolService.AddTool(tool);
                 vm.LoadTools();
                 vm.SelectedTool = vm.Tools.First();
@@ -149,6 +149,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var updated = toolService.GetAllTools().First();
                 Assert.Equal("Updated Hammer", updated.NameDescription);
                 Assert.Equal("Updated Hammer", vm.Tools.First().NameDescription);
+                Assert.Equal("img1.png", updated.ToolImagePath);
+                Assert.Equal("img1.png", vm.Tools.First().ToolImagePath);
             }
             finally
             {

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -167,8 +167,15 @@ namespace ToolManagementAppV2.ViewModels
                 Brand = SelectedTool.Brand,
                 Location = SelectedTool.Location,
                 QuantityOnHand = SelectedTool.QuantityOnHand,
+                RentedQuantity = SelectedTool.RentedQuantity,
                 Supplier = SelectedTool.Supplier,
-                Notes = SelectedTool.Notes
+                PurchasedDate = SelectedTool.PurchasedDate,
+                Notes = SelectedTool.Notes,
+                Keywords = SelectedTool.Keywords,
+                IsCheckedOut = SelectedTool.IsCheckedOut,
+                CheckedOutBy = SelectedTool.CheckedOutBy,
+                CheckedOutTime = SelectedTool.CheckedOutTime,
+                ToolImagePath = SelectedTool.ToolImagePath
             };
 
             var updated = EditToolDialog?.Invoke(clone);


### PR DESCRIPTION
## Summary
- Copy full tool properties, including image path, when cloning tools for editing
- Ensure tool edit workflow retains original `ToolImagePath`
- Expand unit test to verify image path persists after edits

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b8ca4e4948324ba165aa42a9e6263