### PR TITLE
Enforce password change after reset

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -258,11 +258,38 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 vm.ResetPasswordFromRowCommand.Execute(user);
                 var updated = userService.GetUserByID(user.UserID)!;
                 Assert.NotEqual(oldPwd, updated.Password);
+                Assert.True(updated.PasswordExpired);
                 Assert.Equal("Password Reset", dialog.LastInfoTitle);
-                Assert.StartsWith("Password reset to: ", dialog.LastInfoMessage);
                 var prefix = "Password reset to: ";
-                var newPwd = dialog.LastInfoMessage.Substring(prefix.Length);
+                var suffix = ". Please change it at next login.";
+                Assert.StartsWith(prefix, dialog.LastInfoMessage);
+                Assert.EndsWith("Please change it at next login.", dialog.LastInfoMessage);
+                var newPwd = dialog.LastInfoMessage.Substring(prefix.Length,
+                    dialog.LastInfoMessage.Length - prefix.Length - suffix.Length);
                 Assert.True(SecurityHelper.VerifyPassword(newPwd, updated.Salt, updated.Password));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task ResetPasswordFromRowCommand_SetsPasswordExpiredFlag()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IUserService userService = new UserService(db, new ApplicationUserContext());
+                var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
+                userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                await vm.LoadUsersAsync();
+                var user = vm.Users.First();
+                vm.ResetPasswordFromRowCommand.Execute(user);
+                var updated = userService.GetUserByID(user.UserID)!;
+                Assert.True(updated.PasswordExpired);
             }
             finally
             {

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -293,13 +293,18 @@ namespace ToolManagementAppV2.ViewModels
             if (user == null) return;
             var newPassword = SecurityHelper.GeneratePassword();
             _userService.ChangeUserPassword(user.UserID, newPassword);
-            _dialogService.ShowInfo($"Password reset to: {newPassword}", "Password Reset");
             var refreshed = _userService.GetUserByID(user.UserID);
             if (refreshed != null)
             {
+                refreshed.PasswordExpired = true;
+                _userService.UpdateUser(refreshed);
                 user.Password = refreshed.Password;
                 user.Salt = refreshed.Salt;
+                user.PasswordExpired = true;
             }
+            _dialogService.ShowInfo(
+                $"Password reset to: {newPassword}. Please change it at next login.",
+                "Password Reset");
         }
 
         void DeleteUser(UserModel user)


### PR DESCRIPTION
## Summary
- Require users to change password after admin resets by flagging passwords as expired
- Notify administrators that users must change temporary reset passwords on next login
- Add unit tests covering password reset messaging and expiration flag

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689ececca430832484b55d605f22aeec