### PR TITLE
Add default tool image binding to edit window

### DIFF
--- a/ToolManagementAppV2/Views/ToolEditWindow.xaml
+++ b/ToolManagementAppV2/Views/ToolEditWindow.xaml
@@ -2,8 +2,12 @@
 <Window x:Class="ToolManagementAppV2.Views.ToolEditWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:conv="clr-namespace:ToolManagementAppV2.Utilities.Converters"
         Title="Tool" Width="520" Height="420" WindowStartupLocation="CenterOwner"
         Background="{StaticResource BackgroundBrush}">
+    <Window.Resources>
+        <conv:NullToDefaultImageConverter x:Key="NullToDefaultImageConverter"/>
+    </Window.Resources>
     <Grid Margin="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
@@ -45,7 +49,8 @@
             <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Tool.Supplier, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
             <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,0,0,8">
-                <Image Width="100" Height="100" Stretch="Uniform" Source="{Binding Tool.ToolImagePath}"/>
+                <Image Width="100" Height="100" Stretch="Uniform"
+                       Source="{Binding Tool.ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=tool}"/>
                 <StackPanel Orientation="Vertical" Margin="8,0,0,0">
                     <Button Content="Browse" Width="75" Command="{Binding BrowseImageCommand}"/>
                     <Button Content="Remove" Width="75" Margin="0,4,0,0" Command="{Binding RemoveImageCommand}"/>


### PR DESCRIPTION
## Summary
- Ensure ToolEditWindow displays a default placeholder when a tool image isn't specified by wiring NullToDefaultImageConverter to the Image.Source

## Testing
- ⚠️ `dotnet test` *(command not found, .NET SDK unavailable)*


------
https://chatgpt.com/codex/tasks/task_e_689bc045b1f08324afd42a9cbf028a1d