### PR TITLE
Handle ToolManagement event cleanup in MainViewModel

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelDisposalTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelDisposalTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using CommunityToolkit.Mvvm.ComponentModel;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class MainViewModelDisposalTests
+    {
+        [Fact]
+        public void Dispose_RemovesToolManagementPropertyChangedHandler()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(db, userContext);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
+                var fileDialogService = new StubFileDialogService();
+                var dialogService = new StubDialogService();
+
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                    fileDialogService, activityLogService, settingsService, db, dialogService);
+
+                var field = typeof(ObservableObject).GetField("PropertyChanged", BindingFlags.Instance | BindingFlags.NonPublic);
+                var handlersBefore = ((MulticastDelegate?)field?.GetValue(vm.ToolManagement))?.GetInvocationList() ?? Array.Empty<Delegate>();
+                Assert.Contains(handlersBefore, h => ReferenceEquals(h.Target, vm));
+
+                vm.Dispose();
+
+                var handlersAfter = ((MulticastDelegate?)field?.GetValue(vm.ToolManagement))?.GetInvocationList() ?? Array.Empty<Delegate>();
+                Assert.DoesNotContain(handlersAfter, h => ReferenceEquals(h.Target, vm));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void RepeatedCreation_DoesNotCauseMemoryGrowth()
+        {
+            long before = GC.GetTotalMemory(true);
+
+            for (int i = 0; i < 50; i++)
+            {
+                var dbPath = Path.GetTempFileName();
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(db, userContext);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
+                var fileDialogService = new StubFileDialogService();
+                var dialogService = new StubDialogService();
+
+                using var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                    fileDialogService, activityLogService, settingsService, db, dialogService);
+
+                db.Dispose();
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            long after = GC.GetTotalMemory(true);
+            Assert.True(after - before < 5_000_000);
+        }
+
+        class StubDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => false;
+            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+            public void ShowToolDetails(ToolModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+            public Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+            public void ShowScannerStatus() { }
+        }
+
+        class StubFileDialogService : IFileDialogService
+        {
+            public string OpenFile(string filter) => null;
+            public string SaveFile(string filter) => null;
+        }
+    }
+}
+

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -36,6 +37,8 @@ namespace ToolManagementAppV2.ViewModels
         readonly IDialogService _dialogService;
         readonly ILogger<MainViewModel> _logger;
         readonly Func<bool> _showLoginWindow;
+
+        PropertyChangedEventHandler? _toolManagementPropertyChangedHandler;
 
         public ToolManagementViewModel ToolManagement { get; }
         public UserManagementViewModel UserManagement { get; }
@@ -140,7 +143,7 @@ namespace ToolManagementAppV2.ViewModels
             });
 
             ToolManagement = new ToolManagementViewModel(toolService, customerService, rentalService, _dialogService);
-            ToolManagement.PropertyChanged += (s, e) =>
+            _toolManagementPropertyChangedHandler = (s, e) =>
             {
                 if (e.PropertyName == nameof(ToolManagementViewModel.SelectedTool))
                 {
@@ -148,6 +151,7 @@ namespace ToolManagementAppV2.ViewModels
                     OpenRentalHistoryWindowCommand.NotifyCanExecuteChanged();
                 }
             };
+            ToolManagement.PropertyChanged += _toolManagementPropertyChangedHandler;
             UserManagement = new UserManagementViewModel(userService, fileDialogService, _dialogService);
             CustomerManagement = new CustomerManagementViewModel(customerService, _dialogService);
             ManageRentals = new ManageRentalsViewModel(rentalService, _dialogService);
@@ -362,6 +366,11 @@ namespace ToolManagementAppV2.ViewModels
         /// <inheritdoc />
         public void Dispose()
         {
+            if (_toolManagementPropertyChangedHandler != null)
+            {
+                ToolManagement.PropertyChanged -= _toolManagementPropertyChangedHandler;
+                _toolManagementPropertyChangedHandler = null;
+            }
             ToolManagement.Dispose();
         }
     }


### PR DESCRIPTION
## Summary
- Ensure MainViewModel stores and unsubscribes ToolManagement.PropertyChanged handler before disposal
- Add unit test confirming handler is removed and integration test checking repeated MainViewModel creation doesn't grow memory

## Testing
- `dotnet test` *(fails: dotnet command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ef60b7ed88324b7dd84741f656217