### PR TITLE
Request column mapping before imports

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Models.ImportExport;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class ImportExportViewModelTests
+    {
+        [Fact]
+        public void ImportToolsCommand_UsesMappingFromDialog()
+        {
+            var tmp = Path.GetTempFileName();
+            File.WriteAllText(tmp, "ToolNumber\n");
+            var fileDlg = new StubFileDialogService { FileToReturn = tmp };
+            var toolSvc = new CapturingToolService();
+            var dialog = new StubDialogService { MapToReturn = new Dictionary<string,string>{{"ToolNumber","ToolNumber"}} };
+            var vm = new ImportExportViewModel(toolSvc, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
+
+            vm.ImportToolsCommand.Execute(null);
+
+            Assert.True(dialog.ShowImportMappingCalled);
+            Assert.True(toolSvc.ImportCalled);
+            Assert.Equal("ToolNumber", toolSvc.MapUsed!["ToolNumber"]);
+            File.Delete(tmp);
+        }
+
+        [Fact]
+        public void ImportCustomersCommand_UsesMappingFromDialog()
+        {
+            var tmp = Path.GetTempFileName();
+            File.WriteAllText(tmp, "Company\n");
+            var fileDlg = new StubFileDialogService { FileToReturn = tmp };
+            var customerSvc = new CapturingCustomerService();
+            var dialog = new StubDialogService { MapToReturn = new Dictionary<string,string>{{"Company","Company"}} };
+            var vm = new ImportExportViewModel(new StubToolService(), customerSvc, fileDlg, new StubDatabaseBackupService(), dialog);
+
+            vm.ImportCustomersCommand.Execute(null);
+
+            Assert.True(dialog.ShowImportMappingCalled);
+            Assert.True(customerSvc.ImportCalled);
+            Assert.Equal("Company", customerSvc.MapUsed!["Company"]);
+            File.Delete(tmp);
+        }
+
+        [Fact]
+        public void ImportToolsCommand_CancelledMapping_DoesNotCallService()
+        {
+            var tmp = Path.GetTempFileName();
+            File.WriteAllText(tmp, "ToolNumber\n");
+            var fileDlg = new StubFileDialogService { FileToReturn = tmp };
+            var toolSvc = new CapturingToolService();
+            var dialog = new StubDialogService { MapToReturn = null };
+            var vm = new ImportExportViewModel(toolSvc, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
+
+            vm.ImportToolsCommand.Execute(null);
+
+            Assert.True(dialog.ShowImportMappingCalled);
+            Assert.False(toolSvc.ImportCalled);
+            File.Delete(tmp);
+        }
+    }
+
+    class StubFileDialogService : IFileDialogService
+    {
+        public string FileToReturn { get; set; } = string.Empty;
+        public string OpenFile(string filter) => FileToReturn;
+        public string SaveFile(string filter) => FileToReturn;
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public Dictionary<string, string>? MapToReturn { get; set; }
+        public bool ShowImportMappingCalled { get; private set; }
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => false;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties)
+        {
+            ShowImportMappingCalled = true;
+            return MapToReturn;
+        }
+        public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
+    }
+
+    class CapturingToolService : IToolService
+    {
+        public bool ImportCalled { get; private set; }
+        public IDictionary<string,string>? MapUsed { get; private set; }
+        public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map)
+        {
+            ImportCalled = true;
+            MapUsed = map;
+            return new();
+        }
+        public void ExportToolsToCsv(string filePath) { }
+        public List<ToolModel> GetAllTools() => new();
+        public void AddTool(ToolModel tool) => throw new NotImplementedException();
+        public void UpdateTool(ToolModel tool) => throw new NotImplementedException();
+        public void DeleteTool(int toolID) => throw new NotImplementedException();
+        public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
+        public List<ToolModel> SearchTools(string? searchText) => new();
+        public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+        public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
+        public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
+        public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => new();
+        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null) => throw new NotImplementedException();
+    }
+
+    class CapturingCustomerService : ICustomerService
+    {
+        public bool ImportCalled { get; private set; }
+        public IDictionary<string,string>? MapUsed { get; private set; }
+        public CustomerImportResult ImportCustomersFromCsv(string filePath, IDictionary<string, string> map)
+        {
+            ImportCalled = true;
+            MapUsed = map;
+            return new CustomerImportResult();
+        }
+        public void ExportCustomersToCsv(string filePath) { }
+        public System.Threading.Tasks.Task ExportCustomersToCsvAsync(string filePath) => System.Threading.Tasks.Task.CompletedTask;
+        public void AddCustomer(Customer customer) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task AddCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public void UpdateCustomer(Customer customer) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task UpdateCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public void DeleteCustomer(int customerID) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task DeleteCustomerAsync(int customerID) => throw new NotImplementedException();
+        public Customer GetCustomerByID(int customerID) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task<Customer> GetCustomerByIDAsync(int customerID) => throw new NotImplementedException();
+        public List<Customer> GetAllCustomers() => new();
+        public System.Threading.Tasks.Task<List<Customer>> GetAllCustomersAsync() => System.Threading.Tasks.Task.FromResult(new List<Customer>());
+        public List<Customer> SearchCustomers(string searchTerm) => new();
+        public System.Threading.Tasks.Task<List<Customer>> SearchCustomersAsync(string searchTerm) => System.Threading.Tasks.Task.FromResult(new List<Customer>());
+        public System.Threading.Tasks.Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map)
+        {
+            ImportCalled = true;
+            MapUsed = map;
+            return System.Threading.Tasks.Task.FromResult(new CustomerImportResult());
+        }
+    }
+
+    class StubToolService : IToolService
+    {
+        public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => new();
+        public void ExportToolsToCsv(string filePath) { }
+        public List<ToolModel> GetAllTools() => new();
+        public void AddTool(ToolModel tool) => throw new NotImplementedException();
+        public void UpdateTool(ToolModel tool) => throw new NotImplementedException();
+        public void DeleteTool(int toolID) => throw new NotImplementedException();
+        public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
+        public List<ToolModel> SearchTools(string? searchText) => new();
+        public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+        public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
+        public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
+        public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => new();
+        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null) => throw new NotImplementedException();
+    }
+
+    class StubCustomerService : ICustomerService
+    {
+        public CustomerImportResult ImportCustomersFromCsv(string filePath, IDictionary<string, string> map) => new CustomerImportResult();
+        public void ExportCustomersToCsv(string filePath) { }
+        public System.Threading.Tasks.Task ExportCustomersToCsvAsync(string filePath) => System.Threading.Tasks.Task.CompletedTask;
+        public void AddCustomer(Customer customer) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task AddCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public void UpdateCustomer(Customer customer) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task UpdateCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public void DeleteCustomer(int customerID) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task DeleteCustomerAsync(int customerID) => throw new NotImplementedException();
+        public Customer GetCustomerByID(int customerID) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task<Customer> GetCustomerByIDAsync(int customerID) => throw new NotImplementedException();
+        public List<Customer> GetAllCustomers() => new();
+        public System.Threading.Tasks.Task<List<Customer>> GetAllCustomersAsync() => System.Threading.Tasks.Task.FromResult(new List<Customer>());
+        public List<Customer> SearchCustomers(string searchTerm) => new();
+        public System.Threading.Tasks.Task<List<Customer>> SearchCustomersAsync(string searchTerm) => System.Threading.Tasks.Task.FromResult(new List<Customer>());
+        public System.Threading.Tasks.Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map) => System.Threading.Tasks.Task.FromResult(new CustomerImportResult());
+    }
+
+    class StubDatabaseBackupService : IDatabaseBackupService
+    {
+        public System.Threading.Tasks.Task BackupDatabaseAsync(string backupFilePath) => System.Threading.Tasks.Task.CompletedTask;
+    }
+}

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data.SQLite;
 using System.IO;
@@ -43,11 +44,17 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var toolService = new StubToolService();
             var customerService = new StubCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService());
+            var fileDlg = new StubFileDialogService();
+            var tmp = Path.GetTempFileName();
+            File.WriteAllText(tmp, "ToolNumber\n");
+            fileDlg.FileToReturn = tmp;
+            var dialog = new StubDialogService();
+            var vm = new ImportExportViewModel(toolService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
             vm.ImportToolsCommand.Execute(null);
             Assert.True(toolService.ImportCalled);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Successfully imported tools", vm.ImportExportLogs[0]);
+            File.Delete(tmp);
         }
 
         [Fact]
@@ -55,7 +62,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var toolService = new StubToolService();
             var customerService = new StubCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService());
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
             vm.ExportToolsCommand.Execute(null);
             Assert.True(toolService.ExportCalled);
             Assert.Single(vm.ImportExportLogs);
@@ -67,11 +74,17 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var toolService = new StubToolService();
             var customerService = new StubCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService());
+            var fileDlg = new StubFileDialogService();
+            var tmp = Path.GetTempFileName();
+            File.WriteAllText(tmp, "Company\n");
+            fileDlg.FileToReturn = tmp;
+            var dialog = new StubDialogService();
+            var vm = new ImportExportViewModel(toolService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
             vm.ImportCustomersCommand.Execute(null);
             Assert.True(customerService.ImportCalled);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Successfully imported customers", vm.ImportExportLogs[0]);
+            File.Delete(tmp);
         }
 
         [Fact]
@@ -79,7 +92,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var toolService = new StubToolService();
             var customerService = new StubCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService());
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
             vm.ExportCustomersCommand.Execute(null);
             Assert.True(customerService.ExportCalled);
             Assert.Single(vm.ImportExportLogs);
@@ -89,7 +102,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task ImportExportViewModel_BackupDatabaseCommand_LogsSuccess()
         {
-            var vm = new ImportExportViewModel(new StubToolService(), new StubCustomerService(), new StubFileDialogService(), new StubDatabaseBackupService());
+            var vm = new ImportExportViewModel(new StubToolService(), new StubCustomerService(), new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
             await vm.BackupDatabaseCommand.ExecuteAsync(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Successfully backed up database", vm.ImportExportLogs[0]);
@@ -100,10 +113,16 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var toolService = new FailToolService();
             var customerService = new StubCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService());
+            var fileDlg = new StubFileDialogService();
+            var tmp = Path.GetTempFileName();
+            File.WriteAllText(tmp, "ToolNumber\n");
+            fileDlg.FileToReturn = tmp;
+            var dialog = new StubDialogService();
+            var vm = new ImportExportViewModel(toolService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
             vm.ImportToolsCommand.Execute(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Failed to import tools", vm.ImportExportLogs[0]);
+            File.Delete(tmp);
         }
 
         [Fact]
@@ -111,7 +130,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var toolService = new FailToolService();
             var customerService = new StubCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService());
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
             vm.ExportToolsCommand.Execute(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Failed to export tools", vm.ImportExportLogs[0]);
@@ -122,10 +141,16 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var toolService = new StubToolService();
             var customerService = new FailCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService());
+            var fileDlg = new StubFileDialogService();
+            var tmp = Path.GetTempFileName();
+            File.WriteAllText(tmp, "Company\n");
+            fileDlg.FileToReturn = tmp;
+            var dialog = new StubDialogService();
+            var vm = new ImportExportViewModel(toolService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
             vm.ImportCustomersCommand.Execute(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Failed to import customers", vm.ImportExportLogs[0]);
+            File.Delete(tmp);
         }
 
         [Fact]
@@ -133,7 +158,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var toolService = new StubToolService();
             var customerService = new FailCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService());
+            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
             vm.ExportCustomersCommand.Execute(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Failed to export customers", vm.ImportExportLogs[0]);
@@ -162,8 +187,32 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
     class StubFileDialogService : IFileDialogService
     {
-        public string OpenFile(string filter) => "path.csv";
-        public string SaveFile(string filter) => "path.csv";
+        public string FileToReturn { get; set; } = "path.csv";
+        public string OpenFile(string filter) => FileToReturn;
+        public string SaveFile(string filter) => FileToReturn;
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public Dictionary<string, string>? MapToReturn { get; set; } = new();
+        public bool ShowImportMappingCalled { get; private set; }
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => false;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties)
+        {
+            ShowImportMappingCalled = true;
+            return MapToReturn;
+        }
+        public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
     }
 
     class StubToolService : IToolService

--- a/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Windows.Controls;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Models.ImportExport;
+using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Views;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Views
+{
+    public class ImportExportPageTests
+    {
+        [Fact]
+        public void ButtonsExecuteCommandsAndUpdateLogs()
+        {
+            var tmp = Path.GetTempFileName();
+            File.WriteAllText(tmp, "ToolNumber\n");
+            Exception? threadException = null;
+
+            try
+            {
+                var thread = new Thread(() =>
+                {
+                    try
+                    {
+                        var toolSvc = new StubToolService();
+                        var customerSvc = new StubCustomerService();
+                        var fileDlg = new StubFileDialogService { FileToReturn = tmp };
+                        var dialog = new StubDialogService();
+                        var vm = new ImportExportViewModel(toolSvc, customerSvc, fileDlg, new StubDatabaseBackupService(), dialog);
+                        var page = new ImportExportPage { DataContext = vm };
+                        var grid = (Grid)page.Content;
+                        var panel = (WrapPanel)((Border)grid.Children[0]).Child;
+                        var importBtn = (Button)panel.Children[0];
+
+                        Assert.Equal(vm.ImportToolsCommand, importBtn.Command);
+                        importBtn.Command.Execute(null);
+                        Assert.True(toolSvc.ImportCalled);
+                        Assert.Single(vm.ImportExportLogs);
+                    }
+                    catch (Exception ex)
+                    {
+                        threadException = ex;
+                    }
+                });
+                thread.SetApartmentState(ApartmentState.STA);
+                thread.Start();
+                thread.Join();
+
+                if (threadException != null)
+                {
+                    throw threadException;
+                }
+            }
+            finally
+            {
+                if (File.Exists(tmp))
+                    File.Delete(tmp);
+            }
+        }
+    }
+
+    class StubFileDialogService : IFileDialogService
+    {
+        public string FileToReturn { get; set; } = string.Empty;
+        public string OpenFile(string filter) => FileToReturn;
+        public string SaveFile(string filter) => FileToReturn;
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public System.Collections.Generic.Dictionary<string, string>? MapToReturn { get; set; } = new();
+        public bool ShowImportMappingCalled { get; private set; }
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => false;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties)
+        {
+            ShowImportMappingCalled = true;
+            return MapToReturn;
+        }
+        public Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
+    }
+
+    class StubToolService : IToolService
+    {
+        public bool ImportCalled { get; private set; }
+        public System.Collections.Generic.List<int> ImportToolsFromCsv(string filePath, System.Collections.Generic.IDictionary<string, string> map)
+        {
+            ImportCalled = true;
+            return new();
+        }
+        public void ExportToolsToCsv(string filePath) { }
+        public System.Collections.Generic.List<ToolModel> GetAllTools() => new();
+        public void AddTool(ToolModel tool) => throw new NotImplementedException();
+        public void UpdateTool(ToolModel tool) => throw new NotImplementedException();
+        public void DeleteTool(int toolID) => throw new NotImplementedException();
+        public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
+        public System.Collections.Generic.List<ToolModel> SearchTools(string? searchText) => new();
+        public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+        public System.Collections.Generic.List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
+        public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
+        public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, System.Collections.Generic.IEnumerable<string>> keySelector) => new();
+        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null) => throw new NotImplementedException();
+    }
+
+    class StubCustomerService : ICustomerService
+    {
+        public CustomerImportResult ImportCustomersFromCsv(string filePath, System.Collections.Generic.IDictionary<string, string> map) => new CustomerImportResult();
+        public void ExportCustomersToCsv(string filePath) { }
+        public System.Threading.Tasks.Task ExportCustomersToCsvAsync(string filePath) => System.Threading.Tasks.Task.CompletedTask;
+        public void AddCustomer(Customer customer) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task AddCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public void UpdateCustomer(Customer customer) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task UpdateCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public void DeleteCustomer(int customerID) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task DeleteCustomerAsync(int customerID) => throw new NotImplementedException();
+        public Customer GetCustomerByID(int customerID) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task<Customer> GetCustomerByIDAsync(int customerID) => throw new NotImplementedException();
+        public System.Collections.Generic.List<Customer> GetAllCustomers() => new();
+        public System.Threading.Tasks.Task<System.Collections.Generic.List<Customer>> GetAllCustomersAsync() => System.Threading.Tasks.Task.FromResult(new System.Collections.Generic.List<Customer>());
+        public System.Collections.Generic.List<Customer> SearchCustomers(string searchTerm) => new();
+        public System.Threading.Tasks.Task<System.Collections.Generic.List<Customer>> SearchCustomersAsync(string searchTerm) => System.Threading.Tasks.Task.FromResult(new System.Collections.Generic.List<Customer>());
+        public System.Threading.Tasks.Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, System.Collections.Generic.IDictionary<string, string> map) => System.Threading.Tasks.Task.FromResult(new CustomerImportResult());
+    }
+
+    class StubDatabaseBackupService : IDatabaseBackupService
+    {
+        public System.Threading.Tasks.Task BackupDatabaseAsync(string backupFilePath) => System.Threading.Tasks.Task.CompletedTask;
+    }
+}

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -3,8 +3,11 @@ using CommunityToolkit.Mvvm.Input;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.ImportExport;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -16,6 +19,7 @@ namespace ToolManagementAppV2.ViewModels
         private readonly ICustomerService _customerService;
         private readonly IFileDialogService _fileDialogService;
         private readonly IDatabaseBackupService _databaseService;
+        private readonly IDialogService _dialogService;
         private readonly ILogger<ImportExportViewModel> _logger;
 
         public IRelayCommand ImportToolsCommand { get; }
@@ -38,12 +42,14 @@ namespace ToolManagementAppV2.ViewModels
                                      ICustomerService customerService,
                                      IFileDialogService fileDialogService,
                                      IDatabaseBackupService databaseService,
+                                     IDialogService dialogService,
                                      ILogger<ImportExportViewModel>? logger = null)
         {
             _toolService = toolService;
             _customerService = customerService;
             _fileDialogService = fileDialogService;
             _databaseService = databaseService;
+            _dialogService = dialogService;
             _logger = logger ?? NullLogger<ImportExportViewModel>.Instance;
             ImportToolsCommand = new RelayCommand(ImportTools);
             ExportToolsCommand = new RelayCommand(ExportTools);
@@ -58,7 +64,12 @@ namespace ToolManagementAppV2.ViewModels
             if (string.IsNullOrEmpty(path)) return;
             try
             {
-                _toolService.ImportToolsFromCsv(path, new Dictionary<string, string>());
+                var headers = File.ReadLines(path).First().Split(',').Select(h => h.Trim());
+                var properties = typeof(ToolImportDto).GetProperties().Select(p => p.Name);
+                var map = _dialogService.ShowImportMapping(headers, properties);
+                if (map == null)
+                    return;
+                _toolService.ImportToolsFromCsv(path, map);
                 ImportExportLogs.Add($"Successfully imported tools from {path}.");
             }
             catch (Exception ex)
@@ -90,7 +101,12 @@ namespace ToolManagementAppV2.ViewModels
             if (string.IsNullOrEmpty(path)) return;
             try
             {
-                var result = _customerService.ImportCustomersFromCsv(path, new Dictionary<string, string>());
+                var headers = File.ReadLines(path).First().Split(',').Select(h => h.Trim());
+                var properties = typeof(CustomerImportDto).GetProperties().Select(p => p.Name);
+                var map = _dialogService.ShowImportMapping(headers, properties);
+                if (map == null)
+                    return;
+                var result = _customerService.ImportCustomersFromCsv(path, map);
                 ImportExportLogs.Add($"Successfully imported customers from {path}. Imported {result.ImportedCount} customers.");
                 foreach (var msg in result.SkippedRows)
                     ImportExportLogs.Add($"Skipped {msg}");

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -136,7 +136,7 @@ namespace ToolManagementAppV2.ViewModels
             UserManagement = new UserManagementViewModel(userService, fileDialogService, _dialogService);
             CustomerManagement = new CustomerManagementViewModel(customerService, _dialogService);
             ManageRentals = new ManageRentalsViewModel(rentalService, _dialogService);
-            ImportExport = new ImportExportViewModel(toolService, customerService, fileDialogService, databaseService);
+            ImportExport = new ImportExportViewModel(toolService, customerService, fileDialogService, databaseService, _dialogService);
             Reports = new ReportsViewModel(new ReportService(toolService, rentalService, activityLogService, customerService, userService));
             ActivityLogs = new ActivityLogsViewModel(activityLogService);
 


### PR DESCRIPTION
## Summary
- prompt users for column mapping via `ShowImportMapping` before importing tools or customers
- wire up `ImportExportViewModel` with `IDialogService`
- add unit tests for mapping flow and UI tests for Import/Export page

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689db5757ac883248950ba19e3d47907