### PR TITLE
Support cancellation for database backup operations

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Models.ImportExport;
@@ -190,6 +191,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
     class StubDatabaseBackupService : IDatabaseBackupService
     {
-        public System.Threading.Tasks.Task BackupDatabaseAsync(string backupFilePath) => System.Threading.Tasks.Task.CompletedTask;
+        public System.Threading.Tasks.Task BackupDatabaseAsync(string backupFilePath, CancellationToken cancellationToken)
+            => System.Threading.Tasks.Task.CompletedTask;
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data.SQLite;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
@@ -106,6 +107,17 @@ namespace ToolManagementAppV2.Tests.ViewModels
             await vm.BackupDatabaseCommand.ExecuteAsync(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Successfully backed up database", vm.ImportExportLogs[0]);
+        }
+
+        [Fact]
+        public async Task ImportExportViewModel_BackupDatabaseCommand_CancelledOperation_LogsCancellation()
+        {
+            var vm = new ImportExportViewModel(new StubToolService(), new StubCustomerService(), new StubFileDialogService(), new CancellableDatabaseBackupService(), new StubDialogService());
+            var task = vm.BackupDatabaseCommand.ExecuteAsync(null);
+            vm.BackupDatabaseCommand.Cancel();
+            await task;
+            Assert.Single(vm.ImportExportLogs);
+            Assert.Equal("Database backup was cancelled.", vm.ImportExportLogs[0]);
         }
 
         [Fact]
@@ -324,11 +336,17 @@ namespace ToolManagementAppV2.Tests.ViewModels
     class StubDatabaseBackupService : IDatabaseBackupService
     {
         public bool Called { get; private set; }
-        public Task BackupDatabaseAsync(string backupFilePath)
+        public Task BackupDatabaseAsync(string backupFilePath, CancellationToken cancellationToken)
         {
             Called = true;
             return Task.CompletedTask;
         }
+    }
+
+    class CancellableDatabaseBackupService : IDatabaseBackupService
+    {
+        public Task BackupDatabaseAsync(string backupFilePath, CancellationToken cancellationToken)
+            => Task.Delay(Timeout.Infinite, cancellationToken);
     }
 
     class StubUserService : IUserService

--- a/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
@@ -137,6 +137,7 @@ namespace ToolManagementAppV2.Tests.Views
 
     class StubDatabaseBackupService : IDatabaseBackupService
     {
-        public System.Threading.Tasks.Task BackupDatabaseAsync(string backupFilePath) => System.Threading.Tasks.Task.CompletedTask;
+        public System.Threading.Tasks.Task BackupDatabaseAsync(string backupFilePath, CancellationToken cancellationToken)
+            => System.Threading.Tasks.Task.CompletedTask;
     }
 }

--- a/ToolManagementAppV2/Interfaces/IDatabaseBackupService.cs
+++ b/ToolManagementAppV2/Interfaces/IDatabaseBackupService.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ToolManagementAppV2.Interfaces
@@ -11,6 +12,7 @@ namespace ToolManagementAppV2.Interfaces
         /// Creates a backup of the current database asynchronously.
         /// </summary>
         /// <param name="backupFilePath">Destination path for the backup file.</param>
-        Task BackupDatabaseAsync(string backupFilePath);
+        /// <param name="cancellationToken">Token to observe for cancellation.</param>
+        Task BackupDatabaseAsync(string backupFilePath, CancellationToken cancellationToken);
     }
 }

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -1,6 +1,7 @@
 using System.Data.SQLite;
 using System.IO;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -270,7 +271,12 @@ namespace ToolManagementAppV2.Services.Core
         /// Asynchronously creates a backup of the current database.
         /// </summary>
         /// <param name="backupFilePath">Destination path for the backup file.</param>
-        public Task BackupDatabaseAsync(string backupFilePath)
-            => Task.Run(() => BackupDatabase(backupFilePath));
+        /// <param name="cancellationToken">Token to observe for cancellation.</param>
+        public Task BackupDatabaseAsync(string backupFilePath, CancellationToken cancellationToken)
+            => Task.Run(() =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                BackupDatabase(backupFilePath);
+            }, cancellationToken);
     }
 }

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.ImportExport;
@@ -142,14 +143,18 @@ namespace ToolManagementAppV2.ViewModels
         /// while the file copy completes in the background.
         /// </remarks>
         /// <returns>A <see cref="Task"/> representing the asynchronous backup operation.</returns>
-        async Task BackupDatabaseAsync()
+        async Task BackupDatabaseAsync(CancellationToken cancellationToken)
         {
             var path = _fileDialogService.SaveFile("SQLite Database|*.db");
             if (string.IsNullOrEmpty(path)) return;
             try
             {
-                await _databaseService.BackupDatabaseAsync(path);
+                await _databaseService.BackupDatabaseAsync(path, cancellationToken);
                 ImportExportLogs.Add($"Successfully backed up database to {path}.");
+            }
+            catch (OperationCanceledException)
+            {
+                ImportExportLogs.Add("Database backup was cancelled.");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- accept `CancellationToken` in `IDatabaseBackupService` and `DatabaseService`
- forward cancellation through `ImportExportViewModel` and log cancelled backups
- test cancellation flow in `ImportExportViewModel`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_689db716d7408324a11833f2dcb21f97