### PR TITLE
Use async ping for scanners

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ScannerServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ScannerServiceTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Devices;
+using ToolManagementAppV2.Services.Settings;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Services
+{
+    public class ScannerServiceTests
+    {
+        [Fact]
+        public async Task GetScannerDevicesAsync_ReturnsConfiguredDevices()
+        {
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var settings = new SettingsService(db);
+                settings.SaveScannerIpAddresses(new[] { "127.0.0.1" });
+
+                var service = new ScannerService(settings);
+                var devices = await service.GetScannerDevicesAsync();
+
+                var list = devices.ToList();
+                Assert.Single(list);
+                Assert.Equal("127.0.0.1", list[0].Ip);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Services.Core;
@@ -15,24 +16,25 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public int CallCount { get; private set; }
 
-        public IEnumerable<ScannerDevice> GetScannerDevices()
+        public Task<IEnumerable<ScannerDevice>> GetScannerDevicesAsync()
         {
             CallCount++;
-            return new[]
+            IEnumerable<ScannerDevice> result = new[]
             {
                 new ScannerDevice { Name = "A", Ip = "1.1.1.1", Status = "Online", LastSeen = DateTime.Now }
             };
+            return Task.FromResult(result);
         }
     }
 
     public class ScannerStatusViewModelTests
     {
         [Fact]
-        public void RefreshCommand_PopulatesDevices()
+        public async Task RefreshCommand_PopulatesDevices()
         {
             var svc = new FakeScannerService();
             var vm = new ScannerStatusViewModel(svc);
-            vm.RefreshCommand.Execute(null);
+            await vm.RefreshCommand.ExecuteAsync(null);
             Assert.Single(vm.Devices);
             Assert.Equal(1, svc.CallCount);
         }
@@ -49,7 +51,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void RefreshCommand_UsesIpsFromSettings()
+        public async Task RefreshCommand_UsesIpsFromSettings()
         {
             var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
             try
@@ -59,7 +61,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 settings.SaveScannerIpAddresses(new[] { "127.0.0.1" });
                 var svc = new ScannerService(settings);
                 var vm = new ScannerStatusViewModel(svc);
-                vm.RefreshCommand.Execute(null);
+                await vm.RefreshCommand.ExecuteAsync(null);
                 Assert.Single(vm.Devices);
                 Assert.Equal("127.0.0.1", vm.Devices[0].Ip);
             }

--- a/ToolManagementAppV2/Interfaces/IScannerService.cs
+++ b/ToolManagementAppV2/Interfaces/IScannerService.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Models;
 
 namespace ToolManagementAppV2.Interfaces
 {
     public interface IScannerService
     {
-        IEnumerable<ScannerDevice> GetScannerDevices();
+        Task<IEnumerable<ScannerDevice>> GetScannerDevicesAsync();
     }
 }

--- a/ToolManagementAppV2/Services/Devices/ScannerService.cs
+++ b/ToolManagementAppV2/Services/Devices/ScannerService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.NetworkInformation;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models;
 using Microsoft.Extensions.Logging;
@@ -19,10 +21,9 @@ namespace ToolManagementAppV2.Services.Devices
             _logger = logger ?? NullLogger<ScannerService>.Instance;
         }
 
-        public IEnumerable<ScannerDevice> GetScannerDevices()
+        public async Task<IEnumerable<ScannerDevice>> GetScannerDevicesAsync()
         {
-            var list = new List<ScannerDevice>();
-            foreach (var ip in _settingsService.GetScannerIpAddresses())
+            var tasks = _settingsService.GetScannerIpAddresses().Select(async ip =>
             {
                 var device = new ScannerDevice
                 {
@@ -33,7 +34,7 @@ namespace ToolManagementAppV2.Services.Devices
                 try
                 {
                     using var ping = new Ping();
-                    var reply = ping.Send(ip, 1000);
+                    var reply = await ping.SendPingAsync(ip, 1000);
                     device.Status = reply.Status == IPStatus.Success ? "Online" : "Offline";
                 }
                 catch (Exception ex)
@@ -41,9 +42,10 @@ namespace ToolManagementAppV2.Services.Devices
                     _logger.LogError(ex, "Failed to ping scanner {Ip}", ip);
                     device.Status = "Error";
                 }
-                list.Add(device);
-            }
-            return list;
+                return device;
+            });
+
+            return await Task.WhenAll(tasks);
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/ScannerStatusViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ScannerStatusViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
+using System.Threading.Tasks;
 using System.Windows.Threading;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models;
@@ -29,22 +30,23 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        public IRelayCommand RefreshCommand { get; }
+        public IAsyncRelayCommand RefreshCommand { get; }
 
         internal bool IsTimerRunning => _timer.IsEnabled;
 
         public ScannerStatusViewModel(IScannerService service)
         {
             _service = service;
-            RefreshCommand = new RelayCommand(Refresh);
+            RefreshCommand = new AsyncRelayCommand(RefreshAsync);
             _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
-            _timer.Tick += (s, e) => Refresh();
+            _timer.Tick += async (s, e) => await RefreshAsync();
         }
 
-        void Refresh()
+        async Task RefreshAsync()
         {
             Devices.Clear();
-            foreach (var d in _service.GetScannerDevices())
+            var devices = await _service.GetScannerDevicesAsync();
+            foreach (var d in devices)
                 Devices.Add(d);
         }
     }


### PR DESCRIPTION
## Summary
- parallelize scanner pings using `Ping.SendPingAsync` and `Task.WhenAll`
- make `ScannerStatusViewModel` refresh asynchronously with `AsyncRelayCommand`
- add async unit tests for scanner service and view model

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689da61a79c883249f2b5f0ed6fb7c14