### PR TITLE
Handle shutdown failures gracefully

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using System.Windows;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class MainViewModelTests
+    {
+        [Fact]
+        public void ExitCommand_ShowsError_WhenShutdownThrows()
+        {
+            if (Application.Current == null)
+                new Application();
+
+            var app = Application.Current;
+            void ThrowOnExit(object? sender, ExitEventArgs e) => throw new InvalidOperationException("fail");
+            app.Exit += ThrowOnExit;
+
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(db, userContext);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
+                var dialog = new StubDialogService();
+
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                    new StubFileDialogService(), activityLogService, settingsService, db, dialog);
+
+                vm.ExitCommand.Execute(null);
+
+                Assert.True(dialog.InfoShown);
+            }
+            finally
+            {
+                app.Exit -= ThrowOnExit;
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public bool InfoShown { get; private set; }
+        public void ShowInfo(string message, string title) => InfoShown = true;
+        public bool ShowConfirmation(string message, string title) => false;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
+    }
+
+    class StubFileDialogService : IFileDialogService
+    {
+        public string OpenFile(string filter) => null;
+        public string SaveFile(string filter) => null;
+    }
+}

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -271,7 +271,15 @@ namespace ToolManagementAppV2.ViewModels
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to shutdown application");
-                    throw;
+                    _dialogService.ShowInfo("Failed to shutdown application", "Error");
+                    try
+                    {
+                        System.Windows.Application.Current?.Shutdown();
+                    }
+                    catch (Exception shutdownEx)
+                    {
+                        _logger.LogError(shutdownEx, "Secondary shutdown attempt failed");
+                    }
                 }
             });
 


### PR DESCRIPTION
## Summary
- Show dialog error and retry shutdown when exit command fails
- Add integration test covering failed shutdown behavior

## Testing
- `dotnet test` *(failed: command not found)*
- `curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh && chmod +x dotnet-install.sh && ./dotnet-install.sh --version 8.0.100` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ec6b0ca308324981b0feaa5e7aae1