### PR TITLE
Use async global search and test tool search button

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using CommunityToolkit.Mvvm.Input;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Views;
 using Xunit;
@@ -58,6 +60,29 @@ namespace ToolManagementAppV2.Tests.Tests
             var powerFirst = (FrameworkElement)page.PowerToolsList.ItemContainerGenerator.ContainerFromIndex(0);
             Assert.True(handFirst.ActualWidth > 0 && handFirst.ActualHeight > 0);
             Assert.True(powerFirst.ActualWidth > 0 && powerFirst.ActualHeight > 0);
+        }
+
+        [Fact]
+        public void SearchButton_BoundToSearchCommand()
+        {
+            var executed = false;
+            var vm = new TestVm(() => executed = true);
+            var page = new ToolSearchPage { DataContext = vm };
+
+            var root = (Grid)page.Content;
+            var border = (Border)root.Children[0];
+            var innerGrid = (Grid)border.Child;
+            var button = Assert.IsType<Button>(innerGrid.Children[2]);
+
+            Assert.Same(vm.SearchCommand, button.Command);
+            button.Command.Execute(null);
+            Assert.True(executed);
+        }
+
+        class TestVm
+        {
+            public IRelayCommand SearchCommand { get; }
+            public TestVm(Action onExecute) => SearchCommand = new RelayCommand(onExecute);
         }
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -250,8 +250,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
                 vm.GlobalSearchText = "Ham";
 
-                vm.GlobalSearchCommand.Execute(null);
-                await vm.OpenSearchToolsCommand.ExecutionTask!;
+                await vm.GlobalSearchCommand.ExecuteAsync(null);
 
                 var page = Assert.IsType<ToolSearchPage>(vm.CurrentPage);
                 Assert.Equal("Ham", vm.ToolManagement.SearchText);

--- a/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
@@ -3,12 +3,14 @@ using System.Linq;
 using System.Threading;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Threading;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
 using System.IO;
 using System.Runtime.Serialization;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Tests;
+using CommunityToolkit.Mvvm.Input;
 
 namespace ToolManagementAppV2.Tests.Views
 {
@@ -37,7 +39,12 @@ namespace ToolManagementAppV2.Tests.Views
                             .FirstOrDefault(kb => kb.Key == Key.Enter);
                         Assert.NotNull(keyBinding);
 
-                        keyBinding.Command.Execute(null);
+                        var asyncCommand = Assert.IsAssignableFrom<IAsyncRelayCommand>(keyBinding.Command);
+                        asyncCommand.Execute(null);
+
+                        var frame = new DispatcherFrame();
+                        asyncCommand.ExecutionTask!.ContinueWith(_ => frame.Continue = false);
+                        Dispatcher.PushFrame(frame);
 
                         Assert.Equal(string.Empty, vm.GlobalSearchText);
                     }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -94,7 +94,7 @@ namespace ToolManagementAppV2.ViewModels
         public IAsyncRelayCommand OpenImportMappingWindowCommand { get; }
         public IRelayCommand OpenImageImportMappingWindowCommand { get; }
         public IRelayCommand ExitCommand { get; }
-        public IRelayCommand GlobalSearchCommand { get; }
+        public IAsyncRelayCommand GlobalSearchCommand { get; }
         public IRelayCommand SwitchUserCommand { get; }
 
         public IAsyncRelayCommand<ToolModel?> OpenRentalHistoryWindowCommand { get; }
@@ -236,11 +236,12 @@ namespace ToolManagementAppV2.ViewModels
                 }
             });
 
-            GlobalSearchCommand = new RelayCommand(() =>
+            GlobalSearchCommand = new AsyncRelayCommand(async () =>
             {
                 ToolManagement.SearchText = GlobalSearchText;
-                OpenSearchToolsCommand.Execute(null);
-                ToolManagement.SearchCommand?.Execute(null);
+                await OpenSearchToolsCommand.ExecuteAsync(null);
+                if (ToolManagement.SearchCommand != null)
+                    await ToolManagement.SearchCommand.ExecuteAsync(null);
                 GlobalSearchText = string.Empty;
             });
 


### PR DESCRIPTION
## Summary
- Switch `GlobalSearchCommand` to `AsyncRelayCommand` and await the tool search
- Add a test ensuring ToolSearchPage's search button binds and executes `SearchCommand`
- Update existing navigation and window tests for the async global search

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689dcc1a4914832487fb7a0b13cd5ac1