### PR TITLE
Configure WAL mode and timeout on startup

### DIFF
--- a/ToolManagementAppV2.Tests/Services/DatabaseConnectionTests.cs
+++ b/ToolManagementAppV2.Tests/Services/DatabaseConnectionTests.cs
@@ -37,6 +37,32 @@ namespace ToolManagementAppV2.Tests.Services
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void WalModeAndBusyTimeoutConfigured()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                using var conn = dbService.CreateConnection();
+                using (var cmd = new SQLiteCommand("PRAGMA journal_mode;", conn))
+                {
+                    var mode = Convert.ToString(cmd.ExecuteScalar());
+                    Assert.Equal("wal", mode?.ToLowerInvariant());
+                }
+                using (var cmd = new SQLiteCommand("PRAGMA busy_timeout;", conn))
+                {
+                    var timeout = Convert.ToInt32(cmd.ExecuteScalar());
+                    Assert.Equal(5000, timeout);
+                }
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 }
 

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -13,24 +13,25 @@ namespace ToolManagementAppV2.Services.Core
 
         public SQLiteConnection CreateConnection()
         {
-            var connStr = $"{ConnectionString}Pooling=True;Cache=Shared;";
-            var conn = new SQLiteConnection(connStr);
+            var conn = new SQLiteConnection(ConnectionString);
             conn.Open();
-            using (var cmd = new SQLiteCommand("PRAGMA journal_mode=WAL;", conn))
-            {
-                cmd.ExecuteNonQuery();
-            }
-            using (var cmd = new SQLiteCommand("PRAGMA busy_timeout=5000;", conn))
-            {
-                cmd.ExecuteNonQuery();
-            }
             return conn;
         }
 
         public DatabaseService(string dbPath, ILogger<DatabaseService>? logger = null)
         {
-            ConnectionString = $"Data Source={dbPath};Version=3;";
+            var builder = new SQLiteConnectionStringBuilder
+            {
+                DataSource = dbPath,
+                Version = 3,
+                Pooling = true,
+                BusyTimeout = 5000,
+                JournalMode = SQLiteJournalModeEnum.Wal
+            };
+            builder["Cache"] = "Shared";
+            ConnectionString = builder.ToString();
             _logger = logger ?? NullLogger<DatabaseService>.Instance;
+            ConfigureDatabase();
             InitializeDatabase();
             EnsureColumn("Tools", "ToolNumber", "TEXT");
             EnsureColumn("Tools", "NameDescription", "TEXT");
@@ -47,6 +48,16 @@ namespace ToolManagementAppV2.Services.Core
             EnsureColumn("Users", "Role", "TEXT");
             EnsureColumn("Users", "IsActive", "INTEGER");
             EnsureColumn("Users", "CreatedAt", "DATETIME");
+        }
+
+        void ConfigureDatabase()
+        {
+            using var conn = new SQLiteConnection(ConnectionString);
+            conn.Open();
+            using var cmd = new SQLiteCommand("PRAGMA journal_mode=WAL;", conn);
+            cmd.ExecuteNonQuery();
+            using var timeout = new SQLiteCommand("PRAGMA busy_timeout=5000;", conn);
+            timeout.ExecuteNonQuery();
         }
 
         void InitializeDatabase()


### PR DESCRIPTION
## Summary
- configure SQLite connection with WAL journal mode and busy timeout
- initialize WAL and timeout once during database startup
- test that WAL mode and timeout are applied

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c24d380d48324a9dac2816d20260c