### PR TITLE
Prevent duplicate tool collection handlers

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Data.SQLite;
@@ -16,6 +17,7 @@ using Xunit;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using System.Reflection;
 
 namespace ToolManagementAppV2.Tests.ViewModels
 {
@@ -144,6 +146,59 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 vm.Tools.Add(new Tool { ToolNumber = "T2", Brand = "BrandB" });
 
+                Assert.Contains("BrandB", vm.Categories);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task LoadToolsAsync_DoesNotDuplicateCollectionChangedHandlers()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
+
+                toolService.AddTool(new Tool { ToolNumber = "T1" });
+                await vm.LoadToolsAsync();
+                await vm.LoadToolsAsync();
+
+                var field = typeof(ObservableCollection<ToolModel>).GetField("CollectionChanged", BindingFlags.Instance | BindingFlags.NonPublic);
+                var handlers = field?.GetValue(vm.Tools) as MulticastDelegate;
+                var count = handlers?.GetInvocationList().Length ?? 0;
+                Assert.Equal(1, count);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task LoadToolsAsync_CanBeCalledMultipleTimes()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
+
+                toolService.AddTool(new Tool { ToolNumber = "T1", Brand = "BrandA" });
+                await vm.LoadToolsAsync();
+
+                toolService.AddTool(new Tool { ToolNumber = "T2", Brand = "BrandB" });
+                await vm.LoadToolsAsync();
+
+                Assert.Equal(2, vm.Tools.Count);
+                Assert.Contains("BrandA", vm.Categories);
                 Assert.Contains("BrandB", vm.Categories);
             }
             finally

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -139,21 +139,23 @@ namespace ToolManagementAppV2.ViewModels
             SearchCommand.Execute(null);
         }
 
+        bool _suppressToolsChanged;
+
         public async Task LoadToolsAsync()
         {
-            var all = await _toolService.GetAllToolsAsync();
-            // Temporarily detach to prevent intermediate collection changes
-            // from firing the handler and potentially resulting in duplicate
-            // subscriptions.
-            Tools.CollectionChanged -= Tools_CollectionChanged;
-            Tools.ReplaceRange(all);
-            SearchResults.ReplaceRange(all);
-            CategorizeTools(all);
-            LoadCategories(Tools);
-            // Remove again in case the handler was reattached during the load
-            // process, then attach once to guarantee a single subscription.
-            Tools.CollectionChanged -= Tools_CollectionChanged;
-            Tools.CollectionChanged += Tools_CollectionChanged;
+            _suppressToolsChanged = true;
+            try
+            {
+                var all = await _toolService.GetAllToolsAsync();
+                Tools.ReplaceRange(all);
+                SearchResults.ReplaceRange(all);
+                CategorizeTools(all);
+                LoadCategories(Tools);
+            }
+            finally
+            {
+                _suppressToolsChanged = false;
+            }
         }
 
         /// <summary>
@@ -331,7 +333,13 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        void Tools_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e) => LoadCategories(Tools);
+        void Tools_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (_suppressToolsChanged)
+                return;
+
+            LoadCategories(Tools);
+        }
 
         /// <inheritdoc />
         public void Dispose()


### PR DESCRIPTION
## Summary
- guard tool collection updates to avoid repeated CollectionChanged subscriptions
- add unit and integration tests for tool loading and handler counts

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed.)*

------
https://chatgpt.com/codex/tasks/task_e_689efaf94dc483249e09eb9ec34a160b