### PR TITLE
Handle empty scanner IP list by removing setting

### DIFF
--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -271,6 +271,31 @@ namespace ToolManagementAppV2.Tests.Services
             }
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData(new string[0])]
+        public void SaveScannerIpAddresses_NullOrEmpty_DeletesSetting(string[]? input)
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var service = new SettingsService(dbService);
+
+                service.SaveScannerIpAddresses(new[] { "192.168.0.1" });
+                Assert.Single(service.GetScannerIpAddresses());
+
+                var invalid = service.SaveScannerIpAddresses(input).ToList();
+                Assert.Empty(invalid);
+                Assert.Empty(service.GetScannerIpAddresses());
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
         [Fact]
         public void GetPasswordIterations_ReturnsDefault()
         {

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -102,9 +102,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void DeleteSetting(string key) { }
         public IEnumerable<string> ScannerIps { get; set; } = Array.Empty<string>();
         public IEnumerable<string> GetScannerIpAddresses() => ScannerIps;
-        public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string> ipAddresses)
+        public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses)
         {
-            ScannerIps = ipAddresses;
+            ScannerIps = ipAddresses ?? Array.Empty<string>();
             return Array.Empty<string>();
         }
         public int PasswordIterations { get; set; } = 100_000;

--- a/ToolManagementAppV2/Interfaces/ISettingsService.cs
+++ b/ToolManagementAppV2/Interfaces/ISettingsService.cs
@@ -10,7 +10,7 @@ namespace ToolManagementAppV2.Interfaces
         void UpdateSettings(Dictionary<string, string> settings);
         void DeleteSetting(string key);
         IEnumerable<string> GetScannerIpAddresses();
-        IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string> ipAddresses);
+        IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses);
         int GetPasswordIterations();
         void SavePasswordIterations(int iterations);
     }

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -163,10 +163,13 @@ namespace ToolManagementAppV2.Services.Settings
             return valid;
         }
 
-        public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string> ipAddresses)
+        public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses)
         {
             if (ipAddresses == null)
-                throw new ArgumentNullException(nameof(ipAddresses));
+            {
+                DeleteSetting(ScannerIpKey);
+                return Array.Empty<string>();
+            }
 
             var valid = new List<string>();
             var invalid = new List<string>();
@@ -181,8 +184,15 @@ namespace ToolManagementAppV2.Services.Settings
             if (invalid.Count > 0)
                 _logger.LogWarning("Ignoring invalid IP addresses: {InvalidIps}", string.Join(", ", invalid));
 
-            var value = string.Join(';', valid);
-            SaveSetting(ScannerIpKey, value);
+            if (valid.Count > 0)
+            {
+                var value = string.Join(';', valid);
+                SaveSetting(ScannerIpKey, value);
+            }
+            else
+            {
+                DeleteSetting(ScannerIpKey);
+            }
 
             return invalid;
         }


### PR DESCRIPTION
## Summary
- Delete scanner IP setting when saving null or no valid addresses
- Allow `SaveScannerIpAddresses` to accept nullable input
- Test that null or empty IP lists remove stored setting

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689eadb0a7fc8324ad8d0e73fa0b8d29