### PR TITLE
Handle print failures

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/PrintLabelViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/PrintLabelViewModelTests.cs
@@ -26,11 +26,21 @@ namespace ToolManagementAppV2.Tests.ViewModels
             vm.CloseCommand.Execute(null);
             Assert.True(closed);
         }
+
+        [Fact]
+        public void PrintCommand_WhenPrintFails_LogsError()
+        {
+            var ds = new StubDialogService();
+            var vm = new PrintLabelViewModel(ds, () => { }, _ => throw new Exception("print failed"));
+            vm.PrintCommand.Execute(null);
+            Assert.True(ds.InfoShown);
+        }
     }
 
     class StubDialogService : IDialogService
     {
-        public void ShowInfo(string message, string title) { }
+        public bool InfoShown { get; private set; }
+        public void ShowInfo(string message, string title) => InfoShown = true;
         public bool ShowConfirmation(string message, string title) => false;
         public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
         public void ShowToolDetails(ToolModel tool) { }

--- a/ToolManagementAppV2/ViewModels/PrintLabelViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/PrintLabelViewModel.cs
@@ -13,6 +13,7 @@ namespace ToolManagementAppV2.ViewModels
     {
         private readonly System.Action _closeAction;
         private readonly IDialogService _dialogService;
+        private readonly System.Action<FlowDocument> _printAction;
 
         public ObservableCollection<string> Templates { get; }
 
@@ -36,10 +37,16 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand PrintCommand { get; }
         public IRelayCommand CloseCommand { get; }
 
-        public PrintLabelViewModel(IDialogService dialogService, System.Action closeAction)
+        public PrintLabelViewModel(IDialogService dialogService, System.Action closeAction, System.Action<FlowDocument>? printAction = null)
         {
             _dialogService = dialogService;
             _closeAction = closeAction;
+            _printAction = printAction ?? (doc =>
+            {
+                var dlg = new System.Windows.Controls.PrintDialog();
+                if (dlg.ShowDialog() == true)
+                    dlg.PrintDocument(((IDocumentPaginatorSource)doc).DocumentPaginator, "Tool Labels");
+            });
             Templates = new ObservableCollection<string> { "Standard", "Compact" };
             _selectedTemplate = Templates.First();
             Items = new ObservableCollection<Tool>();
@@ -57,9 +64,14 @@ namespace ToolManagementAppV2.ViewModels
         private void Print()
         {
             var doc = BuildDocument();
-            var dlg = new System.Windows.Controls.PrintDialog();
-            if (dlg.ShowDialog() == true)
-                dlg.PrintDocument(((IDocumentPaginatorSource)doc).DocumentPaginator, "Tool Labels");
+            try
+            {
+                _printAction(doc);
+            }
+            catch (System.Exception ex)
+            {
+                _dialogService.ShowInfo($"Failed to print labels: {ex.Message}", "Print Labels");
+            }
         }
 
         private FlowDocument BuildDocument()


### PR DESCRIPTION
## Summary
- Guard PrintLabelViewModel printing with try/catch and log errors through dialog service
- Add unit test verifying print errors are reported

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689da18d3d1083249ff09104d877fec6