### PR TITLE
Handle tool deletion errors

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -550,6 +550,52 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
+        public void DeleteTool_WhenSqlFails_Throws()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                using (var conn = dbService.CreateConnection())
+                using (var cmd = new SQLiteCommand("DROP TABLE Tools;", conn))
+                {
+                    cmd.ExecuteNonQuery();
+                }
+
+                var svc = new ToolService(dbService);
+                var ex = Assert.Throws<InvalidOperationException>(() => svc.DeleteTool(1));
+                Assert.Contains("Failed to delete tool 1", ex.Message);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteToolAsync_WhenSqlFails_Throws()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                using (var conn = dbService.CreateConnection())
+                using (var cmd = new SQLiteCommand("DROP TABLE Tools;", conn))
+                {
+                    cmd.ExecuteNonQuery();
+                }
+
+                var svc = new ToolService(dbService);
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => svc.DeleteToolAsync(1));
+                Assert.Contains("Failed to delete tool 1", ex.Message);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public void AddTool_ConcurrentAdds_Succeeds()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -199,8 +199,16 @@ namespace ToolManagementAppV2.Services.Tools
         public void DeleteTool(int toolID)
         {
             using var conn = _dbService.CreateConnection();
-            SqliteHelper.ExecuteNonQuery(conn, "DELETE FROM Tools WHERE ToolID=@ID",
-                new[] { new SQLiteParameter("@ID", toolID) });
+            try
+            {
+                SqliteHelper.ExecuteNonQuery(conn, "DELETE FROM Tools WHERE ToolID=@ID",
+                    new[] { new SQLiteParameter("@ID", toolID) });
+            }
+            catch (SQLiteException ex)
+            {
+                _logger.LogError(ex, "Failed to delete tool {ToolID}", toolID);
+                throw new InvalidOperationException($"Failed to delete tool {toolID}.", ex);
+            }
         }
     
         public void ToggleToolCheckOutStatus(int toolID, string currentUser)
@@ -538,8 +546,16 @@ namespace ToolManagementAppV2.Services.Tools
         public async Task DeleteToolAsync(int toolID)
         {
             using var conn = _dbService.CreateConnection();
-            await SqliteHelper.ExecuteNonQueryAsync(conn, "DELETE FROM Tools WHERE ToolID=@ID",
-                new[] { new SQLiteParameter("@ID", toolID) });
+            try
+            {
+                await SqliteHelper.ExecuteNonQueryAsync(conn, "DELETE FROM Tools WHERE ToolID=@ID",
+                    new[] { new SQLiteParameter("@ID", toolID) });
+            }
+            catch (SQLiteException ex)
+            {
+                _logger.LogError(ex, "Failed to delete tool {ToolID}", toolID);
+                throw new InvalidOperationException($"Failed to delete tool {toolID}.", ex);
+            }
         }
 
         public async Task<ToolModel> GetToolByIDAsync(int toolID)


### PR DESCRIPTION
## Summary
- add error handling for tool deletion with logging
- cover deletion failure scenarios in tests

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ec212e1e883248b6b28dd26f2b3b7