### PR TITLE
Ensure password resets mark accounts expired

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -256,7 +256,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task ResetPasswordFromRowCommand_ChangesPassword()
+        public async Task ResetPasswordFromRowCommand_DoesNotExposePasswordAndSetsFlag()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -270,41 +270,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var user = vm.Users.First();
                 var original = userService.GetUserByID(user.UserID)!;
                 var oldPwd = original.Password;
-                vm.ResetPasswordFromRowCommand.Execute(user);
+                await vm.ResetPasswordFromRowCommand.ExecuteAsync(user);
                 var updated = userService.GetUserByID(user.UserID)!;
                 Assert.NotEqual(oldPwd, updated.Password);
                 Assert.True(updated.PasswordExpired);
                 Assert.Equal("Password Reset", dialog.LastInfoTitle);
-                var prefix = "Password reset to: ";
-                var suffix = ". Please change it at next login.";
-                Assert.StartsWith(prefix, dialog.LastInfoMessage);
-                Assert.EndsWith("Please change it at next login.", dialog.LastInfoMessage);
-                var newPwd = dialog.LastInfoMessage.Substring(prefix.Length,
-                    dialog.LastInfoMessage.Length - prefix.Length - suffix.Length);
-                Assert.True(SecurityHelper.VerifyPassword(newPwd, updated.Salt, updated.Password));
-            }
-            finally
-            {
-                if (File.Exists(dbPath))
-                    File.Delete(dbPath);
-            }
-        }
-
-        [Fact]
-        public async Task ResetPasswordFromRowCommand_SetsPasswordExpiredFlag()
-        {
-            var dbPath = Path.GetTempFileName();
-            try
-            {
-                var db = new DatabaseService(dbPath);
-                IUserService userService = new UserService(db, new ApplicationUserContext());
-                var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
-                userService.AddUser(new User { UserName = "user1", Password = "pw" });
-                await vm.LoadUsersAsync();
-                var user = vm.Users.First();
-                vm.ResetPasswordFromRowCommand.Execute(user);
-                var updated = userService.GetUserByID(user.UserID)!;
-                Assert.True(updated.PasswordExpired);
+                Assert.Equal("Password has been reset. The user must change it at next login.", dialog.LastInfoMessage);
             }
             finally
             {

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -56,7 +56,7 @@ namespace ToolManagementAppV2.ViewModels
 
         public IRelayCommand EditUserCommand { get; }
         public IRelayCommand EditUserFromRowCommand { get; }
-        public IRelayCommand ResetPasswordFromRowCommand { get; }
+        public IAsyncRelayCommand<UserModel> ResetPasswordFromRowCommand { get; }
         public IRelayCommand DeleteUserFromRowCommand { get; }
 
         public UserManagementViewModel(IUserService userService,
@@ -78,7 +78,7 @@ namespace ToolManagementAppV2.ViewModels
 
             EditUserCommand = new RelayCommand(() => EditUser(SelectedUser), () => SelectedUser != null);
             EditUserFromRowCommand = new RelayCommand<UserModel>(EditUser);
-            ResetPasswordFromRowCommand = new RelayCommand<UserModel>(ResetPasswordFor);
+            ResetPasswordFromRowCommand = new AsyncRelayCommand<UserModel>(ResetPasswordFor);
             DeleteUserFromRowCommand = new RelayCommand<UserModel>(DeleteUser);
         }
 
@@ -291,22 +291,22 @@ namespace ToolManagementAppV2.ViewModels
             catch (Exception ex) { _logger.LogError(ex, "Failed to show UsersEditWindow"); }
         }
 
-        void ResetPasswordFor(UserModel user)
+        async Task ResetPasswordFor(UserModel user)
         {
             if (user == null) return;
             var newPassword = SecurityHelper.GeneratePassword();
-            _userService.ChangeUserPassword(user.UserID, newPassword);
-            var refreshed = _userService.GetUserByID(user.UserID);
+            await _userService.ChangeUserPasswordAsync(user.UserID, newPassword);
+            var refreshed = await _userService.GetUserByIDAsync(user.UserID);
             if (refreshed != null)
             {
                 refreshed.PasswordExpired = true;
-                _userService.UpdateUser(refreshed);
+                await _userService.UpdateUserAsync(refreshed);
                 user.Password = refreshed.Password;
                 user.Salt = refreshed.Salt;
                 user.PasswordExpired = true;
             }
             _dialogService.ShowInfo(
-                $"Password reset to: {newPassword}. Please change it at next login.",
+                "Password has been reset. The user must change it at next login.",
                 "Password Reset");
         }
 


### PR DESCRIPTION
## Summary
- Avoid exposing plaintext when resetting passwords
- Mark accounts as password expired and persist asynchronously
- Test password reset hides plaintext and flags expiration

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eec35e03c8324aabdfe9e869e6cc5