### PR TITLE
Use named logger for PathHelper

### DIFF
--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -55,7 +55,7 @@ namespace ToolManagementAppV2
             _serviceProvider = services.BuildServiceProvider();
 
             var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
-            PathHelper.Configure(loggerFactory.CreateLogger<PathHelper>());
+            PathHelper.Configure(loggerFactory.CreateLogger("PathHelper"));
 
             var db = new DatabaseService(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db"), loggerFactory.CreateLogger<DatabaseService>());
             var toolService = new ToolService(db, loggerFactory.CreateLogger<ToolService>());


### PR DESCRIPTION
## Summary
- Configure PathHelper with a named logger instead of generic `ILogger<PathHelper>`
- Verified no other production code relies on `ILogger<PathHelper>`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ef1a6c418832496d57d920268426a