### PR TITLE
Add password expiration workflow

### DIFF
--- a/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
@@ -169,4 +169,31 @@ public class UserAuthenticationTests
                 File.Delete(dbPath);
         }
     }
+
+    [Fact]
+    public void ChangeUserPassword_SetsPasswordExpiredFlag()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+
+            var user = new User { UserName = "flag", Password = "secret", IsAdmin = false };
+            userService.AddUser(user);
+
+            userService.ChangeUserPassword(user.UserID, "admin");
+            var updated = userService.GetAllUsers().First();
+            Assert.True(updated.PasswordExpired);
+
+            userService.ChangeUserPassword(user.UserID, "newpass");
+            updated = userService.GetAllUsers().First();
+            Assert.False(updated.PasswordExpired);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
 }

--- a/ToolManagementAppV2.Tests/Tests/ChangePasswordWindowLayoutTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ChangePasswordWindowLayoutTests.cs
@@ -1,0 +1,18 @@
+using System.Windows.Controls;
+using ToolManagementAppV2.Views;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Tests
+{
+    public class ChangePasswordWindowLayoutTests
+    {
+        [Fact]
+        public void ChangePasswordWindow_HasPasswordBoxes()
+        {
+            var win = new ChangePasswordWindow();
+            Assert.IsType<PasswordBox>(win.FindName("NewPasswordBox"));
+            Assert.IsType<PasswordBox>(win.FindName("ConfirmPasswordBox"));
+            win.Close();
+        }
+    }
+}

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -9,6 +9,7 @@ using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Utilities.Helpers;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.ViewModels
@@ -39,6 +40,41 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 Assert.True(success);
                 Assert.NotNull(userContext.CurrentUser);
                 Assert.Equal("user", userContext.UserName);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void SelectUserCommand_PromptsForPasswordChange_WhenExpired()
+        {
+            if (Application.Current == null)
+                new Application();
+
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            try
+            {
+                using var dbService = new DatabaseService(dbPath);
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(dbService, userContext);
+                var settingsService = new SettingsService(dbService);
+                userService.AddUser(new User { UserName = "user", Password = "newpassword", IsAdmin = false, PasswordExpired = true });
+
+                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
+                {
+                    PromptForNewPassword = () => "changed"
+                };
+                bool success = false;
+                vm.LoginSucceeded += (_, __) => success = true;
+
+                vm.SelectUserCommand.Execute(vm.Users.First());
+
+                Assert.True(success);
+                var updated = userService.GetAllUsers().First();
+                Assert.False(updated.PasswordExpired);
+                Assert.True(SecurityHelper.VerifyPassword("changed", updated.Salt, updated.Password));
             }
             finally
             {

--- a/ToolManagementAppV2/Models/Domain/User.cs
+++ b/ToolManagementAppV2/Models/Domain/User.cs
@@ -49,5 +49,8 @@ namespace ToolManagementAppV2.Models.Domain
 
         private DateTime? _lockoutUntil;
         public DateTime? LockoutUntil { get => _lockoutUntil; set => SetProperty(ref _lockoutUntil, value); }
+
+        private bool _passwordExpired;
+        public bool PasswordExpired { get => _passwordExpired; set => SetProperty(ref _passwordExpired, value); }
     }
 }

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -60,6 +60,7 @@ namespace ToolManagementAppV2.Services.Core
             EnsureColumn("Users", "CreatedAt", "DATETIME");
             EnsureColumn("Users", "FailedAttempts", "INTEGER", "0");
             EnsureColumn("Users", "LockoutUntil", "DATETIME");
+            EnsureColumn("Users", "PasswordExpired", "INTEGER", "0");
         }
 
         public void Dispose()
@@ -129,7 +130,8 @@ namespace ToolManagementAppV2.Services.Core
                     IsActive INTEGER NOT NULL DEFAULT 1,
                     CreatedAt DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                     FailedAttempts INTEGER NOT NULL DEFAULT 0,
-                    LockoutUntil DATETIME
+                    LockoutUntil DATETIME,
+                    PasswordExpired INTEGER NOT NULL DEFAULT 0
                 );
                 CREATE TABLE IF NOT EXISTS Customers (
                     CustomerID INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -121,9 +121,9 @@ namespace ToolManagementAppV2.Services.Users
         {
             const string sql = @"
                 INSERT INTO Users
-                  (UserName, Password, Salt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt)
+                  (UserName, Password, Salt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, PasswordExpired)
                 VALUES
-                  (@UserName,@Password,@Salt,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role,@IsActive,@CreatedAt);
+                  (@UserName,@Password,@Salt,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role,@IsActive,@CreatedAt,@PasswordExpired);
                 SELECT last_insert_rowid();";
 
             using var conn = _dbService.CreateConnection();
@@ -159,7 +159,8 @@ namespace ToolManagementAppV2.Services.Users
                 new SQLiteParameter("@Address",  (object)user.Address ?? DBNull.Value),
                 new SQLiteParameter("@Role",     (object)user.Role ?? DBNull.Value),
                 new SQLiteParameter("@IsActive", user.IsActive ? 1 : 0),
-                new SQLiteParameter("@CreatedAt", user.CreatedAt)
+                new SQLiteParameter("@CreatedAt", user.CreatedAt),
+                new SQLiteParameter("@PasswordExpired", user.PasswordExpired ? 1 : 0)
             });
             user.UserID = Convert.ToInt32(cmd.ExecuteScalar());
             user.Password = hashed;
@@ -180,7 +181,8 @@ namespace ToolManagementAppV2.Services.Users
                   Mobile        = @Mobile,
                   Address       = @Address,
                   Role          = @Role,
-                  IsActive      = @IsActive
+                  IsActive      = @IsActive,
+                  PasswordExpired = @PasswordExpired
                 WHERE UserID = @UserID";
 
             string hashed = user.Password;
@@ -203,7 +205,8 @@ namespace ToolManagementAppV2.Services.Users
                 new SQLiteParameter("@Mobile",   (object)user.Mobile ?? DBNull.Value),
                 new SQLiteParameter("@Address",  (object)user.Address ?? DBNull.Value),
                 new SQLiteParameter("@Role",     (object)user.Role ?? DBNull.Value),
-                new SQLiteParameter("@IsActive", user.IsActive ? 1 : 0)
+                new SQLiteParameter("@IsActive", user.IsActive ? 1 : 0),
+                new SQLiteParameter("@PasswordExpired", user.PasswordExpired ? 1 : 0)
             };
 
             using var conn = _dbService.CreateConnection();
@@ -214,7 +217,7 @@ namespace ToolManagementAppV2.Services.Users
 
         public void ChangeUserPassword(int userID, string newPassword)
         {
-            var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt WHERE UserID=@ID";
+            var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt, PasswordExpired=@Expired WHERE UserID=@ID";
             string hashed = string.Empty;
             string salt = string.Empty;
             if (!string.IsNullOrWhiteSpace(newPassword))
@@ -222,10 +225,13 @@ namespace ToolManagementAppV2.Services.Users
                 hashed = SecurityHelper.HashPassword(newPassword, out salt);
             }
 
+            var expired = newPassword == "admin" || newPassword == "changeme" || newPassword == "newpassword";
+
             var p = new[]
             {
                 new SQLiteParameter("@Pwd", hashed),
                 new SQLiteParameter("@Salt", salt),
+                new SQLiteParameter("@Expired", expired ? 1 : 0),
                 new SQLiteParameter("@ID",  userID)
             };
             using var conn = _dbService.CreateConnection();
@@ -275,7 +281,8 @@ namespace ToolManagementAppV2.Services.Users
                 IsActive = rdr["IsActive"] != DBNull.Value && Convert.ToInt32(rdr["IsActive"]) == 1,
                 CreatedAt = rdr["CreatedAt"] == DBNull.Value ? DateTime.MinValue : Convert.ToDateTime(rdr["CreatedAt"]),
                 FailedAttempts = rdr["FailedAttempts"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["FailedAttempts"]),
-                LockoutUntil = rdr["LockoutUntil"] == DBNull.Value ? null : Convert.ToDateTime(rdr["LockoutUntil"])
+                LockoutUntil = rdr["LockoutUntil"] == DBNull.Value ? null : Convert.ToDateTime(rdr["LockoutUntil"]),
+                PasswordExpired = rdr["PasswordExpired"] != DBNull.Value && Convert.ToInt32(rdr["PasswordExpired"]) == 1
             };
         }
 
@@ -473,7 +480,7 @@ namespace ToolManagementAppV2.Services.Users
 
         public async Task ChangeUserPasswordAsync(int userID, string newPassword)
         {
-            var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt WHERE UserID=@ID";
+            var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt, PasswordExpired=@Expired WHERE UserID=@ID";
             string hashed = string.Empty;
             string salt = string.Empty;
             if (!string.IsNullOrWhiteSpace(newPassword))
@@ -481,10 +488,13 @@ namespace ToolManagementAppV2.Services.Users
                 hashed = SecurityHelper.HashPassword(newPassword, out salt);
             }
 
+            var expired = newPassword == "admin" || newPassword == "changeme" || newPassword == "newpassword";
+
             var p = new[]
             {
                 new SQLiteParameter("@Pwd", hashed),
                 new SQLiteParameter("@Salt", salt),
+                new SQLiteParameter("@Expired", expired ? 1 : 0),
                 new SQLiteParameter("@ID",  userID)
             };
             using var conn = _dbService.CreateConnection();

--- a/ToolManagementAppV2/ViewModels/ChangePasswordViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ChangePasswordViewModel.cs
@@ -1,0 +1,25 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class ChangePasswordViewModel : ObservableObject
+    {
+        public string NewPassword { get; set; } = string.Empty;
+        public string ConfirmPassword { get; set; } = string.Empty;
+
+        public IRelayCommand SaveCommand { get; }
+        public IRelayCommand CancelCommand { get; }
+
+        public ChangePasswordViewModel(Action onSave, Action onCancel)
+        {
+            SaveCommand = new RelayCommand(() =>
+            {
+                if (!string.IsNullOrWhiteSpace(NewPassword) && NewPassword == ConfirmPassword)
+                    onSave();
+            });
+            CancelCommand = new RelayCommand(onCancel);
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -56,6 +56,12 @@ namespace ToolManagementAppV2.ViewModels
         /// </summary>
         public event EventHandler? LoginSucceeded;
 
+        public Func<string?> PromptForNewPassword { get; set; } = () =>
+        {
+            var dlg = new Views.ChangePasswordWindow();
+            return dlg.ShowDialog() == true ? dlg.NewPassword : null;
+        };
+
         public LoginViewModel(IUserService userService, ISettingsService settingsService, IDialogService dialogService, IUserContext userContext)
         {
             _settingsService = settingsService;
@@ -142,6 +148,7 @@ namespace ToolManagementAppV2.ViewModels
                 {
                     user.Password = refreshed.Password;
                     user.Salt = refreshed.Salt;
+                    user.PasswordExpired = refreshed.PasswordExpired;
                 }
             }
 
@@ -149,6 +156,8 @@ namespace ToolManagementAppV2.ViewModels
                 (string.IsNullOrWhiteSpace(user.Password) ||
                  SecurityHelper.VerifyPassword("newpassword", user.Salt, user.Password)))
             {
+                if (user.PasswordExpired && !PromptChangePassword(user))
+                    return;
                 _userContext.CurrentUser = user;
                 LoginSucceeded?.Invoke(this, EventArgs.Empty);
                 return;
@@ -173,6 +182,7 @@ namespace ToolManagementAppV2.ViewModels
                     {
                         user.Password = refreshed.Password;
                         user.Salt = refreshed.Salt;
+                        user.PasswordExpired = refreshed.PasswordExpired;
                     }
                     LoadUsers();
                     _dialogService.ShowInfo("Password has been reset to default. Please enter the new password to login.",
@@ -183,11 +193,29 @@ namespace ToolManagementAppV2.ViewModels
                 var credential = _userService.AuthenticateUser(user.UserName, prompt.EnteredPassword);
                 if (credential != null)
                 {
+                    if (credential.PasswordExpired && !PromptChangePassword(credential))
+                        return;
                     _userContext.CurrentUser = credential;
                     LoginSucceeded?.Invoke(this, EventArgs.Empty);
                     passwordValidated = true;
                 }
             }
+        }
+
+        bool PromptChangePassword(User user)
+        {
+            var newPwd = PromptForNewPassword?.Invoke();
+            if (string.IsNullOrWhiteSpace(newPwd))
+                return false;
+            _userService.ChangeUserPassword(user.UserID, newPwd);
+            var refreshed = _userService.GetUserByID(user.UserID);
+            if (refreshed != null)
+            {
+                user.Password = refreshed.Password;
+                user.Salt = refreshed.Salt;
+                user.PasswordExpired = refreshed.PasswordExpired;
+            }
+            return true;
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -126,6 +126,7 @@ namespace ToolManagementAppV2.ViewModels
                 const string defaultPwd = "changeme";
                 newUser.Password = SecurityHelper.HashPassword(defaultPwd, out var salt);
                 newUser.Salt = salt;
+                newUser.PasswordExpired = true;
             }
             else
             {

--- a/ToolManagementAppV2/Views/ChangePasswordWindow.xaml
+++ b/ToolManagementAppV2/Views/ChangePasswordWindow.xaml
@@ -1,0 +1,16 @@
+<!-- Views/ChangePasswordWindow.xaml -->
+<Window x:Class="ToolManagementAppV2.Views.ChangePasswordWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Change Password" SizeToContent="WidthAndHeight" WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="20">
+        <TextBlock Text="New Password"/>
+        <PasswordBox x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged"/>
+        <TextBlock Text="Confirm Password" Margin="0,10,0,0"/>
+        <PasswordBox x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" Command="{Binding SaveCommand}" IsDefault="True" Margin="0,0,5,0"/>
+            <Button Content="Cancel" Command="{Binding CancelCommand}" IsCancel="True"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/ToolManagementAppV2/Views/ChangePasswordWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ChangePasswordWindow.xaml.cs
@@ -1,0 +1,25 @@
+// Views/ChangePasswordWindow.xaml.cs
+using System.Windows;
+using System.Windows.Controls;
+using ToolManagementAppV2.ViewModels;
+
+namespace ToolManagementAppV2.Views
+{
+    public partial class ChangePasswordWindow : Window
+    {
+        public ChangePasswordViewModel VM => (ChangePasswordViewModel)DataContext;
+        public string NewPassword => VM.NewPassword;
+
+        public ChangePasswordWindow()
+        {
+            InitializeComponent();
+            DataContext = new ChangePasswordViewModel(() => DialogResult = true, () => DialogResult = false);
+        }
+
+        void NewPasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
+            => VM.NewPassword = ((PasswordBox)sender).Password;
+
+        void ConfirmPasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
+            => VM.ConfirmPassword = ((PasswordBox)sender).Password;
+    }
+}


### PR DESCRIPTION
## Summary
- track password expiration in Users table and default resets
- force expired accounts to change password on login
- add change password dialog with tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dbdb8add883249397f09a81d01543