### PR TITLE
Throw on user deletion failure

### DIFF
--- a/ToolManagementAppV2.Tests/Services/UserDeletionTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserDeletionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using ToolManagementAppV2.Models.Domain;
@@ -21,9 +22,7 @@ public class UserDeletionTests
             userService.AddUser(admin);
 
             var added = userService.GetAllUsers().First();
-            var result = userService.TryDeleteUser(added.UserID);
-
-            Assert.False(result, "Deletion should be blocked when user is the last admin.");
+            Assert.Throws<InvalidOperationException>(() => userService.DeleteUser(added.UserID));
             Assert.Single(userService.GetAllUsers());
         }
         finally

--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 public class UserServiceTests
 {
     [Fact]
-    public void TryDeleteUser_ReturnsFalse_WhenDeletingOnlyAdmin()
+    public void DeleteUser_ThrowsInvalidOperationException_WhenDeletingOnlyAdmin()
     {
         var dbPath = Path.GetTempFileName();
         try
@@ -19,8 +19,7 @@ public class UserServiceTests
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
             var admin = new User { UserName = "admin", Password = "pw", IsAdmin = true };
             userService.AddUser(admin);
-            var result = userService.TryDeleteUser(admin.UserID);
-            Assert.False(result);
+            Assert.Throws<InvalidOperationException>(() => userService.DeleteUser(admin.UserID));
             Assert.NotNull(userService.GetUserByID(admin.UserID));
         }
         finally
@@ -30,7 +29,7 @@ public class UserServiceTests
     }
 
     [Fact]
-    public void TryDeleteUser_AllowsDeletingAdmin_WhenMultipleAdminsExist()
+    public void DeleteUser_AllowsDeletingAdmin_WhenMultipleAdminsExist()
     {
         var dbPath = Path.GetTempFileName();
         try
@@ -41,8 +40,7 @@ public class UserServiceTests
             var admin2 = new User { UserName = "admin2", Password = "pw", IsAdmin = true };
             userService.AddUser(admin1);
             userService.AddUser(admin2);
-            var result = userService.TryDeleteUser(admin1.UserID);
-            Assert.True(result);
+            userService.DeleteUser(admin1.UserID);
             Assert.Null(userService.GetUserByID(admin1.UserID));
             Assert.NotNull(userService.GetUserByID(admin2.UserID));
         }

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -373,8 +373,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task UpdateUserAsync(User user) => Task.CompletedTask;
         public bool TryDeleteUser(int userID) => false;
         public Task<bool> TryDeleteUserAsync(int userID) => Task.FromResult(false);
-        public bool DeleteUser(int userID) => false;
-        public Task<bool> DeleteUserAsync(int userID) => Task.FromResult(false);
+        public void DeleteUser(int userID) { }
+        public Task DeleteUserAsync(int userID) => Task.CompletedTask;
         public bool ChangeUserPassword(int userID, string newPassword) => false;
         public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => Task.FromResult(false);
     }

--- a/ToolManagementAppV2/Interfaces/IUserService.cs
+++ b/ToolManagementAppV2/Interfaces/IUserService.cs
@@ -21,8 +21,8 @@ namespace ToolManagementAppV2.Interfaces
         Task UpdateUserAsync(User user);
         bool TryDeleteUser(int userID);
         Task<bool> TryDeleteUserAsync(int userID);
-        bool DeleteUser(int userID);
-        Task<bool> DeleteUserAsync(int userID);
+        void DeleteUser(int userID);
+        Task DeleteUserAsync(int userID);
         bool ChangeUserPassword(int userID, string newPassword);
         Task<bool> ChangeUserPasswordAsync(int userID, string newPassword);
     }

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -269,7 +269,11 @@ namespace ToolManagementAppV2.Services.Users
             return true;
         }
 
-        public bool DeleteUser(int userID) => TryDeleteUser(userID);
+        public void DeleteUser(int userID)
+        {
+            if (!TryDeleteUser(userID))
+                throw new InvalidOperationException($"Failed to delete user {userID}");
+        }
 
         void DeleteUserInternal(int userID)
         {
@@ -559,6 +563,10 @@ namespace ToolManagementAppV2.Services.Users
             return true;
         }
 
-        public Task<bool> DeleteUserAsync(int userID) => TryDeleteUserAsync(userID);
+        public async Task DeleteUserAsync(int userID)
+        {
+            if (!await TryDeleteUserAsync(userID))
+                throw new InvalidOperationException($"Failed to delete user {userID}");
+        }
     }
 }

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -259,11 +259,16 @@ namespace ToolManagementAppV2.ViewModels
         void DeleteUser(UserModel user)
         {
             if (user == null) return;
-            if (_userService.TryDeleteUser(user.UserID))
+            try
             {
+                _userService.DeleteUser(user.UserID);
                 _allUsers.Remove(user);
                 Users.Remove(user);
                 if (ReferenceEquals(SelectedUser, user)) SelectedUser = null;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to delete user {UserID}", user.UserID);
             }
         }
     }


### PR DESCRIPTION
## Summary
- make `DeleteUser` throw on failure and adjust interface
- handle deletion exceptions in `UserManagementViewModel`
- update tests for new deletion semantics

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ec67840d0832480da56af0fbf03ea