### PR TITLE
Use settings service for password iterations

### DIFF
--- a/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
+++ b/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
@@ -82,6 +82,23 @@ namespace ToolManagementAppV2.Tests.Utilities
             SecurityHelper.SettingsService = null;
         }
 
+        [Fact]
+        public void HashPassword_FallsBackToAsyncIterations()
+        {
+            var settings = new AsyncOnlySettingsService(7);
+            SecurityHelper.SettingsService = settings;
+
+            var saltBytes = Encoding.UTF8.GetBytes("1234567890ABCDEF");
+            var salt = Convert.ToBase64String(saltBytes);
+
+            using var pbkdf2 = new Rfc2898DeriveBytes("secret", saltBytes, 7, HashAlgorithmName.SHA256);
+            var expected = Convert.ToBase64String(pbkdf2.GetBytes(32));
+            var actual = SecurityHelper.HashPassword("secret", salt);
+            Assert.Equal(expected, actual);
+
+            SecurityHelper.SettingsService = null;
+        }
+
         class CountingSettingsService : ISettingsService
         {
             int _counter;
@@ -97,14 +114,55 @@ namespace ToolManagementAppV2.Tests.Utilities
                 return _iterations;
             }
 
+            public Task<int> GetPasswordIterationsAsync()
+            {
+                Interlocked.Increment(ref _counter);
+                return Task.FromResult(_iterations);
+            }
+
             public void SaveSetting(string key, string value) => throw new NotImplementedException();
+            public Task SaveSettingAsync(string key, string value) => throw new NotImplementedException();
             public string? GetSetting(string key) => throw new NotImplementedException();
+            public Task<string?> GetSettingAsync(string key) => throw new NotImplementedException();
             public Dictionary<string, string> GetAllSettings() => throw new NotImplementedException();
+            public Task<Dictionary<string, string>> GetAllSettingsAsync() => throw new NotImplementedException();
             public void UpdateSettings(Dictionary<string, string> settings) => throw new NotImplementedException();
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings) => throw new NotImplementedException();
             public void DeleteSetting(string key) => throw new NotImplementedException();
+            public Task DeleteSettingAsync(string key) => throw new NotImplementedException();
             public IEnumerable<string> GetScannerIpAddresses() => throw new NotImplementedException();
+            public Task<IEnumerable<string>> GetScannerIpAddressesAsync() => throw new NotImplementedException();
             public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses) => throw new NotImplementedException();
+            public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses) => throw new NotImplementedException();
             public void SavePasswordIterations(int iterations) => throw new NotImplementedException();
+            public Task SavePasswordIterationsAsync(int iterations) => throw new NotImplementedException();
+        }
+
+        class AsyncOnlySettingsService : ISettingsService
+        {
+            readonly int _iterations;
+
+            public AsyncOnlySettingsService(int iterations) => _iterations = iterations;
+
+            public int GetPasswordIterations() => 0;
+            public Task<int> GetPasswordIterationsAsync() => Task.FromResult(_iterations);
+
+            public void SaveSetting(string key, string value) => throw new NotImplementedException();
+            public Task SaveSettingAsync(string key, string value) => throw new NotImplementedException();
+            public string? GetSetting(string key) => throw new NotImplementedException();
+            public Task<string?> GetSettingAsync(string key) => throw new NotImplementedException();
+            public Dictionary<string, string> GetAllSettings() => throw new NotImplementedException();
+            public Task<Dictionary<string, string>> GetAllSettingsAsync() => throw new NotImplementedException();
+            public void UpdateSettings(Dictionary<string, string> settings) => throw new NotImplementedException();
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings) => throw new NotImplementedException();
+            public void DeleteSetting(string key) => throw new NotImplementedException();
+            public Task DeleteSettingAsync(string key) => throw new NotImplementedException();
+            public IEnumerable<string> GetScannerIpAddresses() => throw new NotImplementedException();
+            public Task<IEnumerable<string>> GetScannerIpAddressesAsync() => throw new NotImplementedException();
+            public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses) => throw new NotImplementedException();
+            public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses) => throw new NotImplementedException();
+            public void SavePasswordIterations(int iterations) => throw new NotImplementedException();
+            public Task SavePasswordIterationsAsync(int iterations) => throw new NotImplementedException();
         }
     }
 }

--- a/ToolManagementAppV2/Interfaces/ISettingsService.cs
+++ b/ToolManagementAppV2/Interfaces/ISettingsService.cs
@@ -17,10 +17,12 @@ namespace ToolManagementAppV2.Interfaces
         Task DeleteSettingAsync(string key);
         IEnumerable<string> GetScannerIpAddresses();
         IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses);
-        int GetPasswordIterations();
-        void SavePasswordIterations(int iterations);
         Task<IEnumerable<string>> GetScannerIpAddressesAsync();
         Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses);
+
+        // Password hashing configuration
+        int GetPasswordIterations();
+        void SavePasswordIterations(int iterations);
         Task<int> GetPasswordIterationsAsync();
         Task SavePasswordIterationsAsync(int iterations);
     }

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -360,6 +360,7 @@ namespace ToolManagementAppV2.Services.Settings
             return invalid;
         }
 
+        // Password hashing configuration
         public int GetPasswordIterations()
         {
             var value = GetSetting(PasswordIterationsKey);

--- a/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
@@ -92,32 +92,23 @@ namespace ToolManagementAppV2.Utilities.Helpers
                 cached = _iterationCache;
                 if (cached > 0) return cached;
 
-                int value = 0;
+                int value = DefaultIterations;
                 var svc = _settingsService;
                 if (svc != null)
                 {
-                    var t = svc.GetType();
-
-                    var mSync = t.GetMethod("GetPasswordIterations", Type.EmptyTypes);
-                    if (mSync != null && mSync.ReturnType == typeof(int))
+                    value = svc.GetPasswordIterations();
+                    if (value <= 0)
                     {
-                        value = (int)mSync.Invoke(svc, null)!;
-                    }
-                    else
-                    {
-                        var mAsync = t.GetMethod("GetPasswordIterationsAsync", Type.EmptyTypes);
-                        if (mAsync != null)
-                        {
-                            var taskObj = mAsync.Invoke(svc, null);
-                            if (taskObj is Task<int> task)
-                            {
-                                value = task.ConfigureAwait(false).GetAwaiter().GetResult();
-                            }
-                        }
+                        value = svc.GetPasswordIterationsAsync()
+                            .ConfigureAwait(false)
+                            .GetAwaiter()
+                            .GetResult();
                     }
                 }
 
-                if (value <= 0) value = DefaultIterations;
+                if (value <= 0)
+                    value = DefaultIterations;
+
                 Volatile.Write(ref _iterationCache, value);
                 return value;
             }


### PR DESCRIPTION
## Summary
- add explicit password iteration APIs on settings service and use them from SecurityHelper without reflection
- document password hashing configuration in SettingsService and interface
- test SecurityHelper with sync and async iteration providers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ef7ddeb388324836a8f185c1575a0