### PR TITLE
Log skipped customer imports and return summary

### DIFF
--- a/ToolManagementAppV2.Tests/Services/CustomerServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/CustomerServiceTests.cs
@@ -8,6 +8,7 @@ using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Interfaces;
 using Xunit;
 using System.Threading.Tasks;
+using ToolManagementAppV2.Models.ImportExport;
 
 namespace ToolManagementAppV2.Tests.Services
 {
@@ -101,6 +102,43 @@ namespace ToolManagementAppV2.Tests.Services
 
                 Assert.Throws<SQLiteException>(() => service.ImportCustomersFromCsv(csvPath, map));
                 Assert.Empty(service.GetAllCustomers());
+            }
+            finally
+            {
+                if (File.Exists(csvPath)) File.Delete(csvPath);
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void ImportCustomersFromCsv_InvalidRows_ReturnsSummary()
+        {
+            var dbPath = Path.GetTempFileName();
+            var csvPath = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(csvPath,
+                    "Company,Contact,Phone,Mobile\n" +
+                    "Acme,John,1,\n" +
+                    ",,,\n" +
+                    "Acme,John,1,\n" +
+                    "NoPhone,Jane,,\n");
+                var dbService = new DatabaseService(dbPath);
+                var service = new CustomerService(dbService);
+                var map = new Dictionary<string, string>
+                {
+                    {"Company", "Company"},
+                    {"Contact", "Contact"},
+                    {"Phone", "Phone"},
+                    {"Mobile", "Mobile"}
+                };
+
+                var result = service.ImportCustomersFromCsv(csvPath, map);
+                Assert.Equal(1, result.ImportedCount);
+                Assert.Equal(3, result.SkippedRows.Count);
+                Assert.Contains(result.SkippedRows, r => r.Contains("Row 3"));
+                Assert.Contains(result.SkippedRows, r => r.Contains("Row 4") && r.Contains("Duplicate"));
+                Assert.Contains(result.SkippedRows, r => r.Contains("Row 5") && r.Contains("Phone and Mobile"));
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Models.ImportExport;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Rentals;
@@ -221,26 +222,54 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public bool ImportCalled { get; private set; }
         public bool ExportCalled { get; private set; }
-        public void ImportCustomersFromCsv(string filePath, IDictionary<string, string> map) => ImportCalled = true;
+        public CustomerImportResult ImportCustomersFromCsv(string filePath, IDictionary<string, string> map)
+        {
+            ImportCalled = true;
+            return new CustomerImportResult();
+        }
         public void ExportCustomersToCsv(string filePath) => ExportCalled = true;
+        public Task ExportCustomersToCsvAsync(string filePath)
+        {
+            ExportCalled = true;
+            return Task.CompletedTask;
+        }
         public void AddCustomer(Customer customer) => throw new System.NotImplementedException();
+        public Task AddCustomerAsync(Customer customer) => throw new System.NotImplementedException();
         public void UpdateCustomer(Customer customer) => throw new System.NotImplementedException();
+        public Task UpdateCustomerAsync(Customer customer) => throw new System.NotImplementedException();
         public void DeleteCustomer(int customerID) => throw new System.NotImplementedException();
+        public Task DeleteCustomerAsync(int customerID) => throw new System.NotImplementedException();
         public Customer GetCustomerByID(int customerID) => throw new System.NotImplementedException();
+        public Task<Customer> GetCustomerByIDAsync(int customerID) => throw new System.NotImplementedException();
         public List<Customer> GetAllCustomers() => new();
+        public Task<List<Customer>> GetAllCustomersAsync() => Task.FromResult(new List<Customer>());
         public List<Customer> SearchCustomers(string searchTerm) => new();
+        public Task<List<Customer>> SearchCustomersAsync(string searchTerm) => Task.FromResult(new List<Customer>());
+        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map)
+        {
+            ImportCalled = true;
+            return Task.FromResult(new CustomerImportResult());
+        }
     }
 
     class FailCustomerService : ICustomerService
     {
-        public void ImportCustomersFromCsv(string filePath, IDictionary<string, string> map) => throw new System.Exception("fail");
+        public CustomerImportResult ImportCustomersFromCsv(string filePath, IDictionary<string, string> map) => throw new System.Exception("fail");
+        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map) => throw new System.Exception("fail");
         public void ExportCustomersToCsv(string filePath) => throw new System.Exception("fail");
+        public Task ExportCustomersToCsvAsync(string filePath) => throw new System.Exception("fail");
         public void AddCustomer(Customer customer) => throw new System.NotImplementedException();
+        public Task AddCustomerAsync(Customer customer) => throw new System.NotImplementedException();
         public void UpdateCustomer(Customer customer) => throw new System.NotImplementedException();
+        public Task UpdateCustomerAsync(Customer customer) => throw new System.NotImplementedException();
         public void DeleteCustomer(int customerID) => throw new System.NotImplementedException();
+        public Task DeleteCustomerAsync(int customerID) => throw new System.NotImplementedException();
         public Customer GetCustomerByID(int customerID) => throw new System.NotImplementedException();
+        public Task<Customer> GetCustomerByIDAsync(int customerID) => throw new System.NotImplementedException();
         public List<Customer> GetAllCustomers() => new();
+        public Task<List<Customer>> GetAllCustomersAsync() => Task.FromResult(new List<Customer>());
         public List<Customer> SearchCustomers(string searchTerm) => new();
+        public Task<List<Customer>> SearchCustomersAsync(string searchTerm) => Task.FromResult(new List<Customer>());
     }
 
     class StubDatabaseBackupService : IDatabaseBackupService

--- a/ToolManagementAppV2/Interfaces/ICustomerService.cs
+++ b/ToolManagementAppV2/Interfaces/ICustomerService.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Models.ImportExport;
 
 namespace ToolManagementAppV2.Interfaces
 {
@@ -19,8 +20,8 @@ namespace ToolManagementAppV2.Interfaces
         Task<List<Customer>> GetAllCustomersAsync();
         List<Customer> SearchCustomers(string searchTerm);
         Task<List<Customer>> SearchCustomersAsync(string searchTerm);
-        void ImportCustomersFromCsv(string filePath, IDictionary<string, string> map);
-        Task ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map);
+        CustomerImportResult ImportCustomersFromCsv(string filePath, IDictionary<string, string> map);
+        Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map);
         void ExportCustomersToCsv(string filePath);
         Task ExportCustomersToCsvAsync(string filePath);
     }

--- a/ToolManagementAppV2/Models/DTOs/CustomerImportResult.cs
+++ b/ToolManagementAppV2/Models/DTOs/CustomerImportResult.cs
@@ -1,0 +1,8 @@
+namespace ToolManagementAppV2.Models.ImportExport
+{
+    public class CustomerImportResult
+    {
+        public int ImportedCount { get; set; }
+        public List<string> SkippedRows { get; } = new();
+    }
+}

--- a/ToolManagementAppV2/Services/Customers/CustomerService.cs
+++ b/ToolManagementAppV2/Services/Customers/CustomerService.cs
@@ -5,6 +5,7 @@ using System.Data.SQLite;
 using System.IO;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Models.ImportExport;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Utilities.IO;
 using ToolManagementAppV2.Interfaces;
@@ -24,23 +25,40 @@ namespace ToolManagementAppV2.Services.Customers
             _logger = logger ?? NullLogger<CustomerService>.Instance;
         }
 
-        public void ImportCustomersFromCsv(string filePath, IDictionary<string, string> map)
+        public CustomerImportResult ImportCustomersFromCsv(string filePath, IDictionary<string, string> map)
         {
             var customers = CsvHelperUtil.LoadCustomersFromCsv(filePath, map);
+            var result = new CustomerImportResult();
             using var conn = _dbService.CreateConnection();
             using var tran = conn.BeginTransaction();
             try
             {
-                foreach (var c in customers)
+                for (int i = 0; i < customers.Count; i++)
                 {
-                    if (string.IsNullOrWhiteSpace(c.Company)) continue;
-                    if (string.IsNullOrWhiteSpace(c.Contact)) continue;
-                    if (string.IsNullOrWhiteSpace(c.Phone) && string.IsNullOrWhiteSpace(c.Mobile)) continue;
+                    var c = customers[i];
+                    var row = i + 2; // account for header row
+                    var reason = GetSkipReason(c);
+                    if (reason != null)
+                    {
+                        var msg = $"Row {row}: {reason}";
+                        result.SkippedRows.Add(msg);
+                        _logger.LogInformation("{Message}", msg);
+                        continue;
+                    }
 
-                    if (!CustomerExists(c.Contact, c.Phone, c.Mobile))
-                        InsertCustomer(conn, tran, c);
+                    if (CustomerExists(c.Contact, c.Phone, c.Mobile))
+                    {
+                        var msg = $"Row {row}: Duplicate customer";
+                        result.SkippedRows.Add(msg);
+                        _logger.LogInformation("{Message}", msg);
+                        continue;
+                    }
+
+                    InsertCustomer(conn, tran, c);
+                    result.ImportedCount++;
                 }
                 tran.Commit();
+                return result;
             }
             catch (Exception ex)
             {
@@ -48,6 +66,15 @@ namespace ToolManagementAppV2.Services.Customers
                 tran.Rollback();
                 throw;
             }
+        }
+
+        static string? GetSkipReason(CustomerModel c)
+        {
+            var reasons = new List<string>();
+            if (string.IsNullOrWhiteSpace(c.Company)) reasons.Add("Company missing");
+            if (string.IsNullOrWhiteSpace(c.Contact)) reasons.Add("Contact missing");
+            if (string.IsNullOrWhiteSpace(c.Phone) && string.IsNullOrWhiteSpace(c.Mobile)) reasons.Add("Phone and Mobile missing");
+            return reasons.Count > 0 ? string.Join(", ", reasons) : null;
         }
 
 
@@ -179,7 +206,7 @@ namespace ToolManagementAppV2.Services.Customers
         public Task<CustomerModel> GetCustomerByIDAsync(int customerID) => Task.Run(() => GetCustomerByID(customerID));
         public Task<List<CustomerModel>> GetAllCustomersAsync() => Task.Run(GetAllCustomers);
         public Task<List<CustomerModel>> SearchCustomersAsync(string searchTerm) => Task.Run(() => SearchCustomers(searchTerm));
-        public Task ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map) => Task.Run(() => ImportCustomersFromCsv(filePath, map));
+        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map) => Task.Run(() => ImportCustomersFromCsv(filePath, map));
         public Task ExportCustomersToCsvAsync(string filePath) => Task.Run(() => ExportCustomersToCsv(filePath));
     }
 }

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -90,8 +90,10 @@ namespace ToolManagementAppV2.ViewModels
             if (string.IsNullOrEmpty(path)) return;
             try
             {
-                _customerService.ImportCustomersFromCsv(path, new Dictionary<string, string>());
-                ImportExportLogs.Add($"Successfully imported customers from {path}.");
+                var result = _customerService.ImportCustomersFromCsv(path, new Dictionary<string, string>());
+                ImportExportLogs.Add($"Successfully imported customers from {path}. Imported {result.ImportedCount} customers.");
+                foreach (var msg in result.SkippedRows)
+                    ImportExportLogs.Add($"Skipped {msg}");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- Capture skipped customer CSV rows with reasons and log them
- Return detailed import summary and display it in the UI
- Extend tests for customer import edge cases

## Testing
- `dotnet test` *(fails: command not found)*
- `dotnet run --project ToolManagementAppV2/ToolManagementAppV2.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d917319c48324a010badbb81be50a