### PR TITLE
fix: await tasks in report summary to avoid deadlock

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Documents;
+using Xunit;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Services.Customers;
+
+namespace ToolManagementAppV2.Tests.Services
+{
+    public class ReportServiceTests
+    {
+        [Fact]
+        public void GenerateSummaryReportAsync_DoesNotDeadlock()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(db, userContext);
+                var rentalService = new RentalService(db, toolService);
+                var activityLogService = new ActivityLogService(db);
+                var reportService = new ReportService(toolService, rentalService, activityLogService, customerService, userService);
+
+                var tool = new Tool
+                {
+                    ToolNumber = "T1",
+                    NameDescription = "Hammer",
+                    Location = "Loc",
+                    Brand = "Brand",
+                    PartNumber = "PN",
+                    QuantityOnHand = 1,
+                    RentedQuantity = 0
+                };
+                toolService.AddTool(tool);
+
+                var customer = new Customer
+                {
+                    Company = "Comp",
+                    Contact = "John",
+                    Phone = "123",
+                    Email = "john@example.com",
+                    Address = "Addr"
+                };
+                customerService.AddCustomer(customer);
+
+                var user = new User
+                {
+                    UserName = "user",
+                    Password = "pass",
+                    IsAdmin = false
+                };
+                userService.AddUser(user);
+
+                rentalService.RentTool(tool.ToolID, customer.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+
+                var task = reportService.GenerateSummaryReportAsync();
+                Assert.True(task.Wait(TimeSpan.FromSeconds(5)), "GenerateSummaryReportAsync deadlocked.");
+                var doc = task.Result;
+                var text = new TextRange(doc.ContentStart, doc.ContentEnd).Text;
+                Assert.Contains("Total Tools: 1", text);
+                Assert.Contains("Total Rentals (History): 1", text);
+                Assert.Contains("Active Rentals: 1", text);
+                Assert.Contains("Total Customers: 1", text);
+                Assert.Contains("Total Users: 1", text);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/Services/Tools/ReportService.cs
+++ b/ToolManagementAppV2/Services/Tools/ReportService.cs
@@ -173,15 +173,19 @@ namespace ToolManagementAppV2.Services.Tools
             var totalCustomersTask = _customerService.GetAllCustomersAsync();
             var totalUsersTask = _userService.GetAllUsersAsync();
 
-            await Task.WhenAll(totalToolsTask, totalRentalsTask, totalActiveRentalsTask, totalCustomersTask, totalUsersTask);
+            var totalTools = await totalToolsTask;
+            var totalRentals = await totalRentalsTask;
+            var totalActiveRentals = await totalActiveRentalsTask;
+            var totalCustomers = await totalCustomersTask;
+            var totalUsers = await totalUsersTask;
 
             var lines = new[]
             {
-                $"Total Tools: {totalToolsTask.Result.Count}",
-                $"Total Rentals (History): {totalRentalsTask.Result.Count}",
-                $"Active Rentals: {totalActiveRentalsTask.Result.Count}",
-                $"Total Customers: {totalCustomersTask.Result.Count}",
-                $"Total Users: {totalUsersTask.Result.Count}"
+                $"Total Tools: {totalTools.Count}",
+                $"Total Rentals (History): {totalRentals.Count}",
+                $"Active Rentals: {totalActiveRentals.Count}",
+                $"Total Customers: {totalCustomers.Count}",
+                $"Total Users: {totalUsers.Count}"
             };
 
             return BuildReport("Application Summary Report", lines);


### PR DESCRIPTION
## Summary
- await report summary tasks and use awaited results
- add ReportServiceTests to ensure GenerateSummaryReportAsync completes without deadlock

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec659a36c8324b7f14e9319ce2177