### PR TITLE
feat: add async customer import

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -31,7 +31,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void ImportCustomersCommand_UsesMappingFromDialog()
+        public async System.Threading.Tasks.Task ImportCustomersCommand_UsesMappingFromDialog()
         {
             var tmp = Path.GetTempFileName();
             File.WriteAllText(tmp, "Company\n");
@@ -40,11 +40,28 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var dialog = new StubDialogService { MapToReturn = new Dictionary<string,string>{{"Company","Company"}} };
             var vm = new ImportExportViewModel(new StubToolService(), customerSvc, fileDlg, new StubDatabaseBackupService(), dialog);
 
-            vm.ImportCustomersCommand.Execute(null);
+            await vm.ImportCustomersCommand.ExecuteAsync(null);
 
             Assert.True(dialog.ShowImportMappingCalled);
             Assert.True(customerSvc.ImportCalled);
             Assert.Equal("Company", customerSvc.MapUsed!["Company"]);
+            File.Delete(tmp);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task ImportCustomersCommand_CancelledMapping_DoesNotCallService()
+        {
+            var tmp = Path.GetTempFileName();
+            File.WriteAllText(tmp, "Company\n");
+            var fileDlg = new StubFileDialogService { FileToReturn = tmp };
+            var customerSvc = new CapturingCustomerService();
+            var dialog = new StubDialogService { MapToReturn = null };
+            var vm = new ImportExportViewModel(new StubToolService(), customerSvc, fileDlg, new StubDatabaseBackupService(), dialog);
+
+            await vm.ImportCustomersCommand.ExecuteAsync(null);
+
+            Assert.True(dialog.ShowImportMappingCalled);
+            Assert.False(customerSvc.ImportCalled);
             File.Delete(tmp);
         }
 

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -71,7 +71,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void ImportExportViewModel_ImportCustomersCommand_LogsSuccess()
+        public async Task ImportExportViewModel_ImportCustomersCommand_LogsSuccess()
         {
             var toolService = new StubToolService();
             var customerService = new StubCustomerService();
@@ -81,7 +81,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             fileDlg.FileToReturn = tmp;
             var dialog = new StubDialogService();
             var vm = new ImportExportViewModel(toolService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
-            vm.ImportCustomersCommand.Execute(null);
+            await vm.ImportCustomersCommand.ExecuteAsync(null);
             Assert.True(customerService.ImportCalled);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Successfully imported customers", vm.ImportExportLogs[0]);
@@ -149,7 +149,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void ImportExportViewModel_ImportCustomersCommand_LogsFailure()
+        public async Task ImportExportViewModel_ImportCustomersCommand_LogsFailure()
         {
             var toolService = new StubToolService();
             var customerService = new FailCustomerService();
@@ -159,7 +159,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             fileDlg.FileToReturn = tmp;
             var dialog = new StubDialogService();
             var vm = new ImportExportViewModel(toolService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
-            vm.ImportCustomersCommand.Execute(null);
+            await vm.ImportCustomersCommand.ExecuteAsync(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Failed to import customers", vm.ImportExportLogs[0]);
             File.Delete(tmp);

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -26,7 +26,7 @@ namespace ToolManagementAppV2.ViewModels
 
         public IAsyncRelayCommand ImportToolsCommand { get; }
         public IAsyncRelayCommand ExportToolsCommand { get; }
-        public IRelayCommand ImportCustomersCommand { get; }
+        public IAsyncRelayCommand ImportCustomersCommand { get; }
         public IRelayCommand ExportCustomersCommand { get; }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace ToolManagementAppV2.ViewModels
             _logger = logger ?? NullLogger<ImportExportViewModel>.Instance;
             ImportToolsCommand = new AsyncRelayCommand(ImportToolsAsync);
             ExportToolsCommand = new AsyncRelayCommand(ExportToolsAsync);
-            ImportCustomersCommand = new RelayCommand(ImportCustomers);
+            ImportCustomersCommand = new AsyncRelayCommand(ImportCustomersAsync);
             ExportCustomersCommand = new RelayCommand(ExportCustomers);
             BackupDatabaseCommand = new AsyncRelayCommand(BackupDatabaseAsync);
         }
@@ -101,18 +101,18 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        void ImportCustomers()
+        async Task ImportCustomersAsync()
         {
             var path = _fileDialogService.OpenFile("CSV Files|*.csv");
             if (string.IsNullOrEmpty(path)) return;
             try
             {
-                var headers = CsvHelperUtil.ReadHeaders(path);
+                var headers = await CsvHelperUtil.ReadHeadersAsync(path);
                 var properties = typeof(CustomerImportDto).GetProperties().Select(p => p.Name);
                 var map = _dialogService.ShowImportMapping(headers, properties);
                 if (map == null)
                     return;
-                var result = _customerService.ImportCustomersFromCsv(path, map);
+                var result = await _customerService.ImportCustomersFromCsvAsync(path, map);
                 ImportExportLogs.Add($"Successfully imported customers from {path}. Imported {result.ImportedCount} customers.");
                 foreach (var msg in result.SkippedRows)
                     ImportExportLogs.Add($"Skipped {msg}");


### PR DESCRIPTION
## Summary
- implement asynchronous customer import via `ImportCustomersAsync`
- wire `ImportCustomersCommand` to `AsyncRelayCommand`
- expand ImportExportViewModel tests for async customer import and mapping cancellation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec68144c88324a9bf3b3b3824e0fc