### PR TITLE
Reuse SettingsViewModel across settings navigation

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -202,6 +202,46 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public void OpenSettingsCommand_ReusesSettingsViewModelInstance()
+        {
+            var dbPath = Path.GetTempFileName();
+            var tempDb = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db");
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                var userContext = new ApplicationUserContext();
+                IUserService userService = new UserService(db, userContext);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
+
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
+
+                vm.OpenSettingsCommand.Execute(null);
+                var firstPage = Assert.IsType<SettingsPage>(vm.CurrentPage);
+                var firstVm = Assert.IsType<SettingsViewModel>(firstPage.DataContext);
+                firstVm.ApplicationName = "My App";
+
+                vm.OpenDashboardCommand.Execute(null);
+                vm.OpenSettingsCommand.Execute(null);
+                var secondPage = Assert.IsType<SettingsPage>(vm.CurrentPage);
+                var secondVm = Assert.IsType<SettingsViewModel>(secondPage.DataContext);
+
+                Assert.Same(firstVm, secondVm);
+                Assert.Equal("My App", secondVm.ApplicationName);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+                if (File.Exists(tempDb))
+                    File.Delete(tempDb);
+            }
+        }
+
+        [Fact]
         public async Task OpenRentalsCommand_NavigatesToManageRentalsPage()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -42,6 +42,7 @@ namespace ToolManagementAppV2.ViewModels
         public ImportExportViewModel ImportExport { get; }
         public ActivityLogsViewModel ActivityLogs { get; }
         public ReportsViewModel Reports { get; }
+        public SettingsViewModel Settings { get; }
 
         private Page _currentPage;
         public Page CurrentPage
@@ -141,6 +142,7 @@ namespace ToolManagementAppV2.ViewModels
             ImportExport = new ImportExportViewModel(toolService, customerService, fileDialogService, databaseService, _dialogService);
             Reports = new ReportsViewModel(new ReportService(toolService, rentalService, activityLogService, customerService, userService));
             ActivityLogs = new ActivityLogsViewModel(activityLogService);
+            Settings = new SettingsViewModel(_fileDialogService, _settingsService, _dialogService);
 
             OpenDashboardCommand = new RelayCommand(() =>
             {
@@ -194,7 +196,7 @@ namespace ToolManagementAppV2.ViewModels
             {
                 var page = new SettingsPage
                     {
-                        DataContext = new SettingsViewModel(fileDialogService, _settingsService, _dialogService),
+                        DataContext = Settings,
                         Title = "Settings"
                     };
                 CurrentPage = page;


### PR DESCRIPTION
## Summary
- Instantiate and store a single `SettingsViewModel` within `MainViewModel`
- Reuse existing `SettingsViewModel` instance when opening the Settings page
- Add regression test to ensure settings view model is reused and retains state

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures invalid; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689eadb5ad7483248c03e41393c9dae1