### PR TITLE
Add async settings service methods

### DIFF
--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data.SQLite;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Settings;
@@ -326,6 +327,72 @@ namespace ToolManagementAppV2.Tests.Services
 
                 service.SavePasswordIterations(50_000);
                 Assert.Equal(50_000, service.GetPasswordIterations());
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAndRetrieveSettingAsync()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var service = new SettingsService(dbService);
+
+                await service.SaveSettingAsync("Key1", "Value1");
+                var value = await service.GetSettingAsync("Key1");
+                Assert.Equal("Value1", value);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task GetAllSettingsAsync_ReturnsAllEntries()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var service = new SettingsService(dbService);
+
+                await service.SaveSettingAsync("A", "1");
+                await service.SaveSettingAsync("B", "2");
+
+                var settings = await service.GetAllSettingsAsync();
+                Assert.Equal(2, settings.Count);
+                Assert.Equal("1", settings["A"]);
+                Assert.Equal("2", settings["B"]);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteSettingAsync_RemovesEntry()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var service = new SettingsService(dbService);
+
+                await service.SaveSettingAsync("Key1", "Value1");
+                await service.DeleteSettingAsync("Key1");
+
+                var value = await service.GetSettingAsync("Key1");
+                Assert.Null(value);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Interfaces;
 using Xunit;
@@ -110,6 +111,32 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public int PasswordIterations { get; set; } = 100_000;
         public int GetPasswordIterations() => PasswordIterations;
         public void SavePasswordIterations(int iterations) => PasswordIterations = iterations;
+
+        public Task SaveSettingAsync(string key, string value)
+        {
+            SaveSetting(key, value);
+            return Task.CompletedTask;
+        }
+        public Task<string?> GetSettingAsync(string key) => Task.FromResult(GetSetting(key));
+        public Task<Dictionary<string, string>> GetAllSettingsAsync() => Task.FromResult(GetAllSettings());
+        public Task UpdateSettingsAsync(Dictionary<string, string> settings)
+        {
+            UpdateSettings(settings);
+            return Task.CompletedTask;
+        }
+        public Task DeleteSettingAsync(string key)
+        {
+            DeleteSetting(key);
+            return Task.CompletedTask;
+        }
+        public Task<IEnumerable<string>> GetScannerIpAddressesAsync() => Task.FromResult(GetScannerIpAddresses());
+        public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses) => Task.FromResult(SaveScannerIpAddresses(ipAddresses));
+        public Task<int> GetPasswordIterationsAsync() => Task.FromResult(GetPasswordIterations());
+        public Task SavePasswordIterationsAsync(int iterations)
+        {
+            SavePasswordIterations(iterations);
+            return Task.CompletedTask;
+        }
     }
 
     class StubDialogService : IDialogService

--- a/ToolManagementAppV2/Interfaces/ISettingsService.cs
+++ b/ToolManagementAppV2/Interfaces/ISettingsService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace ToolManagementAppV2.Interfaces
 {
@@ -9,9 +10,18 @@ namespace ToolManagementAppV2.Interfaces
         Dictionary<string, string> GetAllSettings();
         void UpdateSettings(Dictionary<string, string> settings);
         void DeleteSetting(string key);
+        Task SaveSettingAsync(string key, string value);
+        Task<string?> GetSettingAsync(string key);
+        Task<Dictionary<string, string>> GetAllSettingsAsync();
+        Task UpdateSettingsAsync(Dictionary<string, string> settings);
+        Task DeleteSettingAsync(string key);
         IEnumerable<string> GetScannerIpAddresses();
         IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses);
         int GetPasswordIterations();
         void SavePasswordIterations(int iterations);
+        Task<IEnumerable<string>> GetScannerIpAddressesAsync();
+        Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses);
+        Task<int> GetPasswordIterationsAsync();
+        Task SavePasswordIterationsAsync(int iterations);
     }
 }

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Data.SQLite;
 using System;
 using System.Net;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Interfaces;
 using Microsoft.Extensions.Logging;
@@ -45,6 +46,28 @@ namespace ToolManagementAppV2.Services.Settings
             }
         }
 
+        public async Task SaveSettingAsync(string key, string value)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentException("Key cannot be null or empty.", nameof(key));
+
+            try
+            {
+                var p = new[]
+                {
+                    new SQLiteParameter("@Key", key),
+                    new SQLiteParameter("@Value", value)
+                };
+                using var conn = _dbService.CreateConnection();
+                await SqliteHelper.ExecuteNonQueryAsync(conn, UpsertSql, p);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save setting {Key}", key);
+                throw new InvalidOperationException($"Failed to save setting '{key}'.", ex);
+            }
+        }
+
         public string? GetSetting(string key)
         {
             try
@@ -54,6 +77,24 @@ namespace ToolManagementAppV2.Services.Settings
                 using var cmd = new SQLiteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@Key", key);
                 return cmd.ExecuteScalar()?.ToString();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve setting {Key}", key);
+                throw new InvalidOperationException($"Failed to retrieve setting '{key}'.", ex);
+            }
+        }
+
+        public async Task<string?> GetSettingAsync(string key)
+        {
+            try
+            {
+                const string sql = "SELECT Value FROM Settings WHERE Key = @Key";
+                using var conn = _dbService.CreateConnection();
+                using var cmd = new SQLiteCommand(sql, conn);
+                cmd.Parameters.AddWithValue("@Key", key);
+                var result = await cmd.ExecuteScalarAsync();
+                return result?.ToString();
             }
             catch (Exception ex)
             {
@@ -72,6 +113,26 @@ namespace ToolManagementAppV2.Services.Settings
                 using var cmd = new SQLiteCommand(sql, conn);
                 using var rdr = cmd.ExecuteReader();
                 while (rdr.Read())
+                    dict[rdr["Key"].ToString()] = rdr["Value"].ToString();
+                return dict;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve all settings");
+                throw new InvalidOperationException("Failed to retrieve all settings.", ex);
+            }
+        }
+
+        public async Task<Dictionary<string, string>> GetAllSettingsAsync()
+        {
+            try
+            {
+                var dict = new Dictionary<string, string>();
+                const string sql = "SELECT Key, Value FROM Settings";
+                using var conn = _dbService.CreateConnection();
+                using var cmd = new SQLiteCommand(sql, conn);
+                using var rdr = await cmd.ExecuteReaderAsync();
+                while (await rdr.ReadAsync())
                     dict[rdr["Key"].ToString()] = rdr["Value"].ToString();
                 return dict;
             }
@@ -126,6 +187,40 @@ namespace ToolManagementAppV2.Services.Settings
             }
         }
 
+        public async Task UpdateSettingsAsync(Dictionary<string, string> settings)
+        {
+            if (settings == null)
+                throw new ArgumentNullException(nameof(settings));
+
+            foreach (var kv in settings)
+            {
+                if (string.IsNullOrWhiteSpace(kv.Key))
+                    throw new ArgumentException("Key cannot be null or empty.", nameof(settings));
+            }
+
+            using var conn = _dbService.CreateConnection();
+            using var tx = conn.BeginTransaction();
+            try
+            {
+                foreach (var kv in settings)
+                {
+                    var p = new[]
+                    {
+                        new SQLiteParameter("@Key", kv.Key),
+                        new SQLiteParameter("@Value", kv.Value)
+                    };
+                    await SqliteHelper.ExecuteNonQueryAsync(conn, tx, UpsertSql, p);
+                }
+                tx.Commit();
+            }
+            catch (Exception ex)
+            {
+                tx.Rollback();
+                _logger.LogError(ex, "Failed to update settings");
+                throw new InvalidOperationException("Failed to update settings.", ex);
+            }
+        }
+
         public void DeleteSetting(string key)
         {
             try
@@ -144,12 +239,46 @@ namespace ToolManagementAppV2.Services.Settings
             }
         }
 
+        public async Task DeleteSettingAsync(string key)
+        {
+            try
+            {
+                const string sql = "DELETE FROM Settings WHERE Key = @Key";
+                var p = new[] { new SQLiteParameter("@Key", key) };
+                using var conn = _dbService.CreateConnection();
+                var affected = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+                if (affected == 0)
+                    _logger.LogWarning("No setting found for key {Key}", key);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to delete setting {Key}", key);
+                throw new InvalidOperationException($"Failed to delete setting '{key}'.", ex);
+            }
+        }
+
         const string ScannerIpKey = "ScannerIpAddresses";
         const string PasswordIterationsKey = "PasswordIterations";
 
         public IEnumerable<string> GetScannerIpAddresses()
         {
             var value = GetSetting(ScannerIpKey);
+            if (string.IsNullOrWhiteSpace(value))
+                return Array.Empty<string>();
+
+            var valid = new List<string>();
+            foreach (var ip in value.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (IPAddress.TryParse(ip, out _))
+                    valid.Add(ip);
+            }
+
+            return valid;
+        }
+
+        public async Task<IEnumerable<string>> GetScannerIpAddressesAsync()
+        {
+            var value = await GetSettingAsync(ScannerIpKey);
             if (string.IsNullOrWhiteSpace(value))
                 return Array.Empty<string>();
 
@@ -197,6 +326,40 @@ namespace ToolManagementAppV2.Services.Settings
             return invalid;
         }
 
+        public async Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses)
+        {
+            if (ipAddresses == null)
+            {
+                await DeleteSettingAsync(ScannerIpKey);
+                return Array.Empty<string>();
+            }
+
+            var valid = new List<string>();
+            var invalid = new List<string>();
+            foreach (var ip in ipAddresses)
+            {
+                if (IPAddress.TryParse(ip, out _))
+                    valid.Add(ip);
+                else
+                    invalid.Add(ip);
+            }
+
+            if (invalid.Count > 0)
+                _logger.LogWarning("Ignoring invalid IP addresses: {InvalidIps}", string.Join(", ", invalid));
+
+            if (valid.Count > 0)
+            {
+                var value = string.Join(';', valid);
+                await SaveSettingAsync(ScannerIpKey, value);
+            }
+            else
+            {
+                await DeleteSettingAsync(ScannerIpKey);
+            }
+
+            return invalid;
+        }
+
         public int GetPasswordIterations()
         {
             var value = GetSetting(PasswordIterationsKey);
@@ -206,6 +369,17 @@ namespace ToolManagementAppV2.Services.Settings
         public void SavePasswordIterations(int iterations)
         {
             SaveSetting(PasswordIterationsKey, iterations.ToString());
+        }
+
+        public async Task<int> GetPasswordIterationsAsync()
+        {
+            var value = await GetSettingAsync(PasswordIterationsKey);
+            return int.TryParse(value, out var i) ? i : 100_000;
+        }
+
+        public async Task SavePasswordIterationsAsync(int iterations)
+        {
+            await SaveSettingAsync(PasswordIterationsKey, iterations.ToString());
         }
     }
 }

--- a/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 
 namespace ToolManagementAppV2.Utilities.Helpers
@@ -95,10 +96,15 @@ namespace ToolManagementAppV2.Utilities.Helpers
 
         static int GetIterations()
         {
+            return GetIterationsAsync().GetAwaiter().GetResult();
+        }
+
+        static async Task<int> GetIterationsAsync()
+        {
             if (_iterations.HasValue)
                 return _iterations.Value;
 
-            var value = _settingsService?.GetPasswordIterations();
+            var value = _settingsService != null ? await _settingsService.GetPasswordIterationsAsync() : 0;
             _iterations = value > 0 ? value : DefaultIterations;
             return _iterations.Value;
         }

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media.Imaging;
@@ -69,17 +70,17 @@ namespace ToolManagementAppV2.ViewModels
             _dialogService = dialogService;
             _userContext = userContext;
 
-            CompanyLogo = LoadLogo();
-            WindowTitle = GetWindowTitle();
+            CompanyLogo = LoadLogoAsync().GetAwaiter().GetResult();
+            WindowTitle = GetWindowTitleAsync().GetAwaiter().GetResult();
 
             SelectUserCommand = new RelayCommand<User>(OnUserSelected);
 
             LoadUsers();
         }
 
-        BitmapImage LoadLogo()
+        async Task<BitmapImage> LoadLogoAsync()
         {
-            var logoPath = _settingsService.GetSetting("CompanyLogoPath");
+            var logoPath = await _settingsService.GetSettingAsync("CompanyLogoPath");
             Uri logoUri;
             if (!string.IsNullOrWhiteSpace(logoPath))
             {
@@ -102,9 +103,9 @@ namespace ToolManagementAppV2.ViewModels
             return bitmap;
         }
 
-        string GetWindowTitle()
+        async Task<string> GetWindowTitleAsync()
         {
-            var appName = _settingsService.GetSetting("ApplicationName");
+            var appName = await _settingsService.GetSettingAsync("ApplicationName");
             return !string.IsNullOrWhiteSpace(appName)
                 ? $"{appName} – Login"
                 : "Tool Inventory Management – Login";


### PR DESCRIPTION
## Summary
- add async ADO.NET methods to SettingsService and interface
- update SecurityHelper and LoginViewModel to use new async calls
- cover async operations with tests in SettingsServiceTests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ec685c0088324a157754603538be0