### PR TITLE
Add async report generation

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ReportsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ReportsViewModelTests.cs
@@ -10,13 +10,14 @@ using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace ToolManagementAppV2.Tests.ViewModels
 {
     public class ReportsViewModelTests
     {
         [Fact]
-        public void ReportsViewModel_ReportsPage_Binding_Wiring()
+        public async Task ReportsViewModel_ReportsPage_Binding_Wiring()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -48,7 +49,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 vm.SelectedReport = "Summary";
                 Assert.True(vm.RunReportCommand.CanExecute(null));
 
-                vm.RunReportCommand.Execute(null);
+                await vm.RunReportCommand.ExecuteAsync(null);
                 Assert.NotNull(vm.ReportResults);
                 Assert.Contains("Total Tools: 1",
                     vm.ReportResults.Rows.Cast<DataRow>().Select(r => r[0]?.ToString()));
@@ -59,7 +60,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 vm.SelectedReport = "Inventory";
                 Assert.True(vm.RunReportCommand.CanExecute(null));
 
-                vm.RunReportCommand.Execute(null);
+                await vm.RunReportCommand.ExecuteAsync(null);
                 Assert.Contains("Tool ID:",
                     vm.ReportResults.Rows.Cast<DataRow>().Select(r => r[0]?.ToString()));
             }

--- a/ToolManagementAppV2/Services/Tools/ReportService.cs
+++ b/ToolManagementAppV2/Services/Tools/ReportService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Documents;
 using System.Windows.Media;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
@@ -42,11 +43,40 @@ namespace ToolManagementAppV2.Services.Tools
             return BuildReport("Tool Inventory Report", lines);
         }
 
+        public async Task<FlowDocument> GenerateInventoryReportAsync()
+        {
+            var tools = await _toolService.GetAllToolsAsync();
+            var lines = tools
+                .Select(t =>
+                    $"Tool ID: {t.ToolID} | ToolNumber: {t.ToolNumber} | Qty: {t.QuantityOnHand} | " +
+                    $"Location: {t.Location} | Supplier: {t.Supplier}");
+            return BuildReport("Tool Inventory Report", lines);
+        }
+
         public FlowDocument GenerateRentalReport(bool activeOnly = true)
         {
             var rentals = activeOnly
                 ? _rentalService.GetActiveRentals()
                 : _rentalService.GetAllRentals();
+
+            var title = activeOnly
+                ? "Active Rental Report"
+                : "Full Rental History Report";
+
+            var lines = rentals.Select(r =>
+                $"Rental ID: {r.RentalID} | Tool ID: {r.ToolID} | Customer ID: {r.CustomerID} | " +
+                $"Rental Date: {r.RentalDate:yyyy-MM-dd} | Due Date: {r.DueDate:yyyy-MM-dd} | " +
+                $"Return Date: {(r.ReturnDate.HasValue ? r.ReturnDate.Value.ToString("yyyy-MM-dd") : "N/A")} | " +
+                $"Status: {r.Status}");
+
+            return BuildReport(title, lines);
+        }
+
+        public async Task<FlowDocument> GenerateRentalReportAsync(bool activeOnly = true)
+        {
+            var rentals = activeOnly
+                ? await _rentalService.GetActiveRentalsAsync()
+                : await _rentalService.GetAllRentalsAsync();
 
             var title = activeOnly
                 ? "Active Rental Report"
@@ -70,6 +100,15 @@ namespace ToolManagementAppV2.Services.Tools
             return BuildReport("Activity Log Report", lines);
         }
 
+        public async Task<FlowDocument> GenerateActivityLogReportAsync()
+        {
+            var logs = await _activityLogService.GetRecentLogsAsync(100) ?? new List<ActivityLog>();
+            var lines = logs.Select(l =>
+                    $"LogID: {l.LogID} | UserID: {l.UserID} | User: {l.UserName} | " +
+                    $"Action: {l.Action} | Timestamp: {l.Timestamp:yyyy-MM-dd HH:mm:ss}");
+            return BuildReport("Activity Log Report", lines);
+        }
+
         public FlowDocument GenerateCustomerReport()
         {
             var lines = _customerService.GetAllCustomers()
@@ -79,9 +118,28 @@ namespace ToolManagementAppV2.Services.Tools
             return BuildReport("Customer Report", lines);
         }
 
+        public async Task<FlowDocument> GenerateCustomerReportAsync()
+        {
+            var customers = await _customerService.GetAllCustomersAsync();
+            var lines = customers
+                .Select(c =>
+                    $"CustomerID: {c.CustomerID} | Company: {c.Company} | Email: {c.Email} | " +
+                    $"Contact: {c.Contact} | Phone: {c.Phone} | Mobile: {c.Mobile} | Address: {c.Address}");
+            return BuildReport("Customer Report", lines);
+        }
+
         public FlowDocument GenerateUserReport()
         {
             var lines = _userService.GetAllUsers()
+                .Select(u =>
+                    $"UserID: {u.UserID} | UserName: {u.UserName} | IsAdmin: {u.IsAdmin}");
+            return BuildReport("User Report", lines);
+        }
+
+        public async Task<FlowDocument> GenerateUserReportAsync()
+        {
+            var users = await _userService.GetAllUsersAsync();
+            var lines = users
                 .Select(u =>
                     $"UserID: {u.UserID} | UserName: {u.UserName} | IsAdmin: {u.IsAdmin}");
             return BuildReport("User Report", lines);
@@ -102,6 +160,28 @@ namespace ToolManagementAppV2.Services.Tools
                 $"Active Rentals: {totalActiveRentals}",
                 $"Total Customers: {totalCustomers}",
                 $"Total Users: {totalUsers}"
+            };
+
+            return BuildReport("Application Summary Report", lines);
+        }
+
+        public async Task<FlowDocument> GenerateSummaryReportAsync()
+        {
+            var totalToolsTask = _toolService.GetAllToolsAsync();
+            var totalRentalsTask = _rentalService.GetAllRentalsAsync();
+            var totalActiveRentalsTask = _rentalService.GetActiveRentalsAsync();
+            var totalCustomersTask = _customerService.GetAllCustomersAsync();
+            var totalUsersTask = _userService.GetAllUsersAsync();
+
+            await Task.WhenAll(totalToolsTask, totalRentalsTask, totalActiveRentalsTask, totalCustomersTask, totalUsersTask);
+
+            var lines = new[]
+            {
+                $"Total Tools: {totalToolsTask.Result.Count}",
+                $"Total Rentals (History): {totalRentalsTask.Result.Count}",
+                $"Active Rentals: {totalActiveRentalsTask.Result.Count}",
+                $"Total Customers: {totalCustomersTask.Result.Count}",
+                $"Total Users: {totalUsersTask.Result.Count}"
             };
 
             return BuildReport("Application Summary Report", lines);

--- a/ToolManagementAppV2/Services/Users/ActivityLogService.cs
+++ b/ToolManagementAppV2/Services/Users/ActivityLogService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SQLite;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ToolManagementAppV2.Models.Domain;
@@ -55,6 +56,25 @@ namespace ToolManagementAppV2.Services.Users
                 var p = new[] { new SQLiteParameter("@Count", count) };
                 using var conn = _dbService.CreateConnection();
                 return SqliteHelper.ExecuteReader(conn, sql, p, MapLog);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve recent activity logs");
+                return null;
+            }
+        }
+
+        public virtual async Task<List<ActivityLog>?> GetRecentLogsAsync(int count = 50)
+        {
+            try
+            {
+                const string sql = @"
+                    SELECT * FROM ActivityLogs
+                     ORDER BY Timestamp DESC
+                     LIMIT @Count";
+                var p = new[] { new SQLiteParameter("@Count", count) };
+                using var conn = _dbService.CreateConnection();
+                return await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapLog);
             }
             catch (Exception ex)
             {

--- a/ToolManagementAppV2/ViewModels/ReportsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ReportsViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Data;
 using System.Linq;
 using System.Windows.Documents;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Services.Tools;
 
 namespace ToolManagementAppV2.ViewModels
@@ -34,7 +35,7 @@ namespace ToolManagementAppV2.ViewModels
             set => SetProperty(ref _reportResults, value);
         }
 
-        public IRelayCommand RunReportCommand { get; }
+        public IAsyncRelayCommand RunReportCommand { get; }
 
         public ReportsViewModel(ReportService reportService)
         {
@@ -51,22 +52,22 @@ namespace ToolManagementAppV2.ViewModels
                 "Full Rental History"
             };
 
-            RunReportCommand = new RelayCommand(RunReport, CanRunReport);
+            RunReportCommand = new AsyncRelayCommand(RunReportAsync, CanRunReport);
         }
 
         private bool CanRunReport() => !string.IsNullOrEmpty(SelectedReport);
 
-        private void RunReport()
+        private async Task RunReportAsync()
         {
             FlowDocument doc = SelectedReport switch
             {
-                "Summary" => _reportService.GenerateSummaryReport(),
-                "Inventory" => _reportService.GenerateInventoryReport(),
-                "Activity Log" => _reportService.GenerateActivityLogReport(),
-                "Customers" => _reportService.GenerateCustomerReport(),
-                "Users" => _reportService.GenerateUserReport(),
-                "Active Rentals" => _reportService.GenerateRentalReport(true),
-                "Full Rental History" => _reportService.GenerateRentalReport(false),
+                "Summary" => await _reportService.GenerateSummaryReportAsync(),
+                "Inventory" => await _reportService.GenerateInventoryReportAsync(),
+                "Activity Log" => await _reportService.GenerateActivityLogReportAsync(),
+                "Customers" => await _reportService.GenerateCustomerReportAsync(),
+                "Users" => await _reportService.GenerateUserReportAsync(),
+                "Active Rentals" => await _reportService.GenerateRentalReportAsync(true),
+                "Full Rental History" => await _reportService.GenerateRentalReportAsync(false),
                 _ => null
             };
 


### PR DESCRIPTION
## Summary
- provide asynchronous report generation methods in ReportService
- update ReportsViewModel to await report generation
- expand ReportsViewModelTests for async commands

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689dcc52be248324a918ecd0451cc154