### PR TITLE
Allow settings to be null

### DIFF
--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -84,6 +84,25 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
+        public void GetSetting_ReturnsNull_WhenKeyMissing()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                ISettingsService service = new SettingsService(dbService);
+
+                var result = service.GetSetting("NonExistentKey");
+                Assert.Null(result);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public void DeleteSetting_ThrowsOnFailure()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -88,7 +88,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public string SavedKey { get; private set; }
         public string SavedValue { get; private set; }
-        public string GetSettingValue { get; set; } = string.Empty;
+        public string? GetSettingValue { get; set; } = string.Empty;
 
         public void SaveSetting(string key, string value)
         {
@@ -96,7 +96,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             SavedValue = value;
         }
 
-        public string GetSetting(string key) => GetSettingValue;
+        public string? GetSetting(string key) => GetSettingValue;
         public Dictionary<string, string> GetAllSettings() => new();
         public void UpdateSettings(Dictionary<string, string> settings) { }
         public void DeleteSetting(string key) { }

--- a/ToolManagementAppV2/Interfaces/ISettingsService.cs
+++ b/ToolManagementAppV2/Interfaces/ISettingsService.cs
@@ -5,7 +5,7 @@ namespace ToolManagementAppV2.Interfaces
     public interface ISettingsService
     {
         void SaveSetting(string key, string value);
-        string GetSetting(string key);
+        string? GetSetting(string key);
         Dictionary<string, string> GetAllSettings();
         void UpdateSettings(Dictionary<string, string> settings);
         void DeleteSetting(string key);

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -41,7 +41,7 @@ namespace ToolManagementAppV2.Services.Settings
             }
         }
 
-        public string GetSetting(string key)
+        public string? GetSetting(string key)
         {
             try
             {

--- a/ToolManagementAppV2/Services/Tools/Printer.cs
+++ b/ToolManagementAppV2/Services/Tools/Printer.cs
@@ -58,7 +58,7 @@ namespace ToolManagementAppV2.Services.Tools
             return !string.IsNullOrEmpty(full) && File.Exists(full) ? full : null;
         }
 
-        private FlowDocument BuildDocument(List<ToolModel> tools, string title, string logoPath)
+        private FlowDocument BuildDocument(List<ToolModel> tools, string title, string? logoPath)
         {
             var doc = new FlowDocument
             {
@@ -203,7 +203,7 @@ namespace ToolManagementAppV2.Services.Tools
             };
         }
 
-        private void AddCompanyLogo(StackPanel host, string logoPath)
+        private void AddCompanyLogo(StackPanel host, string? logoPath)
         {
             if (string.IsNullOrEmpty(logoPath))
                 return;

--- a/ToolManagementAppV2/Views/PrintPreviewWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PrintPreviewWindow.xaml.cs
@@ -12,7 +12,7 @@ namespace ToolManagementAppV2.Views
     {
         private FlowDocument _document;
         private string _title;
-        private string _logoPath;
+        private string _logoPath = string.Empty;
 
         public PrintPreviewWindow()
         {
@@ -20,11 +20,11 @@ namespace ToolManagementAppV2.Views
             DataContext = new PrintPreviewViewModel(OnPageSetup, OnPrint, Close);
         }
 
-        public void ShowPreview(FlowDocument document, string title, string logoPath)
+        public void ShowPreview(FlowDocument document, string title, string? logoPath)
         {
             _document = document ?? throw new ArgumentNullException(nameof(document));
             _title = title ?? throw new ArgumentNullException(nameof(title));
-            _logoPath = logoPath ?? "";
+            _logoPath = logoPath ?? string.Empty;
 
             Title = $"Print Preview – {_title}";
             PreviewTitle.Text = _title;


### PR DESCRIPTION
## Summary
- Return `string?` from `GetSetting` and propagate through callers
- Add null-safe logo handling in printing pipeline
- Extend tests for missing settings

## Testing
- `dotnet test --filter SettingsServiceTests` *(fails: dotnet not installed)*
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689d9afd70cc832495e6221ddefac173