### PR TITLE
Add Enter key binding for global search

### DIFF
--- a/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Windows.Controls;
+using System.Windows.Input;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Views
+{
+    public class MainWindowTests
+    {
+        [Fact]
+        public void EnterKey_ExecutesGlobalSearchCommand()
+        {
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var window = new ToolManagementAppV2.MainWindow();
+                    var textBox = (TextBox)window.FindName("GlobalSearchTextBox");
+                    Assert.NotNull(textBox);
+
+                    var vm = Assert.IsType<MainViewModel>(window.DataContext);
+
+                    vm.GlobalSearchText = "Test";
+
+                    var keyBinding = textBox.InputBindings.OfType<KeyBinding>()
+                        .FirstOrDefault(kb => kb.Key == Key.Enter);
+                    Assert.NotNull(keyBinding);
+
+                    keyBinding.Command.Execute(null);
+
+                    Assert.Equal(string.Empty, vm.GlobalSearchText);
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+            {
+                throw threadException;
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -90,7 +90,11 @@
                 <DockPanel>
                     <TextBlock Text="{Binding CurrentPageTitle}" DockPanel.Dock="Left" FontSize="20" FontWeight="SemiBold"/>
                     <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
-                        <TextBox Width="260" Text="{Binding GlobalSearchText, UpdateSourceTrigger=PropertyChanged}"/>
+                        <TextBox x:Name="GlobalSearchTextBox" Width="260" Text="{Binding GlobalSearchText, UpdateSourceTrigger=PropertyChanged}">
+                            <TextBox.InputBindings>
+                                <KeyBinding Key="Enter" Command="{Binding GlobalSearchCommand}"/>
+                            </TextBox.InputBindings>
+                        </TextBox>
                         <Button Style="{StaticResource PrimaryButton}" Content="Search" Command="{Binding GlobalSearchCommand}" Margin="8,0,0,0"/>
                     </StackPanel>
                 </DockPanel>


### PR DESCRIPTION
## Summary
- Bind Enter key in main search box to GlobalSearchCommand
- Test Enter key executes global search and clears text

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bc28d1e1c8324a9d02bfaae309114