### PR TITLE
Add async dialog methods and tests

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/PasswordPromptViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/PasswordPromptViewModelTests.cs
@@ -53,7 +53,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 SelectedUser = new User { IsAdmin = false }
             };
 
-            vm.ResetPasswordCommand.Execute(null);
+            vm.ResetPasswordCommand.ExecuteAsync(null).GetAwaiter().GetResult();
 
             Assert.True(dialog.InfoShown);
             Assert.False(success);
@@ -70,7 +70,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 SelectedUser = new User { IsAdmin = true }
             };
 
-            vm.ResetPasswordCommand.Execute(null);
+            vm.ResetPasswordCommand.ExecuteAsync(null).GetAwaiter().GetResult();
 
             Assert.True(success);
             Assert.True(vm.IsPasswordResetRequested);

--- a/ToolManagementAppV2.Tests/Views/PasswordPromptWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/PasswordPromptWindowTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Views;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Views
+{
+    public class PasswordPromptWindowTests
+    {
+        [Fact]
+        public void ResetPasswordCommand_SetsFlag_WhenConfirmed()
+        {
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var dialog = new StubDialogService { ConfirmationResult = true };
+                    var window = new PasswordPromptWindow(dialog)
+                    {
+                        SelectedUser = new User { IsAdmin = true }
+                    };
+
+                    window.VM.ResetPasswordCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+
+                    Assert.True(window.IsPasswordResetRequested);
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+            {
+                throw threadException;
+            }
+        }
+
+        private class StubDialogService : IDialogService
+        {
+            public bool ConfirmationResult { get; set; }
+
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => ConfirmationResult;
+            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+            public void ShowToolDetails(ToolModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+            public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+            public void ShowScannerStatus() { }
+        }
+    }
+}
+

--- a/ToolManagementAppV2/Interfaces/IDialogService.cs
+++ b/ToolManagementAppV2/Interfaces/IDialogService.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Documents;
 using ToolManagementAppV2.ViewModels;
 
@@ -8,8 +10,17 @@ namespace ToolManagementAppV2.Interfaces
     public interface IDialogService
     {
         void ShowInfo(string message, string title);
+        Task ShowInfoAsync(string message, string title) =>
+            Application.Current?.Dispatcher?.InvokeAsync(() => ShowInfo(message, title)).Task
+            ?? Task.Run(() => ShowInfo(message, title));
         bool ShowConfirmation(string message, string title);
+        Task<bool> ShowConfirmationAsync(string message, string title) =>
+            Application.Current?.Dispatcher?.InvokeAsync(() => ShowConfirmation(message, title)).Task
+            ?? Task.FromResult(ShowConfirmation(message, title));
         ToolModel? ShowEditToolDialog(ToolModel tool);
+        Task<ToolModel?> ShowEditToolDialogAsync(ToolModel tool) =>
+            Application.Current?.Dispatcher?.InvokeAsync(() => ShowEditToolDialog(tool)).Task
+            ?? Task.FromResult(ShowEditToolDialog(tool));
         void ShowToolDetails(ToolModel tool);
         (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers);
         CustomerModel? ShowAddCustomerDialog();

--- a/ToolManagementAppV2/ViewModels/PasswordPromptViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/PasswordPromptViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 
@@ -15,7 +16,7 @@ namespace ToolManagementAppV2.ViewModels
 
         public IRelayCommand OkCommand { get; }
         public IRelayCommand CancelCommand { get; }
-        public IRelayCommand ResetPasswordCommand { get; }
+        public IAsyncRelayCommand ResetPasswordCommand { get; }
 
         private readonly Action _onSuccess;
         private readonly Action _onCancel;
@@ -31,7 +32,7 @@ namespace ToolManagementAppV2.ViewModels
 
             OkCommand = new RelayCommand(OnOk);
             CancelCommand = new RelayCommand(() => _onCancel());
-            ResetPasswordCommand = new RelayCommand(OnResetPassword);
+            ResetPasswordCommand = new AsyncRelayCommand(OnResetPasswordAsync);
         }
 
         private void OnOk()
@@ -46,17 +47,17 @@ namespace ToolManagementAppV2.ViewModels
             _showError("Incorrect password. Please try again.");
         }
 
-        void OnResetPassword()
+        async Task OnResetPasswordAsync()
         {
             if (SelectedUser?.IsAdmin != true)
             {
-                _dialogService.ShowInfo(
+                await _dialogService.ShowInfoAsync(
                     "Password recovery is only available for admin users.",
                     "Not Allowed");
                 return;
             }
 
-            if (!_dialogService.ShowConfirmation(
+            if (!await _dialogService.ShowConfirmationAsync(
                 "You have entered the wrong password multiple times. Reset to default and change it after login?",
                 "Reset Password"))
                 return;

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -202,12 +202,12 @@ namespace ToolManagementAppV2.ViewModels
             catch (InvalidOperationException ex)
             {
                 _logger.LogError(ex, "Failed to add tool due to invalid operation");
-                _dialogService.ShowInfo(ex.Message, "Error");
+                await _dialogService.ShowInfoAsync(ex.Message, "Error");
             }
             catch (ArgumentException ex)
             {
                 _logger.LogError(ex, "Failed to add tool due to invalid argument");
-                _dialogService.ShowInfo(ex.Message, "Error");
+                await _dialogService.ShowInfoAsync(ex.Message, "Error");
             }
         }
 
@@ -236,7 +236,7 @@ namespace ToolManagementAppV2.ViewModels
                 ToolImagePath = SelectedTool.ToolImagePath
             };
 
-            var updated = _dialogService.ShowEditToolDialog(clone);
+            var updated = await _dialogService.ShowEditToolDialogAsync(clone);
             if (updated == null) return;
 
             await _toolService.UpdateToolAsync(updated);
@@ -254,7 +254,7 @@ namespace ToolManagementAppV2.ViewModels
         async Task DeleteToolAsync()
         {
             if (SelectedTool == null) return;
-            var confirm = _dialogService.ShowConfirmation(
+            var confirm = await _dialogService.ShowConfirmationAsync(
                 $"Delete tool '{SelectedTool.NameDescription}'?",
                 "Confirm Delete");
             if (!confirm)
@@ -270,7 +270,7 @@ namespace ToolManagementAppV2.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to delete tool {ToolID}", SelectedTool.ToolID);
-                _dialogService.ShowInfo($"Failed to delete tool: {ex.Message}", "Error");
+                await _dialogService.ShowInfoAsync($"Failed to delete tool: {ex.Message}", "Error");
             }
         }
 
@@ -295,7 +295,7 @@ namespace ToolManagementAppV2.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to rent tool {ToolID}", SelectedTool?.ToolID);
-                _dialogService.ShowInfo($"Failed to rent tool: {ex.Message}", "Error");
+                await _dialogService.ShowInfoAsync($"Failed to rent tool: {ex.Message}", "Error");
             }
         }
 


### PR DESCRIPTION
## Summary
- add dispatcher-based async wrappers to dialog service
- await dialog results in password reset and tool management workflows
- add UI test for async password reset dialog

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ecc243618832498088497640aafad