### PR TITLE
Use dialog service for rental dialogs

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ManageRentalsPageMenuTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ManageRentalsPageMenuTests.cs
@@ -1,10 +1,12 @@
 using System.IO;
 using System.Linq;
 using System.Windows.Controls;
+using System.Collections.Generic;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Views;
+using ToolManagementAppV2.Interfaces;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.Tests
@@ -19,7 +21,7 @@ namespace ToolManagementAppV2.Tests.Tests
             {
                 var db = new DatabaseService(dbPath);
                 var rentalService = new RentalService(db);
-                var vm = new ManageRentalsViewModel(rentalService);
+                var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
                 var page = new ManageRentalsPage { DataContext = vm };
 
                 var grid = (Grid)page.Content;
@@ -49,7 +51,7 @@ namespace ToolManagementAppV2.Tests.Tests
             {
                 var db = new DatabaseService(dbPath);
                 var rentalService = new RentalService(db);
-                var vm = new ManageRentalsViewModel(rentalService);
+                var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
                 var page = new ManageRentalsPage { DataContext = vm };
 
                 var grid = (Grid)page.Content;
@@ -73,7 +75,7 @@ namespace ToolManagementAppV2.Tests.Tests
             {
                 var db = new DatabaseService(dbPath);
                 var rentalService = new RentalService(db);
-                var vm = new ManageRentalsViewModel(rentalService);
+                var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
                 var page = new ManageRentalsPage { DataContext = vm };
 
                 var grid = (Grid)page.Content;
@@ -88,5 +90,15 @@ namespace ToolManagementAppV2.Tests.Tests
                     File.Delete(dbPath);
             }
         }
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => false;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
@@ -7,6 +7,8 @@ using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Interfaces;
+using System.Collections.Generic;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.ViewModels
@@ -37,7 +39,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var all = rentalService.GetAllRentals();
                 rentalService.ReturnTool(all[1].RentalID, DateTime.Today);
 
-                var vm = new ManageRentalsViewModel(rentalService);
+                var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
                 vm.LoadRentals();
 
                 Assert.Equal(2, vm.Rentals.Count);
@@ -80,7 +82,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 rentalService.RentTool(tool1.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
                 rentalService.RentTool(tool2.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
-                var vm = new ManageRentalsViewModel(rentalService);
+                var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
                 vm.LoadRentals();
 
                 vm.SearchText = "Alpha";
@@ -104,7 +106,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 var rentalService = new RentalService(db);
-                var vm = new ManageRentalsViewModel(rentalService);
+                var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
                 vm.CloseCommand.Execute(null);
             }
             finally
@@ -133,7 +135,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 rentalService.RentTool(tool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
-                var vm = new ManageRentalsViewModel(rentalService);
+                var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
                 vm.LoadRentals();
                 vm.SelectedRental = vm.Rentals.First();
 
@@ -148,5 +150,16 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     File.Delete(dbPath);
             }
         }
+    }
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => false;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
     }
 }

--- a/ToolManagementAppV2/Interfaces/IDialogService.cs
+++ b/ToolManagementAppV2/Interfaces/IDialogService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2.Interfaces
 {
@@ -11,5 +12,8 @@ namespace ToolManagementAppV2.Interfaces
         void ShowToolDetails(ToolModel tool);
         (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers);
         CustomerModel? ShowAddCustomerDialog();
+
+        void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+        void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
     }
 }

--- a/ToolManagementAppV2/Services/DialogService.cs
+++ b/ToolManagementAppV2/Services/DialogService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.ViewModels.Rental;
 using ToolManagementAppV2.Views;
 
@@ -62,6 +63,21 @@ namespace ToolManagementAppV2.Services
                 onCancel: () => win.DialogResult = false);
             try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
             try { return win.ShowDialog() == true ? customer : null; } catch { return null; }
+        }
+
+        public void ShowRentalsFilter(ManageRentalsViewModel viewModel)
+        {
+            var win = new RentalsFilterWindow { DataContext = viewModel };
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
+            try { win.ShowDialog(); } catch { }
+        }
+
+        public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history)
+        {
+            var vm = new RentalHistoryViewModel(tool, history);
+            var win = new RentalHistoryWindow(vm) { Title = $"Rental History - {tool.ToolNumber}" };
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
+            try { win.ShowDialog(); } catch { }
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -115,7 +115,7 @@ namespace ToolManagementAppV2.ViewModels
             ToolManagement = new ToolManagementViewModel(toolService, customerService, rentalService, new DialogService());
             UserManagement = new UserManagementViewModel(userService, fileDialogService);
             CustomerManagement = new CustomerManagementViewModel(customerService, new DialogService());
-            ManageRentals = new ManageRentalsViewModel(rentalService);
+            ManageRentals = new ManageRentalsViewModel(rentalService, new DialogService());
             ImportExport = new ImportExportViewModel(toolService, customerService, fileDialogService);
             Reports = new ReportsViewModel(new ReportService(toolService, rentalService, activityLogService, customerService, userService));
             ActivityLogs = new ActivityLogsViewModel(activityLogService);

--- a/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
@@ -8,8 +8,6 @@ using System.Windows;
 using System.Windows.Documents;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Extensions;
-using ToolManagementAppV2.ViewModels.Rental;
-using ToolManagementAppV2.Views;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -20,6 +18,7 @@ namespace ToolManagementAppV2.ViewModels
     public class ManageRentalsViewModel : ObservableObject
     {
         private readonly IRentalService _rentalService;
+        private readonly IDialogService _dialogService;
         private List<RentalModel> _allRentals = new();
 
         public ObservableCollection<RentalModel> Rentals { get; } = new();
@@ -82,9 +81,10 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand PrintRentalCommand { get; }
         public IRelayCommand DeleteRentalCommand { get; }
 
-        public ManageRentalsViewModel(IRentalService rentalService)
+        public ManageRentalsViewModel(IRentalService rentalService, IDialogService dialogService)
         {
             _rentalService = rentalService;
+            _dialogService = dialogService;
 
             ApplyFilterCommand = new RelayCommand(ApplyFilter);
             ClearFilterCommand = new RelayCommand(ClearFilter);
@@ -137,9 +137,7 @@ namespace ToolManagementAppV2.ViewModels
 
         void OpenFilterWindow()
         {
-            var win = new RentalsFilterWindow { DataContext = this };
-            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
-            try { win.ShowDialog(); } catch { }
+            _dialogService.ShowRentalsFilter(this);
         }
 
         void CloseFilterWindow()
@@ -182,9 +180,7 @@ namespace ToolManagementAppV2.ViewModels
                 ToolNumber = SelectedRental.ToolNumber,
                 NameDescription = SelectedRental.ToolNumber
             };
-            var vm = new RentalHistoryViewModel(tool, history);
-            var win = new RentalHistoryWindow(vm) { Title = $"Rental History - {tool.ToolNumber}" };
-            win.ShowDialog();
+            _dialogService.ShowRentalHistory(tool, history);
         }
 
         void PrintRental()


### PR DESCRIPTION
## Summary
- Inject dialog service into ManageRentalsViewModel
- Replace rental filter and history window creation with dialog service calls
- Update tests to pass stub dialog service

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c1b54f8b48324b1664551c3187341