### PR TITLE
Dispose ChangePasswordWindow when prompting for new password

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -12,6 +12,7 @@ using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Helpers;
+using ToolManagementAppV2.Views;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.ViewModels
@@ -157,6 +158,21 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 if (File.Exists(dbPath)) File.Delete(dbPath);
             }
+        }
+
+        [Fact]
+        public void ChangePasswordWindow_Dispose_ClosesWindow()
+        {
+            if (Application.Current == null)
+                new Application();
+
+            var win = new ChangePasswordWindow();
+            var closed = false;
+            win.Closed += (_, __) => closed = true;
+
+            win.Dispose();
+
+            Assert.True(closed);
         }
     }
 

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -62,7 +62,7 @@ namespace ToolManagementAppV2.ViewModels
 
         public Func<string?> PromptForNewPassword { get; set; } = () =>
         {
-            var dlg = new Views.ChangePasswordWindow();
+            using var dlg = new Views.ChangePasswordWindow();
             return dlg.ShowDialog() == true ? dlg.NewPassword : null;
         };
 

--- a/ToolManagementAppV2/Views/ChangePasswordWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ChangePasswordWindow.xaml.cs
@@ -1,4 +1,5 @@
 // Views/ChangePasswordWindow.xaml.cs
+using System;
 using System.Windows;
 using System.Windows.Controls;
 using ToolManagementAppV2.ViewModels;
@@ -6,8 +7,10 @@ using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
-    public partial class ChangePasswordWindow : Window
+    public partial class ChangePasswordWindow : Window, IDisposable
     {
+        bool _disposed;
+
         public ChangePasswordViewModel VM => (ChangePasswordViewModel)DataContext;
         public string NewPassword => VM.NewPassword;
 
@@ -23,5 +26,13 @@ namespace ToolManagementAppV2.Views
 
         void ConfirmPasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
             => VM.ConfirmPassword = ((PasswordBox)sender).Password;
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            Close();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- wrap ChangePasswordWindow usage in LoginViewModel.PromptForNewPassword with a using statement
- make ChangePasswordWindow IDisposable so Dispose closes the window
- add unit test verifying disposing ChangePasswordWindow closes it

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689eced3eb008324aeb10eb660541e49