### PR TITLE
Refactor report generation to async

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
@@ -16,7 +16,7 @@ namespace ToolManagementAppV2.Tests.Services
     public class ReportServiceTests
     {
         [Fact]
-        public void GenerateSummaryReportAsync_TaskRun_ReturnsSummary()
+        public void GenerateSummaryReport_TaskRun_ReturnsSummary()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -62,8 +62,8 @@ namespace ToolManagementAppV2.Tests.Services
 
                 rentalService.RentTool(tool.ToolID, customer.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
-                var task = Task.Run(() => reportService.GenerateSummaryReportAsync().Result);
-                Assert.True(task.Wait(TimeSpan.FromSeconds(5)), "GenerateSummaryReportAsync deadlocked.");
+                var task = Task.Run(() => reportService.GenerateSummaryReport().Result);
+                Assert.True(task.Wait(TimeSpan.FromSeconds(5)), "GenerateSummaryReport deadlocked.");
                 var doc = task.Result;
                 var text = new TextRange(doc.ContentStart, doc.ContentEnd).Text;
                 Assert.Contains("Total Tools: 1", text);
@@ -80,7 +80,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public async Task GenerateSummaryReportAsync_Await_ReturnsSummary()
+        public async Task GenerateSummaryReport_Await_ReturnsSummary()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -126,7 +126,7 @@ namespace ToolManagementAppV2.Tests.Services
 
                 rentalService.RentTool(tool.ToolID, customer.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
-                var doc = await reportService.GenerateSummaryReportAsync();
+                var doc = await reportService.GenerateSummaryReport();
                 var text = new TextRange(doc.ContentStart, doc.ContentEnd).Text;
                 Assert.Contains("Total Tools: 1", text);
                 Assert.Contains("Total Rentals (History): 1", text);

--- a/ToolManagementAppV2/Services/Tools/ReportService.cs
+++ b/ToolManagementAppV2/Services/Tools/ReportService.cs
@@ -34,18 +34,9 @@ namespace ToolManagementAppV2.Services.Tools
             _userService = userService;
         }
 
-        public FlowDocument GenerateInventoryReport()
+        public async Task<FlowDocument> GenerateInventoryReport()
         {
-            var lines = _toolService.GetAllTools()
-                .Select(t =>
-                    $"Tool ID: {t.ToolID} | ToolNumber: {t.ToolNumber} | Qty: {t.QuantityOnHand} | " +
-                    $"Location: {t.Location} | Supplier: {t.Supplier}");
-            return BuildReport("Tool Inventory Report", lines);
-        }
-
-        public async Task<FlowDocument> GenerateInventoryReportAsync()
-        {
-            var tools = await _toolService.GetAllToolsAsync();
+            var tools = await _toolService.GetAllToolsAsync().ConfigureAwait(false);
             var lines = tools
                 .Select(t =>
                     $"Tool ID: {t.ToolID} | ToolNumber: {t.ToolNumber} | Qty: {t.QuantityOnHand} | " +
@@ -53,11 +44,14 @@ namespace ToolManagementAppV2.Services.Tools
             return BuildReport("Tool Inventory Report", lines);
         }
 
-        public FlowDocument GenerateRentalReport(bool activeOnly = true)
+        public FlowDocument GenerateInventoryReportSync() =>
+            GenerateInventoryReport().GetAwaiter().GetResult();
+
+        public async Task<FlowDocument> GenerateRentalReport(bool activeOnly = true)
         {
             var rentals = activeOnly
-                ? _rentalService.GetActiveRentals()
-                : _rentalService.GetAllRentals();
+                ? await _rentalService.GetActiveRentalsAsync().ConfigureAwait(false)
+                : await _rentalService.GetAllRentalsAsync().ConfigureAwait(false);
 
             var title = activeOnly
                 ? "Active Rental Report"
@@ -72,55 +66,24 @@ namespace ToolManagementAppV2.Services.Tools
             return BuildReport(title, lines);
         }
 
-        public async Task<FlowDocument> GenerateRentalReportAsync(bool activeOnly = true)
+        public FlowDocument GenerateRentalReportSync(bool activeOnly = true) =>
+            GenerateRentalReport(activeOnly).GetAwaiter().GetResult();
+
+        public async Task<FlowDocument> GenerateActivityLogReport()
         {
-            var rentals = activeOnly
-                ? await _rentalService.GetActiveRentalsAsync()
-                : await _rentalService.GetAllRentalsAsync();
-
-            var title = activeOnly
-                ? "Active Rental Report"
-                : "Full Rental History Report";
-
-            var lines = rentals.Select(r =>
-                $"Rental ID: {r.RentalID} | Tool ID: {r.ToolID} | Customer ID: {r.CustomerID} | " +
-                $"Rental Date: {r.RentalDate:yyyy-MM-dd} | Due Date: {r.DueDate:yyyy-MM-dd} | " +
-                $"Return Date: {(r.ReturnDate.HasValue ? r.ReturnDate.Value.ToString("yyyy-MM-dd") : "N/A")} | " +
-                $"Status: {r.Status}");
-
-            return BuildReport(title, lines);
-        }
-
-        public FlowDocument GenerateActivityLogReport()
-        {
-            var logs = _activityLogService.GetRecentLogs(100) ?? new List<ActivityLog>();
+            var logs = await _activityLogService.GetRecentLogsAsync(100).ConfigureAwait(false) ?? new List<ActivityLog>();
             var lines = logs.Select(l =>
                     $"LogID: {l.LogID} | UserID: {l.UserID} | User: {l.UserName} | " +
                     $"Action: {l.Action} | Timestamp: {l.Timestamp:yyyy-MM-dd HH:mm:ss}");
             return BuildReport("Activity Log Report", lines);
         }
 
-        public async Task<FlowDocument> GenerateActivityLogReportAsync()
-        {
-            var logs = await _activityLogService.GetRecentLogsAsync(100) ?? new List<ActivityLog>();
-            var lines = logs.Select(l =>
-                    $"LogID: {l.LogID} | UserID: {l.UserID} | User: {l.UserName} | " +
-                    $"Action: {l.Action} | Timestamp: {l.Timestamp:yyyy-MM-dd HH:mm:ss}");
-            return BuildReport("Activity Log Report", lines);
-        }
+        public FlowDocument GenerateActivityLogReportSync() =>
+            GenerateActivityLogReport().GetAwaiter().GetResult();
 
-        public FlowDocument GenerateCustomerReport()
+        public async Task<FlowDocument> GenerateCustomerReport()
         {
-            var lines = _customerService.GetAllCustomers()
-                .Select(c =>
-                    $"CustomerID: {c.CustomerID} | Company: {c.Company} | Email: {c.Email} | " +
-                    $"Contact: {c.Contact} | Phone: {c.Phone} | Mobile: {c.Mobile} | Address: {c.Address}");
-            return BuildReport("Customer Report", lines);
-        }
-
-        public async Task<FlowDocument> GenerateCustomerReportAsync()
-        {
-            var customers = await _customerService.GetAllCustomersAsync();
+            var customers = await _customerService.GetAllCustomersAsync().ConfigureAwait(false);
             var lines = customers
                 .Select(c =>
                     $"CustomerID: {c.CustomerID} | Company: {c.Company} | Email: {c.Email} | " +
@@ -128,44 +91,22 @@ namespace ToolManagementAppV2.Services.Tools
             return BuildReport("Customer Report", lines);
         }
 
-        public FlowDocument GenerateUserReport()
-        {
-            var lines = _userService.GetAllUsers()
-                .Select(u =>
-                    $"UserID: {u.UserID} | UserName: {u.UserName} | IsAdmin: {u.IsAdmin}");
-            return BuildReport("User Report", lines);
-        }
+        public FlowDocument GenerateCustomerReportSync() =>
+            GenerateCustomerReport().GetAwaiter().GetResult();
 
-        public async Task<FlowDocument> GenerateUserReportAsync()
+        public async Task<FlowDocument> GenerateUserReport()
         {
-            var users = await _userService.GetAllUsersAsync();
+            var users = await _userService.GetAllUsersAsync().ConfigureAwait(false);
             var lines = users
                 .Select(u =>
                     $"UserID: {u.UserID} | UserName: {u.UserName} | IsAdmin: {u.IsAdmin}");
             return BuildReport("User Report", lines);
         }
 
-        public FlowDocument GenerateSummaryReport()
-        {
-            var totalTools = _toolService.GetAllTools().Count;
-            var totalRentals = _rentalService.GetAllRentals().Count;
-            var totalActiveRentals = _rentalService.GetActiveRentals().Count;
-            var totalCustomers = _customerService.GetAllCustomers().Count;
-            var totalUsers = _userService.GetAllUsers().Count;
+        public FlowDocument GenerateUserReportSync() =>
+            GenerateUserReport().GetAwaiter().GetResult();
 
-            var lines = new[]
-            {
-                $"Total Tools: {totalTools}",
-                $"Total Rentals (History): {totalRentals}",
-                $"Active Rentals: {totalActiveRentals}",
-                $"Total Customers: {totalCustomers}",
-                $"Total Users: {totalUsers}"
-            };
-
-            return BuildReport("Application Summary Report", lines);
-        }
-
-        public async Task<FlowDocument> GenerateSummaryReportAsync()
+        public async Task<FlowDocument> GenerateSummaryReport()
         {
             var totalToolsTask = _toolService.GetAllToolsAsync();
             var totalRentalsTask = _rentalService.GetAllRentalsAsync();
@@ -194,6 +135,9 @@ namespace ToolManagementAppV2.Services.Tools
 
             return BuildReport("Application Summary Report", lines);
         }
+
+        public FlowDocument GenerateSummaryReportSync() =>
+            GenerateSummaryReport().GetAwaiter().GetResult();
 
         FlowDocument BuildReport(string title, IEnumerable<string> lines)
         {

--- a/ToolManagementAppV2/ViewModels/ReportsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ReportsViewModel.cs
@@ -61,13 +61,13 @@ namespace ToolManagementAppV2.ViewModels
         {
             FlowDocument doc = SelectedReport switch
             {
-                "Summary" => await _reportService.GenerateSummaryReportAsync(),
-                "Inventory" => await _reportService.GenerateInventoryReportAsync(),
-                "Activity Log" => await _reportService.GenerateActivityLogReportAsync(),
-                "Customers" => await _reportService.GenerateCustomerReportAsync(),
-                "Users" => await _reportService.GenerateUserReportAsync(),
-                "Active Rentals" => await _reportService.GenerateRentalReportAsync(true),
-                "Full Rental History" => await _reportService.GenerateRentalReportAsync(false),
+                "Summary" => await _reportService.GenerateSummaryReport(),
+                "Inventory" => await _reportService.GenerateInventoryReport(),
+                "Activity Log" => await _reportService.GenerateActivityLogReport(),
+                "Customers" => await _reportService.GenerateCustomerReport(),
+                "Users" => await _reportService.GenerateUserReport(),
+                "Active Rentals" => await _reportService.GenerateRentalReport(true),
+                "Full Rental History" => await _reportService.GenerateRentalReport(false),
                 _ => null
             };
 


### PR DESCRIPTION
## Summary
- make report generation use async service calls and return Task<FlowDocument>
- add synchronous wrappers for report methods
- adjust view model and tests for new async API

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ef7e9f434832491dc52ae3de7cc78