### PR TITLE
Pass selected tool to rental history and add UI tests

### DIFF
--- a/ToolManagementAppV2.Tests/Views/ToolEditWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ToolEditWindowTests.cs
@@ -51,5 +51,64 @@ namespace ToolManagementAppV2.Tests.Views
                 throw threadException;
             }
         }
+
+        [Fact]
+        public void CancelCommand_ClosesWindow()
+        {
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var tool = new Tool();
+                    ToolEditWindow? window = null;
+                    bool closed = false;
+
+                    Action onSave = () => window?.Close();
+                    Action onCancel = () => window?.Close();
+
+                    window = new ToolEditWindow(tool, onSave, onCancel);
+                    window.Closed += (_, __) => closed = true;
+
+                    var vm = (ToolEditViewModel)window.DataContext;
+                    vm.CancelCommand.Execute(null);
+
+                    Assert.True(closed);
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+            {
+                throw threadException;
+            }
+        }
+
+        [Fact(Skip = "Manual smoke test for visual inspection")]
+        public void ToolEditWindow_ManualSmokeTest()
+        {
+            var thread = new Thread(() =>
+            {
+                var tool = new Tool();
+                ToolEditWindow? window = null;
+                Action onSave = () => window?.Close();
+                Action onCancel = () => window?.Close();
+
+                window = new ToolEditWindow(tool, onSave, onCancel);
+                window.ShowDialog();
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+        }
     }
 }

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -35,7 +35,7 @@
 
                         <TextBlock Text="Rentals" Foreground="{StaticResource ForegroundMutedBrush}" Margin="6,8,6,2"/>
                         <Button Style="{StaticResource NavButton}" Content="Manage Rentals" Command="{Binding OpenRentalsCommand}"/>
-                        <Button Style="{StaticResource NavButton}" Content="Rental History" Command="{Binding OpenRentalHistoryWindowCommand}"/>
+                        <Button Style="{StaticResource NavButton}" Content="Rental History" Command="{Binding OpenRentalHistoryWindowCommand}" CommandParameter="{Binding DataContext.SelectedTool, ElementName=MainFrame}"/>
 
                         <Separator/>
 

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
@@ -95,7 +96,7 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand GlobalSearchCommand { get; }
         public IRelayCommand SwitchUserCommand { get; }
 
-        public IRelayCommand OpenRentalHistoryWindowCommand { get; }
+        public IAsyncRelayCommand<ToolModel?> OpenRentalHistoryWindowCommand { get; }
         public IRelayCommand OpenPrintPreviewWindowCommand { get; }
         public IRelayCommand OpenPrintLabelWindowCommand { get; }
         public IRelayCommand OpenScannerStatusWindowCommand { get; }
@@ -284,10 +285,12 @@ namespace ToolManagementAppV2.ViewModels
                 }
             });
 
-            OpenRentalHistoryWindowCommand = new RelayCommand(() =>
+            OpenRentalHistoryWindowCommand = new AsyncRelayCommand<ToolModel?>(async tool =>
             {
-                _dialogService.ShowRentalHistory(new ToolModel(), Enumerable.Empty<RentalModel>());
-            });
+                if (tool == null) return;
+                var history = await _rentalService.GetRentalHistoryForToolAsync(tool.ToolID);
+                _dialogService.ShowRentalHistory(tool, history);
+            }, tool => tool != null);
 
             OpenPrintPreviewWindowCommand = new RelayCommand(() =>
             {


### PR DESCRIPTION
## Summary
- allow rental history command to accept a selected tool and load its history
- bind Rental History menu item to the current page's selected tool
- expand ToolEditWindow UI tests with cancel behavior and a manual smoke test

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d9e05f8888324bd8dda8d566068fa