### PR TITLE
Introduce shared IUserContext and update authentication

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -35,14 +35,15 @@ namespace ToolManagementAppV2.Tests.Tests
             {
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
-                IUserService userService = new UserService(db, new ApplicationUserContext());
+                var userContext = new ApplicationUserContext();
+                IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.OpenSearchToolsCommand.Execute(null);
 
                 var page = Assert.IsType<ToolSearchPage>(vm.CurrentPage);

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -24,24 +24,23 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                var userService = new UserService(dbService, new ApplicationUserContext());
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(dbService, userContext);
                 userService.AddUser(new User { UserName = "user", Password = "newpassword", IsAdmin = false });
 
-                var vm = new LoginViewModel(new StubDialogService(), dbPath);
+                var vm = new LoginViewModel(new StubDialogService(), userContext, dbPath);
                 bool success = false;
                 vm.LoginSucceeded += (_, __) => success = true;
 
                 vm.SelectUserCommand.Execute(vm.Users.First());
 
                 Assert.True(success);
-                var current = Application.Current.Properties["CurrentUser"] as User;
-                Assert.NotNull(current);
-                Assert.Equal("user", current.UserName);
+                Assert.NotNull(userContext.CurrentUser);
+                Assert.Equal("user", userContext.UserName);
             }
             finally
             {
                 if (File.Exists(dbPath)) File.Delete(dbPath);
-                Application.Current.Properties.Remove("CurrentUser");
             }
         }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -26,13 +26,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 var toolService = new ToolService(db);
-                var userService = new UserService(db, new ApplicationUserContext());
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
 
                 bool raised = false;
                 vm.PropertyChanged += (s, e) =>
@@ -41,14 +42,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
                         raised = true;
                 };
 
-                Application.Current.Properties["CurrentUser"] = new User { UserName = "admin", IsAdmin = true };
+                userContext.CurrentUser = new User { UserName = "admin", IsAdmin = true };
                 vm.RefreshCurrentUser();
 
                 Assert.True(raised);
                 Assert.True(vm.IsCurrentUserAdmin);
 
                 raised = false;
-                Application.Current.Properties["CurrentUser"] = new User { UserName = "user", IsAdmin = false };
+                userContext.CurrentUser = new User { UserName = "user", IsAdmin = false };
                 vm.RefreshCurrentUser();
 
                 Assert.True(raised);
@@ -58,7 +59,6 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 if (File.Exists(dbPath))
                     File.Delete(dbPath);
-                Application.Current.Properties.Remove("CurrentUser");
             }
         }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -27,13 +27,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
-                IUserService userService = new UserService(db, new ApplicationUserContext());
+                var userContext = new ApplicationUserContext();
+                IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
 
                 Assert.NotNull(vm.ToolManagement);
                 Assert.NotNull(vm.UserManagement);
@@ -58,13 +59,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
-                IUserService userService = new UserService(db, new ApplicationUserContext());
+                var userContext = new ApplicationUserContext();
+                IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.OpenDashboardCommand.Execute(null);
 
                 var page = Assert.IsType<DashboardPage>(vm.CurrentPage);
@@ -85,13 +87,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
-                IUserService userService = new UserService(db, new ApplicationUserContext());
+                var userContext = new ApplicationUserContext();
+                IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.OpenImportExportCommand.Execute(null);
 
                 var page = Assert.IsType<ImportExportPage>(vm.CurrentPage);
@@ -114,12 +117,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 activityLogService.LogAction(1, "user", "action");
                 IToolService toolService = new ToolService(db);
-                IUserService userService = new UserService(db, new ApplicationUserContext());
+                var userContext = new ApplicationUserContext();
+                IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.OpenActivityLogsCommand.Execute(null);
 
                 var page = Assert.IsType<ActivityLogsPage>(vm.CurrentPage);
@@ -142,12 +146,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var db = new DatabaseService(dbPath);
                 var activityLogService = new ActivityLogService(db);
                 IToolService toolService = new ToolService(db);
-                IUserService userService = new UserService(db, new ApplicationUserContext());
+                var userContext = new ApplicationUserContext();
+                IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.OpenReportsCommand.Execute(null);
 
                 var page = Assert.IsType<ReportsPage>(vm.CurrentPage);
@@ -169,13 +174,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
-                IUserService userService = new UserService(db, new ApplicationUserContext());
+                var userContext = new ApplicationUserContext();
+                IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.OpenSettingsCommand.Execute(null);
 
                 var page = Assert.IsType<SettingsPage>(vm.CurrentPage);
@@ -201,13 +207,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
-                IUserService userService = new UserService(db, new ApplicationUserContext());
+                var userContext = new ApplicationUserContext();
+                IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.OpenRentalsCommand.Execute(null);
 
                 var page = Assert.IsType<ManageRentalsPage>(vm.CurrentPage);
@@ -228,7 +235,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
-                IUserService userService = new UserService(db, new ApplicationUserContext());
+                var userContext = new ApplicationUserContext();
+                IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
@@ -237,7 +245,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw" });
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.GlobalSearchText = "Ham";
 
                 vm.GlobalSearchCommand.Execute(null);
@@ -263,13 +271,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
-                IUserService userService = new UserService(db, new ApplicationUserContext());
+                var userContext = new ApplicationUserContext();
+                IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 vm.OpenImportMappingWindowCommand.Execute(null);
             }
             finally
@@ -287,13 +296,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
-                IUserService userService = new UserService(db, new ApplicationUserContext());
+                var userContext = new ApplicationUserContext();
+                IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
                 Assert.NotNull(vm.OpenImageImportMappingWindowCommand);
             }
             finally

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -27,7 +27,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 var toolService = new ToolService(db);
-                var userService = new UserService(db, new ApplicationUserContext());
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
@@ -36,14 +37,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var newUser = new User { UserName = "newuser", IsAdmin = true };
                 Func<bool> stubLogin = () =>
                 {
-                    Application.Current.Properties["CurrentUser"] = newUser;
+                    userContext.CurrentUser = newUser;
                     return true;
                 };
 
-                var vm = new MainViewModel(toolService, userService, customerService, rentalService,
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
                     new StubFileDialogService(), activityLogService, settingsService, null, stubLogin);
 
-                Application.Current.Properties["CurrentUser"] = new User { UserName = "old", IsAdmin = false };
+                userContext.CurrentUser = new User { UserName = "old", IsAdmin = false };
                 vm.RefreshCurrentUser();
 
                 vm.SwitchUserCommand.Execute(null);
@@ -55,7 +56,6 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 if (File.Exists(dbPath))
                     File.Delete(dbPath);
-                Application.Current.Properties.Remove("CurrentUser");
             }
         }
     }

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -32,13 +32,13 @@ namespace ToolManagementAppV2
 
             var main = new MainWindow
             {
-                DataContext = new MainViewModel(toolService, userService, customerService, rentalService, fileDialogService, activityLogService, settingsService)
+                DataContext = new MainViewModel(toolService, userService, userContext, customerService, rentalService, fileDialogService, activityLogService, settingsService)
             };
 
             Current.MainWindow = main;
             main.Show(); // stays visible behind login
 
-            var login = new LoginWindow
+            var login = new LoginWindow(userContext)
             {
                 Owner = main,
                 WindowStartupLocation = WindowStartupLocation.CenterOwner

--- a/ToolManagementAppV2/Interfaces/IUserContext.cs
+++ b/ToolManagementAppV2/Interfaces/IUserContext.cs
@@ -5,5 +5,11 @@ namespace ToolManagementAppV2.Interfaces
     public interface IUserContext
     {
         User? CurrentUser { get; set; }
+
+        bool IsAdmin { get; }
+
+        string UserName { get; }
+
+        string Role { get; }
     }
 }

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -28,7 +28,7 @@ namespace ToolManagementAppV2
             var fileDialogService = new FileDialogService();
             var settingsService = new SettingsService(db);
 
-            DataContext = new MainViewModel(toolService, userService, customerService, rentalService, fileDialogService, activityLogService, settingsService);
+            DataContext = new MainViewModel(toolService, userService, userContext, customerService, rentalService, fileDialogService, activityLogService, settingsService);
         }
     }
 }

--- a/ToolManagementAppV2/Services/Users/ApplicationUserContext.cs
+++ b/ToolManagementAppV2/Services/Users/ApplicationUserContext.cs
@@ -20,5 +20,11 @@ namespace ToolManagementAppV2.Services.Users
                     System.Windows.Application.Current.Properties[Key] = value;
             }
         }
+
+        public bool IsAdmin => CurrentUser?.IsAdmin ?? false;
+
+        public string UserName => CurrentUser?.UserName ?? "Guest";
+
+        public string Role => IsAdmin ? "Admin" : "User";
     }
 }

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -30,6 +30,7 @@ namespace ToolManagementAppV2.ViewModels
         readonly IUserService _userService;
         readonly ISettingsService _settingsService;
         readonly IDialogService _dialogService;
+        readonly IUserContext _userContext;
 
         public ObservableCollection<User> Users { get; } = new();
 
@@ -52,17 +53,18 @@ namespace ToolManagementAppV2.ViewModels
 
         /// <summary>
         /// Raised after <see cref="OnUserSelected"/> successfully authenticates a user
-        /// and stores the result in <see cref="Application.Current"/>.
+        /// and stores the result in <see cref="IUserContext"/>.
         /// </summary>
         public event EventHandler? LoginSucceeded;
 
-        public LoginViewModel(IDialogService dialogService, string? dbPath = null)
+        public LoginViewModel(IDialogService dialogService, IUserContext userContext, string? dbPath = null)
         {
             dbPath ??= Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db");
             var dbService = new DatabaseService(dbPath);
             _settingsService = new SettingsService(dbService);
-            _userService = new UserService(dbService, new ApplicationUserContext());
+            _userService = new UserService(dbService, userContext);
             _dialogService = dialogService;
+            _userContext = userContext;
 
             CompanyLogo = LoadLogo();
             WindowTitle = GetWindowTitle();
@@ -127,7 +129,7 @@ namespace ToolManagementAppV2.ViewModels
         /// Ensures administrators always have a default password, allows first-time
         /// non-admin users to log in with a generated password, prompts for existing
         /// passwords and supports resetting credentials back to the default "admin".
-        /// Successful authentication stores the user in <see cref="Application.Current"/>
+        /// Successful authentication stores the user in the shared context
         /// and raises <see cref="LoginSucceeded"/>.
         /// </summary>
         /// <param name="user">The account to authenticate.</param>
@@ -147,7 +149,7 @@ namespace ToolManagementAppV2.ViewModels
                 (string.IsNullOrWhiteSpace(user.Password) ||
                  SecurityHelper.VerifyPassword("newpassword", user.Salt, user.Password)))
             {
-                System.Windows.Application.Current.Properties["CurrentUser"] = user;
+                _userContext.CurrentUser = user;
                 LoginSucceeded?.Invoke(this, EventArgs.Empty);
                 return;
             }
@@ -178,7 +180,7 @@ namespace ToolManagementAppV2.ViewModels
                 var credential = _userService.AuthenticateUser(user.UserName, prompt.EnteredPassword);
                 if (credential != null)
                 {
-                    System.Windows.Application.Current.Properties["CurrentUser"] = credential;
+                    _userContext.CurrentUser = credential;
                     LoginSucceeded?.Invoke(this, EventArgs.Empty);
                     passwordValidated = true;
                 }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -25,6 +25,7 @@ namespace ToolManagementAppV2.ViewModels
     {
         readonly IToolService _toolService;
         readonly IUserService _userService;
+        readonly IUserContext _userContext;
         readonly ICustomerService _customerService;
         readonly IRentalService _rentalService;
         readonly ActivityLogService _activityLogService;
@@ -65,14 +66,11 @@ namespace ToolManagementAppV2.ViewModels
             set => SetProperty(ref _globalSearchText, value);
         }
 
-        public bool IsCurrentUserAdmin =>
-            System.Windows.Application.Current.Properties["CurrentUser"] is User u && u.IsAdmin;
+        public bool IsCurrentUserAdmin => _userContext.IsAdmin;
 
-        public string CurrentUserName =>
-            (System.Windows.Application.Current.Properties["CurrentUser"] as User)?.UserName ?? "Guest";
+        public string CurrentUserName => _userContext.UserName;
 
-        public string CurrentUserRole =>
-            IsCurrentUserAdmin ? "Admin" : "User";
+        public string CurrentUserRole => _userContext.Role;
 
         public void RefreshCurrentUser()
         {
@@ -104,6 +102,7 @@ namespace ToolManagementAppV2.ViewModels
 
         public MainViewModel(IToolService toolService,
                              IUserService userService,
+                             IUserContext userContext,
                              ICustomerService customerService,
                              IRentalService rentalService,
                              IFileDialogService fileDialogService,
@@ -114,6 +113,7 @@ namespace ToolManagementAppV2.ViewModels
         {
             _toolService = toolService;
             _userService = userService;
+            _userContext = userContext;
             _customerService = customerService;
             _rentalService = rentalService;
             _activityLogService = activityLogService;
@@ -121,7 +121,7 @@ namespace ToolManagementAppV2.ViewModels
             _logger = logger ?? NullLogger<MainViewModel>.Instance;
             _showLoginWindow = showLoginWindow ?? (() =>
             {
-                var login = new LoginWindow { Owner = Application.Current.MainWindow };
+                var login = new LoginWindow(_userContext) { Owner = Application.Current.MainWindow };
                 return login.ShowDialog() == true;
             });
 

--- a/ToolManagementAppV2/Views/LoginWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml.cs
@@ -3,20 +3,18 @@ using System;
 using System.Windows;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Services;
+using ToolManagementAppV2.Interfaces;
 
 namespace ToolManagementAppV2
 {
     public partial class LoginWindow : Window
     {
-        public LoginWindow()
+        public LoginWindow(IUserContext? userContext = null, IDialogService? dialogService = null)
         {
             InitializeComponent();
 
-            if (DataContext is not LoginViewModel vm)
-            {
-                vm = new LoginViewModel(new DialogService());
-                DataContext = vm;
-            }
+            var vm = new LoginViewModel(dialogService ?? new DialogService(), userContext ?? new ApplicationUserContext());
+            DataContext = vm;
 
             vm.LoginSucceeded += OnLoginSucceeded;
             Closed += (_, __) => vm.LoginSucceeded -= OnLoginSucceeded;


### PR DESCRIPTION
## Summary
- expand `IUserContext` to expose current user, admin flag, name and role
- refactor view models and login flow to use `IUserContext` instead of `Application.Current`
- wire up shared `IUserContext` in app startup and window constructors
- adjust unit tests for new `IUserContext` dependency

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c288c5e74832481ca3c737f6f0093