### PR TITLE
Generate password on reset and show in dialog

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -11,6 +11,7 @@ using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.ViewModels.Rental;
 using ToolManagementAppV2.Views;
+using ToolManagementAppV2.Utilities.Helpers;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.ViewModels
@@ -159,7 +160,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
-                var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
+                var dialog = new StubDialogService();
+                var vm = new UserManagementViewModel(userService, new StubFileDialogService(), dialog);
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
                 vm.LoadUsers();
                 var user = vm.Users.First();
@@ -167,6 +169,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 vm.ResetPasswordFromRowCommand.Execute(user);
                 var updated = userService.GetAllUsers().First();
                 Assert.NotEqual(oldPwd, updated.Password);
+                Assert.Equal("Password Reset", dialog.LastInfoTitle);
+                Assert.StartsWith("Password reset to: ", dialog.LastInfoMessage);
+                var prefix = "Password reset to: ";
+                var newPwd = dialog.LastInfoMessage.Substring(prefix.Length);
+                Assert.True(SecurityHelper.VerifyPassword(newPwd, updated.Salt, updated.Password));
             }
             finally
             {
@@ -313,7 +320,13 @@ class StubFileDialogService : IFileDialogService
 
 class StubDialogService : IDialogService
 {
-    public void ShowInfo(string message, string title) { }
+    public string? LastInfoMessage { get; private set; }
+    public string? LastInfoTitle { get; private set; }
+    public void ShowInfo(string message, string title)
+    {
+        LastInfoMessage = message;
+        LastInfoTitle = title;
+    }
     public bool ShowConfirmation(string message, string title) => false;
     public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
     public void ShowToolDetails(ToolModel tool) { }

--- a/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
@@ -6,6 +6,7 @@ namespace ToolManagementAppV2.Utilities.Helpers
     public static class SecurityHelper
     {
         const int Iterations = 100_000;
+        const string PasswordChars = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz0123456789!@#$%^&*";
 
         public static bool IsSha256Hash(string input)
         {
@@ -42,6 +43,18 @@ namespace ToolManagementAppV2.Utilities.Helpers
 
             var computed = HashPassword(password, salt);
             return computed == hash;
+        }
+
+        public static string GeneratePassword(int length = 12)
+        {
+            var bytes = new byte[length];
+            RandomNumberGenerator.Fill(bytes);
+            var chars = new char[length];
+            for (int i = 0; i < length; i++)
+            {
+                chars[i] = PasswordChars[bytes[i] % PasswordChars.Length];
+            }
+            return new string(chars);
         }
 
         // Legacy support for migrating existing SHA256 hashes

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -229,7 +229,9 @@ namespace ToolManagementAppV2.ViewModels
         void ResetPasswordFor(UserModel user)
         {
             if (user == null) return;
-            _userService.ChangeUserPassword(user.UserID, "admin");
+            var newPassword = SecurityHelper.GeneratePassword();
+            _userService.ChangeUserPassword(user.UserID, newPassword);
+            _dialogService.ShowInfo($"Password reset to: {newPassword}", "Password Reset");
             var refreshed = _userService.GetUserByID(user.UserID);
             if (refreshed != null)
             {


### PR DESCRIPTION
## Summary
- add `SecurityHelper.GeneratePassword` helper
- reset user passwords using generated value and display it via `IDialogService`
- verify password reset dialog in unit tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689dbc7854fc8324b27c51ceeafd4614