### PR TITLE
Use avatar selection window for user avatars

### DIFF
--- a/ToolManagementAppV2.Tests/Views/UsersEditWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/UsersEditWindowTests.cs
@@ -24,10 +24,9 @@ namespace ToolManagementAppV2.Tests.Views
 
                     Action onSave = () => window?.Close();
                     Action onCancel = () => window?.Close();
-                    Action onBrowse = () => { };
                     Action onRemove = () => { };
 
-                    window = new UsersEditWindow(user, onSave, onCancel, onBrowse, onRemove);
+                    window = new UsersEditWindow(user, onSave, onCancel, onRemove);
                     window.Closed += (_, __) => closed = true;
 
                     Assert.IsType<UsersEditViewModel>(window.DataContext);

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -210,11 +210,6 @@ namespace ToolManagementAppV2.ViewModels
                     win.DialogResult = true;
                 },
                 onCancel: () => win.Close(),
-                onBrowseAvatar: () =>
-                {
-                    var path = _fileDialogService.OpenFile("Image Files|*.png;*.jpg;*.jpeg;*.bmp|All Files|*.*");
-                    if (!string.IsNullOrEmpty(path)) clone.UserPhotoPath = path;
-                },
                 onRemoveAvatar: () => clone.UserPhotoPath = null);
 
             try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }

--- a/ToolManagementAppV2/Views/UsersEditWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/UsersEditWindow.xaml.cs
@@ -8,10 +8,30 @@ namespace ToolManagementAppV2.Views
 {
     public partial class UsersEditWindow : Window
     {
-        public UsersEditWindow(User user, Action onSave, Action onCancel, Action onBrowseAvatar, Action onRemoveAvatar)
+        public UsersEditWindow(User user, Action onSave, Action onCancel, Action onRemoveAvatar)
         {
             InitializeComponent();
-            DataContext = new UsersEditViewModel(user, onSave, onCancel, onBrowseAvatar, onRemoveAvatar);
+            DataContext = new UsersEditViewModel(user, onSave, onCancel, BrowseAvatar, onRemoveAvatar);
+        }
+
+        private void BrowseAvatar()
+        {
+            var vm = (UsersEditViewModel)DataContext;
+            var avatarWin = new AvatarSelectionWindow();
+
+            try { avatarWin.Owner = this; } catch { }
+
+            try
+            {
+                if (avatarWin.ShowDialog() == true && !string.IsNullOrEmpty(avatarWin.SelectedAvatarPath))
+                {
+                    vm.EditingUser.UserPhotoPath = avatarWin.SelectedAvatarPath;
+                }
+            }
+            catch
+            {
+                // Ignore UI errors in non-interactive environments
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- open AvatarSelectionWindow when browsing for a user avatar and apply selected image
- simplify UserManagementViewModel to defer avatar browsing to UsersEditWindow
- adjust UsersEditWindow tests for new constructor

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(403: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689bc9cf1e6083248e73f7179c6cc51e