### PR TITLE
Handle CSV headers asynchronously

### DIFF
--- a/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
@@ -38,8 +38,8 @@ namespace ToolManagementAppV2.Tests.Views
 
                         Assert.Equal(vm.ImportToolsCommand, importBtn.Command);
                         var asyncCmd = (CommunityToolkit.Mvvm.Input.IAsyncRelayCommand)importBtn.Command;
-                        asyncCmd.Execute(null);
-                        asyncCmd.ExecutionTask!.Wait();
+                        var task = asyncCmd.ExecuteAsync(null);
+                        task.GetAwaiter().GetResult();
                         Assert.True(toolSvc.ImportCalled);
                         Assert.Single(vm.ImportExportLogs);
                     }

--- a/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
@@ -11,6 +11,7 @@ using System.Runtime.Serialization;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Tests;
 using CommunityToolkit.Mvvm.Input;
+using System.Threading.Tasks;
 
 namespace ToolManagementAppV2.Tests.Views
 {
@@ -40,10 +41,10 @@ namespace ToolManagementAppV2.Tests.Views
                         Assert.NotNull(keyBinding);
 
                         var asyncCommand = Assert.IsAssignableFrom<IAsyncRelayCommand>(keyBinding.Command);
-                        asyncCommand.Execute(null);
+                        var task = asyncCommand.ExecuteAsync(null);
 
                         var frame = new DispatcherFrame();
-                        asyncCommand.ExecutionTask!.ContinueWith(_ => frame.Continue = false);
+                        task.ContinueWith(_ => frame.Continue = false);
                         Dispatcher.PushFrame(frame);
 
                         Assert.Equal(string.Empty, vm.GlobalSearchText);

--- a/ToolManagementAppV2/Services/Core/CsvHelper.cs
+++ b/ToolManagementAppV2/Services/Core/CsvHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.VisualBasic.FileIO;
 using System.Linq;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Models.ImportExport;
 
@@ -16,6 +17,15 @@ namespace ToolManagementAppV2.Utilities.IO
             parser.SetDelimiters(",");
             parser.HasFieldsEnclosedInQuotes = true;
             return parser.EndOfData ? Array.Empty<string>() : parser.ReadFields().Select(h => h.Trim());
+        }
+
+        public static async Task<IEnumerable<string>> ReadHeadersAsync(string filePath)
+        {
+            using var parser = new TextFieldParser(filePath);
+            parser.SetDelimiters(",");
+            parser.HasFieldsEnclosedInQuotes = true;
+            return await Task.Run(() =>
+                parser.EndOfData ? Array.Empty<string>() : parser.ReadFields().Select(h => h.Trim()));
         }
 
         public static List<ToolModel> LoadToolsFromCsv(string filePath, IDictionary<string, string> map, out List<int> invalidRows)

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -66,7 +66,7 @@ namespace ToolManagementAppV2.ViewModels
             if (string.IsNullOrEmpty(path)) return;
             try
             {
-                var headers = CsvHelperUtil.ReadHeaders(path);
+                var headers = await CsvHelperUtil.ReadHeadersAsync(path);
                 var properties = typeof(ToolImportDto).GetProperties().Select(p => p.Name);
                 var map = _dialogService.ShowImportMapping(headers, properties);
                 if (map == null)

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -309,7 +309,7 @@ namespace ToolManagementAppV2.ViewModels
                 if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
                     return;
 
-                var headers = CsvHelperUtil.ReadHeaders(path).ToList();
+                var headers = (await CsvHelperUtil.ReadHeadersAsync(path)).ToList();
                 var properties = typeof(ToolModel)
                                     .GetProperties()
                                     .Select(p => p.Name)


### PR DESCRIPTION
## Summary
- Read CSV headers on a background thread with `TextFieldParser`
- Consume the async header reader in import commands
- Update UI tests to await async relay commands

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec20f1f2c83249947967837767b36