### PR TITLE
Inject SettingsService into MainViewModel via DI

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -7,6 +7,7 @@ using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Views;
 using Xunit;
@@ -38,9 +39,10 @@ namespace ToolManagementAppV2.Tests.Tests
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.OpenSearchToolsCommand.Execute(null);
 
                 var page = Assert.IsType<ToolSearchPage>(vm.CurrentPage);

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -8,6 +8,7 @@ using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
 using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Settings;
 
 
 namespace ToolManagementAppV2.Tests.ViewModels
@@ -29,8 +30,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
 
                 bool raised = false;
                 vm.PropertyChanged += (s, e) =>

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
@@ -10,6 +11,7 @@ using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Views;
 using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Settings;
 using Xunit;
 
 
@@ -29,8 +31,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
 
                 Assert.NotNull(vm.ToolManagement);
                 Assert.NotNull(vm.UserManagement);
@@ -59,8 +62,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.OpenDashboardCommand.Execute(null);
 
                 var page = Assert.IsType<DashboardPage>(vm.CurrentPage);
@@ -85,8 +89,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.OpenImportExportCommand.Execute(null);
 
                 var page = Assert.IsType<ImportExportPage>(vm.CurrentPage);
@@ -112,8 +117,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IUserService userService = new UserService(db);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
+                var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.OpenActivityLogsCommand.Execute(null);
 
                 var page = Assert.IsType<ActivityLogsPage>(vm.CurrentPage);
@@ -139,8 +145,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IUserService userService = new UserService(db);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
+                var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.OpenReportsCommand.Execute(null);
 
                 var page = Assert.IsType<ReportsPage>(vm.CurrentPage);
@@ -166,12 +173,16 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.OpenSettingsCommand.Execute(null);
 
                 var page = Assert.IsType<SettingsPage>(vm.CurrentPage);
-                Assert.IsType<SettingsViewModel>(page.DataContext);
+                var settingsVm = Assert.IsType<SettingsViewModel>(page.DataContext);
+                var field = typeof(SettingsViewModel).GetField("_settingsService", BindingFlags.NonPublic | BindingFlags.Instance);
+                var svc = field!.GetValue(settingsVm);
+                Assert.Same(settingsService, svc);
             }
             finally
             {
@@ -194,8 +205,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.OpenRentalsCommand.Execute(null);
 
                 var page = Assert.IsType<ManageRentalsPage>(vm.CurrentPage);
@@ -220,11 +232,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
 
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw" });
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.GlobalSearchText = "Ham";
 
                 vm.GlobalSearchCommand.Execute(null);
@@ -254,8 +267,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.OpenImportMappingWindowCommand.Execute(null);
             }
             finally
@@ -277,8 +291,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService);
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 Assert.NotNull(vm.OpenImageImportMappingWindowCommand);
             }
             finally

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -7,6 +7,7 @@ using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2
@@ -26,10 +27,11 @@ namespace ToolManagementAppV2
             var rentalService = new RentalService(db, toolService);
             var activityLogService = new ActivityLogService(db);
             var fileDialogService = new FileDialogService();
+            var settingsService = new SettingsService(db);
 
             var main = new MainWindow
             {
-                DataContext = new MainViewModel(toolService, userService, customerService, rentalService, fileDialogService, activityLogService)
+                DataContext = new MainViewModel(toolService, userService, customerService, rentalService, fileDialogService, activityLogService, settingsService)
             };
 
             Current.MainWindow = main;

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2
@@ -24,8 +25,9 @@ namespace ToolManagementAppV2
             var rentalService = new RentalService(db, toolService);
             var activityLogService = new ActivityLogService(db);
             var fileDialogService = new FileDialogService();
+            var settingsService = new SettingsService(db);
 
-            DataContext = new MainViewModel(toolService, userService, customerService, rentalService, fileDialogService, activityLogService);
+            DataContext = new MainViewModel(toolService, userService, customerService, rentalService, fileDialogService, activityLogService, settingsService);
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -11,9 +11,7 @@ using Forms = System.Windows.Forms;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services;
-using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Rentals;
-using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.ViewModels.Rental;
@@ -28,6 +26,7 @@ namespace ToolManagementAppV2.ViewModels
         readonly ICustomerService _customerService;
         readonly IRentalService _rentalService;
         readonly ActivityLogService _activityLogService;
+        readonly ISettingsService _settingsService;
 
         public ToolManagementViewModel ToolManagement { get; }
         public UserManagementViewModel UserManagement { get; }
@@ -103,12 +102,15 @@ namespace ToolManagementAppV2.ViewModels
                              ICustomerService customerService,
                              IRentalService rentalService,
                              IFileDialogService fileDialogService,
-                             ActivityLogService activityLogService)
-        {_toolService = toolService;
+                             ActivityLogService activityLogService,
+                             ISettingsService settingsService)
+        {
+            _toolService = toolService;
             _userService = userService;
             _customerService = customerService;
             _rentalService = rentalService;
             _activityLogService = activityLogService;
+            _settingsService = settingsService;
 
             ToolManagement = new ToolManagementViewModel(toolService, customerService, rentalService);
             UserManagement = new UserManagementViewModel(userService, fileDialogService);
@@ -168,11 +170,9 @@ namespace ToolManagementAppV2.ViewModels
 
             OpenSettingsCommand = new RelayCommand(() =>
             {
-                var db = new DatabaseService(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db"));
-                var settingsService = new SettingsService(db);
                 var page = new SettingsPage
                 {
-                    DataContext = new SettingsViewModel(fileDialogService, settingsService, new DialogService()),
+                    DataContext = new SettingsViewModel(fileDialogService, _settingsService, new DialogService()),
                     Title = "Settings"
                 };
                 CurrentPage = page;


### PR DESCRIPTION
## Summary
- Inject ISettingsService into MainViewModel and remove direct service instantiation in OpenSettingsCommand.
- Wire SettingsService through application startup and window constructors.
- Update tests to supply ISettingsService and verify SettingsPage uses the injected service.

## Testing
- `dotnet test` *(fails: command not found; .NET SDK unavailable in container)*


------
https://chatgpt.com/codex/tasks/task_e_689bf7dffd348324896955e75054f79f