### PR TITLE
Handle async summary report tasks and extend tests

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
@@ -62,9 +62,71 @@ namespace ToolManagementAppV2.Tests.Services
 
                 rentalService.RentTool(tool.ToolID, customer.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
-                var task = Task.Run(async () => await reportService.GenerateSummaryReportAsync());
+                var task = Task.Run(() => reportService.GenerateSummaryReportAsync().Result);
                 Assert.True(task.Wait(TimeSpan.FromSeconds(5)), "GenerateSummaryReportAsync deadlocked.");
                 var doc = task.Result;
+                var text = new TextRange(doc.ContentStart, doc.ContentEnd).Text;
+                Assert.Contains("Total Tools: 1", text);
+                Assert.Contains("Total Rentals (History): 1", text);
+                Assert.Contains("Active Rentals: 1", text);
+                Assert.Contains("Total Customers: 1", text);
+                Assert.Contains("Total Users: 1", text);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task GenerateSummaryReportAsync_Await_ReturnsSummary()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(db, userContext);
+                var rentalService = new RentalService(db, toolService);
+                var activityLogService = new ActivityLogService(db);
+                var reportService = new ReportService(toolService, rentalService, activityLogService, customerService, userService);
+
+                var tool = new Tool
+                {
+                    ToolNumber = "T1",
+                    NameDescription = "Hammer",
+                    Location = "Loc",
+                    Brand = "Brand",
+                    PartNumber = "PN",
+                    QuantityOnHand = 1,
+                    RentedQuantity = 0
+                };
+                toolService.AddTool(tool);
+
+                var customer = new Customer
+                {
+                    Company = "Comp",
+                    Contact = "John",
+                    Phone = "123",
+                    Email = "john@example.com",
+                    Address = "Addr"
+                };
+                customerService.AddCustomer(customer);
+
+                var user = new User
+                {
+                    UserName = "user",
+                    Password = "pass",
+                    IsAdmin = false
+                };
+                userService.AddUser(user);
+
+                rentalService.RentTool(tool.ToolID, customer.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+
+                var doc = await reportService.GenerateSummaryReportAsync();
                 var text = new TextRange(doc.ContentStart, doc.ContentEnd).Text;
                 Assert.Contains("Total Tools: 1", text);
                 Assert.Contains("Total Rentals (History): 1", text);

--- a/ToolManagementAppV2/Services/Tools/ReportService.cs
+++ b/ToolManagementAppV2/Services/Tools/ReportService.cs
@@ -173,7 +173,15 @@ namespace ToolManagementAppV2.Services.Tools
             var totalCustomersTask = _customerService.GetAllCustomersAsync();
             var totalUsersTask = _userService.GetAllUsersAsync();
 
-            await Task.WhenAll(totalToolsTask, totalRentalsTask, totalActiveRentalsTask, totalCustomersTask, totalUsersTask).ConfigureAwait(false);
+            await Task
+                .WhenAll(totalToolsTask, totalRentalsTask, totalActiveRentalsTask, totalCustomersTask, totalUsersTask)
+                .ConfigureAwait(false);
+
+            var totalTools = await totalToolsTask;
+            var totalRentals = await totalRentalsTask;
+            var totalActiveRentals = await totalActiveRentalsTask;
+            var totalCustomers = await totalCustomersTask;
+            var totalUsers = await totalUsersTask;
 
             var lines = new[]
             {


### PR DESCRIPTION
## Summary
- Properly await and retrieve results for summary report tasks
- Add unit tests covering async summary report generation and deadlock scenarios

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eec2eead08324b2687ec085f423fb