### PR TITLE
Use UTC timestamps for services

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ScannerServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ScannerServiceTests.cs
@@ -22,11 +22,15 @@ namespace ToolManagementAppV2.Tests.Services
                 settings.SaveScannerIpAddresses(new[] { "127.0.0.1" });
 
                 var service = new ScannerService(settings);
+
+                var before = DateTime.UtcNow;
                 var devices = await service.GetScannerDevicesAsync();
+                var after = DateTime.UtcNow;
 
                 var list = devices.ToList();
                 Assert.Single(list);
                 Assert.Equal("127.0.0.1", list[0].Ip);
+                Assert.InRange(list[0].LastSeen, before, after);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -550,5 +550,38 @@ namespace ToolManagementAppV2.Tests.Services
                 if (File.Exists(dbPath)) File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void ToggleToolCheckOutStatus_SetsUtcTime()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var svc = new ToolService(dbService);
+                svc.AddTool(new Tool
+                {
+                    ToolNumber = "T1",
+                    NameDescription = "Test",
+                    QuantityOnHand = 1,
+                    RentedQuantity = 0
+                });
+
+                var tool = svc.GetAllTools().Single();
+
+                var before = DateTime.UtcNow;
+                svc.ToggleToolCheckOutStatus(tool.ToolID, "user");
+                var after = DateTime.UtcNow;
+
+                var updated = svc.GetToolByID(tool.ToolID);
+                Assert.True(updated.IsCheckedOut);
+                Assert.NotNull(updated.CheckedOutTime);
+                Assert.InRange(updated.CheckedOutTime!.Value, before, after);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/ToolManagementAppV2/Services/Devices/ScannerService.cs
+++ b/ToolManagementAppV2/Services/Devices/ScannerService.cs
@@ -29,7 +29,7 @@ namespace ToolManagementAppV2.Services.Devices
                 {
                     Name = $"Scanner {ip}",
                     Ip = ip,
-                    LastSeen = DateTime.Now
+                    LastSeen = DateTime.UtcNow
                 };
                 try
                 {

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -207,7 +207,7 @@ namespace ToolManagementAppV2.Services.Tools
                 return;
 
             var newStatus = record.Out ? 0 : 1;
-            var time = record.Out ? (object)DBNull.Value : DateTime.Now;
+            var time = record.Out ? (object)DBNull.Value : DateTime.UtcNow;
             var by = record.Out ? (object)DBNull.Value : currentUser;
             var qtyChange = record.Out ? 1 : -1;
 
@@ -572,7 +572,7 @@ namespace ToolManagementAppV2.Services.Tools
             {
                 new SQLiteParameter("@Out", newStatus ? 1 : 0),
                 new SQLiteParameter("@By", newStatus ? currentUser : (object)DBNull.Value),
-                new SQLiteParameter("@Time", newStatus ? DateTime.Now : (object)DBNull.Value),
+                new SQLiteParameter("@Time", newStatus ? DateTime.UtcNow : (object)DBNull.Value),
                 new SQLiteParameter("@ID", toolID)
             };
             await SqliteHelper.ExecuteNonQueryAsync(conn, sql, parameters);


### PR DESCRIPTION
## Summary
- record scanner last-seen times using `DateTime.UtcNow`
- use UTC timestamps when toggling tool checkout status and cover in tests
- verify scanner and tool services store UTC timestamps via updated tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_689dc67670048324a78a4dfa6c8af142