### PR TITLE
Add tool number validation and dialog-aware additions

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -115,7 +115,27 @@ namespace ToolManagementAppV2.Tests.Services
                 service.AddTool(new Tool { ToolNumber = "T1" });
 
                 var dup = new Tool { ToolNumber = "T1" };
-                Assert.Throws<InvalidOperationException>(() => service.AddTool(dup));
+                var ex = Assert.Throws<InvalidOperationException>(() => service.AddTool(dup));
+                Assert.Contains("T1", ex.Message);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void AddTool_NullToolNumber_ThrowsArgumentException()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                IToolService service = new ToolService(dbService);
+
+                var tool = new Tool { ToolNumber = "" };
+                Assert.Throws<ArgumentException>(() => service.AddTool(tool));
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -71,7 +71,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
-                var vm = new ToolManagementViewModel(toolService);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw", Brand = "BrandB" });
                 vm.SelectedCategory = "BrandA";
@@ -84,6 +86,38 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 if (File.Exists(dbPath))
                     File.Delete(dbPath);
             }
+        }
+
+        [Fact]
+        public void AddTool_ShowsDialog_OnError()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var dialog = new StubDialogService();
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
+                vm.NewTool.ToolNumber = string.Empty;
+                vm.NewToolCommand.Execute(null);
+                Assert.True(dialog.InfoShown);
+                Assert.Empty(toolService.GetAllTools());
+                Assert.Equal(string.Empty, vm.NewTool.ToolNumber);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        class StubDialogService : IDialogService
+        {
+            public bool InfoShown;
+            public void ShowInfo(string message, string title) => InfoShown = true;
+            public bool ShowConfirmation(string message, string title) => false;
         }
 
         [Fact]

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -77,6 +77,8 @@ namespace ToolManagementAppV2.Services.Tools
         /// </summary>
         public void AddTool(ToolModel tool)
         {
+            if (string.IsNullOrWhiteSpace(tool?.ToolNumber))
+                throw new ArgumentException("ToolNumber is required.", nameof(tool));
             if (ToolExists(tool.ToolNumber))
                 throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
             using var conn = _dbService.CreateConnection();
@@ -328,6 +330,8 @@ namespace ToolManagementAppV2.Services.Tools
     
         private bool ToolExists(string toolNumber)
         {
+            if (string.IsNullOrWhiteSpace(toolNumber))
+                return false;
             const string sql = "SELECT COUNT(*) FROM Tools WHERE ToolNumber = @TN";
             using var conn = _dbService.CreateConnection();
             var count = Convert.ToInt32(SqliteHelper.ExecuteScalar(conn, sql, new[] {

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -8,6 +8,7 @@ using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Extensions;
 using ToolManagementAppV2.ViewModels.Rental;
 using ToolManagementAppV2.Views;
+using ToolManagementAppV2.Services;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -16,6 +17,7 @@ namespace ToolManagementAppV2.ViewModels
         private readonly IToolService _toolService;
         private readonly ICustomerService _customerService;
         private readonly IRentalService _rentalService;
+        private readonly IDialogService _dialogService;
 
         public ObservableCollection<ToolModel> Tools { get; } = new();
         public ObservableCollection<ToolModel> SearchResults { get; } = new();
@@ -102,12 +104,15 @@ namespace ToolManagementAppV2.ViewModels
 
         public ToolManagementViewModel(IToolService toolService,
                                        ICustomerService customerService,
-                                       IRentalService rentalService)
+                                       IRentalService rentalService,
+                                       IDialogService? dialogService = null)
         {
             _toolService = toolService;
+            _customerService = customerService;
+            _rentalService = rentalService;
+            _dialogService = dialogService ?? new DialogService();
             SearchCommand = new RelayCommand(FilterTools);
             NewToolCommand = new RelayCommand(AddTool);
-            _customerService = customerService;
             EditToolCommand = new RelayCommand(EditTool, () => SelectedTool != null);
             DeleteToolCommand = new RelayCommand(DeleteTool);
             OpenRentalsCommand = new RelayCommand(OpenRentals, () => SelectedTool != null);
@@ -148,10 +153,21 @@ namespace ToolManagementAppV2.ViewModels
 
         void AddTool()
         {
-            _toolService.AddTool(NewTool);
-            LoadTools();
-            FilterTools();
-            NewTool = new ToolModel();
+            try
+            {
+                _toolService.AddTool(NewTool);
+                LoadTools();
+                FilterTools();
+                NewTool = new ToolModel();
+            }
+            catch (InvalidOperationException ex)
+            {
+                _dialogService.ShowInfo(ex.Message, "Error");
+            }
+            catch (ArgumentException ex)
+            {
+                _dialogService.ShowInfo(ex.Message, "Error");
+            }
         }
 
         void EditTool()


### PR DESCRIPTION
## Summary
- enforce tool number requirements and include the number in duplicate errors
- show dialog messages when tool addition fails and reset form only on success
- cover tool number validation and dialog behavior with new unit tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689bf347a70483248c69c4b5938e806a