### PR TITLE
Remove unused x:Name attributes

### DIFF
--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -19,7 +19,7 @@
                 </StackPanel>
 
                 <ScrollViewer Grid.Row="1">
-                    <StackPanel x:Name="LeftMenuStack" Orientation="Vertical" Margin="12,0,12,8">
+                    <StackPanel Orientation="Vertical" Margin="12,0,12,8">
                         <TextBlock Text="Operations" Foreground="{StaticResource ForegroundMutedBrush}" Margin="6,8,6,2"/>
                         <Button Style="{StaticResource NavButton}" Content="Dashboard" Command="{Binding OpenDashboardCommand}"/>
                         <Button Style="{StaticResource NavButton}" Content="Search Tools" Command="{Binding OpenSearchToolsCommand}"/>

--- a/ToolManagementAppV2/Views/AvatarSelectionWindow.xaml
+++ b/ToolManagementAppV2/Views/AvatarSelectionWindow.xaml
@@ -14,8 +14,7 @@
         </Border>
 
         <!-- AVATAR GRID -->
-        <ListBox x:Name="AvatarListBox"
-                 DockPanel.Dock="Top"
+        <ListBox DockPanel.Dock="Top"
                  Margin="0,4,0,0"
                  ItemsSource="{Binding Avatars}">
             <ListBox.ItemsPanel>


### PR DESCRIPTION
## Summary
- Remove unreferenced `x:Name` attribute from the main window's left menu stack
- Drop unused `x:Name` from avatar selection list

## Testing
- `dotnet test --filter AdminButtonVisibilityTests` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*
- `dotnet run --project ToolManagementAppV2/ToolManagementAppV2.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689db014c0ec83248869de8c04696a25