### PR TITLE
Use async SQLite operations

### DIFF
--- a/ToolManagementAppV2.Tests/Services/DatabaseConnectionTests.cs
+++ b/ToolManagementAppV2.Tests/Services/DatabaseConnectionTests.cs
@@ -3,13 +3,14 @@ using System.IO;
 using System.Data.SQLite;
 using ToolManagementAppV2.Services.Core;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace ToolManagementAppV2.Tests.Services
 {
     public class DatabaseConnectionTests
     {
         [Fact]
-        public void MultipleConnections_NoLockingErrors()
+        public async Task MultipleConnections_NoLockingErrors()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -21,12 +22,12 @@ namespace ToolManagementAppV2.Tests.Services
                 using var tx = conn1.BeginTransaction();
                 using (var cmd = new SQLiteCommand("INSERT INTO Settings(Key,Value) VALUES('Test','1')", conn1, tx))
                 {
-                    cmd.ExecuteNonQuery();
+                    await cmd.ExecuteNonQueryAsync();
                 }
 
                 using (var cmd = new SQLiteCommand("SELECT COUNT(*) FROM Settings", conn2))
                 {
-                    var count = Convert.ToInt32(cmd.ExecuteScalar());
+                    var count = Convert.ToInt32(await cmd.ExecuteScalarAsync());
                     Assert.Equal(1, count);
                 }
                 tx.Commit();

--- a/ToolManagementAppV2/Services/Core/SqliteHelper.cs
+++ b/ToolManagementAppV2/Services/Core/SqliteHelper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SQLite;
+using System.Threading.Tasks;
 
 namespace ToolManagementAppV2.Services.Core
 {
@@ -95,6 +96,69 @@ namespace ToolManagementAppV2.Services.Core
             cmd.Parameters.AddWithValue("@name", indexName);
             using var rdr = cmd.ExecuteReader();
             return rdr.Read();
+        }
+
+        public static async Task<int> ExecuteNonQueryAsync(string connStr, string sql, SQLiteParameter[] parameters = null)
+        {
+            using var conn = new SQLiteConnection(connStr);
+            await conn.OpenAsync();
+            using var cmd = new SQLiteCommand(sql, conn);
+            if (parameters != null) cmd.Parameters.AddRange(parameters);
+            return await cmd.ExecuteNonQueryAsync();
+        }
+
+        public static async Task<int> ExecuteNonQueryAsync(SQLiteConnection conn, SQLiteTransaction tx, string sql, SQLiteParameter[] parameters)
+        {
+            using var cmd = new SQLiteCommand(sql, conn, tx);
+            if (parameters != null) cmd.Parameters.AddRange(parameters);
+            return await cmd.ExecuteNonQueryAsync();
+        }
+
+        public static async Task<int> ExecuteNonQueryAsync(SQLiteConnection conn, string sql, SQLiteParameter[] parameters = null)
+        {
+            using var cmd = new SQLiteCommand(sql, conn);
+            if (parameters != null) cmd.Parameters.AddRange(parameters);
+            return await cmd.ExecuteNonQueryAsync();
+        }
+
+        public static async Task<object> ExecuteScalarAsync(string connStr, string sql, SQLiteParameter[] parameters = null)
+        {
+            using var conn = new SQLiteConnection(connStr);
+            await conn.OpenAsync();
+            using var cmd = new SQLiteCommand(sql, conn);
+            if (parameters != null) cmd.Parameters.AddRange(parameters);
+            return await cmd.ExecuteScalarAsync();
+        }
+
+        public static async Task<object> ExecuteScalarAsync(SQLiteConnection conn, string sql, SQLiteParameter[] parameters = null)
+        {
+            using var cmd = new SQLiteCommand(sql, conn);
+            if (parameters != null) cmd.Parameters.AddRange(parameters);
+            return await cmd.ExecuteScalarAsync();
+        }
+
+        public static async Task<List<T>> ExecuteReaderAsync<T>(string connStr, string sql, SQLiteParameter[] parameters, Func<IDataRecord, T> map)
+        {
+            var list = new List<T>();
+            using var conn = new SQLiteConnection(connStr);
+            await conn.OpenAsync();
+            using var cmd = new SQLiteCommand(sql, conn);
+            if (parameters != null) cmd.Parameters.AddRange(parameters);
+            using var rdr = await cmd.ExecuteReaderAsync();
+            while (await rdr.ReadAsync())
+                list.Add(map(rdr));
+            return list;
+        }
+
+        public static async Task<List<T>> ExecuteReaderAsync<T>(SQLiteConnection conn, string sql, SQLiteParameter[] parameters, Func<IDataRecord, T> map)
+        {
+            var list = new List<T>();
+            using var cmd = new SQLiteCommand(sql, conn);
+            if (parameters != null) cmd.Parameters.AddRange(parameters);
+            using var rdr = await cmd.ExecuteReaderAsync();
+            while (await rdr.ReadAsync())
+                list.Add(map(rdr));
+            return list;
         }
     }
 }

--- a/ToolManagementAppV2/Services/Customers/CustomerService.cs
+++ b/ToolManagementAppV2/Services/Customers/CustomerService.cs
@@ -11,6 +11,7 @@ using ToolManagementAppV2.Utilities.IO;
 using ToolManagementAppV2.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Linq;
 
 namespace ToolManagementAppV2.Services.Customers
 {
@@ -143,6 +144,28 @@ namespace ToolManagementAppV2.Services.Customers
             customer.CustomerID = Convert.ToInt32(cmd.ExecuteScalar());
         }
 
+        async Task InsertCustomerAsync(SQLiteConnection conn, SQLiteTransaction? tran, CustomerModel customer)
+        {
+            const string sql = @"
+        INSERT INTO Customers (Company, Email, Contact, Phone, Mobile, Address)
+        VALUES (@Company, @Email, @Contact, @Phone, @Mobile, @Address);
+        SELECT last_insert_rowid();";
+
+            var p = new[]
+            {
+                new SQLiteParameter("@Company", customer.Company ?? string.Empty),
+                new SQLiteParameter("@Email",   customer.Email ?? string.Empty),
+                new SQLiteParameter("@Contact", customer.Contact ?? string.Empty),
+                new SQLiteParameter("@Phone",   customer.Phone ?? string.Empty),
+                new SQLiteParameter("@Mobile",  customer.Mobile ?? string.Empty),
+                new SQLiteParameter("@Address", customer.Address ?? string.Empty)
+            };
+
+            using var cmd = new SQLiteCommand(sql, conn, tran);
+            cmd.Parameters.AddRange(p);
+            customer.CustomerID = Convert.ToInt32(await cmd.ExecuteScalarAsync());
+        }
+
 
         public void UpdateCustomer(CustomerModel customer)
         {
@@ -200,13 +223,74 @@ namespace ToolManagementAppV2.Services.Customers
             Address = r["Address"].ToString()
         };
 
-        public Task AddCustomerAsync(CustomerModel customer) => Task.Run(() => AddCustomer(customer));
-        public Task UpdateCustomerAsync(CustomerModel customer) => Task.Run(() => UpdateCustomer(customer));
-        public Task DeleteCustomerAsync(int customerID) => Task.Run(() => DeleteCustomer(customerID));
-        public Task<CustomerModel> GetCustomerByIDAsync(int customerID) => Task.Run(() => GetCustomerByID(customerID));
-        public Task<List<CustomerModel>> GetAllCustomersAsync() => Task.Run(GetAllCustomers);
-        public Task<List<CustomerModel>> SearchCustomersAsync(string searchTerm) => Task.Run(() => SearchCustomers(searchTerm));
-        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map) => Task.Run(() => ImportCustomersFromCsv(filePath, map));
-        public Task ExportCustomersToCsvAsync(string filePath) => Task.Run(() => ExportCustomersToCsv(filePath));
+        public async Task AddCustomerAsync(CustomerModel customer)
+        {
+            using var conn = _dbService.CreateConnection();
+            await InsertCustomerAsync(conn, null, customer);
+        }
+
+        public async Task UpdateCustomerAsync(CustomerModel customer)
+        {
+            const string sql = @"
+                UPDATE Customers
+                SET Company = @Company, Email = @Email, Contact = @Contact,
+                    Phone = @Phone, Mobile = @Mobile, Address = @Address
+                WHERE CustomerID = @CustomerID";
+            var p = new[]
+            {
+                new SQLiteParameter("@Company", customer.Company),
+                new SQLiteParameter("@Email", customer.Email),
+                new SQLiteParameter("@Contact", customer.Contact),
+                new SQLiteParameter("@Phone", customer.Phone),
+                new SQLiteParameter("@Mobile", customer.Mobile),
+                new SQLiteParameter("@Address", customer.Address),
+                new SQLiteParameter("@CustomerID", customer.CustomerID),
+            };
+            using var conn = _dbService.CreateConnection();
+            await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+        }
+
+        public async Task DeleteCustomerAsync(int customerID)
+        {
+            const string sql = "DELETE FROM Customers WHERE CustomerID = @CustomerID";
+            var p = new[] { new SQLiteParameter("@CustomerID", customerID) };
+            using var conn = _dbService.CreateConnection();
+            await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+        }
+
+        public async Task<CustomerModel> GetCustomerByIDAsync(int customerID)
+        {
+            const string sql = "SELECT * FROM Customers WHERE CustomerID = @id";
+            var p = new[] { new SQLiteParameter("@id", customerID) };
+            using var conn = _dbService.CreateConnection();
+            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapCustomer);
+            return list.FirstOrDefault();
+        }
+
+        public async Task<List<CustomerModel>> GetAllCustomersAsync()
+        {
+            const string sql = "SELECT * FROM Customers";
+            using var conn = _dbService.CreateConnection();
+            return await SqliteHelper.ExecuteReaderAsync(conn, sql, null, MapCustomer);
+        }
+
+        public async Task<List<CustomerModel>> SearchCustomersAsync(string searchTerm)
+        {
+            const string sql = @"
+                SELECT * FROM Customers
+                WHERE Company LIKE @t OR Email LIKE @t OR Phone LIKE @t OR Mobile LIKE @t OR Address LIKE @t";
+            var p = new[] { new SQLiteParameter("@t", $"%{searchTerm}%") };
+            using var conn = _dbService.CreateConnection();
+            return await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapCustomer);
+        }
+
+        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map)
+            => Task.FromResult(ImportCustomersFromCsv(filePath, map));
+
+        public Task ExportCustomersToCsvAsync(string filePath)
+        {
+            ExportCustomersToCsv(filePath);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -146,6 +146,25 @@ namespace ToolManagementAppV2.Services.Rentals
             }
         }
 
+        async Task ExecuteWithTransactionAsync(Func<SQLiteConnection, SQLiteTransaction, Task> action, Func<Task>? postCommitAction = null)
+        {
+            using var conn = _dbService.CreateConnection();
+            using var tx = conn.BeginTransaction();
+            try
+            {
+                await action(conn, tx);
+                tx.Commit();
+                if (postCommitAction != null)
+                    await postCommitAction();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Database transaction failed");
+                tx.Rollback();
+                throw;
+            }
+        }
+
         const string BaseSelect = @"SELECT r.*,
                                     t.ToolNumber,
                                     t.NameDescription,
@@ -218,14 +237,135 @@ namespace ToolManagementAppV2.Services.Rentals
             ToolLocation = r["ToolLocation"].ToString()
         };
 
-        public Task RentToolAsync(int toolID, int customerID, DateTime rentalDate, DateTime dueDate) => Task.Run(() => RentTool(toolID, customerID, rentalDate, dueDate));
-        public Task ReturnToolAsync(int rentalID, DateTime returnDate) => Task.Run(() => ReturnTool(rentalID, returnDate));
-        public Task ExtendRentalAsync(int rentalID, DateTime newDueDate) => Task.Run(() => ExtendRental(rentalID, newDueDate));
-        public Task DeleteRentalAsync(int rentalID) => Task.Run(() => DeleteRental(rentalID));
-        public Task<List<Rental>> GetActiveRentalsAsync() => Task.Run(GetActiveRentals);
-        public Task<List<Rental>> GetOverdueRentalsAsync() => Task.Run(GetOverdueRentals);
-        public Task<List<Rental>> GetAllRentalsAsync() => Task.Run(GetAllRentals);
-        public Task<List<Rental>> GetRentalHistoryForToolAsync(int toolID) => Task.Run(() => GetRentalHistoryForTool(toolID));
-        public Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID) => Task.Run(() => GetRentalHistoryForCustomer(customerID));
+        public async Task RentToolAsync(int toolID, int customerID, DateTime rentalDate, DateTime dueDate)
+        {
+            await ExecuteWithTransactionAsync(async (conn, tx) =>
+            {
+                var availCmd = new SQLiteCommand(
+                    "SELECT AvailableQuantity FROM Tools WHERE ToolID=@ToolID",
+                    conn, tx);
+                availCmd.Parameters.AddWithValue("@ToolID", toolID);
+                int avail = Convert.ToInt32(await availCmd.ExecuteScalarAsync() ?? 0);
+                if (avail < 1)
+                    throw new InvalidOperationException("Insufficient quantity.");
+
+                await SqliteHelper.ExecuteNonQueryAsync(conn, tx,
+                    "INSERT INTO Rentals (ToolID, CustomerID, RentalDate, DueDate, Status) " +
+                    "VALUES (@ToolID, @CustomerID, @RentalDate, @DueDate, 'Rented')",
+                    new[]
+                    {
+                        new SQLiteParameter("@ToolID", toolID),
+                        new SQLiteParameter("@CustomerID", customerID),
+                        new SQLiteParameter("@RentalDate", rentalDate),
+                        new SQLiteParameter("@DueDate", dueDate)
+                    });
+
+                if (_toolService != null)
+                    await _toolService.UpdateToolQuantitiesAsync(toolID, 1, true, conn, tx);
+            });
+        }
+
+        public async Task ReturnToolAsync(int rentalID, DateTime returnDate)
+        {
+            await ExecuteWithTransactionAsync(async (conn, tx) =>
+            {
+                var selCmd = new SQLiteCommand(
+                    "SELECT ToolID FROM Rentals WHERE RentalID=@RentalID AND Status='Rented'", conn, tx);
+                selCmd.Parameters.AddWithValue("@RentalID", rentalID);
+                var result = await selCmd.ExecuteScalarAsync();
+                if (result == null) throw new InvalidOperationException("Rental not found or already returned.");
+                var toolID = Convert.ToInt32(result);
+
+                await SqliteHelper.ExecuteNonQueryAsync(conn, tx,
+                    "UPDATE Rentals SET ReturnDate=@ReturnDate,Status='Returned' WHERE RentalID=@RentalID",
+                    new[]
+                    {
+                        new SQLiteParameter("@ReturnDate", returnDate),
+                        new SQLiteParameter("@RentalID", rentalID)
+                    });
+
+                if (_toolService != null)
+                    await _toolService.UpdateToolQuantitiesAsync(toolID, 1, false, conn, tx);
+            });
+        }
+
+        public async Task ExtendRentalAsync(int rentalID, DateTime newDueDate)
+        {
+            await ExecuteWithTransactionAsync(async (conn, tx) =>
+            {
+                var selectCmd = new SQLiteCommand(
+                    "SELECT ToolID, DueDate FROM Rentals WHERE RentalID=@RentalID AND Status='Rented'",
+                    conn, tx);
+                selectCmd.Parameters.AddWithValue("@RentalID", rentalID);
+                using var reader = await selectCmd.ExecuteReaderAsync();
+                if (!await reader.ReadAsync())
+                    throw new InvalidOperationException("Unable to extend rental. Rental not found or already returned.");
+
+                int toolID = Convert.ToInt32(reader["ToolID"]);
+                DateTime oldDueDate = Convert.ToDateTime(reader["DueDate"]);
+
+                var updateCmd = new SQLiteCommand(
+                    "UPDATE Rentals SET DueDate=@NewDueDate WHERE RentalID=@RentalID AND Status='Rented'",
+                    conn, tx);
+                updateCmd.Parameters.AddWithValue("@NewDueDate", newDueDate);
+                updateCmd.Parameters.AddWithValue("@RentalID", rentalID);
+                if (await updateCmd.ExecuteNonQueryAsync() == 0)
+                    throw new InvalidOperationException("Unable to extend rental. Rental not found or already returned.");
+
+                if (_toolService != null)
+                {
+                    if (oldDueDate <= DateTime.Today && newDueDate > DateTime.Today)
+                        await _toolService.UpdateToolQuantitiesAsync(toolID, 1, true, conn, tx);
+                    else if (oldDueDate > DateTime.Today && newDueDate <= DateTime.Today)
+                        await _toolService.UpdateToolQuantitiesAsync(toolID, 1, false, conn, tx);
+                }
+            });
+        }
+
+        public async Task DeleteRentalAsync(int rentalID)
+        {
+            const string sql = "DELETE FROM Rentals WHERE RentalID = @RentalID";
+            var p = new[] { new SQLiteParameter("@RentalID", rentalID) };
+            using var conn = _dbService.CreateConnection();
+            if (await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p) == 0)
+                throw new InvalidOperationException("Rental not found.");
+        }
+
+        public async Task<List<Rental>> GetActiveRentalsAsync()
+        {
+            using var conn = _dbService.CreateConnection();
+            var sql = BaseSelect + " WHERE r.Status='Rented'";
+            return await SqliteHelper.ExecuteReaderAsync(conn, sql, null, MapRental);
+        }
+
+        public async Task<List<Rental>> GetOverdueRentalsAsync()
+        {
+            const string sql = BaseSelect + @" WHERE r.Status = 'Rented' AND r.DueDate < @Today";
+            var p = new[] { new SQLiteParameter("@Today", DateTime.Today) };
+            using var conn = _dbService.CreateConnection();
+            return await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapRental);
+        }
+
+        public async Task<List<Rental>> GetAllRentalsAsync()
+        {
+            using var conn = _dbService.CreateConnection();
+            return await SqliteHelper.ExecuteReaderAsync(conn, BaseSelect, null, MapRental);
+        }
+
+        public async Task<List<Rental>> GetRentalHistoryForToolAsync(int toolID)
+        {
+            const string sql = BaseSelect + @" WHERE r.ToolID = @ToolID ORDER BY r.RentalDate DESC";
+            var p = new[] { new SQLiteParameter("@ToolID", toolID) };
+            using var conn = _dbService.CreateConnection();
+            return await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapRental);
+        }
+
+        public async Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID)
+        {
+            const string sql = BaseSelect + @" WHERE r.CustomerID = @CustomerID ORDER BY r.RentalDate DESC";
+            var p = new[] { new SQLiteParameter("@CustomerID", customerID) };
+            using var conn = _dbService.CreateConnection();
+            return await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapRental);
+        }
     }
 }

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -286,6 +286,31 @@ namespace ToolManagementAppV2.Services.Tools
             if (result != null)
                 tool.ToolID = Convert.ToInt32(result);
         }
+
+        async Task InsertToolAsync(SQLiteConnection conn, SQLiteTransaction? tran, ToolModel tool)
+        {
+            var p = new[]
+            {
+                new SQLiteParameter("@ToolNumber", tool.ToolNumber),
+                new SQLiteParameter("@Desc", (object)tool.NameDescription ?? DBNull.Value),
+                new SQLiteParameter("@Loc", tool.Location),
+                new SQLiteParameter("@Brand", tool.Brand),
+                new SQLiteParameter("@PN", tool.PartNumber),
+                new SQLiteParameter("@Sup", (object)tool.Supplier ?? DBNull.Value),
+                new SQLiteParameter("@PD", (object)tool.PurchasedDate ?? DBNull.Value),
+                new SQLiteParameter("@Notes", (object)tool.Notes ?? DBNull.Value),
+                new SQLiteParameter("@Keywords", (object)tool.Keywords ?? DBNull.Value),
+                new SQLiteParameter("@Avail", tool.QuantityOnHand),
+                new SQLiteParameter("@Rent", tool.RentedQuantity),
+                new SQLiteParameter("@Img", (object)tool.ToolImagePath ?? DBNull.Value),
+                new SQLiteParameter("@Power", tool.IsPowerTool ? 1 : 0)
+            };
+            using var cmd = new SQLiteCommand(UpsertToolCsv, conn, tran);
+            cmd.Parameters.AddRange(p);
+            var result = await cmd.ExecuteScalarAsync();
+            if (result != null)
+                tool.ToolID = Convert.ToInt32(result);
+        }
     
         public void ExportToolsToCsv(string filePath)
         {
@@ -366,6 +391,19 @@ namespace ToolManagementAppV2.Services.Tools
             }));
             return count > 0;
         }
+
+        private async Task<bool> ToolExistsAsync(string toolNumber)
+        {
+            if (string.IsNullOrWhiteSpace(toolNumber))
+                return false;
+            const string sql = "SELECT COUNT(*) FROM Tools WHERE ToolNumber = @TN";
+            using var conn = _dbService.CreateConnection();
+            var count = Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql, new[]
+            {
+                new SQLiteParameter("@TN", toolNumber)
+            }));
+            return count > 0;
+        }
     
         ToolModel MapTool(IDataRecord r) => new()
         {
@@ -388,18 +426,208 @@ namespace ToolManagementAppV2.Services.Tools
             IsPowerTool = (r["IsPowerTool"] is DBNull ? 0 : Convert.ToInt32(r["IsPowerTool"])) == 1
         };
 
-        public Task AddToolAsync(ToolModel tool) => Task.Run(() => AddTool(tool));
-        public Task UpdateToolAsync(ToolModel tool) => Task.Run(() => UpdateTool(tool));
-        public Task DeleteToolAsync(int toolID) => Task.Run(() => DeleteTool(toolID));
-        public Task<ToolModel> GetToolByIDAsync(int toolID) => Task.Run(() => GetToolByID(toolID));
-        public Task<List<ToolModel>> GetAllToolsAsync() => Task.Run(GetAllTools);
-        public Task<List<ToolModel>> SearchToolsAsync(string? searchText) => Task.Run(() => SearchTools(searchText));
-        public Task ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => Task.Run(() => ToggleToolCheckOutStatus(toolID, currentUser));
-        public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName) => Task.Run(() => GetToolsCheckedOutBy(userName));
-        public Task UpdateToolImageAsync(int toolID, string imagePath) => Task.Run(() => UpdateToolImage(toolID, imagePath));
-        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map) => Task.Run(() => ImportToolsFromCsv(filePath, map));
-        public Task ExportToolsToCsvAsync(string filePath) => Task.Run(() => ExportToolsToCsv(filePath));
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => Task.Run(() => ImportToolImages(folderPath, keySelector));
-        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => Task.Run(() => UpdateToolQuantities(toolID, qtyChange, isRental, conn, tx));
+        public async Task AddToolAsync(ToolModel tool)
+        {
+            if (string.IsNullOrWhiteSpace(tool?.ToolNumber))
+                throw new ArgumentException("ToolNumber is required.", nameof(tool));
+            if (await ToolExistsAsync(tool.ToolNumber))
+                throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
+            using var conn = _dbService.CreateConnection();
+            await InsertToolAsync(conn, null, tool);
+        }
+
+        public async Task UpdateToolAsync(ToolModel tool)
+        {
+            var dup = (await GetAllToolsAsync()).Any(t => t.ToolNumber == tool.ToolNumber && t.ToolID != tool.ToolID);
+            if (dup)
+                throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
+            const string sql = @"
+                UPDATE Tools SET
+                  ToolNumber = @ToolNumber,
+                  NameDescription = @Desc,
+                  Location = @Loc,
+                  Brand = @Brand,
+                  PartNumber = @PN,
+                  Supplier = @Sup,
+                  PurchasedDate = @PD,
+                  Notes = @Notes,
+                  Keywords = @Keywords,
+                  AvailableQuantity = @Avail,
+                  RentedQuantity = @Rent,
+                  IsPowerTool = @Power,
+                  IsCheckedOut = @Out,
+                  CheckedOutBy = @By,
+                  CheckedOutTime = @Time,
+                  ToolImagePath = @Img
+                WHERE ToolID = @ID";
+            var p = new[]
+            {
+                new SQLiteParameter("@ID", tool.ToolID),
+                new SQLiteParameter("@ToolNumber", tool.ToolNumber),
+                new SQLiteParameter("@Desc", (object)tool.NameDescription ?? DBNull.Value),
+                new SQLiteParameter("@Loc", tool.Location),
+                new SQLiteParameter("@Brand", tool.Brand),
+                new SQLiteParameter("@PN", tool.PartNumber),
+                new SQLiteParameter("@Sup", (object)tool.Supplier ?? DBNull.Value),
+                new SQLiteParameter("@PD", (object)tool.PurchasedDate ?? DBNull.Value),
+                new SQLiteParameter("@Notes", (object)tool.Notes ?? DBNull.Value),
+                new SQLiteParameter("@Keywords", (object)tool.Keywords ?? DBNull.Value),
+                new SQLiteParameter("@Avail", tool.QuantityOnHand),
+                new SQLiteParameter("@Rent", tool.RentedQuantity),
+                new SQLiteParameter("@Power", tool.IsPowerTool ? 1 : 0),
+                new SQLiteParameter("@Out", tool.IsCheckedOut ? 1 : 0),
+                new SQLiteParameter("@By", (object)tool.CheckedOutBy ?? DBNull.Value),
+                new SQLiteParameter("@Time", (object)tool.CheckedOutTime ?? DBNull.Value),
+                new SQLiteParameter("@Img", (object)tool.ToolImagePath ?? DBNull.Value)
+            };
+            using var conn = _dbService.CreateConnection();
+            await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+        }
+
+        public async Task DeleteToolAsync(int toolID)
+        {
+            using var conn = _dbService.CreateConnection();
+            await SqliteHelper.ExecuteNonQueryAsync(conn, "DELETE FROM Tools WHERE ToolID=@ID",
+                new[] { new SQLiteParameter("@ID", toolID) });
+        }
+
+        public async Task<ToolModel> GetToolByIDAsync(int toolID)
+        {
+            using var conn = _dbService.CreateConnection();
+            var list = await SqliteHelper.ExecuteReaderAsync(conn, "SELECT * FROM Tools WHERE ToolID=@ToolID",
+                new[] { new SQLiteParameter("@ToolID", toolID) }, MapTool);
+            return list.FirstOrDefault();
+        }
+
+        public async Task<List<ToolModel>> GetAllToolsAsync()
+        {
+            using var conn = _dbService.CreateConnection();
+            return await SqliteHelper.ExecuteReaderAsync(conn, AllToolsSql, null, MapTool);
+        }
+
+        public async Task<List<ToolModel>> SearchToolsAsync(string? searchText)
+        {
+            if (string.IsNullOrWhiteSpace(searchText))
+                return await GetAllToolsAsync();
+
+            using var conn = _dbService.CreateConnection();
+            var terms = searchText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var searchable = new[]
+            {
+                "ToolNumber",
+                "NameDescription",
+                "Brand",
+                "PartNumber",
+                "Supplier",
+                "Location",
+                "Notes",
+                "Keywords"
+            };
+
+            var sb = new StringBuilder("SELECT * FROM Tools WHERE ");
+            var parameters = new List<SQLiteParameter>();
+            for (int i = 0; i < terms.Length; i++)
+            {
+                if (i > 0) sb.Append(" AND ");
+                var paramName = $"@p{i}";
+                var likeClause = string.Join(" OR ", searchable.Select(col => $"{col} LIKE {paramName} COLLATE NOCASE"));
+                sb.Append($"(CAST(ToolID AS TEXT) LIKE {paramName} COLLATE NOCASE OR {likeClause})");
+                parameters.Add(new SQLiteParameter(paramName, $"%{terms[i]}%"));
+            }
+
+            return await SqliteHelper.ExecuteReaderAsync(conn, sb.ToString(), parameters.ToArray(), MapTool);
+        }
+
+        public async Task ToggleToolCheckOutStatusAsync(int toolID, string currentUser)
+        {
+            using var conn = _dbService.CreateConnection();
+            var record = (await SqliteHelper.ExecuteReaderAsync(conn,
+                "SELECT IsCheckedOut, AvailableQuantity FROM Tools WHERE ToolID=@ID",
+                new[] { new SQLiteParameter("@ID", toolID) },
+                r => new { Out = Convert.ToInt32(r["IsCheckedOut"]) == 1, Qty = Convert.ToInt32(r["AvailableQuantity"]) } )).FirstOrDefault();
+
+            if (record == null)
+                throw new InvalidOperationException($"Tool {toolID} not found.");
+
+            if (!record.Out && record.Qty <= 0)
+                throw new InvalidOperationException("Tool is out of stock.");
+
+            const string sql = @"UPDATE Tools SET IsCheckedOut=@Out, CheckedOutBy=@By, CheckedOutTime=@Time WHERE ToolID=@ID";
+            bool newStatus = !record.Out;
+            var parameters = new[]
+            {
+                new SQLiteParameter("@Out", newStatus ? 1 : 0),
+                new SQLiteParameter("@By", newStatus ? currentUser : (object)DBNull.Value),
+                new SQLiteParameter("@Time", newStatus ? DateTime.Now : (object)DBNull.Value),
+                new SQLiteParameter("@ID", toolID)
+            };
+            await SqliteHelper.ExecuteNonQueryAsync(conn, sql, parameters);
+        }
+
+        public async Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName)
+        {
+            using var conn = _dbService.CreateConnection();
+            return await SqliteHelper.ExecuteReaderAsync(conn,
+                "SELECT * FROM Tools WHERE CheckedOutBy=@U", new[] { new SQLiteParameter("@U", userName) }, MapTool);
+        }
+
+        public async Task UpdateToolImageAsync(int toolID, string imagePath)
+        {
+            const string sql = "UPDATE Tools SET ToolImagePath=@Img WHERE ToolID=@ID";
+            var p = new[]
+            {
+                new SQLiteParameter("@Img", imagePath),
+                new SQLiteParameter("@ID", toolID)
+            };
+            using var conn = _dbService.CreateConnection();
+            await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+        }
+
+        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map)
+            => Task.FromResult(ImportToolsFromCsv(filePath, map));
+
+        public Task ExportToolsToCsvAsync(string filePath)
+        {
+            ExportToolsToCsv(filePath);
+            return Task.CompletedTask;
+        }
+
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector)
+            => Task.FromResult(ImportToolImages(folderPath, keySelector));
+
+        public async Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null)
+        {
+            if (qtyChange <= 0) throw new ArgumentException("Quantity change must be positive.", nameof(qtyChange));
+            var sql = isRental
+                ? @"UPDATE Tools SET AvailableQuantity = AvailableQuantity - @Q, RentedQuantity = RentedQuantity + @Q WHERE ToolID = @ID AND AvailableQuantity >= @Q"
+                : @"UPDATE Tools SET AvailableQuantity = AvailableQuantity + @Q, RentedQuantity = RentedQuantity - @Q WHERE ToolID = @ID AND RentedQuantity >= @Q";
+            var p = new[]
+            {
+                new SQLiteParameter("@ID", toolID),
+                new SQLiteParameter("@Q", qtyChange)
+            };
+
+            if (conn != null)
+            {
+                int rows = tx != null
+                    ? await SqliteHelper.ExecuteNonQueryAsync(conn, tx, sql, p)
+                    : await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+                if (rows == 0)
+                {
+                    _logger.LogWarning("Quantity update affected 0 rows for ToolID {ToolID}", toolID);
+                    throw new InvalidOperationException("Quantity update failed.");
+                }
+            }
+            else
+            {
+                using var c = _dbService.CreateConnection();
+                int rows = await SqliteHelper.ExecuteNonQueryAsync(c, sql, p);
+                if (rows == 0)
+                {
+                    _logger.LogWarning("Quantity update affected 0 rows for ToolID {ToolID}", toolID);
+                    throw new InvalidOperationException("Quantity update failed.");
+                }
+            }
+        }
     }
 }

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -6,6 +6,7 @@ using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Utilities.Helpers;
 using ToolManagementAppV2.Interfaces;
+using System.Linq;
 
 namespace ToolManagementAppV2.Services.Users
 {
@@ -229,14 +230,193 @@ namespace ToolManagementAppV2.Services.Users
             };
         }
 
-        public Task<List<User>> GetAllUsersAsync() => Task.Run(GetAllUsers);
-        public Task<User?> GetUserByIDAsync(int userID) => Task.Run(() => GetUserByID(userID));
-        public Task<User?> AuthenticateUserAsync(string userName, string password) => Task.Run(() => AuthenticateUser(userName, password));
-        public Task<User?> GetCurrentUserAsync() => Task.Run(GetCurrentUser);
-        public Task AddUserAsync(User user) => Task.Run(() => AddUser(user));
-        public Task UpdateUserAsync(User user) => Task.Run(() => UpdateUser(user));
-        public Task<bool> TryDeleteUserAsync(int userID) => Task.Run(() => TryDeleteUser(userID));
-        public Task<bool> DeleteUserAsync(int userID) => Task.Run(() => DeleteUser(userID));
-        public Task ChangeUserPasswordAsync(int userID, string newPassword) => Task.Run(() => ChangeUserPassword(userID, newPassword));
+        public async Task<List<User>> GetAllUsersAsync()
+        {
+            using var conn = _dbService.CreateConnection();
+            return await SqliteHelper.ExecuteReaderAsync(conn, "SELECT * FROM Users", null, MapUser);
+        }
+
+        public async Task<User?> GetUserByIDAsync(int userID)
+        {
+            using var conn = _dbService.CreateConnection();
+            var list = await SqliteHelper.ExecuteReaderAsync(conn, "SELECT * FROM Users WHERE UserID=@ID",
+                new[] { new SQLiteParameter("@ID", userID) }, MapUser);
+            return list.FirstOrDefault();
+        }
+
+        public async Task<User?> AuthenticateUserAsync(string userName, string password)
+        {
+            using var conn = _dbService.CreateConnection();
+            var users = await SqliteHelper.ExecuteReaderAsync(conn,
+                "SELECT * FROM Users WHERE UserName=@UserName",
+                new[] { new SQLiteParameter("@UserName", userName) }, MapUser);
+            var u = users.FirstOrDefault();
+            if (u == null) return null;
+
+            if (string.IsNullOrWhiteSpace(u.Salt) && SecurityHelper.IsSha256Hash(u.Password))
+            {
+                var legacy = SecurityHelper.ComputeSha256HashLegacy(password ?? string.Empty);
+                if (u.Password != legacy) return null;
+                var upgraded = SecurityHelper.HashPassword(password ?? string.Empty, out var salt);
+                var p = new[]
+                {
+                    new SQLiteParameter("@Pwd", upgraded),
+                    new SQLiteParameter("@Salt", salt),
+                    new SQLiteParameter("@ID", u.UserID)
+                };
+                await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET Password=@Pwd, Salt=@Salt WHERE UserID=@ID", p);
+                u.Password = upgraded;
+                u.Salt = salt;
+                return u;
+            }
+
+            return SecurityHelper.VerifyPassword(password ?? string.Empty, u.Salt, u.Password) ? u : null;
+        }
+
+        public async Task<User?> GetCurrentUserAsync()
+        {
+            if (_context.CurrentUser is User u)
+                return await GetUserByIDAsync(u.UserID);
+            return null;
+        }
+
+        public async Task AddUserAsync(User user)
+        {
+            const string sql = @"
+                INSERT INTO Users
+                  (UserName, Password, Salt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt)
+                VALUES
+                  (@UserName,@Password,@Salt,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role,@IsActive,@CreatedAt);
+                SELECT last_insert_rowid();";
+
+            using var conn = _dbService.CreateConnection();
+            using var cmd = new SQLiteCommand(sql, conn);
+
+            string hashed = string.Empty;
+            string salt = string.Empty;
+            if (!string.IsNullOrWhiteSpace(user.Password))
+            {
+                if (!string.IsNullOrWhiteSpace(user.Salt))
+                {
+                    hashed = user.Password;
+                    salt = user.Salt;
+                }
+                else
+                {
+                    hashed = SecurityHelper.HashPassword(user.Password, out salt);
+                }
+            }
+
+            if (user.CreatedAt == default)
+                user.CreatedAt = DateTime.UtcNow;
+            cmd.Parameters.AddRange(new[]
+            {
+                new SQLiteParameter("@UserName", user.UserName),
+                new SQLiteParameter("@Password", hashed),
+                new SQLiteParameter("@Salt",     salt),
+                new SQLiteParameter("@Photo",    (object)user.UserPhotoPath ?? DBNull.Value),
+                new SQLiteParameter("@Admin",    user.IsAdmin ? 1 : 0),
+                new SQLiteParameter("@Email",    (object)user.Email ?? DBNull.Value),
+                new SQLiteParameter("@Phone",    (object)user.Phone ?? DBNull.Value),
+                new SQLiteParameter("@Mobile",   (object)user.Mobile ?? DBNull.Value),
+                new SQLiteParameter("@Address",  (object)user.Address ?? DBNull.Value),
+                new SQLiteParameter("@Role",     (object)user.Role ?? DBNull.Value),
+                new SQLiteParameter("@IsActive", user.IsActive ? 1 : 0),
+                new SQLiteParameter("@CreatedAt", user.CreatedAt)
+            });
+            user.UserID = Convert.ToInt32(await cmd.ExecuteScalarAsync());
+            user.Password = hashed;
+            user.Salt = salt;
+        }
+
+        public async Task UpdateUserAsync(User user)
+        {
+            const string sql = @"
+                UPDATE Users SET
+                  UserName      = @UserName,
+                  Password      = @Password,
+                  Salt          = @Salt,
+                  UserPhotoPath = @Photo,
+                  IsAdmin       = @Admin,
+                  Email         = @Email,
+                  Phone         = @Phone,
+                  Mobile        = @Mobile,
+                  Address       = @Address,
+                  Role          = @Role,
+                  IsActive      = @IsActive
+                WHERE UserID = @UserID";
+
+            string hashed = user.Password;
+            string salt = user.Salt;
+            if (!string.IsNullOrWhiteSpace(user.Password) && string.IsNullOrWhiteSpace(user.Salt))
+            {
+                hashed = SecurityHelper.HashPassword(user.Password, out salt);
+            }
+
+            var p = new[]
+            {
+                new SQLiteParameter("@UserID",   user.UserID),
+                new SQLiteParameter("@UserName", user.UserName),
+                new SQLiteParameter("@Password", hashed),
+                new SQLiteParameter("@Salt",     salt),
+                new SQLiteParameter("@Photo",    (object)user.UserPhotoPath ?? DBNull.Value),
+                new SQLiteParameter("@Admin",    user.IsAdmin ? 1 : 0),
+                new SQLiteParameter("@Email",    (object)user.Email ?? DBNull.Value),
+                new SQLiteParameter("@Phone",    (object)user.Phone ?? DBNull.Value),
+                new SQLiteParameter("@Mobile",   (object)user.Mobile ?? DBNull.Value),
+                new SQLiteParameter("@Address",  (object)user.Address ?? DBNull.Value),
+                new SQLiteParameter("@Role",     (object)user.Role ?? DBNull.Value),
+                new SQLiteParameter("@IsActive", user.IsActive ? 1 : 0)
+            };
+
+            using var conn = _dbService.CreateConnection();
+            await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+            user.Password = hashed;
+            user.Salt = salt;
+        }
+
+        public async Task ChangeUserPasswordAsync(int userID, string newPassword)
+        {
+            var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt WHERE UserID=@ID";
+            string hashed = string.Empty;
+            string salt = string.Empty;
+            if (!string.IsNullOrWhiteSpace(newPassword))
+            {
+                hashed = SecurityHelper.HashPassword(newPassword, out salt);
+            }
+
+            var p = new[]
+            {
+                new SQLiteParameter("@Pwd", hashed),
+                new SQLiteParameter("@Salt", salt),
+                new SQLiteParameter("@ID",  userID)
+            };
+            using var conn = _dbService.CreateConnection();
+            await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+        }
+
+        async Task DeleteUserInternalAsync(int userID)
+        {
+            var sql = "DELETE FROM Users WHERE UserID=@ID";
+            using var conn = _dbService.CreateConnection();
+            await SqliteHelper.ExecuteNonQueryAsync(conn, sql, new[] { new SQLiteParameter("@ID", userID) });
+        }
+
+        public async Task<bool> TryDeleteUserAsync(int userID)
+        {
+            var user = await GetUserByIDAsync(userID);
+            if (user == null) return false;
+            if (user.IsAdmin)
+            {
+                const string sql = "SELECT COUNT(*) FROM Users WHERE IsAdmin = 1";
+                using var conn = _dbService.CreateConnection();
+                var adminCount = Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql));
+                if (adminCount <= 1) return false;
+            }
+            await DeleteUserInternalAsync(userID);
+            return true;
+        }
+
+        public Task<bool> DeleteUserAsync(int userID) => TryDeleteUserAsync(userID);
     }
 }


### PR DESCRIPTION
## Summary
- expose asynchronous Execute* helpers for SQLite commands
- refactor services to await SQLite APIs instead of Task.Run
- update database connection test to exercise async commands

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d9504c6c08324b7687f4b8c260409