### PR TITLE
Add user security column tests

### DIFF
--- a/ToolManagementAppV2.Tests/Services/DatabaseColumnDefaultsTests.cs
+++ b/ToolManagementAppV2.Tests/Services/DatabaseColumnDefaultsTests.cs
@@ -46,5 +46,45 @@ namespace ToolManagementAppV2.Tests.Services
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void UserColumnsBackfilledWithDefaults()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                using (var conn = new SQLiteConnection($"Data Source={dbPath};Version=3;"))
+                {
+                    conn.Open();
+                    using var cmd = new SQLiteCommand(@"CREATE TABLE Users (
+                            UserID INTEGER PRIMARY KEY AUTOINCREMENT,
+                            UserName TEXT NOT NULL
+                        );
+                        INSERT INTO Users (UserName) VALUES ('user1');", conn);
+                    cmd.ExecuteNonQuery();
+                }
+
+                var service = new DatabaseService(dbPath);
+
+                using var conn2 = service.CreateConnection();
+                using (var cmdCheck = new SQLiteCommand("SELECT FailedAttempts, LockoutUntil, PasswordExpired FROM Users", conn2))
+                using (var reader = cmdCheck.ExecuteReader())
+                {
+                    Assert.True(reader.Read());
+                    Assert.Equal(0, reader.GetInt32(0));
+                    Assert.True(reader.IsDBNull(1));
+                    Assert.Equal(0, reader.GetInt32(2));
+                }
+
+                using var cmdNulls = new SQLiteCommand("SELECT COUNT(*) FROM Users WHERE FailedAttempts IS NULL OR PasswordExpired IS NULL", conn2);
+                var nullCount = Convert.ToInt32(cmdNulls.ExecuteScalar());
+                Assert.Equal(0, nullCount);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -58,6 +58,7 @@ namespace ToolManagementAppV2.Services.Core
             EnsureColumn("Users", "Role", "TEXT");
             EnsureColumn("Users", "IsActive", "INTEGER", "1");
             EnsureColumn("Users", "CreatedAt", "DATETIME");
+            // Security-related columns for login tracking
             EnsureColumn("Users", "FailedAttempts", "INTEGER", "0");
             EnsureColumn("Users", "LockoutUntil", "DATETIME");
             EnsureColumn("Users", "PasswordExpired", "INTEGER", "0");


### PR DESCRIPTION
## Summary
- document new security-related columns on Users table
- test migration backfills for FailedAttempts, LockoutUntil and PasswordExpired

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ebe7d74508324aad3e03746380bb4