### PR TITLE
Alias WPF TextBox in SettingsPage

### DIFF
--- a/ToolManagementAppV2/Views/SettingsPage.xaml.cs
+++ b/ToolManagementAppV2/Views/SettingsPage.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Controls;
 using System.Windows.Input;
+using TextBox = System.Windows.Controls.TextBox;
 
 namespace ToolManagementAppV2.Views
 {


### PR DESCRIPTION
## Summary
- Alias WPF TextBox in SettingsPage to ensure cast uses System.Windows.Controls control

## Testing
- `dotnet test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ef1a1a94483249d7840b0ebac9cd6