### PR TITLE
Prevent dialog event handler memory leaks

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -1,12 +1,16 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Threading;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.ViewModels.Rental;
+using ToolManagementAppV2.Views;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.ViewModels
@@ -241,6 +245,61 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 if (File.Exists(dbPath))
                     File.Delete(dbPath);
             }
+        }
+
+        [Fact]
+        public void RentToolPopupWindow_RequestCloseHandler_DoesNotLeak()
+        {
+            WeakReference? winRef = null;
+            bool? aliveBeforeUnsubscribe = null;
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var vm = new RentToolPopupViewModel(new ToolModel(), new List<CustomerModel>());
+                    var win = new RentToolPopupWindow { DataContext = vm };
+                    var captured = win;
+                    EventHandler handler = (_, _) => captured.Close();
+                    vm.RequestClose += handler;
+                    winRef = new WeakReference(captured);
+                    win = null;
+
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect();
+                    aliveBeforeUnsubscribe = winRef.IsAlive;
+
+                    vm.RequestClose -= handler;
+                    captured = null;
+
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect();
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+            {
+                throw threadException;
+            }
+
+            Assert.True(aliveBeforeUnsubscribe);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            Assert.False(winRef!.IsAlive);
         }
     }
 }

--- a/ToolManagementAppV2/Services/DialogService.cs
+++ b/ToolManagementAppV2/Services/DialogService.cs
@@ -57,8 +57,19 @@ namespace ToolManagementAppV2.Services
         {
             var vm = new RentToolPopupViewModel(tool, customers);
             var win = new RentToolPopupWindow { DataContext = vm };
-            vm.RequestClose += (_, _) => win.Close();
-            win.ShowDialog();
+
+            EventHandler handler = null!;
+            handler = (_, _) => win.Close();
+            vm.RequestClose += handler;
+
+            try
+            {
+                win.ShowDialog();
+            }
+            finally
+            {
+                vm.RequestClose -= handler;
+            }
 
             if (vm.SelectedCustomerResult != null)
             {


### PR DESCRIPTION
## Summary
- Ensure RentToolPopupWindow request-close handlers are unsubscribed to avoid retaining windows
- Add memory leak unit test using WeakReference

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689dac1f9bd88324893f010bc5a8840c