### PR TITLE
Use transaction for rental extensions

### DIFF
--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -1,7 +1,11 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Collections.Generic;
+using System.Data.SQLite;
+using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Models.ImportExport;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
@@ -319,6 +323,65 @@ namespace ToolManagementAppV2.Tests.Services
                 if (File.Exists(dbPath))
                     File.Delete(dbPath);
             }
+        }
+
+        [Fact]
+        public void ExtendRental_Failure_RollsBack()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db, toolService);
+
+                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
+                var tool = toolService.GetAllTools().First();
+
+                customerService.AddCustomer(new Customer { Company = "Acme" });
+                var cust = customerService.GetAllCustomers().First();
+
+                rentalService.RentTool(tool.ToolID, cust.CustomerID, DateTime.Today.AddDays(-2), DateTime.Today.AddDays(-1));
+                var rental = rentalService.GetAllRentals().First();
+                var originalDue = rental.DueDate;
+
+                var failingToolService = new FailingToolService();
+                var rentalService2 = new RentalService(db, failingToolService);
+
+                Assert.Throws<InvalidOperationException>(() =>
+                    rentalService2.ExtendRental(rental.RentalID, DateTime.Today.AddDays(1)));
+
+                var after = rentalService2.GetAllRentals().First();
+                Assert.Equal(originalDue, after.DueDate);
+
+                var toolAfter = toolService.GetToolByID(tool.ToolID);
+                Assert.Equal(0, toolAfter.QuantityOnHand);
+                Assert.Equal(1, toolAfter.RentedQuantity);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        class FailingToolService : IToolService
+        {
+            public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
+            public void ExportToolsToCsv(string filePath) => throw new NotImplementedException();
+            public List<ToolModel> GetAllTools() => new();
+            public void AddTool(ToolModel tool) => throw new NotImplementedException();
+            public void UpdateTool(ToolModel tool) => throw new NotImplementedException();
+            public void DeleteTool(int toolID) => throw new NotImplementedException();
+            public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
+            public List<ToolModel> SearchTools(string? searchText) => new();
+            public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+            public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
+            public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
+            public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => new();
+            public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null)
+                => throw new InvalidOperationException("fail");
         }
     }
 }

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -77,18 +77,45 @@ namespace ToolManagementAppV2.Services.Rentals
 
         public void ExtendRental(int rentalID, DateTime newDueDate)
         {
-            const string sql = @"
-                UPDATE Rentals
-                   SET DueDate = @NewDueDate
-                 WHERE RentalID = @RentalID AND Status = 'Rented'";
-                    var p = new[]
+            ExecuteWithTransaction((conn, tx) =>
+            {
+                var selectCmd = new SQLiteCommand(
+                    "SELECT ToolID, DueDate FROM Rentals WHERE RentalID=@RentalID AND Status='Rented'",
+                    conn, tx);
+                selectCmd.Parameters.AddWithValue("@RentalID", rentalID);
+                using var reader = selectCmd.ExecuteReader();
+                if (!reader.Read())
+                    throw new InvalidOperationException("Unable to extend rental. Rental not found or already returned.");
+
+                int toolID = Convert.ToInt32(reader["ToolID"]);
+                DateTime oldDueDate = Convert.ToDateTime(reader["DueDate"]);
+
+                var updateCmd = new SQLiteCommand(
+                    "UPDATE Rentals SET DueDate=@NewDueDate WHERE RentalID=@RentalID AND Status='Rented'",
+                    conn, tx);
+                updateCmd.Parameters.AddWithValue("@NewDueDate", newDueDate);
+                updateCmd.Parameters.AddWithValue("@RentalID", rentalID);
+                if (updateCmd.ExecuteNonQuery() == 0)
+                    throw new InvalidOperationException("Unable to extend rental. Rental not found or already returned.");
+
+                if (_toolService != null)
+                {
+                    // When extending a rental, inventory counts shift only if the
+                    // due date crosses "today". Moving from an overdue date
+                    // (oldDueDate <= today) to a future date makes the tool
+                    // rented again, decreasing available quantity. Moving from a
+                    // future date to today or earlier means the tool is now
+                    // considered overdue and becomes available for others.
+                    if (oldDueDate <= DateTime.Today && newDueDate > DateTime.Today)
                     {
-                        new SQLiteParameter("@NewDueDate", newDueDate),
-                        new SQLiteParameter("@RentalID", rentalID)
-                    };
-                    using var conn = _dbService.CreateConnection();
-                    if (SqliteHelper.ExecuteNonQuery(conn, sql, p) == 0)
-                        throw new InvalidOperationException("Unable to extend rental. Rental not found or already returned.");
+                        _toolService.UpdateToolQuantities(toolID, 1, true, conn, tx);
+                    }
+                    else if (oldDueDate > DateTime.Today && newDueDate <= DateTime.Today)
+                    {
+                        _toolService.UpdateToolQuantities(toolID, 1, false, conn, tx);
+                    }
+                }
+            });
         }
 
         public void DeleteRental(int rentalID)


### PR DESCRIPTION
## Summary
- switch rental due date updates to ExecuteWithTransaction and adjust tool quantities when due date crosses availability
- document inventory update rules in ExtendRental
- add unit test ensuring rental extension rolls back on failure

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cdfd2305c8324b8d2150e4d8d071f