### PR TITLE
Refactor dialogs to centralized service

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -11,6 +11,7 @@ using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Views;
 using Xunit;
+using System.Collections.Generic;
 
 namespace ToolManagementAppV2.Tests.Tests
 {
@@ -44,7 +45,7 @@ namespace ToolManagementAppV2.Tests.Tests
                 var settingsService = new SettingsService(db);
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
                 vm.OpenSearchToolsCommand.Execute(null);
 
                 var page = Assert.IsType<ToolSearchPage>(vm.CurrentPage);
@@ -65,4 +66,14 @@ class StubFileDialogService : IFileDialogService
 {
     public string OpenFile(string filter) => null;
     public string SaveFile(string filter) => null;
+}
+
+class StubDialogService : IDialogService
+{
+    public void ShowInfo(string message, string title) { }
+    public bool ShowConfirmation(string message, string title) => false;
+    public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+    public void ShowToolDetails(ToolModel tool) { }
+    public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+    public CustomerModel? ShowAddCustomerDialog() => null;
 }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Windows;
+using System.Collections.Generic;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
@@ -9,6 +10,7 @@ using ToolManagementAppV2.ViewModels;
 using Xunit;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Interfaces;
 
 
 namespace ToolManagementAppV2.Tests.ViewModels
@@ -33,7 +35,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
 
                 bool raised = false;
                 vm.PropertyChanged += (s, e) =>
@@ -68,4 +70,14 @@ class StubFileDialogService : ToolManagementAppV2.Interfaces.IFileDialogService
 {
     public string OpenFile(string filter) => null;
     public string SaveFile(string filter) => null;
+}
+
+class StubDialogService : IDialogService
+{
+    public void ShowInfo(string message, string title) { }
+    public bool ShowConfirmation(string message, string title) => false;
+    public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+    public void ShowToolDetails(ToolModel tool) { }
+    public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+    public CustomerModel? ShowAddCustomerDialog() => null;
 }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Collections.Generic;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
@@ -34,7 +35,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
 
                 Assert.NotNull(vm.ToolManagement);
                 Assert.NotNull(vm.UserManagement);
@@ -66,7 +67,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
                 vm.OpenDashboardCommand.Execute(null);
 
                 var page = Assert.IsType<DashboardPage>(vm.CurrentPage);
@@ -94,7 +95,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
                 vm.OpenImportExportCommand.Execute(null);
 
                 var page = Assert.IsType<ImportExportPage>(vm.CurrentPage);
@@ -123,7 +124,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IRentalService rentalService = new RentalService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
                 vm.OpenActivityLogsCommand.Execute(null);
 
                 var page = Assert.IsType<ActivityLogsPage>(vm.CurrentPage);
@@ -152,7 +153,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IRentalService rentalService = new RentalService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
                 vm.OpenReportsCommand.Execute(null);
 
                 var page = Assert.IsType<ReportsPage>(vm.CurrentPage);
@@ -181,7 +182,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
                 vm.OpenSettingsCommand.Execute(null);
 
                 var page = Assert.IsType<SettingsPage>(vm.CurrentPage);
@@ -214,7 +215,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
                 vm.OpenRentalsCommand.Execute(null);
 
                 var page = Assert.IsType<ManageRentalsPage>(vm.CurrentPage);
@@ -245,7 +246,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw" });
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
                 vm.GlobalSearchText = "Ham";
 
                 vm.GlobalSearchCommand.Execute(null);
@@ -278,7 +279,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
                 vm.OpenImportMappingWindowCommand.Execute(null);
             }
             finally
@@ -303,7 +304,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db);
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
                 Assert.NotNull(vm.OpenImageImportMappingWindowCommand);
             }
             finally
@@ -319,4 +320,14 @@ class StubFileDialogService : ToolManagementAppV2.Interfaces.IFileDialogService
 {
     public string OpenFile(string filter) => null;
     public string SaveFile(string filter) => null;
+}
+
+class StubDialogService : IDialogService
+{
+    public void ShowInfo(string message, string title) { }
+    public bool ShowConfirmation(string message, string title) => false;
+    public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+    public void ShowToolDetails(ToolModel tool) { }
+    public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+    public CustomerModel? ShowAddCustomerDialog() => null;
 }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Windows;
+using System.Collections.Generic;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
@@ -42,7 +43,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 };
 
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
-                    new StubFileDialogService(), activityLogService, settingsService, db, null, stubLogin);
+                    new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService(), null, stubLogin);
 
                 userContext.CurrentUser = new User { UserName = "old", IsAdmin = false };
                 vm.RefreshCurrentUser();
@@ -64,5 +65,15 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public string OpenFile(string filter) => null;
         public string SaveFile(string filter) => null;
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => false;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/PrintLabelViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/PrintLabelViewModelTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Interfaces;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.ViewModels
@@ -9,7 +11,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void Constructor_InitializesDefaults()
         {
-            var vm = new PrintLabelViewModel(() => { });
+            var vm = new PrintLabelViewModel(new StubDialogService(), () => { });
             Assert.NotEmpty(vm.Templates);
             Assert.Equal(vm.Templates[0], vm.SelectedTemplate);
             Assert.False(vm.IncludeQr);
@@ -20,9 +22,19 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void CloseCommand_InvokesAction()
         {
             bool closed = false;
-            var vm = new PrintLabelViewModel(() => closed = true);
+            var vm = new PrintLabelViewModel(new StubDialogService(), () => closed = true);
             vm.CloseCommand.Execute(null);
             Assert.True(closed);
         }
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => false;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
     }
 }

--- a/ToolManagementAppV2/Interfaces/IDialogService.cs
+++ b/ToolManagementAppV2/Interfaces/IDialogService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Windows.Documents;
 using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2.Interfaces
@@ -15,5 +16,10 @@ namespace ToolManagementAppV2.Interfaces
 
         void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
         void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+        Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+        Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        void ShowPrintPreview(FlowDocument document, string title, string description) { }
+        void ShowPrintLabelDialog() { }
+        void ShowScannerStatus() { }
     }
 }

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Services;
 using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2
@@ -52,8 +53,9 @@ namespace ToolManagementAppV2
                 var activityLogService = new ActivityLogService(_ownedDb);
                 var fileDialogService = new FileDialogService();
                 var settingsService = new SettingsService(_ownedDb);
+                var dialogService = new DialogService();
 
-                DataContext = new MainViewModel(toolService, userService, userContext, customerService, rentalService, fileDialogService, activityLogService, settingsService, _ownedDb);
+                DataContext = new MainViewModel(toolService, userService, userContext, customerService, rentalService, fileDialogService, activityLogService, settingsService, _ownedDb, dialogService);
             }
 
             Closed += (_, __) => _ownedDb?.Dispose();

--- a/ToolManagementAppV2/Services/DialogService.cs
+++ b/ToolManagementAppV2/Services/DialogService.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Documents;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.ViewModels.Rental;
@@ -96,6 +98,58 @@ namespace ToolManagementAppV2.Services
             catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for RentalHistoryWindow"); }
             try { win.ShowDialog(); }
             catch (Exception ex) { _logger.LogError(ex, "Failed to show RentalHistoryWindow"); }
+        }
+
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> propertyNames)
+        {
+            var win = new ImportMappingWindow(headers, propertyNames);
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for ImportMappingWindow"); }
+            try
+            {
+                if (win.ShowDialog() == true)
+                {
+                    return win.VM.Mappings.ToDictionary(m => m.SelectedColumn, m => m.PropertyName);
+                }
+            }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to show ImportMappingWindow"); }
+            return null;
+        }
+
+        public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping()
+        {
+            var win = new ImageImportMappingWindow();
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for ImageImportMappingWindow"); }
+            try { return win.ShowDialog() == true ? win.VM.BuildSelector() : null; }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to show ImageImportMappingWindow"); return null; }
+        }
+
+        public void ShowPrintPreview(FlowDocument document, string title, string description)
+        {
+            var win = new PrintPreviewWindow();
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for PrintPreviewWindow"); }
+            try { win.ShowPreview(document, title, description); }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to show PrintPreviewWindow"); }
+        }
+
+        public void ShowPrintLabelDialog()
+        {
+            var win = new PrintLabelWindow(this);
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for PrintLabelWindow"); }
+            try { win.ShowDialog(); }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to show PrintLabelWindow"); }
+        }
+
+        public void ShowScannerStatus()
+        {
+            var win = new ScannerStatusWindow();
+            try { win.Owner = System.Windows.Application.Current?.MainWindow; }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for ScannerStatusWindow"); }
+            try { win.ShowDialog(); }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to show ScannerStatusWindow"); }
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -14,7 +14,6 @@ using ToolManagementAppV2.Services;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Services.Users;
-using ToolManagementAppV2.ViewModels.Rental;
 using ToolManagementAppV2.Views;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -30,6 +29,7 @@ namespace ToolManagementAppV2.ViewModels
         readonly IRentalService _rentalService;
         readonly ActivityLogService _activityLogService;
         readonly ISettingsService _settingsService;
+        readonly IDialogService _dialogService;
         readonly ILogger<MainViewModel> _logger;
         readonly Func<bool> _showLoginWindow;
 
@@ -109,6 +109,7 @@ namespace ToolManagementAppV2.ViewModels
                              ActivityLogService activityLogService,
                              ISettingsService settingsService,
                              IDatabaseBackupService databaseService,
+                             IDialogService dialogService,
                              ILogger<MainViewModel>? logger = null,
                              Func<bool>? showLoginWindow = null)
         {
@@ -119,20 +120,21 @@ namespace ToolManagementAppV2.ViewModels
             _rentalService = rentalService;
             _activityLogService = activityLogService;
             _settingsService = settingsService;
+            _dialogService = dialogService;
             _logger = logger ?? NullLogger<MainViewModel>.Instance;
             _showLoginWindow = showLoginWindow ?? (() =>
             {
-                var login = new LoginWindow(_userContext, _userService, _settingsService)
+                var login = new LoginWindow(_userContext, _userService, _settingsService, _dialogService)
                 {
                     Owner = Application.Current.MainWindow
                 };
                 return login.ShowDialog() == true;
             });
 
-            ToolManagement = new ToolManagementViewModel(toolService, customerService, rentalService, new DialogService());
+            ToolManagement = new ToolManagementViewModel(toolService, customerService, rentalService, _dialogService);
             UserManagement = new UserManagementViewModel(userService, fileDialogService);
-            CustomerManagement = new CustomerManagementViewModel(customerService, new DialogService());
-            ManageRentals = new ManageRentalsViewModel(rentalService, new DialogService());
+            CustomerManagement = new CustomerManagementViewModel(customerService, _dialogService);
+            ManageRentals = new ManageRentalsViewModel(rentalService, _dialogService);
             ImportExport = new ImportExportViewModel(toolService, customerService, fileDialogService, databaseService);
             Reports = new ReportsViewModel(new ReportService(toolService, rentalService, activityLogService, customerService, userService));
             ActivityLogs = new ActivityLogsViewModel(activityLogService);
@@ -188,10 +190,10 @@ namespace ToolManagementAppV2.ViewModels
             OpenSettingsCommand = new RelayCommand(() =>
             {
                 var page = new SettingsPage
-                {
-                    DataContext = new SettingsViewModel(fileDialogService, _settingsService, new DialogService()),
-                    Title = "Settings"
-                };
+                    {
+                        DataContext = new SettingsViewModel(fileDialogService, _settingsService, _dialogService),
+                        Title = "Settings"
+                    };
                 CurrentPage = page;
             });
 
@@ -229,10 +231,9 @@ namespace ToolManagementAppV2.ViewModels
                                     .GetProperties()
                                     .Select(p => p.Name)
                                     .ToList();
-                var win = new ImportMappingWindow(headers, properties);
-                if (win.ShowDialog() == true)
+                var map = _dialogService.ShowImportMapping(headers, properties);
+                if (map != null)
                 {
-                    var map = win.VM.Mappings.ToDictionary(m => m.SelectedColumn, m => m.PropertyName);
                     var invalid = _toolService.ImportToolsFromCsv(path, map);
                     var msg = invalid.Count == 0
                         ? "Successfully imported tools."
@@ -246,10 +247,10 @@ namespace ToolManagementAppV2.ViewModels
                 using var dlg = new Forms.FolderBrowserDialog();
                 if (dlg.ShowDialog() != Forms.DialogResult.OK)
                     return;
-                var win = new ImageImportMappingWindow();
-                if (win.ShowDialog() == true)
+                var selector = _dialogService.ShowImageImportMapping();
+                if (selector != null)
                 {
-                    var result = _toolService.ImportToolImages(dlg.SelectedPath, win.VM.BuildSelector());
+                    var result = _toolService.ImportToolImages(dlg.SelectedPath, selector);
                     System.Windows.MessageBox.Show(
                         $"Imported {result.ImportedCount} images. Unmatched: {result.UnmatchedFiles.Count}, Conflicts: {result.ConflictingFiles.Count}",
                         "Import Images");
@@ -285,31 +286,23 @@ namespace ToolManagementAppV2.ViewModels
 
             OpenRentalHistoryWindowCommand = new RelayCommand(() =>
             {
-                // Constructor requires (Tool tool, IEnumerable<Rental> history)
-                var vm = new RentalHistoryViewModel(null, Enumerable.Empty<Models.Domain.Rental>());
-                var win = new RentalHistoryWindow(vm);
-                win.ShowDialog();
+                _dialogService.ShowRentalHistory(new ToolModel(), Enumerable.Empty<RentalModel>());
             });
 
             OpenPrintPreviewWindowCommand = new RelayCommand(() =>
             {
                 var doc = new FlowDocument(new Paragraph(new Run("Preview document")));
-                var win = new PrintPreviewWindow();
-                win.ShowPreview(doc, "Print Preview", "");
+                _dialogService.ShowPrintPreview(doc, "Print Preview", string.Empty);
             });
 
             OpenPrintLabelWindowCommand = new RelayCommand(() =>
             {
-                // Avoid missing VM type by opening the window directly
-                var win = new PrintLabelWindow();
-                win.ShowDialog();
+                _dialogService.ShowPrintLabelDialog();
             });
 
             OpenScannerStatusWindowCommand = new RelayCommand(() =>
             {
-                // Avoid missing VM type by opening the window directly
-                var win = new ScannerStatusWindow();
-                win.ShowDialog();
+                _dialogService.ShowScannerStatus();
             });
 
             OpenDashboardCommand.Execute(null);

--- a/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
@@ -8,7 +8,6 @@ using System.Windows;
 using System.Windows.Documents;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Extensions;
-using ToolManagementAppV2.Views;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -229,8 +228,7 @@ namespace ToolManagementAppV2.ViewModels
 
             doc.Blocks.Add(table);
 
-            var preview = new PrintPreviewWindow();
-            preview.ShowPreview(doc, $"Rental {SelectedRental.RentalID}", string.Empty);
+            _dialogService.ShowPrintPreview(doc, $"Rental {SelectedRental.RentalID}", string.Empty);
         }
 
         void DeleteRental()

--- a/ToolManagementAppV2/ViewModels/PrintLabelViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/PrintLabelViewModel.cs
@@ -5,13 +5,14 @@ using System.Windows.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ToolManagementAppV2.Models.Domain;
-using ToolManagementAppV2.Views;
+using ToolManagementAppV2.Interfaces;
 
 namespace ToolManagementAppV2.ViewModels
 {
     public class PrintLabelViewModel : ObservableObject
     {
         private readonly System.Action _closeAction;
+        private readonly IDialogService _dialogService;
 
         public ObservableCollection<string> Templates { get; }
 
@@ -35,8 +36,9 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand PrintCommand { get; }
         public IRelayCommand CloseCommand { get; }
 
-        public PrintLabelViewModel(System.Action closeAction)
+        public PrintLabelViewModel(IDialogService dialogService, System.Action closeAction)
         {
+            _dialogService = dialogService;
             _closeAction = closeAction;
             Templates = new ObservableCollection<string> { "Standard", "Compact" };
             _selectedTemplate = Templates.First();
@@ -49,8 +51,7 @@ namespace ToolManagementAppV2.ViewModels
         private void Preview()
         {
             var doc = BuildDocument();
-            var preview = new PrintPreviewWindow();
-            preview.ShowPreview(doc, "Tool Labels", string.Empty);
+            _dialogService.ShowPrintPreview(doc, "Tool Labels", string.Empty);
         }
 
         private void Print()

--- a/ToolManagementAppV2/Views/PrintLabelWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PrintLabelWindow.xaml.cs
@@ -12,6 +12,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Interfaces;
 
 namespace ToolManagementAppV2.Views
 {
@@ -20,10 +21,12 @@ namespace ToolManagementAppV2.Views
     /// </summary>
     public partial class PrintLabelWindow : Window
     {
-        public PrintLabelWindow()
+        public PrintLabelWindow(IDialogService dialogService)
         {
             InitializeComponent();
-            DataContext = new PrintLabelViewModel(() => Close());
+            DataContext = new PrintLabelViewModel(dialogService, () => Close());
         }
+
+        public PrintLabelWindow() : this(new ToolManagementAppV2.Services.DialogService()) { }
     }
 }


### PR DESCRIPTION
## Summary
- extend IDialogService for import mapping, print preview, label and scanner dialogs
- inject dialog service into main, rentals, and label view models and remove direct window construction
- update tests to use stubbed dialog service

## Testing
- `dotnet test` *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cf745a9808324ad1188d27269f392