### PR TITLE
Support cancellation in scanner services

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ScannerServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ScannerServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Devices;
@@ -24,13 +25,36 @@ namespace ToolManagementAppV2.Tests.Services
                 var service = new ScannerService(settings);
 
                 var before = DateTime.UtcNow;
-                var devices = await service.GetScannerDevicesAsync();
+                var devices = await service.GetScannerDevicesAsync(CancellationToken.None);
                 var after = DateTime.UtcNow;
 
                 var list = devices.ToList();
                 Assert.Single(list);
                 Assert.Equal("127.0.0.1", list[0].Ip);
                 Assert.InRange(list[0].LastSeen, before, after);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+        [Fact]
+        public async Task GetScannerDevicesAsync_HonorsCancellation()
+        {
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var settings = new SettingsService(db);
+                settings.SaveScannerIpAddresses(new[] { "127.0.0.1" });
+
+                var service = new ScannerService(settings);
+
+                using var cts = new CancellationTokenSource();
+                cts.Cancel();
+
+                await Assert.ThrowsAsync<OperationCanceledException>(
+                    () => service.GetScannerDevicesAsync(cts.Token));
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models;
@@ -16,7 +17,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public int CallCount { get; private set; }
 
-        public Task<IEnumerable<ScannerDevice>> GetScannerDevicesAsync()
+        public Task<IEnumerable<ScannerDevice>> GetScannerDevicesAsync(CancellationToken cancellationToken)
         {
             CallCount++;
             IEnumerable<ScannerDevice> result = new[]

--- a/ToolManagementAppV2/Interfaces/IScannerService.cs
+++ b/ToolManagementAppV2/Interfaces/IScannerService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Models;
 
@@ -6,6 +7,6 @@ namespace ToolManagementAppV2.Interfaces
 {
     public interface IScannerService
     {
-        Task<IEnumerable<ScannerDevice>> GetScannerDevicesAsync();
+        Task<IEnumerable<ScannerDevice>> GetScannerDevicesAsync(CancellationToken cancellationToken);
     }
 }

--- a/ToolManagementAppV2/Services/Devices/ScannerService.cs
+++ b/ToolManagementAppV2/Services/Devices/ScannerService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.NetworkInformation;
+using System.Threading;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models;
@@ -21,10 +22,14 @@ namespace ToolManagementAppV2.Services.Devices
             _logger = logger ?? NullLogger<ScannerService>.Instance;
         }
 
-        public async Task<IEnumerable<ScannerDevice>> GetScannerDevicesAsync()
+        public async Task<IEnumerable<ScannerDevice>> GetScannerDevicesAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var tasks = _settingsService.GetScannerIpAddresses().Select(async ip =>
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 var device = new ScannerDevice
                 {
                     Name = $"Scanner {ip}",

--- a/ToolManagementAppV2/ViewModels/ScannerStatusViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ScannerStatusViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Threading;
 using ToolManagementAppV2.Interfaces;
@@ -39,13 +40,13 @@ namespace ToolManagementAppV2.ViewModels
             _service = service;
             RefreshCommand = new AsyncRelayCommand(RefreshAsync);
             _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
-            _timer.Tick += async (s, e) => await RefreshAsync();
+            _timer.Tick += async (s, e) => await RefreshAsync(CancellationToken.None);
         }
 
-        async Task RefreshAsync()
+        async Task RefreshAsync(CancellationToken cancellationToken)
         {
             Devices.Clear();
-            var devices = await _service.GetScannerDevicesAsync();
+            var devices = await _service.GetScannerDevicesAsync(cancellationToken);
             foreach (var d in devices)
                 Devices.Add(d);
         }


### PR DESCRIPTION
## Summary
- allow `IScannerService` to accept a `CancellationToken`
- propagate cancellation through `ScannerService` and `ScannerStatusViewModel`
- add unit test ensuring scanner service honors cancellation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc8d3b79883248f8efca148ec4875