### PR TITLE
Implement user lockout tracking

### DIFF
--- a/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Data.SQLite;
@@ -92,6 +93,75 @@ public class UserAuthenticationTests
 
             var auth = userService.AuthenticateUser("emptysalt", "secret");
             Assert.Null(auth);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public void AuthenticateUser_LockoutAfterFailedAttempts()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+
+            var user = new User { UserName = "lock", Password = "secret", IsAdmin = false };
+            userService.AddUser(user);
+
+            for (int i = 0; i < 3; i++)
+            {
+                var auth = userService.AuthenticateUser("lock", "bad");
+                Assert.Null(auth);
+            }
+
+            var stored = userService.GetAllUsers().First();
+            Assert.Equal(3, stored.FailedAttempts);
+            Assert.NotNull(stored.LockoutUntil);
+
+            var afterLock = userService.AuthenticateUser("lock", "secret");
+            Assert.Null(afterLock);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public void AuthenticateUser_ResetAfterSuccess()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+
+            var user = new User { UserName = "reset", Password = "secret", IsAdmin = false };
+            userService.AddUser(user);
+
+            for (int i = 0; i < 3; i++)
+                userService.AuthenticateUser("reset", "bad");
+
+            using (var conn = dbService.CreateConnection())
+            using (var cmd = new SQLiteCommand("UPDATE Users SET LockoutUntil=@t WHERE UserID=@id", conn))
+            {
+                cmd.Parameters.AddWithValue("@t", DateTime.UtcNow.AddMinutes(-1));
+                cmd.Parameters.AddWithValue("@id", user.UserID);
+                cmd.ExecuteNonQuery();
+            }
+
+            var auth = userService.AuthenticateUser("reset", "secret");
+            Assert.NotNull(auth);
+
+            var stored = userService.GetAllUsers().First(u => u.UserName == "reset");
+            Assert.Equal(0, stored.FailedAttempts);
+            Assert.Null(stored.LockoutUntil);
         }
         finally
         {

--- a/ToolManagementAppV2/Models/Domain/User.cs
+++ b/ToolManagementAppV2/Models/Domain/User.cs
@@ -43,5 +43,11 @@ namespace ToolManagementAppV2.Models.Domain
 
         private DateTime _createdAt;
         public DateTime CreatedAt { get => _createdAt; set => SetProperty(ref _createdAt, value); }
+
+        private int _failedAttempts;
+        public int FailedAttempts { get => _failedAttempts; set => SetProperty(ref _failedAttempts, value); }
+
+        private DateTime? _lockoutUntil;
+        public DateTime? LockoutUntil { get => _lockoutUntil; set => SetProperty(ref _lockoutUntil, value); }
     }
 }

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -58,6 +58,8 @@ namespace ToolManagementAppV2.Services.Core
             EnsureColumn("Users", "Role", "TEXT");
             EnsureColumn("Users", "IsActive", "INTEGER", "1");
             EnsureColumn("Users", "CreatedAt", "DATETIME");
+            EnsureColumn("Users", "FailedAttempts", "INTEGER", "0");
+            EnsureColumn("Users", "LockoutUntil", "DATETIME");
         }
 
         public void Dispose()
@@ -125,7 +127,9 @@ namespace ToolManagementAppV2.Services.Core
                     Address TEXT,
                     Role TEXT,
                     IsActive INTEGER NOT NULL DEFAULT 1,
-                    CreatedAt DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+                    CreatedAt DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    FailedAttempts INTEGER NOT NULL DEFAULT 0,
+                    LockoutUntil DATETIME
                 );
                 CREATE TABLE IF NOT EXISTS Customers (
                     CustomerID INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -42,25 +42,72 @@ namespace ToolManagementAppV2.Services.Users
                 new[] { new SQLiteParameter("@UserName", userName) }, MapUser);
             var u = users.FirstOrDefault();
             if (u == null) return null;
+            if (u.LockoutUntil.HasValue && u.LockoutUntil > DateTime.UtcNow)
+                return null;
+            if (u.LockoutUntil.HasValue && u.LockoutUntil <= DateTime.UtcNow)
+            {
+                var reset = new[]
+                {
+                    new SQLiteParameter("@Attempts", 0),
+                    new SQLiteParameter("@Lockout", DBNull.Value),
+                    new SQLiteParameter("@ID", u.UserID)
+                };
+                SqliteHelper.ExecuteNonQuery(conn, "UPDATE Users SET FailedAttempts=@Attempts, LockoutUntil=@Lockout WHERE UserID=@ID", reset);
+                u.FailedAttempts = 0;
+                u.LockoutUntil = null;
+            }
 
+            bool success;
             if (string.IsNullOrWhiteSpace(u.Salt) && SecurityHelper.IsSha256Hash(u.Password))
             {
                 var legacy = SecurityHelper.ComputeSha256HashLegacy(password ?? string.Empty);
-                if (u.Password != legacy) return null;
-                var upgraded = SecurityHelper.HashPassword(password ?? string.Empty, out var salt);
-                var p = new[]
+                success = u.Password == legacy;
+                if (success)
                 {
-                    new SQLiteParameter("@Pwd", upgraded),
-                    new SQLiteParameter("@Salt", salt),
+                    var upgraded = SecurityHelper.HashPassword(password ?? string.Empty, out var salt);
+                    var p = new[]
+                    {
+                        new SQLiteParameter("@Pwd", upgraded),
+                        new SQLiteParameter("@Salt", salt),
+                        new SQLiteParameter("@ID", u.UserID)
+                    };
+                    SqliteHelper.ExecuteNonQuery(conn, "UPDATE Users SET Password=@Pwd, Salt=@Salt WHERE UserID=@ID", p);
+                    u.Password = upgraded;
+                    u.Salt = salt;
+                }
+            }
+            else
+            {
+                success = SecurityHelper.VerifyPassword(password ?? string.Empty, u.Salt, u.Password);
+            }
+
+            if (success)
+            {
+                var reset = new[]
+                {
+                    new SQLiteParameter("@Attempts", 0),
+                    new SQLiteParameter("@Lockout", DBNull.Value),
                     new SQLiteParameter("@ID", u.UserID)
                 };
-                SqliteHelper.ExecuteNonQuery(conn, "UPDATE Users SET Password=@Pwd, Salt=@Salt WHERE UserID=@ID", p);
-                u.Password = upgraded;
-                u.Salt = salt;
+                SqliteHelper.ExecuteNonQuery(conn, "UPDATE Users SET FailedAttempts=@Attempts, LockoutUntil=@Lockout WHERE UserID=@ID", reset);
+                u.FailedAttempts = 0;
+                u.LockoutUntil = null;
                 return u;
             }
 
-            return SecurityHelper.VerifyPassword(password ?? string.Empty, u.Salt, u.Password) ? u : null;
+            u.FailedAttempts++;
+            DateTime? lockout = null;
+            if (u.FailedAttempts >= 3)
+                lockout = DateTime.UtcNow.AddMinutes(15);
+            var update = new[]
+            {
+                new SQLiteParameter("@Attempts", u.FailedAttempts),
+                new SQLiteParameter("@Lockout", (object?)lockout ?? DBNull.Value),
+                new SQLiteParameter("@ID", u.UserID)
+            };
+            SqliteHelper.ExecuteNonQuery(conn, "UPDATE Users SET FailedAttempts=@Attempts, LockoutUntil=@Lockout WHERE UserID=@ID", update);
+            u.LockoutUntil = lockout;
+            return null;
         }
 
         public User? GetCurrentUser()
@@ -226,7 +273,9 @@ namespace ToolManagementAppV2.Services.Users
                 Address = rdr["Address"]?.ToString(),
                 Role = rdr["Role"]?.ToString(),
                 IsActive = rdr["IsActive"] != DBNull.Value && Convert.ToInt32(rdr["IsActive"]) == 1,
-                CreatedAt = rdr["CreatedAt"] == DBNull.Value ? DateTime.MinValue : Convert.ToDateTime(rdr["CreatedAt"])
+                CreatedAt = rdr["CreatedAt"] == DBNull.Value ? DateTime.MinValue : Convert.ToDateTime(rdr["CreatedAt"]),
+                FailedAttempts = rdr["FailedAttempts"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["FailedAttempts"]),
+                LockoutUntil = rdr["LockoutUntil"] == DBNull.Value ? null : Convert.ToDateTime(rdr["LockoutUntil"])
             };
         }
 
@@ -252,25 +301,72 @@ namespace ToolManagementAppV2.Services.Users
                 new[] { new SQLiteParameter("@UserName", userName) }, MapUser);
             var u = users.FirstOrDefault();
             if (u == null) return null;
+            if (u.LockoutUntil.HasValue && u.LockoutUntil > DateTime.UtcNow)
+                return null;
+            if (u.LockoutUntil.HasValue && u.LockoutUntil <= DateTime.UtcNow)
+            {
+                var reset = new[]
+                {
+                    new SQLiteParameter("@Attempts", 0),
+                    new SQLiteParameter("@Lockout", DBNull.Value),
+                    new SQLiteParameter("@ID", u.UserID)
+                };
+                await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET FailedAttempts=@Attempts, LockoutUntil=@Lockout WHERE UserID=@ID", reset);
+                u.FailedAttempts = 0;
+                u.LockoutUntil = null;
+            }
 
+            bool success;
             if (string.IsNullOrWhiteSpace(u.Salt) && SecurityHelper.IsSha256Hash(u.Password))
             {
                 var legacy = SecurityHelper.ComputeSha256HashLegacy(password ?? string.Empty);
-                if (u.Password != legacy) return null;
-                var upgraded = SecurityHelper.HashPassword(password ?? string.Empty, out var salt);
-                var p = new[]
+                success = u.Password == legacy;
+                if (success)
                 {
-                    new SQLiteParameter("@Pwd", upgraded),
-                    new SQLiteParameter("@Salt", salt),
+                    var upgraded = SecurityHelper.HashPassword(password ?? string.Empty, out var salt);
+                    var p = new[]
+                    {
+                        new SQLiteParameter("@Pwd", upgraded),
+                        new SQLiteParameter("@Salt", salt),
+                        new SQLiteParameter("@ID", u.UserID)
+                    };
+                    await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET Password=@Pwd, Salt=@Salt WHERE UserID=@ID", p);
+                    u.Password = upgraded;
+                    u.Salt = salt;
+                }
+            }
+            else
+            {
+                success = SecurityHelper.VerifyPassword(password ?? string.Empty, u.Salt, u.Password);
+            }
+
+            if (success)
+            {
+                var reset = new[]
+                {
+                    new SQLiteParameter("@Attempts", 0),
+                    new SQLiteParameter("@Lockout", DBNull.Value),
                     new SQLiteParameter("@ID", u.UserID)
                 };
-                await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET Password=@Pwd, Salt=@Salt WHERE UserID=@ID", p);
-                u.Password = upgraded;
-                u.Salt = salt;
+                await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET FailedAttempts=@Attempts, LockoutUntil=@Lockout WHERE UserID=@ID", reset);
+                u.FailedAttempts = 0;
+                u.LockoutUntil = null;
                 return u;
             }
 
-            return SecurityHelper.VerifyPassword(password ?? string.Empty, u.Salt, u.Password) ? u : null;
+            u.FailedAttempts++;
+            DateTime? lockout = null;
+            if (u.FailedAttempts >= 3)
+                lockout = DateTime.UtcNow.AddMinutes(15);
+            var update = new[]
+            {
+                new SQLiteParameter("@Attempts", u.FailedAttempts),
+                new SQLiteParameter("@Lockout", (object?)lockout ?? DBNull.Value),
+                new SQLiteParameter("@ID", u.UserID)
+            };
+            await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET FailedAttempts=@Attempts, LockoutUntil=@Lockout WHERE UserID=@ID", update);
+            u.LockoutUntil = lockout;
+            return null;
         }
 
         public async Task<User?> GetCurrentUserAsync()


### PR DESCRIPTION
## Summary
- extend Users table with FailedAttempts and LockoutUntil columns
- add lockout and reset logic to UserService authentication
- cover lockout and reset scenarios in unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dbaf60b388324ae115044069d94d5