### PR TITLE
Use explicit delegate for login window creation

### DIFF
--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -122,7 +122,7 @@ namespace ToolManagementAppV2.ViewModels
             _settingsService = settingsService;
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<MainViewModel>.Instance;
-            _showLoginWindow = showLoginWindow ?? (() =>
+            _showLoginWindow = showLoginWindow ?? new Func<bool>(() =>
             {
                 var login = new LoginWindow(_userContext, _userService, _settingsService, _dialogService)
                 {


### PR DESCRIPTION
## Summary
- ensure MainViewModel initializes the login delegate using an explicit `Func<bool>`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d1ec1aea88324b87a5a4d0f7c89d4