### PR TITLE
Optimize CSV import and add performance test

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
@@ -104,5 +104,47 @@ public class CsvImportTests
             if (File.Exists(dbPath)) File.Delete(dbPath);
         }
     }
+
+    [Fact]
+    public async System.Threading.Tasks.Task ImportToolsFromCsvAsync_PerformanceWithDuplicates()
+    {
+        var dbPath = Path.GetTempFileName();
+        var csvPath = Path.GetTempFileName();
+        try
+        {
+            var db = new DatabaseService(dbPath);
+            var service = new ToolService(db);
+
+            for (int i = 0; i < 100; i++)
+                service.AddTool(new ToolModel { ToolNumber = $"E{i}", NameDescription = $"Existing {i}" });
+
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine("ToolNumber,NameDescription");
+            for (int i = 0; i < 100; i++)
+                sb.AppendLine($"E{i},Dup {i}");
+            for (int i = 0; i < 900; i++)
+                sb.AppendLine($"N{i},New {i}");
+            File.WriteAllText(csvPath, sb.ToString());
+
+            var map = new Dictionary<string, string>
+            {
+                {"ToolNumber", "ToolNumber"},
+                {"NameDescription", "NameDescription"}
+            };
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var invalid = await service.ImportToolsFromCsvAsync(csvPath, map);
+            sw.Stop();
+
+            Assert.True(sw.ElapsedMilliseconds < 5000, $"Import took {sw.ElapsedMilliseconds}ms");
+            Assert.Empty(invalid);
+            Assert.Equal(1000, service.GetAllTools().Count);
+        }
+        finally
+        {
+            if (File.Exists(csvPath)) File.Delete(csvPath);
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
 }
 

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -257,13 +257,21 @@ namespace ToolManagementAppV2.Services.Tools
         {
             var tools = CsvHelperUtil.LoadToolsFromCsv(filePath, map, out var invalidRows);
             using var conn = _dbService.CreateConnection();
+            var existingNumbers = new HashSet<string>(
+                SqliteHelper.ExecuteReader(conn,
+                    "SELECT ToolNumber FROM Tools", null,
+                    r => r.GetString(0)));
+
             using var tran = conn.BeginTransaction();
             try
             {
                 foreach (var tool in tools)
                 {
-                    if (!ToolExists(tool.ToolNumber))
-                        InsertTool(conn, tran, tool);
+                    if (string.IsNullOrWhiteSpace(tool.ToolNumber) ||
+                        existingNumbers.Contains(tool.ToolNumber))
+                        continue;
+                    InsertTool(conn, tran, tool);
+                    existingNumbers.Add(tool.ToolNumber);
                 }
                 tran.Commit();
                 return invalidRows;


### PR DESCRIPTION
## Summary
- preload existing tool numbers into a hash set during CSV import to avoid repeated queries and skip duplicates
- add performance test for importing CSV with duplicates

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ebe6b93c48324bee38873fdf9b319