### PR TITLE
Limit scanner ping concurrency and use ConfigureAwait

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ScannerServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ScannerServiceTests.cs
@@ -38,6 +38,30 @@ namespace ToolManagementAppV2.Tests.Services
                 if (File.Exists(dbPath)) File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public async Task GetScannerDevicesAsync_ReturnsAllConfiguredDevices()
+        {
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var settings = new SettingsService(db);
+                settings.SaveScannerIpAddresses(new[] { "127.0.0.1", "127.0.0.2" });
+
+                var service = new ScannerService(settings);
+
+                var devices = await service.GetScannerDevicesAsync(CancellationToken.None);
+                var list = devices.ToList();
+                Assert.Equal(2, list.Count);
+                Assert.Contains(list, d => d.Ip == "127.0.0.1");
+                Assert.Contains(list, d => d.Ip == "127.0.0.2");
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
         [Fact]
         public async Task GetScannerDevicesAsync_HonorsCancellation()
         {

--- a/ToolManagementAppV2/Services/Devices/ScannerService.cs
+++ b/ToolManagementAppV2/Services/Devices/ScannerService.cs
@@ -26,31 +26,40 @@ namespace ToolManagementAppV2.Services.Devices
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            using var semaphore = new SemaphoreSlim(5);
             var tasks = _settingsService.GetScannerIpAddresses().Select(async ip =>
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var device = new ScannerDevice
-                {
-                    Name = $"Scanner {ip}",
-                    Ip = ip,
-                    LastSeen = DateTime.UtcNow
-                };
+                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try
                 {
-                    using var ping = new Ping();
-                    var reply = await ping.SendPingAsync(ip, 1000);
-                    device.Status = reply.Status == IPStatus.Success ? "Online" : "Offline";
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var device = new ScannerDevice
+                    {
+                        Name = $"Scanner {ip}",
+                        Ip = ip,
+                        LastSeen = DateTime.UtcNow
+                    };
+                    try
+                    {
+                        using var ping = new Ping();
+                        var reply = await ping.SendPingAsync(ip, 1000).ConfigureAwait(false);
+                        device.Status = reply.Status == IPStatus.Success ? "Online" : "Offline";
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to ping scanner {Ip}", ip);
+                        device.Status = "Error";
+                    }
+                    return device;
                 }
-                catch (Exception ex)
+                finally
                 {
-                    _logger.LogError(ex, "Failed to ping scanner {Ip}", ip);
-                    device.Status = "Error";
+                    semaphore.Release();
                 }
-                return device;
             });
 
-            return await Task.WhenAll(tasks);
+            return await Task.WhenAll(tasks).ConfigureAwait(false);
         }
     }
 }

--- a/ToolManagementAppV2/Services/Tools/ReportService.cs
+++ b/ToolManagementAppV2/Services/Tools/ReportService.cs
@@ -173,7 +173,7 @@ namespace ToolManagementAppV2.Services.Tools
             var totalCustomersTask = _customerService.GetAllCustomersAsync();
             var totalUsersTask = _userService.GetAllUsersAsync();
 
-            await Task.WhenAll(totalToolsTask, totalRentalsTask, totalActiveRentalsTask, totalCustomersTask, totalUsersTask);
+            await Task.WhenAll(totalToolsTask, totalRentalsTask, totalActiveRentalsTask, totalCustomersTask, totalUsersTask).ConfigureAwait(false);
 
             var lines = new[]
             {


### PR DESCRIPTION
## Summary
- Add ConfigureAwait to asynchronous operations in scanner and report services
- Limit simultaneous scanner pings with SemaphoreSlim
- Test scanner service returns multiple configured devices

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ec6b69d348324a014d062d78400cc