### PR TITLE
Add async database backup and integrate in Import/Export page

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ConsoleLoggingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ConsoleLoggingTests.cs
@@ -16,6 +16,7 @@ using ToolManagementAppV2.Utilities.Helpers;
 using ToolManagementAppV2.Models.Domain;
 using Xunit;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace ToolManagementAppV2.Tests
 {
@@ -111,7 +112,7 @@ namespace ToolManagementAppV2.Tests
         }
 
         [Fact]
-        public void BackupDatabase_LogsException()
+        public async Task BackupDatabaseAsync_LogsException()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -120,7 +121,7 @@ namespace ToolManagementAppV2.Tests
                 var sw = new StringWriter();
                 var original = Console.Out;
                 Console.SetOut(sw);
-                Assert.Throws<IOException>(() => db.BackupDatabase("invalid|path.db"));
+                await Assert.ThrowsAsync<IOException>(() => db.BackupDatabaseAsync("invalid|path.db"));
                 Console.SetOut(original);
                 Assert.NotEqual(string.Empty, sw.ToString());
             }

--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -44,7 +44,7 @@ namespace ToolManagementAppV2.Tests.Tests
                 var settingsService = new SettingsService(db);
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
                 vm.OpenSearchToolsCommand.Execute(null);
 
                 var page = Assert.IsType<ToolSearchPage>(vm.CurrentPage);

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -33,7 +33,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
 
                 bool raised = false;
                 vm.PropertyChanged += (s, e) =>

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -34,7 +34,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
 
                 Assert.NotNull(vm.ToolManagement);
                 Assert.NotNull(vm.UserManagement);
@@ -66,7 +66,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
                 vm.OpenDashboardCommand.Execute(null);
 
                 var page = Assert.IsType<DashboardPage>(vm.CurrentPage);
@@ -94,7 +94,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
                 vm.OpenImportExportCommand.Execute(null);
 
                 var page = Assert.IsType<ImportExportPage>(vm.CurrentPage);
@@ -123,7 +123,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IRentalService rentalService = new RentalService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
                 vm.OpenActivityLogsCommand.Execute(null);
 
                 var page = Assert.IsType<ActivityLogsPage>(vm.CurrentPage);
@@ -152,7 +152,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IRentalService rentalService = new RentalService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
                 vm.OpenReportsCommand.Execute(null);
 
                 var page = Assert.IsType<ReportsPage>(vm.CurrentPage);
@@ -181,7 +181,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
                 vm.OpenSettingsCommand.Execute(null);
 
                 var page = Assert.IsType<SettingsPage>(vm.CurrentPage);
@@ -214,7 +214,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
                 vm.OpenRentalsCommand.Execute(null);
 
                 var page = Assert.IsType<ManageRentalsPage>(vm.CurrentPage);
@@ -245,7 +245,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw" });
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
                 vm.GlobalSearchText = "Ham";
 
                 vm.GlobalSearchCommand.Execute(null);
@@ -278,7 +278,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
                 vm.OpenImportMappingWindowCommand.Execute(null);
             }
             finally
@@ -303,7 +303,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
                 Assert.NotNull(vm.OpenImageImportMappingWindowCommand);
             }
             finally

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -42,7 +42,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 };
 
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
-                    new StubFileDialogService(), activityLogService, settingsService, null, stubLogin);
+                    new StubFileDialogService(), activityLogService, settingsService, db, null, stubLogin);
 
                 userContext.CurrentUser = new User { UserName = "old", IsAdmin = false };
                 vm.RefreshCurrentUser();

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -12,6 +12,7 @@ using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace ToolManagementAppV2.Tests.ViewModels
 {
@@ -41,7 +42,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var toolService = new StubToolService();
             var customerService = new StubCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService());
             vm.ImportToolsCommand.Execute(null);
             Assert.True(toolService.ImportCalled);
             Assert.Single(vm.ImportExportLogs);
@@ -53,7 +54,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var toolService = new StubToolService();
             var customerService = new StubCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService());
             vm.ExportToolsCommand.Execute(null);
             Assert.True(toolService.ExportCalled);
             Assert.Single(vm.ImportExportLogs);
@@ -65,7 +66,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var toolService = new StubToolService();
             var customerService = new StubCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService());
             vm.ImportCustomersCommand.Execute(null);
             Assert.True(customerService.ImportCalled);
             Assert.Single(vm.ImportExportLogs);
@@ -77,7 +78,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var toolService = new StubToolService();
             var customerService = new StubCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService());
             vm.ExportCustomersCommand.Execute(null);
             Assert.True(customerService.ExportCalled);
             Assert.Single(vm.ImportExportLogs);
@@ -85,11 +86,20 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public async Task ImportExportViewModel_BackupDatabaseCommand_LogsSuccess()
+        {
+            var vm = new ImportExportViewModel(new StubToolService(), new StubCustomerService(), new StubFileDialogService(), new StubDatabaseBackupService());
+            await vm.BackupDatabaseCommand.ExecuteAsync(null);
+            Assert.Single(vm.ImportExportLogs);
+            Assert.StartsWith("Successfully backed up database", vm.ImportExportLogs[0]);
+        }
+
+        [Fact]
         public void ImportExportViewModel_ImportToolsCommand_LogsFailure()
         {
             var toolService = new FailToolService();
             var customerService = new StubCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService());
             vm.ImportToolsCommand.Execute(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Failed to import tools", vm.ImportExportLogs[0]);
@@ -100,7 +110,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var toolService = new FailToolService();
             var customerService = new StubCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService());
             vm.ExportToolsCommand.Execute(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Failed to export tools", vm.ImportExportLogs[0]);
@@ -111,7 +121,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var toolService = new StubToolService();
             var customerService = new FailCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService());
             vm.ImportCustomersCommand.Execute(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Failed to import customers", vm.ImportExportLogs[0]);
@@ -122,7 +132,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var toolService = new StubToolService();
             var customerService = new FailCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService());
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService());
             vm.ExportCustomersCommand.Execute(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Failed to export customers", vm.ImportExportLogs[0]);
@@ -231,6 +241,16 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Customer GetCustomerByID(int customerID) => throw new System.NotImplementedException();
         public List<Customer> GetAllCustomers() => new();
         public List<Customer> SearchCustomers(string searchTerm) => new();
+    }
+
+    class StubDatabaseBackupService : IDatabaseBackupService
+    {
+        public bool Called { get; private set; }
+        public Task BackupDatabaseAsync(string backupFilePath)
+        {
+            Called = true;
+            return Task.CompletedTask;
+        }
     }
 
     class StubUserService : IUserService

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -30,7 +30,7 @@ namespace ToolManagementAppV2
             var fileDialogService = new FileDialogService();
             var settingsService = new SettingsService(db);
 
-            var mainVm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, fileDialogService, activityLogService, settingsService);
+            var mainVm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, fileDialogService, activityLogService, settingsService, db);
             var main = new MainWindow(mainVm, db);
 
             Current.MainWindow = main;

--- a/ToolManagementAppV2/Interfaces/IDatabaseBackupService.cs
+++ b/ToolManagementAppV2/Interfaces/IDatabaseBackupService.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+
+namespace ToolManagementAppV2.Interfaces
+{
+    /// <summary>
+    /// Provides database backup capabilities.
+    /// </summary>
+    public interface IDatabaseBackupService
+    {
+        /// <summary>
+        /// Creates a backup of the current database asynchronously.
+        /// </summary>
+        /// <param name="backupFilePath">Destination path for the backup file.</param>
+        Task BackupDatabaseAsync(string backupFilePath);
+    }
+}

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -53,7 +53,7 @@ namespace ToolManagementAppV2
                 var fileDialogService = new FileDialogService();
                 var settingsService = new SettingsService(_ownedDb);
 
-                DataContext = new MainViewModel(toolService, userService, userContext, customerService, rentalService, fileDialogService, activityLogService, settingsService);
+                DataContext = new MainViewModel(toolService, userService, userContext, customerService, rentalService, fileDialogService, activityLogService, settingsService, _ownedDb);
             }
 
             Closed += (_, __) => _ownedDb?.Dispose();

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -1,8 +1,10 @@
 using System.Data.SQLite;
 using System.IO;
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using ToolManagementAppV2.Interfaces;
 
 namespace ToolManagementAppV2.Services.Core
 {
@@ -10,7 +12,7 @@ namespace ToolManagementAppV2.Services.Core
     /// Provides SQLite database access for the application. Instances should be
     /// disposed when no longer needed to release pooled connections.
     /// </summary>
-    public class DatabaseService : IDisposable
+    public class DatabaseService : IDisposable, IDatabaseBackupService
     {
         public string ConnectionString { get; }
         private readonly ILogger<DatabaseService> _logger;
@@ -243,5 +245,12 @@ namespace ToolManagementAppV2.Services.Core
                 throw new IOException("Failed to backup database.", ex);
             }
         }
+
+        /// <summary>
+        /// Asynchronously creates a backup of the current database.
+        /// </summary>
+        /// <param name="backupFilePath">Destination path for the backup file.</param>
+        public Task BackupDatabaseAsync(string backupFilePath)
+            => Task.Run(() => BackupDatabase(backupFilePath));
     }
 }

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -14,6 +15,7 @@ namespace ToolManagementAppV2.ViewModels
         private readonly IToolService _toolService;
         private readonly ICustomerService _customerService;
         private readonly IFileDialogService _fileDialogService;
+        private readonly IDatabaseBackupService _databaseService;
         private readonly ILogger<ImportExportViewModel> _logger;
 
         public IRelayCommand ImportToolsCommand { get; }
@@ -21,21 +23,33 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand ImportCustomersCommand { get; }
         public IRelayCommand ExportCustomersCommand { get; }
 
+        /// <summary>
+        /// Command that triggers an asynchronous database backup.
+        /// </summary>
+        /// <remarks>
+        /// The backup work executes off the UI thread via <see cref="BackupDatabaseAsync"/>,
+        /// keeping the interface responsive while the operation runs.
+        /// </remarks>
+        public IAsyncRelayCommand BackupDatabaseCommand { get; }
+
         public ObservableCollection<string> ImportExportLogs { get; } = new();
 
         public ImportExportViewModel(IToolService toolService,
                                      ICustomerService customerService,
                                      IFileDialogService fileDialogService,
+                                     IDatabaseBackupService databaseService,
                                      ILogger<ImportExportViewModel>? logger = null)
         {
             _toolService = toolService;
             _customerService = customerService;
             _fileDialogService = fileDialogService;
+            _databaseService = databaseService;
             _logger = logger ?? NullLogger<ImportExportViewModel>.Instance;
             ImportToolsCommand = new RelayCommand(ImportTools);
             ExportToolsCommand = new RelayCommand(ExportTools);
             ImportCustomersCommand = new RelayCommand(ImportCustomers);
             ExportCustomersCommand = new RelayCommand(ExportCustomers);
+            BackupDatabaseCommand = new AsyncRelayCommand(BackupDatabaseAsync);
         }
 
         void ImportTools()
@@ -99,6 +113,30 @@ namespace ToolManagementAppV2.ViewModels
             {
                 _logger.LogError(ex, "Failed to export customers to {Path}", path);
                 ImportExportLogs.Add($"Failed to export customers to {path}: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Prompts the user for a destination file and backs up the database asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// The backup is performed using asynchronous I/O, allowing the UI thread to remain responsive
+        /// while the file copy completes in the background.
+        /// </remarks>
+        /// <returns>A <see cref="Task"/> representing the asynchronous backup operation.</returns>
+        async Task BackupDatabaseAsync()
+        {
+            var path = _fileDialogService.SaveFile("SQLite Database|*.db");
+            if (string.IsNullOrEmpty(path)) return;
+            try
+            {
+                await _databaseService.BackupDatabaseAsync(path);
+                ImportExportLogs.Add($"Successfully backed up database to {path}.");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to backup database to {Path}", path);
+                ImportExportLogs.Add($"Failed to backup database to {path}: {ex.Message}");
             }
         }
     }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -108,6 +108,7 @@ namespace ToolManagementAppV2.ViewModels
                              IFileDialogService fileDialogService,
                              ActivityLogService activityLogService,
                              ISettingsService settingsService,
+                             IDatabaseBackupService databaseService,
                              ILogger<MainViewModel>? logger = null,
                              Func<bool>? showLoginWindow = null)
         {
@@ -132,7 +133,7 @@ namespace ToolManagementAppV2.ViewModels
             UserManagement = new UserManagementViewModel(userService, fileDialogService);
             CustomerManagement = new CustomerManagementViewModel(customerService, new DialogService());
             ManageRentals = new ManageRentalsViewModel(rentalService, new DialogService());
-            ImportExport = new ImportExportViewModel(toolService, customerService, fileDialogService);
+            ImportExport = new ImportExportViewModel(toolService, customerService, fileDialogService, databaseService);
             Reports = new ReportsViewModel(new ReportService(toolService, rentalService, activityLogService, customerService, userService));
             ActivityLogs = new ActivityLogsViewModel(activityLogService);
 

--- a/ToolManagementAppV2/Views/ImportExportPage.xaml
+++ b/ToolManagementAppV2/Views/ImportExportPage.xaml
@@ -14,6 +14,7 @@
                 <Button Style="{StaticResource PrimaryButton}" Content="Export Tools CSV" Command="{Binding ExportToolsCommand}" Margin="0,0,8,8"/>
                 <Button Style="{StaticResource PrimaryButton}" Content="Import Customers CSV" Command="{Binding ImportCustomersCommand}" Margin="0,0,8,8"/>
                 <Button Style="{StaticResource PrimaryButton}" Content="Export Customers CSV" Command="{Binding ExportCustomersCommand}" Margin="0,0,8,8"/>
+                <Button Style="{StaticResource PrimaryButton}" Content="Backup Database" Command="{Binding BackupDatabaseCommand}" Margin="0,0,8,8"/>
             </WrapPanel>
         </Border>
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">


### PR DESCRIPTION
## Summary
- add `IDatabaseBackupService` and implement `BackupDatabaseAsync` in `DatabaseService`
- expose async backup through `ImportExportViewModel` with UI command and button
- update view models and app startup to pass database service
- cover asynchronous backup with unit tests
- document async backup command and method to explain UI-thread behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cdfe053648324be0d77386cb1e7f6