### PR TITLE
Use SQL count for admin deletion check

### DIFF
--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -1,0 +1,60 @@
+using System.IO;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Interfaces;
+using Xunit;
+
+public class UserServiceTests
+{
+    [Fact]
+    public void TryDeleteUser_ReturnsFalse_WhenDeletingOnlyAdmin()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+
+            var admin = new User { UserName = "admin", Password = "pw", IsAdmin = true };
+            userService.AddUser(admin);
+
+            var result = userService.TryDeleteUser(admin.UserID);
+
+            Assert.False(result);
+            Assert.NotNull(userService.GetUserByID(admin.UserID));
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public void TryDeleteUser_AllowsDeletingAdmin_WhenMultipleAdminsExist()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+
+            var admin1 = new User { UserName = "admin1", Password = "pw", IsAdmin = true };
+            var admin2 = new User { UserName = "admin2", Password = "pw", IsAdmin = true };
+            userService.AddUser(admin1);
+            userService.AddUser(admin2);
+
+            var result = userService.TryDeleteUser(admin1.UserID);
+
+            Assert.True(result);
+            Assert.Null(userService.GetUserByID(admin1.UserID));
+            Assert.NotNull(userService.GetUserByID(admin2.UserID));
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+}

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -190,7 +190,9 @@ namespace ToolManagementAppV2.Services.Users
             if (user == null) return false;
             if (user.IsAdmin)
             {
-                var adminCount = GetAllUsers().Count(u => u.IsAdmin);
+                const string sql = "SELECT COUNT(*) FROM Users WHERE IsAdmin = 1";
+                using var conn = _dbService.CreateConnection();
+                var adminCount = Convert.ToInt32(SqliteHelper.ExecuteScalar(conn, sql));
                 if (adminCount <= 1) return false;
             }
             DeleteUserInternal(userID);


### PR DESCRIPTION
## Summary
- Use direct SQL COUNT query to determine number of admin users before deletion
- Add tests covering deletion behavior for single and multiple admins

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_689cdbee5b04832487775970325e9da5