### PR TITLE
Return status for password updates

### DIFF
--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -103,4 +103,44 @@ public class UserServiceTests
                 File.Delete(dbPath);
         }
     }
+
+    [Fact]
+    public void ChangeUserPassword_ReturnsFalse_ForInvalidUserID()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+
+            var result = userService.ChangeUserPassword(9999, "newpass");
+
+            Assert.False(result);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task ChangeUserPasswordAsync_ReturnsFalse_ForInvalidUserID()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+
+            var result = await userService.ChangeUserPasswordAsync(9999, "newpass");
+
+            Assert.False(result);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -373,7 +373,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task<bool> TryDeleteUserAsync(int userID) => Task.FromResult(false);
         public bool DeleteUser(int userID) => false;
         public Task<bool> DeleteUserAsync(int userID) => Task.FromResult(false);
-        public void ChangeUserPassword(int userID, string newPassword) { }
-        public Task ChangeUserPasswordAsync(int userID, string newPassword) => Task.CompletedTask;
+        public bool ChangeUserPassword(int userID, string newPassword) => false;
+        public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => Task.FromResult(false);
     }
 }

--- a/ToolManagementAppV2/Interfaces/IUserService.cs
+++ b/ToolManagementAppV2/Interfaces/IUserService.cs
@@ -23,8 +23,8 @@ namespace ToolManagementAppV2.Interfaces
         Task<bool> TryDeleteUserAsync(int userID);
         bool DeleteUser(int userID);
         Task<bool> DeleteUserAsync(int userID);
-        void ChangeUserPassword(int userID, string newPassword);
-        Task ChangeUserPasswordAsync(int userID, string newPassword);
+        bool ChangeUserPassword(int userID, string newPassword);
+        Task<bool> ChangeUserPasswordAsync(int userID, string newPassword);
     }
 }
 

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -7,6 +7,8 @@ using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Utilities.Helpers;
 using ToolManagementAppV2.Interfaces;
 using System.Linq;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.Services.Users
 {
@@ -14,11 +16,13 @@ namespace ToolManagementAppV2.Services.Users
     {
         readonly DatabaseService _dbService;
         readonly IUserContext _context;
+        readonly ILogger<UserService> _logger;
 
-        public UserService(DatabaseService dbService, IUserContext context)
+        public UserService(DatabaseService dbService, IUserContext context, ILogger<UserService>? logger = null)
         {
             _dbService = dbService;
             _context = context;
+            _logger = logger ?? NullLogger<UserService>.Instance;
         }
 
         public List<User> GetAllUsers()
@@ -223,7 +227,7 @@ namespace ToolManagementAppV2.Services.Users
             user.Salt = salt;
         }
 
-        public void ChangeUserPassword(int userID, string newPassword)
+        public bool ChangeUserPassword(int userID, string newPassword)
         {
             var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt, PasswordExpired=@Expired WHERE UserID=@ID";
             string hashed = string.Empty;
@@ -243,7 +247,10 @@ namespace ToolManagementAppV2.Services.Users
                 new SQLiteParameter("@ID",  userID)
             };
             using var conn = _dbService.CreateConnection();
-            SqliteHelper.ExecuteNonQuery(conn, sql, p);
+            int rows = SqliteHelper.ExecuteNonQuery(conn, sql, p);
+            if (rows == 0)
+                _logger.LogWarning("Password update affected 0 rows for UserID {UserID}", userID);
+            return rows > 0;
         }
 
         public bool TryDeleteUser(int userID)
@@ -494,7 +501,7 @@ namespace ToolManagementAppV2.Services.Users
             user.Salt = salt;
         }
 
-        public async Task ChangeUserPasswordAsync(int userID, string newPassword)
+        public async Task<bool> ChangeUserPasswordAsync(int userID, string newPassword)
         {
             var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt, PasswordExpired=@Expired WHERE UserID=@ID";
             string hashed = string.Empty;
@@ -514,7 +521,10 @@ namespace ToolManagementAppV2.Services.Users
                 new SQLiteParameter("@ID",  userID)
             };
             using var conn = _dbService.CreateConnection();
-            await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+            int rows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+            if (rows == 0)
+                _logger.LogWarning("Password update affected 0 rows for UserID {UserID}", userID);
+            return rows > 0;
         }
 
         async Task DeleteUserInternalAsync(int userID)


### PR DESCRIPTION
## Summary
- make ChangeUserPassword return success bool and warn when no rows updated
- expose success state in IUserService
- add unit tests for invalid user IDs

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689dcc4df5f883249951fb50f5850c83