### PR TITLE
Validate scanner IP addresses and log invalid entries

### DIFF
--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.SQLite;
 using System.IO;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Settings;
@@ -201,6 +202,67 @@ namespace ToolManagementAppV2.Tests.Services
 
                 Assert.Single(logs);
                 Assert.Equal(LogLevel.Warning, logs[0].Level);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void SaveScannerIpAddresses_SkipsInvalidAndLogsWarning()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var logs = new List<LogEntry>();
+                using var factory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
+                var logger = factory.CreateLogger<SettingsService>();
+                var service = new SettingsService(dbService, logger);
+
+                var invalid = service.SaveScannerIpAddresses(new[] { "192.168.1.1", "bad", "999.999.999.999" }).ToList();
+
+                Assert.Equal(new[] { "bad", "999.999.999.999" }, invalid);
+
+                var saved = service.GetScannerIpAddresses().ToList();
+                Assert.Single(saved);
+                Assert.Equal("192.168.1.1", saved[0]);
+
+                Assert.Single(logs);
+                Assert.Equal(LogLevel.Warning, logs[0].Level);
+                Assert.Contains("bad", logs[0].Message);
+                Assert.Contains("999.999.999.999", logs[0].Message);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void SaveScannerIpAddresses_AllValid_NoWarning()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var logs = new List<LogEntry>();
+                using var factory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
+                var logger = factory.CreateLogger<SettingsService>();
+                var service = new SettingsService(dbService, logger);
+
+                var invalid = service.SaveScannerIpAddresses(new[] { "127.0.0.1", "10.0.0.2" });
+                Assert.Empty(invalid);
+
+                var saved = service.GetScannerIpAddresses().ToList();
+                Assert.Equal(2, saved.Count);
+                Assert.Contains("127.0.0.1", saved);
+                Assert.Contains("10.0.0.2", saved);
+
+                Assert.Empty(logs);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -102,7 +102,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void DeleteSetting(string key) { }
         public IEnumerable<string> ScannerIps { get; set; } = Array.Empty<string>();
         public IEnumerable<string> GetScannerIpAddresses() => ScannerIps;
-        public void SaveScannerIpAddresses(IEnumerable<string> ipAddresses) => ScannerIps = ipAddresses;
+        public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string> ipAddresses)
+        {
+            ScannerIps = ipAddresses;
+            return Array.Empty<string>();
+        }
         public int PasswordIterations { get; set; } = 100_000;
         public int GetPasswordIterations() => PasswordIterations;
         public void SavePasswordIterations(int iterations) => PasswordIterations = iterations;

--- a/ToolManagementAppV2/Interfaces/ISettingsService.cs
+++ b/ToolManagementAppV2/Interfaces/ISettingsService.cs
@@ -10,7 +10,7 @@ namespace ToolManagementAppV2.Interfaces
         void UpdateSettings(Dictionary<string, string> settings);
         void DeleteSetting(string key);
         IEnumerable<string> GetScannerIpAddresses();
-        void SaveScannerIpAddresses(IEnumerable<string> ipAddresses);
+        IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string> ipAddresses);
         int GetPasswordIterations();
         void SavePasswordIterations(int iterations);
     }

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Data.SQLite;
 using System;
+using System.Net;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Interfaces;
 using Microsoft.Extensions.Logging;
@@ -151,13 +152,39 @@ namespace ToolManagementAppV2.Services.Settings
             var value = GetSetting(ScannerIpKey);
             if (string.IsNullOrWhiteSpace(value))
                 return Array.Empty<string>();
-            return value.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            var valid = new List<string>();
+            foreach (var ip in value.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (IPAddress.TryParse(ip, out _))
+                    valid.Add(ip);
+            }
+
+            return valid;
         }
 
-        public void SaveScannerIpAddresses(IEnumerable<string> ipAddresses)
+        public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string> ipAddresses)
         {
-            var value = string.Join(';', ipAddresses);
+            if (ipAddresses == null)
+                throw new ArgumentNullException(nameof(ipAddresses));
+
+            var valid = new List<string>();
+            var invalid = new List<string>();
+            foreach (var ip in ipAddresses)
+            {
+                if (IPAddress.TryParse(ip, out _))
+                    valid.Add(ip);
+                else
+                    invalid.Add(ip);
+            }
+
+            if (invalid.Count > 0)
+                _logger.LogWarning("Ignoring invalid IP addresses: {InvalidIps}", string.Join(", ", invalid));
+
+            var value = string.Join(';', valid);
             SaveSetting(ScannerIpKey, value);
+
+            return invalid;
         }
 
         public int GetPasswordIterations()


### PR DESCRIPTION
## Summary
- validate and store only well-formed scanner IP addresses, logging any skipped values
- expose skipped IP addresses to callers and update interface accordingly
- add unit tests for scanner IP validation

## Testing
- ⚠️ `dotnet test` *(dotnet not installed)*
- ⚠️ `apt-get update` *(403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689dcc0e4ad88324bdb9e7cffb1a4ff2