### PR TITLE
Handle nullable user retrievals

### DIFF
--- a/ToolManagementAppV2.Tests/Services/UserActiveTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserActiveTests.cs
@@ -17,7 +17,7 @@ namespace ToolManagementAppV2.Tests.Services
             var dbPath = Path.GetTempFileName();
             try
             {
-                var db = new DatabaseService(dbPath);
+                using var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var user = new User { UserName = "u", Password = "p" };
                 userService.AddUser(user);
@@ -37,7 +37,7 @@ namespace ToolManagementAppV2.Tests.Services
             var dbPath = Path.GetTempFileName();
             try
             {
-                var db = new DatabaseService(dbPath);
+                using var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var user = new User { UserName = "u", Password = "p" };
                 userService.AddUser(user);
@@ -45,7 +45,8 @@ namespace ToolManagementAppV2.Tests.Services
                 added.IsActive = false;
                 userService.UpdateUser(added);
                 var updated = userService.GetUserByID(added.UserID);
-                Assert.False(updated.IsActive);
+                Assert.NotNull(updated);
+                Assert.False(updated!.IsActive);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Services/UserMobileTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserMobileTests.cs
@@ -16,7 +16,7 @@ namespace ToolManagementAppV2.Tests.Services
             var dbPath = Path.GetTempFileName();
             try
             {
-                var dbService = new DatabaseService(dbPath);
+                using var dbService = new DatabaseService(dbPath);
                 IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
                 var user = new User { UserName = "u", Password = "p", Mobile = "111" };
@@ -38,7 +38,7 @@ namespace ToolManagementAppV2.Tests.Services
             var dbPath = Path.GetTempFileName();
             try
             {
-                var dbService = new DatabaseService(dbPath);
+                using var dbService = new DatabaseService(dbPath);
                 IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
                 var user = new User { UserName = "u", Password = "p", Mobile = "1" };
@@ -49,7 +49,8 @@ namespace ToolManagementAppV2.Tests.Services
                 userService.UpdateUser(added);
 
                 var updated = userService.GetUserByID(added.UserID);
-                Assert.Equal("2", updated.Mobile);
+                Assert.NotNull(updated);
+                Assert.Equal("2", updated!.Mobile);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -256,13 +256,22 @@ namespace ToolManagementAppV2.Tests.ViewModels
     class StubUserService : IUserService
     {
         public List<User> GetAllUsers() => new();
-        public User GetUserByID(int userID) => throw new System.NotImplementedException();
-        public User AuthenticateUser(string userName, string password) => throw new System.NotImplementedException();
-        public User GetCurrentUser() => throw new System.NotImplementedException();
-        public void AddUser(User user) => throw new System.NotImplementedException();
-        public void UpdateUser(User user) => throw new System.NotImplementedException();
-        public bool TryDeleteUser(int userID) => throw new System.NotImplementedException();
-        public bool DeleteUser(int userID) => throw new System.NotImplementedException();
-        public void ChangeUserPassword(int userID, string newPassword) => throw new System.NotImplementedException();
+        public Task<List<User>> GetAllUsersAsync() => Task.FromResult(new List<User>());
+        public User? GetUserByID(int userID) => null;
+        public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult<User?>(null);
+        public User? AuthenticateUser(string userName, string password) => null;
+        public Task<User?> AuthenticateUserAsync(string userName, string password) => Task.FromResult<User?>(null);
+        public User? GetCurrentUser() => null;
+        public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
+        public void AddUser(User user) { }
+        public Task AddUserAsync(User user) => Task.CompletedTask;
+        public void UpdateUser(User user) { }
+        public Task UpdateUserAsync(User user) => Task.CompletedTask;
+        public bool TryDeleteUser(int userID) => false;
+        public Task<bool> TryDeleteUserAsync(int userID) => Task.FromResult(false);
+        public bool DeleteUser(int userID) => false;
+        public Task<bool> DeleteUserAsync(int userID) => Task.FromResult(false);
+        public void ChangeUserPassword(int userID, string newPassword) { }
+        public Task ChangeUserPasswordAsync(int userID, string newPassword) => Task.CompletedTask;
     }
 }

--- a/ToolManagementAppV2/Interfaces/IUserService.cs
+++ b/ToolManagementAppV2/Interfaces/IUserService.cs
@@ -9,12 +9,12 @@ namespace ToolManagementAppV2.Interfaces
     {
         List<User> GetAllUsers();
         Task<List<User>> GetAllUsersAsync();
-        User GetUserByID(int userID);
-        Task<User> GetUserByIDAsync(int userID);
-        User AuthenticateUser(string userName, string password);
-        Task<User> AuthenticateUserAsync(string userName, string password);
-        User GetCurrentUser();
-        Task<User> GetCurrentUserAsync();
+        User? GetUserByID(int userID);
+        Task<User?> GetUserByIDAsync(int userID);
+        User? AuthenticateUser(string userName, string password);
+        Task<User?> AuthenticateUserAsync(string userName, string password);
+        User? GetCurrentUser();
+        Task<User?> GetCurrentUserAsync();
         void AddUser(User user);
         Task AddUserAsync(User user);
         void UpdateUser(User user);

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -26,7 +26,7 @@ namespace ToolManagementAppV2.Services.Users
             return SqliteHelper.ExecuteReader(conn, "SELECT * FROM Users", null, MapUser);
         }
 
-        public User GetUserByID(int userID)
+        public User? GetUserByID(int userID)
         {
             using var conn = _dbService.CreateConnection();
             return SqliteHelper.ExecuteReader(conn, "SELECT * FROM Users WHERE UserID=@ID",
@@ -62,7 +62,7 @@ namespace ToolManagementAppV2.Services.Users
             return SecurityHelper.VerifyPassword(password ?? string.Empty, u.Salt, u.Password) ? u : null;
         }
 
-        public User GetCurrentUser()
+        public User? GetCurrentUser()
         {
             if (_context.CurrentUser is User u)
                 return GetUserByID(u.UserID);
@@ -230,9 +230,9 @@ namespace ToolManagementAppV2.Services.Users
         }
 
         public Task<List<User>> GetAllUsersAsync() => Task.Run(GetAllUsers);
-        public Task<User> GetUserByIDAsync(int userID) => Task.Run(() => GetUserByID(userID));
-        public Task<User> AuthenticateUserAsync(string userName, string password) => Task.Run(() => AuthenticateUser(userName, password));
-        public Task<User> GetCurrentUserAsync() => Task.Run(GetCurrentUser);
+        public Task<User?> GetUserByIDAsync(int userID) => Task.Run(() => GetUserByID(userID));
+        public Task<User?> AuthenticateUserAsync(string userName, string password) => Task.Run(() => AuthenticateUser(userName, password));
+        public Task<User?> GetCurrentUserAsync() => Task.Run(GetCurrentUser);
         public Task AddUserAsync(User user) => Task.Run(() => AddUser(user));
         public Task UpdateUserAsync(User user) => Task.Run(() => UpdateUser(user));
         public Task<bool> TryDeleteUserAsync(int userID) => Task.Run(() => TryDeleteUser(userID));

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -138,8 +138,11 @@ namespace ToolManagementAppV2.ViewModels
             {
                 _userService.ChangeUserPassword(user.UserID, "admin");
                 var refreshed = _userService.GetUserByID(user.UserID);
-                user.Password = refreshed.Password;
-                user.Salt = refreshed.Salt;
+                if (refreshed != null)
+                {
+                    user.Password = refreshed.Password;
+                    user.Salt = refreshed.Salt;
+                }
             }
 
             if (!user.IsAdmin &&
@@ -166,8 +169,11 @@ namespace ToolManagementAppV2.ViewModels
                 {
                     _userService.ChangeUserPassword(user.UserID, "admin");
                     var refreshed = _userService.GetUserByID(user.UserID);
-                    user.Password = refreshed.Password;
-                    user.Salt = refreshed.Salt;
+                    if (refreshed != null)
+                    {
+                        user.Password = refreshed.Password;
+                        user.Salt = refreshed.Salt;
+                    }
                     LoadUsers();
                     _dialogService.ShowInfo("Password has been reset to default. Please enter the new password to login.",
                         "Password Reset");

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -227,8 +227,11 @@ namespace ToolManagementAppV2.ViewModels
             if (user == null) return;
             _userService.ChangeUserPassword(user.UserID, "admin");
             var refreshed = _userService.GetUserByID(user.UserID);
-            user.Password = refreshed.Password;
-            user.Salt = refreshed.Salt;
+            if (refreshed != null)
+            {
+                user.Password = refreshed.Password;
+                user.Salt = refreshed.Salt;
+            }
         }
 
         void DeleteUser(UserModel user)


### PR DESCRIPTION
## Summary
- Dispose test database connections using `using` declarations
- Implement no-op `StubUserService` that returns nullables for updated interface methods

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689cef0975cc83248df2534dddca3c7e