### PR TITLE
Make login authentication async

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Threading.Tasks;
+using System.Threading;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
@@ -37,7 +38,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 bool success = false;
                 vm.LoginSucceeded += (_, __) => success = true;
 
-                vm.SelectUserCommand.Execute(vm.Users.First());
+                await vm.SelectUserCommand.ExecuteAsync(vm.Users.First());
 
                 Assert.True(success);
                 Assert.NotNull(userContext.CurrentUser);
@@ -73,12 +74,84 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 bool success = false;
                 vm.LoginSucceeded += (_, __) => success = true;
 
-                vm.SelectUserCommand.Execute(vm.Users.First());
+                await vm.SelectUserCommand.ExecuteAsync(vm.Users.First());
 
                 Assert.True(success);
                 var updated = userService.GetUserByID(user.UserID)!;
                 Assert.False(updated.PasswordExpired);
                 Assert.True(SecurityHelper.VerifyPassword("changed", updated.Salt, updated.Password));
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task SelectUserCommand_PromptsForPassword_AuthenticatesAdmin()
+        {
+            if (Application.Current == null)
+                new Application();
+
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            try
+            {
+                using var dbService = new DatabaseService(dbPath);
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(dbService, userContext);
+                var settingsService = new SettingsService(dbService);
+                userService.AddUser(new User { UserName = "admin", Password = "secret", IsAdmin = true });
+
+                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
+                {
+                    PromptForPasswordAsync = (u, ct) =>
+                        Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("secret", false))
+                };
+                await vm.LoadUsersCommand.ExecuteAsync(null);
+                bool success = false;
+                vm.LoginSucceeded += (_, __) => success = true;
+
+                await vm.SelectUserCommand.ExecuteAsync(vm.Users.First());
+
+                Assert.True(success);
+                Assert.Equal("admin", userContext.UserName);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task SelectUserCommand_CanBeCancelled()
+        {
+            if (Application.Current == null)
+                new Application();
+
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            try
+            {
+                using var dbService = new DatabaseService(dbPath);
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(dbService, userContext);
+                var settingsService = new SettingsService(dbService);
+                userService.AddUser(new User { UserName = "admin", Password = "secret", IsAdmin = true });
+
+                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
+                {
+                    PromptForPasswordAsync = async (u, ct) =>
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(5), ct);
+                        return new PasswordPromptResult("secret", false);
+                    }
+                };
+                await vm.LoadUsersCommand.ExecuteAsync(null);
+
+                var execTask = vm.SelectUserCommand.ExecuteAsync(vm.Users.First());
+                vm.SelectUserCommand.Cancel();
+
+                await Assert.ThrowsAsync<OperationCanceledException>(async () => await execTask);
+                Assert.Null(userContext.CurrentUser);
             }
             finally
             {

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -3,11 +3,11 @@ using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media.Imaging;
-using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Settings;
@@ -50,7 +50,7 @@ namespace ToolManagementAppV2.ViewModels
         /// <see cref="OnUserSelected"/> to perform authentication, including prompting
         /// for passwords and handling resets.
         /// </summary>
-        public ICommand SelectUserCommand { get; }
+        public IAsyncRelayCommand<User> SelectUserCommand { get; }
 
         public IAsyncRelayCommand LoadUsersCommand { get; }
 
@@ -66,6 +66,9 @@ namespace ToolManagementAppV2.ViewModels
             return dlg.ShowDialog() == true ? dlg.NewPassword : null;
         };
 
+        public Func<User, CancellationToken, Task<PasswordPromptResult?>>? PromptForPasswordAsync { get; set; }
+            
+
         public LoginViewModel(IUserService userService, ISettingsService settingsService, IDialogService dialogService, IUserContext userContext)
         {
             _settingsService = settingsService;
@@ -76,7 +79,19 @@ namespace ToolManagementAppV2.ViewModels
             CompanyLogo = LoadLogoAsync().GetAwaiter().GetResult();
             WindowTitle = GetWindowTitleAsync().GetAwaiter().GetResult();
 
-            SelectUserCommand = new RelayCommand<User>(OnUserSelected);
+            SelectUserCommand = new AsyncRelayCommand<User>(OnUserSelected);
+
+            PromptForPasswordAsync = (u, ct) =>
+            {
+                var prompt = new PasswordPromptWindow(_dialogService)
+                {
+                    SelectedUser = u
+                };
+                var result = prompt.ShowDialog();
+                if (result == true)
+                    return Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult(prompt.EnteredPassword, prompt.IsPasswordResetRequested));
+                return Task.FromResult<PasswordPromptResult?>(null);
+            };
 
             LoadUsersCommand = new AsyncRelayCommand(LoadUsersAsync);
             LoadUsersCommand.Execute(null);
@@ -148,7 +163,8 @@ namespace ToolManagementAppV2.ViewModels
         /// and raises <see cref="LoginSucceeded"/>.
         /// </summary>
         /// <param name="user">The account to authenticate.</param>
-        void OnUserSelected(User user)
+        /// <param name="cancellationToken">Token used to cancel the authentication loop.</param>
+        async Task OnUserSelected(User user, CancellationToken cancellationToken)
         {
             if (user == null) return;
 
@@ -175,18 +191,17 @@ namespace ToolManagementAppV2.ViewModels
                 return;
             }
 
-            var passwordValidated = false;
-            while (!passwordValidated)
+            User? credential = null;
+            while (credential == null)
             {
-                var prompt = new PasswordPromptWindow(_dialogService)
-                {
-                    SelectedUser = user,
-                    ValidatePassword = pwd => _userService.AuthenticateUser(user.UserName, pwd) != null
-                };
+                cancellationToken.ThrowIfCancellationRequested();
 
-                if (prompt.ShowDialog() != true) return;
+                var promptResult = await (PromptForPasswordAsync?.Invoke(user, cancellationToken)
+                    ?? Task.FromResult<PasswordPromptResult?>(null));
+                if (promptResult == null)
+                    return;
 
-                if (prompt.IsPasswordResetRequested)
+                if (promptResult.IsPasswordResetRequested)
                 {
                     _userService.ChangeUserPassword(user.UserID, "admin");
                     var refreshed = _userService.GetUserByID(user.UserID);
@@ -202,16 +217,17 @@ namespace ToolManagementAppV2.ViewModels
                     continue;
                 }
 
-                var credential = _userService.AuthenticateUser(user.UserName, prompt.EnteredPassword);
-                if (credential != null)
+                credential = await _userService.AuthenticateUserAsync(user.UserName, promptResult.Password);
+                if (credential == null)
                 {
-                    if (credential.PasswordExpired && !PromptChangePassword(credential))
-                        return;
-                    _userContext.CurrentUser = credential;
-                    LoginSucceeded?.Invoke(this, EventArgs.Empty);
-                    passwordValidated = true;
+                    _dialogService.ShowInfo("Incorrect password. Please try again.", "Login Failed");
                 }
             }
+
+            if (credential.PasswordExpired && !PromptChangePassword(credential))
+                return;
+            _userContext.CurrentUser = credential;
+            LoginSucceeded?.Invoke(this, EventArgs.Empty);
         }
 
         bool PromptChangePassword(User user)
@@ -230,4 +246,6 @@ namespace ToolManagementAppV2.ViewModels
             return true;
         }
     }
+
+    public record PasswordPromptResult(string Password, bool IsPasswordResetRequested);
 }


### PR DESCRIPTION
## Summary
- Convert `OnUserSelected` to asynchronous `Task` with cancellation support and async command
- Replace password validation loop with cancellable async prompts using `AuthenticateUserAsync`
- Expand login view model tests to cover admin authentication and cancellation scenarios

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689ecbf1c9fc832484b7e70bb09b0992