### PR TITLE
Load activity logs asynchronously

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ActivityLogsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ActivityLogsViewModelTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
@@ -12,7 +13,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     public class ActivityLogsViewModelTests
     {
         [Fact]
-        public void Constructor_LoadsLogs()
+        public async Task Constructor_LoadsLogs()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -21,6 +22,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var service = new ActivityLogService(db);
                 service.LogAction(1, "user", "action");
                 var vm = new ActivityLogsViewModel(service);
+                await vm.RefreshCommand.ExecutionTask;
                 Assert.Single(vm.Logs);
             }
             finally
@@ -31,7 +33,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void RefreshCommand_ReloadsLogs()
+        public async Task RefreshCommand_ReloadsLogs()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -40,10 +42,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var service = new ActivityLogService(db);
                 service.LogAction(1, "user", "first");
                 var vm = new ActivityLogsViewModel(service);
+                await vm.RefreshCommand.ExecutionTask;
                 Assert.Single(vm.Logs);
                 service.LogAction(1, "user", "second");
                 Assert.Single(vm.Logs);
-                vm.RefreshCommand.Execute(null);
+                await vm.RefreshCommand.ExecuteAsync(null);
                 Assert.Equal(2, vm.Logs.Count);
             }
             finally
@@ -54,7 +57,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void LoadLogs_ReturnsFalse_OnFailure()
+        public async Task LoadLogs_ReturnsFalse_OnFailure()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -62,7 +65,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var db = new DatabaseService(dbPath);
                 var service = new FailingActivityLogService(db);
                 var vm = new ActivityLogsViewModel(service);
-                Assert.False(vm.LoadLogs());
+                Assert.False(await vm.LoadLogsAsync());
                 Assert.Empty(vm.Logs);
             }
             finally
@@ -75,7 +78,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         class FailingActivityLogService : ActivityLogService
         {
             public FailingActivityLogService(DatabaseService db) : base(db) { }
-            public override List<ActivityLog>? GetRecentLogs(int count = 50) => throw new Exception("fail");
+            public override Task<List<ActivityLog>?> GetRecentLogsAsync(int count = 50) => throw new Exception("fail");
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/ActivityLogsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ActivityLogsViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ToolManagementAppV2.Models.Domain;
@@ -16,22 +17,22 @@ namespace ToolManagementAppV2.ViewModels
 
         public ObservableCollection<ActivityLog> Logs { get; } = new();
 
-        public IRelayCommand RefreshCommand { get; }
+        public IAsyncRelayCommand RefreshCommand { get; }
 
         public ActivityLogsViewModel(ActivityLogService service, ILogger<ActivityLogsViewModel>? logger = null)
         {
             _service = service;
             _logger = logger ?? NullLogger<ActivityLogsViewModel>.Instance;
-            RefreshCommand = new RelayCommand(() => LoadLogs());
-            LoadLogs();
+            RefreshCommand = new AsyncRelayCommand(LoadLogsAsync);
+            _ = RefreshCommand.ExecuteAsync(null);
         }
 
-        public bool LoadLogs()
+        public async Task<bool> LoadLogsAsync()
         {
             try
             {
                 Logs.Clear();
-                var logs = _service.GetRecentLogs();
+                var logs = await _service.GetRecentLogsAsync();
                 if (logs == null)
                     return false;
                 foreach (var log in logs)
@@ -44,5 +45,7 @@ namespace ToolManagementAppV2.ViewModels
                 return false;
             }
         }
+
+        public bool LoadLogs() => LoadLogsAsync().GetAwaiter().GetResult();
     }
 }


### PR DESCRIPTION
## Summary
- Implement asynchronous activity log loading via `AsyncRelayCommand` and `LoadLogsAsync`
- Await log retrieval using `GetRecentLogsAsync` and expose a sync wrapper
- Update `ActivityLogsViewModelTests` for async behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec6a9a6908324ac2530f02b5997d3