### PR TITLE
Move secondary tool actions to context menu

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ManageToolsPageMenuTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ManageToolsPageMenuTests.cs
@@ -1,0 +1,76 @@
+using System.IO;
+using System.Linq;
+using System.Windows.Controls;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Views;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Tests
+{
+    public class ManageToolsPageMenuTests
+    {
+        [Fact]
+        public void ContextMenu_BindsToSecondaryCommands()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db, toolService);
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+                var page = new ManageToolsPage { DataContext = vm };
+
+                var grid = (Grid)page.Content;
+                var border = (Border)grid.Children[0];
+                var innerGrid = (Grid)border.Child;
+                var listView = (ListView)innerGrid.Children[1];
+                var menu = listView.ContextMenu;
+                var items = menu.Items.OfType<MenuItem>().ToArray();
+
+                Assert.Equal(vm.OpenRentalsCommand, items[0].Command);
+                Assert.Equal(vm.DeleteToolCommand, items[1].Command);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void PrimaryButtons_BindToPrimaryCommands()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db, toolService);
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+                var page = new ManageToolsPage { DataContext = vm };
+
+                var grid = (Grid)page.Content;
+                var border = (Border)grid.Children[0];
+                var innerGrid = (Grid)border.Child;
+                var stack = (StackPanel)innerGrid.Children[2];
+
+                Assert.Equal(3, stack.Children.Count);
+                Assert.Equal(vm.EditToolCommand, ((Button)stack.Children[0]).Command);
+                Assert.Equal(vm.ViewDetailsCommand, ((Button)stack.Children[1]).Command);
+                Assert.Equal(vm.NewToolCommand, ((Button)stack.Children[2]).Command);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/Views/ManageToolsPage.xaml
+++ b/ToolManagementAppV2/Views/ManageToolsPage.xaml
@@ -38,14 +38,18 @@
                             <GridViewColumn Header="Location" DisplayMemberBinding="{Binding Location}" Width="180"/>
                         </GridView>
                     </ListView.View>
+                    <ListView.ContextMenu>
+                        <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                            <MenuItem Header="Rent" Command="{Binding OpenRentalsCommand}"/>
+                            <MenuItem Header="Delete" Command="{Binding DeleteToolCommand}"/>
+                        </ContextMenu>
+                    </ListView.ContextMenu>
                 </ListView>
 
                 <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
                     <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditToolCommand}"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="View Details" Command="{Binding ViewDetailsCommand}" Margin="8,0,0,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="New" Command="{Binding NewToolCommand}" Margin="8,0,0,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Delete" Command="{Binding DeleteToolCommand}" Margin="8,0,0,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Rent" Command="{Binding OpenRentalsCommand}" Margin="8,0,0,0"/>
                 </StackPanel>
             </Grid>
         </Border>


### PR DESCRIPTION
## Summary
- move Delete and Rent actions on the tool management page into a context menu
- keep primary buttons visible and add tests for bindings

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b98266aec8324be1711ab8f594fba