### PR TITLE
Use page navigation for settings

### DIFF
--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -62,7 +62,7 @@
                         <Separator/>
 
                         <TextBlock Text="Administration" Foreground="{StaticResource ForegroundMutedBrush}" Margin="6,8,6,2"/>
-                        <Button Style="{StaticResource NavButton}" Content="Settings" Command="{Binding OpenSettingsWindowCommand}" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
+                        <Button Style="{StaticResource NavButton}" Content="Settings" Command="{Binding OpenSettingsCommand}" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
 
                         <Separator/>
 

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -95,7 +95,6 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand OpenPrintPreviewWindowCommand { get; }
         public IRelayCommand OpenPrintLabelWindowCommand { get; }
         public IRelayCommand OpenScannerStatusWindowCommand { get; }
-        public IRelayCommand OpenSettingsWindowCommand { get; }
         public IRelayCommand OpenPasswordPromptWindowCommand { get; }
         public IRelayCommand OpenImportMappingWindowCommand { get; }
         public IRelayCommand OpenImageImportMappingWindowCommand { get; }
@@ -236,12 +235,6 @@ namespace ToolManagementAppV2.ViewModels
             {
                 // Avoid missing VM type by opening the window directly
                 var win = new ScannerStatusWindow();
-                win.ShowDialog();
-            });
-
-            OpenSettingsWindowCommand = new RelayCommand(() =>
-            {
-                var win = new SettingsWindow();
                 win.ShowDialog();
             });
 


### PR DESCRIPTION
## Summary
- Bind Settings button to `OpenSettingsCommand` for in-frame navigation
- Remove unused `OpenSettingsWindowCommand` from main view model

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689bb7094ccc83248b7e0b271e9253cf