### PR TITLE
Handle ConvertBack for ZeroToDisabledConverter

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ZeroToDisabledConverterTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ZeroToDisabledConverterTests.cs
@@ -30,10 +30,19 @@ namespace ToolManagementAppV2.Tests
         }
 
         [Fact]
-        public void ConvertBack_Throws()
+        public void ConvertBack_Bool_ReturnsBindingDoNothing()
         {
             var c = new ZeroToDisabledConverter();
-            Assert.Throws<NotImplementedException>(() => c.ConvertBack(true, typeof(int), null, CultureInfo.InvariantCulture));
+            var result = c.ConvertBack(true, typeof(int), null, CultureInfo.InvariantCulture);
+            Assert.Equal(System.Windows.Data.Binding.DoNothing, result);
+        }
+
+        [Fact]
+        public void ConvertBack_Int_ReturnsSameValue()
+        {
+            var c = new ZeroToDisabledConverter();
+            var result = c.ConvertBack(3, typeof(int), null, CultureInfo.InvariantCulture);
+            Assert.Equal(3, result);
         }
     }
 }

--- a/ToolManagementAppV2/Utilities/Converters/ZeroToDisabledConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/ZeroToDisabledConverter.cs
@@ -13,7 +13,7 @@ namespace ToolManagementAppV2.Utilities.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return value is int i ? i : Binding.DoNothing;
         }
     }
 }


### PR DESCRIPTION
## Summary
- return Binding.DoNothing instead of throwing in ZeroToDisabledConverter.ConvertBack
- add tests ensuring ConvertBack returns Binding.DoNothing or same integer

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689bc122882c8324aaf46ca77b76cd9a