### PR TITLE
Add explicit power tool classification

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -55,7 +55,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var dialog = new StubDialogService();
                 var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
-                toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Cordless Drill" });
+                toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Cordless Drill", IsPowerTool = true });
                 vm.SearchTerm = string.Empty;
                 await vm.SearchCommand.ExecuteAsync(null);
                 Assert.Single(vm.HandTools);
@@ -154,6 +154,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 vm.NewTool.QuantityOnHand = 5;
                 vm.NewTool.Supplier = "ABC";
                 vm.NewTool.Notes = "Note";
+                vm.NewTool.IsPowerTool = true;
                 await vm.NewToolCommand.ExecuteAsync(null);
                 var tools = toolService.GetAllTools();
                 Assert.Single(tools);
@@ -166,6 +167,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 Assert.Equal(5, tool.QuantityOnHand);
                 Assert.Equal("ABC", tool.Supplier);
                 Assert.Equal("Note", tool.Notes);
+                Assert.True(tool.IsPowerTool);
             }
             finally
             {

--- a/ToolManagementAppV2/Models/Domain/Tool.cs
+++ b/ToolManagementAppV2/Models/Domain/Tool.cs
@@ -100,6 +100,13 @@ namespace ToolManagementAppV2.Models.Domain
             set => SetProperty(ref _keywords, value);
         }
 
+        private bool _isPowerTool;
+        public bool IsPowerTool
+        {
+            get => _isPowerTool;
+            set => SetProperty(ref _isPowerTool, value);
+        }
+
         private bool _isCheckedOut;
         public bool IsCheckedOut
         {

--- a/ToolManagementAppV2/Services/Core/CsvHelper.cs
+++ b/ToolManagementAppV2/Services/Core/CsvHelper.cs
@@ -43,7 +43,8 @@ namespace ToolManagementAppV2.Utilities.IO
                     Supplier = GetMapped(cols, headers, map, "Supplier"),
                     PurchasedDate = TryParseDate(GetMapped(cols, headers, map, "PurchasedDate")),
                     Notes = GetMapped(cols, headers, map, "Notes"),
-                    QuantityOnHand = TryParseInt(GetMapped(cols, headers, map, "AvailableQuantity"))
+                    QuantityOnHand = TryParseInt(GetMapped(cols, headers, map, "AvailableQuantity")),
+                    IsPowerTool = TryParseBool(GetMapped(cols, headers, map, "IsPowerTool"))
                 });
             }
 
@@ -54,7 +55,7 @@ namespace ToolManagementAppV2.Utilities.IO
         {
             var lines = new List<string>
             {
-                "ToolNumber,NameDescription,Location,Brand,PartNumber,Supplier,PurchasedDate,Notes,AvailableQuantity"
+                "ToolNumber,NameDescription,Location,Brand,PartNumber,Supplier,PurchasedDate,Notes,AvailableQuantity,IsPowerTool"
             };
             lines.AddRange(tools.Select(t =>
                 string.Join(",",
@@ -66,7 +67,8 @@ namespace ToolManagementAppV2.Utilities.IO
                     Quote(t.Supplier),
                     Quote(t.PurchasedDate?.ToString("yyyy-MM-dd")),
                     Quote(t.Notes),
-                    Quote(t.QuantityOnHand.ToString()))));
+                    Quote(t.QuantityOnHand.ToString()),
+                    Quote(t.IsPowerTool ? "1" : "0"))));
             File.WriteAllLines(filePath, lines);
         }
 
@@ -125,6 +127,9 @@ namespace ToolManagementAppV2.Utilities.IO
 
         private static int TryParseInt(string input) =>
             int.TryParse(input, out var result) ? result : 0;
+
+        private static bool TryParseBool(string input) =>
+            input != null && (input.Equals("1") || bool.TryParse(input, out var b) && b);
 
         private static DateTime? TryParseDate(string input) =>
             DateTime.TryParse(input, out var result) ? result : null;

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -44,6 +44,7 @@ namespace ToolManagementAppV2.Services.Core
             EnsureColumn("Tools", "CheckedOutBy", "TEXT");
             EnsureColumn("Tools", "CheckedOutTime", "DATETIME");
             EnsureColumn("Tools", "Keywords", "TEXT");
+            EnsureColumn("Tools", "IsPowerTool", "INTEGER");
             EnsureColumn("Users", "Password", "TEXT");
             EnsureColumn("Users", "Salt", "TEXT");
             EnsureColumn("Users", "Email", "TEXT");
@@ -102,6 +103,7 @@ namespace ToolManagementAppV2.Services.Core
                     Notes TEXT,
                     AvailableQuantity INTEGER NOT NULL DEFAULT 0,
                     RentedQuantity INTEGER NOT NULL DEFAULT 0,
+                    IsPowerTool INTEGER NOT NULL DEFAULT 0,
                     IsCheckedOut INTEGER NOT NULL DEFAULT 0,
                     CheckedOutBy TEXT,
                     CheckedOutTime DATETIME

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -23,8 +23,8 @@ namespace ToolManagementAppV2.Services.Tools
         const string AllToolsSql = "SELECT * FROM Tools";
         const string UpsertToolCsv = @"
             INSERT INTO Tools
-              (ToolNumber, NameDescription, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity, RentedQuantity, ToolImagePath, IsCheckedOut)
-            VALUES (@ToolNumber,@Desc,@Loc,@Brand,@PN,@Sup,@PD,@Notes,@Keywords,@Avail,@Rent,@Img,0);
+              (ToolNumber, NameDescription, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity, RentedQuantity, ToolImagePath, IsCheckedOut, IsPowerTool)
+            VALUES (@ToolNumber,@Desc,@Loc,@Brand,@PN,@Sup,@PD,@Notes,@Keywords,@Avail,@Rent,@Img,0,@Power);
             SELECT last_insert_rowid();";
     
         readonly ILogger<ToolService> _logger;
@@ -110,6 +110,7 @@ namespace ToolManagementAppV2.Services.Tools
                   Keywords = @Keywords,
                   AvailableQuantity = @Avail,
                   RentedQuantity = @Rent,
+                  IsPowerTool = @Power,
                   IsCheckedOut = @Out,
                   CheckedOutBy = @By,
                   CheckedOutTime = @Time,
@@ -129,6 +130,7 @@ namespace ToolManagementAppV2.Services.Tools
                 new SQLiteParameter("@Keywords", (object)tool.Keywords ?? DBNull.Value),
                 new SQLiteParameter("@Avail", tool.QuantityOnHand),
                 new SQLiteParameter("@Rent", tool.RentedQuantity),
+                new SQLiteParameter("@Power", tool.IsPowerTool ? 1 : 0),
                 new SQLiteParameter("@Out", tool.IsCheckedOut ? 1 : 0),
                 new SQLiteParameter("@By", (object)tool.CheckedOutBy ?? DBNull.Value),
                 new SQLiteParameter("@Time", (object)tool.CheckedOutTime ?? DBNull.Value),
@@ -272,7 +274,8 @@ namespace ToolManagementAppV2.Services.Tools
                 new SQLiteParameter("@Keywords", (object)tool.Keywords ?? DBNull.Value),
                 new SQLiteParameter("@Avail", tool.QuantityOnHand),
                 new SQLiteParameter("@Rent", tool.RentedQuantity),
-                new SQLiteParameter("@Img", (object)tool.ToolImagePath ?? DBNull.Value)
+                new SQLiteParameter("@Img", (object)tool.ToolImagePath ?? DBNull.Value),
+                new SQLiteParameter("@Power", tool.IsPowerTool ? 1 : 0)
             };
             using var cmd = new SQLiteCommand(UpsertToolCsv, conn, tran);
             cmd.Parameters.AddRange(p);
@@ -378,7 +381,8 @@ namespace ToolManagementAppV2.Services.Tools
             CheckedOutBy = r["CheckedOutBy"].ToString(),
             CheckedOutTime = r["CheckedOutTime"] is DBNull ? (DateTime?)null : Convert.ToDateTime(r["CheckedOutTime"]),
             ToolImagePath = r["ToolImagePath"]?.ToString(),
-            Keywords = r["Keywords"]?.ToString()
+            Keywords = r["Keywords"]?.ToString(),
+            IsPowerTool = Convert.ToInt32(r["IsPowerTool"]) == 1
         };
 
         public Task AddToolAsync(ToolModel tool) => Task.Run(() => AddTool(tool));

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -189,6 +189,7 @@ namespace ToolManagementAppV2.ViewModels
                 PurchasedDate = SelectedTool.PurchasedDate,
                 Notes = SelectedTool.Notes,
                 Keywords = SelectedTool.Keywords,
+                IsPowerTool = SelectedTool.IsPowerTool,
                 IsCheckedOut = SelectedTool.IsCheckedOut,
                 CheckedOutBy = SelectedTool.CheckedOutBy,
                 CheckedOutTime = SelectedTool.CheckedOutTime,
@@ -242,11 +243,7 @@ namespace ToolManagementAppV2.ViewModels
             PowerTools.ReplaceRange(tools.Where(IsPowerTool));
         }
 
-        static bool IsPowerTool(ToolModel tool) =>
-            tool?.NameDescription?.Contains("power", StringComparison.OrdinalIgnoreCase) == true ||
-            tool?.NameDescription?.Contains("cordless", StringComparison.OrdinalIgnoreCase) == true ||
-            tool?.NameDescription?.Contains("electric", StringComparison.OrdinalIgnoreCase) == true ||
-            tool?.NameDescription?.Contains("drill", StringComparison.OrdinalIgnoreCase) == true;
+        static bool IsPowerTool(ToolModel tool) => tool?.IsPowerTool == true;
 
         void LoadCategories(IEnumerable<ToolModel> tools)
         {

--- a/ToolManagementAppV2/Views/ToolEditWindow.xaml
+++ b/ToolManagementAppV2/Views/ToolEditWindow.xaml
@@ -27,6 +27,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
@@ -48,7 +49,9 @@
             <TextBlock Grid.Row="5" Grid.Column="0" Text="Supplier" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Tool.Supplier, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,0,0,8">
+            <CheckBox Grid.Row="6" Grid.ColumnSpan="2" Content="Power Tool" IsChecked="{Binding Tool.IsPowerTool}" Margin="0,0,0,8"/>
+
+            <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,0,0,8">
                 <Image Width="100" Height="100" Stretch="Uniform"
                        Source="{Binding Tool.ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=tool}"/>
                 <StackPanel Orientation="Vertical" Margin="8,0,0,0">
@@ -57,7 +60,7 @@
                 </StackPanel>
             </StackPanel>
 
-            <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Vertical">
+            <StackPanel Grid.Row="8" Grid.ColumnSpan="2" Orientation="Vertical">
                 <TextBlock Text="Notes" Margin="0,0,0,4"/>
                 <TextBox Text="{Binding Tool.Notes, UpdateSourceTrigger=PropertyChanged}" Height="90" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
             </StackPanel>


### PR DESCRIPTION
## Summary
- track a tool's power status with new `IsPowerTool` column
- persist and import/export power-tool flag
- categorize tools by the stored flag and expose checkbox in edit dialog

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689cdc17dfac83249453505b76d1c3a5