### PR TITLE
Remove default dialog implementations

### DIFF
--- a/ToolManagementAppV2.Tests/TestHelpers.cs
+++ b/ToolManagementAppV2.Tests/TestHelpers.cs
@@ -50,6 +50,13 @@ namespace ToolManagementAppV2.Tests
             public void ShowToolDetails(ToolModel tool) { }
             public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+            public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+            public void ShowScannerStatus() { }
         }
     }
 }

--- a/ToolManagementAppV2.Tests/Tests/CustomersPageBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CustomersPageBindingTests.cs
@@ -50,5 +50,12 @@ namespace ToolManagementAppV2.Tests.Tests
         public void ShowToolDetails(ToolModel tool) { }
         public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
     }
 }

--- a/ToolManagementAppV2.Tests/Tests/ManageRentalsPageMenuTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ManageRentalsPageMenuTests.cs
@@ -100,5 +100,12 @@ namespace ToolManagementAppV2.Tests.Tests
         public void ShowToolDetails(ToolModel tool) { }
         public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
     }
 }

--- a/ToolManagementAppV2.Tests/Tests/ManageToolsPageMenuTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ManageToolsPageMenuTests.cs
@@ -85,6 +85,13 @@ namespace ToolManagementAppV2.Tests.Tests
             public void ShowToolDetails(ToolModel tool) { }
             public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+            public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+            public void ShowScannerStatus() { }
         }
     }
 }

--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -85,4 +85,11 @@ class StubDialogService : IDialogService
     public void ShowToolDetails(ToolModel tool) { }
     public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
     public CustomerModel? ShowAddCustomerDialog() => null;
+    public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+    public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+    public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+    public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+    public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+    public void ShowPrintLabelDialog() { }
+    public void ShowScannerStatus() { }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/CustomerManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/CustomerManagementViewModelTests.cs
@@ -297,5 +297,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void ShowToolDetails(ToolModel tool) { }
         public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => AddCustomerResult;
+        public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -51,9 +51,16 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => true;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+       public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
         public void ShowToolDetails(ToolModel tool) { }
         public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -80,4 +80,11 @@ class StubDialogService : IDialogService
     public void ShowToolDetails(ToolModel tool) { }
     public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
     public CustomerModel? ShowAddCustomerDialog() => null;
+    public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+    public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+    public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+    public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+    public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+    public void ShowPrintLabelDialog() { }
+    public void ShowScannerStatus() { }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -378,4 +378,10 @@ class StubDialogService : IDialogService
     public CustomerModel? ShowAddCustomerDialog() => null;
 
     public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => ImportMap;
+    public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+    public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+    public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+    public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+    public void ShowPrintLabelDialog() { }
+    public void ShowScannerStatus() { }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -115,6 +115,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void ShowToolDetails(ToolModel tool) { }
         public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
     }
 
     class StubLogger<T> : ILogger<T>

--- a/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
@@ -230,5 +230,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void ShowToolDetails(ToolModel tool) { }
         public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/PasswordPromptViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/PasswordPromptViewModelTests.cs
@@ -88,5 +88,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void ShowToolDetails(ToolModel tool) { }
         public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/PrintLabelViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/PrintLabelViewModelTests.cs
@@ -46,5 +46,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void ShowToolDetails(ToolModel tool) { }
         public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/RentalHistoryViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/RentalHistoryViewModelTests.cs
@@ -96,6 +96,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
             public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
 
             public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+            public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+            public void ShowScannerStatus() { }
         }
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -113,6 +113,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void ShowToolDetails(ToolModel tool) { }
         public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
     }
 }
 

--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -189,6 +189,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
             public void ShowToolDetails(ToolModel tool) => ViewDetailsHandler?.Invoke(tool);
             public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+            public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+            public void ShowScannerStatus() { }
         }
 
         [Fact]

--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -319,6 +319,13 @@ class StubDialogService : IDialogService
     public void ShowToolDetails(ToolModel tool) { }
     public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
     public CustomerModel? ShowAddCustomerDialog() => null;
+    public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+    public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+    public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+    public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+    public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+    public void ShowPrintLabelDialog() { }
+    public void ShowScannerStatus() { }
 }
 
 class CancelPromptUserManagementViewModel : UserManagementViewModel

--- a/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
@@ -93,5 +93,12 @@ namespace ToolManagementAppV2.Tests.Views
         public void ShowToolDetails(ToolModel tool) { }
         public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
     }
 }

--- a/ToolManagementAppV2/Interfaces/IDialogService.cs
+++ b/ToolManagementAppV2/Interfaces/IDialogService.cs
@@ -14,12 +14,12 @@ namespace ToolManagementAppV2.Interfaces
         (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers);
         CustomerModel? ShowAddCustomerDialog();
 
-        void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
-        void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
-        Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
-        Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
-        void ShowPrintPreview(FlowDocument document, string title, string description) { }
-        void ShowPrintLabelDialog() { }
-        void ShowScannerStatus() { }
+        void ShowRentalsFilter(ManageRentalsViewModel viewModel);
+        void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history);
+        Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties);
+        Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping();
+        void ShowPrintPreview(FlowDocument document, string title, string description);
+        void ShowPrintLabelDialog();
+        void ShowScannerStatus();
     }
 }


### PR DESCRIPTION
## Summary
- eliminate default method bodies from `IDialogService`
- add explicit implementations in test stubs for new dialog methods

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689db180b32883249e26e63d73ca101b