### PR TITLE
Handle database update errors

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -289,6 +289,33 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
+        public void UpdateTool_DatabaseError_LogsAndThrows()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var logs = new List<LogEntry>();
+                using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
+                var dbService = new DatabaseService(dbPath);
+                var service = new ToolService(dbService, loggerFactory.CreateLogger<ToolService>());
+
+                service.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
+                var tool = service.GetAllTools().First();
+                tool.ToolNumber = null;
+
+                var ex = Assert.Throws<InvalidOperationException>(() => service.UpdateTool(tool));
+                Assert.Contains("Failed to update tool", ex.Message);
+                Assert.IsType<SQLiteException>(ex.InnerException);
+                Assert.Contains(logs, l => l.Level == LogLevel.Error && l.Message.Contains("Failed to update tool"));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public void ImportToolImages_UpdatesImagePathsAndReportsIssues()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -146,7 +146,15 @@ namespace ToolManagementAppV2.Services.Tools
                 new SQLiteParameter("@Time", (object)tool.CheckedOutTime ?? DBNull.Value),
                 new SQLiteParameter("@Img", (object)tool.ToolImagePath ?? DBNull.Value)
             };
-            SqliteHelper.ExecuteNonQuery(conn, sql, p);
+            try
+            {
+                SqliteHelper.ExecuteNonQuery(conn, sql, p);
+            }
+            catch (SQLiteException ex)
+            {
+                _logger.LogError(ex, "Failed to update tool {ToolID}", tool.ToolID);
+                throw new InvalidOperationException($"Failed to update tool {tool.ToolID}.", ex);
+            }
         }
     
         public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental,
@@ -495,7 +503,15 @@ namespace ToolManagementAppV2.Services.Tools
                 new SQLiteParameter("@Time", (object)tool.CheckedOutTime ?? DBNull.Value),
                 new SQLiteParameter("@Img", (object)tool.ToolImagePath ?? DBNull.Value)
             };
-            await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+            try
+            {
+                await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+            }
+            catch (SQLiteException ex)
+            {
+                _logger.LogError(ex, "Failed to update tool {ToolID}", tool.ToolID);
+                throw new InvalidOperationException($"Failed to update tool {tool.ToolID}.", ex);
+            }
         }
 
         public async Task DeleteToolAsync(int toolID)


### PR DESCRIPTION
## Summary
- wrap ToolService database updates with error handling and logging
- test ToolService failure path when database update fails

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689eadcc88888324a39acedc70a9e0fd