### PR TITLE
Implement disposal for scanner status

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
@@ -82,6 +82,17 @@ namespace ToolManagementAppV2.Tests.ViewModels
             Assert.True(dialog.InfoShown);
             Assert.Empty(vm.Devices);
         }
+
+        [Fact]
+        public void Dispose_StopsTimer()
+        {
+            var svc = new FakeScannerService();
+            var vm = new ScannerStatusViewModel(svc, new StubDialogService());
+            vm.AutoRefresh = true;
+            Assert.True(vm.IsTimerRunning);
+            vm.Dispose();
+            Assert.False(vm.IsTimerRunning);
+        }
     }
 
     class ThrowingScannerService : IScannerService

--- a/ToolManagementAppV2.Tests/Views/ScannerStatusWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ScannerStatusWindowTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading;
+using ToolManagementAppV2.Views;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Views
+{
+    public class ScannerStatusWindowTests
+    {
+        [Fact]
+        public void DisposesDataContextWhenClosed()
+        {
+            Exception? threadException = null;
+            var disposed = false;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var window = new ScannerStatusWindow();
+                    window.DataContext = new DisposableVm(() => disposed = true);
+                    window.Close();
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+                throw threadException!;
+
+            Assert.True(disposed);
+        }
+
+        class DisposableVm : IDisposable
+        {
+            readonly Action _onDispose;
+            public DisposableVm(Action onDispose) => _onDispose = onDispose;
+            public void Dispose() => _onDispose();
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/ScannerStatusViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ScannerStatusViewModel.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.ViewModels
 {
-    public class ScannerStatusViewModel : ObservableObject
+    public class ScannerStatusViewModel : ObservableObject, IDisposable
     {
         readonly IScannerService _service;
         readonly IDialogService _dialogService;
@@ -46,7 +46,12 @@ namespace ToolManagementAppV2.ViewModels
             _logger = logger ?? NullLogger<ScannerStatusViewModel>.Instance;
             RefreshCommand = new AsyncRelayCommand(RefreshAsync);
             _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
-            _timer.Tick += async (s, e) => await RefreshAsync(CancellationToken.None);
+            _timer.Tick += OnTimerTick;
+        }
+
+        void OnTimerTick(object? s, EventArgs e)
+        {
+            _ = RefreshAsync(CancellationToken.None);
         }
 
         async Task RefreshAsync(CancellationToken cancellationToken)
@@ -63,6 +68,12 @@ namespace ToolManagementAppV2.ViewModels
                 _logger.LogError(ex, "Failed to refresh scanner devices");
                 await _dialogService.ShowInfoAsync($"Failed to refresh scanner devices: {ex.Message}", "Error");
             }
+        }
+
+        public void Dispose()
+        {
+            _timer.Tick -= OnTimerTick;
+            _timer.Stop();
         }
     }
 }


### PR DESCRIPTION
## Summary
- stop ScannerStatusViewModel timer and detach Tick handler on dispose
- add unit test ensuring timer stops when disposed
- add UI test verifying ScannerStatusWindow disposes its DataContext when closed

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ef7e7be8c83248808ccdd4f97e6b0