### PR TITLE
Filter tools before ordering in Printer

### DIFF
--- a/ToolManagementAppV2/Services/Tools/Printer.cs
+++ b/ToolManagementAppV2/Services/Tools/Printer.cs
@@ -99,9 +99,10 @@ namespace ToolManagementAppV2.Services.Tools
         private async Task<FlowDocument> BuildDocumentIncrementallyAsync(IEnumerable<ToolModel> tools, string title, string? logoPath, string? currentUserName, int batchSize)
         {
             var doc = BuildDocument(title, logoPath);
-            var ordered = tools.OrderBy(t => t.Location);
+            var ordered = tools;
             if (!string.IsNullOrEmpty(currentUserName))
                 ordered = ordered.Where(t => t.CheckedOutBy == currentUserName);
+            ordered = ordered.OrderBy(t => t.Location);
 
             foreach (var batch in ordered.Chunk(batchSize))
             {


### PR DESCRIPTION
## Summary
- ensure tool listing filters by user before ordering by location for printing

## Testing
- `dotnet test` *(fails: bash: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689ef19f94a083248cbac7d5861ce0e1