### PR TITLE
Limit sensitive user data in lists

### DIFF
--- a/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
@@ -22,7 +22,7 @@ public class UserAuthenticationTests
 
             var user = new User { UserName = "test", Password = "secret", IsAdmin = false };
             userService.AddUser(user);
-            var added = userService.GetAllUsers().First();
+            var added = userService.GetUserByID(user.UserID)!;
 
             Assert.NotEqual("secret", added.Password);
             Assert.False(SecurityHelper.IsSha256Hash(added.Password));
@@ -60,7 +60,7 @@ public class UserAuthenticationTests
             var auth = userService.AuthenticateUser("legacy", "secret");
             Assert.NotNull(auth);
 
-            var updated = userService.GetAllUsers().First(u => u.UserName == "legacy");
+            var updated = userService.GetUserByID(auth!.UserID)!;
             Assert.False(SecurityHelper.IsSha256Hash(updated.Password));
             Assert.False(string.IsNullOrWhiteSpace(updated.Salt));
             Assert.True(SecurityHelper.VerifyPassword("secret", updated.Salt, updated.Password));

--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -103,4 +103,48 @@ public class UserServiceTests
                 File.Delete(dbPath);
         }
     }
+
+    [Fact]
+    public void GetAllUsers_DoesNotIncludeSensitiveFields()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+
+            userService.AddUser(new User { UserName = "list", Password = "pw", Salt = "s" });
+            var users = userService.GetAllUsers();
+            var user = users[0];
+            Assert.Null(user.Password);
+            Assert.Null(user.Salt);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task GetAllUsersAsync_DoesNotIncludeSensitiveFields()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            var userService = new UserService(dbService, new ApplicationUserContext());
+
+            await userService.AddUserAsync(new User { UserName = "list", Password = "pw", Salt = "s" });
+            var users = await userService.GetAllUsersAsync();
+            var user = users[0];
+            Assert.Null(user.Password);
+            Assert.Null(user.Salt);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -60,7 +60,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(dbService, userContext);
                 var settingsService = new SettingsService(dbService);
-                userService.AddUser(new User { UserName = "user", Password = "newpassword", IsAdmin = false, PasswordExpired = true });
+                var user = new User { UserName = "user", Password = "newpassword", IsAdmin = false, PasswordExpired = true };
+                userService.AddUser(user);
 
                 var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
                 {
@@ -72,7 +73,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 vm.SelectUserCommand.Execute(vm.Users.First());
 
                 Assert.True(success);
-                var updated = userService.GetAllUsers().First();
+                var updated = userService.GetUserByID(user.UserID)!;
                 Assert.False(updated.PasswordExpired);
                 Assert.True(SecurityHelper.VerifyPassword("changed", updated.Salt, updated.Password));
             }

--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -165,9 +165,10 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
                 vm.LoadUsers();
                 var user = vm.Users.First();
-                var oldPwd = user.Password;
+                var original = userService.GetUserByID(user.UserID)!;
+                var oldPwd = original.Password;
                 vm.ResetPasswordFromRowCommand.Execute(user);
-                var updated = userService.GetAllUsers().First();
+                var updated = userService.GetUserByID(user.UserID)!;
                 Assert.NotEqual(oldPwd, updated.Password);
                 Assert.Equal("Password Reset", dialog.LastInfoTitle);
                 Assert.StartsWith("Password reset to: ", dialog.LastInfoMessage);

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -24,7 +24,8 @@ namespace ToolManagementAppV2.Services.Users
         public List<User> GetAllUsers()
         {
             using var conn = _dbService.CreateConnection();
-            return SqliteHelper.ExecuteReader(conn, "SELECT * FROM Users", null, MapUser);
+            const string sql = "SELECT UserID, UserName, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, FailedAttempts, LockoutUntil, PasswordExpired FROM Users";
+            return SqliteHelper.ExecuteReader(conn, sql, null, MapUser);
         }
 
         public User? GetUserByID(int userID)
@@ -273,12 +274,20 @@ namespace ToolManagementAppV2.Services.Users
 
         User MapUser(IDataRecord rdr)
         {
+            bool HasColumn(string columnName)
+            {
+                for (int i = 0; i < rdr.FieldCount; i++)
+                    if (rdr.GetName(i).Equals(columnName, StringComparison.OrdinalIgnoreCase))
+                        return true;
+                return false;
+            }
+
             return new User
             {
                 UserID = rdr["UserID"] != DBNull.Value ? Convert.ToInt32(rdr["UserID"]) : 0,
                 UserName = rdr["UserName"].ToString(),
-                Password = rdr["Password"].ToString(),
-                Salt = rdr["Salt"]?.ToString(),
+                Password = HasColumn("Password") && rdr["Password"] != DBNull.Value ? rdr["Password"].ToString() : null,
+                Salt = HasColumn("Salt") && rdr["Salt"] != DBNull.Value ? rdr["Salt"].ToString() : null,
                 UserPhotoPath = rdr["UserPhotoPath"]?.ToString(),
                 IsAdmin = rdr["IsAdmin"] != DBNull.Value && Convert.ToInt32(rdr["IsAdmin"]) == 1,
                 Email = rdr["Email"]?.ToString(),
@@ -297,7 +306,8 @@ namespace ToolManagementAppV2.Services.Users
         public async Task<List<User>> GetAllUsersAsync()
         {
             using var conn = _dbService.CreateConnection();
-            return await SqliteHelper.ExecuteReaderAsync(conn, "SELECT * FROM Users", null, MapUser);
+            const string sql = "SELECT UserID, UserName, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, FailedAttempts, LockoutUntil, PasswordExpired FROM Users";
+            return await SqliteHelper.ExecuteReaderAsync(conn, sql, null, MapUser);
         }
 
         public async Task<User?> GetUserByIDAsync(int userID)


### PR DESCRIPTION
## Summary
- avoid retrieving Password and Salt for user lists
- safely map optional password fields
- add tests ensuring list users omit sensitive fields

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dcc31b3308324adfc5d0518c225eb