### PR TITLE
Load company logo setting in SettingsViewModel

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -18,6 +18,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public void Constructor_PopulatesCompanyLogoPath_WhenSettingExists()
+        {
+            var settings = new StubSettingsService { GetSettingValue = "logo.png" };
+            var vm = new SettingsViewModel(new StubFileDialogService(), settings, new StubDialogService());
+            Assert.Equal("logo.png", vm.CompanyLogoPath);
+        }
+
+        [Fact]
         public void TestDbConnection_CreatesDatabaseFile()
         {
             var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
@@ -80,6 +88,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public string SavedKey { get; private set; }
         public string SavedValue { get; private set; }
+        public string GetSettingValue { get; set; } = string.Empty;
 
         public void SaveSetting(string key, string value)
         {
@@ -87,7 +96,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             SavedValue = value;
         }
 
-        public string GetSetting(string key) => string.Empty;
+        public string GetSetting(string key) => GetSettingValue;
         public Dictionary<string, string> GetAllSettings() => new();
         public void UpdateSettings(Dictionary<string, string> settings) { }
         public void DeleteSetting(string key) { }

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -19,6 +19,10 @@ namespace ToolManagementAppV2.ViewModels
             _settingsService = settingsService;
             _dialogService = dialogService;
 
+            var logoPath = _settingsService.GetSetting("CompanyLogoPath");
+            if (!string.IsNullOrWhiteSpace(logoPath))
+                CompanyLogoPath = logoPath;
+
             ThemeOptions = new ObservableCollection<string> { "Light", "Dark" };
             _theme = ThemeOptions[0];
             TestDbCommand = new RelayCommand(() =>


### PR DESCRIPTION
## Summary
- populate CompanyLogoPath from settings on SettingsViewModel construction
- add unit test ensuring CompanyLogoPath is loaded when setting exists

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689bf5af04ec83248d1e52fb2c679cd2