### PR TITLE
Add user photo and update menu items with collection refresh tests

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -28,6 +28,10 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 vm.UpdateUserCommand.Execute(null);
                 var updated = userService.GetAllUsers().First();
                 Assert.Equal("test@example.com", updated.Email);
+                var field = typeof(UserManagementViewModel).GetField("_allUsers", BindingFlags.NonPublic | BindingFlags.Instance);
+                var allUsers = (System.Collections.Generic.List<User>)field!.GetValue(vm);
+                Assert.Equal("test@example.com", vm.Users.First().Email);
+                Assert.Equal("test@example.com", allUsers.First().Email);
             }
             finally
             {
@@ -52,6 +56,10 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 vm.UploadUserPhotoCommand.Execute(null);
                 var updated = userService.GetAllUsers().First();
                 Assert.Equal("path/to/image.png", updated.UserPhotoPath);
+                var field = typeof(UserManagementViewModel).GetField("_allUsers", BindingFlags.NonPublic | BindingFlags.Instance);
+                var allUsers = (System.Collections.Generic.List<User>)field!.GetValue(vm);
+                Assert.Equal("path/to/image.png", vm.Users.First().UserPhotoPath);
+                Assert.Equal("path/to/image.png", allUsers.First().UserPhotoPath);
             }
             finally
             {

--- a/ToolManagementAppV2/Views/UsersPage.xaml
+++ b/ToolManagementAppV2/Views/UsersPage.xaml
@@ -60,6 +60,8 @@
                     <ContextMenu>
                         <MenuItem Header="Edit" Command="{Binding PlacementTarget.DataContext.EditUserFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
                         <MenuItem Header="Reset Password" Command="{Binding PlacementTarget.DataContext.ResetPasswordFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
+                        <MenuItem Header="Upload Photo" Command="{Binding PlacementTarget.DataContext.UploadUserPhotoCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                        <MenuItem Header="Update" Command="{Binding PlacementTarget.DataContext.UpdateUserCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                         <MenuItem Header="Delete" Command="{Binding PlacementTarget.DataContext.DeleteUserFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
                     </ContextMenu>
                 </DataGrid.ContextMenu>


### PR DESCRIPTION
## Summary
- add Upload Photo and Update menu items to Users page
- verify _allUsers and Users collections refresh after updating user or uploading photo

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bc85bfdfc8324b399be188e8da9e9