### PR TITLE
Refactor login initialization to async

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -20,6 +20,34 @@ namespace ToolManagementAppV2.Tests.ViewModels
     public class LoginViewModelTests
     {
         [Fact]
+        public async Task InitializeAsync_LoadsLogoAndTitle()
+        {
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
+
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            try
+            {
+                using var dbService = new DatabaseService(dbPath);
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(dbService, userContext);
+                var settingsService = new SettingsService(dbService);
+                await settingsService.SaveSettingAsync("ApplicationName", "TestApp");
+
+                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext);
+                await vm.InitializeAsync();
+
+                Assert.Equal("TestApp – Login", vm.WindowTitle);
+                Assert.NotNull(vm.CompanyLogo);
+                Assert.NotEmpty(vm.Users);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public async Task SelectUserCommand_SetsCurrentUser()
         {
             if (System.Windows.Application.Current == null)
@@ -35,7 +63,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 userService.AddUser(new User { UserName = "user", Password = "newpassword", IsAdmin = false });
 
                 var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext);
-                await vm.LoadUsersCommand.ExecuteAsync(null);
+                await vm.InitializeAsync();
                 bool success = false;
                 vm.LoginSucceeded += (_, __) => success = true;
 
@@ -71,7 +99,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 {
                     PromptForNewPassword = () => "changed"
                 };
-                await vm.LoadUsersCommand.ExecuteAsync(null);
+                await vm.InitializeAsync();
                 bool success = false;
                 vm.LoginSucceeded += (_, __) => success = true;
 
@@ -108,7 +136,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     PromptForPasswordAsync = (u, ct) =>
                         Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("secret", false))
                 };
-                await vm.LoadUsersCommand.ExecuteAsync(null);
+                await vm.InitializeAsync();
                 bool success = false;
                 vm.LoginSucceeded += (_, __) => success = true;
 
@@ -146,7 +174,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                         return new PasswordPromptResult("secret", false);
                     }
                 };
-                await vm.LoadUsersCommand.ExecuteAsync(null);
+                await vm.InitializeAsync();
 
                 var execTask = vm.SelectUserCommand.ExecuteAsync(vm.Users.First());
                 vm.SelectUserCommand.Cancel();

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Windows;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
@@ -19,7 +20,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     public class MainViewModelSwitchUserTests
     {
         [Fact]
-        public void SwitchUserCommand_UpdatesCurrentUser()
+        public async Task SwitchUserCommand_UpdatesCurrentUser()
         {
             if (System.Windows.Application.Current == null)
                 new System.Windows.Application();
@@ -37,10 +38,10 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var settingsService = new SettingsService(db);
 
                 var newUser = new User { UserName = "newuser", IsAdmin = true };
-                Func<bool> stubLogin = () =>
+                Func<Task<bool>> stubLogin = () =>
                 {
                     userContext.CurrentUser = newUser;
-                    return true;
+                    return Task.FromResult(true);
                 };
 
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
@@ -49,7 +50,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 userContext.CurrentUser = new User { UserName = "old", IsAdmin = false };
                 vm.RefreshCurrentUser();
 
-                vm.SwitchUserCommand.Execute(null);
+                await vm.SwitchUserCommand.ExecuteAsync(null);
 
                 Assert.Equal("newuser", vm.CurrentUserName);
                 Assert.True(vm.IsCurrentUserAdmin);
@@ -62,7 +63,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void SwitchUserCommand_ShowsWarning_WhenLoginCancelled()
+        public async Task SwitchUserCommand_ShowsWarning_WhenLoginCancelled()
         {
             if (System.Windows.Application.Current == null)
                 new System.Windows.Application();
@@ -82,12 +83,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var dialog = new StubDialogService();
                 var logger = new StubLogger<MainViewModel>();
 
-                Func<bool> stubLogin = () => false;
+                Func<Task<bool>> stubLogin = () => Task.FromResult(false);
 
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
                     new StubFileDialogService(), activityLogService, settingsService, db, dialog, logger, stubLogin);
 
-                vm.SwitchUserCommand.Execute(null);
+                await vm.SwitchUserCommand.ExecuteAsync(null);
 
                 Assert.True(dialog.InfoShown);
                 Assert.Equal("Switch user cancelled.", logger.LastWarning);

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -24,7 +24,7 @@ namespace ToolManagementAppV2
     {
         private ServiceProvider? _serviceProvider;
 
-        protected override void OnStartup(StartupEventArgs e)
+        protected override async void OnStartup(StartupEventArgs e)
         {
             ShutdownMode = ShutdownMode.OnMainWindowClose;
             base.OnStartup(e);
@@ -80,6 +80,9 @@ namespace ToolManagementAppV2
                 Owner = main,
                 WindowStartupLocation = WindowStartupLocation.CenterOwner
             };
+
+            if (login.DataContext is LoginViewModel lvm)
+                await lvm.InitializeAsync();
 
             var ok = login.ShowDialog() == true;
             if (!ok)

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -42,8 +42,19 @@ namespace ToolManagementAppV2.ViewModels
             set => SetProperty(ref _selectedUser, value);
         }
 
-        public BitmapImage CompanyLogo { get; }
-        public string WindowTitle { get; }
+        BitmapImage _companyLogo;
+        public BitmapImage CompanyLogo
+        {
+            get => _companyLogo;
+            private set => SetProperty(ref _companyLogo, value);
+        }
+
+        string _windowTitle = string.Empty;
+        public string WindowTitle
+        {
+            get => _windowTitle;
+            private set => SetProperty(ref _windowTitle, value);
+        }
 
         /// <summary>
         /// Command invoked when the user selects an account from the list. It calls
@@ -76,9 +87,6 @@ namespace ToolManagementAppV2.ViewModels
             _dialogService = dialogService;
             _userContext = userContext;
 
-            CompanyLogo = LoadLogoAsync().GetAwaiter().GetResult();
-            WindowTitle = GetWindowTitleAsync().GetAwaiter().GetResult();
-
             SelectUserCommand = new AsyncRelayCommand<User>(OnUserSelected);
 
             PromptForPasswordAsync = (u, ct) =>
@@ -94,7 +102,13 @@ namespace ToolManagementAppV2.ViewModels
             };
 
             LoadUsersCommand = new AsyncRelayCommand(LoadUsersAsync);
-            LoadUsersCommand.Execute(null);
+        }
+
+        public async Task InitializeAsync()
+        {
+            CompanyLogo = await LoadLogoAsync();
+            WindowTitle = await GetWindowTitleAsync();
+            await LoadUsersCommand.ExecuteAsync(null);
         }
 
         async Task<BitmapImage> LoadLogoAsync()

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -35,7 +35,7 @@ namespace ToolManagementAppV2.ViewModels
         readonly IFileDialogService _fileDialogService;
         readonly IDialogService _dialogService;
         readonly ILogger<MainViewModel> _logger;
-        readonly Func<bool> _showLoginWindow;
+        readonly Func<Task<bool>> _showLoginWindow;
 
         public ToolManagementViewModel ToolManagement { get; }
         public UserManagementViewModel UserManagement { get; }
@@ -100,7 +100,7 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand OpenImageImportMappingWindowCommand { get; }
         public IRelayCommand ExitCommand { get; }
         public IAsyncRelayCommand GlobalSearchCommand { get; }
-        public IRelayCommand SwitchUserCommand { get; }
+        public IAsyncRelayCommand SwitchUserCommand { get; }
 
         public IAsyncRelayCommand<ToolModel?> OpenRentalHistoryWindowCommand { get; }
         public IRelayCommand OpenPrintPreviewWindowCommand { get; }
@@ -118,7 +118,7 @@ namespace ToolManagementAppV2.ViewModels
                              IDatabaseBackupService databaseService,
                              IDialogService dialogService,
                              ILogger<MainViewModel>? logger = null,
-                             Func<bool>? showLoginWindow = null)
+                             Func<Task<bool>>? showLoginWindow = null)
         {
             _toolService = toolService;
             _userService = userService;
@@ -130,12 +130,14 @@ namespace ToolManagementAppV2.ViewModels
             _dialogService = dialogService;
             _fileDialogService = fileDialogService;
             _logger = logger ?? NullLogger<MainViewModel>.Instance;
-            _showLoginWindow = showLoginWindow ?? new Func<bool>(() =>
+            _showLoginWindow = showLoginWindow ?? new Func<Task<bool>>(async () =>
             {
                 var login = new LoginWindow(_userContext, _userService, _settingsService, _dialogService)
                 {
                     Owner = System.Windows.Application.Current.MainWindow
                 };
+                if (login.DataContext is LoginViewModel lvm)
+                    await lvm.InitializeAsync();
                 return login.ShowDialog() == true;
             });
 
@@ -259,9 +261,9 @@ namespace ToolManagementAppV2.ViewModels
                 GlobalSearchText = string.Empty;
             });
 
-            SwitchUserCommand = new RelayCommand(() =>
+            SwitchUserCommand = new AsyncRelayCommand(async () =>
             {
-                if (_showLoginWindow())
+                if (await _showLoginWindow())
                 {
                     RefreshCurrentUser();
                     OpenDashboardCommand.Execute(null);


### PR DESCRIPTION
## Summary
- move logo and window title loading into async `InitializeAsync` in `LoginViewModel`
- await view-model initialization before showing the login window
- make switching users await the login initialization

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ef6054ec08324bb6ea90242473948