### PR TITLE
feat: display tool image in details window

### DIFF
--- a/ToolManagementAppV2/Views/ToolDetailsWindow.xaml
+++ b/ToolManagementAppV2/Views/ToolDetailsWindow.xaml
@@ -2,8 +2,12 @@
 <Window x:Class="ToolManagementAppV2.Views.ToolDetailsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:conv="clr-namespace:ToolManagementAppV2.Utilities.Converters"
         Title="Tool Details" Width="520" Height="420" WindowStartupLocation="CenterOwner"
         Background="{StaticResource BackgroundBrush}">
+    <Window.Resources>
+        <conv:NullToDefaultImageConverter x:Key="NullToDefaultImageConverter"/>
+    </Window.Resources>
     <Grid Margin="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
@@ -12,6 +16,7 @@
 
         <Grid>
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/> <!-- Image -->
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -25,25 +30,28 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-            <TextBlock Grid.Row="0" Grid.Column="0" Text="Tool Number" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-            <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Tool.ToolNumber}" Margin="8,4"/>
+            <Image Grid.Row="0" Grid.ColumnSpan="2" Width="120" Height="120" Margin="0,0,0,8" HorizontalAlignment="Center"
+                   Source="{Binding Tool.ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=tool}"/>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Tool.NameDescription}" Margin="8,4"/>
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Tool Number" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Tool.ToolNumber}" Margin="8,4"/>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Brand" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Tool.Brand}" Margin="8,4"/>
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Name" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Tool.NameDescription}" Margin="8,4"/>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="Location" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Tool.Location}" Margin="8,4"/>
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Brand" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Tool.Brand}" Margin="8,4"/>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Text="Part #" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-            <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Tool.PartNumber}" Margin="8,4"/>
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Location" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Tool.Location}" Margin="8,4"/>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Supplier" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
-            <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding Tool.Supplier}" Margin="8,4"/>
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Part #" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding Tool.PartNumber}" Margin="8,4"/>
 
-            <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Vertical" Margin="0,8,0,0">
+            <TextBlock Grid.Row="6" Grid.Column="0" Text="Supplier" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding Tool.Supplier}" Margin="8,4"/>
+
+            <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Vertical" Margin="0,8,0,0">
                 <TextBlock Text="Notes" Foreground="{StaticResource ForegroundMutedBrush}"/>
                 <ScrollViewer Height="90" VerticalScrollBarVisibility="Auto">
                     <TextBlock Text="{Binding Tool.Notes}" TextWrapping="Wrap"/>


### PR DESCRIPTION
## Summary
- show tool image in details window with fallback using NullToDefaultImageConverter
- keep details layout responsive with additional row and bindings

## Testing
- `dotnet test` *(fails: command not found)*
- `wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh` *(fails: Proxy tunneling failed: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b903fd8b48324836e04ecc18f3537