### PR TITLE
Implement asynchronous CSV export for tools

### DIFF
--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -372,6 +372,7 @@ namespace ToolManagementAppV2.Tests.Services
             public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
             public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
             public void ExportToolsToCsv(string filePath) => throw new NotImplementedException();
+            public Task ExportToolsToCsvAsync(string filePath) => Task.CompletedTask;
             public List<ToolModel> GetAllTools() => new();
             public void AddTool(ToolModel tool) => throw new NotImplementedException();
             public void UpdateTool(ToolModel tool) => throw new NotImplementedException();

--- a/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
@@ -146,5 +146,30 @@ public class CsvImportTests
             if (File.Exists(dbPath)) File.Delete(dbPath);
         }
     }
+
+    [Fact]
+    public async System.Threading.Tasks.Task ExportToolsToCsvAsync_WritesExpectedFile()
+    {
+        var dbPath = Path.GetTempFileName();
+        var csvPath = Path.GetTempFileName();
+        try
+        {
+            using var db = new DatabaseService(dbPath);
+            var service = new ToolService(db);
+            service.AddTool(new ToolModel { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 5, IsPowerTool = true });
+
+            await service.ExportToolsToCsvAsync(csvPath);
+
+            var lines = await File.ReadAllLinesAsync(csvPath);
+            Assert.True(lines.Length > 1);
+            Assert.Equal("ToolNumber,NameDescription,Location,Brand,PartNumber,Supplier,PurchasedDate,Notes,AvailableQuantity,IsPowerTool", lines[0]);
+            Assert.Contains("T1", lines[1]);
+        }
+        finally
+        {
+            if (File.Exists(csvPath)) File.Delete(csvPath);
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
 }
 

--- a/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -113,6 +113,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             return System.Threading.Tasks.Task.FromResult(new List<int>());
         }
         public void ExportToolsToCsv(string filePath) { }
+        public System.Threading.Tasks.Task ExportToolsToCsvAsync(string filePath) => System.Threading.Tasks.Task.CompletedTask;
         public List<ToolModel> GetAllTools() => new();
         public void AddTool(ToolModel tool) => throw new NotImplementedException();
         public void UpdateTool(ToolModel tool) => throw new NotImplementedException();
@@ -164,6 +165,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public System.Threading.Tasks.Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map)
             => System.Threading.Tasks.Task.FromResult(new List<int>());
         public void ExportToolsToCsv(string filePath) { }
+        public System.Threading.Tasks.Task ExportToolsToCsvAsync(string filePath) => System.Threading.Tasks.Task.CompletedTask;
         public List<ToolModel> GetAllTools() => new();
         public void AddTool(ToolModel tool) => throw new NotImplementedException();
         public void UpdateTool(ToolModel tool) => throw new NotImplementedException();

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -59,12 +59,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void ImportExportViewModel_ExportToolsCommand_LogsSuccess()
+        public async Task ImportExportViewModel_ExportToolsCommand_LogsSuccess()
         {
             var toolService = new StubToolService();
             var customerService = new StubCustomerService();
             var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
-            vm.ExportToolsCommand.Execute(null);
+            await vm.ExportToolsCommand.ExecuteAsync(null);
             Assert.True(toolService.ExportCalled);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Successfully exported tools", vm.ImportExportLogs[0]);
@@ -138,12 +138,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void ImportExportViewModel_ExportToolsCommand_LogsFailure()
+        public async Task ImportExportViewModel_ExportToolsCommand_LogsFailure()
         {
             var toolService = new FailToolService();
             var customerService = new StubCustomerService();
             var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
-            vm.ExportToolsCommand.Execute(null);
+            await vm.ExportToolsCommand.ExecuteAsync(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Failed to export tools", vm.ImportExportLogs[0]);
         }
@@ -242,6 +242,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             return Task.FromResult(new List<int>());
         }
         public void ExportToolsToCsv(string filePath) => ExportCalled = true;
+        public Task ExportToolsToCsvAsync(string filePath) { ExportCalled = true; return Task.CompletedTask; }
         public List<ToolModel> GetAllTools() => new();
         public void AddTool(ToolModel tool) => throw new System.NotImplementedException();
         public void UpdateTool(ToolModel tool) => throw new System.NotImplementedException();
@@ -260,6 +261,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => throw new System.Exception("fail");
         public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map) => Task.FromException<List<int>>(new System.Exception("fail"));
         public void ExportToolsToCsv(string filePath) => throw new System.Exception("fail");
+        public Task ExportToolsToCsvAsync(string filePath) => Task.FromException(new System.Exception("fail"));
         public List<ToolModel> GetAllTools() => new();
         public void AddTool(ToolModel tool) => throw new System.NotImplementedException();
         public void UpdateTool(ToolModel tool) => throw new System.NotImplementedException();

--- a/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
@@ -109,6 +109,7 @@ namespace ToolManagementAppV2.Tests.Views
             return System.Threading.Tasks.Task.FromResult(new System.Collections.Generic.List<int>());
         }
         public void ExportToolsToCsv(string filePath) { }
+        public System.Threading.Tasks.Task ExportToolsToCsvAsync(string filePath) => System.Threading.Tasks.Task.CompletedTask;
         public System.Collections.Generic.List<ToolModel> GetAllTools() => new();
         public void AddTool(ToolModel tool) => throw new NotImplementedException();
         public void UpdateTool(ToolModel tool) => throw new NotImplementedException();

--- a/ToolManagementAppV2/Services/Core/CsvHelper.cs
+++ b/ToolManagementAppV2/Services/Core/CsvHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using Microsoft.VisualBasic.FileIO;
 using System.Linq;
 using ToolManagementAppV2.Models.Domain;
@@ -79,6 +80,27 @@ namespace ToolManagementAppV2.Utilities.IO
                     Quote(t.QuantityOnHand.ToString()),
                     Quote(t.IsPowerTool ? "1" : "0"))));
             File.WriteAllLines(filePath, lines);
+        }
+
+        public static Task ExportToolsToCsvAsync(string filePath, List<ToolModel> tools)
+        {
+            var lines = new List<string>
+            {
+                "ToolNumber,NameDescription,Location,Brand,PartNumber,Supplier,PurchasedDate,Notes,AvailableQuantity,IsPowerTool"
+            };
+            lines.AddRange(tools.Select(t =>
+                string.Join(",",
+                    Quote(t.ToolNumber),
+                    Quote(t.NameDescription),
+                    Quote(t.Location),
+                    Quote(t.Brand),
+                    Quote(t.PartNumber),
+                    Quote(t.Supplier),
+                    Quote(t.PurchasedDate?.ToString("yyyy-MM-dd")),
+                    Quote(t.Notes),
+                    Quote(t.QuantityOnHand.ToString()),
+                    Quote(t.IsPowerTool ? "1" : "0"))));
+            return File.WriteAllLinesAsync(filePath, lines);
         }
 
         public static List<CustomerModel> LoadCustomersFromCsv(string filePath, IDictionary<string, string> map)

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -637,10 +637,10 @@ namespace ToolManagementAppV2.Services.Tools
         public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map)
             => Task.FromResult(ImportToolsFromCsv(filePath, map));
 
-        public Task ExportToolsToCsvAsync(string filePath)
+        public async Task ExportToolsToCsvAsync(string filePath)
         {
-            ExportToolsToCsv(filePath);
-            return Task.CompletedTask;
+            var tools = GetAllTools();
+            await CsvHelperUtil.ExportToolsToCsvAsync(filePath, tools);
         }
 
         public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector)

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -25,7 +25,7 @@ namespace ToolManagementAppV2.ViewModels
         private readonly ILogger<ImportExportViewModel> _logger;
 
         public IAsyncRelayCommand ImportToolsCommand { get; }
-        public IRelayCommand ExportToolsCommand { get; }
+        public IAsyncRelayCommand ExportToolsCommand { get; }
         public IRelayCommand ImportCustomersCommand { get; }
         public IRelayCommand ExportCustomersCommand { get; }
 
@@ -54,7 +54,7 @@ namespace ToolManagementAppV2.ViewModels
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<ImportExportViewModel>.Instance;
             ImportToolsCommand = new AsyncRelayCommand(ImportToolsAsync);
-            ExportToolsCommand = new RelayCommand(ExportTools);
+            ExportToolsCommand = new AsyncRelayCommand(ExportToolsAsync);
             ImportCustomersCommand = new RelayCommand(ImportCustomers);
             ExportCustomersCommand = new RelayCommand(ExportCustomers);
             BackupDatabaseCommand = new AsyncRelayCommand(BackupDatabaseAsync);
@@ -85,13 +85,13 @@ namespace ToolManagementAppV2.ViewModels
             _dialogService.ShowInfo($"Successfully imported tools from {path}.", "Import Tools");
         }
 
-        void ExportTools()
+        async Task ExportToolsAsync()
         {
             var path = _fileDialogService.SaveFile("CSV Files|*.csv");
             if (string.IsNullOrEmpty(path)) return;
             try
             {
-                _toolService.ExportToolsToCsv(path);
+                await _toolService.ExportToolsToCsvAsync(path);
                 ImportExportLogs.Add($"Successfully exported tools to {path}.");
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- add async CSV export helper and service method using File.WriteAllLinesAsync
- call asynchronous export from ImportExportViewModel via IAsyncRelayCommand
- test CSV export path using ExportToolsToCsvAsync

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden for package sources)*

------
https://chatgpt.com/codex/tasks/task_e_689ec212f51083248a49acd174823292