### PR TITLE
Add debounced search command

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -470,6 +470,28 @@ namespace ToolManagementAppV2.Tests.ViewModels
             Assert.Equal(1, toolService.GetAllToolsAsyncCalls);
         }
 
+        [Fact]
+        public void SearchText_DebouncesRapidChanges()
+        {
+            var tools = new List<ToolModel>
+            {
+                new Tool { ToolNumber = "T1", NameDescription = "Hammer" }
+            };
+            var toolService = new CountingToolService(tools);
+            var timer = new TestDispatcherTimer();
+            var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService(), null, timer);
+
+            vm.SearchText = "H";
+            vm.SearchText = "Ha";
+            vm.SearchText = "Ham";
+
+            Assert.Equal(0, toolService.SearchToolsAsyncCalls);
+
+            timer.RaiseTick();
+
+            Assert.Equal(1, toolService.SearchToolsAsyncCalls);
+        }
+
         class CountingToolService : IToolService
         {
             public int GetAllToolsAsyncCalls { get; private set; }
@@ -532,6 +554,20 @@ namespace ToolManagementAppV2.Tests.ViewModels
             public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => throw new NotImplementedException();
             public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => throw new NotImplementedException();
             public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => throw new NotImplementedException();
+        }
+
+        class TestDispatcherTimer : IDispatcherTimer
+        {
+            public event EventHandler Tick;
+            public TimeSpan Interval { get; set; }
+            public bool IsEnabled { get; private set; }
+            public void Start() => IsEnabled = true;
+            public void Stop() => IsEnabled = false;
+            public void RaiseTick()
+            {
+                if (IsEnabled)
+                    Tick?.Invoke(this, EventArgs.Empty);
+            }
         }
     }
 }

--- a/ToolManagementAppV2.Tests/Views/ToolSearchTypingTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ToolSearchTypingTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Threading;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Views;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Views
+{
+    public class ToolSearchTypingTests
+    {
+        [Fact(Skip = "Manual test for verifying search debounce while typing")]
+        public void SearchText_Debounce_Manual()
+        {
+            var thread = new Thread(() =>
+            {
+                var dbPath = Path.GetTempFileName();
+                try
+                {
+                    var db = new DatabaseService(dbPath);
+                    IToolService toolService = new ToolService(db);
+                    var customerService = new CustomerService(db);
+                    var rentalService = new RentalService(db);
+                    var dialog = new StubDialogService();
+                    var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
+                    toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
+                    toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Hand Saw" });
+                    vm.LoadToolsAsync().Wait();
+                    var page = new ToolSearchPage { DataContext = vm };
+                    var window = new System.Windows.Window { Content = page, Width = 800, Height = 600 };
+                    window.ShowDialog();
+                }
+                finally
+                {
+                    if (File.Exists(dbPath))
+                        File.Delete(dbPath);
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+        }
+
+        class StubDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => false;
+            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+            public void ShowToolDetails(ToolModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+        }
+    }
+}

--- a/ToolManagementAppV2/Interfaces/IDispatcherTimer.cs
+++ b/ToolManagementAppV2/Interfaces/IDispatcherTimer.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace ToolManagementAppV2.Interfaces
+{
+    /// <summary>
+    /// Abstraction over a dispatcher timer to allow testable scheduling.
+    /// </summary>
+    public interface IDispatcherTimer
+    {
+        /// <summary>
+        /// Occurs when the timer interval elapses.
+        /// </summary>
+        event EventHandler Tick;
+
+        /// <summary>
+        /// Gets or sets the amount of time between ticks.
+        /// </summary>
+        TimeSpan Interval { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the timer is enabled.
+        /// </summary>
+        bool IsEnabled { get; }
+
+        /// <summary>
+        /// Starts the timer.
+        /// </summary>
+        void Start();
+
+        /// <summary>
+        /// Stops the timer.
+        /// </summary>
+        void Stop();
+    }
+}

--- a/ToolManagementAppV2/Utilities/DispatcherTimerWrapper.cs
+++ b/ToolManagementAppV2/Utilities/DispatcherTimerWrapper.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Windows.Threading;
+using ToolManagementAppV2.Interfaces;
+
+namespace ToolManagementAppV2.Utilities
+{
+    /// <summary>
+    /// Wraps the WPF <see cref="DispatcherTimer"/> for testability.
+    /// </summary>
+    public class DispatcherTimerWrapper : IDispatcherTimer
+    {
+        readonly DispatcherTimer _timer = new();
+
+        public event EventHandler Tick
+        {
+            add => _timer.Tick += value;
+            remove => _timer.Tick -= value;
+        }
+
+        public TimeSpan Interval
+        {
+            get => _timer.Interval;
+            set => _timer.Interval = value;
+        }
+
+        public bool IsEnabled => _timer.IsEnabled;
+
+        public void Start() => _timer.Start();
+
+        public void Stop() => _timer.Stop();
+    }
+}

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -7,6 +7,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Utilities;
 using ToolManagementAppV2.Utilities.Extensions;
 using ToolManagementAppV2.Services;
 using Microsoft.Extensions.Logging;
@@ -87,6 +88,8 @@ namespace ToolManagementAppV2.ViewModels
         public IAsyncRelayCommand OpenRentalsCommand { get; }
         public IRelayCommand ViewDetailsCommand { get; }
 
+        readonly IDispatcherTimer _searchDebounceTimer;
+
         // Writable for TwoWay binding from XAML. Mirrors SearchTerm and triggers search.
         private string _searchText = string.Empty;
         public string SearchText
@@ -97,7 +100,8 @@ namespace ToolManagementAppV2.ViewModels
                 if (SetProperty(ref _searchText, value))
                 {
                     SearchTerm = value;
-                    SearchCommand.Execute(null);
+                    _searchDebounceTimer.Stop();
+                    _searchDebounceTimer.Start();
                 }
             }
         }
@@ -106,7 +110,8 @@ namespace ToolManagementAppV2.ViewModels
                                        ICustomerService customerService,
                                        IRentalService rentalService,
                                        IDialogService dialogService,
-                                       ILogger<ToolManagementViewModel>? logger = null)
+                                       ILogger<ToolManagementViewModel>? logger = null,
+                                       IDispatcherTimer? searchDebounceTimer = null)
         {
             _toolService = toolService;
             _customerService = customerService;
@@ -114,6 +119,12 @@ namespace ToolManagementAppV2.ViewModels
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<ToolManagementViewModel>.Instance;
             SearchCommand = new AsyncRelayCommand(FilterToolsAsync);
+            _searchDebounceTimer = searchDebounceTimer ?? new DispatcherTimerWrapper { Interval = TimeSpan.FromMilliseconds(300) };
+            _searchDebounceTimer.Tick += (s, e) =>
+            {
+                _searchDebounceTimer.Stop();
+                SearchCommand.Execute(null);
+            };
             NewToolCommand = new AsyncRelayCommand(AddToolAsync);
             EditToolCommand = new AsyncRelayCommand(EditToolAsync, () => SelectedTool != null);
             DeleteToolCommand = new AsyncRelayCommand(DeleteToolAsync);


### PR DESCRIPTION
## Summary
- Debounce tool search text using a dispatcher timer
- Add unit test for throttled search execution
- Include manual UI test for verifying search debounce behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689db1a263a88324863d20e52393eb49