### PR TITLE
Add SQL LIKE search with indexes and multi-term tests

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -45,6 +45,52 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
+        public void SearchTools_PartialMatch_ReturnsMatches()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                IToolService service = new ToolService(dbService);
+
+                service.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
+                service.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw" });
+
+                var results = service.SearchTools("Ham");
+                Assert.Single(results);
+                Assert.Equal("T1", results[0].ToolNumber);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void SearchTools_MultipleTermsAcrossColumns_ReturnsMatches()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                IToolService service = new ToolService(dbService);
+
+                service.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
+                service.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Hammer", Brand = "BrandB" });
+
+                var results = service.SearchTools("Hammer BrandA");
+                Assert.Single(results);
+                Assert.Equal("BrandA", results[0].Brand);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public void AddTool_SetsGeneratedToolID()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -46,6 +46,32 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public async Task SearchCommand_SupportsMultipleTerms()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var dialog = new StubDialogService();
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
+                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
+                toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Hammer", Brand = "BrandB" });
+                vm.SearchTerm = "Hammer BrandA";
+                await vm.SearchCommand.ExecuteAsync(null);
+                Assert.Single(vm.SearchResults);
+                Assert.Equal("BrandA", vm.SearchResults.First().Brand);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public async Task SearchCommand_SortsResultsIntoCategories()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -162,6 +162,13 @@ namespace ToolManagementAppV2.Services.Core
             cmd.ExecuteNonQuery();
 
             EnsureIndex(conn, "Tools", "ToolNumber", true);
+            EnsureIndex(conn, "Tools", "NameDescription");
+            EnsureIndex(conn, "Tools", "Brand");
+            EnsureIndex(conn, "Tools", "PartNumber");
+            EnsureIndex(conn, "Tools", "Supplier");
+            EnsureIndex(conn, "Tools", "Location");
+            EnsureIndex(conn, "Tools", "Notes");
+            EnsureIndex(conn, "Tools", "Keywords");
             EnsureIndex(conn, "Users", "UserName");
         }
 

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -58,22 +58,35 @@ namespace ToolManagementAppV2.Services.Tools
     
         public List<ToolModel> SearchTools(string? searchText)
         {
-            var all = GetAllTools();
             if (string.IsNullOrWhiteSpace(searchText))
-                return new List<ToolModel>(all);
+                return GetAllTools();
 
+            using var conn = _dbService.CreateConnection();
             var terms = searchText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            return all.Where(t => terms.All(term =>
-                t.ToolID.ToString().Contains(term, StringComparison.OrdinalIgnoreCase) ||
-                (t.ToolNumber?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                (t.NameDescription?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                (t.Brand?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                (t.PartNumber?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                (t.Supplier?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                (t.Location?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                (t.Notes?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                (t.Keywords?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false)
-            )).ToList();
+            var searchable = new[]
+            {
+                "ToolNumber",
+                "NameDescription",
+                "Brand",
+                "PartNumber",
+                "Supplier",
+                "Location",
+                "Notes",
+                "Keywords"
+            };
+
+            var sb = new StringBuilder("SELECT * FROM Tools WHERE ");
+            var parameters = new List<SQLiteParameter>();
+            for (int i = 0; i < terms.Length; i++)
+            {
+                if (i > 0) sb.Append(" AND ");
+                var paramName = $"@p{i}";
+                var likeClause = string.Join(" OR ", searchable.Select(col => $"{col} LIKE {paramName} COLLATE NOCASE"));
+                sb.Append($"(CAST(ToolID AS TEXT) LIKE {paramName} COLLATE NOCASE OR {likeClause})");
+                parameters.Add(new SQLiteParameter(paramName, $"%{terms[i]}%"));
+            }
+
+            return SqliteHelper.ExecuteReader(conn, sb.ToString(), parameters.ToArray(), MapTool);
         }
     
         /// <summary>


### PR DESCRIPTION
## Summary
- implement parameterized LIKE-based search in ToolService
- ensure indexes for searchable Tool columns
- add integration and UI tests for partial and multi-term searches

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d67b4306c8324b547cbcdafe55fdc