### PR TITLE
Handle ActivityLogService errors with Result types

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ActivityLogServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ActivityLogServiceTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Data.SQLite;
+using System.IO;
+using System.Threading.Tasks;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Users;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Services
+{
+    public class ActivityLogServiceTests
+    {
+        [Fact]
+        public void LogAction_ReturnsFailure_WhenTableMissing()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                using var db = new DatabaseService(dbPath);
+                using (var conn = db.CreateConnection())
+                using (var cmd = new SQLiteCommand("DROP TABLE ActivityLogs", conn))
+                    cmd.ExecuteNonQuery();
+
+                var service = new ActivityLogService(db);
+                var result = service.LogAction(1, "user", "action");
+                Assert.False(result.Success);
+                Assert.NotNull(result.ErrorMessage);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void GetRecentLogs_ReturnsFailure_WhenTableMissing()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                using var db = new DatabaseService(dbPath);
+                using (var conn = db.CreateConnection())
+                using (var cmd = new SQLiteCommand("DROP TABLE ActivityLogs", conn))
+                    cmd.ExecuteNonQuery();
+
+                var service = new ActivityLogService(db);
+                var result = service.GetRecentLogs();
+                Assert.False(result.Success);
+                Assert.NotNull(result.ErrorMessage);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task LogAction_And_GetRecentLogs_WorkTogether()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                using var db = new DatabaseService(dbPath);
+                var service = new ActivityLogService(db);
+                var logResult = service.LogAction(1, "user", "action");
+                Assert.True(logResult.Success);
+
+                var recent = await service.GetRecentLogsAsync();
+                Assert.True(recent.Success);
+                Assert.NotNull(recent.Value);
+                Assert.Single(recent.Value);
+                Assert.Equal("action", recent.Value[0].Action);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2.Tests/ViewModels/ActivityLogsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ActivityLogsViewModelTests.cs
@@ -78,7 +78,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         class FailingActivityLogService : ActivityLogService
         {
             public FailingActivityLogService(DatabaseService db) : base(db) { }
-            public override Task<List<ActivityLog>?> GetRecentLogsAsync(int count = 50) => throw new Exception("fail");
+            public override Task<ToolManagementAppV2.Models.Result<List<ActivityLog>>> GetRecentLogsAsync(int count = 50) => throw new Exception("fail");
         }
     }
 }

--- a/ToolManagementAppV2/Models/Result.cs
+++ b/ToolManagementAppV2/Models/Result.cs
@@ -1,0 +1,7 @@
+namespace ToolManagementAppV2.Models
+{
+    public record Result(bool Success, string? ErrorMessage = null);
+
+    public record Result<T>(T? Value, bool Success, string? ErrorMessage = null)
+        : Result(Success, ErrorMessage);
+}

--- a/ToolManagementAppV2/Services/Tools/ReportService.cs
+++ b/ToolManagementAppV2/Services/Tools/ReportService.cs
@@ -5,6 +5,7 @@ using System.Windows.Documents;
 using System.Windows.Media;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Users;
@@ -93,7 +94,8 @@ namespace ToolManagementAppV2.Services.Tools
 
         public FlowDocument GenerateActivityLogReport()
         {
-            var logs = _activityLogService.GetRecentLogs(100) ?? new List<ActivityLog>();
+            var result = _activityLogService.GetRecentLogs(100);
+            var logs = result.Success && result.Value != null ? result.Value : new List<ActivityLog>();
             var lines = logs.Select(l =>
                     $"LogID: {l.LogID} | UserID: {l.UserID} | User: {l.UserName} | " +
                     $"Action: {l.Action} | Timestamp: {l.Timestamp:yyyy-MM-dd HH:mm:ss}");
@@ -102,7 +104,8 @@ namespace ToolManagementAppV2.Services.Tools
 
         public async Task<FlowDocument> GenerateActivityLogReportAsync()
         {
-            var logs = await _activityLogService.GetRecentLogsAsync(100) ?? new List<ActivityLog>();
+            var result = await _activityLogService.GetRecentLogsAsync(100);
+            var logs = result.Success && result.Value != null ? result.Value : new List<ActivityLog>();
             var lines = logs.Select(l =>
                     $"LogID: {l.LogID} | UserID: {l.UserID} | User: {l.UserName} | " +
                     $"Action: {l.Action} | Timestamp: {l.Timestamp:yyyy-MM-dd HH:mm:ss}");

--- a/ToolManagementAppV2/Services/Users/ActivityLogService.cs
+++ b/ToolManagementAppV2/Services/Users/ActivityLogService.cs
@@ -5,6 +5,7 @@ using System.Data.SQLite;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 
@@ -21,7 +22,7 @@ namespace ToolManagementAppV2.Services.Users
             _logger = logger ?? NullLogger<ActivityLogService>.Instance;
         }
 
-        public virtual bool LogAction(int userID, string userName, string action)
+        public virtual Result LogAction(int userID, string userName, string action)
         {
             try
             {
@@ -36,16 +37,16 @@ namespace ToolManagementAppV2.Services.Users
                 };
                 using var conn = _dbService.CreateConnection();
                 SqliteHelper.ExecuteNonQuery(conn, sql, p);
-                return true;
+                return new Result(true);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to log activity {Action}", action);
-                return false;
+                return new Result(false, ex.Message);
             }
         }
 
-        public virtual List<ActivityLog>? GetRecentLogs(int count = 50)
+        public virtual Result<List<ActivityLog>> GetRecentLogs(int count = 50)
         {
             try
             {
@@ -55,16 +56,17 @@ namespace ToolManagementAppV2.Services.Users
                      LIMIT @Count";
                 var p = new[] { new SQLiteParameter("@Count", count) };
                 using var conn = _dbService.CreateConnection();
-                return SqliteHelper.ExecuteReader(conn, sql, p, MapLog);
+                var logs = SqliteHelper.ExecuteReader(conn, sql, p, MapLog);
+                return new Result<List<ActivityLog>>(logs, true);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to retrieve recent activity logs");
-                return null;
+                return new Result<List<ActivityLog>>(null, false, ex.Message);
             }
         }
 
-        public virtual async Task<List<ActivityLog>?> GetRecentLogsAsync(int count = 50)
+        public virtual async Task<Result<List<ActivityLog>>> GetRecentLogsAsync(int count = 50)
         {
             try
             {
@@ -74,16 +76,17 @@ namespace ToolManagementAppV2.Services.Users
                      LIMIT @Count";
                 var p = new[] { new SQLiteParameter("@Count", count) };
                 using var conn = _dbService.CreateConnection();
-                return await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapLog);
+                var logs = await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapLog);
+                return new Result<List<ActivityLog>>(logs, true);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to retrieve recent activity logs");
-                return null;
+                return new Result<List<ActivityLog>>(null, false, ex.Message);
             }
         }
 
-        public virtual bool PurgeOldLogs(DateTime threshold)
+        public virtual Result PurgeOldLogs(DateTime threshold)
         {
             try
             {
@@ -93,12 +96,12 @@ namespace ToolManagementAppV2.Services.Users
                 var p = new[] { new SQLiteParameter("@Threshold", threshold) };
                 using var conn = _dbService.CreateConnection();
                 SqliteHelper.ExecuteNonQuery(conn, sql, p);
-                return true;
+                return new Result(true);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to purge old activity logs prior to {Threshold}", threshold);
-                return false;
+                return new Result(false, ex.Message);
             }
         }
 

--- a/ToolManagementAppV2/ViewModels/ActivityLogsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ActivityLogsViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Users;
 
@@ -32,10 +33,13 @@ namespace ToolManagementAppV2.ViewModels
             try
             {
                 Logs.Clear();
-                var logs = await _service.GetRecentLogsAsync();
-                if (logs == null)
+                var result = await _service.GetRecentLogsAsync();
+                if (!result.Success || result.Value == null)
+                {
+                    _logger.LogError("Failed to load activity logs: {Error}", result.ErrorMessage);
                     return false;
-                foreach (var log in logs)
+                }
+                foreach (var log in result.Value)
                     Logs.Add(log);
                 return true;
             }

--- a/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
@@ -93,10 +93,13 @@ namespace ToolManagementAppV2.ViewModels
             try
             {
                 RecentActivity.Clear();
-                var logs = _activityLogService.GetRecentLogs(10);
-                if (logs == null)
+                var result = _activityLogService.GetRecentLogs(10);
+                if (!result.Success || result.Value == null)
+                {
+                    _logger.LogError("Failed to load recent activity: {Error}", result.ErrorMessage);
                     return;
-                foreach (var log in logs)
+                }
+                foreach (var log in result.Value)
                     RecentActivity.Add(log);
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- Introduce generic `Result` type for success/error reporting
- Return `Result` from ActivityLogService methods and update consumers
- Add tests for activity log error propagation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ef7d8411883249bfe5816b21bc278