### PR TITLE
Handle activity log DB failures

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ActivityLogsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ActivityLogsViewModelTests.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
+using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.ViewModels;
@@ -48,6 +51,31 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 if (File.Exists(dbPath))
                     File.Delete(dbPath);
             }
+        }
+
+        [Fact]
+        public void LoadLogs_ReturnsFalse_OnFailure()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var service = new FailingActivityLogService(db);
+                var vm = new ActivityLogsViewModel(service);
+                Assert.False(vm.LoadLogs());
+                Assert.Empty(vm.Logs);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        class FailingActivityLogService : ActivityLogService
+        {
+            public FailingActivityLogService(DatabaseService db) : base(db) { }
+            public override List<ActivityLog>? GetRecentLogs(int count = 50) => throw new Exception("fail");
         }
     }
 }

--- a/ToolManagementAppV2/Services/Tools/ReportService.cs
+++ b/ToolManagementAppV2/Services/Tools/ReportService.cs
@@ -1,6 +1,9 @@
 ﻿using System.Windows;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Documents;
 using System.Windows.Media;
+using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Users;
@@ -60,8 +63,8 @@ namespace ToolManagementAppV2.Services.Tools
 
         public FlowDocument GenerateActivityLogReport()
         {
-            var lines = _activityLogService.GetRecentLogs(100)
-                .Select(l =>
+            var logs = _activityLogService.GetRecentLogs(100) ?? new List<ActivityLog>();
+            var lines = logs.Select(l =>
                     $"LogID: {l.LogID} | UserID: {l.UserID} | User: {l.UserName} | " +
                     $"Action: {l.Action} | Timestamp: {l.Timestamp:yyyy-MM-dd HH:mm:ss}");
             return BuildReport("Activity Log Report", lines);

--- a/ToolManagementAppV2/Services/Users/ActivityLogService.cs
+++ b/ToolManagementAppV2/Services/Users/ActivityLogService.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SQLite;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 
@@ -10,46 +12,74 @@ namespace ToolManagementAppV2.Services.Users
     public class ActivityLogService
     {
         readonly DatabaseService _dbService;
+        readonly ILogger<ActivityLogService> _logger;
 
-        public ActivityLogService(DatabaseService dbService)
+        public ActivityLogService(DatabaseService dbService, ILogger<ActivityLogService>? logger = null)
         {
             _dbService = dbService;
+            _logger = logger ?? NullLogger<ActivityLogService>.Instance;
         }
 
-        public void LogAction(int userID, string userName, string action)
+        public virtual bool LogAction(int userID, string userName, string action)
         {
-            const string sql = @"
-                INSERT INTO ActivityLogs (UserID, UserName, Action)
-                VALUES (@UserID, @UserName, @Action)";
-            var p = new[]
+            try
             {
-                new SQLiteParameter("@UserID",   userID),
-                new SQLiteParameter("@UserName", userName),
-                new SQLiteParameter("@Action",   action)
-            };
-            using var conn = _dbService.CreateConnection();
-            SqliteHelper.ExecuteNonQuery(conn, sql, p);
+                const string sql = @"
+                    INSERT INTO ActivityLogs (UserID, UserName, Action)
+                    VALUES (@UserID, @UserName, @Action)";
+                var p = new[]
+                {
+                    new SQLiteParameter("@UserID",   userID),
+                    new SQLiteParameter("@UserName", userName),
+                    new SQLiteParameter("@Action",   action)
+                };
+                using var conn = _dbService.CreateConnection();
+                SqliteHelper.ExecuteNonQuery(conn, sql, p);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to log activity {Action}", action);
+                return false;
+            }
         }
 
-        public List<ActivityLog> GetRecentLogs(int count = 50)
+        public virtual List<ActivityLog>? GetRecentLogs(int count = 50)
         {
-            const string sql = @"
-                SELECT * FROM ActivityLogs
-                 ORDER BY Timestamp DESC
-                 LIMIT @Count";
-            var p = new[] { new SQLiteParameter("@Count", count) };
-            using var conn = _dbService.CreateConnection();
-            return SqliteHelper.ExecuteReader(conn, sql, p, MapLog);
+            try
+            {
+                const string sql = @"
+                    SELECT * FROM ActivityLogs
+                     ORDER BY Timestamp DESC
+                     LIMIT @Count";
+                var p = new[] { new SQLiteParameter("@Count", count) };
+                using var conn = _dbService.CreateConnection();
+                return SqliteHelper.ExecuteReader(conn, sql, p, MapLog);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve recent activity logs");
+                return null;
+            }
         }
 
-        public void PurgeOldLogs(DateTime threshold)
+        public virtual bool PurgeOldLogs(DateTime threshold)
         {
-            const string sql = @"
-                DELETE FROM ActivityLogs
-                 WHERE Timestamp < @Threshold";
-            var p = new[] { new SQLiteParameter("@Threshold", threshold) };
-            using var conn = _dbService.CreateConnection();
-            SqliteHelper.ExecuteNonQuery(conn, sql, p);
+            try
+            {
+                const string sql = @"
+                    DELETE FROM ActivityLogs
+                     WHERE Timestamp < @Threshold";
+                var p = new[] { new SQLiteParameter("@Threshold", threshold) };
+                using var conn = _dbService.CreateConnection();
+                SqliteHelper.ExecuteNonQuery(conn, sql, p);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to purge old activity logs prior to {Threshold}", threshold);
+                return false;
+            }
         }
 
         ActivityLog MapLog(IDataRecord r)

--- a/ToolManagementAppV2/ViewModels/ActivityLogsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ActivityLogsViewModel.cs
@@ -1,6 +1,9 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System;
 using System.Collections.ObjectModel;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Users;
 
@@ -9,23 +12,37 @@ namespace ToolManagementAppV2.ViewModels
     public class ActivityLogsViewModel : ObservableObject
     {
         private readonly ActivityLogService _service;
+        private readonly ILogger<ActivityLogsViewModel> _logger;
 
         public ObservableCollection<ActivityLog> Logs { get; } = new();
 
         public IRelayCommand RefreshCommand { get; }
 
-        public ActivityLogsViewModel(ActivityLogService service)
+        public ActivityLogsViewModel(ActivityLogService service, ILogger<ActivityLogsViewModel>? logger = null)
         {
             _service = service;
-            RefreshCommand = new RelayCommand(LoadLogs);
+            _logger = logger ?? NullLogger<ActivityLogsViewModel>.Instance;
+            RefreshCommand = new RelayCommand(() => LoadLogs());
             LoadLogs();
         }
 
-        public void LoadLogs()
+        public bool LoadLogs()
         {
-            Logs.Clear();
-            foreach (var log in _service.GetRecentLogs())
-                Logs.Add(log);
+            try
+            {
+                Logs.Clear();
+                var logs = _service.GetRecentLogs();
+                if (logs == null)
+                    return false;
+                foreach (var log in logs)
+                    Logs.Add(log);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load activity logs");
+                return false;
+            }
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
@@ -93,7 +93,10 @@ namespace ToolManagementAppV2.ViewModels
             try
             {
                 RecentActivity.Clear();
-                foreach (var log in _activityLogService.GetRecentLogs(10))
+                var logs = _activityLogService.GetRecentLogs(10);
+                if (logs == null)
+                    return;
+                foreach (var log in logs)
                     RecentActivity.Add(log);
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- wrap activity log database calls in try/catch blocks and log errors
- allow activity log operations to report success
- cover log load failures in ActivityLogsViewModel tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d9c8bb4908324a1d4a186ca7ebbd0