### PR TITLE
Add configurable password hashing iterations

### DIFF
--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -208,5 +208,43 @@ namespace ToolManagementAppV2.Tests.Services
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void GetPasswordIterations_ReturnsDefault()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                ISettingsService service = new SettingsService(dbService);
+
+                var iterations = service.GetPasswordIterations();
+                Assert.Equal(100_000, iterations);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void SaveAndRetrievePasswordIterations()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                ISettingsService service = new SettingsService(dbService);
+
+                service.SavePasswordIterations(50_000);
+                Assert.Equal(50_000, service.GetPasswordIterations());
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
+++ b/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Utilities.Helpers;
+using ToolManagementAppV2.Interfaces;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Utilities
+{
+    public class SecurityHelperTests
+    {
+        [Fact]
+        public void HashPassword_UsesConfiguredIterations()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                ISettingsService settings = new SettingsService(dbService);
+                settings.SavePasswordIterations(5);
+                SecurityHelper.SettingsService = settings;
+
+                var saltBytes = Encoding.UTF8.GetBytes("1234567890ABCDEF");
+                var salt = Convert.ToBase64String(saltBytes);
+
+                using var pbkdf2 = new Rfc2898DeriveBytes("secret", saltBytes, 5, HashAlgorithmName.SHA256);
+                var expected = Convert.ToBase64String(pbkdf2.GetBytes(32));
+                var actual = SecurityHelper.HashPassword("secret", salt);
+                Assert.Equal(expected, actual);
+            }
+            finally
+            {
+                SecurityHelper.SettingsService = null;
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void HashPassword_DefaultIterationsWhenNotConfigured()
+        {
+            SecurityHelper.SettingsService = null;
+            var saltBytes = Encoding.UTF8.GetBytes("1234567890ABCDEF");
+            var salt = Convert.ToBase64String(saltBytes);
+
+            using var pbkdf2 = new Rfc2898DeriveBytes("secret", saltBytes, 100_000, HashAlgorithmName.SHA256);
+            var expected = Convert.ToBase64String(pbkdf2.GetBytes(32));
+            var actual = SecurityHelper.HashPassword("secret", salt);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -103,6 +103,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public IEnumerable<string> ScannerIps { get; set; } = Array.Empty<string>();
         public IEnumerable<string> GetScannerIpAddresses() => ScannerIps;
         public void SaveScannerIpAddresses(IEnumerable<string> ipAddresses) => ScannerIps = ipAddresses;
+        public int PasswordIterations { get; set; } = 100_000;
+        public int GetPasswordIterations() => PasswordIterations;
+        public void SavePasswordIterations(int iterations) => PasswordIterations = iterations;
     }
 
     class StubDialogService : IDialogService

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -16,6 +16,7 @@ using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Utilities.Helpers;
 
 namespace ToolManagementAppV2
 {
@@ -59,6 +60,7 @@ namespace ToolManagementAppV2
             var activityLogService = new ActivityLogService(db);
             var fileDialogService = new FileDialogService();
             var settingsService = new SettingsService(db);
+            SecurityHelper.SettingsService = settingsService;
             IDialogService dialogService = new DialogService();
 
             var mainVm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, fileDialogService, activityLogService, settingsService, db, dialogService);

--- a/ToolManagementAppV2/Interfaces/ISettingsService.cs
+++ b/ToolManagementAppV2/Interfaces/ISettingsService.cs
@@ -11,5 +11,7 @@ namespace ToolManagementAppV2.Interfaces
         void DeleteSetting(string key);
         IEnumerable<string> GetScannerIpAddresses();
         void SaveScannerIpAddresses(IEnumerable<string> ipAddresses);
+        int GetPasswordIterations();
+        void SavePasswordIterations(int iterations);
     }
 }

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -144,6 +144,7 @@ namespace ToolManagementAppV2.Services.Settings
         }
 
         const string ScannerIpKey = "ScannerIpAddresses";
+        const string PasswordIterationsKey = "PasswordIterations";
 
         public IEnumerable<string> GetScannerIpAddresses()
         {
@@ -157,6 +158,17 @@ namespace ToolManagementAppV2.Services.Settings
         {
             var value = string.Join(';', ipAddresses);
             SaveSetting(ScannerIpKey, value);
+        }
+
+        public int GetPasswordIterations()
+        {
+            var value = GetSetting(PasswordIterationsKey);
+            return int.TryParse(value, out var i) ? i : 100_000;
+        }
+
+        public void SavePasswordIterations(int iterations)
+        {
+            SaveSetting(PasswordIterationsKey, iterations.ToString());
         }
     }
 }

--- a/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
@@ -1,11 +1,24 @@
 using System.Security.Cryptography;
 using System.Text;
+using ToolManagementAppV2.Interfaces;
 
 namespace ToolManagementAppV2.Utilities.Helpers
 {
     public static class SecurityHelper
     {
-        const int Iterations = 100_000;
+        const int DefaultIterations = 100_000;
+        static int? _iterations;
+        static ISettingsService? _settingsService;
+
+        public static ISettingsService? SettingsService
+        {
+            get => _settingsService;
+            set
+            {
+                _settingsService = value;
+                _iterations = null;
+            }
+        }
         const string PasswordChars = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz0123456789!@#$%^&*";
 
         public static bool IsSha256Hash(string input)
@@ -32,7 +45,7 @@ namespace ToolManagementAppV2.Utilities.Helpers
         public static string HashPassword(string password, string salt)
         {
             var saltBytes = Convert.FromBase64String(salt);
-            using var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, Iterations, HashAlgorithmName.SHA256);
+            using var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, GetIterations(), HashAlgorithmName.SHA256);
             return Convert.ToBase64String(pbkdf2.GetBytes(32));
         }
 
@@ -68,6 +81,16 @@ namespace ToolManagementAppV2.Utilities.Helpers
                 builder.Append(b.ToString("x2"));
             }
             return builder.ToString();
+        }
+
+        static int GetIterations()
+        {
+            if (_iterations.HasValue)
+                return _iterations.Value;
+
+            var value = _settingsService?.GetPasswordIterations();
+            _iterations = value > 0 ? value : DefaultIterations;
+            return _iterations.Value;
         }
     }
 }


### PR DESCRIPTION
## Summary
- support `PasswordIterations` setting in `SettingsService` and expose through interface
- load password iteration count in `SecurityHelper` with default of 100,000 and initialize from `App`
- add unit tests for new setting and hashing behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dbf4d93108324801ee7669a35828b