### PR TITLE
Provide real CSV context to import mapping

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ImportMappingViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportMappingViewModelTests.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class ImportMappingViewModelTests
+    {
+        [Fact]
+        public void Constructor_PopulatesMappingsWithProvidedLists()
+        {
+            var headers = new[] { "ToolNumber", "NameDescription", "SerialNumber" };
+            var properties = new[] { "ToolNumber", "NameDescription" };
+
+            var vm = new ImportMappingViewModel(headers, properties, () => { }, () => { });
+
+            Assert.Equal(headers, vm.ColumnHeaders);
+            Assert.Equal(properties, vm.Mappings.Select(m => m.PropertyName));
+            foreach (var mapping in vm.Mappings)
+            {
+                Assert.Equal(headers, mapping.AvailableColumns);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -200,8 +200,15 @@ namespace ToolManagementAppV2.ViewModels
                 if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
                     return;
 
-                var headers = File.ReadLines(path).First().Split(',');
-                var properties = typeof(ToolModel).GetProperties().Select(p => p.Name);
+                var headers = File.ReadLines(path)
+                                   .First()
+                                   .Split(',')
+                                   .Select(h => h.Trim())
+                                   .ToList();
+                var properties = typeof(ToolModel)
+                                    .GetProperties()
+                                    .Select(p => p.Name)
+                                    .ToList();
                 var win = new ImportMappingWindow(headers, properties);
                 if (win.ShowDialog() == true)
                 {


### PR DESCRIPTION
## Summary
- Parse selected CSV file to supply actual headers and tool property names to the import mapping window
- Ensure mapping view model tests validate population of mappings with provided data

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bbe817bc08324b829f314885ea7fe