### PR TITLE
Clear selected rental after deletion

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ManageRentalsPageDeleteTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ManageRentalsPageDeleteTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+using System.Windows.Controls;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Views;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Tests
+{
+    public class ManageRentalsPageDeleteTests
+    {
+        [Fact]
+        public async System.Threading.Tasks.Task DeleteRental_RemovesFromDataGridAndClearsSelection()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+
+                var tool = new Tool { ToolNumber = "T1" };
+                toolService.AddTool(tool);
+                var customer = new Customer { Company = "C1" };
+                customerService.AddCustomer(customer);
+                var cust = customerService.GetAllCustomers().First();
+
+                rentalService.RentTool(tool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+
+                var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
+                await vm.LoadRentalsAsync();
+
+                var page = new ManageRentalsPage { DataContext = vm };
+                var grid = (Grid)page.Content;
+                var border = (Border)grid.Children[1];
+                var dataGrid = (DataGrid)border.Child;
+
+                dataGrid.SelectedItem = vm.Rentals.First();
+
+                await vm.DeleteRentalCommand.ExecuteAsync(null);
+
+                Assert.Equal(0, dataGrid.Items.Count);
+                Assert.Null(dataGrid.SelectedItem);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+
+    class StubDialogService : IDialogService
+    {
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => false;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+        public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
+    }
+}

--- a/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
@@ -118,7 +118,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task DeleteRentalCommand_RemovesRental()
+        public async Task DeleteRentalCommand_RemovesRentalAndClearsSelection()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -144,6 +144,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 Assert.Empty(vm.Rentals);
                 Assert.Empty(rentalService.GetAllRentals());
+                Assert.Null(vm.SelectedRental);
             }
             finally
             {

--- a/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
@@ -271,9 +271,11 @@ namespace ToolManagementAppV2.ViewModels
                 return;
             try
             {
-                await _rentalService.DeleteRentalAsync(SelectedRental.RentalID);
-                _allRentals.Remove(SelectedRental);
-                Rentals.Remove(SelectedRental);
+                var rentalToDelete = SelectedRental;
+                await _rentalService.DeleteRentalAsync(rentalToDelete.RentalID);
+                _allRentals.Remove(rentalToDelete);
+                Rentals.Remove(rentalToDelete);
+                SelectedRental = null;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- clear selected rental after removing it from rental collections
- verify deletion clears selection in view model
- add UI test ensuring rental deletion removes the row and clears selection

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689efafd0ca883248f94066f101b2a35