### PR TITLE
Refresh categories when tools change

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -95,6 +95,34 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public async Task Categories_Update_WhenToolsCollectionChanges()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var dialog = new StubDialogService();
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
+                toolService.AddTool(new Tool { ToolNumber = "T1", Brand = "BrandA" });
+                await vm.LoadToolsAsync();
+
+                Assert.Contains("BrandA", vm.Categories);
+
+                vm.Tools.Add(new Tool { ToolNumber = "T2", Brand = "BrandB" });
+
+                Assert.Contains("BrandB", vm.Categories);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public async Task AddTool_ShowsDialog_OnError()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
@@ -118,15 +119,19 @@ namespace ToolManagementAppV2.ViewModels
             DeleteToolCommand = new AsyncRelayCommand(DeleteToolAsync);
             OpenRentalsCommand = new AsyncRelayCommand(OpenRentalsAsync, () => SelectedTool != null);
             ViewDetailsCommand = new RelayCommand(ViewDetails, () => SelectedTool != null);
+
+            Tools.CollectionChanged += Tools_CollectionChanged;
         }
 
         public async Task LoadToolsAsync()
         {
             var all = await _toolService.GetAllToolsAsync();
+            Tools.CollectionChanged -= Tools_CollectionChanged;
             Tools.ReplaceRange(all);
             SearchResults.ReplaceRange(all);
             CategorizeTools(all);
-            LoadCategories(all);
+            LoadCategories(Tools);
+            Tools.CollectionChanged += Tools_CollectionChanged;
         }
 
         /// <summary>
@@ -138,7 +143,6 @@ namespace ToolManagementAppV2.ViewModels
         {
             var term = string.IsNullOrWhiteSpace(SearchTerm) ? string.Empty : SearchTerm.Trim();
             var all = await _toolService.GetAllToolsAsync();
-            LoadCategories(all);
             IEnumerable<ToolModel> results = string.IsNullOrEmpty(term)
                 ? all
                 : await _toolService.SearchToolsAsync(term);
@@ -254,7 +258,14 @@ namespace ToolManagementAppV2.ViewModels
                                    .ToList();
             categories.Insert(0, "All");
             Categories.ReplaceRange(categories);
+
+            if (!Categories.Contains(SelectedCategory))
+            {
+                SelectedCategory = "All";
+            }
         }
+
+        void Tools_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e) => LoadCategories(Tools);
 
     }
 }


### PR DESCRIPTION
## Summary
- Update ToolManagementViewModel to rebuild categories on tools collection changes
- Remove redundant category reload during filtering and reset selection when categories shift
- Add unit test verifying category list refreshes when tools collection updates

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689cdf865ff48324aad5ab92965087c0