### PR TITLE
Use async user service methods

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
@@ -19,7 +20,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     public class UserManagementViewModelTests
     {
         [Fact]
-        public void UpdateUserCommand_PersistsChanges()
+        public async Task UpdateUserCommand_PersistsChanges()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -28,10 +29,10 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
-                vm.LoadUsers();
+                await vm.LoadUsersAsync();
                 vm.SelectedUser = vm.Users.First();
                 vm.SelectedUser.Email = "test@example.com";
-                vm.UpdateUserCommand.Execute(null);
+                await vm.UpdateUserCommand.ExecuteAsync(null);
                 var updated = userService.GetAllUsers().First();
                 Assert.Equal("test@example.com", updated.Email);
                 var field = typeof(UserManagementViewModel).GetField("_allUsers", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -47,7 +48,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void UploadUserPhotoCommand_SetsPhotoPathAndPersists()
+        public async Task UploadUserPhotoCommand_SetsPhotoPathAndPersists()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -57,9 +58,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var fileSvc = new StubFileDialogService { FileToReturn = "path/to/image.png" };
                 var vm = new UserManagementViewModel(userService, fileSvc, new StubDialogService());
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
-                vm.LoadUsers();
+                await vm.LoadUsersAsync();
                 vm.SelectedUser = vm.Users.First();
-                vm.UploadUserPhotoCommand.Execute(null);
+                await vm.UploadUserPhotoCommand.ExecuteAsync(null);
                 var updated = userService.GetAllUsers().First();
                 Assert.Equal("path/to/image.png", updated.UserPhotoPath);
                 var field = typeof(UserManagementViewModel).GetField("_allUsers", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -75,7 +76,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void UpdateUserAndUploadPhoto_UpdateCollections()
+        public async Task UpdateUserAndUploadPhoto_UpdateCollections()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -85,13 +86,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var fileSvc = new StubFileDialogService { FileToReturn = "img.png" };
                 var vm = new UserManagementViewModel(userService, fileSvc, new StubDialogService());
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
-                vm.LoadUsers();
+                await vm.LoadUsersAsync();
                 vm.SelectedUser = vm.Users.First();
 
                 vm.SelectedUser.Email = "test@example.com";
-                vm.UpdateUserCommand.Execute(null);
+                await vm.UpdateUserCommand.ExecuteAsync(null);
 
-                vm.UploadUserPhotoCommand.Execute(null);
+                await vm.UploadUserPhotoCommand.ExecuteAsync(null);
 
                 var field = typeof(UserManagementViewModel).GetField("_allUsers", BindingFlags.NonPublic | BindingFlags.Instance);
                 var allUsers = (System.Collections.Generic.List<User>)field!.GetValue(vm);
@@ -109,7 +110,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void CommandsDisabledWhenNoUserSelected()
+        public async Task CommandsDisabledWhenNoUserSelected()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -118,7 +119,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
-                vm.LoadUsers();
+                await vm.LoadUsersAsync();
                 Assert.False(vm.UpdateUserCommand.CanExecute(null));
                 Assert.False(vm.EditUserCommand.CanExecute(null));
                 vm.SelectedUser = vm.Users.First();
@@ -133,7 +134,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void AddUserCommand_AddsUser()
+        public async Task AddUserCommand_AddsUser()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -141,7 +142,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
-                vm.AddUserCommand.Execute(null);
+                await vm.AddUserCommand.ExecuteAsync(null);
                 Assert.Single(vm.Users);
                 Assert.Single(userService.GetAllUsers());
             }
@@ -153,7 +154,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void AddUserCommand_SkipsExistingNameFromService()
+        public async Task AddUserCommand_SkipsExistingNameFromService()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -165,7 +166,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 // The view model has not loaded users, so its local collection is empty
                 var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
-                vm.AddUserCommand.Execute(null);
+                await vm.AddUserCommand.ExecuteAsync(null);
 
                 // Ensure a second user was added with an incremented name
                 var all = userService.GetAllUsers();
@@ -182,7 +183,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void AddUserCommand_FindsFirstAvailableNumber()
+        public async Task AddUserCommand_FindsFirstAvailableNumber()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -194,7 +195,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 userService.AddUser(new User { UserName = "user3", Password = "pw" });
 
                 var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
-                vm.AddUserCommand.Execute(null);
+                await vm.AddUserCommand.ExecuteAsync(null);
 
                 var all = userService.GetAllUsers();
                 Assert.Equal(3, all.Count);
@@ -210,7 +211,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void ResetPasswordFromRowCommand_ChangesPassword()
+        public async Task ResetPasswordFromRowCommand_ChangesPassword()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -220,7 +221,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var dialog = new StubDialogService();
                 var vm = new UserManagementViewModel(userService, new StubFileDialogService(), dialog);
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
-                vm.LoadUsers();
+                await vm.LoadUsersAsync();
                 var user = vm.Users.First();
                 var original = userService.GetUserByID(user.UserID)!;
                 var oldPwd = original.Password;
@@ -241,7 +242,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void SearchAndClearUsers_WorkAsExpected()
+        public async Task SearchAndClearUsers_WorkAsExpected()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -251,7 +252,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
                 userService.AddUser(new User { UserName = "alice", Password = "pw" });
                 userService.AddUser(new User { UserName = "bob", Password = "pw" });
-                vm.LoadUsers();
+                await vm.LoadUsersAsync();
 
                 vm.UserSearchText = "alice";
                 vm.SearchUsersCommand.Execute(null);
@@ -269,7 +270,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void DeleteUserFromRowCommand_RemovesUser()
+        public async Task DeleteUserFromRowCommand_RemovesUser()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -279,7 +280,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
                 userService.AddUser(new User { UserName = "user2", Password = "pw" });
-                vm.LoadUsers();
+                await vm.LoadUsersAsync();
                 var toDelete = vm.Users.First();
                 vm.DeleteUserFromRowCommand.Execute(toDelete);
                 Assert.Single(vm.Users);
@@ -293,7 +294,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void AddUserCommand_CancelledPrompt_DoesNotAddUser()
+        public async Task AddUserCommand_CancelledPrompt_DoesNotAddUser()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -301,7 +302,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var vm = new CancelPromptUserManagementViewModel(userService, new StubFileDialogService());
-                vm.AddUserCommand.Execute(null);
+                await vm.AddUserCommand.ExecuteAsync(null);
                 Assert.Empty(vm.Users);
                 Assert.Empty(userService.GetAllUsers());
             }

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Extensions;
 using ToolManagementAppV2.Utilities.Helpers;
@@ -39,16 +40,16 @@ namespace ToolManagementAppV2.ViewModels
             {
                 if (SetProperty(ref _selectedUser, value))
                 {
-                    ((RelayCommand)UpdateUserCommand).NotifyCanExecuteChanged();
+                    ((AsyncRelayCommand)UpdateUserCommand).NotifyCanExecuteChanged();
                     ((RelayCommand)EditUserCommand).NotifyCanExecuteChanged();
                 }
             }
         }
 
-        public IRelayCommand LoadUsersCommand { get; }
-        public IRelayCommand UploadUserPhotoCommand { get; }
-        public IRelayCommand UpdateUserCommand { get; }
-        public IRelayCommand AddUserCommand { get; }
+        public IAsyncRelayCommand LoadUsersCommand { get; }
+        public IAsyncRelayCommand UploadUserPhotoCommand { get; }
+        public IAsyncRelayCommand UpdateUserCommand { get; }
+        public IAsyncRelayCommand AddUserCommand { get; }
 
         public IRelayCommand SearchUsersCommand { get; }
         public IRelayCommand ClearUserSearchCommand { get; }
@@ -67,10 +68,10 @@ namespace ToolManagementAppV2.ViewModels
             _fileDialogService = fileDialogService;
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<UserManagementViewModel>.Instance;
-            LoadUsersCommand = new RelayCommand(LoadUsers);
-            UploadUserPhotoCommand = new RelayCommand(UploadUserPhoto);
-            UpdateUserCommand = new RelayCommand(UpdateUser, () => SelectedUser != null);
-            AddUserCommand = new RelayCommand(AddUser);
+            LoadUsersCommand = new AsyncRelayCommand(LoadUsersAsync);
+            UploadUserPhotoCommand = new AsyncRelayCommand(UploadUserPhotoAsync);
+            UpdateUserCommand = new AsyncRelayCommand(UpdateUserAsync, () => SelectedUser != null);
+            AddUserCommand = new AsyncRelayCommand(AddUserAsync);
 
             SearchUsersCommand = new RelayCommand(SearchUsers);
             ClearUserSearchCommand = new RelayCommand(ClearUserSearch);
@@ -81,46 +82,76 @@ namespace ToolManagementAppV2.ViewModels
             DeleteUserFromRowCommand = new RelayCommand<UserModel>(DeleteUser);
         }
 
-        public void LoadUsers()
+        public async Task LoadUsersAsync()
         {
-            _allUsers = _userService.GetAllUsers();
-            Users.ReplaceRange(_allUsers);
+            try
+            {
+                _allUsers = await _userService.GetAllUsersAsync();
+                Users.ReplaceRange(_allUsers);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load users");
+            }
         }
 
-        public void UploadUserPhoto()
+        public async Task UploadUserPhotoAsync()
         {
             if (SelectedUser == null) return;
             var path = _fileDialogService.OpenFile("Image Files|*.png;*.jpg;*.jpeg;*.bmp|All Files|*.*");
             if (!string.IsNullOrEmpty(path))
             {
                 SelectedUser.UserPhotoPath = path;
-                _userService.UpdateUser(SelectedUser);
+                try
+                {
+                    await _userService.UpdateUserAsync(SelectedUser);
+                    var idxAll = _allUsers.IndexOf(SelectedUser);
+                    if (idxAll >= 0) _allUsers[idxAll] = SelectedUser;
+                    var idx = Users.IndexOf(SelectedUser);
+                    if (idx >= 0) Users[idx] = SelectedUser;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to update user photo");
+                }
+            }
+        }
+
+        public async Task UpdateUserAsync()
+        {
+            if (SelectedUser == null) return;
+            try
+            {
+                await _userService.UpdateUserAsync(SelectedUser);
                 var idxAll = _allUsers.IndexOf(SelectedUser);
                 if (idxAll >= 0) _allUsers[idxAll] = SelectedUser;
                 var idx = Users.IndexOf(SelectedUser);
                 if (idx >= 0) Users[idx] = SelectedUser;
             }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to update user");
+            }
         }
 
-        public void UpdateUser()
-        {
-            if (SelectedUser == null) return;
-            _userService.UpdateUser(SelectedUser);
-            var idxAll = _allUsers.IndexOf(SelectedUser);
-            if (idxAll >= 0) _allUsers[idxAll] = SelectedUser;
-            var idx = Users.IndexOf(SelectedUser);
-            if (idx >= 0) Users[idx] = SelectedUser;
-        }
-
-        public void AddUser()
+        public async Task AddUserAsync()
         {
             // Determine the next available user name by querying the service
             // for all existing names and incrementing the suffix until an
             // unused value is found. This avoids collisions even if the
             // local collection is out of date.
-            var existingNames = new HashSet<string>(
-                _userService.GetAllUsers().Select(u => u.UserName),
-                StringComparer.OrdinalIgnoreCase);
+            HashSet<string> existingNames;
+            try
+            {
+                existingNames = new HashSet<string>(
+                    (await _userService.GetAllUsersAsync()).Select(u => u.UserName),
+                    StringComparer.OrdinalIgnoreCase);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve existing users");
+                return;
+            }
 
             var idx = 1;
             string name;
@@ -148,10 +179,17 @@ namespace ToolManagementAppV2.ViewModels
                 newUser.Password = entered;
             }
 
-            _userService.AddUser(newUser);
-            _allUsers.Add(newUser);
-            Users.Add(newUser);
-            SelectedUser = newUser;
+            try
+            {
+                await _userService.AddUserAsync(newUser);
+                _allUsers.Add(newUser);
+                Users.Add(newUser);
+                SelectedUser = newUser;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to add user");
+            }
         }
 
         protected virtual bool TryPromptForPassword(UserModel newUser, out string password)
@@ -225,13 +263,20 @@ namespace ToolManagementAppV2.ViewModels
             win = new UsersEditWindow(clone,
                 onSave: () =>
                 {
-                    _userService.UpdateUser(clone);
-                    var idx = Users.IndexOf(user);
-                    if (idx >= 0) Users[idx] = clone;
-                    var idxAll = _allUsers.IndexOf(user);
-                    if (idxAll >= 0) _allUsers[idxAll] = clone;
-                    if (ReferenceEquals(SelectedUser, user)) SelectedUser = clone;
-                    win.DialogResult = true;
+                    try
+                    {
+                        _userService.UpdateUserAsync(clone).GetAwaiter().GetResult();
+                        var idx = Users.IndexOf(user);
+                        if (idx >= 0) Users[idx] = clone;
+                        var idxAll = _allUsers.IndexOf(user);
+                        if (idxAll >= 0) _allUsers[idxAll] = clone;
+                        if (ReferenceEquals(SelectedUser, user)) SelectedUser = clone;
+                        win.DialogResult = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to update user");
+                    }
                 },
                 onCancel: () => win.Close(),
                 onRemoveAvatar: () => clone.UserPhotoPath = null);


### PR DESCRIPTION
## Summary
- swap synchronous user service calls with async methods
- add logging around async user operations
- update UserManagementViewModel tests for async commands

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec6727c6c8324845def3fabbfc06d