### PR TITLE
Warn on missing setting deletions

### DIFF
--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Data.SQLite;
 using System.IO;
+using Microsoft.Extensions.Logging;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.Interfaces;
@@ -118,6 +119,30 @@ namespace ToolManagementAppV2.Tests.Services
                 }
 
                 Assert.Throws<InvalidOperationException>(() => service.DeleteSetting("Key1"));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void DeleteSetting_NonExistingKey_LogsWarning()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var logs = new List<LogEntry>();
+                using var factory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
+                var logger = factory.CreateLogger<SettingsService>();
+                ISettingsService service = new SettingsService(dbService, logger);
+
+                service.DeleteSetting("MissingKey");
+
+                Assert.Single(logs);
+                Assert.Equal(LogLevel.Warning, logs[0].Level);
             }
             finally
             {

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -120,7 +120,9 @@ namespace ToolManagementAppV2.Services.Settings
                 const string sql = "DELETE FROM Settings WHERE Key = @Key";
                 var p = new[] { new SQLiteParameter("@Key", key) };
                 using var conn = _dbService.CreateConnection();
-                SqliteHelper.ExecuteNonQuery(conn, sql, p);
+                var affected = SqliteHelper.ExecuteNonQuery(conn, sql, p);
+                if (affected == 0)
+                    _logger.LogWarning("No setting found for key {Key}", key);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- log a warning when deleting a non-existent setting
- test settings deletion warning for missing keys

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689da382afec8324b67cec07f689707c