### PR TITLE
Use dialog service for adding customers

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/CustomersPageBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CustomersPageBindingTests.cs
@@ -1,9 +1,11 @@
 using System.IO;
 using System.Windows.Controls;
+using System.Collections.Generic;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Views;
+using ToolManagementAppV2.Interfaces;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.Tests
@@ -18,7 +20,7 @@ namespace ToolManagementAppV2.Tests.Tests
             {
                 var db = new DatabaseService(dbPath);
                 var customerService = new CustomerService(db);
-                var vm = new CustomerManagementViewModel(customerService);
+                var vm = new CustomerManagementViewModel(customerService, new StubDialogService());
                 var page = new CustomersPage { DataContext = vm };
 
                 var grid = (Grid)page.Content;
@@ -38,5 +40,15 @@ namespace ToolManagementAppV2.Tests.Tests
                     File.Delete(dbPath);
             }
         }
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => false;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
     }
 }

--- a/ToolManagementAppV2.Tests/Tests/ManageToolsPageMenuTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ManageToolsPageMenuTests.cs
@@ -84,6 +84,7 @@ namespace ToolManagementAppV2.Tests.Tests
             public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
             public void ShowToolDetails(ToolModel tool) { }
             public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
         }
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/CustomerManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/CustomerManagementViewModelTests.cs
@@ -20,9 +20,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 ICustomerService customerService = new CustomerService(db);
-                var vm = new CustomerManagementViewModel(customerService)
+                var dialog = new StubDialogService
                 {
-                    AddCustomerDialog = () => new CustomerModel
+                    AddCustomerResult = new CustomerModel
                     {
                         Company = "ACME",
                         Email = "a@b.com",
@@ -32,6 +32,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                         Address = "Addr"
                     }
                 };
+                var vm = new CustomerManagementViewModel(customerService, dialog);
                 await vm.AddCustomerCommand.ExecuteAsync(null);
                 var customers = customerService.GetAllCustomers();
                 Assert.Single(customers);
@@ -58,10 +59,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 ICustomerService customerService = new CustomerService(db);
-                var vm = new CustomerManagementViewModel(customerService)
-                {
-                    AddCustomerDialog = () => null
-                };
+                var dialog = new StubDialogService { AddCustomerResult = null };
+                var vm = new CustomerManagementViewModel(customerService, dialog);
                 await vm.AddCustomerCommand.ExecuteAsync(null);
                 var customers = customerService.GetAllCustomers();
                 Assert.Empty(customers);
@@ -91,7 +90,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     Address = "Addr"
                 });
                 var existing = customerService.GetAllCustomers().First();
-                var vm = new CustomerManagementViewModel(customerService);
+                var vm = new CustomerManagementViewModel(customerService, new StubDialogService());
                 vm.SelectedCustomer = existing;
 
                 Assert.Equal("ACME", vm.NewCustomerName);
@@ -118,7 +117,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 customerService.AddCustomer(new ToolManagementAppV2.Models.Domain.Customer { Company = "Old" });
                 var existing = customerService.GetAllCustomers().First();
-                var vm = new CustomerManagementViewModel(customerService);
+                var vm = new CustomerManagementViewModel(customerService, new StubDialogService());
                 vm.SelectedCustomer = existing;
                 vm.NewCustomerName = "New";
                 vm.NewCustomerEmail = "e@e.com";
@@ -152,7 +151,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 customerService.AddCustomer(new ToolManagementAppV2.Models.Domain.Customer { Company = "Alpha" });
                 customerService.AddCustomer(new ToolManagementAppV2.Models.Domain.Customer { Company = "Beta" });
-                var vm = new CustomerManagementViewModel(customerService);
+                var vm = new CustomerManagementViewModel(customerService, new StubDialogService());
                 vm.CustomerSearchTerm = "Beta";
                 await vm.SearchCustomersCommand.ExecuteAsync(null);
                 Assert.Single(vm.Customers);
@@ -175,7 +174,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 customerService.AddCustomer(new ToolManagementAppV2.Models.Domain.Customer { Company = "ACME" });
                 customerService.AddCustomer(new ToolManagementAppV2.Models.Domain.Customer { Company = "Beta" });
-                var vm = new CustomerManagementViewModel(customerService);
+                var vm = new CustomerManagementViewModel(customerService, new StubDialogService());
                 await vm.SearchCustomersCommand.ExecuteAsync(null);
                 vm.SelectedCustomer = vm.Customers.First(c => c.Company == "ACME");
                 await vm.DeleteCustomerCommand.ExecuteAsync(null);
@@ -200,7 +199,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 ICustomerService customerService = new CustomerService(db);
-                var vm = new CustomerManagementViewModel(customerService);
+                var vm = new CustomerManagementViewModel(customerService, new StubDialogService());
                 Assert.False(vm.DeleteCustomerCommand.CanExecute(null));
                 vm.SelectedCustomer = new ToolManagementAppV2.Models.Domain.Customer { Company = "ACME" };
                 Assert.True(vm.DeleteCustomerCommand.CanExecute(null));
@@ -213,5 +212,17 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     File.Delete(dbPath);
             }
         }
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public CustomerModel? AddCustomerResult;
+
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => false;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => AddCustomerResult;
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -53,5 +53,6 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
         public void ShowToolDetails(ToolModel tool) { }
         public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/PasswordPromptViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/PasswordPromptViewModelTests.cs
@@ -87,5 +87,6 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
         public void ShowToolDetails(ToolModel tool) { }
         public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -109,6 +109,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
         public void ShowToolDetails(ToolModel tool) { }
         public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
     }
 }
 

--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -131,6 +131,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             public ToolModel? ShowEditToolDialog(ToolModel tool) => EditToolHandler?.Invoke(tool);
             public void ShowToolDetails(ToolModel tool) => ViewDetailsHandler?.Invoke(tool);
             public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
         }
 
         [Fact]

--- a/ToolManagementAppV2/Interfaces/IDialogService.cs
+++ b/ToolManagementAppV2/Interfaces/IDialogService.cs
@@ -10,5 +10,6 @@ namespace ToolManagementAppV2.Interfaces
         ToolModel? ShowEditToolDialog(ToolModel tool);
         void ShowToolDetails(ToolModel tool);
         (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers);
+        CustomerModel? ShowAddCustomerDialog();
     }
 }

--- a/ToolManagementAppV2/Services/DialogService.cs
+++ b/ToolManagementAppV2/Services/DialogService.cs
@@ -52,5 +52,16 @@ namespace ToolManagementAppV2.Services
 
             return null;
         }
+
+        public CustomerModel? ShowAddCustomerDialog()
+        {
+            var customer = new CustomerModel();
+            CustomerEditWindow win = null!;
+            win = new CustomerEditWindow(customer,
+                onSave: () => win.DialogResult = true,
+                onCancel: () => win.DialogResult = false);
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
+            try { return win.ShowDialog() == true ? customer : null; } catch { return null; }
+        }
     }
 }

--- a/ToolManagementAppV2/ViewModels/CustomerManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/CustomerManagementViewModel.cs
@@ -6,13 +6,13 @@ using System.Linq;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Extensions;
-using ToolManagementAppV2.Views;
 
 namespace ToolManagementAppV2.ViewModels
 {
     public class CustomerManagementViewModel : ObservableObject
     {
         private readonly ICustomerService _customerService;
+        private readonly IDialogService _dialogService;
 
         public ObservableCollection<CustomerModel> Customers { get; } = new();
 
@@ -74,13 +74,11 @@ namespace ToolManagementAppV2.ViewModels
         public IAsyncRelayCommand SearchCustomersCommand { get; }
         public IAsyncRelayCommand DeleteCustomerCommand { get; }
 
-        public Func<CustomerModel?> AddCustomerDialog { get; set; }
-
-        public CustomerManagementViewModel(ICustomerService customerService)
+        public CustomerManagementViewModel(ICustomerService customerService, IDialogService dialogService)
         {
-        
+
             _customerService = customerService;
-            AddCustomerDialog = DefaultAddCustomerDialog;
+            _dialogService = dialogService;
             AddCustomerCommand = new AsyncRelayCommand(AddCustomerAsync);
             UpdateCustomerCommand = new AsyncRelayCommand(UpdateCustomerAsync, () => SelectedCustomer != null);
             SearchCustomersCommand = new AsyncRelayCommand(SearchCustomersAsync);
@@ -95,7 +93,7 @@ namespace ToolManagementAppV2.ViewModels
 
         async Task AddCustomerAsync()
         {
-            var customer = AddCustomerDialog?.Invoke();
+            var customer = _dialogService.ShowAddCustomerDialog();
             if (customer == null) return;
 
             await _customerService.AddCustomerAsync(customer);
@@ -106,17 +104,6 @@ namespace ToolManagementAppV2.ViewModels
             NewCustomerPhone = string.Empty;
             NewCustomerMobile = string.Empty;
             NewCustomerAddress = string.Empty;
-        }
-
-        CustomerModel? DefaultAddCustomerDialog()
-        {
-            var customer = new CustomerModel();
-            CustomerEditWindow win = null!;
-            win = new CustomerEditWindow(customer,
-                onSave: () => win.DialogResult = true,
-                onCancel: () => win.DialogResult = false);
-            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
-            try { return win.ShowDialog() == true ? customer : null; } catch { return null; }
         }
 
         async Task UpdateCustomerAsync()

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -114,7 +114,7 @@ namespace ToolManagementAppV2.ViewModels
 
             ToolManagement = new ToolManagementViewModel(toolService, customerService, rentalService, new DialogService());
             UserManagement = new UserManagementViewModel(userService, fileDialogService);
-            CustomerManagement = new CustomerManagementViewModel(customerService);
+            CustomerManagement = new CustomerManagementViewModel(customerService, new DialogService());
             ManageRentals = new ManageRentalsViewModel(rentalService);
             ImportExport = new ImportExportViewModel(toolService, customerService, fileDialogService);
             Reports = new ReportsViewModel(new ReportService(toolService, rentalService, activityLogService, customerService, userService));


### PR DESCRIPTION
## Summary
- inject `IDialogService` into `CustomerManagementViewModel`
- delegate customer creation to dialog service
- adjust tests to use stubbed dialog service

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c184fb5348324a4e2ba6459ed3046