### PR TITLE
Guard against invalid paths outside base directory

### DIFF
--- a/ToolManagementAppV2.Tests/Utilities/PathHelperTests.cs
+++ b/ToolManagementAppV2.Tests/Utilities/PathHelperTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using ToolManagementAppV2.Utilities.Helpers;
+using ToolManagementAppV2.Tests;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Utilities
+{
+    public class PathHelperTests
+    {
+        [Fact]
+        public void GetAbsolutePath_OutsideBaseDir_LogsWarning()
+        {
+            var logs = new List<LogEntry>();
+            var factory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
+            var originalFactory = App.LoggerFactory;
+            App.LoggerFactory = factory;
+            try
+            {
+                var result = PathHelper.GetAbsolutePath(Path.Combine("..", "outside.txt"));
+                Assert.Null(result);
+            }
+            finally
+            {
+                App.LoggerFactory = originalFactory;
+                factory.Dispose();
+            }
+            Assert.Contains(logs, l => l.Level == LogLevel.Warning);
+        }
+
+        [Fact]
+        public void GetAbsolutePath_OutsideBaseDir_ThrowsWhenRequested()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                PathHelper.GetAbsolutePath(Path.Combine("..", "outside.txt"), true));
+        }
+    }
+}

--- a/ToolManagementAppV2/Services/Tools/Printer.cs
+++ b/ToolManagementAppV2/Services/Tools/Printer.cs
@@ -54,8 +54,15 @@ namespace ToolManagementAppV2.Services.Tools
             if (string.IsNullOrEmpty(path))
                 return null;
 
-            var full = Utilities.Helpers.PathHelper.GetAbsolutePath(path);
-            return !string.IsNullOrEmpty(full) && File.Exists(full) ? full : null;
+            try
+            {
+                var full = Utilities.Helpers.PathHelper.GetAbsolutePath(path, true);
+                return !string.IsNullOrEmpty(full) && File.Exists(full) ? full : null;
+            }
+            catch (InvalidOperationException)
+            {
+                return null;
+            }
         }
 
         private FlowDocument BuildDocument(List<ToolModel> tools, string title, string? logoPath)
@@ -104,7 +111,14 @@ namespace ToolManagementAppV2.Services.Tools
             string imgPath = null;
             if (!string.IsNullOrEmpty(tool.ToolImagePath))
             {
-                imgPath = Utilities.Helpers.PathHelper.GetAbsolutePath(tool.ToolImagePath);
+                try
+                {
+                    imgPath = Utilities.Helpers.PathHelper.GetAbsolutePath(tool.ToolImagePath, true);
+                }
+                catch (InvalidOperationException)
+                {
+                    imgPath = null;
+                }
             }
 
             if (!string.IsNullOrEmpty(imgPath) && File.Exists(imgPath))
@@ -181,7 +195,15 @@ namespace ToolManagementAppV2.Services.Tools
 
         private Border CreateOptimizedImage(string path)
         {
-            var full = Utilities.Helpers.PathHelper.GetAbsolutePath(path);
+            string? full;
+            try
+            {
+                full = Utilities.Helpers.PathHelper.GetAbsolutePath(path, true);
+            }
+            catch (InvalidOperationException)
+            {
+                return new Border { Width = 120, Height = 120, CornerRadius = new CornerRadius(10) };
+            }
             if (string.IsNullOrEmpty(full))
                 return new Border { Width = 120, Height = 120, CornerRadius = new CornerRadius(10) };
 
@@ -208,7 +230,15 @@ namespace ToolManagementAppV2.Services.Tools
             if (string.IsNullOrEmpty(logoPath))
                 return;
 
-            var full = Utilities.Helpers.PathHelper.GetAbsolutePath(logoPath);
+            string? full;
+            try
+            {
+                full = Utilities.Helpers.PathHelper.GetAbsolutePath(logoPath, true);
+            }
+            catch (InvalidOperationException)
+            {
+                return;
+            }
             if (string.IsNullOrEmpty(full) || !File.Exists(full))
                 return;
             var bmp = new BitmapImage();

--- a/ToolManagementAppV2/Utilities/Converters/NullToDefaultImageConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/NullToDefaultImageConverter.cs
@@ -30,7 +30,7 @@ namespace ToolManagementAppV2.Utilities.Converters
                 {
                     var absPath = Uri.IsWellFormedUriString(path, UriKind.Absolute)
                         ? path
-                        : Helpers.PathHelper.GetAbsolutePath(path);
+                        : Helpers.PathHelper.GetAbsolutePath(path, true);
 
                     if (!string.IsNullOrEmpty(absPath))
                     {

--- a/ToolManagementAppV2/Utilities/Helpers/PathHelper.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/PathHelper.cs
@@ -13,8 +13,9 @@ namespace ToolManagementAppV2.Utilities.Helpers
         /// and ensures the resulting absolute path stays within that directory.
         /// </summary>
         /// <param name="path">Relative or absolute path.</param>
+        /// <param name="throwOnInvalid">Throw if the path resolves outside the application's base directory.</param>
         /// <returns>The validated absolute path, or <c>null</c> if validation fails.</returns>
-        public static string? GetAbsolutePath(string? path)
+        public static string? GetAbsolutePath(string? path, bool throwOnInvalid = false)
         {
             if (string.IsNullOrWhiteSpace(path))
                 return null;
@@ -29,7 +30,12 @@ namespace ToolManagementAppV2.Utilities.Helpers
                 var fullPath = Path.GetFullPath(combined);
 
                 if (!fullPath.StartsWith(baseDir, StringComparison.OrdinalIgnoreCase))
+                {
+                    Logger.LogWarning("Resolved path {Path} is outside base directory {BaseDir}", fullPath, baseDir);
+                    if (throwOnInvalid)
+                        throw new InvalidOperationException("Path is outside of the application's base directory.");
                     return null;
+                }
 
                 return fullPath;
             }

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -83,10 +83,17 @@ namespace ToolManagementAppV2.ViewModels
             Uri logoUri;
             if (!string.IsNullOrWhiteSpace(logoPath))
             {
-                var full = PathHelper.GetAbsolutePath(logoPath);
-                logoUri = !string.IsNullOrEmpty(full) && File.Exists(full)
-                    ? new Uri(full)
-                    : new Uri("pack://application:,,,/Resources/DefaultLogo.png");
+                try
+                {
+                    var full = PathHelper.GetAbsolutePath(logoPath, true);
+                    logoUri = !string.IsNullOrEmpty(full) && File.Exists(full)
+                        ? new Uri(full)
+                        : new Uri("pack://application:,,,/Resources/DefaultLogo.png");
+                }
+                catch (InvalidOperationException)
+                {
+                    logoUri = new Uri("pack://application:,,,/Resources/DefaultLogo.png");
+                }
             }
             else
             {

--- a/ToolManagementAppV2/Views/PrintPreviewWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PrintPreviewWindow.xaml.cs
@@ -47,9 +47,16 @@ namespace ToolManagementAppV2.Views
         {
             if (!string.IsNullOrWhiteSpace(path))
             {
-                var full = Utilities.Helpers.PathHelper.GetAbsolutePath(path);
-                if (!string.IsNullOrEmpty(full) && File.Exists(full))
-                    return new Uri(full, UriKind.Absolute);
+                try
+                {
+                    var full = Utilities.Helpers.PathHelper.GetAbsolutePath(path, true);
+                    if (!string.IsNullOrEmpty(full) && File.Exists(full))
+                        return new Uri(full, UriKind.Absolute);
+                }
+                catch (InvalidOperationException)
+                {
+                    // fall through to default
+                }
             }
             return new Uri("pack://application:,,,/Resources/DefaultLogo.png");
         }


### PR DESCRIPTION
## Summary
- log and optionally throw InvalidOperationException when paths escape the application's base directory
- update callers to handle InvalidOperationException
- add unit tests covering warning and exception behavior

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ec6c0cf5083249eba92704a4750ce