### PR TITLE
Load users asynchronously on login

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
@@ -17,7 +18,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     public class LoginViewModelTests
     {
         [Fact]
-        public void SelectUserCommand_SetsCurrentUser()
+        public async Task SelectUserCommand_SetsCurrentUser()
         {
             if (Application.Current == null)
                 new Application();
@@ -32,6 +33,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 userService.AddUser(new User { UserName = "user", Password = "newpassword", IsAdmin = false });
 
                 var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext);
+                await vm.LoadUsersCommand.ExecuteAsync(null);
                 bool success = false;
                 vm.LoginSucceeded += (_, __) => success = true;
 
@@ -48,7 +50,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void SelectUserCommand_PromptsForPasswordChange_WhenExpired()
+        public async Task SelectUserCommand_PromptsForPasswordChange_WhenExpired()
         {
             if (Application.Current == null)
                 new Application();
@@ -67,6 +69,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 {
                     PromptForNewPassword = () => "changed"
                 };
+                await vm.LoadUsersCommand.ExecuteAsync(null);
                 bool success = false;
                 vm.LoginSucceeded += (_, __) => success = true;
 

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media.Imaging;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Settings;
@@ -50,6 +51,8 @@ namespace ToolManagementAppV2.ViewModels
         /// </summary>
         public ICommand SelectUserCommand { get; }
 
+        public IAsyncRelayCommand LoadUsersCommand { get; }
+
         /// <summary>
         /// Raised after <see cref="OnUserSelected"/> successfully authenticates a user
         /// and stores the result in <see cref="IUserContext"/>.
@@ -74,7 +77,8 @@ namespace ToolManagementAppV2.ViewModels
 
             SelectUserCommand = new RelayCommand<User>(OnUserSelected);
 
-            LoadUsers();
+            LoadUsersCommand = new AsyncRelayCommand(LoadUsersAsync);
+            LoadUsersCommand.Execute(null);
         }
 
         BitmapImage LoadLogo()
@@ -110,9 +114,9 @@ namespace ToolManagementAppV2.ViewModels
                 : "Tool Inventory Management – Login";
         }
 
-        void LoadUsers()
+        async Task LoadUsersAsync()
         {
-            var users = _userService.GetAllUsers();
+            var users = await _userService.GetAllUsersAsync();
             if (users.Count == 0)
             {
                 _dialogService.ShowInfo(
@@ -121,7 +125,7 @@ namespace ToolManagementAppV2.ViewModels
 
                 var admin = new User { UserName = "admin", Password = "admin", IsAdmin = true };
                 _userService.AddUser(admin);
-                users = _userService.GetAllUsers();
+                users = await _userService.GetAllUsersAsync();
             }
 
             Users.ReplaceRange(users);
@@ -184,7 +188,7 @@ namespace ToolManagementAppV2.ViewModels
                         user.Salt = refreshed.Salt;
                         user.PasswordExpired = refreshed.PasswordExpired;
                     }
-                    LoadUsers();
+                    LoadUsersCommand.Execute(null);
                     _dialogService.ShowInfo("Password has been reset to default. Please enter the new password to login.",
                         "Password Reset");
                     continue;


### PR DESCRIPTION
## Summary
- add LoadUsersCommand and asynchronous user loading in LoginViewModel
- refresh users after password reset using the async command
- adjust LoginViewModel tests to await async user loading

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec65db05c8324ac479d90627c3b24