### PR TITLE
Guard MapTool conversions against null values

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -244,5 +244,58 @@ namespace ToolManagementAppV2.Tests.Services
                 if (File.Exists(dbPath)) File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void GetAllTools_AllowsNullNumericColumns()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                using (var conn = new SQLiteConnection($"Data Source={dbPath};Version=3;"))
+                {
+                    conn.Open();
+                    using var cmd = conn.CreateCommand();
+                    cmd.CommandText = @"
+                        CREATE TABLE Tools (
+                            ToolID INTEGER PRIMARY KEY AUTOINCREMENT,
+                            ToolNumber TEXT,
+                            NameDescription TEXT,
+                            Location TEXT,
+                            Brand TEXT,
+                            PartNumber TEXT,
+                            Supplier TEXT,
+                            PurchasedDate DATETIME,
+                            Notes TEXT,
+                            AvailableQuantity INTEGER,
+                            RentedQuantity INTEGER,
+                            IsPowerTool INTEGER,
+                            IsCheckedOut INTEGER,
+                            CheckedOutBy TEXT,
+                            CheckedOutTime DATETIME,
+                            ToolImagePath TEXT,
+                            Keywords TEXT
+                        );
+                        INSERT INTO Tools (ToolNumber, NameDescription, AvailableQuantity, RentedQuantity, IsPowerTool, IsCheckedOut)
+                        VALUES ('T1', 'Test', NULL, NULL, NULL, NULL);
+                    ";
+                    cmd.ExecuteNonQuery();
+                }
+
+                var dbService = new DatabaseService(dbPath);
+                var svc = new ToolService(dbService);
+                var tools = svc.GetAllTools();
+
+                Assert.Single(tools);
+                var tool = tools[0];
+                Assert.Equal(0, tool.QuantityOnHand);
+                Assert.Equal(0, tool.RentedQuantity);
+                Assert.False(tool.IsPowerTool);
+                Assert.False(tool.IsCheckedOut);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -366,23 +366,23 @@ namespace ToolManagementAppV2.Services.Tools
     
         ToolModel MapTool(IDataRecord r) => new()
         {
-            ToolID = Convert.ToInt32(r["ToolID"]),
+            ToolID = r["ToolID"] is DBNull ? 0 : Convert.ToInt32(r["ToolID"]),
             ToolNumber = r["ToolNumber"].ToString(),
             PartNumber = r["PartNumber"].ToString(),
             NameDescription = r["NameDescription"].ToString(),
             Brand = r["Brand"].ToString(),
             Location = r["Location"].ToString(),
-            QuantityOnHand = Convert.ToInt32(r["AvailableQuantity"]),
-            RentedQuantity = Convert.ToInt32(r["RentedQuantity"]),
+            QuantityOnHand = r["AvailableQuantity"] is DBNull ? 0 : Convert.ToInt32(r["AvailableQuantity"]),
+            RentedQuantity = r["RentedQuantity"] is DBNull ? 0 : Convert.ToInt32(r["RentedQuantity"]),
             Supplier = r["Supplier"].ToString(),
             PurchasedDate = r["PurchasedDate"] is DBNull ? (DateTime?)null : Convert.ToDateTime(r["PurchasedDate"]),
             Notes = r["Notes"].ToString(),
-            IsCheckedOut = Convert.ToInt32(r["IsCheckedOut"]) == 1,
+            IsCheckedOut = (r["IsCheckedOut"] is DBNull ? 0 : Convert.ToInt32(r["IsCheckedOut"])) == 1,
             CheckedOutBy = r["CheckedOutBy"].ToString(),
             CheckedOutTime = r["CheckedOutTime"] is DBNull ? (DateTime?)null : Convert.ToDateTime(r["CheckedOutTime"]),
             ToolImagePath = r["ToolImagePath"]?.ToString(),
             Keywords = r["Keywords"]?.ToString(),
-            IsPowerTool = Convert.ToInt32(r["IsPowerTool"]) == 1
+            IsPowerTool = (r["IsPowerTool"] is DBNull ? 0 : Convert.ToInt32(r["IsPowerTool"])) == 1
         };
 
         public Task AddToolAsync(ToolModel tool) => Task.Run(() => AddTool(tool));


### PR DESCRIPTION
## Summary
- prevent null database values from causing exceptions in ToolService.MapTool
- ensure GetAllTools handles null numeric columns

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d2a24832483248b4aaa7f814bdbe8