### PR TITLE
Use concurrent image cache with eviction

### DIFF
--- a/ToolManagementAppV2.Tests/Utilities/NullToDefaultImageConverterTests.cs
+++ b/ToolManagementAppV2.Tests/Utilities/NullToDefaultImageConverterTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Windows.Media.Imaging;
+using ToolManagementAppV2.Utilities.Converters;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Utilities
+{
+    public class NullToDefaultImageConverterTests
+    {
+        private static readonly byte[] PngBytes = Convert.FromBase64String(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2NgYGD4DwABBAEAj4SR7QAAAABJRU5ErkJggg==");
+
+        [Fact]
+        public void Convert_CachesLoadedImages()
+        {
+            var converter = new NullToDefaultImageConverter();
+            var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+            var path = Path.Combine(baseDir, "cache_test.png");
+            File.WriteAllBytes(path, PngBytes);
+            try
+            {
+                var first = (BitmapImage)converter.Convert(path, typeof(BitmapImage), null, CultureInfo.InvariantCulture);
+                var second = (BitmapImage)converter.Convert(path, typeof(BitmapImage), null, CultureInfo.InvariantCulture);
+                Assert.Same(first, second);
+            }
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void Convert_EvictsOldestEntries_WhenMaxExceeded()
+        {
+            var converter = new NullToDefaultImageConverter();
+            var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+            var field = typeof(NullToDefaultImageConverter).GetField("MaxCacheEntries", BindingFlags.NonPublic | BindingFlags.Static);
+            var max = (int)field!.GetValue(null)!;
+
+            var firstPath = Path.Combine(baseDir, "evict0.png");
+            File.WriteAllBytes(firstPath, PngBytes);
+            var first = (BitmapImage)converter.Convert(firstPath, typeof(BitmapImage), null, CultureInfo.InvariantCulture);
+
+            for (int i = 1; i <= max; i++)
+            {
+                var p = Path.Combine(baseDir, $"evict{i}.png");
+                File.WriteAllBytes(p, PngBytes);
+                converter.Convert(p, typeof(BitmapImage), null, CultureInfo.InvariantCulture);
+            }
+
+            var again = (BitmapImage)converter.Convert(firstPath, typeof(BitmapImage), null, CultureInfo.InvariantCulture);
+            Assert.NotSame(first, again);
+
+            for (int i = 0; i <= max; i++)
+            {
+                var p = Path.Combine(baseDir, $"evict{i}.png");
+                if (File.Exists(p))
+                    File.Delete(p);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/Utilities/Converters/NullToDefaultImageConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/NullToDefaultImageConverter.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Media.Imaging;
 using System.IO;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 
 namespace ToolManagementAppV2.Utilities.Converters
@@ -14,8 +14,10 @@ namespace ToolManagementAppV2.Utilities.Converters
         private static BitmapImage _defaultUser;
         private static BitmapImage _defaultTool;
         private static BitmapImage _defaultLogo;
-        private static readonly Dictionary<string, BitmapImage> _imageCache =
-            new Dictionary<string, BitmapImage>(StringComparer.OrdinalIgnoreCase);
+        private const int MaxCacheEntries = 100;
+        private static readonly ConcurrentDictionary<string, BitmapImage> _imageCache =
+            new ConcurrentDictionary<string, BitmapImage>(StringComparer.OrdinalIgnoreCase);
+        private static readonly ConcurrentQueue<string> _cacheOrder = new ConcurrentQueue<string>();
         private static readonly ILogger Logger = App.LoggerFactory.CreateLogger<NullToDefaultImageConverter>();
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
@@ -43,7 +45,16 @@ namespace ToolManagementAppV2.Utilities.Converters
                         image.UriSource = new Uri(absPath, UriKind.Absolute);
                         image.EndInit();
                         image.Freeze();
-                        _imageCache[absPath] = image;
+
+                        if (_imageCache.TryAdd(absPath, image))
+                        {
+                            _cacheOrder.Enqueue(absPath);
+                            while (_cacheOrder.Count > MaxCacheEntries && _cacheOrder.TryDequeue(out var oldKey))
+                            {
+                                _imageCache.TryRemove(oldKey, out _);
+                            }
+                        }
+
                         return image;
                     }
                 }


### PR DESCRIPTION
## Summary
- replace NullToDefaultImageConverter image cache with ConcurrentDictionary
- evict oldest entries when cache exceeds 100 items
- add unit tests for caching and eviction behavior

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ec69ef36c8324b42c151882d07e9b