### PR TITLE
Fully qualify Application reference in Navigation

### DIFF
--- a/ToolManagementAppV2/Utilities/Navigation.cs
+++ b/ToolManagementAppV2/Utilities/Navigation.cs
@@ -8,7 +8,7 @@ namespace ToolManagementAppV2
     {
         public static void ShowMainWindow()
         {
-            var current = Application.Current.MainWindow as MainWindow;
+            var current = System.Windows.Application.Current.MainWindow as MainWindow;
 
             if (current == null)
                 throw new InvalidOperationException("Main window is not initialized.");


### PR DESCRIPTION
## Summary
- fully qualify System.Windows.Application in navigation helper

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ef1ad9abc83249f225c448bb0fa7b