### PR TITLE
Use async CSV import with progress

### DIFF
--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -11,6 +11,7 @@ using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Interfaces;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.Services
@@ -369,6 +370,7 @@ namespace ToolManagementAppV2.Tests.Services
         class FailingToolService : IToolService
         {
             public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
+            public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
             public void ExportToolsToCsv(string filePath) => throw new NotImplementedException();
             public List<ToolModel> GetAllTools() => new();
             public void AddTool(ToolModel tool) => throw new NotImplementedException();

--- a/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
@@ -2,6 +2,9 @@ using System.Collections.Generic;
 using System.IO;
 using System;
 using ToolManagementAppV2.Utilities.IO;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Models.Domain;
 using Xunit;
 
 public class CsvImportTests
@@ -44,6 +47,39 @@ public class CsvImportTests
         };
 
         Assert.Throws<ArgumentException>(() => CsvHelperUtil.LoadToolsFromCsv(path, map, out _));
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task ImportToolsFromCsvAsync_SkipsInvalidRows()
+    {
+        var dbPath = Path.GetTempFileName();
+        var csvPath = Path.GetTempFileName();
+        try
+        {
+            var csv = string.Join('\n',
+                "ToolNumber,NameDescription",
+                ",Hammer",
+                "T1,Screwdriver");
+            File.WriteAllText(csvPath, csv);
+            var db = new DatabaseService(dbPath);
+            var service = new ToolService(db);
+            var map = new Dictionary<string, string>
+            {
+                {"ToolNumber", "ToolNumber"},
+                {"NameDescription", "NameDescription"}
+            };
+
+            var invalid = await service.ImportToolsFromCsvAsync(csvPath, map);
+
+            Assert.Single(invalid);
+            Assert.Contains(2, invalid);
+            Assert.Single(service.GetAllTools());
+        }
+        finally
+        {
+            if (File.Exists(csvPath)) File.Delete(csvPath);
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
     }
 }
 

--- a/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -13,7 +13,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     public class ImportExportViewModelTests
     {
         [Fact]
-        public void ImportToolsCommand_UsesMappingFromDialog()
+        public async System.Threading.Tasks.Task ImportToolsCommand_UsesMappingFromDialog()
         {
             var tmp = Path.GetTempFileName();
             File.WriteAllText(tmp, "ToolNumber\n");
@@ -22,7 +22,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var dialog = new StubDialogService { MapToReturn = new Dictionary<string,string>{{"ToolNumber","ToolNumber"}} };
             var vm = new ImportExportViewModel(toolSvc, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
 
-            vm.ImportToolsCommand.Execute(null);
+            await vm.ImportToolsCommand.ExecuteAsync(null);
 
             Assert.True(dialog.ShowImportMappingCalled);
             Assert.True(toolSvc.ImportCalled);
@@ -49,7 +49,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void ImportToolsCommand_CancelledMapping_DoesNotCallService()
+        public async System.Threading.Tasks.Task ImportToolsCommand_CancelledMapping_DoesNotCallService()
         {
             var tmp = Path.GetTempFileName();
             File.WriteAllText(tmp, "ToolNumber\n");
@@ -58,7 +58,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var dialog = new StubDialogService { MapToReturn = null };
             var vm = new ImportExportViewModel(toolSvc, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
 
-            vm.ImportToolsCommand.Execute(null);
+            await vm.ImportToolsCommand.ExecuteAsync(null);
 
             Assert.True(dialog.ShowImportMappingCalled);
             Assert.False(toolSvc.ImportCalled);
@@ -105,6 +105,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
             ImportCalled = true;
             MapUsed = map;
             return new();
+        }
+        public System.Threading.Tasks.Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map)
+        {
+            ImportCalled = true;
+            MapUsed = map;
+            return System.Threading.Tasks.Task.FromResult(new List<int>());
         }
         public void ExportToolsToCsv(string filePath) { }
         public List<ToolModel> GetAllTools() => new();
@@ -155,6 +161,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
     class StubToolService : IToolService
     {
         public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => new();
+        public System.Threading.Tasks.Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map)
+            => System.Threading.Tasks.Task.FromResult(new List<int>());
         public void ExportToolsToCsv(string filePath) { }
         public List<ToolModel> GetAllTools() => new();
         public void AddTool(ToolModel tool) => throw new NotImplementedException();

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -267,7 +267,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void OpenImportMappingWindowCommand_NoFile_Returns()
+        public async Task OpenImportMappingWindowCommand_NoFile_Returns()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -282,7 +282,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var settingsService = new SettingsService(db);
 
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
-                vm.OpenImportMappingWindowCommand.Execute(null);
+                await vm.OpenImportMappingWindowCommand.ExecuteAsync(null);
             }
             finally
             {
@@ -317,7 +317,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void OpenImportMappingWindowCommand_ShowsInfo_OnSuccess()
+        public async Task OpenImportMappingWindowCommand_ShowsInfo_OnSuccess()
         {
             var dbPath = Path.GetTempFileName();
             var csvPath = Path.GetTempFileName();
@@ -344,7 +344,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 };
 
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, fileDialog, activityLogService, settingsService, db, dialog);
-                vm.OpenImportMappingWindowCommand.Execute(null);
+                await vm.OpenImportMappingWindowCommand.ExecuteAsync(null);
 
                 Assert.True(dialog.InfoShown);
             }

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -41,7 +41,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void ImportExportViewModel_ImportToolsCommand_LogsSuccess()
+        public async Task ImportExportViewModel_ImportToolsCommand_LogsSuccess()
         {
             var toolService = new StubToolService();
             var customerService = new StubCustomerService();
@@ -51,7 +51,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             fileDlg.FileToReturn = tmp;
             var dialog = new StubDialogService();
             var vm = new ImportExportViewModel(toolService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
-            vm.ImportToolsCommand.Execute(null);
+            await vm.ImportToolsCommand.ExecuteAsync(null);
             Assert.True(toolService.ImportCalled);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Successfully imported tools", vm.ImportExportLogs[0]);
@@ -121,7 +121,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void ImportExportViewModel_ImportToolsCommand_LogsFailure()
+        public async Task ImportExportViewModel_ImportToolsCommand_LogsFailure()
         {
             var toolService = new FailToolService();
             var customerService = new StubCustomerService();
@@ -131,7 +131,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             fileDlg.FileToReturn = tmp;
             var dialog = new StubDialogService();
             var vm = new ImportExportViewModel(toolService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
-            vm.ImportToolsCommand.Execute(null);
+            await vm.ImportToolsCommand.ExecuteAsync(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Failed to import tools", vm.ImportExportLogs[0]);
             File.Delete(tmp);
@@ -236,6 +236,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
             ImportCalled = true;
             return new();
         }
+        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map)
+        {
+            ImportCalled = true;
+            return Task.FromResult(new List<int>());
+        }
         public void ExportToolsToCsv(string filePath) => ExportCalled = true;
         public List<ToolModel> GetAllTools() => new();
         public void AddTool(ToolModel tool) => throw new System.NotImplementedException();
@@ -253,6 +258,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     class FailToolService : IToolService
     {
         public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => throw new System.Exception("fail");
+        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map) => Task.FromException<List<int>>(new System.Exception("fail"));
         public void ExportToolsToCsv(string filePath) => throw new System.Exception("fail");
         public List<ToolModel> GetAllTools() => new();
         public void AddTool(ToolModel tool) => throw new System.NotImplementedException();

--- a/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
@@ -37,7 +37,9 @@ namespace ToolManagementAppV2.Tests.Views
                         var importBtn = (Button)panel.Children[0];
 
                         Assert.Equal(vm.ImportToolsCommand, importBtn.Command);
-                        importBtn.Command.Execute(null);
+                        var asyncCmd = (CommunityToolkit.Mvvm.Input.IAsyncRelayCommand)importBtn.Command;
+                        asyncCmd.Execute(null);
+                        asyncCmd.ExecutionTask!.Wait();
                         Assert.True(toolSvc.ImportCalled);
                         Assert.Single(vm.ImportExportLogs);
                     }
@@ -100,6 +102,11 @@ namespace ToolManagementAppV2.Tests.Views
         {
             ImportCalled = true;
             return new();
+        }
+        public System.Threading.Tasks.Task<System.Collections.Generic.List<int>> ImportToolsFromCsvAsync(string filePath, System.Collections.Generic.IDictionary<string, string> map)
+        {
+            ImportCalled = true;
+            return System.Threading.Tasks.Task.FromResult(new System.Collections.Generic.List<int>());
         }
         public void ExportToolsToCsv(string filePath) { }
         public System.Collections.Generic.List<ToolModel> GetAllTools() => new();

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -23,7 +23,7 @@ namespace ToolManagementAppV2.ViewModels
         private readonly IDialogService _dialogService;
         private readonly ILogger<ImportExportViewModel> _logger;
 
-        public IRelayCommand ImportToolsCommand { get; }
+        public IAsyncRelayCommand ImportToolsCommand { get; }
         public IRelayCommand ExportToolsCommand { get; }
         public IRelayCommand ImportCustomersCommand { get; }
         public IRelayCommand ExportCustomersCommand { get; }
@@ -52,14 +52,14 @@ namespace ToolManagementAppV2.ViewModels
             _databaseService = databaseService;
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<ImportExportViewModel>.Instance;
-            ImportToolsCommand = new RelayCommand(ImportTools);
+            ImportToolsCommand = new AsyncRelayCommand(ImportToolsAsync);
             ExportToolsCommand = new RelayCommand(ExportTools);
             ImportCustomersCommand = new RelayCommand(ImportCustomers);
             ExportCustomersCommand = new RelayCommand(ExportCustomers);
             BackupDatabaseCommand = new AsyncRelayCommand(BackupDatabaseAsync);
         }
 
-        void ImportTools()
+        async Task ImportToolsAsync()
         {
             var path = _fileDialogService.OpenFile("CSV Files|*.csv");
             if (string.IsNullOrEmpty(path)) return;
@@ -70,14 +70,18 @@ namespace ToolManagementAppV2.ViewModels
                 var map = _dialogService.ShowImportMapping(headers, properties);
                 if (map == null)
                     return;
-                _toolService.ImportToolsFromCsv(path, map);
+                _dialogService.ShowInfo("Importing tools...", "Import Tools");
+                await _toolService.ImportToolsFromCsvAsync(path, map);
                 ImportExportLogs.Add($"Successfully imported tools from {path}.");
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to import tools from {Path}", path);
                 ImportExportLogs.Add($"Failed to import tools from {path}: {ex.Message}");
+                _dialogService.ShowInfo($"Failed to import tools from {path}: {ex.Message}", "Import Tools");
+                return;
             }
+            _dialogService.ShowInfo($"Successfully imported tools from {path}.", "Import Tools");
         }
 
         void ExportTools()

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -30,6 +30,7 @@ namespace ToolManagementAppV2.ViewModels
         readonly IRentalService _rentalService;
         readonly ActivityLogService _activityLogService;
         readonly ISettingsService _settingsService;
+        readonly IFileDialogService _fileDialogService;
         readonly IDialogService _dialogService;
         readonly ILogger<MainViewModel> _logger;
         readonly Func<bool> _showLoginWindow;
@@ -90,7 +91,7 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand OpenImportExportCommand { get; }
         public IRelayCommand OpenActivityLogsCommand { get; }
         public IRelayCommand OpenReportsCommand { get; }
-        public IRelayCommand OpenImportMappingWindowCommand { get; }
+        public IAsyncRelayCommand OpenImportMappingWindowCommand { get; }
         public IRelayCommand OpenImageImportMappingWindowCommand { get; }
         public IRelayCommand ExitCommand { get; }
         public IRelayCommand GlobalSearchCommand { get; }
@@ -122,6 +123,7 @@ namespace ToolManagementAppV2.ViewModels
             _activityLogService = activityLogService;
             _settingsService = settingsService;
             _dialogService = dialogService;
+            _fileDialogService = fileDialogService;
             _logger = logger ?? NullLogger<MainViewModel>.Instance;
             _showLoginWindow = showLoginWindow ?? new Func<bool>(() =>
             {
@@ -217,39 +219,7 @@ namespace ToolManagementAppV2.ViewModels
                 CurrentPage = page;
             });
 
-            OpenImportMappingWindowCommand = new RelayCommand(() =>
-            {
-                try
-                {
-                    var path = fileDialogService.OpenFile("CSV Files|*.csv");
-                    if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
-                        return;
-
-                    var headers = File.ReadLines(path)
-                                       .First()
-                                       .Split(',')
-                                       .Select(h => h.Trim())
-                                       .ToList();
-                    var properties = typeof(ToolModel)
-                                        .GetProperties()
-                                        .Select(p => p.Name)
-                                        .ToList();
-                    var map = _dialogService.ShowImportMapping(headers, properties);
-                    if (map != null)
-                    {
-                        var invalid = _toolService.ImportToolsFromCsv(path, map);
-                        var msg = invalid.Count == 0
-                            ? "Successfully imported tools."
-                            : $"Imported with {invalid.Count} invalid rows.";
-                        _dialogService.ShowInfo(msg, "Import Tools");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Failed to import tools from CSV");
-                    _dialogService.ShowInfo($"Failed to import tools: {ex.Message}", "Import Tools");
-                }
-            });
+            OpenImportMappingWindowCommand = new AsyncRelayCommand(OpenImportMappingWindowAsync);
 
             OpenImageImportMappingWindowCommand = new RelayCommand(() =>
             {
@@ -325,6 +295,41 @@ namespace ToolManagementAppV2.ViewModels
             });
 
             OpenDashboardCommand.Execute(null);
+        }
+
+        async Task OpenImportMappingWindowAsync()
+        {
+            try
+            {
+                var path = _fileDialogService.OpenFile("CSV Files|*.csv");
+                if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+                    return;
+
+                var headers = File.ReadLines(path)
+                                   .First()
+                                   .Split(',')
+                                   .Select(h => h.Trim())
+                                   .ToList();
+                var properties = typeof(ToolModel)
+                                    .GetProperties()
+                                    .Select(p => p.Name)
+                                    .ToList();
+                var map = _dialogService.ShowImportMapping(headers, properties);
+                if (map != null)
+                {
+                    _dialogService.ShowInfo("Importing tools...", "Import Tools");
+                    var invalid = await _toolService.ImportToolsFromCsvAsync(path, map);
+                    var msg = invalid.Count == 0
+                        ? "Successfully imported tools."
+                        : $"Imported with {invalid.Count} invalid rows.";
+                    _dialogService.ShowInfo(msg, "Import Tools");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to import tools from CSV");
+                _dialogService.ShowInfo($"Failed to import tools: {ex.Message}", "Import Tools");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace direct CSV import calls with `ImportToolsFromCsvAsync`
- expose import operations through `AsyncRelayCommand`
- log import progress via `IDialogService`
- add coverage for async CSV import scenarios

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc880b42c8324aa6bc138505c3c35