### PR TITLE
Validate password iteration count

### DIFF
--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -335,6 +335,26 @@ namespace ToolManagementAppV2.Tests.Services
             }
         }
 
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void SavePasswordIterations_Invalid_Throws(int iterations)
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                ISettingsService service = new SettingsService(dbService);
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => service.SavePasswordIterations(iterations));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
         [Fact]
         public async Task SaveAndRetrieveSettingAsync()
         {

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -368,6 +368,8 @@ namespace ToolManagementAppV2.Services.Settings
 
         public void SavePasswordIterations(int iterations)
         {
+            if (iterations <= 0)
+                throw new ArgumentOutOfRangeException(nameof(iterations));
             SaveSetting(PasswordIterationsKey, iterations.ToString());
         }
 
@@ -379,6 +381,8 @@ namespace ToolManagementAppV2.Services.Settings
 
         public async Task SavePasswordIterationsAsync(int iterations)
         {
+            if (iterations <= 0)
+                throw new ArgumentOutOfRangeException(nameof(iterations));
             await SaveSettingAsync(PasswordIterationsKey, iterations.ToString());
         }
     }

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -29,6 +29,7 @@ namespace ToolManagementAppV2.ViewModels
 
             ThemeOptions = new ObservableCollection<string> { "Light", "Dark" };
             _theme = ThemeOptions[0];
+            _passwordIterations = _settingsService.GetPasswordIterations();
             TestDbCommand = new RelayCommand(() =>
             {
                 var success = TestDbConnection(out var message);
@@ -71,6 +72,18 @@ namespace ToolManagementAppV2.ViewModels
         {
             get => _theme;
             set => SetProperty(ref _theme, value);
+        }
+
+        private int _passwordIterations;
+        public int PasswordIterations
+        {
+            get => _passwordIterations;
+            set
+            {
+                if (value <= 0) return;
+                if (SetProperty(ref _passwordIterations, value))
+                    _settingsService.SavePasswordIterations(value);
+            }
         }
 
         public ObservableCollection<string> ThemeOptions { get; }

--- a/ToolManagementAppV2/Views/SettingsPage.xaml
+++ b/ToolManagementAppV2/Views/SettingsPage.xaml
@@ -34,8 +34,14 @@
                             <ColumnDefinition Width="200"/>
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
                         <TextBlock Text="Theme" VerticalAlignment="Center"/>
                         <ComboBox Grid.Column="1" SelectedItem="{Binding Theme}" ItemsSource="{Binding ThemeOptions}" Margin="8,0,0,0"/>
+                        <TextBlock Grid.Row="1" Text="Password Iterations" VerticalAlignment="Center"/>
+                        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding PasswordIterations}" Margin="8,0,0,0" PreviewTextInput="PasswordIterationsBox_PreviewTextInput"/>
                     </Grid>
                 </StackPanel>
             </Border>

--- a/ToolManagementAppV2/Views/SettingsPage.xaml.cs
+++ b/ToolManagementAppV2/Views/SettingsPage.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace ToolManagementAppV2.Views
 {
@@ -7,6 +8,13 @@ namespace ToolManagementAppV2.Views
         public SettingsPage()
         {
             InitializeComponent();
+        }
+
+        void PasswordIterationsBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
+        {
+            var textBox = (TextBox)sender;
+            var proposed = textBox.Text.Insert(textBox.SelectionStart, e.Text);
+            e.Handled = !int.TryParse(proposed, out var value) || value <= 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
- reject invalid password iteration counts and surface configuration in Settings page
- validate Settings UI to only accept positive iteration values
- test SettingsService password iteration validation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ecc1528c48324a4929f2250b692a2