### PR TITLE
Ensure default zero for numeric columns

### DIFF
--- a/ToolManagementAppV2.Tests/Services/DatabaseColumnDefaultsTests.cs
+++ b/ToolManagementAppV2.Tests/Services/DatabaseColumnDefaultsTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Data.SQLite;
+using System.IO;
+using ToolManagementAppV2.Services.Core;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Services
+{
+    public class DatabaseColumnDefaultsTests
+    {
+        [Fact]
+        public void NumericColumnsBackfilledWithZero()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                using (var conn = new SQLiteConnection($"Data Source={dbPath};Version=3;"))
+                {
+                    conn.Open();
+                    using var cmd = new SQLiteCommand(@"CREATE TABLE Tools (
+                            ToolID INTEGER PRIMARY KEY AUTOINCREMENT,
+                            ToolNumber TEXT NOT NULL
+                        );
+                        INSERT INTO Tools (ToolNumber) VALUES ('T1');", conn);
+                    cmd.ExecuteNonQuery();
+                }
+
+                var service = new DatabaseService(dbPath);
+
+                using var conn2 = service.CreateConnection();
+                using (var cmdCheck = new SQLiteCommand("SELECT IsPowerTool, IsCheckedOut FROM Tools", conn2))
+                using (var reader = cmdCheck.ExecuteReader())
+                {
+                    Assert.True(reader.Read());
+                    Assert.Equal(0, reader.GetInt32(0));
+                    Assert.Equal(0, reader.GetInt32(1));
+                }
+
+                using var cmdNulls = new SQLiteCommand("SELECT COUNT(*) FROM Tools WHERE IsPowerTool IS NULL OR IsCheckedOut IS NULL", conn2);
+                var nullCount = Convert.ToInt32(cmdNulls.ExecuteScalar());
+                Assert.Equal(0, nullCount);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -46,7 +46,8 @@ namespace ToolManagementAppV2.Services.Core
             EnsureColumn("Tools", "CheckedOutBy", "TEXT");
             EnsureColumn("Tools", "CheckedOutTime", "DATETIME");
             EnsureColumn("Tools", "Keywords", "TEXT");
-            EnsureColumn("Tools", "IsPowerTool", "INTEGER");
+            EnsureColumn("Tools", "IsPowerTool", "INTEGER", "0");
+            EnsureColumn("Tools", "IsCheckedOut", "INTEGER", "0");
             EnsureColumn("Users", "Password", "TEXT");
             EnsureColumn("Users", "Salt", "TEXT");
             EnsureColumn("Users", "Email", "TEXT");
@@ -54,7 +55,7 @@ namespace ToolManagementAppV2.Services.Core
             EnsureColumn("Users", "Mobile", "TEXT");
             EnsureColumn("Users", "Address", "TEXT");
             EnsureColumn("Users", "Role", "TEXT");
-            EnsureColumn("Users", "IsActive", "INTEGER");
+            EnsureColumn("Users", "IsActive", "INTEGER", "1");
             EnsureColumn("Users", "CreatedAt", "DATETIME");
         }
 
@@ -164,14 +165,20 @@ namespace ToolManagementAppV2.Services.Core
             EnsureIndex(conn, "Users", "UserName");
         }
 
-        void EnsureColumn(string table, string column, string type)
+        void EnsureColumn(string table, string column, string type, string? defaultValue = null)
         {
             if (SqliteHelper.ColumnExists(ConnectionString, table, column)) return;
             try
             {
                 using var conn = CreateConnection();
-                using var alter = new SQLiteCommand($"ALTER TABLE {table} ADD COLUMN {column} {type}", conn);
+                var defaultClause = defaultValue != null ? $" NOT NULL DEFAULT {defaultValue}" : string.Empty;
+                using var alter = new SQLiteCommand($"ALTER TABLE {table} ADD COLUMN {column} {type}{defaultClause}", conn);
                 alter.ExecuteNonQuery();
+                if (defaultValue != null)
+                {
+                    using var update = new SQLiteCommand($"UPDATE {table} SET {column}={defaultValue} WHERE {column} IS NULL", conn);
+                    update.ExecuteNonQuery();
+                }
             }
             catch (SQLiteException ex)
             {


### PR DESCRIPTION
## Summary
- ensure numeric columns like IsPowerTool and IsCheckedOut are added with `DEFAULT 0` and backfilled
- add regression test to confirm these columns contain no NULL values after database initialization

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d36f19c948324a9688f864823e685