### PR TITLE
Handle file IO errors with dialog

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/RentalHistoryViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/RentalHistoryViewModelTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.ViewModels.Rental;
 using Xunit;
 
@@ -17,7 +18,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 new Rental { RentalID = 1, ToolNumber = "T1", CustomerName = "Alice", Status = "Rented", RentalDate=DateTime.Today, DueDate=DateTime.Today },
                 new Rental { RentalID = 2, ToolNumber = "T2", CustomerName = "Bob", Status = "Returned", RentalDate=DateTime.Today, DueDate=DateTime.Today }
             };
-            var vm = new RentalHistoryViewModel(null, history);
+            var vm = new RentalHistoryViewModel(null, history, new StubDialogService());
 
             vm.SearchText = "T1";
             vm.SearchCommand.Execute(null);
@@ -33,7 +34,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 new Rental { RentalID = 1, ToolNumber = "T1", CustomerName = "Alice", Status = "Rented", RentalDate=DateTime.Today, DueDate=DateTime.Today }
             };
-            var vm = new RentalHistoryViewModel(null, history);
+            var vm = new RentalHistoryViewModel(null, history, new StubDialogService());
 
             var original = Environment.CurrentDirectory;
             var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -51,6 +52,50 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 if (Directory.Exists(tempDir))
                     Directory.Delete(tempDir, true);
             }
+        }
+
+        [Fact]
+        public void ExportCsvCommand_ShowsError_WhenWriteFails()
+        {
+            var history = new List<Rental>
+            {
+                new Rental { RentalID = 1, ToolNumber = "T1", CustomerName = "Alice", Status = "Rented", RentalDate=DateTime.Today, DueDate=DateTime.Today }
+            };
+            var dialog = new StubDialogService();
+            var vm = new RentalHistoryViewModel(null, history, dialog);
+
+            var original = Environment.CurrentDirectory;
+            var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDir);
+            Environment.CurrentDirectory = tempDir;
+
+            var target = Path.Combine(tempDir, "rental_history.csv");
+            using (new FileStream(target, FileMode.Create, FileAccess.Read, FileShare.None))
+            {
+                vm.ExportCsvCommand.Execute(null);
+            }
+
+            Environment.CurrentDirectory = original;
+            Directory.Delete(tempDir, true);
+
+            Assert.True(dialog.InfoShown);
+        }
+
+        class StubDialogService : IDialogService
+        {
+            public bool InfoShown { get; private set; }
+
+            public void ShowInfo(string message, string title) => InfoShown = true;
+
+            public bool ShowConfirmation(string message, string title) => true;
+
+            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+
+            public void ShowToolDetails(ToolModel tool) { }
+
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+
+            public CustomerModel? ShowAddCustomerDialog() => null;
         }
     }
 }

--- a/ToolManagementAppV2/Services/DialogService.cs
+++ b/ToolManagementAppV2/Services/DialogService.cs
@@ -92,7 +92,7 @@ namespace ToolManagementAppV2.Services
 
         public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history)
         {
-            var vm = new RentalHistoryViewModel(tool, history);
+            var vm = new RentalHistoryViewModel(tool, history, this);
             var win = new RentalHistoryWindow(vm) { Title = $"Rental History - {tool.ToolNumber}" };
             try { win.Owner = System.Windows.Application.Current?.MainWindow; }
             catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for RentalHistoryWindow"); }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -219,27 +219,35 @@ namespace ToolManagementAppV2.ViewModels
 
             OpenImportMappingWindowCommand = new RelayCommand(() =>
             {
-                var path = fileDialogService.OpenFile("CSV Files|*.csv");
-                if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
-                    return;
-
-                var headers = File.ReadLines(path)
-                                   .First()
-                                   .Split(',')
-                                   .Select(h => h.Trim())
-                                   .ToList();
-                var properties = typeof(ToolModel)
-                                    .GetProperties()
-                                    .Select(p => p.Name)
-                                    .ToList();
-                var map = _dialogService.ShowImportMapping(headers, properties);
-                if (map != null)
+                try
                 {
-                    var invalid = _toolService.ImportToolsFromCsv(path, map);
-                    var msg = invalid.Count == 0
-                        ? "Successfully imported tools."
-                        : $"Imported with {invalid.Count} invalid rows.";
-                    _dialogService.ShowInfo(msg, "Import Tools");
+                    var path = fileDialogService.OpenFile("CSV Files|*.csv");
+                    if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+                        return;
+
+                    var headers = File.ReadLines(path)
+                                       .First()
+                                       .Split(',')
+                                       .Select(h => h.Trim())
+                                       .ToList();
+                    var properties = typeof(ToolModel)
+                                        .GetProperties()
+                                        .Select(p => p.Name)
+                                        .ToList();
+                    var map = _dialogService.ShowImportMapping(headers, properties);
+                    if (map != null)
+                    {
+                        var invalid = _toolService.ImportToolsFromCsv(path, map);
+                        var msg = invalid.Count == 0
+                            ? "Successfully imported tools."
+                            : $"Imported with {invalid.Count} invalid rows.";
+                        _dialogService.ShowInfo(msg, "Import Tools");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to import tools from CSV");
+                    _dialogService.ShowInfo($"Failed to import tools: {ex.Message}", "Import Tools");
                 }
             });
 

--- a/ToolManagementAppV2/ViewModels/RentalHistoryViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/RentalHistoryViewModel.cs
@@ -12,6 +12,7 @@ using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Utilities.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using ToolManagementAppV2.Interfaces;
 
 namespace ToolManagementAppV2.ViewModels.Rental
 {
@@ -19,6 +20,7 @@ namespace ToolManagementAppV2.ViewModels.Rental
     {
         private readonly List<RentalModel> _allHistory;
         private readonly ILogger<RentalHistoryViewModel> _logger;
+        private readonly IDialogService _dialogService;
 
         public ObservableCollection<RentalModel> History { get; }
         public string ToolDisplayName { get; }
@@ -41,7 +43,7 @@ namespace ToolManagementAppV2.ViewModels.Rental
         public IRelayCommand ExportCsvCommand { get; }
         public IRelayCommand CloseCommand { get; }
 
-        public RentalHistoryViewModel(ToolModel? tool, IEnumerable<RentalModel>? history, ILogger<RentalHistoryViewModel>? logger = null)
+        public RentalHistoryViewModel(ToolModel? tool, IEnumerable<RentalModel>? history, IDialogService dialogService, ILogger<RentalHistoryViewModel>? logger = null)
         {
             ToolDisplayName = tool != null
                 ? $"{tool.ToolNumber} - {tool.NameDescription}"
@@ -50,6 +52,7 @@ namespace ToolManagementAppV2.ViewModels.Rental
             _allHistory = (history ?? Enumerable.Empty<RentalModel>()).ToList();
             History = new ObservableCollection<RentalModel>(_allHistory);
             _logger = logger ?? NullLogger<RentalHistoryViewModel>.Instance;
+            _dialogService = dialogService;
 
             SearchCommand = new RelayCommand(ExecuteSearch);
             ExportCsvCommand = new RelayCommand(ExportCsv);
@@ -110,7 +113,15 @@ namespace ToolManagementAppV2.ViewModels.Rental
                     Escape(r.Status)));
             }
 
-            File.WriteAllText(path, sb.ToString());
+            try
+            {
+                File.WriteAllText(path, sb.ToString());
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to export rental history to {Path}", path);
+                _dialogService.ShowInfo($"Failed to export rental history: {ex.Message}", "Error");
+            }
         }
 
         static string Escape(string? value) =>


### PR DESCRIPTION
## Summary
- show errors when importing CSVs during tool import
- inject dialog service into rental history export and handle file write failures
- cover rental history export failure with unit tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://apt.llvm.org/noble llvm-toolchain-noble-20 InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689d9fc7c2bc8324b7d409b16b77773f