### PR TITLE
Qualify Application.Current references to System.Windows.Application

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/AdminButtonVisibilityTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/AdminButtonVisibilityTests.cs
@@ -14,10 +14,10 @@ namespace ToolManagementAppV2.Tests.Tests
         [Fact]
         public void NonAdminUser_HidesAdminButtons()
         {
-            if (Application.Current == null)
-                new Application();
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
 
-            Application.Current.Properties["CurrentUser"] = new UserModel { UserName = "user", IsAdmin = false };
+            System.Windows.Application.Current.Properties["CurrentUser"] = new UserModel { UserName = "user", IsAdmin = false };
             try
             {
                 var (window, dbPath) = TestHelpers.CreateMainWindow();
@@ -43,7 +43,7 @@ namespace ToolManagementAppV2.Tests.Tests
             }
             finally
             {
-                Application.Current.Properties.Remove("CurrentUser");
+                System.Windows.Application.Current.Properties.Remove("CurrentUser");
             }
         }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -22,8 +22,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task SelectUserCommand_SetsCurrentUser()
         {
-            if (Application.Current == null)
-                new Application();
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
 
             var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
             try
@@ -54,8 +54,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task SelectUserCommand_PromptsForPasswordChange_WhenExpired()
         {
-            if (Application.Current == null)
-                new Application();
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
 
             var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
             try
@@ -91,8 +91,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task SelectUserCommand_PromptsForPassword_AuthenticatesAdmin()
         {
-            if (Application.Current == null)
-                new Application();
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
 
             var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
             try
@@ -126,8 +126,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task SelectUserCommand_CanBeCancelled()
         {
-            if (Application.Current == null)
-                new Application();
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
 
             var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
             try
@@ -163,8 +163,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void ChangePasswordWindow_Dispose_ClosesWindow()
         {
-            if (Application.Current == null)
-                new Application();
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
 
             var win = new ChangePasswordWindow();
             var closed = false;

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -20,8 +20,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void RefreshCurrentUser_RaisesPropertyChanged()
         {
-            if (Application.Current == null)
-                new Application();
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
 
             var dbPath = Path.GetTempFileName();
             try

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -21,8 +21,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void SwitchUserCommand_UpdatesCurrentUser()
         {
-            if (Application.Current == null)
-                new Application();
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
 
             var dbPath = Path.GetTempFileName();
             try
@@ -64,8 +64,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void SwitchUserCommand_ShowsWarning_WhenLoginCancelled()
         {
-            if (Application.Current == null)
-                new Application();
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
 
             var dbPath = Path.GetTempFileName();
             try

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
@@ -19,10 +19,10 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void ExitCommand_ShowsError_WhenShutdownThrows()
         {
-            if (Application.Current == null)
-                new Application();
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
 
-            var app = Application.Current;
+            var app = System.Windows.Application.Current;
             void ThrowOnExit(object? sender, ExitEventArgs e) => throw new InvalidOperationException("fail");
             app.Exit += ThrowOnExit;
 
@@ -57,8 +57,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void OpenPrintLabelWindow_ShowsError_WhenDialogFails()
         {
-            if (Application.Current == null)
-                new Application();
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
 
             var dbPath = Path.GetTempFileName();
             try

--- a/ToolManagementAppV2.Tests/Views/DialogServiceAsyncTests.cs
+++ b/ToolManagementAppV2.Tests/Views/DialogServiceAsyncTests.cs
@@ -20,12 +20,12 @@ namespace ToolManagementAppV2.Tests.Views
             {
                 try
                 {
-                    var app = new Application();
+                    var app = new System.Windows.Application();
                     var service = new DialogService();
                     var task = service.ShowInfoAsync("Message", "Title");
-                    Application.Current.Dispatcher.BeginInvoke(new Action(() =>
+                    System.Windows.Application.Current.Dispatcher.BeginInvoke(new Action(() =>
                     {
-                        var win = Application.Current.Windows.OfType<InfoDialogWindow>().FirstOrDefault();
+                        var win = System.Windows.Application.Current.Windows.OfType<InfoDialogWindow>().FirstOrDefault();
                         win?.Close();
                     }), DispatcherPriority.ApplicationIdle);
                     Assert.True(task.Wait(TimeSpan.FromSeconds(1)));
@@ -51,12 +51,12 @@ namespace ToolManagementAppV2.Tests.Views
             {
                 try
                 {
-                    var app = new Application();
+                    var app = new System.Windows.Application();
                     var service = new DialogService();
                     var task = service.ShowConfirmationAsync("?", "Confirm");
-                    Application.Current.Dispatcher.BeginInvoke(new Action(() =>
+                    System.Windows.Application.Current.Dispatcher.BeginInvoke(new Action(() =>
                     {
-                        var win = Application.Current.Windows.OfType<ConfirmDialogWindow>().FirstOrDefault();
+                        var win = System.Windows.Application.Current.Windows.OfType<ConfirmDialogWindow>().FirstOrDefault();
                         if (win != null)
                             win.DialogResult = true;
                     }), DispatcherPriority.ApplicationIdle);

--- a/ToolManagementAppV2/Interfaces/IDialogService.cs
+++ b/ToolManagementAppV2/Interfaces/IDialogService.cs
@@ -11,15 +11,15 @@ namespace ToolManagementAppV2.Interfaces
     {
         void ShowInfo(string message, string title);
         Task ShowInfoAsync(string message, string title) =>
-            Application.Current?.Dispatcher?.InvokeAsync(() => ShowInfo(message, title)).Task
+            System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowInfo(message, title)).Task
             ?? Task.Run(() => ShowInfo(message, title));
         bool ShowConfirmation(string message, string title);
         Task<bool> ShowConfirmationAsync(string message, string title) =>
-            Application.Current?.Dispatcher?.InvokeAsync(() => ShowConfirmation(message, title)).Task
+            System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowConfirmation(message, title)).Task
             ?? Task.FromResult(ShowConfirmation(message, title));
         ToolModel? ShowEditToolDialog(ToolModel tool);
         Task<ToolModel?> ShowEditToolDialogAsync(ToolModel tool) =>
-            Application.Current?.Dispatcher?.InvokeAsync(() => ShowEditToolDialog(tool)).Task
+            System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowEditToolDialog(tool)).Task
             ?? Task.FromResult(ShowEditToolDialog(tool));
         void ShowToolDetails(ToolModel tool);
         (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers);

--- a/ToolManagementAppV2/Services/DialogService.cs
+++ b/ToolManagementAppV2/Services/DialogService.cs
@@ -28,7 +28,7 @@ namespace ToolManagementAppV2.Services
         }
 
         public Task ShowInfoAsync(string message, string title) =>
-            Application.Current?.Dispatcher?.InvokeAsync(() => ShowInfo(message, title)).Task
+            System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowInfo(message, title)).Task
             ?? Task.Run(() => ShowInfo(message, title));
 
         public bool ShowConfirmation(string message, string title)
@@ -38,7 +38,7 @@ namespace ToolManagementAppV2.Services
         }
 
         public Task<bool> ShowConfirmationAsync(string message, string title) =>
-            Application.Current?.Dispatcher?.InvokeAsync(() => ShowConfirmation(message, title)).Task
+            System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowConfirmation(message, title)).Task
             ?? Task.FromResult(ShowConfirmation(message, title));
 
         public ToolModel? ShowEditToolDialog(ToolModel tool)
@@ -54,7 +54,7 @@ namespace ToolManagementAppV2.Services
         }
 
         public Task<ToolModel?> ShowEditToolDialogAsync(ToolModel tool) =>
-            Application.Current?.Dispatcher?.InvokeAsync(() => ShowEditToolDialog(tool)).Task
+            System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowEditToolDialog(tool)).Task
             ?? Task.FromResult(ShowEditToolDialog(tool));
 
         public void ShowToolDetails(ToolModel tool)

--- a/ToolManagementAppV2/Utilities/Navigation.cs
+++ b/ToolManagementAppV2/Utilities/Navigation.cs
@@ -8,7 +8,7 @@ namespace ToolManagementAppV2
     {
         public static void ShowMainWindow()
         {
-            var current = Application.Current.MainWindow as MainWindow;
+            var current = System.Windows.Application.Current.MainWindow as MainWindow;
 
             if (current == null)
                 throw new InvalidOperationException("Main window is not initialized.");

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -24,7 +24,7 @@ namespace ToolManagementAppV2.ViewModels
     /// authentication workflow via <see cref="SelectUserCommand"/>. The process covers
     /// default password generation and resets so future logins remain possible. When a
     /// user successfully authenticates the <see cref="LoginSucceeded"/> event is raised
-    /// and the authenticated user is stored in <see cref="Application.Current"/>.
+    /// and the authenticated user is stored in <see cref="System.Windows.Application.Current"/>.
     /// </summary>
     public class LoginViewModel : ObservableObject
     {


### PR DESCRIPTION
## Summary
- fully qualify Application.Current usages to System.Windows.Application to avoid Windows Forms ambiguity
- update tests and services to use fully-qualified WPF Application

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ef1af8fa0832492504ad6bd56009d