### PR TITLE
Refactor tool management dialogs with service abstraction

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ManageToolsPageMenuTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ManageToolsPageMenuTests.cs
@@ -1,6 +1,9 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows.Controls;
+using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Services.Customers;
@@ -23,7 +26,8 @@ namespace ToolManagementAppV2.Tests.Tests
                 var toolService = new ToolService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db, toolService);
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+                var dialog = new StubDialogService();
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
                 var page = new ManageToolsPage { DataContext = vm };
 
                 var grid = (Grid)page.Content;
@@ -53,7 +57,8 @@ namespace ToolManagementAppV2.Tests.Tests
                 var toolService = new ToolService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db, toolService);
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+                var dialog = new StubDialogService();
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
                 var page = new ManageToolsPage { DataContext = vm };
 
                 var grid = (Grid)page.Content;
@@ -71,6 +76,14 @@ namespace ToolManagementAppV2.Tests.Tests
                 if (File.Exists(dbPath))
                     File.Delete(dbPath);
             }
+        }
+        class StubDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => true;
+            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+            public void ShowToolDetails(ToolModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
         }
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows;
@@ -49,5 +50,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => true;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/PasswordPromptViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/PasswordPromptViewModelTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
@@ -82,5 +84,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
         public void ShowInfo(string message, string title) => InfoShown = true;
         public bool ShowConfirmation(string message, string title) => ConfirmationResult;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -106,6 +106,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => true;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
     }
 }
 

--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using ToolManagementAppV2.Models.Domain;
@@ -24,7 +26,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+                var dialog = new StubDialogService();
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw" });
                 vm.SearchTerm = "Ham";
@@ -49,7 +52,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+                var dialog = new StubDialogService();
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Cordless Drill" });
                 vm.SearchTerm = string.Empty;
@@ -74,7 +78,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+                var dialog = new StubDialogService();
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw", Brand = "BrandB" });
                 vm.SelectedCategory = "BrandA";
@@ -117,8 +122,15 @@ namespace ToolManagementAppV2.Tests.ViewModels
         class StubDialogService : IDialogService
         {
             public bool InfoShown;
+            public bool ConfirmationResult;
+            public Func<ToolModel, ToolModel?>? EditToolHandler;
+            public Action<ToolModel>? ViewDetailsHandler;
+
             public void ShowInfo(string message, string title) => InfoShown = true;
-            public bool ShowConfirmation(string message, string title) => false;
+            public bool ShowConfirmation(string message, string title) => ConfirmationResult;
+            public ToolModel? ShowEditToolDialog(ToolModel tool) => EditToolHandler?.Invoke(tool);
+            public void ShowToolDetails(ToolModel tool) => ViewDetailsHandler?.Invoke(tool);
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
         }
 
         [Fact]
@@ -131,7 +143,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+                var dialog = new StubDialogService();
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
                 vm.NewTool.ToolNumber = "TN1";
                 vm.NewTool.NameDescription = "Hammer";
                 vm.NewTool.PartNumber = "PN1";
@@ -170,12 +183,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+                var dialog = new StubDialogService();
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
                 var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", ToolImagePath = "img1.png" };
                 toolService.AddTool(tool);
                 await vm.LoadToolsAsync();
                 vm.SelectedTool = vm.Tools.First();
-                vm.EditToolDialog = t =>
+                dialog.EditToolHandler = t =>
                 {
                     t.NameDescription = "Updated Hammer";
                     return t;
@@ -204,12 +218,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+                var dialog = new StubDialogService();
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
                 var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer" };
                 toolService.AddTool(tool);
                 await vm.LoadToolsAsync();
                 vm.SelectedTool = vm.Tools.First();
-                vm.EditToolDialog = _ => null;
+                dialog.EditToolHandler = _ => null;
                 await vm.EditToolCommand.ExecuteAsync(null);
                 var unchanged = toolService.GetAllTools().First();
                 Assert.Equal("Hammer", unchanged.NameDescription);
@@ -231,7 +246,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+                var dialog = new StubDialogService();
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
                 var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer" };
                 toolService.AddTool(tool);
                 await vm.LoadToolsAsync();
@@ -257,7 +273,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+                var dialog = new StubDialogService();
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
 
                 Assert.False(vm.OpenRentalsCommand.CanExecute(null));
 
@@ -284,14 +301,15 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+                var dialog = new StubDialogService();
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
                 var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer" };
                 toolService.AddTool(tool);
                 await vm.LoadToolsAsync();
                 vm.SelectedTool = vm.Tools.First();
                 bool called = false;
                 Tool? passed = null;
-                vm.ViewDetailsDialog = t => { called = true; passed = t; };
+                dialog.ViewDetailsHandler = t => { called = true; passed = t; };
                 vm.ViewDetailsCommand.Execute(null);
                 Assert.True(called);
                 Assert.Equal(vm.SelectedTool, passed);
@@ -313,7 +331,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IToolService toolService = new ToolService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService);
+                var dialog = new StubDialogService();
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
 
                 Assert.False(vm.ViewDetailsCommand.CanExecute(null));
 

--- a/ToolManagementAppV2/Interfaces/IDialogService.cs
+++ b/ToolManagementAppV2/Interfaces/IDialogService.cs
@@ -1,8 +1,14 @@
+using System;
+using System.Collections.Generic;
+
 namespace ToolManagementAppV2.Interfaces
 {
     public interface IDialogService
     {
         void ShowInfo(string message, string title);
         bool ShowConfirmation(string message, string title);
+        ToolModel? ShowEditToolDialog(ToolModel tool);
+        void ShowToolDetails(ToolModel tool);
+        (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers);
     }
 }

--- a/ToolManagementAppV2/Services/DialogService.cs
+++ b/ToolManagementAppV2/Services/DialogService.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.ViewModels.Rental;
 using ToolManagementAppV2.Views;
 
 namespace ToolManagementAppV2.Services
@@ -15,6 +18,39 @@ namespace ToolManagementAppV2.Services
         {
             var dialog = new ConfirmDialogWindow(message) { Title = title };
             return dialog.ShowDialog() == true;
+        }
+
+        public ToolModel? ShowEditToolDialog(ToolModel tool)
+        {
+            ToolEditWindow win = null!;
+            win = new ToolEditWindow(tool,
+                onSave: () => win.DialogResult = true,
+                onCancel: () => win.DialogResult = false);
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
+            try { return win.ShowDialog() == true ? tool : null; } catch { return null; }
+        }
+
+        public void ShowToolDetails(ToolModel tool)
+        {
+            ToolDetailsWindow win = null!;
+            win = new ToolDetailsWindow(tool);
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
+            try { win.ShowDialog(); } catch { }
+        }
+
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers)
+        {
+            var vm = new RentToolPopupViewModel(tool, customers);
+            var win = new RentToolPopupWindow { DataContext = vm };
+            vm.RequestClose += (_, _) => win.Close();
+            win.ShowDialog();
+
+            if (vm.SelectedCustomerResult != null)
+            {
+                return (vm.SelectedCustomerResult, vm.SelectedDueDateResult);
+            }
+
+            return null;
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -112,7 +112,7 @@ namespace ToolManagementAppV2.ViewModels
             _activityLogService = activityLogService;
             _settingsService = settingsService;
 
-            ToolManagement = new ToolManagementViewModel(toolService, customerService, rentalService);
+            ToolManagement = new ToolManagementViewModel(toolService, customerService, rentalService, new DialogService());
             UserManagement = new UserManagementViewModel(userService, fileDialogService);
             CustomerManagement = new CustomerManagementViewModel(customerService);
             ManageRentals = new ManageRentalsViewModel(rentalService);

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -7,8 +7,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Extensions;
-using ToolManagementAppV2.ViewModels.Rental;
-using ToolManagementAppV2.Views;
 using ToolManagementAppV2.Services;
 
 namespace ToolManagementAppV2.ViewModels
@@ -85,9 +83,6 @@ namespace ToolManagementAppV2.ViewModels
         public IAsyncRelayCommand OpenRentalsCommand { get; }
         public IRelayCommand ViewDetailsCommand { get; }
 
-        public Func<ToolModel, ToolModel?> EditToolDialog { get; set; }
-        public Action<ToolModel>? ViewDetailsDialog { get; set; }
-
         // Writable for TwoWay binding from XAML. Mirrors SearchTerm and triggers search.
         private string _searchText = string.Empty;
         public string SearchText
@@ -106,20 +101,18 @@ namespace ToolManagementAppV2.ViewModels
         public ToolManagementViewModel(IToolService toolService,
                                        ICustomerService customerService,
                                        IRentalService rentalService,
-                                       IDialogService? dialogService = null)
+                                       IDialogService dialogService)
         {
             _toolService = toolService;
             _customerService = customerService;
             _rentalService = rentalService;
-            _dialogService = dialogService ?? new DialogService();
+            _dialogService = dialogService;
             SearchCommand = new AsyncRelayCommand(FilterToolsAsync);
             NewToolCommand = new AsyncRelayCommand(AddToolAsync);
             EditToolCommand = new AsyncRelayCommand(EditToolAsync, () => SelectedTool != null);
             DeleteToolCommand = new AsyncRelayCommand(DeleteToolAsync);
             OpenRentalsCommand = new AsyncRelayCommand(OpenRentalsAsync, () => SelectedTool != null);
             ViewDetailsCommand = new RelayCommand(ViewDetails, () => SelectedTool != null);
-            EditToolDialog = DefaultEditToolDialog;
-            ViewDetailsDialog = DefaultViewDetailsDialog;
         }
 
         public async Task LoadToolsAsync()
@@ -195,7 +188,7 @@ namespace ToolManagementAppV2.ViewModels
                 ToolImagePath = SelectedTool.ToolImagePath
             };
 
-            var updated = EditToolDialog?.Invoke(clone);
+            var updated = _dialogService.ShowEditToolDialog(clone);
             if (updated == null) return;
 
             await _toolService.UpdateToolAsync(updated);
@@ -207,7 +200,7 @@ namespace ToolManagementAppV2.ViewModels
         void ViewDetails()
         {
             if (SelectedTool == null) return;
-            ViewDetailsDialog?.Invoke(SelectedTool);
+            _dialogService.ShowToolDetails(SelectedTool);
         }
 
         async Task DeleteToolAsync()
@@ -224,17 +217,14 @@ namespace ToolManagementAppV2.ViewModels
             if (SelectedTool == null) return;
 
             var customers = await _customerService.GetAllCustomersAsync();
-            var vm = new RentToolPopupViewModel(SelectedTool, customers);
-            var win = new RentToolPopupWindow { DataContext = vm };
-            vm.RequestClose += (_, _) => win.Close();
-            win.ShowDialog();
-
-            if (vm.SelectedCustomerResult != null)
+            var result = _dialogService.ShowRentToolDialog(SelectedTool, customers);
+            if (result != null)
             {
+                var (customer, dueDate) = result.Value;
                 await _rentalService.RentToolAsync(SelectedTool.ToolID,
-                    vm.SelectedCustomerResult.CustomerID,
+                    customer.CustomerID,
                     DateTime.Today,
-                    vm.SelectedDueDateResult);
+                    dueDate);
                 await LoadToolsAsync();
             }
         }
@@ -262,22 +252,5 @@ namespace ToolManagementAppV2.ViewModels
             Categories.ReplaceRange(categories);
         }
 
-        ToolModel? DefaultEditToolDialog(ToolModel tool)
-        {
-            ToolEditWindow win = null!;
-            win = new ToolEditWindow(tool,
-                onSave: () => win.DialogResult = true,
-                onCancel: () => win.DialogResult = false);
-            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
-            try { return win.ShowDialog() == true ? tool : null; } catch { return null; }
-        }
-
-        void DefaultViewDetailsDialog(ToolModel tool)
-        {
-            ToolDetailsWindow win = null!;
-            win = new ToolDetailsWindow(tool);
-            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
-            try { win.ShowDialog(); } catch { }
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Add dialog service methods for editing tools, viewing details, and renting
- Inject dialog service into ToolManagementViewModel and MainViewModel
- Update tests to stub the dialog service

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c0c3284d88324a5e4aa965dd6a770