### PR TITLE
Add logging to catch blocks in view models and services

### DIFF
--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -1,12 +1,15 @@
 using System.Data.SQLite;
 using System.IO;
 using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.Services.Core
 {
     public class DatabaseService
     {
         public string ConnectionString { get; }
+        private readonly ILogger<DatabaseService> _logger;
 
         public SQLiteConnection CreateConnection()
         {
@@ -24,9 +27,10 @@ namespace ToolManagementAppV2.Services.Core
             return conn;
         }
 
-        public DatabaseService(string dbPath)
+        public DatabaseService(string dbPath, ILogger<DatabaseService>? logger = null)
         {
             ConnectionString = $"Data Source={dbPath};Version=3;";
+            _logger = logger ?? NullLogger<DatabaseService>.Instance;
             InitializeDatabase();
             EnsureColumn("Tools", "ToolNumber", "TEXT");
             EnsureColumn("Tools", "NameDescription", "TEXT");
@@ -136,7 +140,7 @@ namespace ToolManagementAppV2.Services.Core
                 }
                 else
                 {
-                    Console.WriteLine(ex);
+                    _logger.LogError(ex, "Failed to ensure column {Column} on table {Table}", column, table);
                     throw;
                 }
             }
@@ -160,7 +164,7 @@ namespace ToolManagementAppV2.Services.Core
                 }
                 else
                 {
-                    Console.WriteLine(ex);
+                    _logger.LogError(ex, "Failed to ensure index on {Table}.{Column}", table, column);
                     throw;
                 }
             }
@@ -196,7 +200,7 @@ namespace ToolManagementAppV2.Services.Core
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                _logger.LogError(ex, "Failed to backup database");
                 throw new IOException("Failed to backup database.", ex);
             }
         }

--- a/ToolManagementAppV2/Services/Customers/CustomerService.cs
+++ b/ToolManagementAppV2/Services/Customers/CustomerService.cs
@@ -8,16 +8,20 @@ using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Utilities.IO;
 using ToolManagementAppV2.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.Services.Customers
 {
     public class CustomerService : ICustomerService
     {
         readonly DatabaseService _dbService;
+        readonly ILogger<CustomerService> _logger;
 
-        public CustomerService(DatabaseService dbService)
+        public CustomerService(DatabaseService dbService, ILogger<CustomerService>? logger = null)
         {
             _dbService = dbService;
+            _logger = logger ?? NullLogger<CustomerService>.Instance;
         }
 
         public void ImportCustomersFromCsv(string filePath, IDictionary<string, string> map)
@@ -38,8 +42,9 @@ namespace ToolManagementAppV2.Services.Customers
                 }
                 tran.Commit();
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Failed to import customers from CSV");
                 tran.Rollback();
                 throw;
             }

--- a/ToolManagementAppV2/Services/Devices/ScannerService.cs
+++ b/ToolManagementAppV2/Services/Devices/ScannerService.cs
@@ -3,11 +3,19 @@ using System.Collections.Generic;
 using System.Net.NetworkInformation;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.Services.Devices
 {
     public class ScannerService : IScannerService
     {
+        private readonly ILogger<ScannerService> _logger;
+
+        public ScannerService(ILogger<ScannerService>? logger = null)
+        {
+            _logger = logger ?? NullLogger<ScannerService>.Instance;
+        }
         static readonly string[] IpAddresses = new[]
         {
             "192.168.1.10",
@@ -33,7 +41,7 @@ namespace ToolManagementAppV2.Services.Devices
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine(ex);
+                    _logger.LogError(ex, "Failed to ping scanner {Ip}", ip);
                     device.Status = "Error";
                 }
                 list.Add(device);

--- a/ToolManagementAppV2/Services/DialogService.cs
+++ b/ToolManagementAppV2/Services/DialogService.cs
@@ -4,11 +4,19 @@ using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.ViewModels.Rental;
 using ToolManagementAppV2.Views;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.Services
 {
     public class DialogService : IDialogService
     {
+        readonly ILogger<DialogService> _logger;
+
+        public DialogService(ILogger<DialogService>? logger = null)
+        {
+            _logger = logger ?? NullLogger<DialogService>.Instance;
+        }
         public void ShowInfo(string message, string title)
         {
             var dialog = new InfoDialogWindow(message) { Title = title };
@@ -27,16 +35,20 @@ namespace ToolManagementAppV2.Services
             win = new ToolEditWindow(tool,
                 onSave: () => win.DialogResult = true,
                 onCancel: () => win.DialogResult = false);
-            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
-            try { return win.ShowDialog() == true ? tool : null; } catch { return null; }
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for ToolEditWindow"); }
+            try { return win.ShowDialog() == true ? tool : null; }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to show ToolEditWindow"); return null; }
         }
 
         public void ShowToolDetails(ToolModel tool)
         {
             ToolDetailsWindow win = null!;
             win = new ToolDetailsWindow(tool);
-            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
-            try { win.ShowDialog(); } catch { }
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for ToolDetailsWindow"); }
+            try { win.ShowDialog(); }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to show ToolDetailsWindow"); }
         }
 
         public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers)
@@ -61,23 +73,29 @@ namespace ToolManagementAppV2.Services
             win = new CustomerEditWindow(customer,
                 onSave: () => win.DialogResult = true,
                 onCancel: () => win.DialogResult = false);
-            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
-            try { return win.ShowDialog() == true ? customer : null; } catch { return null; }
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for CustomerEditWindow"); }
+            try { return win.ShowDialog() == true ? customer : null; }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to show CustomerEditWindow"); return null; }
         }
 
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel)
         {
             var win = new RentalsFilterWindow { DataContext = viewModel };
-            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
-            try { win.ShowDialog(); } catch { }
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for RentalsFilterWindow"); }
+            try { win.ShowDialog(); }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to show RentalsFilterWindow"); }
         }
 
         public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history)
         {
             var vm = new RentalHistoryViewModel(tool, history);
             var win = new RentalHistoryWindow(vm) { Title = $"Rental History - {tool.ToolNumber}" };
-            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
-            try { win.ShowDialog(); } catch { }
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for RentalHistoryWindow"); }
+            try { win.ShowDialog(); }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to show RentalHistoryWindow"); }
         }
     }
 }

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.Services.Rentals
 {
@@ -14,11 +16,13 @@ namespace ToolManagementAppV2.Services.Rentals
     {
         private readonly DatabaseService _dbService;
         private readonly IToolService? _toolService;
+        private readonly ILogger<RentalService> _logger;
 
-        public RentalService(DatabaseService dbService, IToolService? toolService = null)
+        public RentalService(DatabaseService dbService, IToolService? toolService = null, ILogger<RentalService>? logger = null)
         {
             _dbService = dbService ?? throw new ArgumentNullException(nameof(dbService));
             _toolService = toolService; // may be null if inventory sync not desired
+            _logger = logger ?? NullLogger<RentalService>.Instance;
         }
 
         public void RentTool(int toolID, int customerID, DateTime rentalDate, DateTime dueDate)
@@ -107,8 +111,9 @@ namespace ToolManagementAppV2.Services.Rentals
                 tx.Commit();
                 postCommitAction?.Invoke();
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Database transaction failed");
                 tx.Rollback();
                 throw;
             }

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -2,20 +2,24 @@
 using System;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.Services.Settings
 {
     public class SettingsService : ISettingsService
     {
         readonly DatabaseService _dbService;
+        readonly ILogger<SettingsService> _logger;
         const string UpsertSql = @"
             INSERT INTO Settings (Key, Value) 
             VALUES (@Key, @Value)
             ON CONFLICT(Key) DO UPDATE SET Value = @Value";
 
-        public SettingsService(DatabaseService dbService)
+        public SettingsService(DatabaseService dbService, ILogger<SettingsService>? logger = null)
         {
             _dbService = dbService;
+            _logger = logger ?? NullLogger<SettingsService>.Instance;
         }
 
         public void SaveSetting(string key, string value)
@@ -80,7 +84,7 @@ namespace ToolManagementAppV2.Services.Settings
             catch (Exception ex)
             {
                 tx.Rollback();
-                Console.WriteLine(ex);
+                _logger.LogError(ex, "Failed to update settings");
                 throw;
             }
         }

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -11,6 +11,8 @@ using ToolManagementAppV2.Utilities.IO;
 using ToolManagementAppV2.Models.ImportExport;
 using ToolManagementAppV2.Interfaces;
 using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.Services.Tools
 {
@@ -25,9 +27,12 @@ namespace ToolManagementAppV2.Services.Tools
             VALUES (@ToolNumber,@Desc,@Loc,@Brand,@PN,@Sup,@PD,@Notes,@Keywords,@Avail,@Rent,@Img,0);
             SELECT last_insert_rowid();";
     
-        public ToolService(DatabaseService dbService)
+        readonly ILogger<ToolService> _logger;
+
+        public ToolService(DatabaseService dbService, ILogger<ToolService>? logger = null)
         {
             _dbService = dbService;
+            _logger = logger ?? NullLogger<ToolService>.Instance;
         }
     
         public List<ToolModel> GetAllTools()
@@ -244,8 +249,9 @@ namespace ToolManagementAppV2.Services.Tools
                 _cache = null;
                 return invalidRows;
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Failed to import tools from CSV");
                 tran.Rollback();
                 throw;
             }

--- a/ToolManagementAppV2/ToolManagementAppV2.csproj
+++ b/ToolManagementAppV2/ToolManagementAppV2.csproj
@@ -111,6 +111,7 @@
     <PackageReference Include="MaterialDesignThemes" Version="5.2.1" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.119" />
     <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
@@ -6,6 +6,8 @@ using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Users;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -19,6 +21,7 @@ namespace ToolManagementAppV2.ViewModels
         readonly IRelayCommand _openManageToolsCommand;
         readonly IRelayCommand _openRentalsCommand;
         readonly IRelayCommand _openImportExportCommand;
+        readonly ILogger<DashboardViewModel> _logger;
 
         public ObservableCollection<StatCard> StatCards { get; } = new();
         public ObservableCollection<ActivityLog> RecentActivity { get; } = new();
@@ -34,7 +37,8 @@ namespace ToolManagementAppV2.ViewModels
                                   ActivityLogService activityLogService,
                                   IRelayCommand openManageToolsCommand,
                                   IRelayCommand openRentalsCommand,
-                                  IRelayCommand openImportExportCommand)
+                                  IRelayCommand openImportExportCommand,
+                                  ILogger<DashboardViewModel>? logger = null)
         {
             _toolService = toolService ?? throw new ArgumentNullException(nameof(toolService));
             _rentalService = rentalService ?? throw new ArgumentNullException(nameof(rentalService));
@@ -44,23 +48,24 @@ namespace ToolManagementAppV2.ViewModels
             _openManageToolsCommand = openManageToolsCommand ?? throw new ArgumentNullException(nameof(openManageToolsCommand));
             _openRentalsCommand = openRentalsCommand ?? throw new ArgumentNullException(nameof(openRentalsCommand));
             _openImportExportCommand = openImportExportCommand ?? throw new ArgumentNullException(nameof(openImportExportCommand));
+            _logger = logger ?? NullLogger<DashboardViewModel>.Instance;
 
             NewToolCommand = new RelayCommand(() =>
             {
                 try { _openManageToolsCommand.Execute(null); }
-                catch (Exception ex) { Console.WriteLine(ex); }
+                catch (Exception ex) { _logger.LogError(ex, "Failed to open manage tools page"); }
             });
 
             OpenRentalsCommand = new RelayCommand(() =>
             {
                 try { _openRentalsCommand.Execute(null); }
-                catch (Exception ex) { Console.WriteLine(ex); }
+                catch (Exception ex) { _logger.LogError(ex, "Failed to open rentals page"); }
             });
 
             OpenImportExportCommand = new RelayCommand(() =>
             {
                 try { _openImportExportCommand.Execute(null); }
-                catch (Exception ex) { Console.WriteLine(ex); }
+                catch (Exception ex) { _logger.LogError(ex, "Failed to open import/export page"); }
             });
 
             LoadStats();
@@ -79,7 +84,7 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                _logger.LogError(ex, "Failed to load dashboard statistics");
             }
         }
 
@@ -93,7 +98,7 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                _logger.LogError(ex, "Failed to load recent activity");
             }
         }
     }

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System;
 using ToolManagementAppV2.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -12,6 +14,7 @@ namespace ToolManagementAppV2.ViewModels
         private readonly IToolService _toolService;
         private readonly ICustomerService _customerService;
         private readonly IFileDialogService _fileDialogService;
+        private readonly ILogger<ImportExportViewModel> _logger;
 
         public IRelayCommand ImportToolsCommand { get; }
         public IRelayCommand ExportToolsCommand { get; }
@@ -22,11 +25,13 @@ namespace ToolManagementAppV2.ViewModels
 
         public ImportExportViewModel(IToolService toolService,
                                      ICustomerService customerService,
-                                     IFileDialogService fileDialogService)
+                                     IFileDialogService fileDialogService,
+                                     ILogger<ImportExportViewModel>? logger = null)
         {
             _toolService = toolService;
             _customerService = customerService;
             _fileDialogService = fileDialogService;
+            _logger = logger ?? NullLogger<ImportExportViewModel>.Instance;
             ImportToolsCommand = new RelayCommand(ImportTools);
             ExportToolsCommand = new RelayCommand(ExportTools);
             ImportCustomersCommand = new RelayCommand(ImportCustomers);
@@ -44,6 +49,7 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "Failed to import tools from {Path}", path);
                 ImportExportLogs.Add($"Failed to import tools from {path}: {ex.Message}");
             }
         }
@@ -59,6 +65,7 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "Failed to export tools to {Path}", path);
                 ImportExportLogs.Add($"Failed to export tools to {path}: {ex.Message}");
             }
         }
@@ -74,6 +81,7 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "Failed to import customers from {Path}", path);
                 ImportExportLogs.Add($"Failed to import customers from {path}: {ex.Message}");
             }
         }
@@ -89,6 +97,7 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "Failed to export customers to {Path}", path);
                 ImportExportLogs.Add($"Failed to export customers to {path}: {ex.Message}");
             }
         }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -16,6 +16,8 @@ using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.ViewModels.Rental;
 using ToolManagementAppV2.Views;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -27,6 +29,7 @@ namespace ToolManagementAppV2.ViewModels
         readonly IRentalService _rentalService;
         readonly ActivityLogService _activityLogService;
         readonly ISettingsService _settingsService;
+        readonly ILogger<MainViewModel> _logger;
 
         public ToolManagementViewModel ToolManagement { get; }
         public UserManagementViewModel UserManagement { get; }
@@ -103,7 +106,8 @@ namespace ToolManagementAppV2.ViewModels
                              IRentalService rentalService,
                              IFileDialogService fileDialogService,
                              ActivityLogService activityLogService,
-                             ISettingsService settingsService)
+                             ISettingsService settingsService,
+                             ILogger<MainViewModel>? logger = null)
         {
             _toolService = toolService;
             _userService = userService;
@@ -111,6 +115,7 @@ namespace ToolManagementAppV2.ViewModels
             _rentalService = rentalService;
             _activityLogService = activityLogService;
             _settingsService = settingsService;
+            _logger = logger ?? NullLogger<MainViewModel>.Instance;
 
             ToolManagement = new ToolManagementViewModel(toolService, customerService, rentalService, new DialogService());
             UserManagement = new UserManagementViewModel(userService, fileDialogService);
@@ -250,7 +255,11 @@ namespace ToolManagementAppV2.ViewModels
             ExitCommand = new RelayCommand(() =>
             {
                 try { System.Windows.Application.Current.Shutdown(); }
-                catch { System.Environment.Exit(0); }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to shutdown application");
+                    System.Environment.Exit(0);
+                }
             });
 
             OpenRentalHistoryWindowCommand = new RelayCommand(() =>

--- a/ToolManagementAppV2/ViewModels/RentalHistoryViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/RentalHistoryViewModel.cs
@@ -10,12 +10,15 @@ using System.Windows;
 using Microsoft.Win32;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Utilities.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.ViewModels.Rental
 {
     public class RentalHistoryViewModel : ObservableObject
     {
         private readonly List<RentalModel> _allHistory;
+        private readonly ILogger<RentalHistoryViewModel> _logger;
 
         public ObservableCollection<RentalModel> History { get; }
         public string ToolDisplayName { get; }
@@ -38,7 +41,7 @@ namespace ToolManagementAppV2.ViewModels.Rental
         public IRelayCommand ExportCsvCommand { get; }
         public IRelayCommand CloseCommand { get; }
 
-        public RentalHistoryViewModel(ToolModel? tool, IEnumerable<RentalModel>? history)
+        public RentalHistoryViewModel(ToolModel? tool, IEnumerable<RentalModel>? history, ILogger<RentalHistoryViewModel>? logger = null)
         {
             ToolDisplayName = tool != null
                 ? $"{tool.ToolNumber} - {tool.NameDescription}"
@@ -46,6 +49,7 @@ namespace ToolManagementAppV2.ViewModels.Rental
 
             _allHistory = (history ?? Enumerable.Empty<RentalModel>()).ToList();
             History = new ObservableCollection<RentalModel>(_allHistory);
+            _logger = logger ?? NullLogger<RentalHistoryViewModel>.Instance;
 
             SearchCommand = new RelayCommand(ExecuteSearch);
             ExportCsvCommand = new RelayCommand(ExportCsv);
@@ -84,9 +88,9 @@ namespace ToolManagementAppV2.ViewModels.Rental
                     if (dlg.ShowDialog() == true)
                         path = dlg.FileName;
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // ignore dialog errors in non-interactive environments
+                    _logger.LogError(ex, "Failed to show save file dialog for rental history export");
                 }
             }
 

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.ObjectModel;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Services.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -12,12 +14,14 @@ namespace ToolManagementAppV2.ViewModels
         readonly IFileDialogService _fileDialog;
         readonly ISettingsService _settingsService;
         readonly IDialogService _dialogService;
+        readonly ILogger<SettingsViewModel> _logger;
 
-        public SettingsViewModel(IFileDialogService fileDialog, ISettingsService settingsService, IDialogService dialogService)
+        public SettingsViewModel(IFileDialogService fileDialog, ISettingsService settingsService, IDialogService dialogService, ILogger<SettingsViewModel>? logger = null)
         {
             _fileDialog = fileDialog;
             _settingsService = settingsService;
             _dialogService = dialogService;
+            _logger = logger ?? NullLogger<SettingsViewModel>.Instance;
 
             var logoPath = _settingsService.GetSetting("CompanyLogoPath");
             if (!string.IsNullOrWhiteSpace(logoPath))
@@ -86,6 +90,7 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "Database connection test failed");
                 message = $"Connection failed: {ex.Message}";
                 return false;
             }

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Extensions;
 using ToolManagementAppV2.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -17,6 +19,7 @@ namespace ToolManagementAppV2.ViewModels
         private readonly ICustomerService _customerService;
         private readonly IRentalService _rentalService;
         private readonly IDialogService _dialogService;
+        private readonly ILogger<ToolManagementViewModel> _logger;
 
         public ObservableCollection<ToolModel> Tools { get; } = new();
         public ObservableCollection<ToolModel> SearchResults { get; } = new();
@@ -101,12 +104,14 @@ namespace ToolManagementAppV2.ViewModels
         public ToolManagementViewModel(IToolService toolService,
                                        ICustomerService customerService,
                                        IRentalService rentalService,
-                                       IDialogService dialogService)
+                                       IDialogService dialogService,
+                                       ILogger<ToolManagementViewModel>? logger = null)
         {
             _toolService = toolService;
             _customerService = customerService;
             _rentalService = rentalService;
             _dialogService = dialogService;
+            _logger = logger ?? NullLogger<ToolManagementViewModel>.Instance;
             SearchCommand = new AsyncRelayCommand(FilterToolsAsync);
             NewToolCommand = new AsyncRelayCommand(AddToolAsync);
             EditToolCommand = new AsyncRelayCommand(EditToolAsync, () => SelectedTool != null);
@@ -156,10 +161,12 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (InvalidOperationException ex)
             {
+                _logger.LogError(ex, "Failed to add tool due to invalid operation");
                 _dialogService.ShowInfo(ex.Message, "Error");
             }
             catch (ArgumentException ex)
             {
+                _logger.LogError(ex, "Failed to add tool due to invalid argument");
                 _dialogService.ShowInfo(ex.Message, "Error");
             }
         }

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -9,6 +9,8 @@ using ToolManagementAppV2.Utilities.Extensions;
 using ToolManagementAppV2.Utilities.Helpers;
 using ToolManagementAppV2.Views;
 using ToolManagementAppV2.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -16,6 +18,7 @@ namespace ToolManagementAppV2.ViewModels
     {
         private readonly IUserService _userService;
         private readonly IFileDialogService _fileDialogService;
+        private readonly ILogger<UserManagementViewModel> _logger;
 
         private List<UserModel> _allUsers = new();
 
@@ -55,10 +58,11 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand ResetPasswordFromRowCommand { get; }
         public IRelayCommand DeleteUserFromRowCommand { get; }
 
-        public UserManagementViewModel(IUserService userService, IFileDialogService fileDialogService)
+        public UserManagementViewModel(IUserService userService, IFileDialogService fileDialogService, ILogger<UserManagementViewModel>? logger = null)
         {
             _userService = userService;
             _fileDialogService = fileDialogService;
+            _logger = logger ?? NullLogger<UserManagementViewModel>.Instance;
             LoadUsersCommand = new RelayCommand(LoadUsers);
             UploadUserPhotoCommand = new RelayCommand(UploadUserPhoto);
             UpdateUserCommand = new RelayCommand(UpdateUser, () => SelectedUser != null);
@@ -146,9 +150,9 @@ namespace ToolManagementAppV2.ViewModels
                     }
                     return false;
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Ignore UI errors in non-interactive environments
+                    _logger.LogError(ex, "Failed to prompt for password");
                 }
             }
 
@@ -212,8 +216,10 @@ namespace ToolManagementAppV2.ViewModels
                 onCancel: () => win.Close(),
                 onRemoveAvatar: () => clone.UserPhotoPath = null);
 
-            try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
-            try { win.ShowDialog(); } catch { }
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for UsersEditWindow"); }
+            try { win.ShowDialog(); }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to show UsersEditWindow"); }
         }
 
         void ResetPasswordFor(UserModel user)

--- a/ToolManagementAppV2/ViewModels/UserViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserViewModel.cs
@@ -5,6 +5,8 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -12,6 +14,7 @@ namespace ToolManagementAppV2.ViewModels
     {
         readonly IUserService _userService;
         readonly IFileDialogService _fileDialog;
+        readonly ILogger<UsersViewModel> _logger;
 
         public ObservableCollection<User> Users { get; } = new ObservableCollection<User>();
 
@@ -27,10 +30,11 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand DeleteUserCommand { get; }
         public IRelayCommand NewUserCommand { get; }
 
-        public UsersViewModel(IUserService userService, IFileDialogService fileDialog)
+        public UsersViewModel(IUserService userService, IFileDialogService fileDialog, ILogger<UsersViewModel>? logger = null)
         {
             _userService = userService;
             _fileDialog = fileDialog;
+            _logger = logger ?? NullLogger<UsersViewModel>.Instance;
 
             BrowseUserPhotoCommand = new RelayCommand(BrowseUserPhoto);
             SaveUserCommand = new RelayCommand(SaveUser);
@@ -68,7 +72,7 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                _logger.LogError(ex, "Failed to save user");
             }
         }
 
@@ -82,7 +86,7 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                _logger.LogError(ex, "Failed to delete user");
             }
         }
 


### PR DESCRIPTION
## Summary
- inject ILogger into view models and services
- log and rethrow or handle exceptions in previously empty catch blocks
- add Microsoft.Extensions.Logging.Abstractions package

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(403 Forbidden while attempting to install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689c1e8230448324ae7949dd7825d6d0