### PR TITLE
Remove Environment.Exit and surface shutdown errors

### DIFF
--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -290,11 +290,14 @@ namespace ToolManagementAppV2.ViewModels
 
             ExitCommand = new RelayCommand(() =>
             {
-                try { System.Windows.Application.Current.Shutdown(); }
+                try
+                {
+                    System.Windows.Application.Current.Shutdown();
+                }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to shutdown application");
-                    System.Environment.Exit(0);
+                    throw;
                 }
             });
 


### PR DESCRIPTION
## Summary
- Use `Application.Current.Shutdown()` for exiting
- Log and rethrow shutdown errors instead of forcing exit

## Testing
- `dotnet test` *(fails: command not found)*
- `dotnet run --project ToolManagementAppV2` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689da2c22f448324a3c149662b8eb733