### PR TITLE
Use TextFieldParser for CSV headers

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
@@ -33,6 +33,29 @@ public class CsvImportTests
     }
 
     [Fact]
+    public void LoadToolsFromCsv_HandlesQuotedHeaders()
+    {
+        var csv = string.Join('\n',
+            "\"ToolNumber\",\"NameDescription\",\"AvailableQuantity\"",
+            "T1,Hammer,5");
+        var path = Path.GetTempFileName();
+        File.WriteAllText(path, csv);
+
+        var map = new Dictionary<string, string>
+        {
+            { "ToolNumber", "ToolNumber" },
+            { "NameDescription", "NameDescription" },
+            { "AvailableQuantity", "AvailableQuantity" }
+        };
+
+        var tools = CsvHelperUtil.LoadToolsFromCsv(path, map, out var invalid);
+
+        Assert.Single(tools);
+        Assert.Empty(invalid);
+        Assert.Equal("T1", tools[0].ToolNumber);
+    }
+
+    [Fact]
     public void LoadToolsFromCsv_MissingRequiredMapping_Throws()
     {
         var csv = string.Join('\n',

--- a/ToolManagementAppV2/Services/Core/CsvHelper.cs
+++ b/ToolManagementAppV2/Services/Core/CsvHelper.cs
@@ -10,6 +10,14 @@ namespace ToolManagementAppV2.Utilities.IO
 {
     public static class CsvHelperUtil
     {
+        public static IEnumerable<string> ReadHeaders(string filePath)
+        {
+            using var parser = new TextFieldParser(filePath);
+            parser.SetDelimiters(",");
+            parser.HasFieldsEnclosedInQuotes = true;
+            return parser.EndOfData ? Array.Empty<string>() : parser.ReadFields().Select(h => h.Trim());
+        }
+
         public static List<ToolModel> LoadToolsFromCsv(string filePath, IDictionary<string, string> map, out List<int> invalidRows)
         {
             ValidateRequired(map, "ToolNumber");

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -11,6 +11,7 @@ using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.ImportExport;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using ToolManagementAppV2.Utilities.IO;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -65,7 +66,7 @@ namespace ToolManagementAppV2.ViewModels
             if (string.IsNullOrEmpty(path)) return;
             try
             {
-                var headers = File.ReadLines(path).First().Split(',').Select(h => h.Trim());
+                var headers = CsvHelperUtil.ReadHeaders(path);
                 var properties = typeof(ToolImportDto).GetProperties().Select(p => p.Name);
                 var map = _dialogService.ShowImportMapping(headers, properties);
                 if (map == null)
@@ -106,7 +107,7 @@ namespace ToolManagementAppV2.ViewModels
             if (string.IsNullOrEmpty(path)) return;
             try
             {
-                var headers = File.ReadLines(path).First().Split(',').Select(h => h.Trim());
+                var headers = CsvHelperUtil.ReadHeaders(path);
                 var properties = typeof(CustomerImportDto).GetProperties().Select(p => p.Name);
                 var map = _dialogService.ShowImportMapping(headers, properties);
                 if (map == null)

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -18,6 +18,7 @@ using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Views;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using ToolManagementAppV2.Utilities.IO;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -306,11 +307,7 @@ namespace ToolManagementAppV2.ViewModels
                 if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
                     return;
 
-                var headers = File.ReadLines(path)
-                                   .First()
-                                   .Split(',')
-                                   .Select(h => h.Trim())
-                                   .ToList();
+                var headers = CsvHelperUtil.ReadHeaders(path).ToList();
                 var properties = typeof(ToolModel)
                                     .GetProperties()
                                     .Select(p => p.Name)


### PR DESCRIPTION
## Summary
- safely parse CSV header row with TextFieldParser via new CsvHelperUtil.ReadHeaders
- refactor header extraction in MainViewModel and ImportExportViewModel to use the helper
- add unit test covering quoted CSV headers

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689eada8c7708324bc4a906c03ed92e4