### PR TITLE
Load scanner IPs from settings

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Devices;
+using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
 
@@ -42,6 +46,27 @@ namespace ToolManagementAppV2.Tests.ViewModels
             Assert.True(vm.IsTimerRunning);
             vm.AutoRefresh = false;
             Assert.False(vm.IsTimerRunning);
+        }
+
+        [Fact]
+        public void RefreshCommand_UsesIpsFromSettings()
+        {
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var settings = new SettingsService(db);
+                settings.SaveScannerIpAddresses(new[] { "127.0.0.1" });
+                var svc = new ScannerService(settings);
+                var vm = new ScannerStatusViewModel(svc);
+                vm.RefreshCommand.Execute(null);
+                Assert.Single(vm.Devices);
+                Assert.Equal("127.0.0.1", vm.Devices[0].Ip);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
         }
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -100,6 +100,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Dictionary<string, string> GetAllSettings() => new();
         public void UpdateSettings(Dictionary<string, string> settings) { }
         public void DeleteSetting(string key) { }
+        public IEnumerable<string> ScannerIps { get; set; } = Array.Empty<string>();
+        public IEnumerable<string> GetScannerIpAddresses() => ScannerIps;
+        public void SaveScannerIpAddresses(IEnumerable<string> ipAddresses) => ScannerIps = ipAddresses;
     }
 
     class StubDialogService : IDialogService

--- a/ToolManagementAppV2/Interfaces/ISettingsService.cs
+++ b/ToolManagementAppV2/Interfaces/ISettingsService.cs
@@ -9,5 +9,7 @@ namespace ToolManagementAppV2.Interfaces
         Dictionary<string, string> GetAllSettings();
         void UpdateSettings(Dictionary<string, string> settings);
         void DeleteSetting(string key);
+        IEnumerable<string> GetScannerIpAddresses();
+        void SaveScannerIpAddresses(IEnumerable<string> ipAddresses);
     }
 }

--- a/ToolManagementAppV2/Services/Devices/ScannerService.cs
+++ b/ToolManagementAppV2/Services/Devices/ScannerService.cs
@@ -11,21 +11,18 @@ namespace ToolManagementAppV2.Services.Devices
     public class ScannerService : IScannerService
     {
         private readonly ILogger<ScannerService> _logger;
+        private readonly ISettingsService _settingsService;
 
-        public ScannerService(ILogger<ScannerService>? logger = null)
+        public ScannerService(ISettingsService settingsService, ILogger<ScannerService>? logger = null)
         {
+            _settingsService = settingsService;
             _logger = logger ?? NullLogger<ScannerService>.Instance;
         }
-        static readonly string[] IpAddresses = new[]
-        {
-            "192.168.1.10",
-            "192.168.1.11"
-        };
 
         public IEnumerable<ScannerDevice> GetScannerDevices()
         {
             var list = new List<ScannerDevice>();
-            foreach (var ip in IpAddresses)
+            foreach (var ip in _settingsService.GetScannerIpAddresses())
             {
                 var device = new ScannerDevice
                 {

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -130,5 +130,21 @@ namespace ToolManagementAppV2.Services.Settings
                 throw new InvalidOperationException($"Failed to delete setting '{key}'.", ex);
             }
         }
+
+        const string ScannerIpKey = "ScannerIpAddresses";
+
+        public IEnumerable<string> GetScannerIpAddresses()
+        {
+            var value = GetSetting(ScannerIpKey);
+            if (string.IsNullOrWhiteSpace(value))
+                return Array.Empty<string>();
+            return value.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        }
+
+        public void SaveScannerIpAddresses(IEnumerable<string> ipAddresses)
+        {
+            var value = string.Join(';', ipAddresses);
+            SaveSetting(ScannerIpKey, value);
+        }
     }
 }

--- a/ToolManagementAppV2/Views/ScannerStatusWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ScannerStatusWindow.xaml.cs
@@ -1,17 +1,9 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.IO;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 using ToolManagementAppV2.Services.Devices;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2.Views
@@ -21,10 +13,16 @@ namespace ToolManagementAppV2.Views
     /// </summary>
     public partial class ScannerStatusWindow : Window
     {
+        readonly DatabaseService _ownedDb;
+
         public ScannerStatusWindow()
         {
             InitializeComponent();
-            DataContext = new ScannerStatusViewModel(new ScannerService());
+            var dbPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db");
+            _ownedDb = new DatabaseService(dbPath);
+            var settingsService = new SettingsService(_ownedDb);
+            DataContext = new ScannerStatusViewModel(new ScannerService(settingsService));
+            Closed += (_, __) => _ownedDb.Dispose();
         }
     }
 }


### PR DESCRIPTION
## Summary
- read scanner IPs from Settings table instead of hardcoding
- expose Get/SaveScannerIpAddresses on SettingsService
- cover scanner IP loading in ScannerStatusViewModel integration test

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689da4a632948324b1fa83036fd1eab5