### PR TITLE
Add guard for invalid tool quantities

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -199,6 +199,35 @@ namespace ToolManagementAppV2.Tests.ViewModels
             public void ShowScannerStatus() { }
         }
 
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(10001)]
+        public async Task AddToolCommand_ShowsDialog_OnInvalidQuantity(int quantity)
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var dialog = new StubDialogService();
+                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
+                vm.NewTool.ToolNumber = "TN1";
+                vm.NewTool.NameDescription = "Hammer";
+                vm.NewTool.QuantityOnHand = quantity;
+                await vm.NewToolCommand.ExecuteAsync(null);
+                Assert.True(dialog.InfoShown);
+                Assert.Empty(toolService.GetAllTools());
+                Assert.Equal(quantity, vm.NewTool.QuantityOnHand);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
         [Fact]
         public async Task NewToolCommand_PersistsNewToolValues()
         {

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -25,6 +25,7 @@ namespace ToolManagementAppV2.Services.Tools
               (ToolNumber, NameDescription, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity, RentedQuantity, ToolImagePath, IsCheckedOut, IsPowerTool)
             VALUES (@ToolNumber,@Desc,@Loc,@Brand,@PN,@Sup,@PD,@Notes,@Keywords,@Avail,@Rent,@Img,0,@Power);
             SELECT last_insert_rowid();";
+        const int MaxQuantityOnHand = 10000;
     
         readonly ILogger<ToolService> _logger;
 
@@ -91,6 +92,7 @@ namespace ToolManagementAppV2.Services.Tools
                 throw new ArgumentException("ToolNumber is required.", nameof(tool));
             if (ToolExists(tool.ToolNumber))
                 throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
+            ValidateQuantity(tool.QuantityOnHand);
             using var conn = _dbService.CreateConnection();
             InsertTool(conn, null, tool);
         }
@@ -107,6 +109,7 @@ namespace ToolManagementAppV2.Services.Tools
             var dup = Convert.ToInt32(SqliteHelper.ExecuteScalar(conn, dupSql, dupParams)) > 0;
             if (dup)
                 throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
+            ValidateQuantity(tool.QuantityOnHand);
             const string sql = @"
                 UPDATE Tools SET
                   ToolNumber = @ToolNumber,
@@ -276,8 +279,15 @@ namespace ToolManagementAppV2.Services.Tools
             }
         }
 
+        static void ValidateQuantity(int quantity)
+        {
+            if (quantity < 0 || quantity > MaxQuantityOnHand)
+                throw new ArgumentOutOfRangeException(nameof(Tool.QuantityOnHand), $"QuantityOnHand must be between 0 and {MaxQuantityOnHand}.");
+        }
+
         void InsertTool(SQLiteConnection conn, SQLiteTransaction? tran, ToolModel tool)
         {
+            ValidateQuantity(tool.QuantityOnHand);
             var p = new[]
             {
                 new SQLiteParameter("@ToolNumber", tool.ToolNumber),
@@ -303,6 +313,7 @@ namespace ToolManagementAppV2.Services.Tools
 
         async Task InsertToolAsync(SQLiteConnection conn, SQLiteTransaction? tran, ToolModel tool)
         {
+            ValidateQuantity(tool.QuantityOnHand);
             var p = new[]
             {
                 new SQLiteParameter("@ToolNumber", tool.ToolNumber),
@@ -455,6 +466,7 @@ namespace ToolManagementAppV2.Services.Tools
                 throw new ArgumentException("ToolNumber is required.", nameof(tool));
             if (await ToolExistsAsync(tool.ToolNumber))
                 throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
+            ValidateQuantity(tool.QuantityOnHand);
             using var conn = _dbService.CreateConnection();
             await InsertToolAsync(conn, null, tool);
         }
@@ -464,6 +476,7 @@ namespace ToolManagementAppV2.Services.Tools
             if (await ToolExistsAsync(tool.ToolNumber, tool.ToolID))
                 throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
             using var conn = _dbService.CreateConnection();
+            ValidateQuantity(tool.QuantityOnHand);
             const string sql = @"
                 UPDATE Tools SET
                   ToolNumber = @ToolNumber,


### PR DESCRIPTION
## Summary
- validate QuantityOnHand is non-negative and capped via new guard in ToolService
- cover invalid quantities with unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ebe7237608324bdcba0faa64b80e6