### PR TITLE
Add switch user button

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Windows;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Interfaces;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class MainViewModelSwitchUserTests
+    {
+        [Fact]
+        public void SwitchUserCommand_UpdatesCurrentUser()
+        {
+            if (Application.Current == null)
+                new Application();
+
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var userService = new UserService(db, new ApplicationUserContext());
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
+
+                var newUser = new User { UserName = "newuser", IsAdmin = true };
+                Func<bool> stubLogin = () =>
+                {
+                    Application.Current.Properties["CurrentUser"] = newUser;
+                    return true;
+                };
+
+                var vm = new MainViewModel(toolService, userService, customerService, rentalService,
+                    new StubFileDialogService(), activityLogService, settingsService, null, stubLogin);
+
+                Application.Current.Properties["CurrentUser"] = new User { UserName = "old", IsAdmin = false };
+                vm.RefreshCurrentUser();
+
+                vm.SwitchUserCommand.Execute(null);
+
+                Assert.Equal("newuser", vm.CurrentUserName);
+                Assert.True(vm.IsCurrentUserAdmin);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+                Application.Current.Properties.Remove("CurrentUser");
+            }
+        }
+    }
+
+    class StubFileDialogService : IFileDialogService
+    {
+        public string OpenFile(string filter) => null;
+        public string SaveFile(string filter) => null;
+    }
+}

--- a/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
@@ -50,5 +50,37 @@ namespace ToolManagementAppV2.Tests.Views
                 throw threadException;
             }
         }
+
+        [Fact]
+        public void SwitchUserButton_BoundToSwitchUserCommand()
+        {
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var window = new ToolManagementAppV2.MainWindow();
+                    var button = (Button)window.FindName("SwitchUserButton");
+                    Assert.NotNull(button);
+
+                    var vm = Assert.IsType<MainViewModel>(window.DataContext);
+                    Assert.Same(vm.SwitchUserCommand, button.Command);
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+            {
+                throw threadException;
+            }
+        }
     }
 }

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -96,6 +96,7 @@
                             </TextBox.InputBindings>
                         </TextBox>
                         <Button Style="{StaticResource PrimaryButton}" Content="Search" Command="{Binding GlobalSearchCommand}" Margin="8,0,0,0"/>
+                        <Button x:Name="SwitchUserButton" Style="{StaticResource PrimaryButton}" Content="Switch User" Command="{Binding SwitchUserCommand}" Margin="8,0,0,0"/>
                     </StackPanel>
                 </DockPanel>
             </Border>

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -30,6 +30,7 @@ namespace ToolManagementAppV2.ViewModels
         readonly ActivityLogService _activityLogService;
         readonly ISettingsService _settingsService;
         readonly ILogger<MainViewModel> _logger;
+        readonly Func<bool> _showLoginWindow;
 
         public ToolManagementViewModel ToolManagement { get; }
         public UserManagementViewModel UserManagement { get; }
@@ -94,6 +95,7 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand OpenImageImportMappingWindowCommand { get; }
         public IRelayCommand ExitCommand { get; }
         public IRelayCommand GlobalSearchCommand { get; }
+        public IRelayCommand SwitchUserCommand { get; }
 
         public IRelayCommand OpenRentalHistoryWindowCommand { get; }
         public IRelayCommand OpenPrintPreviewWindowCommand { get; }
@@ -107,7 +109,8 @@ namespace ToolManagementAppV2.ViewModels
                              IFileDialogService fileDialogService,
                              ActivityLogService activityLogService,
                              ISettingsService settingsService,
-                             ILogger<MainViewModel>? logger = null)
+                             ILogger<MainViewModel>? logger = null,
+                             Func<bool>? showLoginWindow = null)
         {
             _toolService = toolService;
             _userService = userService;
@@ -116,6 +119,11 @@ namespace ToolManagementAppV2.ViewModels
             _activityLogService = activityLogService;
             _settingsService = settingsService;
             _logger = logger ?? NullLogger<MainViewModel>.Instance;
+            _showLoginWindow = showLoginWindow ?? (() =>
+            {
+                var login = new LoginWindow { Owner = Application.Current.MainWindow };
+                return login.ShowDialog() == true;
+            });
 
             ToolManagement = new ToolManagementViewModel(toolService, customerService, rentalService, new DialogService());
             UserManagement = new UserManagementViewModel(userService, fileDialogService);
@@ -250,6 +258,15 @@ namespace ToolManagementAppV2.ViewModels
                 OpenSearchToolsCommand.Execute(null);
                 ToolManagement.SearchCommand?.Execute(null);
                 GlobalSearchText = string.Empty;
+            });
+
+            SwitchUserCommand = new RelayCommand(() =>
+            {
+                if (_showLoginWindow())
+                {
+                    RefreshCurrentUser();
+                    OpenDashboardCommand.Execute(null);
+                }
             });
 
             ExitCommand = new RelayCommand(() =>


### PR DESCRIPTION
## Summary
- Add Switch User button to main window header for quickly re-authenticating
- Implement SwitchUserCommand and configurable login workflow in MainViewModel
- Add tests covering button binding and command-driven user refresh

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c225d76188324b640af0aeb114c79