### PR TITLE
Fix OnCollectionChanged reflection ambiguity

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ObservableCollectionExtensionsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ObservableCollectionExtensionsTests.cs
@@ -21,4 +21,18 @@ public class ObservableCollectionExtensionsTests
         Assert.Equal(NotifyCollectionChangedAction.Reset, notifications[0].Action);
         Assert.Equal(new[] { 4, 5, 6 }, collection);
     }
+
+    [Fact]
+    public void AddRange_RaisesSingleResetNotification()
+    {
+        var collection = new ObservableCollection<int> { 1, 2, 3 };
+        var notifications = new List<NotifyCollectionChangedEventArgs>();
+        collection.CollectionChanged += (_, e) => notifications.Add(e);
+
+        collection.AddRange(new[] { 4, 5 });
+
+        Assert.Single(notifications);
+        Assert.Equal(NotifyCollectionChangedAction.Reset, notifications[0].Action);
+        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, collection);
+    }
 }

--- a/ToolManagementAppV2/Utilities/Extensions/ObservableCollectionExtensions.cs
+++ b/ToolManagementAppV2/Utilities/Extensions/ObservableCollectionExtensions.cs
@@ -13,7 +13,12 @@ namespace ToolManagementAppV2.Utilities.Extensions
         private sealed class NotificationSuspender<T> : IDisposable
         {
             private static readonly MethodInfo? OnCollectionChangedMethod =
-                typeof(ObservableCollection<T>).GetMethod("OnCollectionChanged", BindingFlags.Instance | BindingFlags.NonPublic);
+                typeof(ObservableCollection<T>).GetMethod(
+                    "OnCollectionChanged",
+                    BindingFlags.Instance | BindingFlags.NonPublic,
+                    binder: null,
+                    types: new[] { typeof(NotifyCollectionChangedEventArgs) },
+                    modifiers: null);
 
             private readonly ObservableCollection<T> _collection;
             private readonly NotifyCollectionChangedEventHandler? _handlers;


### PR DESCRIPTION
## Summary
- Disambiguate `OnCollectionChanged` reflection in `NotificationSuspender` to avoid `TypeInitializationException`
- Add unit test for `AddRange` verifying reset notification

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d4a5c3e388324a675568c7f416162