### PR TITLE
Rename RentalManagementViewModel to CustomerManagement

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/CustomersPageBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CustomersPageBindingTests.cs
@@ -18,7 +18,7 @@ namespace ToolManagementAppV2.Tests.Tests
             {
                 var db = new DatabaseService(dbPath);
                 var customerService = new CustomerService(db);
-                var vm = new RentalManagementViewModel(customerService);
+                var vm = new CustomerManagementViewModel(customerService);
                 var page = new CustomersPage { DataContext = vm };
 
                 var grid = (Grid)page.Content;

--- a/ToolManagementAppV2.Tests/ViewModels/CustomerManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/CustomerManagementViewModelTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace ToolManagementAppV2.Tests.ViewModels
 {
-    public class RentalManagementViewModelTests
+    public class CustomerManagementViewModelTests
     {
         [Fact]
         public void AddCustomerCommand_UsesDialogValues()
@@ -19,7 +19,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 ICustomerService customerService = new CustomerService(db);
-                var vm = new RentalManagementViewModel(customerService)
+                var vm = new CustomerManagementViewModel(customerService)
                 {
                     AddCustomerDialog = () => new CustomerModel
                     {
@@ -57,7 +57,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 ICustomerService customerService = new CustomerService(db);
-                var vm = new RentalManagementViewModel(customerService)
+                var vm = new CustomerManagementViewModel(customerService)
                 {
                     AddCustomerDialog = () => null
                 };
@@ -90,7 +90,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     Address = "Addr"
                 });
                 var existing = customerService.GetAllCustomers().First();
-                var vm = new RentalManagementViewModel(customerService);
+                var vm = new CustomerManagementViewModel(customerService);
                 vm.SelectedCustomer = existing;
 
                 Assert.Equal("ACME", vm.NewCustomerName);
@@ -117,7 +117,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 customerService.AddCustomer(new ToolManagementAppV2.Models.Domain.Customer { Company = "Old" });
                 var existing = customerService.GetAllCustomers().First();
-                var vm = new RentalManagementViewModel(customerService);
+                var vm = new CustomerManagementViewModel(customerService);
                 vm.SelectedCustomer = existing;
                 vm.NewCustomerName = "New";
                 vm.NewCustomerEmail = "e@e.com";
@@ -151,7 +151,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 customerService.AddCustomer(new ToolManagementAppV2.Models.Domain.Customer { Company = "Alpha" });
                 customerService.AddCustomer(new ToolManagementAppV2.Models.Domain.Customer { Company = "Beta" });
-                var vm = new RentalManagementViewModel(customerService);
+                var vm = new CustomerManagementViewModel(customerService);
                 vm.CustomerSearchTerm = "Beta";
                 vm.SearchCustomersCommand.Execute(null);
                 Assert.Single(vm.Customers);
@@ -174,7 +174,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 customerService.AddCustomer(new ToolManagementAppV2.Models.Domain.Customer { Company = "ACME" });
                 customerService.AddCustomer(new ToolManagementAppV2.Models.Domain.Customer { Company = "Beta" });
-                var vm = new RentalManagementViewModel(customerService);
+                var vm = new CustomerManagementViewModel(customerService);
                 vm.SearchCustomersCommand.Execute(null);
                 vm.SelectedCustomer = vm.Customers.First(c => c.Company == "ACME");
                 vm.DeleteCustomerCommand.Execute(null);
@@ -199,7 +199,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 ICustomerService customerService = new CustomerService(db);
-                var vm = new RentalManagementViewModel(customerService);
+                var vm = new CustomerManagementViewModel(customerService);
                 Assert.False(vm.DeleteCustomerCommand.CanExecute(null));
                 vm.SelectedCustomer = new ToolManagementAppV2.Models.Domain.Customer { Company = "ACME" };
                 Assert.True(vm.DeleteCustomerCommand.CanExecute(null));

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -33,7 +33,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 Assert.NotNull(vm.ToolManagement);
                 Assert.NotNull(vm.UserManagement);
-                Assert.NotNull(vm.RentalManagement);
+                Assert.NotNull(vm.CustomerManagement);
                 Assert.NotNull(vm.Rentals);
                 Assert.NotNull(vm.ManageRentals);
                 Assert.NotNull(vm.ImportExport);

--- a/ToolManagementAppV2/ViewModels/CustomerManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/CustomerManagementViewModel.cs
@@ -9,7 +9,7 @@ using ToolManagementAppV2.Views;
 
 namespace ToolManagementAppV2.ViewModels
 {
-    public class RentalManagementViewModel : ObservableObject
+    public class CustomerManagementViewModel : ObservableObject
     {
         private readonly ICustomerService _customerService;
 
@@ -75,7 +75,7 @@ namespace ToolManagementAppV2.ViewModels
 
         public Func<CustomerModel?> AddCustomerDialog { get; set; }
 
-        public RentalManagementViewModel(ICustomerService customerService)
+        public CustomerManagementViewModel(ICustomerService customerService)
         {
         
             _customerService = customerService;

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -31,7 +31,7 @@ namespace ToolManagementAppV2.ViewModels
 
         public ToolManagementViewModel ToolManagement { get; }
         public UserManagementViewModel UserManagement { get; }
-        public RentalManagementViewModel RentalManagement { get; }
+        public CustomerManagementViewModel CustomerManagement { get; }
         public RentalViewModel Rentals { get; }
         public ManageRentalsViewModel ManageRentals { get; }
         public ImportExportViewModel ImportExport { get; }
@@ -113,7 +113,7 @@ namespace ToolManagementAppV2.ViewModels
 
             ToolManagement = new ToolManagementViewModel(toolService, customerService, rentalService);
             UserManagement = new UserManagementViewModel(userService, fileDialogService);
-            RentalManagement = new RentalManagementViewModel(customerService);
+            CustomerManagement = new CustomerManagementViewModel(customerService);
             Rentals = new RentalViewModel(rentalService);
             ManageRentals = new ManageRentalsViewModel(rentalService);
             ImportExport = new ImportExportViewModel(toolService, customerService, fileDialogService);
@@ -151,8 +151,8 @@ namespace ToolManagementAppV2.ViewModels
 
             OpenCustomersCommand = new RelayCommand(() =>
             {
-                RentalManagement.LoadCustomers();
-                var page = new CustomersPage { DataContext = RentalManagement, Title = "Customers" };
+                CustomerManagement.LoadCustomers();
+                var page = new CustomersPage { DataContext = CustomerManagement, Title = "Customers" };
                 CurrentPage = page;
             });
 


### PR DESCRIPTION
## Summary
- rename RentalManagementViewModel to CustomerManagementViewModel
- update MainViewModel and tests to use CustomerManagementViewModel

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689bd1e707b083249cfc695f1e1d87e1