### PR TITLE
style: improve login user card appearance

### DIFF
--- a/ToolManagementAppV2/Views/LoginWindow.xaml
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml
@@ -53,10 +53,18 @@
                                     <RowDefinition Height="140"/>
                                     <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
-                                <Border Background="#0e1420" CornerRadius="8" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1">
+                                <Border Background="#0e1420"
+                                        CornerRadius="8"
+                                        BorderBrush="{StaticResource BorderBrushAlt}"
+                                        BorderThickness="1"
+                                        ClipToBounds="True">
                                     <Image Stretch="UniformToFill" Source="{Binding UserPhotoPath}"/>
                                 </Border>
-                                <TextBlock Grid.Row="1" Text="{Binding UserName}" HorizontalAlignment="Center" Margin="0,6,0,0"/>
+                                <TextBlock Grid.Row="1"
+                                           Text="{Binding UserName}"
+                                           HorizontalAlignment="Center"
+                                           Margin="0,6,0,0"
+                                           Foreground="{StaticResource ForegroundMutedBrush}"/>
                             </Grid>
                         </Button>
                     </DataTemplate>


### PR DESCRIPTION
## Summary
- ensure user avatars in login window clip to card boundaries
- soften login user name color for better blending

## Testing
- `dotnet test` *(command failed: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689c20b9ddf4832496ea6304934a8380