### PR TITLE
Use async commands for rental actions

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
@@ -201,7 +202,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void OpenRentalsCommand_NavigatesToManageRentalsPage()
+        public async Task OpenRentalsCommand_NavigatesToManageRentalsPage()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -216,7 +217,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var settingsService = new SettingsService(db);
 
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
-                vm.OpenRentalsCommand.Execute(null);
+                await vm.OpenRentalsCommand.ExecuteAsync(null);
 
                 var page = Assert.IsType<ManageRentalsPage>(vm.CurrentPage);
                 Assert.IsType<ManageRentalsViewModel>(page.DataContext);

--- a/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Services.Customers;
@@ -16,7 +17,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     public class ManageRentalsViewModelTests
     {
         [Fact]
-        public void ApplyFilter_FiltersByStatus()
+        public async Task ApplyFilter_FiltersByStatus()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -40,7 +41,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 rentalService.ReturnTool(all[1].RentalID, DateTime.Today);
 
                 var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
-                vm.LoadRentals();
+                await vm.LoadRentalsAsync();
 
                 Assert.Equal(2, vm.Rentals.Count);
 
@@ -61,7 +62,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void ApplyFilter_FiltersBySearchText()
+        public async Task ApplyFilter_FiltersBySearchText()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -83,7 +84,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 rentalService.RentTool(tool2.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
                 var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
-                vm.LoadRentals();
+                await vm.LoadRentalsAsync();
 
                 vm.SearchText = "Alpha";
                 vm.ApplyFilterCommand.Execute(null);
@@ -117,7 +118,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void DeleteRentalCommand_RemovesRental()
+        public async Task DeleteRentalCommand_RemovesRental()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -136,10 +137,10 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 rentalService.RentTool(tool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
                 var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
-                vm.LoadRentals();
+                await vm.LoadRentalsAsync();
                 vm.SelectedRental = vm.Rentals.First();
 
-                vm.DeleteRentalCommand.Execute(null);
+                await vm.DeleteRentalCommand.ExecuteAsync(null);
 
                 Assert.Empty(vm.Rentals);
                 Assert.Empty(rentalService.GetAllRentals());
@@ -150,7 +151,75 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     File.Delete(dbPath);
             }
         }
-    }
+
+        [Fact]
+        public async Task CheckInCommand_UpdatesRentalStatus()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+
+                var tool = new Tool { ToolNumber = "T1" };
+                toolService.AddTool(tool);
+                var customer = new Customer { Company = "C1" };
+                customerService.AddCustomer(customer);
+                var cust = customerService.GetAllCustomers().First();
+
+                rentalService.RentTool(tool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+
+                var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
+                await vm.LoadRentalsAsync();
+                vm.SelectedRental = vm.Rentals.First();
+
+                await vm.CheckInCommand.ExecuteAsync(null);
+
+                Assert.Equal("Returned", vm.Rentals.First().Status);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task ExtendCommand_ExtendsDueDate()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+
+                var tool = new Tool { ToolNumber = "T1" };
+                toolService.AddTool(tool);
+                var customer = new Customer { Company = "C1" };
+                customerService.AddCustomer(customer);
+                var cust = customerService.GetAllCustomers().First();
+
+                rentalService.RentTool(tool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+
+                var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
+                await vm.LoadRentalsAsync();
+                vm.SelectedRental = vm.Rentals.First();
+                var oldDue = vm.SelectedRental.DueDate;
+
+                await vm.ExtendCommand.ExecuteAsync(null);
+
+                Assert.Equal(oldDue.AddDays(7), vm.Rentals.First().DueDate);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 
     class StubDialogService : IDialogService

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -82,7 +82,7 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand OpenDashboardCommand { get; }
         public IRelayCommand OpenSearchToolsCommand { get; }
         public IRelayCommand OpenManageToolsCommand { get; }
-        public IRelayCommand OpenRentalsCommand { get; }
+        public IAsyncRelayCommand OpenRentalsCommand { get; }
         public IRelayCommand OpenCustomersCommand { get; }
         public IRelayCommand OpenUsersCommand { get; }
         public IRelayCommand OpenSettingsCommand { get; }
@@ -161,9 +161,9 @@ namespace ToolManagementAppV2.ViewModels
                 CurrentPage = page;
             });
 
-            OpenRentalsCommand = new RelayCommand(() =>
+            OpenRentalsCommand = new AsyncRelayCommand(async () =>
             {
-                ManageRentals.LoadRentals();
+                await ManageRentals.LoadRentalsAsync();
                 var page = new ManageRentalsPage { DataContext = ManageRentals, Title = "Manage Rentals" };
                 CurrentPage = page;
             });

--- a/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Documents;
 using ToolManagementAppV2.Interfaces;
@@ -62,11 +63,11 @@ namespace ToolManagementAppV2.ViewModels
             {
                 if (SetProperty(ref _selectedRental, value))
                 {
-                    ((RelayCommand)CheckInCommand).NotifyCanExecuteChanged();
-                    ((RelayCommand)ExtendCommand).NotifyCanExecuteChanged();
-                    ((RelayCommand)OpenHistoryCommand).NotifyCanExecuteChanged();
-                    ((RelayCommand)PrintRentalCommand).NotifyCanExecuteChanged();
-                    ((RelayCommand)DeleteRentalCommand).NotifyCanExecuteChanged();
+                    CheckInCommand.NotifyCanExecuteChanged();
+                    ExtendCommand.NotifyCanExecuteChanged();
+                    OpenHistoryCommand.NotifyCanExecuteChanged();
+                    PrintRentalCommand.NotifyCanExecuteChanged();
+                    DeleteRentalCommand.NotifyCanExecuteChanged();
                 }
             }
         }
@@ -75,11 +76,11 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand ClearFilterCommand { get; }
         public IRelayCommand OpenFilterWindowCommand { get; }
         public IRelayCommand CloseCommand { get; }
-        public IRelayCommand CheckInCommand { get; }
-        public IRelayCommand ExtendCommand { get; }
-        public IRelayCommand OpenHistoryCommand { get; }
+        public IAsyncRelayCommand CheckInCommand { get; }
+        public IAsyncRelayCommand ExtendCommand { get; }
+        public IAsyncRelayCommand OpenHistoryCommand { get; }
         public IRelayCommand PrintRentalCommand { get; }
-        public IRelayCommand DeleteRentalCommand { get; }
+        public IAsyncRelayCommand DeleteRentalCommand { get; }
 
         public ManageRentalsViewModel(IRentalService rentalService, IDialogService dialogService)
         {
@@ -90,17 +91,17 @@ namespace ToolManagementAppV2.ViewModels
             ClearFilterCommand = new RelayCommand(ClearFilter);
             OpenFilterWindowCommand = new RelayCommand(OpenFilterWindow);
             CloseCommand = new RelayCommand(CloseFilterWindow);
-            CheckInCommand = new RelayCommand(CheckIn, () => SelectedRental != null);
-            ExtendCommand = new RelayCommand(Extend, () => SelectedRental != null);
-            OpenHistoryCommand = new RelayCommand(OpenHistory, () => SelectedRental != null);
+            CheckInCommand = new AsyncRelayCommand(CheckInAsync, () => SelectedRental != null);
+            ExtendCommand = new AsyncRelayCommand(ExtendAsync, () => SelectedRental != null);
+            OpenHistoryCommand = new AsyncRelayCommand(OpenHistoryAsync, () => SelectedRental != null);
             PrintRentalCommand = new RelayCommand(PrintRental, () => SelectedRental != null);
-            DeleteRentalCommand = new RelayCommand(DeleteRental, () => SelectedRental != null);
+            DeleteRentalCommand = new AsyncRelayCommand(DeleteRentalAsync, () => SelectedRental != null);
         }
 
         /// <summary>Loads all rentals from the service.</summary>
-        public void LoadRentals()
+        public async Task LoadRentalsAsync()
         {
-            _allRentals = _rentalService.GetAllRentals();
+            _allRentals = await _rentalService.GetAllRentalsAsync();
             Rentals.ReplaceRange(_allRentals);
         }
 
@@ -149,31 +150,31 @@ namespace ToolManagementAppV2.ViewModels
             window?.Close();
         }
 
-        void CheckIn()
+        async Task CheckInAsync()
         {
             if (SelectedRental == null)
                 return;
 
-            _rentalService.ReturnTool(SelectedRental.RentalID, DateTime.Today);
-            LoadRentals();
+            await _rentalService.ReturnToolAsync(SelectedRental.RentalID, DateTime.Today);
+            await LoadRentalsAsync();
         }
 
-        void Extend()
+        async Task ExtendAsync()
         {
             if (SelectedRental == null)
                 return;
 
             var newDueDate = SelectedRental.DueDate.AddDays(7);
-            _rentalService.ExtendRental(SelectedRental.RentalID, newDueDate);
-            LoadRentals();
+            await _rentalService.ExtendRentalAsync(SelectedRental.RentalID, newDueDate);
+            await LoadRentalsAsync();
         }
 
-        void OpenHistory()
+        async Task OpenHistoryAsync()
         {
             if (SelectedRental == null)
                 return;
 
-            var history = _rentalService.GetRentalHistoryForTool(SelectedRental.ToolID);
+            var history = await _rentalService.GetRentalHistoryForToolAsync(SelectedRental.ToolID);
             var tool = new ToolModel
             {
                 ToolID = SelectedRental.ToolID,
@@ -231,11 +232,11 @@ namespace ToolManagementAppV2.ViewModels
             _dialogService.ShowPrintPreview(doc, $"Rental {SelectedRental.RentalID}", string.Empty);
         }
 
-        void DeleteRental()
+        async Task DeleteRentalAsync()
         {
             if (SelectedRental == null)
                 return;
-            _rentalService.DeleteRental(SelectedRental.RentalID);
+            await _rentalService.DeleteRentalAsync(SelectedRental.RentalID);
             _allRentals.Remove(SelectedRental);
             Rentals.Remove(SelectedRental);
         }


### PR DESCRIPTION
## Summary
- Switch rental commands to AsyncRelayCommand and await IRentalService calls
- Load, check-in, extend, and delete rentals through async service methods
- Add async tests verifying rental updates and navigation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d042799c883249082bf584ff4a0e4