### PR TITLE
Use COUNT query for tool update duplicate detection

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -194,6 +194,50 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
+        public void UpdateTool_DuplicateToolNumber_Throws()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var service = new ToolService(dbService);
+                service.AddTool(new Tool { ToolNumber = "T1" });
+                service.AddTool(new Tool { ToolNumber = "T2" });
+                var t2 = service.GetAllTools().First(t => t.ToolNumber == "T2");
+                t2.ToolNumber = "T1";
+                var ex = Assert.Throws<InvalidOperationException>(() => service.UpdateTool(t2));
+                Assert.Contains("T1", ex.Message);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateToolAsync_DuplicateToolNumber_Throws()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var service = new ToolService(dbService);
+                service.AddTool(new Tool { ToolNumber = "T1" });
+                service.AddTool(new Tool { ToolNumber = "T2" });
+                var t2 = service.GetAllTools().First(t => t.ToolNumber == "T2");
+                t2.ToolNumber = "T1";
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => service.UpdateToolAsync(t2));
+                Assert.Contains("T1", ex.Message);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public void ImportToolImages_UpdatesImagePathsAndReportsIssues()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -97,7 +97,14 @@ namespace ToolManagementAppV2.Services.Tools
     
         public void UpdateTool(ToolModel tool)
         {
-            var dup = GetAllTools().Any(t => t.ToolNumber == tool.ToolNumber && t.ToolID != tool.ToolID);
+            const string dupSql = "SELECT COUNT(*) FROM Tools WHERE ToolNumber = @TN AND ToolID <> @ID";
+            var dupParams = new[]
+            {
+                new SQLiteParameter("@TN", tool.ToolNumber),
+                new SQLiteParameter("@ID", tool.ToolID)
+            };
+            using var conn = _dbService.CreateConnection();
+            var dup = Convert.ToInt32(SqliteHelper.ExecuteScalar(conn, dupSql, dupParams)) > 0;
             if (dup)
                 throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
             const string sql = @"
@@ -139,7 +146,6 @@ namespace ToolManagementAppV2.Services.Tools
                 new SQLiteParameter("@Time", (object)tool.CheckedOutTime ?? DBNull.Value),
                 new SQLiteParameter("@Img", (object)tool.ToolImagePath ?? DBNull.Value)
             };
-            using var conn = _dbService.CreateConnection();
             SqliteHelper.ExecuteNonQuery(conn, sql, p);
         }
     
@@ -438,7 +444,14 @@ namespace ToolManagementAppV2.Services.Tools
 
         public async Task UpdateToolAsync(ToolModel tool)
         {
-            var dup = (await GetAllToolsAsync()).Any(t => t.ToolNumber == tool.ToolNumber && t.ToolID != tool.ToolID);
+            const string dupSql = "SELECT COUNT(*) FROM Tools WHERE ToolNumber = @TN AND ToolID <> @ID";
+            var dupParams = new[]
+            {
+                new SQLiteParameter("@TN", tool.ToolNumber),
+                new SQLiteParameter("@ID", tool.ToolID)
+            };
+            using var conn = _dbService.CreateConnection();
+            var dup = Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, dupSql, dupParams)) > 0;
             if (dup)
                 throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
             const string sql = @"
@@ -480,7 +493,6 @@ namespace ToolManagementAppV2.Services.Tools
                 new SQLiteParameter("@Time", (object)tool.CheckedOutTime ?? DBNull.Value),
                 new SQLiteParameter("@Img", (object)tool.ToolImagePath ?? DBNull.Value)
             };
-            using var conn = _dbService.CreateConnection();
             await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
         }
 


### PR DESCRIPTION
## Summary
- avoid loading all tools when updating by using a `SELECT COUNT(*)` query that excludes the current tool ID
- add unit tests ensuring both sync and async updates throw on duplicate tool numbers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc2fada108324bab36832dd9468bb