### PR TITLE
Handle rental errors and add tests for service failures

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
@@ -248,6 +248,62 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
             Assert.Contains("boom", dialog.LastInfoMessage);
         }
+
+        [Fact]
+        public async Task ExtendCommand_ShowsDialogOnFailure()
+        {
+            var rentals = new List<Rental>
+            {
+                new Rental
+                {
+                    RentalID = 1,
+                    ToolID = 1,
+                    ToolNumber = "T1",
+                    CustomerID = 1,
+                    CustomerName = "C1",
+                    RentalDate = DateTime.Today,
+                    DueDate = DateTime.Today.AddDays(1),
+                    Status = "Rented"
+                }
+            };
+            var rentalService = new ExceptionRentalService(rentals);
+            var dialog = new StubDialogService();
+            var vm = new ManageRentalsViewModel(rentalService, dialog);
+            await vm.LoadRentalsAsync();
+            vm.SelectedRental = vm.Rentals.First();
+
+            await vm.ExtendCommand.ExecuteAsync(null);
+
+            Assert.Contains("boom", dialog.LastInfoMessage);
+        }
+
+        [Fact]
+        public async Task DeleteRentalCommand_ShowsDialogOnFailure()
+        {
+            var rentals = new List<Rental>
+            {
+                new Rental
+                {
+                    RentalID = 1,
+                    ToolID = 1,
+                    ToolNumber = "T1",
+                    CustomerID = 1,
+                    CustomerName = "C1",
+                    RentalDate = DateTime.Today,
+                    DueDate = DateTime.Today.AddDays(1),
+                    Status = "Rented"
+                }
+            };
+            var rentalService = new ExceptionRentalService(rentals);
+            var dialog = new StubDialogService();
+            var vm = new ManageRentalsViewModel(rentalService, dialog);
+            await vm.LoadRentalsAsync();
+            vm.SelectedRental = vm.Rentals.First();
+
+            await vm.DeleteRentalCommand.ExecuteAsync(null);
+
+            Assert.Contains("boom", dialog.LastInfoMessage);
+        }
     }
 
     class StubDialogService : IDialogService
@@ -279,20 +335,20 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public ExceptionRentalService(List<Rental> rentals) => _rentals = rentals;
         public Task<List<Rental>> GetAllRentalsAsync() => Task.FromResult(_rentals);
         public Task ReturnToolAsync(int rentalID, DateTime returnDate) => throw new InvalidOperationException("boom");
+        public Task ExtendRentalAsync(int rentalID, DateTime newDueDate) => throw new InvalidOperationException("boom");
+        public Task DeleteRentalAsync(int rentalID) => throw new InvalidOperationException("boom");
+        public Task<List<Rental>> GetRentalHistoryForToolAsync(int toolID) => throw new InvalidOperationException("boom");
         public void RentTool(int toolID, int customerID, DateTime rentalDate, DateTime dueDate) => throw new NotImplementedException();
         public Task RentToolAsync(int toolID, int customerID, DateTime rentalDate, DateTime dueDate) => throw new NotImplementedException();
         public void ReturnTool(int rentalID, DateTime returnDate) => throw new NotImplementedException();
         public void ExtendRental(int rentalID, DateTime newDueDate) => throw new NotImplementedException();
-        public Task ExtendRentalAsync(int rentalID, DateTime newDueDate) => throw new NotImplementedException();
         public void DeleteRental(int rentalID) => throw new NotImplementedException();
-        public Task DeleteRentalAsync(int rentalID) => throw new NotImplementedException();
         public List<Rental> GetActiveRentals() => throw new NotImplementedException();
         public Task<List<Rental>> GetActiveRentalsAsync() => throw new NotImplementedException();
         public List<Rental> GetOverdueRentals() => throw new NotImplementedException();
         public Task<List<Rental>> GetOverdueRentalsAsync() => throw new NotImplementedException();
         public List<Rental> GetAllRentals() => throw new NotImplementedException();
         public List<Rental> GetRentalHistoryForTool(int toolID) => throw new NotImplementedException();
-        public Task<List<Rental>> GetRentalHistoryForToolAsync(int toolID) => throw new NotImplementedException();
         public List<Rental> GetRentalHistoryForCustomer(int customerID) => throw new NotImplementedException();
         public Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID) => throw new NotImplementedException();
     }

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -268,16 +268,24 @@ namespace ToolManagementAppV2.ViewModels
         {
             if (SelectedTool == null) return;
 
-            var customers = await _customerService.GetAllCustomersAsync();
-            var result = _dialogService.ShowRentToolDialog(SelectedTool, customers);
-            if (result != null)
+            try
             {
-                var (customer, dueDate) = result.Value;
-                await _rentalService.RentToolAsync(SelectedTool.ToolID,
-                    customer.CustomerID,
-                    DateTime.Today,
-                    dueDate);
-                await LoadToolsAsync();
+                var customers = await _customerService.GetAllCustomersAsync();
+                var result = _dialogService.ShowRentToolDialog(SelectedTool, customers);
+                if (result != null)
+                {
+                    var (customer, dueDate) = result.Value;
+                    await _rentalService.RentToolAsync(SelectedTool.ToolID,
+                        customer.CustomerID,
+                        DateTime.Today,
+                        dueDate);
+                    await LoadToolsAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to rent tool {ToolID}", SelectedTool?.ToolID);
+                _dialogService.ShowInfo($"Failed to rent tool: {ex.Message}", "Error");
             }
         }
 


### PR DESCRIPTION
## Summary
- Guard tool rental operation with try/catch, logging, and user notification
- Add ManageRentalsViewModel tests simulating service failures

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689dc8cf0c6c8324997fa4a7da629e0f