### PR TITLE
Cache tool list and add service call tests

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -2,7 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Data.SQLite;
 using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Models;
+using ToolManagementAppV2.Models.ImportExport;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Services.Customers;
@@ -405,6 +408,104 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 if (File.Exists(dbPath))
                     File.Delete(dbPath);
             }
+        }
+
+        [Fact]
+        public async Task FilterToolsAsync_UsesSearchService_WhenTermProvided()
+        {
+            var tools = new List<ToolModel>
+            {
+                new Tool { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" },
+                new Tool { ToolNumber = "T2", NameDescription = "Saw", Brand = "BrandB" }
+            };
+            var toolService = new CountingToolService(tools);
+            var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
+            vm.SearchTerm = "Ham";
+            await vm.SearchCommand.ExecuteAsync(null);
+            Assert.Equal(1, toolService.SearchToolsAsyncCalls);
+            Assert.Equal(0, toolService.GetAllToolsAsyncCalls);
+        }
+
+        [Fact]
+        public async Task FilterToolsAsync_ReusesCache_WhenNoSearchTerm()
+        {
+            var tools = new List<ToolModel>
+            {
+                new Tool { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" }
+            };
+            var toolService = new CountingToolService(tools);
+            var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
+
+            await vm.SearchCommand.ExecuteAsync(null);
+            Assert.Equal(1, toolService.GetAllToolsAsyncCalls);
+            Assert.Equal(0, toolService.SearchToolsAsyncCalls);
+
+            await vm.SearchCommand.ExecuteAsync(null);
+            Assert.Equal(1, toolService.GetAllToolsAsyncCalls);
+        }
+
+        class CountingToolService : IToolService
+        {
+            public int GetAllToolsAsyncCalls { get; private set; }
+            public int SearchToolsAsyncCalls { get; private set; }
+            readonly List<ToolModel> _tools;
+            public CountingToolService(IEnumerable<ToolModel> tools) => _tools = tools.ToList();
+
+            public List<ToolModel> GetAllTools()
+            {
+                GetAllToolsAsyncCalls++;
+                return _tools.ToList();
+            }
+
+            public Task<List<ToolModel>> GetAllToolsAsync()
+            {
+                GetAllToolsAsyncCalls++;
+                return Task.FromResult(_tools.ToList());
+            }
+
+            public List<ToolModel> SearchTools(string? searchText)
+            {
+                SearchToolsAsyncCalls++;
+                return _tools.ToList();
+            }
+
+            public Task<List<ToolModel>> SearchToolsAsync(string? searchText)
+            {
+                SearchToolsAsyncCalls++;
+                if (string.IsNullOrWhiteSpace(searchText))
+                    return Task.FromResult(_tools.ToList());
+                var term = searchText.Trim();
+                var results = _tools.Where(t =>
+                    (t.ToolNumber?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    (t.NameDescription?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    (t.Brand?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    (t.PartNumber?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false))
+                    .ToList();
+                return Task.FromResult(results);
+            }
+
+            public void AddTool(ToolModel tool) => throw new NotImplementedException();
+            public Task AddToolAsync(ToolModel tool) => throw new NotImplementedException();
+            public void UpdateTool(ToolModel tool) => throw new NotImplementedException();
+            public Task UpdateToolAsync(ToolModel tool) => throw new NotImplementedException();
+            public void DeleteTool(int toolID) => throw new NotImplementedException();
+            public Task DeleteToolAsync(int toolID) => throw new NotImplementedException();
+            public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
+            public Task<ToolModel> GetToolByIDAsync(int toolID) => throw new NotImplementedException();
+            public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+            public Task ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
+            public List<ToolModel> GetToolsCheckedOutBy(string userName) => throw new NotImplementedException();
+            public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName) => throw new NotImplementedException();
+            public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
+            public Task UpdateToolImageAsync(int toolID, string imagePath) => throw new NotImplementedException();
+            public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
+            public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
+            public void ExportToolsToCsv(string filePath) => throw new NotImplementedException();
+            public Task ExportToolsToCsvAsync(string filePath) => throw new NotImplementedException();
+            public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => throw new NotImplementedException();
+            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => throw new NotImplementedException();
+            public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => throw new NotImplementedException();
+            public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => throw new NotImplementedException();
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -151,16 +151,30 @@ namespace ToolManagementAppV2.ViewModels
         async Task FilterToolsAsync()
         {
             var term = string.IsNullOrWhiteSpace(SearchTerm) ? string.Empty : SearchTerm.Trim();
-            var all = await _toolService.GetAllToolsAsync();
-            IEnumerable<ToolModel> results = string.IsNullOrEmpty(term)
-                ? all
-                : await _toolService.SearchToolsAsync(term);
+            IEnumerable<ToolModel> source;
+
+            if (!string.IsNullOrEmpty(term))
+            {
+                source = await _toolService.SearchToolsAsync(term);
+            }
+            else
+            {
+                if (Tools.Count == 0)
+                {
+                    var all = await _toolService.GetAllToolsAsync();
+                    Tools.ReplaceRange(all);
+                }
+                source = Tools;
+            }
+
             if (!string.IsNullOrEmpty(SelectedCategory) && SelectedCategory != "All")
             {
-                results = results.Where(t => string.Equals(t.Brand, SelectedCategory, StringComparison.OrdinalIgnoreCase));
+                source = source.Where(t => string.Equals(t.Brand, SelectedCategory, StringComparison.OrdinalIgnoreCase));
             }
-            SearchResults.ReplaceRange(results);
-            CategorizeTools(results);
+
+            SearchResults.ReplaceRange(source);
+            CategorizeTools(source);
+            LoadCategories(source, suppressSearch: true);
         }
 
         async Task AddToolAsync()
@@ -264,7 +278,7 @@ namespace ToolManagementAppV2.ViewModels
 
         static bool IsPowerTool(ToolModel tool) => tool?.IsPowerTool == true;
 
-        void LoadCategories(IEnumerable<ToolModel> tools)
+        void LoadCategories(IEnumerable<ToolModel> tools, bool suppressSearch = false)
         {
             var categories = tools.Select(t => t.Brand)
                                    .Where(b => !string.IsNullOrWhiteSpace(b))
@@ -276,7 +290,15 @@ namespace ToolManagementAppV2.ViewModels
 
             if (!Categories.Contains(SelectedCategory))
             {
-                SelectedCategory = "All";
+                if (suppressSearch)
+                {
+                    _selectedCategory = "All";
+                    OnPropertyChanged(nameof(SelectedCategory));
+                }
+                else
+                {
+                    SelectedCategory = "All";
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- cache tool list and only search when term provided
- recompute categories from filtered results
- test that filtering uses a single service method

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689cfc13244c83248ecdff6048394a16