### PR TITLE
Add key validation for settings service operations

### DIFF
--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data.SQLite;
 using System.IO;
@@ -11,6 +12,63 @@ namespace ToolManagementAppV2.Tests.Services
 {
     public class SettingsServiceTests
     {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void SaveSetting_ThrowsOnNullOrEmptyKey(string key)
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                ISettingsService service = new SettingsService(dbService);
+
+                Assert.Throws<ArgumentException>(() => service.SaveSetting(key!, "Value1"));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void UpdateSettings_ThrowsOnEmptyKey()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                ISettingsService service = new SettingsService(dbService);
+
+                var settings = new Dictionary<string, string> { [""] = "Value1" };
+                Assert.Throws<ArgumentException>(() => service.UpdateSettings(settings));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void UpdateSettings_ThrowsOnNullSettings()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                ISettingsService service = new SettingsService(dbService);
+
+                Assert.Throws<ArgumentNullException>(() => service.UpdateSettings(null!));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
         [Fact]
         public void UpdateSettings_ThrowsOnFailure()
         {

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -24,6 +24,9 @@ namespace ToolManagementAppV2.Services.Settings
 
         public void SaveSetting(string key, string value)
         {
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentException("Key cannot be null or empty.", nameof(key));
+
             try
             {
                 var p = new[]
@@ -90,6 +93,15 @@ namespace ToolManagementAppV2.Services.Settings
         /// </exception>
         public void UpdateSettings(Dictionary<string, string> settings)
         {
+            if (settings == null)
+                throw new ArgumentNullException(nameof(settings));
+
+            foreach (var kv in settings)
+            {
+                if (string.IsNullOrWhiteSpace(kv.Key))
+                    throw new ArgumentException("Key cannot be null or empty.", nameof(settings));
+            }
+
             using var conn = _dbService.CreateConnection();
             using var tx = conn.BeginTransaction();
             try


### PR DESCRIPTION
## Summary
- validate setting keys in SaveSetting and UpdateSettings
- cover null/empty key scenarios in SettingsServiceTests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689da75b4a6483249435b70f57cef0ba