### PR TITLE
Improve ReplaceRange to suspend notifications

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ObservableCollectionExtensionsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ObservableCollectionExtensionsTests.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using ToolManagementAppV2.Utilities.Extensions;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests;
+
+public class ObservableCollectionExtensionsTests
+{
+    [Fact]
+    public void ReplaceRange_RaisesSingleResetNotification()
+    {
+        var collection = new ObservableCollection<int> { 1, 2, 3 };
+        var notifications = new List<NotifyCollectionChangedEventArgs>();
+        collection.CollectionChanged += (_, e) => notifications.Add(e);
+
+        collection.ReplaceRange(new[] { 4, 5, 6 });
+
+        Assert.Single(notifications);
+        Assert.Equal(NotifyCollectionChangedAction.Reset, notifications[0].Action);
+        Assert.Equal(new[] { 4, 5, 6 }, collection);
+    }
+}

--- a/ToolManagementAppV2/Utilities/Extensions/ObservableCollectionExtensions.cs
+++ b/ToolManagementAppV2/Utilities/Extensions/ObservableCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.Collections;
 
 namespace ToolManagementAppV2.Utilities.Extensions
 {
@@ -6,9 +8,12 @@ namespace ToolManagementAppV2.Utilities.Extensions
     {
         public static void ReplaceRange<T>(this ObservableCollection<T> collection, IEnumerable<T> items)
         {
-            collection.Clear();
-            foreach (var i in items)
-                collection.Add(i);
+            using (collection.SuspendNotifications())
+            {
+                collection.Clear();
+                foreach (var i in items)
+                    collection.Add(i);
+            }
         }
 
         public static void AddRange<T>(this ObservableCollection<T> collection, IEnumerable<T> items)
@@ -18,3 +23,4 @@ namespace ToolManagementAppV2.Utilities.Extensions
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- suppress `ObservableCollection` change notifications during `ReplaceRange`
- add unit test ensuring `ReplaceRange` fires a single reset notification

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden when contacting Ubuntu archives)*

------
https://chatgpt.com/codex/tasks/task_e_689ceb9122f88324bde23b9a45c5234f