### PR TITLE
Fix user loading command and SettingsViewModel accessibility

### DIFF
--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -91,7 +91,7 @@ namespace ToolManagementAppV2.ViewModels
         public IAsyncRelayCommand OpenManageToolsCommand { get; }
         public IAsyncRelayCommand OpenRentalsCommand { get; }
         public IAsyncRelayCommand OpenCustomersCommand { get; }
-        public IRelayCommand OpenUsersCommand { get; }
+        public IAsyncRelayCommand OpenUsersCommand { get; }
         public IRelayCommand OpenSettingsCommand { get; }
         public IRelayCommand OpenImportExportCommand { get; }
         public IRelayCommand OpenActivityLogsCommand { get; }
@@ -192,9 +192,9 @@ namespace ToolManagementAppV2.ViewModels
                 CurrentPage = page;
             });
 
-            OpenUsersCommand = new RelayCommand(() =>
+            OpenUsersCommand = new AsyncRelayCommand(async () =>
             {
-                UserManagement.LoadUsers();
+                await UserManagement.LoadUsersAsync();
                 var page = new UsersPage
                 {
                     // UsersPage expects a UserManagementViewModel as its DataContext

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.ViewModels
 {
-    internal class SettingsViewModel : ObservableObject
+    public class SettingsViewModel : ObservableObject
     {
         readonly IFileDialogService _fileDialog;
         readonly ISettingsService _settingsService;


### PR DESCRIPTION
## Summary
- load users asynchronously in MainViewModel
- expose SettingsViewModel publicly

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eef1abc208324b2bfe090272a9c51