### PR TITLE
Dispose search timer on view model teardown

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -548,6 +548,25 @@ namespace ToolManagementAppV2.Tests.ViewModels
             Assert.Equal(1, toolService.SearchToolsAsyncCalls);
         }
 
+        [Fact]
+        public void Dispose_StopsSearchDebounceTimer()
+        {
+            var tools = new List<ToolModel>
+            {
+                new Tool { ToolNumber = "T1", NameDescription = "Hammer" }
+            };
+            var toolService = new CountingToolService(tools);
+            var timer = new TestDispatcherTimer();
+            var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService(), null, timer);
+
+            vm.SearchText = "Ha";
+            Assert.True(timer.IsEnabled);
+
+            vm.Dispose();
+
+            Assert.False(timer.IsEnabled);
+        }
+
         class CountingToolService : IToolService
         {
             public int GetAllToolsAsyncCalls { get; private set; }

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System;
 using System.Windows;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2
 {
@@ -23,6 +24,7 @@ namespace ToolManagementAppV2
 
             DataContext = viewModel;
             _ownedDb = ownedDatabaseService;
+            this.DisposeDataContextOnUnload();
 
             Closed += (_, __) => _ownedDb?.Dispose();
         }

--- a/ToolManagementAppV2/Utilities/Extensions/FrameworkElementExtensions.cs
+++ b/ToolManagementAppV2/Utilities/Extensions/FrameworkElementExtensions.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Windows;
+
+namespace ToolManagementAppV2.Utilities.Extensions
+{
+    /// <summary>
+    /// Helper methods for view cleanup.
+    /// </summary>
+    public static class FrameworkElementExtensions
+    {
+        /// <summary>
+        /// Disposes the current or previous <see cref="FrameworkElement.DataContext"/>
+        /// when the element is unloaded or its data context changes.
+        /// </summary>
+        /// <param name="element">Element to monitor.</param>
+        public static void DisposeDataContextOnUnload(this FrameworkElement element)
+        {
+            if (element is null) return;
+
+            element.DataContextChanged += OnDataContextChanged;
+
+            if (element is Window window)
+                window.Closed += OnUnloaded;
+            else
+                element.Unloaded += OnUnloaded;
+        }
+
+        static void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.OldValue is IDisposable disposable)
+                disposable.Dispose();
+        }
+
+        static void OnUnloaded(object sender, EventArgs e)
+        {
+            if (sender is FrameworkElement fe)
+            {
+                if (fe.DataContext is IDisposable disposable)
+                    disposable.Dispose();
+
+                fe.DataContextChanged -= OnDataContextChanged;
+
+                if (sender is Window window)
+                    window.Closed -= OnUnloaded;
+                else
+                    fe.Unloaded -= OnUnloaded;
+            }
+        }
+    }
+}
+

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -22,7 +22,7 @@ using ToolManagementAppV2.Utilities.IO;
 
 namespace ToolManagementAppV2.ViewModels
 {
-    public class MainViewModel : ObservableObject
+    public class MainViewModel : ObservableObject, IDisposable
     {
         readonly IToolService _toolService;
         readonly IUserService _userService;
@@ -330,6 +330,12 @@ namespace ToolManagementAppV2.ViewModels
                 _logger.LogError(ex, "Failed to import tools from CSV");
                 _dialogService.ShowInfo($"Failed to import tools: {ex.Message}", "Import Tools");
             }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            ToolManagement.Dispose();
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.ViewModels
 {
-    public class ToolManagementViewModel : ObservableObject
+    public class ToolManagementViewModel : ObservableObject, IDisposable
     {
         private readonly IToolService _toolService;
         private readonly ICustomerService _customerService;
@@ -120,11 +120,7 @@ namespace ToolManagementAppV2.ViewModels
             _logger = logger ?? NullLogger<ToolManagementViewModel>.Instance;
             SearchCommand = new AsyncRelayCommand(FilterToolsAsync);
             _searchDebounceTimer = searchDebounceTimer ?? new DispatcherTimerWrapper { Interval = TimeSpan.FromMilliseconds(300) };
-            _searchDebounceTimer.Tick += (s, e) =>
-            {
-                _searchDebounceTimer.Stop();
-                SearchCommand.Execute(null);
-            };
+            _searchDebounceTimer.Tick += OnSearchDebounceTimerTick;
             NewToolCommand = new AsyncRelayCommand(AddToolAsync);
             EditToolCommand = new AsyncRelayCommand(EditToolAsync, () => SelectedTool != null);
             DeleteToolCommand = new AsyncRelayCommand(DeleteToolAsync);
@@ -135,6 +131,12 @@ namespace ToolManagementAppV2.ViewModels
             // instances.
             Tools.CollectionChanged -= Tools_CollectionChanged;
             Tools.CollectionChanged += Tools_CollectionChanged;
+        }
+
+        void OnSearchDebounceTimerTick(object? s, EventArgs e)
+        {
+            _searchDebounceTimer.Stop();
+            SearchCommand.Execute(null);
         }
 
         public async Task LoadToolsAsync()
@@ -331,5 +333,12 @@ namespace ToolManagementAppV2.ViewModels
 
         void Tools_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e) => LoadCategories(Tools);
 
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _searchDebounceTimer.Tick -= OnSearchDebounceTimerTick;
+            _searchDebounceTimer.Stop();
+            Tools.CollectionChanged -= Tools_CollectionChanged;
+        }
     }
 }

--- a/ToolManagementAppV2/Views/AvatarSelectionWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/AvatarSelectionWindow.xaml.cs
@@ -6,6 +6,7 @@ using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Utilities.Extensions;
 
 
 namespace ToolManagementAppV2.Views
@@ -35,6 +36,7 @@ namespace ToolManagementAppV2.Views
                     .ToArray();
 
             DataContext = new AvatarSelectionViewModel(avatars, () => DialogResult = true);
+            this.DisposeDataContextOnUnload();
         }
     }
 }

--- a/ToolManagementAppV2/Views/ChangePasswordWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ChangePasswordWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
@@ -14,6 +15,7 @@ namespace ToolManagementAppV2.Views
         {
             InitializeComponent();
             DataContext = new ChangePasswordViewModel(() => DialogResult = true, () => DialogResult = false);
+            this.DisposeDataContextOnUnload();
         }
 
         void NewPasswordBox_PasswordChanged(object sender, RoutedEventArgs e)

--- a/ToolManagementAppV2/Views/ConfirmDialogWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ConfirmDialogWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
@@ -12,6 +13,7 @@ namespace ToolManagementAppV2.Views
         {
             InitializeComponent();
             DataContext = new ConfirmDialogViewModel(message, result => DialogResult = result);
+            this.DisposeDataContextOnUnload();
         }
 
         public ConfirmDialogWindow() : this(string.Empty) { }

--- a/ToolManagementAppV2/Views/CustomerEditWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/CustomerEditWindow.xaml.cs
@@ -3,6 +3,7 @@ using System;
 using System.Windows;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
@@ -12,6 +13,7 @@ namespace ToolManagementAppV2.Views
         {
             InitializeComponent();
             DataContext = new CustomerEditViewModel(customer, onSave, onCancel);
+            this.DisposeDataContextOnUnload();
         }
     }
 }

--- a/ToolManagementAppV2/Views/ImageImportMappingWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ImageImportMappingWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
@@ -11,6 +12,7 @@ namespace ToolManagementAppV2.Views
             DataContext = new ImageImportMappingViewModel(
                 () => { DialogResult = true; Close(); },
                 () => { DialogResult = false; Close(); });
+            this.DisposeDataContextOnUnload();
         }
 
         public ImageImportMappingViewModel VM => (ImageImportMappingViewModel)DataContext;

--- a/ToolManagementAppV2/Views/ImportMappingWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ImportMappingWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
@@ -17,6 +18,7 @@ namespace ToolManagementAppV2.Views
                 propertyNames,
                 () => { DialogResult = true; Close(); },
                 () => { DialogResult = false; Close(); });
+            this.DisposeDataContextOnUnload();
         }
 
         public ImportMappingViewModel VM => (ImportMappingViewModel)DataContext;

--- a/ToolManagementAppV2/Views/InfoDialogWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/InfoDialogWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
@@ -12,6 +13,7 @@ namespace ToolManagementAppV2.Views
         {
             InitializeComponent();
             DataContext = new InfoDialogViewModel(message, () => DialogResult = true);
+            this.DisposeDataContextOnUnload();
         }
 
         public InfoDialogWindow() : this(string.Empty) { }

--- a/ToolManagementAppV2/Views/LoginWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml.cs
@@ -5,6 +5,7 @@ using ToolManagementAppV2.Services;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2
 {
@@ -28,6 +29,7 @@ namespace ToolManagementAppV2
 
             var vm = new LoginViewModel(userService, settingsService, dialogService ?? new DialogService(), userContext);
             DataContext = vm;
+            this.DisposeDataContextOnUnload();
 
             vm.LoginSucceeded += OnLoginSucceeded;
             Closed += (_, __) => vm.LoginSucceeded -= OnLoginSucceeded;

--- a/ToolManagementAppV2/Views/PasswordPromptWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PasswordPromptWindow.xaml.cs
@@ -5,6 +5,7 @@ using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
@@ -39,6 +40,7 @@ namespace ToolManagementAppV2.Views
                 () => { DialogResult = true; },
                 () => { DialogResult = false; },
                 ShowError);
+            this.DisposeDataContextOnUnload();
             Loaded += OnLoaded;
         }
 

--- a/ToolManagementAppV2/Views/PrintLabelWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PrintLabelWindow.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
@@ -25,6 +26,7 @@ namespace ToolManagementAppV2.Views
         {
             InitializeComponent();
             DataContext = new PrintLabelViewModel(dialogService, () => Close());
+            this.DisposeDataContextOnUnload();
         }
 
         public PrintLabelWindow() : this(new ToolManagementAppV2.Services.DialogService()) { }

--- a/ToolManagementAppV2/Views/PrintPreviewWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PrintPreviewWindow.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Documents;
 using System.Windows.Media.Imaging;
 using System.Windows.Controls; // WPF PrintDialog
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
@@ -18,6 +19,7 @@ namespace ToolManagementAppV2.Views
         {
             InitializeComponent();
             DataContext = new PrintPreviewViewModel(OnPageSetup, OnPrint, Close);
+            this.DisposeDataContextOnUnload();
         }
 
         public void ShowPreview(FlowDocument document, string title, string? logoPath)

--- a/ToolManagementAppV2/Views/RentToolPopupWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/RentToolPopupWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
@@ -7,6 +8,7 @@ namespace ToolManagementAppV2.Views
         public RentToolPopupWindow()
         {
             InitializeComponent();
+            this.DisposeDataContextOnUnload();
         }
     }
 }

--- a/ToolManagementAppV2/Views/RentalHistoryWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/RentalHistoryWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using ToolManagementAppV2.ViewModels.Rental;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
@@ -8,6 +9,7 @@ namespace ToolManagementAppV2.Views
         public RentalHistoryWindow()
         {
             InitializeComponent();
+            this.DisposeDataContextOnUnload();
         }
 
         public RentalHistoryWindow(RentalHistoryViewModel viewModel) : this()

--- a/ToolManagementAppV2/Views/RentalsFilterWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/RentalsFilterWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
@@ -10,6 +11,7 @@ namespace ToolManagementAppV2.Views
         public RentalsFilterWindow()
         {
             InitializeComponent();
+            this.DisposeDataContextOnUnload();
         }
     }
 }

--- a/ToolManagementAppV2/Views/ScannerStatusWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ScannerStatusWindow.xaml.cs
@@ -5,6 +5,7 @@ using ToolManagementAppV2.Services.Devices;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
@@ -22,6 +23,7 @@ namespace ToolManagementAppV2.Views
             _ownedDb = new DatabaseService(dbPath);
             var settingsService = new SettingsService(_ownedDb);
             DataContext = new ScannerStatusViewModel(new ScannerService(settingsService));
+            this.DisposeDataContextOnUnload();
             Closed += (_, __) => _ownedDb.Dispose();
         }
     }

--- a/ToolManagementAppV2/Views/ToolDetailsWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ToolDetailsWindow.xaml.cs
@@ -1,6 +1,7 @@
 // Views/ToolDetailsWindow.xaml.cs
 using System.Windows;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
@@ -10,6 +11,7 @@ namespace ToolManagementAppV2.Views
         {
             InitializeComponent();
             DataContext = new ToolDetailsViewModel(tool, () => Close());
+            this.DisposeDataContextOnUnload();
         }
     }
 }

--- a/ToolManagementAppV2/Views/ToolEditWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ToolEditWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
@@ -14,6 +15,7 @@ namespace ToolManagementAppV2.Views
             InitializeComponent();
             var fileDialog = new FileDialogService();
             DataContext = new ToolEditViewModel(tool, onSave, onCancel, fileDialog);
+            this.DisposeDataContextOnUnload();
         }
     }
 }

--- a/ToolManagementAppV2/Views/UsersEditWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/UsersEditWindow.xaml.cs
@@ -3,6 +3,7 @@ using System;
 using System.Windows;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
@@ -12,6 +13,7 @@ namespace ToolManagementAppV2.Views
         {
             InitializeComponent();
             DataContext = new UsersEditViewModel(user, onSave, onCancel, BrowseAvatar, onRemoveAvatar);
+            this.DisposeDataContextOnUnload();
         }
 
         private void BrowseAvatar()


### PR DESCRIPTION
## Summary
- implement `IDisposable` on `ToolManagementViewModel` and stop debounce timer on disposal
- dispose child `ToolManagementViewModel` through `MainViewModel` and ensure windows dispose their data contexts
- add test confirming the search timer stops when the view model is disposed

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec692eb6c8324984b8d6aff00b752