### PR TITLE
Add SearchTools test for null numeric fields

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -297,5 +297,57 @@ namespace ToolManagementAppV2.Tests.Services
                 if (File.Exists(dbPath)) File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void SearchTools_AllowsNullNumericColumns()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                using (var conn = new SQLiteConnection($"Data Source={dbPath};Version=3;"))
+                {
+                    conn.Open();
+                    using var cmd = conn.CreateCommand();
+                    cmd.CommandText = @"
+                        CREATE TABLE Tools (
+                            ToolID INTEGER PRIMARY KEY AUTOINCREMENT,
+                            ToolNumber TEXT,
+                            NameDescription TEXT,
+                            Location TEXT,
+                            Brand TEXT,
+                            PartNumber TEXT,
+                            Supplier TEXT,
+                            PurchasedDate DATETIME,
+                            Notes TEXT,
+                            AvailableQuantity INTEGER,
+                            RentedQuantity INTEGER,
+                            IsPowerTool INTEGER,
+                            IsCheckedOut INTEGER,
+                            CheckedOutBy TEXT,
+                            CheckedOutTime DATETIME,
+                            ToolImagePath TEXT,
+                            Keywords TEXT
+                        );
+                        INSERT INTO Tools (ToolNumber, NameDescription, AvailableQuantity, RentedQuantity, IsPowerTool, IsCheckedOut)
+                        VALUES ('T1', 'Test', NULL, NULL, NULL, NULL);
+                    ";
+                    cmd.ExecuteNonQuery();
+                }
+
+                var dbService = new DatabaseService(dbPath);
+                var svc = new ToolService(dbService);
+                var tools = svc.SearchTools("T1");
+
+                Assert.Single(tools);
+                var tool = tools[0];
+                Assert.Equal("T1", tool.ToolNumber);
+                Assert.False(tool.IsPowerTool);
+                Assert.Equal(0, tool.QuantityOnHand);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add regression test ensuring `SearchTools` handles tools with NULL numeric fields

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 when attempting to install .NET SDK)*

------
https://chatgpt.com/codex/tasks/task_e_689d39bc0f488324b848278cf130cc22