### PR TITLE
Add async dialog helpers and update view models

### DIFF
--- a/ToolManagementAppV2.Tests/Views/DialogServiceAsyncTests.cs
+++ b/ToolManagementAppV2.Tests/Views/DialogServiceAsyncTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Threading;
+using ToolManagementAppV2.Services;
+using ToolManagementAppV2.Views;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Views
+{
+    public class DialogServiceAsyncTests
+    {
+        [Fact]
+        public void ShowInfoAsync_DialogClosesWithoutBlocking()
+        {
+            Exception? threadException = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    var service = new DialogService();
+                    var task = service.ShowInfoAsync("Message", "Title");
+                    Application.Current.Dispatcher.BeginInvoke(new Action(() =>
+                    {
+                        var win = Application.Current.Windows.OfType<InfoDialogWindow>().FirstOrDefault();
+                        win?.Close();
+                    }), DispatcherPriority.ApplicationIdle);
+                    Assert.True(task.Wait(TimeSpan.FromSeconds(1)));
+                    app.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadException != null)
+                throw threadException;
+        }
+
+        [Fact]
+        public void ShowConfirmationAsync_ReturnsResultWithoutBlocking()
+        {
+            Exception? threadException = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    var service = new DialogService();
+                    var task = service.ShowConfirmationAsync("?", "Confirm");
+                    Application.Current.Dispatcher.BeginInvoke(new Action(() =>
+                    {
+                        var win = Application.Current.Windows.OfType<ConfirmDialogWindow>().FirstOrDefault();
+                        if (win != null)
+                            win.DialogResult = true;
+                    }), DispatcherPriority.ApplicationIdle);
+                    Assert.True(task.Wait(TimeSpan.FromSeconds(1)));
+                    Assert.True(task.Result);
+                    app.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadException != null)
+                throw threadException;
+        }
+    }
+}

--- a/ToolManagementAppV2/Services/DialogService.cs
+++ b/ToolManagementAppV2/Services/DialogService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Documents;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.ViewModels;
@@ -25,11 +27,19 @@ namespace ToolManagementAppV2.Services
             dialog.ShowDialog();
         }
 
+        public Task ShowInfoAsync(string message, string title) =>
+            Application.Current?.Dispatcher?.InvokeAsync(() => ShowInfo(message, title)).Task
+            ?? Task.Run(() => ShowInfo(message, title));
+
         public bool ShowConfirmation(string message, string title)
         {
             var dialog = new ConfirmDialogWindow(message) { Title = title };
             return dialog.ShowDialog() == true;
         }
+
+        public Task<bool> ShowConfirmationAsync(string message, string title) =>
+            Application.Current?.Dispatcher?.InvokeAsync(() => ShowConfirmation(message, title)).Task
+            ?? Task.FromResult(ShowConfirmation(message, title));
 
         public ToolModel? ShowEditToolDialog(ToolModel tool)
         {
@@ -42,6 +52,10 @@ namespace ToolManagementAppV2.Services
             try { return win.ShowDialog() == true ? tool : null; }
             catch (Exception ex) { _logger.LogError(ex, "Failed to show ToolEditWindow"); return null; }
         }
+
+        public Task<ToolModel?> ShowEditToolDialogAsync(ToolModel tool) =>
+            Application.Current?.Dispatcher?.InvokeAsync(() => ShowEditToolDialog(tool)).Task
+            ?? Task.FromResult(ShowEditToolDialog(tool));
 
         public void ShowToolDetails(ToolModel tool)
         {

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -71,21 +71,21 @@ namespace ToolManagementAppV2.ViewModels
                 var map = _dialogService.ShowImportMapping(headers, properties);
                 if (map == null)
                     return;
-                _dialogService.ShowInfo("Importing tools...", "Import Tools");
+                await _dialogService.ShowInfoAsync("Importing tools...", "Import Tools");
                 await _toolService.ImportToolsFromCsvAsync(path, map, cancellationToken);
                 ImportExportLogs.Add($"Successfully imported tools from {path}.");
-                _dialogService.ShowInfo($"Successfully imported tools from {path}.", "Import Tools");
+                await _dialogService.ShowInfoAsync($"Successfully imported tools from {path}.", "Import Tools");
             }
             catch (OperationCanceledException)
             {
                 ImportExportLogs.Add("Tool import was cancelled.");
-                _dialogService.ShowInfo("Tool import was cancelled.", "Import Tools");
+                await _dialogService.ShowInfoAsync("Tool import was cancelled.", "Import Tools");
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to import tools from {Path}", path);
                 ImportExportLogs.Add($"Failed to import tools from {path}: {ex.Message}");
-                _dialogService.ShowInfo($"Failed to import tools from {path}: {ex.Message}", "Import Tools");
+                await _dialogService.ShowInfoAsync($"Failed to import tools from {path}: {ex.Message}", "Import Tools");
             }
         }
 

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -142,7 +142,7 @@ namespace ToolManagementAppV2.ViewModels
             var users = await _userService.GetAllUsersAsync();
             if (users.Count == 0)
             {
-                _dialogService.ShowInfo(
+                await _dialogService.ShowInfoAsync(
                     "No users exist. A default admin account will be created (username: admin, password: admin).",
                     "Setup");
 
@@ -220,7 +220,7 @@ namespace ToolManagementAppV2.ViewModels
                         user.PasswordExpired = refreshed.PasswordExpired;
                     }
                     await LoadUsersCommand.ExecuteAsync(null);
-                    _dialogService.ShowInfo("Password has been reset to default. Please enter the new password to login.",
+                    await _dialogService.ShowInfoAsync("Password has been reset to default. Please enter the new password to login.",
                         "Password Reset");
                     continue;
                 }
@@ -228,7 +228,7 @@ namespace ToolManagementAppV2.ViewModels
                 credential = await _userService.AuthenticateUserAsync(user.UserName, promptResult.Password);
                 if (credential == null)
                 {
-                    _dialogService.ShowInfo("Incorrect password. Please try again.", "Login Failed");
+                    await _dialogService.ShowInfoAsync("Incorrect password. Please try again.", "Login Failed");
                 }
             }
 

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -344,18 +344,18 @@ namespace ToolManagementAppV2.ViewModels
                 var map = _dialogService.ShowImportMapping(headers, properties);
                 if (map != null)
                 {
-                    _dialogService.ShowInfo("Importing tools...", "Import Tools");
+                    await _dialogService.ShowInfoAsync("Importing tools...", "Import Tools");
                     var invalid = await _toolService.ImportToolsFromCsvAsync(path, map, CancellationToken.None);
                     var msg = invalid.Count == 0
                         ? "Successfully imported tools."
                         : $"Imported with {invalid.Count} invalid rows.";
-                    _dialogService.ShowInfo(msg, "Import Tools");
+                    await _dialogService.ShowInfoAsync(msg, "Import Tools");
                 }
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to import tools from CSV");
-                _dialogService.ShowInfo($"Failed to import tools: {ex.Message}", "Import Tools");
+                await _dialogService.ShowInfoAsync($"Failed to import tools: {ex.Message}", "Import Tools");
             }
         }
 

--- a/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
@@ -113,7 +113,7 @@ namespace ToolManagementAppV2.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load rentals");
-                _dialogService.ShowInfo($"Failed to load rentals: {ex.Message}", "Error");
+                await _dialogService.ShowInfoAsync($"Failed to load rentals: {ex.Message}", "Error");
             }
         }
 
@@ -174,7 +174,7 @@ namespace ToolManagementAppV2.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to check in rental {RentalID}", SelectedRental.RentalID);
-                _dialogService.ShowInfo($"Failed to check in rental: {ex.Message}", "Error");
+                await _dialogService.ShowInfoAsync($"Failed to check in rental: {ex.Message}", "Error");
             }
         }
 
@@ -191,7 +191,7 @@ namespace ToolManagementAppV2.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to extend rental {RentalID}", SelectedRental.RentalID);
-                _dialogService.ShowInfo($"Failed to extend rental: {ex.Message}", "Error");
+                await _dialogService.ShowInfoAsync($"Failed to extend rental: {ex.Message}", "Error");
             }
         }
 
@@ -213,7 +213,7 @@ namespace ToolManagementAppV2.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to open rental history for tool {ToolID}", SelectedRental.ToolID);
-                _dialogService.ShowInfo($"Failed to load rental history: {ex.Message}", "Error");
+                await _dialogService.ShowInfoAsync($"Failed to load rental history: {ex.Message}", "Error");
             }
         }
 
@@ -278,7 +278,7 @@ namespace ToolManagementAppV2.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to delete rental {RentalID}", SelectedRental.RentalID);
-                _dialogService.ShowInfo($"Failed to delete rental: {ex.Message}", "Error");
+                await _dialogService.ShowInfoAsync($"Failed to delete rental: {ex.Message}", "Error");
             }
         }
     }

--- a/ToolManagementAppV2/ViewModels/ScannerStatusViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ScannerStatusViewModel.cs
@@ -61,7 +61,7 @@ namespace ToolManagementAppV2.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to refresh scanner devices");
-                _dialogService.ShowInfo($"Failed to refresh scanner devices: {ex.Message}", "Error");
+                await _dialogService.ShowInfoAsync($"Failed to refresh scanner devices: {ex.Message}", "Error");
             }
         }
     }

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -115,7 +115,7 @@ namespace ToolManagementAppV2.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to update user photo");
-                _dialogService.ShowInfo($"Failed to update user photo: {ex.Message}", "Error");
+                await _dialogService.ShowInfoAsync($"Failed to update user photo: {ex.Message}", "Error");
             }
         }
 
@@ -133,7 +133,7 @@ namespace ToolManagementAppV2.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to update user");
-                _dialogService.ShowInfo($"Failed to update user: {ex.Message}", "Error");
+                await _dialogService.ShowInfoAsync($"Failed to update user: {ex.Message}", "Error");
             }
         }
 


### PR DESCRIPTION
## Summary
- Add asynchronous dialog methods in `DialogService` for info, confirmation, and edit dialogs
- Refactor view models to await non-blocking dialog operations
- Add integration tests verifying dialogs close without blocking

## Testing
- `dotnet test` *(fails: bash: command not found: dotnet)*
- `apt-get update` *(fails: repository InRelease not signed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689eec6caee483249592853a5386fc46