### PR TITLE
Add user photo and update buttons with collection refresh

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
@@ -51,6 +52,40 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 vm.UploadUserPhotoCommand.Execute(null);
                 var updated = userService.GetAllUsers().First();
                 Assert.Equal("path/to/image.png", updated.UserPhotoPath);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void UpdateUserAndUploadPhoto_UpdateCollections()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IUserService userService = new UserService(db);
+                var fileSvc = new StubFileDialogService { FileToReturn = "img.png" };
+                var vm = new UserManagementViewModel(userService, fileSvc);
+                userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                vm.LoadUsers();
+                vm.SelectedUser = vm.Users.First();
+
+                vm.SelectedUser.Email = "test@example.com";
+                vm.UpdateUserCommand.Execute(null);
+
+                vm.UploadUserPhotoCommand.Execute(null);
+
+                var field = typeof(UserManagementViewModel).GetField("_allUsers", BindingFlags.NonPublic | BindingFlags.Instance);
+                var allUsers = (System.Collections.Generic.List<User>)field!.GetValue(vm);
+
+                Assert.Equal("test@example.com", vm.Users.First().Email);
+                Assert.Equal("test@example.com", allUsers.First().Email);
+                Assert.Equal("img.png", vm.Users.First().UserPhotoPath);
+                Assert.Equal("img.png", allUsers.First().UserPhotoPath);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Windows.Controls;
+using System.Reflection;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Views;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Views
+{
+    public class UsersPageTests
+    {
+        [Fact]
+        public void ButtonsExecuteCommandsAndUpdateCollections()
+        {
+            var dbPath = System.IO.Path.GetTempFileName();
+            Exception? threadException = null;
+
+            try
+            {
+                var thread = new Thread(() =>
+                {
+                    try
+                    {
+                        var db = new DatabaseService(dbPath);
+                        IUserService userService = new UserService(db);
+                        var fileSvc = new StubFileDialogService { FileToReturn = "img.png" };
+                        var vm = new UserManagementViewModel(userService, fileSvc);
+                        userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                        vm.LoadUsers();
+                        vm.SelectedUser = vm.Users.First();
+                        vm.SelectedUser.Email = "user@example.com";
+
+                        var page = new UsersPage { DataContext = vm };
+                        var updateBtn = (Button)page.FindName("UpdateUserButton");
+                        var uploadBtn = (Button)page.FindName("UploadPhotoButton");
+
+                        Assert.Equal(vm.UpdateUserCommand, updateBtn.Command);
+                        Assert.Equal(vm.UploadUserPhotoCommand, uploadBtn.Command);
+
+                        updateBtn.Command.Execute(null);
+                        uploadBtn.Command.Execute(null);
+
+                        var field = typeof(UserManagementViewModel).GetField("_allUsers", BindingFlags.NonPublic | BindingFlags.Instance);
+                        var allUsers = (System.Collections.Generic.List<User>)field!.GetValue(vm);
+
+                        Assert.Equal("user@example.com", vm.Users.First().Email);
+                        Assert.Equal("user@example.com", allUsers.First().Email);
+                        Assert.Equal("img.png", vm.Users.First().UserPhotoPath);
+                        Assert.Equal("img.png", allUsers.First().UserPhotoPath);
+                    }
+                    catch (Exception ex)
+                    {
+                        threadException = ex;
+                    }
+                });
+
+                thread.SetApartmentState(ApartmentState.STA);
+                thread.Start();
+                thread.Join();
+
+                if (threadException != null)
+                {
+                    throw threadException;
+                }
+            }
+            finally
+            {
+                if (System.IO.File.Exists(dbPath))
+                    System.IO.File.Delete(dbPath);
+            }
+        }
+    }
+
+    class StubFileDialogService : IFileDialogService
+    {
+        public string FileToReturn { get; set; }
+        public string OpenFile(string filter) => FileToReturn;
+        public string SaveFile(string filter) => FileToReturn;
+    }
+}

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -87,6 +87,10 @@ namespace ToolManagementAppV2.ViewModels
             {
                 SelectedUser.UserPhotoPath = path;
                 _userService.UpdateUser(SelectedUser);
+                var idxAll = _allUsers.IndexOf(SelectedUser);
+                if (idxAll >= 0) _allUsers[idxAll] = SelectedUser;
+                var idx = Users.IndexOf(SelectedUser);
+                if (idx >= 0) Users[idx] = SelectedUser;
             }
         }
 
@@ -94,6 +98,10 @@ namespace ToolManagementAppV2.ViewModels
         {
             if (SelectedUser == null) return;
             _userService.UpdateUser(SelectedUser);
+            var idxAll = _allUsers.IndexOf(SelectedUser);
+            if (idxAll >= 0) _allUsers[idxAll] = SelectedUser;
+            var idx = Users.IndexOf(SelectedUser);
+            if (idx >= 0) Users[idx] = SelectedUser;
         }
 
         public void AddUser()

--- a/ToolManagementAppV2/Views/UsersPage.xaml
+++ b/ToolManagementAppV2/Views/UsersPage.xaml
@@ -20,6 +20,8 @@
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
                     <Button Style="{StaticResource PrimaryButton}" Content="Add User" Command="{Binding AddUserCommand}" Margin="0,0,8,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Edit User" Command="{Binding EditUserCommand}" Margin="0,0,8,0"/>
+                    <Button x:Name="UploadPhotoButton" Style="{StaticResource PrimaryButton}" Content="Upload Photo" Command="{Binding UploadUserPhotoCommand}" Margin="0,0,8,0"/>
+                    <Button x:Name="UpdateUserButton" Style="{StaticResource PrimaryButton}" Content="Update User" Command="{Binding UpdateUserCommand}" Margin="0,0,8,0"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
                     <TextBox Width="260" Text="{Binding UserSearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0"/>


### PR DESCRIPTION
## Summary
- Add Upload Photo and Update User buttons to Users page
- Refresh user collections on photo upload and profile update
- Test user collection refresh and page command bindings

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689bc650775c832498e07b6546e5b27e