### PR TITLE
Use integer ToolID across the application

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -63,7 +63,7 @@ namespace ToolManagementAppV2.Tests.Services
 
                 service.AddTool(tool);
 
-                Assert.True(int.Parse(tool.ToolID) > 0);
+                Assert.True(tool.ToolID > 0);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
@@ -35,10 +35,10 @@ namespace ToolManagementAppV2.Tests.Tests
         {
             var page = new ToolSearchPage();
             page.HandToolsList.ItemsSource = Enumerable.Range(0, 1000)
-                .Select(i => new Tool { ToolID = i.ToString(), NameDescription = $"Tool {i}" })
+                .Select(i => new Tool { ToolID = i, NameDescription = $"Tool {i}" })
                 .ToList();
             page.PowerToolsList.ItemsSource = Enumerable.Range(0, 1000)
-                .Select(i => new Tool { ToolID = i.ToString(), NameDescription = $"Power {i}" })
+                .Select(i => new Tool { ToolID = i, NameDescription = $"Power {i}" })
                 .ToList();
 
             page.HandToolsList.Measure(new Size(800, 300));

--- a/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
@@ -24,16 +24,16 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool1 = new Tool { ToolID = "T1", ToolNumber = "T1" };
-                var tool2 = new Tool { ToolID = "T2", ToolNumber = "T2" };
+                var tool1 = new Tool { ToolNumber = "T1" };
+                var tool2 = new Tool { ToolNumber = "T2" };
                 toolService.AddTool(tool1);
                 toolService.AddTool(tool2);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
 
-                rentalService.RentTool("T1", cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
-                rentalService.RentTool("T2", cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentTool(tool1.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentTool(tool2.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
                 var all = rentalService.GetAllRentals();
                 rentalService.ReturnTool(all[1].RentalID, DateTime.Today);
 
@@ -69,16 +69,16 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool1 = new Tool { ToolID = "T1", ToolNumber = "Alpha" };
-                var tool2 = new Tool { ToolID = "T2", ToolNumber = "Beta" };
+                var tool1 = new Tool { ToolNumber = "Alpha" };
+                var tool2 = new Tool { ToolNumber = "Beta" };
                 toolService.AddTool(tool1);
                 toolService.AddTool(tool2);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
 
-                rentalService.RentTool("T1", cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
-                rentalService.RentTool("T2", cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentTool(tool1.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentTool(tool2.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
                 var vm = new ManageRentalsViewModel(rentalService);
                 vm.LoadRentals();
@@ -125,13 +125,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool = new Tool { ToolID = "T1", ToolNumber = "T1" };
+                var tool = new Tool { ToolNumber = "T1" };
                 toolService.AddTool(tool);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
 
-                rentalService.RentTool("T1", cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentTool(tool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
                 var vm = new ManageRentalsViewModel(rentalService);
                 vm.LoadRentals();

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -167,14 +167,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public List<ToolModel> GetAllTools() => new();
         public void AddTool(ToolModel tool) => throw new System.NotImplementedException();
         public void UpdateTool(ToolModel tool) => throw new System.NotImplementedException();
-        public void DeleteTool(string toolID) => throw new System.NotImplementedException();
-        public ToolModel GetToolByID(string toolID) => throw new System.NotImplementedException();
+        public void DeleteTool(int toolID) => throw new System.NotImplementedException();
+        public ToolModel GetToolByID(int toolID) => throw new System.NotImplementedException();
         public List<ToolModel> SearchTools(string? searchText) => new();
-        public void ToggleToolCheckOutStatus(string toolID, string currentUser) => throw new System.NotImplementedException();
+        public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new System.NotImplementedException();
         public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
-        public void UpdateToolImage(string toolID, string imagePath) => throw new System.NotImplementedException();
+        public void UpdateToolImage(int toolID, string imagePath) => throw new System.NotImplementedException();
         public ImageImportResult ImportToolImages(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector) => new();
-        public void UpdateToolQuantities(string toolID, int qtyChange, bool isRental) => throw new System.NotImplementedException();
+        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental) => throw new System.NotImplementedException();
     }
 
     class FailToolService : IToolService
@@ -184,25 +184,25 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public List<ToolModel> GetAllTools() => new();
         public void AddTool(ToolModel tool) => throw new System.NotImplementedException();
         public void UpdateTool(ToolModel tool) => throw new System.NotImplementedException();
-        public void DeleteTool(string toolID) => throw new System.NotImplementedException();
-        public ToolModel GetToolByID(string toolID) => throw new System.NotImplementedException();
+        public void DeleteTool(int toolID) => throw new System.NotImplementedException();
+        public ToolModel GetToolByID(int toolID) => throw new System.NotImplementedException();
         public List<ToolModel> SearchTools(string? searchText) => new();
-        public void ToggleToolCheckOutStatus(string toolID, string currentUser) => throw new System.NotImplementedException();
+        public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new System.NotImplementedException();
         public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
-        public void UpdateToolImage(string toolID, string imagePath) => throw new System.NotImplementedException();
+        public void UpdateToolImage(int toolID, string imagePath) => throw new System.NotImplementedException();
         public ImageImportResult ImportToolImages(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector) => new();
-        public void UpdateToolQuantities(string toolID, int qtyChange, bool isRental) => throw new System.NotImplementedException();
+        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental) => throw new System.NotImplementedException();
     }
 
     class StubRentalService : IRentalService
     {
-        public void RentTool(string toolID, int customerID, System.DateTime rentalDate, System.DateTime dueDate) => throw new System.NotImplementedException();
+        public void RentTool(int toolID, int customerID, System.DateTime rentalDate, System.DateTime dueDate) => throw new System.NotImplementedException();
         public void ReturnTool(int rentalID, System.DateTime returnDate) => throw new System.NotImplementedException();
         public void ExtendRental(int rentalID, System.DateTime newDueDate) => throw new System.NotImplementedException();
         public List<Rental> GetActiveRentals() => new();
         public List<Rental> GetOverdueRentals() => new();
         public List<Rental> GetAllRentals() => new();
-        public List<Rental> GetRentalHistoryForTool(string toolID) => new();
+        public List<Rental> GetRentalHistoryForTool(int toolID) => new();
         public List<Rental> GetRentalHistoryForCustomer(int customerID) => new();
     }
 

--- a/ToolManagementAppV2/Interfaces/IRentalService.cs
+++ b/ToolManagementAppV2/Interfaces/IRentalService.cs
@@ -16,7 +16,7 @@ namespace ToolManagementAppV2.Interfaces
         /// <param name="customerID">Identifier of the customer renting the tool.</param>
         /// <param name="rentalDate">The date the rental begins.</param>
         /// <param name="dueDate">The date the tool is due to be returned.</param>
-        void RentTool(string toolID, int customerID, DateTime rentalDate, DateTime dueDate);
+        void RentTool(int toolID, int customerID, DateTime rentalDate, DateTime dueDate);
 
         /// <summary>
         /// Returns a rented tool within a database transaction.
@@ -31,7 +31,7 @@ namespace ToolManagementAppV2.Interfaces
         List<Rental> GetActiveRentals();
         List<Rental> GetOverdueRentals();
         List<Rental> GetAllRentals();
-        List<Rental> GetRentalHistoryForTool(string toolID);
+        List<Rental> GetRentalHistoryForTool(int toolID);
         List<Rental> GetRentalHistoryForCustomer(int customerID);
     }
 }

--- a/ToolManagementAppV2/Interfaces/IToolService.cs
+++ b/ToolManagementAppV2/Interfaces/IToolService.cs
@@ -10,16 +10,16 @@ namespace ToolManagementAppV2.Interfaces
     {
         void AddTool(ToolModel tool);
         void UpdateTool(ToolModel tool);
-        void DeleteTool(string toolID);
-        ToolModel GetToolByID(string toolID);
+        void DeleteTool(int toolID);
+        ToolModel GetToolByID(int toolID);
         List<ToolModel> GetAllTools();
         List<ToolModel> SearchTools(string? searchText);
-        void ToggleToolCheckOutStatus(string toolID, string currentUser);
+        void ToggleToolCheckOutStatus(int toolID, string currentUser);
         List<ToolModel> GetToolsCheckedOutBy(string userName);
-        void UpdateToolImage(string toolID, string imagePath);
+        void UpdateToolImage(int toolID, string imagePath);
         List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map);
         void ExportToolsToCsv(string filePath);
         ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector);
-        void UpdateToolQuantities(string toolID, int qtyChange, bool isRental);
+        void UpdateToolQuantities(int toolID, int qtyChange, bool isRental);
     }
 }

--- a/ToolManagementAppV2/Models/Domain/Rental.cs
+++ b/ToolManagementAppV2/Models/Domain/Rental.cs
@@ -11,8 +11,8 @@ namespace ToolManagementAppV2.Models.Domain
             set => SetProperty(ref _rentalID, value);
         }
 
-        private string _toolID = string.Empty;
-        public string ToolID
+        private int _toolID;
+        public int ToolID
         {
             get => _toolID;
             set => SetProperty(ref _toolID, value);

--- a/ToolManagementAppV2/Models/Domain/Tool.cs
+++ b/ToolManagementAppV2/Models/Domain/Tool.cs
@@ -4,8 +4,8 @@ namespace ToolManagementAppV2.Models.Domain
 {
     public class Tool : ObservableObject
     {
-        private string _toolID = string.Empty;
-        public string ToolID
+        private int _toolID;
+        public int ToolID
         {
             get => _toolID;
             set => SetProperty(ref _toolID, value);

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -20,9 +20,7 @@ namespace ToolManagementAppV2.Services.Rentals
             _toolService = toolService; // may be null if inventory sync not desired
         }
 
-        // toolID is passed as a string even though the underlying column is INTEGER
-        // to keep consistency with ToolModel.ToolID
-        public void RentTool(string toolID, int customerID, DateTime rentalDate, DateTime dueDate)
+        public void RentTool(int toolID, int customerID, DateTime rentalDate, DateTime dueDate)
         {
             ExecuteWithTransaction((conn, tx) =>
             {
@@ -59,7 +57,7 @@ namespace ToolManagementAppV2.Services.Rentals
 
         public void ReturnTool(int rentalID, DateTime returnDate)
         {
-            string? toolID = null;
+            int? toolID = null;
             ExecuteWithTransaction((conn, tx) =>
             {
                 var selCmd = new SQLiteCommand(
@@ -67,7 +65,7 @@ namespace ToolManagementAppV2.Services.Rentals
                 selCmd.Parameters.AddWithValue("@RentalID", rentalID);
                 var result = selCmd.ExecuteScalar();
                 if (result == null) throw new InvalidOperationException("Rental not found or already returned.");
-                toolID = result.ToString();
+                toolID = Convert.ToInt32(result);
 
                 SqliteHelper.ExecuteNonQuery(conn, tx,
                     "UPDATE Rentals SET ReturnDate=@ReturnDate,Status='Returned' WHERE RentalID=@RentalID",
@@ -79,8 +77,8 @@ namespace ToolManagementAppV2.Services.Rentals
             },
             () =>
             {
-                if (_toolService == null || string.IsNullOrWhiteSpace(toolID)) return;
-                var tool = _toolService.GetToolByID(toolID);
+                if (_toolService == null || toolID == null) return;
+                var tool = _toolService.GetToolByID(toolID.Value);
                 if (tool != null)
                 {
                     tool.QuantityOnHand++;
@@ -168,7 +166,7 @@ namespace ToolManagementAppV2.Services.Rentals
             return SqliteHelper.ExecuteReader(conn, BaseSelect, null, MapRental);
         }
 
-        public List<Rental> GetRentalHistoryForTool(string toolID)
+        public List<Rental> GetRentalHistoryForTool(int toolID)
         {
             const string sql = BaseSelect + @" WHERE r.ToolID = @ToolID ORDER BY r.RentalDate DESC";
             var p = new[] { new SQLiteParameter("@ToolID", toolID) };
@@ -187,7 +185,7 @@ namespace ToolManagementAppV2.Services.Rentals
         Rental MapRental(IDataRecord r) => new()
         {
             RentalID = Convert.ToInt32(r["RentalID"]),
-            ToolID = r["ToolID"].ToString(),
+            ToolID = Convert.ToInt32(r["ToolID"]),
             CustomerID = Convert.ToInt32(r["CustomerID"]),
             RentalDate = Convert.ToDateTime(r["RentalDate"]),
             DueDate = Convert.ToDateTime(r["DueDate"]),

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -39,7 +39,7 @@ namespace ToolManagementAppV2.Services.Tools
             return _cache;
         }
     
-        public ToolModel GetToolByID(string toolID)
+        public ToolModel GetToolByID(int toolID)
         {
             var cached = GetAllTools().FirstOrDefault(t => t.ToolID == toolID);
             if (cached != null)
@@ -58,7 +58,7 @@ namespace ToolManagementAppV2.Services.Tools
 
             var terms = searchText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             return all.Where(t => terms.All(term =>
-                (t.ToolID?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                t.ToolID.ToString().Contains(term, StringComparison.OrdinalIgnoreCase) ||
                 (t.ToolNumber?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
                 (t.NameDescription?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
                 (t.Brand?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
@@ -133,7 +133,7 @@ namespace ToolManagementAppV2.Services.Tools
             _cache = null;
         }
     
-        public void UpdateToolQuantities(string toolID, int qtyChange, bool isRental)
+        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental)
         {
             if (qtyChange <= 0) throw new ArgumentException("Quantity change must be positive.", nameof(qtyChange));
             var sql = isRental
@@ -150,7 +150,7 @@ namespace ToolManagementAppV2.Services.Tools
             _cache = null;
         }
     
-        public void DeleteTool(string toolID)
+        public void DeleteTool(int toolID)
         {
             using var conn = _dbService.CreateConnection();
             SqliteHelper.ExecuteNonQuery(conn, "DELETE FROM Tools WHERE ToolID=@ID",
@@ -158,7 +158,7 @@ namespace ToolManagementAppV2.Services.Tools
             _cache = null;
         }
     
-        public void ToggleToolCheckOutStatus(string toolID, string currentUser)
+        public void ToggleToolCheckOutStatus(int toolID, string currentUser)
         {
             using var conn = _dbService.CreateConnection();
             var record = SqliteHelper.ExecuteReader(conn,
@@ -201,7 +201,7 @@ namespace ToolManagementAppV2.Services.Tools
                 new[] { new SQLiteParameter("@User", userName) }, MapTool);
         }
     
-        public void UpdateToolImage(string toolID, string imagePath)
+        public void UpdateToolImage(int toolID, string imagePath)
         {
             using var conn = _dbService.CreateConnection();
             SqliteHelper.ExecuteNonQuery(conn, "UPDATE Tools SET ToolImagePath=@Img WHERE ToolID=@ID",
@@ -257,7 +257,7 @@ namespace ToolManagementAppV2.Services.Tools
             cmd.Parameters.AddRange(p);
             var result = cmd.ExecuteScalar();
             if (result != null)
-                tool.ToolID = result.ToString();
+                tool.ToolID = Convert.ToInt32(result);
         }
     
         public void ExportToolsToCsv(string filePath)
@@ -342,7 +342,7 @@ namespace ToolManagementAppV2.Services.Tools
     
         ToolModel MapTool(IDataRecord r) => new()
         {
-            ToolID = r["ToolID"].ToString(),
+            ToolID = Convert.ToInt32(r["ToolID"]),
             ToolNumber = r["ToolNumber"].ToString(),
             PartNumber = r["PartNumber"].ToString(),
             NameDescription = r["NameDescription"].ToString(),


### PR DESCRIPTION
## Summary
- Switch ToolID properties in domain models to `int` and update service interfaces
- Adjust tool and rental services to operate on integer IDs
- Align tests and view models with the new integer-based IDs

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bffad6d0083248a0d4061c86771bd