### PR TITLE
Add image selection to tool editor

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ToolEditViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolEditViewModelTests.cs
@@ -1,0 +1,36 @@
+using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class ToolEditViewModelTests
+    {
+        [Fact]
+        public void BrowseImageCommand_SetsToolImagePath()
+        {
+            var tool = new Tool();
+            var fileDialog = new StubFileDialogService { OpenPath = "img.png" };
+            var vm = new ToolEditViewModel(tool, () => { }, () => { }, fileDialog);
+            vm.BrowseImageCommand.Execute(null);
+            Assert.Equal("img.png", tool.ToolImagePath);
+        }
+
+        [Fact]
+        public void RemoveImageCommand_ClearsToolImagePath()
+        {
+            var tool = new Tool { ToolImagePath = "img.png" };
+            var vm = new ToolEditViewModel(tool, () => { }, () => { }, new StubFileDialogService());
+            vm.RemoveImageCommand.Execute(null);
+            Assert.Equal(string.Empty, tool.ToolImagePath);
+        }
+
+        private class StubFileDialogService : IFileDialogService
+        {
+            public string? OpenPath { get; set; }
+            public string? OpenFile(string filter) => OpenPath;
+            public string? SaveFile(string filter) => null;
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/ToolEditViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolEditViewModel.cs
@@ -2,21 +2,46 @@
 using System;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using ToolManagementAppV2.Interfaces;
 
 namespace ToolManagementAppV2.ViewModels
 {
     public class ToolEditViewModel : ObservableObject
     {
+        private readonly IFileDialogService _fileDialog;
+
         public ToolModel Tool { get; }
 
         public IRelayCommand SaveCommand { get; }
         public IRelayCommand CancelCommand { get; }
 
-        public ToolEditViewModel(ToolModel tool, Action onSave, Action onCancel)
+        public IRelayCommand BrowseImageCommand { get; }
+        public IRelayCommand RemoveImageCommand { get; }
+
+        public ToolEditViewModel(ToolModel tool, Action onSave, Action onCancel, IFileDialogService fileDialog)
         {
             Tool = tool;
+            _fileDialog = fileDialog;
+
             SaveCommand = new RelayCommand(onSave);
             CancelCommand = new RelayCommand(onCancel);
+
+            BrowseImageCommand = new RelayCommand(BrowseImage);
+            RemoveImageCommand = new RelayCommand(RemoveImage);
+        }
+
+        void BrowseImage()
+        {
+            var path = _fileDialog.OpenFile("Image Files|*.png;*.jpg;*.jpeg;*.bmp|All Files|*.*");
+            if (!string.IsNullOrEmpty(path))
+            {
+                Tool.ToolImagePath = path;
+            }
+        }
+
+        void RemoveImage()
+        {
+            Tool.ToolImagePath = string.Empty;
         }
     }
 }

--- a/ToolManagementAppV2/Views/ToolEditWindow.xaml
+++ b/ToolManagementAppV2/Views/ToolEditWindow.xaml
@@ -22,6 +22,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
@@ -43,7 +44,15 @@
             <TextBlock Grid.Row="5" Grid.Column="0" Text="Supplier" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Tool.Supplier, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Vertical">
+            <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,0,0,8">
+                <Image Width="100" Height="100" Stretch="Uniform" Source="{Binding Tool.ToolImagePath}"/>
+                <StackPanel Orientation="Vertical" Margin="8,0,0,0">
+                    <Button Content="Browse" Width="75" Command="{Binding BrowseImageCommand}"/>
+                    <Button Content="Remove" Width="75" Margin="0,4,0,0" Command="{Binding RemoveImageCommand}"/>
+                </StackPanel>
+            </StackPanel>
+
+            <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Vertical">
                 <TextBlock Text="Notes" Margin="0,0,0,4"/>
                 <TextBox Text="{Binding Tool.Notes, UpdateSourceTrigger=PropertyChanged}" Height="90" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
             </StackPanel>

--- a/ToolManagementAppV2/Views/ToolEditWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ToolEditWindow.xaml.cs
@@ -3,6 +3,7 @@ using System;
 using System.Windows;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Services.Core;
 
 namespace ToolManagementAppV2.Views
 {
@@ -11,7 +12,8 @@ namespace ToolManagementAppV2.Views
         public ToolEditWindow(ToolModel tool, Action onSave, Action onCancel)
         {
             InitializeComponent();
-            DataContext = new ToolEditViewModel(tool, onSave, onCancel);
+            var fileDialog = new FileDialogService();
+            DataContext = new ToolEditViewModel(tool, onSave, onCancel, fileDialog);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Display tool image preview with Browse and Remove buttons
- Add commands to manage ToolImagePath and hook up file dialog service
- Test image browse and remove behavior in ToolEditViewModel

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b8db109e08324affeaf9b2f9f15db