### PR TITLE
Handle rental service errors in ManageRentalsViewModel

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
@@ -220,11 +220,45 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public async Task CheckInCommand_ShowsDialogOnFailure()
+        {
+            var rentals = new List<Rental>
+            {
+                new Rental
+                {
+                    RentalID = 1,
+                    ToolID = 1,
+                    ToolNumber = "T1",
+                    CustomerID = 1,
+                    CustomerName = "C1",
+                    RentalDate = DateTime.Today,
+                    DueDate = DateTime.Today.AddDays(1),
+                    Status = "Rented"
+                }
+            };
+            var rentalService = new ExceptionRentalService(rentals);
+            var dialog = new StubDialogService();
+            var vm = new ManageRentalsViewModel(rentalService, dialog);
+            await vm.LoadRentalsAsync();
+            vm.SelectedRental = vm.Rentals.First();
+
+            await vm.CheckInCommand.ExecuteAsync(null);
+
+            Assert.Contains("boom", dialog.LastInfoMessage);
+        }
     }
 
     class StubDialogService : IDialogService
     {
-        public void ShowInfo(string message, string title) { }
+        public string? LastInfoMessage { get; private set; }
+        public string? LastInfoTitle { get; private set; }
+        public void ShowInfo(string message, string title)
+        {
+            LastInfoMessage = message;
+            LastInfoTitle = title;
+        }
         public bool ShowConfirmation(string message, string title) => false;
         public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
         public void ShowToolDetails(ToolModel tool) { }
@@ -237,5 +271,29 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
         public void ShowScannerStatus() { }
+    }
+
+    class ExceptionRentalService : IRentalService
+    {
+        readonly List<Rental> _rentals;
+        public ExceptionRentalService(List<Rental> rentals) => _rentals = rentals;
+        public Task<List<Rental>> GetAllRentalsAsync() => Task.FromResult(_rentals);
+        public Task ReturnToolAsync(int rentalID, DateTime returnDate) => throw new InvalidOperationException("boom");
+        public void RentTool(int toolID, int customerID, DateTime rentalDate, DateTime dueDate) => throw new NotImplementedException();
+        public Task RentToolAsync(int toolID, int customerID, DateTime rentalDate, DateTime dueDate) => throw new NotImplementedException();
+        public void ReturnTool(int rentalID, DateTime returnDate) => throw new NotImplementedException();
+        public void ExtendRental(int rentalID, DateTime newDueDate) => throw new NotImplementedException();
+        public Task ExtendRentalAsync(int rentalID, DateTime newDueDate) => throw new NotImplementedException();
+        public void DeleteRental(int rentalID) => throw new NotImplementedException();
+        public Task DeleteRentalAsync(int rentalID) => throw new NotImplementedException();
+        public List<Rental> GetActiveRentals() => throw new NotImplementedException();
+        public Task<List<Rental>> GetActiveRentalsAsync() => throw new NotImplementedException();
+        public List<Rental> GetOverdueRentals() => throw new NotImplementedException();
+        public Task<List<Rental>> GetOverdueRentalsAsync() => throw new NotImplementedException();
+        public List<Rental> GetAllRentals() => throw new NotImplementedException();
+        public List<Rental> GetRentalHistoryForTool(int toolID) => throw new NotImplementedException();
+        public Task<List<Rental>> GetRentalHistoryForToolAsync(int toolID) => throw new NotImplementedException();
+        public List<Rental> GetRentalHistoryForCustomer(int customerID) => throw new NotImplementedException();
+        public Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID) => throw new NotImplementedException();
     }
 }

--- a/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
@@ -9,6 +9,8 @@ using System.Windows;
 using System.Windows.Documents;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -20,6 +22,7 @@ namespace ToolManagementAppV2.ViewModels
     {
         private readonly IRentalService _rentalService;
         private readonly IDialogService _dialogService;
+        private readonly ILogger<ManageRentalsViewModel> _logger;
         private List<RentalModel> _allRentals = new();
 
         public ObservableCollection<RentalModel> Rentals { get; } = new();
@@ -82,10 +85,11 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand PrintRentalCommand { get; }
         public IAsyncRelayCommand DeleteRentalCommand { get; }
 
-        public ManageRentalsViewModel(IRentalService rentalService, IDialogService dialogService)
+        public ManageRentalsViewModel(IRentalService rentalService, IDialogService dialogService, ILogger<ManageRentalsViewModel>? logger = null)
         {
             _rentalService = rentalService;
             _dialogService = dialogService;
+            _logger = logger ?? NullLogger<ManageRentalsViewModel>.Instance;
 
             ApplyFilterCommand = new RelayCommand(ApplyFilter);
             ClearFilterCommand = new RelayCommand(ClearFilter);
@@ -101,8 +105,16 @@ namespace ToolManagementAppV2.ViewModels
         /// <summary>Loads all rentals from the service.</summary>
         public async Task LoadRentalsAsync()
         {
-            _allRentals = await _rentalService.GetAllRentalsAsync();
-            Rentals.ReplaceRange(_allRentals);
+            try
+            {
+                _allRentals = await _rentalService.GetAllRentalsAsync();
+                Rentals.ReplaceRange(_allRentals);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load rentals");
+                _dialogService.ShowInfo($"Failed to load rentals: {ex.Message}", "Error");
+            }
         }
 
         void ApplyFilter()
@@ -154,34 +166,55 @@ namespace ToolManagementAppV2.ViewModels
         {
             if (SelectedRental == null)
                 return;
-
-            await _rentalService.ReturnToolAsync(SelectedRental.RentalID, DateTime.Today);
-            await LoadRentalsAsync();
+            try
+            {
+                await _rentalService.ReturnToolAsync(SelectedRental.RentalID, DateTime.Today);
+                await LoadRentalsAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to check in rental {RentalID}", SelectedRental.RentalID);
+                _dialogService.ShowInfo($"Failed to check in rental: {ex.Message}", "Error");
+            }
         }
 
         async Task ExtendAsync()
         {
             if (SelectedRental == null)
                 return;
-
-            var newDueDate = SelectedRental.DueDate.AddDays(7);
-            await _rentalService.ExtendRentalAsync(SelectedRental.RentalID, newDueDate);
-            await LoadRentalsAsync();
+            try
+            {
+                var newDueDate = SelectedRental.DueDate.AddDays(7);
+                await _rentalService.ExtendRentalAsync(SelectedRental.RentalID, newDueDate);
+                await LoadRentalsAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to extend rental {RentalID}", SelectedRental.RentalID);
+                _dialogService.ShowInfo($"Failed to extend rental: {ex.Message}", "Error");
+            }
         }
 
         async Task OpenHistoryAsync()
         {
             if (SelectedRental == null)
                 return;
-
-            var history = await _rentalService.GetRentalHistoryForToolAsync(SelectedRental.ToolID);
-            var tool = new ToolModel
+            try
             {
-                ToolID = SelectedRental.ToolID,
-                ToolNumber = SelectedRental.ToolNumber,
-                NameDescription = SelectedRental.ToolNumber
-            };
-            _dialogService.ShowRentalHistory(tool, history);
+                var history = await _rentalService.GetRentalHistoryForToolAsync(SelectedRental.ToolID);
+                var tool = new ToolModel
+                {
+                    ToolID = SelectedRental.ToolID,
+                    ToolNumber = SelectedRental.ToolNumber,
+                    NameDescription = SelectedRental.ToolNumber
+                };
+                _dialogService.ShowRentalHistory(tool, history);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to open rental history for tool {ToolID}", SelectedRental.ToolID);
+                _dialogService.ShowInfo($"Failed to load rental history: {ex.Message}", "Error");
+            }
         }
 
         void PrintRental()
@@ -236,9 +269,17 @@ namespace ToolManagementAppV2.ViewModels
         {
             if (SelectedRental == null)
                 return;
-            await _rentalService.DeleteRentalAsync(SelectedRental.RentalID);
-            _allRentals.Remove(SelectedRental);
-            Rentals.Remove(SelectedRental);
+            try
+            {
+                await _rentalService.DeleteRentalAsync(SelectedRental.RentalID);
+                _allRentals.Remove(SelectedRental);
+                Rentals.Remove(SelectedRental);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to delete rental {RentalID}", SelectedRental.RentalID);
+                _dialogService.ShowInfo($"Failed to delete rental: {ex.Message}", "Error");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- log and surface errors in rental operations via IDialogService
- cover rental failure cases in ManageRentalsViewModel tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689db42af6508324bd65befae39b9e71