### PR TITLE
Use non-generic logger for PathHelper

### DIFF
--- a/ToolManagementAppV2/Utilities/Helpers/PathHelper.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/PathHelper.cs
@@ -6,7 +6,7 @@ namespace ToolManagementAppV2.Utilities.Helpers
 {
     public static class PathHelper
     {
-        private static readonly ILogger Logger = App.LoggerFactory.CreateLogger<PathHelper>();
+        private static readonly ILogger Logger = App.LoggerFactory.CreateLogger(nameof(PathHelper));
 
         /// <summary>
         /// Resolves <paramref name="path"/> against the application's base directory


### PR DESCRIPTION
## Summary
- Use `CreateLogger(nameof(PathHelper))` instead of generic logger

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689d1ec26a508324baa0b295a584849b