### PR TITLE
Refactor MainWindow to use injected services

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ This project adheres to the rules in `AGENTS.md`, including:
 
 ### Resource Management
 `DatabaseService` implements `IDisposable` and should be disposed when no longer in use.
-`MainWindow` accepts an optional `DatabaseService` in its constructor when an external
-`MainViewModel` is supplied; pass the instance to have the window dispose it on close.
-Otherwise, register the service with a DI container so scoped lifetimes handle disposal
-automatically, or explicitly call `Dispose`/`using` in the application startup and tests.
+`MainWindow` requires a `MainViewModel` and optionally an owned `DatabaseService`. Pass the
+database service to have the window dispose it on close. Create services in `App` or resolve
+them from a DI container before constructing the window.
 

--- a/ToolManagementAppV2.Tests/TestHelpers.cs
+++ b/ToolManagementAppV2.Tests/TestHelpers.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using ToolManagementAppV2;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.ViewModels;
+
+namespace ToolManagementAppV2.Tests
+{
+    public static class TestHelpers
+    {
+        public static (MainWindow window, string dbPath) CreateMainWindow()
+        {
+            var dbPath = Path.GetTempFileName();
+            var db = new DatabaseService(dbPath);
+            var toolService = new ToolService(db);
+            var customerService = new CustomerService(db);
+            var userContext = new ApplicationUserContext();
+            var userService = new UserService(db, userContext);
+            var rentalService = new RentalService(db, toolService);
+            var activityLogService = new ActivityLogService(db);
+            var fileDialogService = new StubFileDialogService();
+            var settingsService = new SettingsService(db);
+            var dialogService = new StubDialogService();
+            var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                fileDialogService, activityLogService, settingsService, db, dialogService);
+            var window = new MainWindow(vm, db);
+            return (window, dbPath);
+        }
+
+        class StubFileDialogService : IFileDialogService
+        {
+            public string OpenFile(string filter) => null;
+            public string SaveFile(string filter) => null;
+        }
+
+        class StubDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => false;
+            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+            public void ShowToolDetails(ToolModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+        }
+    }
+}

--- a/ToolManagementAppV2.Tests/Tests/AdminButtonVisibilityTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/AdminButtonVisibilityTests.cs
@@ -1,8 +1,10 @@
+using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using ToolManagementAppV2;
 using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Tests;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.Tests
@@ -18,18 +20,26 @@ namespace ToolManagementAppV2.Tests.Tests
             Application.Current.Properties["CurrentUser"] = new UserModel { UserName = "user", IsAdmin = false };
             try
             {
-                var window = new MainWindow();
-                var dock = Assert.IsType<DockPanel>(window.Content);
-                var stack = Assert.IsType<StackPanel>(dock.Children[0]);
+                var (window, dbPath) = TestHelpers.CreateMainWindow();
+                try
+                {
+                    var dock = Assert.IsType<DockPanel>(window.Content);
+                    var stack = Assert.IsType<StackPanel>(dock.Children[0]);
 
-                var restricted = new[] { "Tool Management", "Users", "Settings", "Import/Export" };
-                bool anyVisible = stack.Children
-                    .OfType<Button>()
-                    .Where(b => restricted.Contains(b.Content?.ToString()))
-                    .Any(b => b.Visibility == Visibility.Visible);
+                    var restricted = new[] { "Tool Management", "Users", "Settings", "Import/Export" };
+                    bool anyVisible = stack.Children
+                        .OfType<Button>()
+                        .Where(b => restricted.Contains(b.Content?.ToString()))
+                        .Any(b => b.Visibility == Visibility.Visible);
 
-                Assert.False(anyVisible);
-                window.Close();
+                    Assert.False(anyVisible);
+                }
+                finally
+                {
+                    window.Close();
+                    if (File.Exists(dbPath))
+                        File.Delete(dbPath);
+                }
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using ToolManagementAppV2;
+using ToolManagementAppV2.Tests;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
@@ -20,13 +21,21 @@ namespace ToolManagementAppV2.Tests.Tests
         [Fact]
         public void OpenSearchToolsCommand_NavigatesToToolSearchPage()
         {
-            var window = new MainWindow();
-            var vm = Assert.IsType<MainViewModel>(window.DataContext);
+            var (window, dbPath) = TestHelpers.CreateMainWindow();
+            try
+            {
+                var vm = Assert.IsType<MainViewModel>(window.DataContext);
 
-            vm.OpenSearchToolsCommand.Execute(null);
+                vm.OpenSearchToolsCommand.Execute(null);
 
-            Assert.IsType<ToolSearchPage>(vm.CurrentPage);
-            window.Close();
+                Assert.IsType<ToolSearchPage>(vm.CurrentPage);
+            }
+            finally
+            {
+                window.Close();
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
         }
 
         [Fact]

--- a/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 using System.IO;
 using System.Runtime.Serialization;
 using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Tests;
 
 namespace ToolManagementAppV2.Tests.Views
 {
@@ -22,21 +23,30 @@ namespace ToolManagementAppV2.Tests.Views
             {
                 try
                 {
-                    var window = new ToolManagementAppV2.MainWindow();
-                    var textBox = (TextBox)window.FindName("GlobalSearchTextBox");
-                    Assert.NotNull(textBox);
+                    var (window, dbPath) = TestHelpers.CreateMainWindow();
+                    try
+                    {
+                        var textBox = (TextBox)window.FindName("GlobalSearchTextBox");
+                        Assert.NotNull(textBox);
 
-                    var vm = Assert.IsType<MainViewModel>(window.DataContext);
+                        var vm = Assert.IsType<MainViewModel>(window.DataContext);
 
-                    vm.GlobalSearchText = "Test";
+                        vm.GlobalSearchText = "Test";
 
-                    var keyBinding = textBox.InputBindings.OfType<KeyBinding>()
-                        .FirstOrDefault(kb => kb.Key == Key.Enter);
-                    Assert.NotNull(keyBinding);
+                        var keyBinding = textBox.InputBindings.OfType<KeyBinding>()
+                            .FirstOrDefault(kb => kb.Key == Key.Enter);
+                        Assert.NotNull(keyBinding);
 
-                    keyBinding.Command.Execute(null);
+                        keyBinding.Command.Execute(null);
 
-                    Assert.Equal(string.Empty, vm.GlobalSearchText);
+                        Assert.Equal(string.Empty, vm.GlobalSearchText);
+                    }
+                    finally
+                    {
+                        window.Close();
+                        if (File.Exists(dbPath))
+                            File.Delete(dbPath);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -63,12 +73,21 @@ namespace ToolManagementAppV2.Tests.Views
             {
                 try
                 {
-                    var window = new ToolManagementAppV2.MainWindow();
-                    var button = (Button)window.FindName("SwitchUserButton");
-                    Assert.NotNull(button);
+                    var (window, dbPath) = TestHelpers.CreateMainWindow();
+                    try
+                    {
+                        var button = (Button)window.FindName("SwitchUserButton");
+                        Assert.NotNull(button);
 
-                    var vm = Assert.IsType<MainViewModel>(window.DataContext);
-                    Assert.Same(vm.SwitchUserCommand, button.Command);
+                        var vm = Assert.IsType<MainViewModel>(window.DataContext);
+                        Assert.Same(vm.SwitchUserCommand, button.Command);
+                    }
+                    finally
+                    {
+                        window.Close();
+                        if (File.Exists(dbPath))
+                            File.Delete(dbPath);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -1,14 +1,7 @@
 // MainWindow.xaml.cs
 using System;
-using System.IO;
 using System.Windows;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
-using ToolManagementAppV2.Services.Customers;
-using ToolManagementAppV2.Services.Users;
-using ToolManagementAppV2.Services.Rentals;
-using ToolManagementAppV2.Services.Settings;
-using ToolManagementAppV2.Services;
 using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2
@@ -18,45 +11,18 @@ namespace ToolManagementAppV2
         readonly DatabaseService? _ownedDb;
 
         /// <summary>
-        /// Creates a <see cref="MainWindow"/> with its own internally managed services.
-        /// The window owns the database service and will dispose it when closed.
+        /// Initializes a new instance of <see cref="MainWindow"/> with the provided services.
+        /// When <paramref name="ownedDatabaseService"/> is supplied, the window will dispose it
+        /// when closed.
         /// </summary>
-        public MainWindow() : this(null, null)
-        {
-        }
-
-        /// <summary>
-        /// Creates a <see cref="MainWindow"/> with a supplied <paramref name="viewModel"/>.
-        /// When <paramref name="ownedDatabaseService"/> is provided, the window will dispose it
-        /// upon closing. If <c>null</c>, the caller is responsible for managing the database
-        /// service's lifetime.
-        /// </summary>
-        /// <param name="viewModel">Optional view model to use as the window's data context.</param>
+        /// <param name="viewModel">View model to use as the window's data context.</param>
         /// <param name="ownedDatabaseService">Database service owned by the window; disposed on close.</param>
-        public MainWindow(MainViewModel? viewModel, DatabaseService? ownedDatabaseService = null)
+        public MainWindow(MainViewModel viewModel, DatabaseService? ownedDatabaseService = null)
         {
             InitializeComponent();
 
-            if (viewModel != null)
-            {
-                DataContext = viewModel;
-                _ownedDb = ownedDatabaseService;
-            }
-            else
-            {
-                _ownedDb = new DatabaseService(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db"));
-                var toolService = new ToolService(_ownedDb);
-                var customerService = new CustomerService(_ownedDb);
-                var userContext = new ApplicationUserContext();
-                var userService = new UserService(_ownedDb, userContext);
-                var rentalService = new RentalService(_ownedDb, toolService);
-                var activityLogService = new ActivityLogService(_ownedDb);
-                var fileDialogService = new FileDialogService();
-                var settingsService = new SettingsService(_ownedDb);
-                var dialogService = new DialogService();
-
-                DataContext = new MainViewModel(toolService, userService, userContext, customerService, rentalService, fileDialogService, activityLogService, settingsService, _ownedDb, dialogService);
-            }
+            DataContext = viewModel;
+            _ownedDb = ownedDatabaseService;
 
             Closed += (_, __) => _ownedDb?.Dispose();
         }

--- a/ToolManagementAppV2/Utilities/Navigation.cs
+++ b/ToolManagementAppV2/Utilities/Navigation.cs
@@ -1,4 +1,5 @@
-﻿// Utilities/Navigation.cs
+// Utilities/Navigation.cs
+using System;
 using System.Windows;
 
 namespace ToolManagementAppV2
@@ -7,13 +8,10 @@ namespace ToolManagementAppV2
     {
         public static void ShowMainWindow()
         {
-            var current = System.Windows.Application.Current.MainWindow as MainWindow;
+            var current = Application.Current.MainWindow as MainWindow;
 
-            if (current == null || !current.IsLoaded)
-            {
-                current = new MainWindow();
-                System.Windows.Application.Current.MainWindow = current;
-            }
+            if (current == null)
+                throw new InvalidOperationException("Main window is not initialized.");
 
             if (!current.IsVisible) current.Show();
             if (current.WindowState == WindowState.Minimized) current.WindowState = WindowState.Normal;


### PR DESCRIPTION
## Summary
- Remove internal service creation from MainWindow and require a supplied MainViewModel/database service
- Simplify Navigation by only showing an existing MainWindow
- Add test helper for constructing MainWindow and update tests accordingly

## Testing
- `dotnet test` *(fails: command not found)*
- `dotnet run --project ToolManagementAppV2/ToolManagementAppV2.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dadfc8c048324b1cedf50a7e05385