### PR TITLE
Add rental deletion support

### DIFF
--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -228,6 +228,25 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
+        public void DeleteRental_InvalidRentalID_Throws()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var rentalService = new RentalService(db, toolService);
+
+                Assert.Throws<InvalidOperationException>(() => rentalService.DeleteRental(1));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public void GetActiveRentals_ReturnsCustomerAndToolDetails()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -196,6 +196,38 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
+        public void DeleteRental_RemovesRecord()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db, toolService);
+
+                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 };
+                toolService.AddTool(tool);
+                var addedTool = toolService.GetAllTools().First();
+
+                customerService.AddCustomer(new Customer { Company = "Acme" });
+                var cust = customerService.GetAllCustomers().First();
+
+                rentalService.RentTool(addedTool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                var rental = rentalService.GetAllRentals().First();
+
+                rentalService.DeleteRental(rental.RentalID);
+
+                Assert.Empty(rentalService.GetAllRentals());
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public void GetActiveRentals_ReturnsCustomerAndToolDetails()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
@@ -113,5 +113,40 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void DeleteRentalCommand_RemovesRental()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+
+                var tool = new Tool { ToolID = "T1", ToolNumber = "T1" };
+                toolService.AddTool(tool);
+                var customer = new Customer { Company = "C1" };
+                customerService.AddCustomer(customer);
+                var cust = customerService.GetAllCustomers().First();
+
+                rentalService.RentTool("T1", cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+
+                var vm = new ManageRentalsViewModel(rentalService);
+                vm.LoadRentals();
+                vm.SelectedRental = vm.Rentals.First();
+
+                vm.DeleteRentalCommand.Execute(null);
+
+                Assert.Empty(vm.Rentals);
+                Assert.Empty(rentalService.GetAllRentals());
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/ToolManagementAppV2/Interfaces/IRentalService.cs
+++ b/ToolManagementAppV2/Interfaces/IRentalService.cs
@@ -27,6 +27,7 @@ namespace ToolManagementAppV2.Interfaces
         /// <param name="returnDate">The date the tool is returned.</param>
         void ReturnTool(int rentalID, DateTime returnDate);
         void ExtendRental(int rentalID, DateTime newDueDate);
+        void DeleteRental(int rentalID);
         List<Rental> GetActiveRentals();
         List<Rental> GetOverdueRentals();
         List<Rental> GetAllRentals();

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -105,6 +105,15 @@ namespace ToolManagementAppV2.Services.Rentals
                         throw new InvalidOperationException("Unable to extend rental. Rental not found or already returned.");
         }
 
+        public void DeleteRental(int rentalID)
+        {
+            const string sql = "DELETE FROM Rentals WHERE RentalID = @RentalID";
+            var p = new[] { new SQLiteParameter("@RentalID", rentalID) };
+            using var conn = _dbService.CreateConnection();
+            if (SqliteHelper.ExecuteNonQuery(conn, sql, p) == 0)
+                throw new InvalidOperationException("Rental not found.");
+        }
+
 
         void ExecuteWithTransaction(Action<SQLiteConnection, SQLiteTransaction> action, Action? postCommitAction = null)
         {

--- a/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
@@ -240,7 +240,7 @@ namespace ToolManagementAppV2.ViewModels
         {
             if (SelectedRental == null)
                 return;
-
+            _rentalService.DeleteRental(SelectedRental.RentalID);
             _allRentals.Remove(SelectedRental);
             Rentals.Remove(SelectedRental);
         }


### PR DESCRIPTION
## Summary
- extend rental service interface and implementation with DeleteRental
- call rental deletion from ManageRentalsViewModel
- add unit tests for rental deletion

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bd43b37948324b64dfb3ab9c3af77