### PR TITLE
Remove cache and add concurrency tests

### DIFF
--- a/ToolManagementAppV2.Tests/Services/DatabaseServiceConcurrentTests.cs
+++ b/ToolManagementAppV2.Tests/Services/DatabaseServiceConcurrentTests.cs
@@ -38,5 +38,43 @@ namespace ToolManagementAppV2.Tests.Services
                 if (File.Exists(dbPath)) File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void EnsureIndex_ConcurrentCalls_NoDuplicateException()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var colMethod = typeof(DatabaseService).GetMethod("EnsureColumn", BindingFlags.NonPublic | BindingFlags.Instance);
+                var idxMethod = typeof(DatabaseService).GetMethod("EnsureIndex", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                var db = new DatabaseService(dbPath);
+                colMethod.Invoke(db, new object[] { "Tools", "ConcurrentIdxCol", "TEXT" });
+
+                var t1 = Task.Run(() =>
+                {
+                    var d = new DatabaseService(dbPath);
+                    using var conn = d.CreateConnection();
+                    idxMethod.Invoke(d, new object[] { conn, "Tools", "ConcurrentIdxCol", false });
+                });
+                var t2 = Task.Run(() =>
+                {
+                    var d = new DatabaseService(dbPath);
+                    using var conn = d.CreateConnection();
+                    idxMethod.Invoke(d, new object[] { conn, "Tools", "ConcurrentIdxCol", false });
+                });
+
+                var ex = Record.Exception(() => Task.WaitAll(t1, t2));
+                Assert.Null(ex);
+
+                using var checkDb = new DatabaseService(dbPath);
+                using var checkConn = checkDb.CreateConnection();
+                Assert.True(SqliteHelper.IndexExists(checkConn, "idx_Tools_ConcurrentIdxCol"));
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -395,5 +395,34 @@ namespace ToolManagementAppV2.Tests.Services
                 if (File.Exists(dbPath)) File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void AddTool_ConcurrentAdds_Succeeds()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var svc = new ToolService(dbService);
+
+                var tasks = Enumerable.Range(0, 10).Select(i => Task.Run(() =>
+                    svc.AddTool(new Tool
+                    {
+                        ToolNumber = $"T{i}",
+                        NameDescription = $"Tool{i}"
+                    }))
+                ).ToArray();
+
+                var ex = Record.Exception(() => Task.WaitAll(tasks));
+                Assert.Null(ex);
+
+                var all = svc.GetAllTools();
+                Assert.Equal(10, all.Count);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -19,7 +19,6 @@ namespace ToolManagementAppV2.Services.Tools
     public class ToolService : IToolService
     {
         readonly DatabaseService _dbService;
-        List<ToolModel>? _cache;
         const string AllToolsSql = "SELECT * FROM Tools";
         const string UpsertToolCsv = @"
             INSERT INTO Tools
@@ -37,20 +36,12 @@ namespace ToolManagementAppV2.Services.Tools
     
         public List<ToolModel> GetAllTools()
         {
-            if (_cache != null)
-                return _cache;
-
             using var conn = _dbService.CreateConnection();
-            _cache = SqliteHelper.ExecuteReader(conn, AllToolsSql, null, MapTool);
-            return _cache;
+            return SqliteHelper.ExecuteReader(conn, AllToolsSql, null, MapTool);
         }
     
         public ToolModel GetToolByID(int toolID)
         {
-            var cached = GetAllTools().FirstOrDefault(t => t.ToolID == toolID);
-            if (cached != null)
-                return cached;
-
             using var conn = _dbService.CreateConnection();
             return SqliteHelper.ExecuteReader(conn, "SELECT * FROM Tools WHERE ToolID=@ToolID",
                 new[] { new SQLiteParameter("@ToolID", toolID) }, MapTool).FirstOrDefault();
@@ -102,7 +93,6 @@ namespace ToolManagementAppV2.Services.Tools
                 throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
             using var conn = _dbService.CreateConnection();
             InsertTool(conn, null, tool);
-            _cache = null;
         }
     
         public void UpdateTool(ToolModel tool)
@@ -151,7 +141,6 @@ namespace ToolManagementAppV2.Services.Tools
             };
             using var conn = _dbService.CreateConnection();
             SqliteHelper.ExecuteNonQuery(conn, sql, p);
-            _cache = null;
         }
     
         public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental,
@@ -181,8 +170,6 @@ namespace ToolManagementAppV2.Services.Tools
                 if (SqliteHelper.ExecuteNonQuery(c, sql, p) == 0)
                     throw new InvalidOperationException("Quantity update failed.");
             }
-
-            _cache = null;
         }
     
         public void DeleteTool(int toolID)
@@ -190,7 +177,6 @@ namespace ToolManagementAppV2.Services.Tools
             using var conn = _dbService.CreateConnection();
             SqliteHelper.ExecuteNonQuery(conn, "DELETE FROM Tools WHERE ToolID=@ID",
                 new[] { new SQLiteParameter("@ID", toolID) });
-            _cache = null;
         }
     
         public void ToggleToolCheckOutStatus(int toolID, string currentUser)
@@ -226,7 +212,6 @@ namespace ToolManagementAppV2.Services.Tools
                 new SQLiteParameter("@Q", qtyChange),
                 new SQLiteParameter("@ID", toolID)
             });
-            _cache = null;
         }
     
         public List<ToolModel> GetToolsCheckedOutBy(string userName)
@@ -245,7 +230,6 @@ namespace ToolManagementAppV2.Services.Tools
                     new SQLiteParameter("@Img", imagePath),
                     new SQLiteParameter("@ID", toolID)
                 });
-            _cache = null;
         }
     
         public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map)
@@ -261,7 +245,6 @@ namespace ToolManagementAppV2.Services.Tools
                         InsertTool(conn, tran, tool);
                 }
                 tran.Commit();
-                _cache = null;
                 return invalidRows;
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- Remove in-memory cache from tool service and rely on database queries
- Add concurrent addition test for ToolService
- Add concurrent index creation test for DatabaseService

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

Manual UI regression for tool listings could not be executed in this environment.

------
https://chatgpt.com/codex/tasks/task_e_689d7022befc83248c75457afae401eb