### PR TITLE
Implement disposable database service and update consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ This project adheres to the rules in `AGENTS.md`, including:
 - Running `dotnet test` before commits and updating tests for new functionality.
 - Summarizing changes and referencing test results in pull requests.
 
+### Resource Management
+`DatabaseService` implements `IDisposable` and should be disposed when no longer in use.
+`MainWindow` accepts an optional `DatabaseService` in its constructor when an external
+`MainViewModel` is supplied; pass the instance to have the window dispose it on close.
+Otherwise, register the service with a DI container so scoped lifetimes handle disposal
+automatically, or explicitly call `Dispose`/`using` in the application startup and tests.
+

--- a/ToolManagementAppV2.Tests/Tests/AdminButtonVisibilityTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/AdminButtonVisibilityTests.cs
@@ -29,6 +29,7 @@ namespace ToolManagementAppV2.Tests.Tests
                     .Any(b => b.Visibility == Visibility.Visible);
 
                 Assert.False(anyVisible);
+                window.Close();
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Tests/LoginWindowLayoutTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/LoginWindowLayoutTests.cs
@@ -1,8 +1,13 @@
+using System;
+using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Services.Settings;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.Tests
@@ -12,19 +17,30 @@ namespace ToolManagementAppV2.Tests.Tests
         [Fact]
         public void UsersListBox_UsesHorizontalStackPanel()
         {
-            var window = new LoginWindow();
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            using var db = new DatabaseService(dbPath);
+            var userContext = new ApplicationUserContext();
+            var userService = new UserService(db, userContext);
+            var settingsService = new SettingsService(db);
+            var window = new LoginWindow(userContext, userService, settingsService);
             var panel = window.UsersListBox.ItemsPanel.LoadContent();
             var stackPanel = Assert.IsType<VirtualizingStackPanel>(panel);
             Assert.Equal(Orientation.Horizontal, stackPanel.Orientation);
             Assert.Equal(ScrollBarVisibility.Auto, ScrollViewer.GetHorizontalScrollBarVisibility(window.UsersListBox));
             Assert.Equal(ScrollBarVisibility.Disabled, ScrollViewer.GetVerticalScrollBarVisibility(window.UsersListBox));
             Assert.True(VirtualizingStackPanel.GetIsVirtualizing(window.UsersListBox));
+            window.Close();
         }
 
         [Fact]
         public void UsersListBox_VirtualizesLargeCollections()
         {
-            var window = new LoginWindow();
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            using var db = new DatabaseService(dbPath);
+            var userContext = new ApplicationUserContext();
+            var userService = new UserService(db, userContext);
+            var settingsService = new SettingsService(db);
+            var window = new LoginWindow(userContext, userService, settingsService);
             window.UsersListBox.ItemsSource = Enumerable.Range(0, 1000)
                 .Select(i => new User { UserID = i, UserName = $"User {i}" })
                 .ToList();
@@ -35,6 +51,7 @@ namespace ToolManagementAppV2.Tests.Tests
 
             Assert.NotNull(window.UsersListBox.ItemContainerGenerator.ContainerFromIndex(0));
             Assert.Null(window.UsersListBox.ItemContainerGenerator.ContainerFromIndex(999));
+            window.Close();
         }
     }
 }

--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -25,6 +25,7 @@ namespace ToolManagementAppV2.Tests.Tests
             vm.OpenSearchToolsCommand.Execute(null);
 
             Assert.IsType<ToolSearchPage>(vm.CurrentPage);
+            window.Close();
         }
 
         [Fact]
@@ -33,7 +34,7 @@ namespace ToolManagementAppV2.Tests.Tests
             var dbPath = Path.GetTempFileName();
             try
             {
-                var db = new DatabaseService(dbPath);
+                using var db = new DatabaseService(dbPath);
                 IToolService toolService = new ToolService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -6,6 +6,7 @@ using System.Windows;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Interfaces;
 using Xunit;
@@ -23,12 +24,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
             try
             {
-                var dbService = new DatabaseService(dbPath);
+                using var dbService = new DatabaseService(dbPath);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(dbService, userContext);
+                var settingsService = new SettingsService(dbService);
                 userService.AddUser(new User { UserName = "user", Password = "newpassword", IsAdmin = false });
 
-                var vm = new LoginViewModel(new StubDialogService(), userContext, dbPath);
+                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext);
                 bool success = false;
                 vm.LoginSucceeded += (_, __) => success = true;
 

--- a/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
@@ -5,6 +5,9 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
+using System.IO;
+using System.Runtime.Serialization;
+using ToolManagementAppV2.Services.Core;
 
 namespace ToolManagementAppV2.Tests.Views
 {
@@ -80,6 +83,51 @@ namespace ToolManagementAppV2.Tests.Views
             if (threadException != null)
             {
                 throw threadException;
+            }
+        }
+
+        [Fact]
+        public void DisposesOwnedDatabaseServiceWhenClosed()
+        {
+            Exception? threadException = null;
+            var disposed = false;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var db = new TestDb(() => disposed = true);
+                    var vm = (MainViewModel)FormatterServices.GetUninitializedObject(typeof(MainViewModel));
+                    var window = new ToolManagementAppV2.MainWindow(vm, db);
+                    window.Close();
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+            {
+                throw threadException;
+            }
+
+            Assert.True(disposed);
+        }
+
+        class TestDb : DatabaseService
+        {
+            readonly Action _onDispose;
+            public TestDb(Action onDispose) : base(Path.GetTempFileName()) => _onDispose = onDispose;
+
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+                if (disposing) _onDispose();
             }
         }
     }

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -30,15 +30,13 @@ namespace ToolManagementAppV2
             var fileDialogService = new FileDialogService();
             var settingsService = new SettingsService(db);
 
-            var main = new MainWindow
-            {
-                DataContext = new MainViewModel(toolService, userService, userContext, customerService, rentalService, fileDialogService, activityLogService, settingsService)
-            };
+            var mainVm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, fileDialogService, activityLogService, settingsService);
+            var main = new MainWindow(mainVm, db);
 
             Current.MainWindow = main;
             main.Show(); // stays visible behind login
 
-            var login = new LoginWindow(userContext)
+            var login = new LoginWindow(userContext, userService, settingsService)
             {
                 Owner = main,
                 WindowStartupLocation = WindowStartupLocation.CenterOwner

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -14,21 +14,49 @@ namespace ToolManagementAppV2
 {
     public partial class MainWindow : Window
     {
-        public MainWindow()
+        readonly DatabaseService? _ownedDb;
+
+        /// <summary>
+        /// Creates a <see cref="MainWindow"/> with its own internally managed services.
+        /// The window owns the database service and will dispose it when closed.
+        /// </summary>
+        public MainWindow() : this(null, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a <see cref="MainWindow"/> with a supplied <paramref name="viewModel"/>.
+        /// When <paramref name="ownedDatabaseService"/> is provided, the window will dispose it
+        /// upon closing. If <c>null</c>, the caller is responsible for managing the database
+        /// service's lifetime.
+        /// </summary>
+        /// <param name="viewModel">Optional view model to use as the window's data context.</param>
+        /// <param name="ownedDatabaseService">Database service owned by the window; disposed on close.</param>
+        public MainWindow(MainViewModel? viewModel, DatabaseService? ownedDatabaseService = null)
         {
             InitializeComponent();
 
-            var db = new DatabaseService(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db"));
-            var toolService = new ToolService(db);
-            var customerService = new CustomerService(db);
-            var userContext = new ApplicationUserContext();
-            var userService = new UserService(db, userContext);
-            var rentalService = new RentalService(db, toolService);
-            var activityLogService = new ActivityLogService(db);
-            var fileDialogService = new FileDialogService();
-            var settingsService = new SettingsService(db);
+            if (viewModel != null)
+            {
+                DataContext = viewModel;
+                _ownedDb = ownedDatabaseService;
+            }
+            else
+            {
+                _ownedDb = new DatabaseService(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db"));
+                var toolService = new ToolService(_ownedDb);
+                var customerService = new CustomerService(_ownedDb);
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(_ownedDb, userContext);
+                var rentalService = new RentalService(_ownedDb, toolService);
+                var activityLogService = new ActivityLogService(_ownedDb);
+                var fileDialogService = new FileDialogService();
+                var settingsService = new SettingsService(_ownedDb);
 
-            DataContext = new MainViewModel(toolService, userService, userContext, customerService, rentalService, fileDialogService, activityLogService, settingsService);
+                DataContext = new MainViewModel(toolService, userService, userContext, customerService, rentalService, fileDialogService, activityLogService, settingsService);
+            }
+
+            Closed += (_, __) => _ownedDb?.Dispose();
         }
     }
 }

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -6,10 +6,15 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.Services.Core
 {
-    public class DatabaseService
+    /// <summary>
+    /// Provides SQLite database access for the application. Instances should be
+    /// disposed when no longer needed to release pooled connections.
+    /// </summary>
+    public class DatabaseService : IDisposable
     {
         public string ConnectionString { get; }
         private readonly ILogger<DatabaseService> _logger;
+        bool _disposed;
 
         public SQLiteConnection CreateConnection()
         {
@@ -48,6 +53,27 @@ namespace ToolManagementAppV2.Services.Core
             EnsureColumn("Users", "Role", "TEXT");
             EnsureColumn("Users", "IsActive", "INTEGER");
             EnsureColumn("Users", "CreatedAt", "DATETIME");
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+            if (disposing)
+            {
+                SQLiteConnection.ClearAllPools();
+            }
+            _disposed = true;
+        }
+
+        ~DatabaseService()
+        {
+            Dispose(false);
         }
 
         void ConfigureDatabase()

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -8,7 +8,6 @@ using System.Windows.Input;
 using System.Windows.Media.Imaging;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
-using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Utilities.Extensions;
@@ -57,12 +56,10 @@ namespace ToolManagementAppV2.ViewModels
         /// </summary>
         public event EventHandler? LoginSucceeded;
 
-        public LoginViewModel(IDialogService dialogService, IUserContext userContext, string? dbPath = null)
+        public LoginViewModel(IUserService userService, ISettingsService settingsService, IDialogService dialogService, IUserContext userContext)
         {
-            dbPath ??= Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db");
-            var dbService = new DatabaseService(dbPath);
-            _settingsService = new SettingsService(dbService);
-            _userService = new UserService(dbService, userContext);
+            _settingsService = settingsService;
+            _userService = userService;
             _dialogService = dialogService;
             _userContext = userContext;
 

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -121,7 +121,10 @@ namespace ToolManagementAppV2.ViewModels
             _logger = logger ?? NullLogger<MainViewModel>.Instance;
             _showLoginWindow = showLoginWindow ?? (() =>
             {
-                var login = new LoginWindow(_userContext) { Owner = Application.Current.MainWindow };
+                var login = new LoginWindow(_userContext, _userService, _settingsService)
+                {
+                    Owner = Application.Current.MainWindow
+                };
                 return login.ShowDialog() == true;
             });
 

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -83,7 +83,7 @@ namespace ToolManagementAppV2.ViewModels
         {
             try
             {
-                var db = new DatabaseService(ConnectionString);
+                using var db = new DatabaseService(ConnectionString);
                 using var conn = db.CreateConnection();
                 message = "Connection successful.";
                 return true;

--- a/ToolManagementAppV2/Views/AvatarSelectionWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/AvatarSelectionWindow.xaml.cs
@@ -20,7 +20,7 @@ namespace ToolManagementAppV2.Views
             InitializeComponent();
 
             var dbPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db");
-            var dbService = new DatabaseService(dbPath);
+            using var dbService = new DatabaseService(dbPath);
             var settingsService = new SettingsService(dbService);
             var appName = settingsService.GetSetting("ApplicationName");
             if (!string.IsNullOrWhiteSpace(appName))

--- a/ToolManagementAppV2/Views/LoginWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml.cs
@@ -3,6 +3,8 @@ using System.Windows;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Services;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Services.Settings;
 
 namespace ToolManagementAppV2
 {
@@ -17,12 +19,14 @@ namespace ToolManagementAppV2
         /// Initializes a new instance of the <see cref="LoginWindow"/> class.
         /// </summary>
         /// <param name="userContext">Context containing information about the current user.</param>
+        /// <param name="userService">Service used for user operations.</param>
+        /// <param name="settingsService">Service used for application settings.</param>
         /// <param name="dialogService">Optional dialog service used by the view model.</param>
-        public LoginWindow(IUserContext? userContext = null, IDialogService? dialogService = null)
+        public LoginWindow(IUserContext userContext, IUserService userService, ISettingsService settingsService, IDialogService? dialogService = null)
         {
             InitializeComponent();
 
-            var vm = new LoginViewModel(dialogService ?? new DialogService(), userContext ?? new ApplicationUserContext());
+            var vm = new LoginViewModel(userService, settingsService, dialogService ?? new DialogService(), userContext);
             DataContext = vm;
 
             vm.LoginSucceeded += OnLoginSucceeded;


### PR DESCRIPTION
## Summary
- clarify MainWindow's responsibility for disposing an owned DatabaseService
- pass the database service to MainWindow during app startup and document ownership expectations
- add unit test verifying the window disposes an owned DatabaseService

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c2aef38508324b4f3cf94493ea53f