### PR TITLE
Ensure thread-safe password iteration retrieval

### DIFF
--- a/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
+++ b/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.Utilities.Helpers;
@@ -59,6 +62,49 @@ namespace ToolManagementAppV2.Tests.Utilities
             var hash = SecurityHelper.HashPassword("secret", out var salt);
             var result = SecurityHelper.VerifyPassword("secret", salt, hash);
             Assert.True(result);
+        }
+
+        [Fact]
+        public void HashPassword_OnlyFetchesIterationsOnceAcrossThreads()
+        {
+            var settings = new CountingSettingsService(5);
+            SecurityHelper.SettingsService = settings;
+
+            var saltBytes = Encoding.UTF8.GetBytes("1234567890ABCDEF");
+            var salt = Convert.ToBase64String(saltBytes);
+
+            Parallel.For(0, 20, _ =>
+            {
+                SecurityHelper.HashPassword("secret", salt);
+            });
+
+            Assert.Equal(1, settings.Counter);
+            SecurityHelper.SettingsService = null;
+        }
+
+        class CountingSettingsService : ISettingsService
+        {
+            int _counter;
+            readonly int _iterations;
+
+            public CountingSettingsService(int iterations) => _iterations = iterations;
+
+            public int Counter => _counter;
+
+            public int GetPasswordIterations()
+            {
+                Interlocked.Increment(ref _counter);
+                return _iterations;
+            }
+
+            public void SaveSetting(string key, string value) => throw new NotImplementedException();
+            public string? GetSetting(string key) => throw new NotImplementedException();
+            public Dictionary<string, string> GetAllSettings() => throw new NotImplementedException();
+            public void UpdateSettings(Dictionary<string, string> settings) => throw new NotImplementedException();
+            public void DeleteSetting(string key) => throw new NotImplementedException();
+            public IEnumerable<string> GetScannerIpAddresses() => throw new NotImplementedException();
+            public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses) => throw new NotImplementedException();
+            public void SavePasswordIterations(int iterations) => throw new NotImplementedException();
         }
     }
 }

--- a/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
@@ -8,7 +8,7 @@ namespace ToolManagementAppV2.Utilities.Helpers
     public static class SecurityHelper
     {
         const int DefaultIterations = 100_000;
-        static int? _iterations;
+        static Lazy<int> _iterations = CreateIterations();
         static ISettingsService? _settingsService;
 
         public static ISettingsService? SettingsService
@@ -17,7 +17,7 @@ namespace ToolManagementAppV2.Utilities.Helpers
             set
             {
                 _settingsService = value;
-                _iterations = null;
+                _iterations = CreateIterations();
             }
         }
         const string PasswordChars = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz0123456789!@#$%^&*";
@@ -93,14 +93,12 @@ namespace ToolManagementAppV2.Utilities.Helpers
             return builder.ToString();
         }
 
-        static int GetIterations()
+        static Lazy<int> CreateIterations() => new(() =>
         {
-            if (_iterations.HasValue)
-                return _iterations.Value;
-
             var value = _settingsService?.GetPasswordIterations();
-            _iterations = value > 0 ? value : DefaultIterations;
-            return _iterations.Value;
-        }
+            return value > 0 ? value : DefaultIterations;
+        }, true);
+
+        static int GetIterations() => _iterations.Value;
     }
 }


### PR DESCRIPTION
## Summary
- use Lazy<int> for iteration retrieval to avoid races when accessing settings
- add concurrency unit test to assert iterations are fetched once

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ec6897bd083249e40f6210f3f7a42