### PR TITLE
Limit search term count and log truncation

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -93,6 +93,32 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
+        public void SearchTools_ExceedsMaxTerms_TruncatesAndLogs()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var logs = new List<LogEntry>();
+                using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
+                var dbService = new DatabaseService(dbPath);
+                var service = new ToolService(dbService, loggerFactory.CreateLogger<ToolService>());
+
+                service.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
+
+                var search = string.Join(' ', Enumerable.Repeat("Hammer", 10)) + " extra";
+                var results = service.SearchTools(search);
+
+                Assert.Single(results);
+                Assert.Contains(logs, l => l.Level == LogLevel.Information && l.Message.Contains("truncating"));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public void AddTool_SetsGeneratedToolID()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -27,6 +27,7 @@ namespace ToolManagementAppV2.Services.Tools
             VALUES (@ToolNumber,@Desc,@Loc,@Brand,@PN,@Sup,@PD,@Notes,@Keywords,@Avail,@Rent,@Img,0,@Power);
             SELECT last_insert_rowid();";
         const int MaxQuantityOnHand = 10000;
+        const int MaxSearchTerms = 10;
     
         readonly ILogger<ToolService> _logger;
 
@@ -56,6 +57,14 @@ namespace ToolManagementAppV2.Services.Tools
 
             using var conn = _dbService.CreateConnection();
             var terms = searchText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var originalCount = terms.Length;
+            if (originalCount > MaxSearchTerms)
+            {
+                _logger.LogInformation(
+                    "Search term limit exceeded; truncating from {OriginalCount} to {Max}",
+                    originalCount, MaxSearchTerms);
+                terms = terms.Take(MaxSearchTerms).ToArray();
+            }
             var searchable = new[]
             {
                 "ToolNumber",
@@ -580,6 +589,14 @@ namespace ToolManagementAppV2.Services.Tools
 
             using var conn = _dbService.CreateConnection();
             var terms = searchText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var originalCount = terms.Length;
+            if (originalCount > MaxSearchTerms)
+            {
+                _logger.LogInformation(
+                    "Search term limit exceeded; truncating from {OriginalCount} to {Max}",
+                    originalCount, MaxSearchTerms);
+                terms = terms.Take(MaxSearchTerms).ToArray();
+            }
             var searchable = new[]
             {
                 "ToolNumber",


### PR DESCRIPTION
## Summary
- Add constant to cap search term count at 10 and log when terms are truncated
- Apply term cap to synchronous and asynchronous search methods
- Verify truncation and logging with new unit test

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eced979dc8324a6f77168050fa4f8