### PR TITLE
Implement async tool existence check and extend tests

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -122,6 +122,35 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
+        public async Task AddToolAsync_SetsGeneratedToolID()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                IToolService service = new ToolService(dbService);
+
+                var tool = new Tool
+                {
+                    ToolNumber = "ATID1",
+                    NameDescription = "Test",
+                    Location = "Loc",
+                    Brand = "Brand",
+                    PartNumber = "PN"
+                };
+
+                await service.AddToolAsync(tool);
+
+                Assert.True(tool.ToolID > 0);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public void AddTool_WithImagePath_PersistsPath()
         {
             var dbPath = Path.GetTempFileName();
@@ -229,6 +258,28 @@ namespace ToolManagementAppV2.Tests.Services
                 t2.ToolNumber = "T1";
                 var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => service.UpdateToolAsync(t2));
                 Assert.Contains("T1", ex.Message);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateToolAsync_SameToolNumber_DoesNotThrow()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var service = new ToolService(dbService);
+                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer" };
+                await service.AddToolAsync(tool);
+
+                tool.NameDescription = "Updated";
+                var ex = await Record.ExceptionAsync(() => service.UpdateToolAsync(tool));
+                Assert.Null(ex);
             }
             finally
             {

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -398,16 +398,25 @@ namespace ToolManagementAppV2.Services.Tools
             return count > 0;
         }
 
-        private async Task<bool> ToolExistsAsync(string toolNumber)
+        private async Task<bool> ToolExistsAsync(string toolNumber, int? exceptId = null)
         {
             if (string.IsNullOrWhiteSpace(toolNumber))
                 return false;
-            const string sql = "SELECT COUNT(*) FROM Tools WHERE ToolNumber = @TN";
-            using var conn = _dbService.CreateConnection();
-            var count = Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql, new[]
+
+            var sql = "SELECT COUNT(*) FROM Tools WHERE ToolNumber = @TN";
+            var parameters = new List<SQLiteParameter>
             {
-                new SQLiteParameter("@TN", toolNumber)
-            }));
+                new("@TN", toolNumber)
+            };
+
+            if (exceptId.HasValue)
+            {
+                sql += " AND ToolID <> @ID";
+                parameters.Add(new SQLiteParameter("@ID", exceptId.Value));
+            }
+
+            using var conn = _dbService.CreateConnection();
+            var count = Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql, parameters.ToArray()));
             return count > 0;
         }
     
@@ -444,16 +453,9 @@ namespace ToolManagementAppV2.Services.Tools
 
         public async Task UpdateToolAsync(ToolModel tool)
         {
-            const string dupSql = "SELECT COUNT(*) FROM Tools WHERE ToolNumber = @TN AND ToolID <> @ID";
-            var dupParams = new[]
-            {
-                new SQLiteParameter("@TN", tool.ToolNumber),
-                new SQLiteParameter("@ID", tool.ToolID)
-            };
-            using var conn = _dbService.CreateConnection();
-            var dup = Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, dupSql, dupParams)) > 0;
-            if (dup)
+            if (await ToolExistsAsync(tool.ToolNumber, tool.ToolID))
                 throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
+            using var conn = _dbService.CreateConnection();
             const string sql = @"
                 UPDATE Tools SET
                   ToolNumber = @ToolNumber,


### PR DESCRIPTION
## Summary
- Add async `ToolExistsAsync` supporting excluded ID to avoid duplicate tool numbers
- Update `UpdateToolAsync` to reuse async existence check
- Add asynchronous `AddToolAsync` and `UpdateToolAsync` tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689dc4976ad0832489ed64675db49ec4