### PR TITLE
Validate rental filter date range

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
@@ -100,6 +100,45 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public async Task ApplyFilter_ShowsMessage_WhenFromAfterTo()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+
+                var tool = new Tool { ToolNumber = "T1" };
+                toolService.AddTool(tool);
+                var customer = new Customer { Company = "C1" };
+                customerService.AddCustomer(customer);
+                var cust = customerService.GetAllCustomers().First();
+
+                rentalService.RentTool(tool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentTool(tool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+
+                var dialog = new StubDialogService();
+                var vm = new ManageRentalsViewModel(rentalService, dialog);
+                await vm.LoadRentalsAsync();
+
+                vm.FilterFrom = DateTime.Today.AddDays(1);
+                vm.FilterTo = DateTime.Today;
+
+                vm.ApplyFilterCommand.Execute(null);
+
+                Assert.Equal(2, vm.Rentals.Count);
+                Assert.Equal("\"From\" date cannot be later than \"To\" date.", dialog.LastInfoMessage);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public void CloseCommand_DoesNotThrowWithoutWindow()
         {
             var dbPath = Path.GetTempFileName();
@@ -314,6 +353,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             LastInfoMessage = message;
             LastInfoTitle = title;
+        }
+        public Task ShowInfoAsync(string message, string title)
+        {
+            ShowInfo(message, title);
+            return Task.CompletedTask;
         }
         public bool ShowConfirmation(string message, string title) => false;
         public ToolModel? ShowEditToolDialog(ToolModel tool) => null;

--- a/ToolManagementAppV2.Tests/Views/RentalsFilterWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/RentalsFilterWindowTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Windows.Controls;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Views;
+using Xunit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ToolManagementAppV2.Tests.Views
+{
+    public class RentalsFilterWindowTests
+    {
+        [Fact]
+        public void ApplyButton_InvalidDateRange_ShowsDialog()
+        {
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var dbPath = Path.GetTempFileName();
+                    try
+                    {
+                        var db = new DatabaseService(dbPath);
+                        var rentalService = new RentalService(db);
+                        var dialog = new StubDialogService();
+                        var vm = new ManageRentalsViewModel(rentalService, dialog);
+
+                        var window = new RentalsFilterWindow { DataContext = vm };
+                        var grid = (Grid)window.Content;
+                        var stack = (StackPanel)grid.Children[0];
+                        var fromPicker = (DatePicker)stack.Children[1];
+                        var toPicker = (DatePicker)stack.Children[2];
+                        var buttons = (StackPanel)grid.Children[1];
+                        var applyButton = (Button)buttons.Children[0];
+
+                        fromPicker.SelectedDate = DateTime.Today.AddDays(1);
+                        toPicker.SelectedDate = DateTime.Today;
+
+                        applyButton.Command.Execute(null);
+
+                        Assert.Equal("\"From\" date cannot be later than \"To\" date.", dialog.LastInfoMessage);
+                    }
+                    finally
+                    {
+                        if (File.Exists(dbPath))
+                            File.Delete(dbPath);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+            {
+                throw threadException;
+            }
+        }
+
+        class StubDialogService : IDialogService
+        {
+            public string? LastInfoMessage { get; private set; }
+            public void ShowInfo(string message, string title)
+            {
+                LastInfoMessage = message;
+            }
+            public Task ShowInfoAsync(string message, string title)
+            {
+                ShowInfo(message, title);
+                return Task.CompletedTask;
+            }
+            public bool ShowConfirmation(string message, string title) => false;
+            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+            public void ShowToolDetails(ToolModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+            public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+            public void ShowScannerStatus() { }
+        }
+    }
+}
+

--- a/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
@@ -119,6 +119,12 @@ namespace ToolManagementAppV2.ViewModels
 
         void ApplyFilter()
         {
+            if (FilterFrom.HasValue && FilterTo.HasValue && FilterFrom > FilterTo)
+            {
+                _ = _dialogService.ShowInfoAsync("\"From\" date cannot be later than \"To\" date.", "Invalid Date Range");
+                return;
+            }
+
             IEnumerable<RentalModel> filtered = _allRentals;
 
             if (!string.IsNullOrWhiteSpace(SearchText))


### PR DESCRIPTION
## Summary
- prevent applying invalid rental date ranges and inform the user
- cover invalid range with unit test and RentalsFilterWindow UI test

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repositories 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689efafb36908324892d67b3dd3ca6c4