### PR TITLE
Add cancellation support for CSV tool import

### DIFF
--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -11,6 +11,7 @@ using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Interfaces;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -370,7 +371,7 @@ namespace ToolManagementAppV2.Tests.Services
         class FailingToolService : IToolService
         {
             public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
-            public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
+            public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
             public void ExportToolsToCsv(string filePath) => throw new NotImplementedException();
             public Task ExportToolsToCsvAsync(string filePath) => Task.CompletedTask;
             public List<ToolModel> GetAllTools() => new();

--- a/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
@@ -6,6 +6,7 @@ using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Models.Domain;
 using Xunit;
+using System.Threading;
 
 public class CsvImportTests
 {
@@ -92,7 +93,7 @@ public class CsvImportTests
                 {"NameDescription", "NameDescription"}
             };
 
-            var invalid = await service.ImportToolsFromCsvAsync(csvPath, map);
+            var invalid = await service.ImportToolsFromCsvAsync(csvPath, map, CancellationToken.None);
 
             Assert.Single(invalid);
             Assert.Contains(2, invalid);
@@ -133,7 +134,7 @@ public class CsvImportTests
             };
 
             var sw = System.Diagnostics.Stopwatch.StartNew();
-            var invalid = await service.ImportToolsFromCsvAsync(csvPath, map);
+            var invalid = await service.ImportToolsFromCsvAsync(csvPath, map, CancellationToken.None);
             sw.Stop();
 
             Assert.True(sw.ElapsedMilliseconds < 5000, $"Import took {sw.ElapsedMilliseconds}ms");

--- a/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -81,6 +81,25 @@ namespace ToolManagementAppV2.Tests.ViewModels
             Assert.False(toolSvc.ImportCalled);
             File.Delete(tmp);
         }
+
+        [Fact]
+        public async System.Threading.Tasks.Task ImportToolsCommand_CanBeCancelled()
+        {
+            var tmp = Path.GetTempFileName();
+            File.WriteAllText(tmp, "ToolNumber\n");
+            var fileDlg = new StubFileDialogService { FileToReturn = tmp };
+            var toolSvc = new CancelableToolService();
+            var dialog = new StubDialogService { MapToReturn = new Dictionary<string,string>{{"ToolNumber","ToolNumber"}} };
+            var vm = new ImportExportViewModel(toolSvc, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
+
+            var execute = vm.ImportToolsCommand.ExecuteAsync(null);
+            vm.ImportToolsCommand.Cancel();
+            await execute;
+
+            Assert.Single(vm.ImportExportLogs);
+            Assert.Contains("cancel", vm.ImportExportLogs[0], StringComparison.OrdinalIgnoreCase);
+            File.Delete(tmp);
+        }
     }
 
     class StubFileDialogService : IFileDialogService
@@ -123,7 +142,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             MapUsed = map;
             return new();
         }
-        public System.Threading.Tasks.Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map)
+        public System.Threading.Tasks.Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
             ImportCalled = true;
             MapUsed = map;
@@ -179,8 +198,31 @@ namespace ToolManagementAppV2.Tests.ViewModels
     class StubToolService : IToolService
     {
         public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => new();
-        public System.Threading.Tasks.Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map)
+        public System.Threading.Tasks.Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
             => System.Threading.Tasks.Task.FromResult(new List<int>());
+        public void ExportToolsToCsv(string filePath) { }
+        public System.Threading.Tasks.Task ExportToolsToCsvAsync(string filePath) => System.Threading.Tasks.Task.CompletedTask;
+        public List<ToolModel> GetAllTools() => new();
+        public void AddTool(ToolModel tool) => throw new NotImplementedException();
+        public void UpdateTool(ToolModel tool) => throw new NotImplementedException();
+        public void DeleteTool(int toolID) => throw new NotImplementedException();
+        public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
+        public List<ToolModel> SearchTools(string? searchText) => new();
+        public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+        public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
+        public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
+        public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => new();
+        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null) => throw new NotImplementedException();
+    }
+
+    class CancelableToolService : IToolService
+    {
+        public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => new();
+        public async System.Threading.Tasks.Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
+        {
+            await System.Threading.Tasks.Task.Delay(System.Threading.Timeout.Infinite, cancellationToken);
+            return new List<int>();
+        }
         public void ExportToolsToCsv(string filePath) { }
         public System.Threading.Tasks.Task ExportToolsToCsvAsync(string filePath) => System.Threading.Tasks.Task.CompletedTask;
         public List<ToolModel> GetAllTools() => new();

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -236,7 +236,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             ImportCalled = true;
             return new();
         }
-        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map)
+        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
             ImportCalled = true;
             return Task.FromResult(new List<int>());
@@ -259,7 +259,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     class FailToolService : IToolService
     {
         public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => throw new System.Exception("fail");
-        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map) => Task.FromException<List<int>>(new System.Exception("fail"));
+        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromException<List<int>>(new System.Exception("fail"));
         public void ExportToolsToCsv(string filePath) => throw new System.Exception("fail");
         public Task ExportToolsToCsvAsync(string filePath) => Task.FromException(new System.Exception("fail"));
         public List<ToolModel> GetAllTools() => new();

--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -13,6 +13,7 @@ using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -622,7 +623,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
             public Task UpdateToolImageAsync(int toolID, string imagePath) => throw new NotImplementedException();
             public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
-            public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
+            public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
             public void ExportToolsToCsv(string filePath) => throw new NotImplementedException();
             public Task ExportToolsToCsvAsync(string filePath) => throw new NotImplementedException();
             public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => throw new NotImplementedException();
@@ -652,7 +653,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
             public Task UpdateToolImageAsync(int toolID, string imagePath) => throw new NotImplementedException();
             public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => new();
-            public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map) => Task.FromResult(new List<int>());
+            public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
             public void ExportToolsToCsv(string filePath) { }
             public Task ExportToolsToCsvAsync(string filePath) => Task.CompletedTask;
             public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => new();

--- a/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
@@ -103,7 +103,7 @@ namespace ToolManagementAppV2.Tests.Views
             ImportCalled = true;
             return new();
         }
-        public System.Threading.Tasks.Task<System.Collections.Generic.List<int>> ImportToolsFromCsvAsync(string filePath, System.Collections.Generic.IDictionary<string, string> map)
+        public System.Threading.Tasks.Task<System.Collections.Generic.List<int>> ImportToolsFromCsvAsync(string filePath, System.Collections.Generic.IDictionary<string, string> map, CancellationToken cancellationToken)
         {
             ImportCalled = true;
             return System.Threading.Tasks.Task.FromResult(new System.Collections.Generic.List<int>());

--- a/ToolManagementAppV2/Interfaces/IToolService.cs
+++ b/ToolManagementAppV2/Interfaces/IToolService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.SQLite;
+using System.Threading;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.ImportExport;
@@ -28,7 +29,7 @@ namespace ToolManagementAppV2.Interfaces
         void UpdateToolImage(int toolID, string imagePath);
         Task UpdateToolImageAsync(int toolID, string imagePath);
         List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map);
-        Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map);
+        Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken);
         void ExportToolsToCsv(string filePath);
         Task ExportToolsToCsvAsync(string filePath);
         ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector);

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Data;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Models.Domain;
@@ -650,8 +651,8 @@ namespace ToolManagementAppV2.Services.Tools
             await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
         }
 
-        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map)
-            => Task.FromResult(ImportToolsFromCsv(filePath, map));
+        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
+            => Task.Run(() => ImportToolsFromCsv(filePath, map), cancellationToken);
 
         public async Task ExportToolsToCsvAsync(string filePath)
         {

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -60,7 +60,7 @@ namespace ToolManagementAppV2.ViewModels
             BackupDatabaseCommand = new AsyncRelayCommand(BackupDatabaseAsync);
         }
 
-        async Task ImportToolsAsync()
+        async Task ImportToolsAsync(CancellationToken cancellationToken)
         {
             var path = _fileDialogService.OpenFile("CSV Files|*.csv");
             if (string.IsNullOrEmpty(path)) return;
@@ -72,17 +72,21 @@ namespace ToolManagementAppV2.ViewModels
                 if (map == null)
                     return;
                 _dialogService.ShowInfo("Importing tools...", "Import Tools");
-                await _toolService.ImportToolsFromCsvAsync(path, map);
+                await _toolService.ImportToolsFromCsvAsync(path, map, cancellationToken);
                 ImportExportLogs.Add($"Successfully imported tools from {path}.");
+                _dialogService.ShowInfo($"Successfully imported tools from {path}.", "Import Tools");
+            }
+            catch (OperationCanceledException)
+            {
+                ImportExportLogs.Add("Tool import was cancelled.");
+                _dialogService.ShowInfo("Tool import was cancelled.", "Import Tools");
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to import tools from {Path}", path);
                 ImportExportLogs.Add($"Failed to import tools from {path}: {ex.Message}");
                 _dialogService.ShowInfo($"Failed to import tools from {path}: {ex.Message}", "Import Tools");
-                return;
             }
-            _dialogService.ShowInfo($"Successfully imported tools from {path}.", "Import Tools");
         }
 
         async Task ExportToolsAsync()

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -326,7 +327,7 @@ namespace ToolManagementAppV2.ViewModels
                 if (map != null)
                 {
                     _dialogService.ShowInfo("Importing tools...", "Import Tools");
-                    var invalid = await _toolService.ImportToolsFromCsvAsync(path, map);
+                    var invalid = await _toolService.ImportToolsFromCsvAsync(path, map, CancellationToken.None);
                     var msg = invalid.Count == 0
                         ? "Successfully imported tools."
                         : $"Imported with {invalid.Count} invalid rows.";

--- a/ToolManagementAppV2/Views/ImportExportPage.xaml
+++ b/ToolManagementAppV2/Views/ImportExportPage.xaml
@@ -11,6 +11,7 @@
         <Border Style="{StaticResource Card}">
             <WrapPanel>
                 <Button Style="{StaticResource PrimaryButton}" Content="Import Tools CSV" Command="{Binding ImportToolsCommand}" Margin="0,0,8,8"/>
+                <Button Style="{StaticResource PrimaryButton}" Content="Cancel Import" Command="{Binding ImportToolsCommand.CancelCommand}" Margin="0,0,8,8" IsEnabled="{Binding ImportToolsCommand.IsRunning}"/>
                 <Button Style="{StaticResource PrimaryButton}" Content="Export Tools CSV" Command="{Binding ExportToolsCommand}" Margin="0,0,8,8"/>
                 <Button Style="{StaticResource PrimaryButton}" Content="Import Customers CSV" Command="{Binding ImportCustomersCommand}" Margin="0,0,8,8"/>
                 <Button Style="{StaticResource PrimaryButton}" Content="Export Customers CSV" Command="{Binding ExportCustomersCommand}" Margin="0,0,8,8"/>


### PR DESCRIPTION
## Summary
- allow tool CSV import to accept `CancellationToken`
- add cancel button and handle `OperationCanceledException`
- cover import cancellation with integration test

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ecc02e1048324b17a105c49600bd2