### PR TITLE
Log warning on tool quantity update failure

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -9,6 +9,8 @@ using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Interfaces;
 using Xunit;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ToolManagementAppV2.Tests;
 
 namespace ToolManagementAppV2.Tests.Services
 {
@@ -389,6 +391,35 @@ namespace ToolManagementAppV2.Tests.Services
                 Assert.Equal("T1", tool.ToolNumber);
                 Assert.False(tool.IsPowerTool);
                 Assert.Equal(0, tool.QuantityOnHand);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void UpdateToolQuantities_NoRows_LogsWarningAndThrows()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var logs = new List<LogEntry>();
+                using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
+                var dbService = new DatabaseService(dbPath);
+                IToolService service = new ToolService(dbService, loggerFactory.CreateLogger<ToolService>());
+
+                service.AddTool(new Tool
+                {
+                    ToolNumber = "T1",
+                    NameDescription = "Hammer",
+                    QuantityOnHand = 0,
+                    RentedQuantity = 0
+                });
+
+                var addedTool = service.GetAllTools().First();
+                Assert.Throws<InvalidOperationException>(() => service.UpdateToolQuantities(addedTool.ToolID, 1, true));
+                Assert.Contains(logs, l => l.Level == LogLevel.Warning && l.Message.Contains("Quantity update affected 0 rows"));
             }
             finally
             {

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -162,13 +162,20 @@ namespace ToolManagementAppV2.Services.Tools
                     ? SqliteHelper.ExecuteNonQuery(conn, tx, sql, p)
                     : SqliteHelper.ExecuteNonQuery(conn, sql, p);
                 if (rows == 0)
+                {
+                    _logger.LogWarning("Quantity update affected 0 rows for ToolID {ToolID}", toolID);
                     throw new InvalidOperationException("Quantity update failed.");
+                }
             }
             else
             {
                 using var c = _dbService.CreateConnection();
-                if (SqliteHelper.ExecuteNonQuery(c, sql, p) == 0)
+                int rows = SqliteHelper.ExecuteNonQuery(c, sql, p);
+                if (rows == 0)
+                {
+                    _logger.LogWarning("Quantity update affected 0 rows for ToolID {ToolID}", toolID);
                     throw new InvalidOperationException("Quantity update failed.");
+                }
             }
         }
     


### PR DESCRIPTION
## Summary
- log a warning before throwing when updating tool quantities affects no rows
- add unit test that exercises failed quantity update

## Testing
- `dotnet test --filter RentalServiceTests` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689d7457d5a883249f4ff876021e82e9