### PR TITLE
Ensure rental and inventory updates are transactional

### DIFF
--- a/ToolManagementAppV2.Tests/Services/RentalServiceConcurrentTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceConcurrentTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Tools;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Services
+{
+    public class RentalServiceConcurrentTests
+    {
+        [Fact]
+        public void RentTool_ConcurrentRequests_MaintainsQuantities()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db, toolService);
+
+                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
+                var tool = toolService.GetAllTools().First();
+
+                customerService.AddCustomer(new Customer { Company = "Acme" });
+                var cust = customerService.GetAllCustomers().First();
+
+                var barrier = new Barrier(2);
+                var t1 = Task.Run(() =>
+                {
+                    barrier.SignalAndWait();
+                    try
+                    {
+                        rentalService.RentTool(tool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                    }
+                    catch { }
+                });
+                var t2 = Task.Run(() =>
+                {
+                    barrier.SignalAndWait();
+                    try
+                    {
+                        rentalService.RentTool(tool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                    }
+                    catch { }
+                });
+
+                Task.WaitAll(t1, t2);
+
+                var updated = toolService.GetToolByID(tool.ToolID);
+                Assert.Equal(0, updated.QuantityOnHand);
+                Assert.Equal(1, updated.RentedQuantity);
+                Assert.Single(rentalService.GetAllRentals());
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+    }
+}
+

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Data.SQLite;
 using System.IO;
 using System.Linq;
 using ToolManagementAppV2.Interfaces;
@@ -174,7 +175,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
         public void UpdateToolImage(int toolID, string imagePath) => throw new System.NotImplementedException();
         public ImageImportResult ImportToolImages(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector) => new();
-        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental) => throw new System.NotImplementedException();
+        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => throw new System.NotImplementedException();
     }
 
     class FailToolService : IToolService
@@ -191,7 +192,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
         public void UpdateToolImage(int toolID, string imagePath) => throw new System.NotImplementedException();
         public ImageImportResult ImportToolImages(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector) => new();
-        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental) => throw new System.NotImplementedException();
+        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => throw new System.NotImplementedException();
     }
 
     class StubRentalService : IRentalService

--- a/ToolManagementAppV2/Interfaces/IToolService.cs
+++ b/ToolManagementAppV2/Interfaces/IToolService.cs
@@ -1,8 +1,8 @@
 using System;
-﻿using System.Collections.Generic;
-using ToolManagementAppV2.Models.ImportExport;
+using System.Collections.Generic;
+using System.Data.SQLite;
 using ToolManagementAppV2.Models;
-
+using ToolManagementAppV2.Models.ImportExport;
 
 namespace ToolManagementAppV2.Interfaces
 {
@@ -20,6 +20,8 @@ namespace ToolManagementAppV2.Interfaces
         List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map);
         void ExportToolsToCsv(string filePath);
         ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector);
-        void UpdateToolQuantities(int toolID, int qtyChange, bool isRental);
+        void UpdateToolQuantities(int toolID, int qtyChange, bool isRental,
+            SQLiteConnection? conn = null, SQLiteTransaction? tx = null);
     }
 }
+

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -42,22 +42,13 @@ namespace ToolManagementAppV2.Services.Rentals
                         new SQLiteParameter("@RentalDate", rentalDate),
                         new SQLiteParameter("@DueDate", dueDate)
                     });
-            },
-            () =>
-            {
-                if (_toolService == null) return;
-                var tool = _toolService.GetToolByID(toolID);
-                if (tool != null)
-                {
-                    tool.QuantityOnHand--;
-                    _toolService.UpdateTool(tool);
-                }
+
+                _toolService?.UpdateToolQuantities(toolID, 1, true, conn, tx);
             });
         }
 
         public void ReturnTool(int rentalID, DateTime returnDate)
         {
-            int? toolID = null;
             ExecuteWithTransaction((conn, tx) =>
             {
                 var selCmd = new SQLiteCommand(
@@ -65,7 +56,7 @@ namespace ToolManagementAppV2.Services.Rentals
                 selCmd.Parameters.AddWithValue("@RentalID", rentalID);
                 var result = selCmd.ExecuteScalar();
                 if (result == null) throw new InvalidOperationException("Rental not found or already returned.");
-                toolID = Convert.ToInt32(result);
+                var toolID = Convert.ToInt32(result);
 
                 SqliteHelper.ExecuteNonQuery(conn, tx,
                     "UPDATE Rentals SET ReturnDate=@ReturnDate,Status='Returned' WHERE RentalID=@RentalID",
@@ -74,16 +65,8 @@ namespace ToolManagementAppV2.Services.Rentals
                         new SQLiteParameter("@ReturnDate", returnDate),
                         new SQLiteParameter("@RentalID", rentalID)
                     });
-            },
-            () =>
-            {
-                if (_toolService == null || toolID == null) return;
-                var tool = _toolService.GetToolByID(toolID.Value);
-                if (tool != null)
-                {
-                    tool.QuantityOnHand++;
-                    _toolService.UpdateTool(tool);
-                }
+
+                _toolService?.UpdateToolQuantities(toolID, 1, false, conn, tx);
             });
         }
 

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -133,7 +133,8 @@ namespace ToolManagementAppV2.Services.Tools
             _cache = null;
         }
     
-        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental)
+        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental,
+            SQLiteConnection? conn = null, SQLiteTransaction? tx = null)
         {
             if (qtyChange <= 0) throw new ArgumentException("Quantity change must be positive.", nameof(qtyChange));
             var sql = isRental
@@ -144,9 +145,22 @@ namespace ToolManagementAppV2.Services.Tools
                 new SQLiteParameter("@ID", toolID),
                 new SQLiteParameter("@Q", qtyChange)
             };
-            using var conn = _dbService.CreateConnection();
-            if (SqliteHelper.ExecuteNonQuery(conn, sql, p) == 0)
-                throw new InvalidOperationException("Quantity update failed.");
+
+            if (conn != null)
+            {
+                int rows = tx != null
+                    ? SqliteHelper.ExecuteNonQuery(conn, tx, sql, p)
+                    : SqliteHelper.ExecuteNonQuery(conn, sql, p);
+                if (rows == 0)
+                    throw new InvalidOperationException("Quantity update failed.");
+            }
+            else
+            {
+                using var c = _dbService.CreateConnection();
+                if (SqliteHelper.ExecuteNonQuery(c, sql, p) == 0)
+                    throw new InvalidOperationException("Quantity update failed.");
+            }
+
             _cache = null;
         }
     


### PR DESCRIPTION
## Summary
- Allow `IToolService.UpdateToolQuantities` to use an existing transaction
- Adjust `RentalService` to update tool quantities inside the same transaction as rental changes
- Add concurrency test to verify quantity integrity under simultaneous rentals

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c06c0c6308324865755520ba329fd