### PR TITLE
Handle scanner service errors

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
@@ -34,7 +34,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task RefreshCommand_PopulatesDevices()
         {
             var svc = new FakeScannerService();
-            var vm = new ScannerStatusViewModel(svc);
+            var vm = new ScannerStatusViewModel(svc, new StubDialogService());
             await vm.RefreshCommand.ExecuteAsync(null);
             Assert.Single(vm.Devices);
             Assert.Equal(1, svc.CallCount);
@@ -44,7 +44,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void AutoRefresh_TogglesTimer()
         {
             var svc = new FakeScannerService();
-            var vm = new ScannerStatusViewModel(svc);
+            var vm = new ScannerStatusViewModel(svc, new StubDialogService());
             vm.AutoRefresh = true;
             Assert.True(vm.IsTimerRunning);
             vm.AutoRefresh = false;
@@ -61,7 +61,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var settings = new SettingsService(db);
                 settings.SaveScannerIpAddresses(new[] { "127.0.0.1" });
                 var svc = new ScannerService(settings);
-                var vm = new ScannerStatusViewModel(svc);
+                var vm = new ScannerStatusViewModel(svc, new StubDialogService());
                 await vm.RefreshCommand.ExecuteAsync(null);
                 Assert.Single(vm.Devices);
                 Assert.Equal("127.0.0.1", vm.Devices[0].Ip);
@@ -71,5 +71,39 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 if (File.Exists(dbPath)) File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public async Task RefreshCommand_ShowsDialog_OnServiceFailure()
+        {
+            var svc = new ThrowingScannerService();
+            var dialog = new StubDialogService();
+            var vm = new ScannerStatusViewModel(svc, dialog);
+            await vm.RefreshCommand.ExecuteAsync(null);
+            Assert.True(dialog.InfoShown);
+            Assert.Empty(vm.Devices);
+        }
+    }
+
+    class ThrowingScannerService : IScannerService
+    {
+        public Task<IEnumerable<ScannerDevice>> GetScannerDevicesAsync(CancellationToken cancellationToken) => throw new InvalidOperationException("fail");
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public bool InfoShown;
+        public void ShowInfo(string message, string title) => InfoShown = true;
+        public bool ShowConfirmation(string message, string title) => false;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+        public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
     }
 }

--- a/ToolManagementAppV2/ViewModels/ScannerStatusViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ScannerStatusViewModel.cs
@@ -7,12 +7,16 @@ using System.Threading.Tasks;
 using System.Windows.Threading;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.ViewModels
 {
     public class ScannerStatusViewModel : ObservableObject
     {
         readonly IScannerService _service;
+        readonly IDialogService _dialogService;
+        readonly ILogger<ScannerStatusViewModel> _logger;
         readonly DispatcherTimer _timer;
 
         public ObservableCollection<ScannerDevice> Devices { get; } = new();
@@ -35,9 +39,11 @@ namespace ToolManagementAppV2.ViewModels
 
         internal bool IsTimerRunning => _timer.IsEnabled;
 
-        public ScannerStatusViewModel(IScannerService service)
+        public ScannerStatusViewModel(IScannerService service, IDialogService dialogService, ILogger<ScannerStatusViewModel>? logger = null)
         {
             _service = service;
+            _dialogService = dialogService;
+            _logger = logger ?? NullLogger<ScannerStatusViewModel>.Instance;
             RefreshCommand = new AsyncRelayCommand(RefreshAsync);
             _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
             _timer.Tick += async (s, e) => await RefreshAsync(CancellationToken.None);
@@ -45,10 +51,18 @@ namespace ToolManagementAppV2.ViewModels
 
         async Task RefreshAsync(CancellationToken cancellationToken)
         {
-            Devices.Clear();
-            var devices = await _service.GetScannerDevicesAsync(cancellationToken);
-            foreach (var d in devices)
-                Devices.Add(d);
+            try
+            {
+                var devices = await _service.GetScannerDevicesAsync(cancellationToken);
+                Devices.Clear();
+                foreach (var d in devices)
+                    Devices.Add(d);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to refresh scanner devices");
+                _dialogService.ShowInfo($"Failed to refresh scanner devices: {ex.Message}", "Error");
+            }
         }
     }
 }

--- a/ToolManagementAppV2/Views/ScannerStatusWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ScannerStatusWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using ToolManagementAppV2.Services.Devices;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Services;
 using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2.Views
@@ -21,7 +22,7 @@ namespace ToolManagementAppV2.Views
             var dbPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db");
             _ownedDb = new DatabaseService(dbPath);
             var settingsService = new SettingsService(_ownedDb);
-            DataContext = new ScannerStatusViewModel(new ScannerService(settingsService));
+            DataContext = new ScannerStatusViewModel(new ScannerService(settingsService), new DialogService());
             Closed += (_, __) => _ownedDb.Dispose();
         }
     }


### PR DESCRIPTION
## Summary
- add logging and dialog-based error handling to `ScannerStatusViewModel`
- construct `ScannerStatusViewModel` with a `DialogService`
- test scanner refresh error handling

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ec67e0e90832481fc8293a090cea1