### PR TITLE
Simplify rental history binding and add UI test

### DIFF
--- a/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
@@ -12,6 +12,8 @@ using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Tests;
 using CommunityToolkit.Mvvm.Input;
 using System.Threading.Tasks;
+using System.Windows;
+using ToolManagementAppV2.Models.Domain;
 
 namespace ToolManagementAppV2.Tests.Views
 {
@@ -111,6 +113,67 @@ namespace ToolManagementAppV2.Tests.Views
             {
                 throw threadException;
             }
+        }
+
+        [Fact]
+        public void RentalHistoryButton_BoundToSelectedTool()
+        {
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var (window, dbPath) = TestHelpers.CreateMainWindow();
+                    try
+                    {
+                        var vm = Assert.IsType<MainViewModel>(window.DataContext);
+                        var button = FindButtonByContent(window, "Rental History");
+                        Assert.NotNull(button);
+
+                        var tool = new ToolModel { ToolID = 1 };
+                        vm.ToolManagement.SelectedTool = tool;
+
+                        Assert.Same(tool, button!.CommandParameter);
+                        Assert.Same(vm.OpenRentalHistoryWindowCommand, button.Command);
+                    }
+                    finally
+                    {
+                        window.Close();
+                        if (File.Exists(dbPath))
+                            File.Delete(dbPath);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+            {
+                throw threadException;
+            }
+        }
+
+        static Button? FindButtonByContent(DependencyObject parent, string content)
+        {
+            if (parent is Button btn && btn.Content as string == content)
+                return btn;
+
+            foreach (var child in LogicalTreeHelper.GetChildren(parent))
+            {
+                if (child is DependencyObject dep)
+                {
+                    var result = FindButtonByContent(dep, content);
+                    if (result != null) return result;
+                }
+            }
+            return null;
         }
 
         [Fact]

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -35,7 +35,7 @@
 
                         <TextBlock Text="Rentals" Foreground="{StaticResource ForegroundMutedBrush}" Margin="6,8,6,2"/>
                         <Button Style="{StaticResource NavButton}" Content="Manage Rentals" Command="{Binding OpenRentalsCommand}"/>
-                        <Button Style="{StaticResource NavButton}" Content="Rental History" Command="{Binding OpenRentalHistoryWindowCommand}" CommandParameter="{Binding DataContext.SelectedTool, ElementName=MainFrame}"/>
+                        <Button Style="{StaticResource NavButton}" Content="Rental History" Command="{Binding OpenRentalHistoryWindowCommand}" CommandParameter="{Binding SelectedTool}"/>
 
                         <Separator/>
 

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -76,6 +76,8 @@ namespace ToolManagementAppV2.ViewModels
 
         public string CurrentUserRole => _userContext.Role;
 
+        public ToolModel? SelectedTool => ToolManagement.SelectedTool;
+
         public void RefreshCurrentUser()
         {
             OnPropertyChanged(nameof(IsCurrentUserAdmin));
@@ -137,6 +139,14 @@ namespace ToolManagementAppV2.ViewModels
             });
 
             ToolManagement = new ToolManagementViewModel(toolService, customerService, rentalService, _dialogService);
+            ToolManagement.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(ToolManagementViewModel.SelectedTool))
+                {
+                    OnPropertyChanged(nameof(SelectedTool));
+                    OpenRentalHistoryWindowCommand.NotifyCanExecuteChanged();
+                }
+            };
             UserManagement = new UserManagementViewModel(userService, fileDialogService, _dialogService);
             CustomerManagement = new CustomerManagementViewModel(customerService, _dialogService);
             ManageRentals = new ManageRentalsViewModel(rentalService, _dialogService);


### PR DESCRIPTION
## Summary
- Simplify Rental History button to bind directly to SelectedTool
- Expose SelectedTool on MainViewModel and keep command state updated
- Add UI test verifying Rental History button uses the selected tool

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ecc0b6e108324858633670a5dcd46