### PR TITLE
Ensure unique usernames when adding users

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -153,6 +153,63 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public void AddUserCommand_SkipsExistingNameFromService()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IUserService userService = new UserService(db, new ApplicationUserContext());
+                // Pre-populate the database with a user named "user1"
+                userService.AddUser(new User { UserName = "user1", Password = "pw" });
+
+                // The view model has not loaded users, so its local collection is empty
+                var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
+                vm.AddUserCommand.Execute(null);
+
+                // Ensure a second user was added with an incremented name
+                var all = userService.GetAllUsers();
+                Assert.Equal(2, all.Count);
+                Assert.Contains(all, u => u.UserName == "user2");
+                Assert.Single(vm.Users);
+                Assert.Equal("user2", vm.Users.First().UserName);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void AddUserCommand_FindsFirstAvailableNumber()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IUserService userService = new UserService(db, new ApplicationUserContext());
+                // Create a gap: user1 and user3 exist
+                userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                userService.AddUser(new User { UserName = "user3", Password = "pw" });
+
+                var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
+                vm.AddUserCommand.Execute(null);
+
+                var all = userService.GetAllUsers();
+                Assert.Equal(3, all.Count);
+                Assert.Contains(all, u => u.UserName == "user2");
+                Assert.Single(vm.Users);
+                Assert.Equal("user2", vm.Users.First().UserName);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public void ResetPasswordFromRowCommand_ChangesPassword()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -114,7 +114,22 @@ namespace ToolManagementAppV2.ViewModels
 
         public void AddUser()
         {
-            var newUser = new UserModel { UserName = $"user{Users.Count + 1}" };
+            // Determine the next available user name by querying the service
+            // for all existing names and incrementing the suffix until an
+            // unused value is found. This avoids collisions even if the
+            // local collection is out of date.
+            var existingNames = new HashSet<string>(
+                _userService.GetAllUsers().Select(u => u.UserName),
+                StringComparer.OrdinalIgnoreCase);
+
+            var idx = 1;
+            string name;
+            do
+            {
+                name = $"user{idx++}";
+            } while (existingNames.Contains(name));
+
+            var newUser = new UserModel { UserName = name };
 
             if (!TryPromptForPassword(newUser, out var entered))
                 return;


### PR DESCRIPTION
## Summary
- Ensure AddUser consults IUserService and increments user name until an unused one is found
- Add unit tests covering name collision and gap scenarios

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ebe77ad588324808bf77b1a3ad957