### PR TITLE
Use constant-time password verification

### DIFF
--- a/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
+++ b/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
@@ -51,5 +51,14 @@ namespace ToolManagementAppV2.Tests.Utilities
             var actual = SecurityHelper.HashPassword("secret", salt);
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void VerifyPassword_ReturnsTrueForValidHash()
+        {
+            SecurityHelper.SettingsService = null;
+            var hash = SecurityHelper.HashPassword("secret", out var salt);
+            var result = SecurityHelper.VerifyPassword("secret", salt, hash);
+            Assert.True(result);
+        }
     }
 }

--- a/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Security.Cryptography;
 using System.Text;
 using ToolManagementAppV2.Interfaces;
@@ -51,11 +52,20 @@ namespace ToolManagementAppV2.Utilities.Helpers
 
         public static bool VerifyPassword(string password, string salt, string hash)
         {
-            if (string.IsNullOrEmpty(salt))
+            if (string.IsNullOrEmpty(salt) || string.IsNullOrEmpty(hash))
                 return false;
 
             var computed = HashPassword(password, salt);
-            return computed == hash;
+            try
+            {
+                var computedBytes = Convert.FromBase64String(computed);
+                var hashBytes = Convert.FromBase64String(hash);
+                return CryptographicOperations.FixedTimeEquals(computedBytes, hashBytes);
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
         }
 
         public static string GeneratePassword(int length = 12)


### PR DESCRIPTION
## Summary
- replace string equality with `CryptographicOperations.FixedTimeEquals` for password hashes
- add unit test verifying password check still succeeds

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689dcc0f0f8083248a6f951892d1cc81