### PR TITLE
Make edit user workflow async

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -64,6 +64,117 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public async Task EditUserAsync_PersistsChanges()
+        {
+            var svc = new InMemoryUserService();
+            svc.AddUser(new User { UserName = "user1", Password = "pw" });
+            var dialog = new StubDialogService();
+            var vm = new UserManagementViewModel(svc, new StubFileDialogService(), dialog);
+            await vm.LoadUsersAsync();
+            var user = vm.Users.First();
+            vm.SelectedUser = user;
+
+            var clone = new User
+            {
+                UserID = user.UserID,
+                UserName = user.UserName,
+                Password = user.Password,
+                Salt = user.Salt,
+                UserPhotoPath = user.UserPhotoPath,
+                IsAdmin = user.IsAdmin,
+                Email = "edited@example.com",
+                Phone = user.Phone,
+                Mobile = user.Mobile,
+                Address = user.Address,
+                Role = user.Role,
+                IsActive = user.IsActive,
+                CreatedAt = user.CreatedAt
+            };
+
+            Func<Task> onSave = async () =>
+            {
+                try
+                {
+                    await svc.UpdateUserAsync(clone);
+                    var idx = vm.Users.IndexOf(user);
+                    if (idx >= 0) vm.Users[idx] = clone;
+                    var field = typeof(UserManagementViewModel).GetField("_allUsers", BindingFlags.NonPublic | BindingFlags.Instance);
+                    var allUsers = (List<User>)field!.GetValue(vm);
+                    var idxAll = allUsers.IndexOf(user);
+                    if (idxAll >= 0) allUsers[idxAll] = clone;
+                    if (ReferenceEquals(vm.SelectedUser, user)) vm.SelectedUser = clone;
+                }
+                catch (Exception ex)
+                {
+                    dialog.ShowInfo($"Failed to update user: {ex.Message}", "Error");
+                }
+            };
+
+            var editVm = new UsersEditViewModel(clone, onSave, () => { }, () => { }, () => { });
+            await editVm.SaveCommand.ExecuteAsync(null);
+
+            Assert.Equal("edited@example.com", svc.Users.First().Email);
+            Assert.Equal("edited@example.com", vm.Users.First().Email);
+            var allField = typeof(UserManagementViewModel).GetField("_allUsers", BindingFlags.NonPublic | BindingFlags.Instance);
+            var allList = (List<User>)allField!.GetValue(vm);
+            Assert.Equal("edited@example.com", allList.First().Email);
+        }
+
+        [Fact]
+        public async Task EditUserAsync_ShowsErrorOnFailure()
+        {
+            var svc = new FailingUserService();
+            svc.AddUser(new User { UserID = 1, UserName = "user1", Password = "pw" });
+            var dialog = new StubDialogService();
+            var vm = new UserManagementViewModel(svc, new StubFileDialogService(), dialog);
+            await vm.LoadUsersAsync();
+            var user = vm.Users.First();
+            vm.SelectedUser = user;
+
+            var clone = new User
+            {
+                UserID = user.UserID,
+                UserName = user.UserName,
+                Password = user.Password,
+                Salt = user.Salt,
+                UserPhotoPath = user.UserPhotoPath,
+                IsAdmin = user.IsAdmin,
+                Email = "edited@example.com",
+                Phone = user.Phone,
+                Mobile = user.Mobile,
+                Address = user.Address,
+                Role = user.Role,
+                IsActive = user.IsActive,
+                CreatedAt = user.CreatedAt
+            };
+
+            Func<Task> onSave = async () =>
+            {
+                try
+                {
+                    await svc.UpdateUserAsync(clone);
+                    var idx = vm.Users.IndexOf(user);
+                    if (idx >= 0) vm.Users[idx] = clone;
+                    var field = typeof(UserManagementViewModel).GetField("_allUsers", BindingFlags.NonPublic | BindingFlags.Instance);
+                    var allUsers = (List<User>)field!.GetValue(vm);
+                    var idxAll = allUsers.IndexOf(user);
+                    if (idxAll >= 0) allUsers[idxAll] = clone;
+                    if (ReferenceEquals(vm.SelectedUser, user)) vm.SelectedUser = clone;
+                }
+                catch (Exception ex)
+                {
+                    dialog.ShowInfo($"Failed to update user: {ex.Message}", "Error");
+                }
+            };
+
+            var editVm = new UsersEditViewModel(clone, onSave, () => { }, () => { }, () => { });
+            await editVm.SaveCommand.ExecuteAsync(null);
+
+            Assert.Equal("Error", dialog.LastInfoTitle);
+            Assert.StartsWith("Failed to update user:", dialog.LastInfoMessage);
+        }
+
+        [Fact]
         public async Task UploadUserPhotoCommand_SetsPhotoPathAndPersists()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2.Tests/Views/UsersEditWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/UsersEditWindowTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Views;
@@ -22,7 +23,7 @@ namespace ToolManagementAppV2.Tests.Views
                     UsersEditWindow? window = null;
                     bool closed = false;
 
-                    Action onSave = () => window?.Close();
+                    Func<Task> onSave = () => { window?.Close(); return Task.CompletedTask; };
                     Action onCancel = () => window?.Close();
                     Action onRemove = () => { };
 

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -264,11 +264,11 @@ namespace ToolManagementAppV2.ViewModels
 
             UsersEditWindow? win = null;
             win = new UsersEditWindow(clone,
-                onSave: () =>
+                onSave: async () =>
                 {
                     try
                     {
-                        _userService.UpdateUserAsync(clone).GetAwaiter().GetResult();
+                        await _userService.UpdateUserAsync(clone);
                         var idx = Users.IndexOf(user);
                         if (idx >= 0) Users[idx] = clone;
                         var idxAll = _allUsers.IndexOf(user);

--- a/ToolManagementAppV2/ViewModels/UsersEditViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UsersEditViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ToolManagementAppV2.Models.Domain;
 using System;
+using System.Threading.Tasks;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -13,16 +14,16 @@ namespace ToolManagementAppV2.ViewModels
 
         public IRelayCommand BrowseAvatarCommand { get; }
         public IRelayCommand RemoveAvatarCommand { get; }
-        public IRelayCommand SaveCommand { get; }
+        public IAsyncRelayCommand SaveCommand { get; }
         public IRelayCommand CancelCommand { get; }
 
-        public UsersEditViewModel(User user, Action onSave, Action onCancel, Action onBrowseAvatar, Action onRemoveAvatar)
+        public UsersEditViewModel(User user, Func<Task> onSave, Action onCancel, Action onBrowseAvatar, Action onRemoveAvatar)
         {
             EditingUser = user ?? new User();
             Title = (EditingUser.UserID == 0) ? "Add User" : "Edit User";
             BrowseAvatarCommand = new RelayCommand(onBrowseAvatar);
             RemoveAvatarCommand = new RelayCommand(onRemoveAvatar);
-            SaveCommand = new RelayCommand(onSave);
+            SaveCommand = new AsyncRelayCommand(onSave);
             CancelCommand = new RelayCommand(onCancel);
         }
     }

--- a/ToolManagementAppV2/Views/UsersEditWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/UsersEditWindow.xaml.cs
@@ -1,5 +1,6 @@
 // Views/UsersEditWindow.xaml.cs
 using System;
+using System.Threading.Tasks;
 using System.Windows;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.ViewModels;
@@ -9,7 +10,7 @@ namespace ToolManagementAppV2.Views
 {
     public partial class UsersEditWindow : Window
     {
-        public UsersEditWindow(User user, Action onSave, Action onCancel, Action onRemoveAvatar)
+        public UsersEditWindow(User user, Func<Task> onSave, Action onCancel, Action onRemoveAvatar)
         {
             InitializeComponent();
             DataContext = new UsersEditViewModel(user, onSave, onCancel, BrowseAvatar, onRemoveAvatar);


### PR DESCRIPTION
## Summary
- Make UsersEditWindow and ViewModel use async save command
- Await user updates in edit workflow and surface errors through dialog service
- Cover async edit flow with unit tests

## Testing
- `dotnet test` *(fails: command not found; environment lacks .NET SDK)*

------
https://chatgpt.com/codex/tasks/task_e_689eec6db9508324b2366f76a35c18a3