### PR TITLE
Hash default admin password and support pre-hashed passwords

### DIFF
--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -5,6 +5,7 @@ using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Utilities.Helpers;
 using Xunit;
 
 public class UserServiceTests
@@ -153,6 +154,29 @@ public class UserServiceTests
             var user = users[0];
             Assert.Null(user.Password);
             Assert.Null(user.Salt);
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public void AddUser_UsesPreHashedPassword_WhenProvided()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+            var hash = SecurityHelper.HashPassword("secret", out var salt);
+            var user = new User { UserName = "prehashed", Password = hash, Salt = salt, PasswordExpired = true };
+            userService.AddUser(user);
+            var fetched = userService.GetUserByID(user.UserID)!;
+            Assert.Equal(hash, fetched.Password);
+            Assert.Equal(salt, fetched.Salt);
+            Assert.True(fetched.PasswordExpired);
+            Assert.True(SecurityHelper.VerifyPassword("secret", fetched.Salt, fetched.Password));
         }
         finally
         {

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -138,7 +138,8 @@ namespace ToolManagementAppV2.Services.Users
             string salt = string.Empty;
             if (!string.IsNullOrWhiteSpace(user.Password))
             {
-                if (!string.IsNullOrWhiteSpace(user.Salt))
+                if (!string.IsNullOrWhiteSpace(user.Salt) &&
+                    IsBase64String(user.Password) && IsBase64String(user.Salt))
                 {
                     hashed = user.Password;
                     salt = user.Salt;
@@ -416,9 +417,9 @@ namespace ToolManagementAppV2.Services.Users
         {
             const string sql = @"
                 INSERT INTO Users
-                  (UserName, Password, Salt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt)
+                  (UserName, Password, Salt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, PasswordExpired)
                 VALUES
-                  (@UserName,@Password,@Salt,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role,@IsActive,@CreatedAt);
+                  (@UserName,@Password,@Salt,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role,@IsActive,@CreatedAt,@PasswordExpired);
                 SELECT last_insert_rowid();";
 
             using var conn = _dbService.CreateConnection();
@@ -428,7 +429,8 @@ namespace ToolManagementAppV2.Services.Users
             string salt = string.Empty;
             if (!string.IsNullOrWhiteSpace(user.Password))
             {
-                if (!string.IsNullOrWhiteSpace(user.Salt))
+                if (!string.IsNullOrWhiteSpace(user.Salt) &&
+                    IsBase64String(user.Password) && IsBase64String(user.Salt))
                 {
                     hashed = user.Password;
                     salt = user.Salt;
@@ -454,7 +456,8 @@ namespace ToolManagementAppV2.Services.Users
                 new SQLiteParameter("@Address",  (object)user.Address ?? DBNull.Value),
                 new SQLiteParameter("@Role",     (object)user.Role ?? DBNull.Value),
                 new SQLiteParameter("@IsActive", user.IsActive ? 1 : 0),
-                new SQLiteParameter("@CreatedAt", user.CreatedAt)
+                new SQLiteParameter("@CreatedAt", user.CreatedAt),
+                new SQLiteParameter("@PasswordExpired", user.PasswordExpired ? 1 : 0)
             });
             try
             {
@@ -567,6 +570,13 @@ namespace ToolManagementAppV2.Services.Users
         {
             if (!await TryDeleteUserAsync(userID))
                 throw new InvalidOperationException($"Failed to delete user {userID}");
+        }
+
+        static bool IsBase64String(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input)) return false;
+            Span<byte> buffer = new Span<byte>(new byte[input.Length]);
+            return Convert.TryFromBase64String(input, buffer, out _);
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -146,7 +146,15 @@ namespace ToolManagementAppV2.ViewModels
                     "No users exist. A default admin account will be created (username: admin, password: admin).",
                     "Setup");
 
-                var admin = new User { UserName = "admin", Password = "admin", IsAdmin = true };
+                var hashed = SecurityHelper.HashPassword("admin", out var salt);
+                var admin = new User
+                {
+                    UserName = "admin",
+                    Password = hashed,
+                    Salt = salt,
+                    IsAdmin = true,
+                    PasswordExpired = true
+                };
                 _userService.AddUser(admin);
                 users = await _userService.GetAllUsersAsync();
             }


### PR DESCRIPTION
## Summary
- Hash default admin credentials on first run and flag password as expired
- Ensure `UserService.AddUser` safely accepts pre-hashed passwords and add coverage

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ecec9f8b483248c2704da0a8c491e