### PR TITLE
Enforce unique usernames and handle duplicates

### DIFF
--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.IO;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
@@ -50,6 +52,50 @@ public class UserServiceTests
             Assert.True(result);
             Assert.Null(userService.GetUserByID(admin1.UserID));
             Assert.NotNull(userService.GetUserByID(admin2.UserID));
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public void AddUser_ThrowsInvalidOperationException_WhenUserNameExists()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+
+            userService.AddUser(new User { UserName = "dup", Password = "pw" });
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                userService.AddUser(new User { UserName = "dup", Password = "pw" }));
+            Assert.Contains("username", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task AddUserAsync_ThrowsInvalidOperationException_WhenUserNameExists()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            var userService = new UserService(dbService, new ApplicationUserContext());
+
+            await userService.AddUserAsync(new User { UserName = "dup", Password = "pw" });
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                userService.AddUserAsync(new User { UserName = "dup", Password = "pw" }));
+            Assert.Contains("username", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -176,7 +176,8 @@ namespace ToolManagementAppV2.Services.Core
             EnsureIndex(conn, "Tools", "Location");
             EnsureIndex(conn, "Tools", "Notes");
             EnsureIndex(conn, "Tools", "Keywords");
-            EnsureIndex(conn, "Users", "UserName");
+            // Ensure each user has a unique username
+            EnsureIndex(conn, "Users", "UserName", true);
             EnsureIndex(conn, "Customers", "Contact");
             EnsureIndex(conn, "Rentals", new[] { "ToolID", "CustomerID" });
         }

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -162,7 +162,15 @@ namespace ToolManagementAppV2.Services.Users
                 new SQLiteParameter("@CreatedAt", user.CreatedAt),
                 new SQLiteParameter("@PasswordExpired", user.PasswordExpired ? 1 : 0)
             });
-            user.UserID = Convert.ToInt32(cmd.ExecuteScalar());
+            try
+            {
+                user.UserID = Convert.ToInt32(cmd.ExecuteScalar());
+            }
+            catch (SQLiteException ex) when (ex.ResultCode == SQLiteErrorCode.Constraint &&
+                                             ex.Message.Contains("Users.UserName", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("A user with the same username already exists.", ex);
+            }
             user.Password = hashed;
             user.Salt = salt;
         }
@@ -427,7 +435,15 @@ namespace ToolManagementAppV2.Services.Users
                 new SQLiteParameter("@IsActive", user.IsActive ? 1 : 0),
                 new SQLiteParameter("@CreatedAt", user.CreatedAt)
             });
-            user.UserID = Convert.ToInt32(await cmd.ExecuteScalarAsync());
+            try
+            {
+                user.UserID = Convert.ToInt32(await cmd.ExecuteScalarAsync());
+            }
+            catch (SQLiteException ex) when (ex.ResultCode == SQLiteErrorCode.Constraint &&
+                                             ex.Message.Contains("Users.UserName", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("A user with the same username already exists.", ex);
+            }
             user.Password = hashed;
             user.Salt = salt;
         }


### PR DESCRIPTION
## Summary
- enforce unique index on Users table usernames
- handle duplicate username conflicts with clear error messages
- add tests for duplicate username handling

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc6911f348324bd0ea78f7bbac5fe