### PR TITLE
Inject dialog service into user management

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Collections.Generic;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
@@ -20,7 +21,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
-                var vm = new UserManagementViewModel(userService, new StubFileDialogService());
+                var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
                 vm.LoadUsers();
                 vm.SelectedUser = vm.Users.First();
@@ -49,7 +50,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var fileSvc = new StubFileDialogService { FileToReturn = "path/to/image.png" };
-                var vm = new UserManagementViewModel(userService, fileSvc);
+                var vm = new UserManagementViewModel(userService, fileSvc, new StubDialogService());
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
                 vm.LoadUsers();
                 vm.SelectedUser = vm.Users.First();
@@ -77,7 +78,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var fileSvc = new StubFileDialogService { FileToReturn = "img.png" };
-                var vm = new UserManagementViewModel(userService, fileSvc);
+                var vm = new UserManagementViewModel(userService, fileSvc, new StubDialogService());
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
                 vm.LoadUsers();
                 vm.SelectedUser = vm.Users.First();
@@ -110,7 +111,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
-                var vm = new UserManagementViewModel(userService, new StubFileDialogService());
+                var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
                 vm.LoadUsers();
                 Assert.False(vm.UpdateUserCommand.CanExecute(null));
@@ -134,7 +135,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
-                var vm = new UserManagementViewModel(userService, new StubFileDialogService());
+                var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
                 vm.AddUserCommand.Execute(null);
                 Assert.Single(vm.Users);
                 Assert.Single(userService.GetAllUsers());
@@ -154,7 +155,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
-                var vm = new UserManagementViewModel(userService, new StubFileDialogService());
+                var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
                 vm.LoadUsers();
                 var user = vm.Users.First();
@@ -178,7 +179,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
-                var vm = new UserManagementViewModel(userService, new StubFileDialogService());
+                var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
                 userService.AddUser(new User { UserName = "alice", Password = "pw" });
                 userService.AddUser(new User { UserName = "bob", Password = "pw" });
                 vm.LoadUsers();
@@ -206,7 +207,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
-                var vm = new UserManagementViewModel(userService, new StubFileDialogService());
+                var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
                 userService.AddUser(new User { UserName = "user2", Password = "pw" });
                 vm.LoadUsers();
@@ -251,10 +252,20 @@ class StubFileDialogService : IFileDialogService
     public string SaveFile(string filter) => FileToReturn;
 }
 
+class StubDialogService : IDialogService
+{
+    public void ShowInfo(string message, string title) { }
+    public bool ShowConfirmation(string message, string title) => false;
+    public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+    public void ShowToolDetails(ToolModel tool) { }
+    public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+    public CustomerModel? ShowAddCustomerDialog() => null;
+}
+
 class CancelPromptUserManagementViewModel : UserManagementViewModel
 {
     public CancelPromptUserManagementViewModel(IUserService userService, IFileDialogService fileDialogService)
-        : base(userService, fileDialogService) { }
+        : base(userService, fileDialogService, new StubDialogService()) { }
 
     protected override bool TryPromptForPassword(UserModel newUser, out string password)
     {

--- a/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Windows.Controls;
 using System.Reflection;
+using System.Collections.Generic;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
@@ -30,7 +31,7 @@ namespace ToolManagementAppV2.Tests.Views
                         var db = new DatabaseService(dbPath);
                         IUserService userService = new UserService(db, new ApplicationUserContext());
                         var fileSvc = new StubFileDialogService { FileToReturn = "img.png" };
-                        var vm = new UserManagementViewModel(userService, fileSvc);
+                        var vm = new UserManagementViewModel(userService, fileSvc, new StubDialogService());
                         userService.AddUser(new User { UserName = "user1", Password = "pw" });
                         vm.LoadUsers();
                         vm.SelectedUser = vm.Users.First();
@@ -82,5 +83,15 @@ namespace ToolManagementAppV2.Tests.Views
         public string FileToReturn { get; set; }
         public string OpenFile(string filter) => FileToReturn;
         public string SaveFile(string filter) => FileToReturn;
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => false;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
     }
 }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -133,7 +133,7 @@ namespace ToolManagementAppV2.ViewModels
             });
 
             ToolManagement = new ToolManagementViewModel(toolService, customerService, rentalService, _dialogService);
-            UserManagement = new UserManagementViewModel(userService, fileDialogService);
+            UserManagement = new UserManagementViewModel(userService, fileDialogService, _dialogService);
             CustomerManagement = new CustomerManagementViewModel(customerService, _dialogService);
             ManageRentals = new ManageRentalsViewModel(rentalService, _dialogService);
             ImportExport = new ImportExportViewModel(toolService, customerService, fileDialogService, databaseService);

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -8,7 +8,6 @@ using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Extensions;
 using ToolManagementAppV2.Utilities.Helpers;
 using ToolManagementAppV2.Views;
-using ToolManagementAppV2.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -18,6 +17,7 @@ namespace ToolManagementAppV2.ViewModels
     {
         private readonly IUserService _userService;
         private readonly IFileDialogService _fileDialogService;
+        private readonly IDialogService _dialogService;
         private readonly ILogger<UserManagementViewModel> _logger;
 
         private List<UserModel> _allUsers = new();
@@ -58,10 +58,14 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand ResetPasswordFromRowCommand { get; }
         public IRelayCommand DeleteUserFromRowCommand { get; }
 
-        public UserManagementViewModel(IUserService userService, IFileDialogService fileDialogService, ILogger<UserManagementViewModel>? logger = null)
+        public UserManagementViewModel(IUserService userService,
+                                       IFileDialogService fileDialogService,
+                                       IDialogService dialogService,
+                                       ILogger<UserManagementViewModel>? logger = null)
         {
             _userService = userService;
             _fileDialogService = fileDialogService;
+            _dialogService = dialogService;
             _logger = logger ?? NullLogger<UserManagementViewModel>.Instance;
             LoadUsersCommand = new RelayCommand(LoadUsers);
             UploadUserPhotoCommand = new RelayCommand(UploadUserPhoto);
@@ -142,7 +146,7 @@ namespace ToolManagementAppV2.ViewModels
             {
                 try
                 {
-                    var prompt = new PasswordPromptWindow(new DialogService()) { SelectedUser = newUser };
+                    var prompt = new PasswordPromptWindow(_dialogService) { SelectedUser = newUser };
                     if (prompt.ShowDialog() == true)
                     {
                         password = prompt.EnteredPassword;


### PR DESCRIPTION
## Summary
- Inject `IDialogService` into `UserManagementViewModel` and use it for password prompts
- Pass shared dialog service from `MainViewModel`
- Update user management tests to supply a stub dialog service

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689da9a068648324adf186eb35046687