### PR TITLE
Handle exceptions when printing rentals

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
@@ -304,6 +304,34 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
             Assert.Contains("boom", dialog.LastInfoMessage);
         }
+
+        [Fact]
+        public async Task PrintRental_ShowsDialogOnFailure()
+        {
+            var rentals = new List<Rental>
+            {
+                new Rental
+                {
+                    RentalID = 1,
+                    ToolID = 1,
+                    ToolNumber = "T1",
+                    CustomerID = 1,
+                    CustomerName = "C1",
+                    RentalDate = DateTime.Today,
+                    DueDate = DateTime.Today.AddDays(1),
+                    Status = "Rented"
+                }
+            };
+            var rentalService = new ExceptionRentalService(rentals);
+            var dialog = new ExceptionDialogService();
+            var vm = new ManageRentalsViewModel(rentalService, dialog);
+            await vm.LoadRentalsAsync();
+            vm.SelectedRental = vm.Rentals.First();
+
+            vm.PrintRentalCommand.Execute(null);
+
+            Assert.Contains("boom", dialog.LastInfoMessage);
+        }
     }
 
     class StubDialogService : IDialogService
@@ -325,6 +353,24 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
         public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
+    }
+
+    class ExceptionDialogService : IDialogService
+    {
+        public string? LastInfoMessage { get; private set; }
+        public void ShowInfo(string message, string title) => LastInfoMessage = message;
+        public bool ShowConfirmation(string message, string title) => false;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+        public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) => throw new InvalidOperationException("boom");
         public void ShowPrintLabelDialog() { }
         public void ShowScannerStatus() { }
     }

--- a/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
@@ -221,48 +221,56 @@ namespace ToolManagementAppV2.ViewModels
         {
             if (SelectedRental == null)
                 return;
-            var doc = new FlowDocument
+            try
             {
-                PagePadding = new Thickness(40),
-                FontFamily = new System.Windows.Media.FontFamily("Calibri"),
-                FontSize = 16
-            };
-
-            doc.Blocks.Add(new Paragraph(new Bold(new Run("Rental Information")))
-            {
-                FontSize = 22,
-                TextAlignment = TextAlignment.Center,
-                Margin = new Thickness(0, 0, 0, 20)
-            });
-
-            var table = new Table();
-            table.Columns.Add(new TableColumn { Width = new GridLength(150) });
-            table.Columns.Add(new TableColumn());
-            var group = new TableRowGroup();
-            table.RowGroups.Add(group);
-
-            void AddRow(string label, string value)
-            {
-                var row = new TableRow();
-                row.Cells.Add(new TableCell(new Paragraph(new Run(label))
+                var doc = new FlowDocument
                 {
-                    FontWeight = FontWeights.Bold
-                }));
-                row.Cells.Add(new TableCell(new Paragraph(new Run(value ?? string.Empty))));
-                group.Rows.Add(row);
+                    PagePadding = new Thickness(40),
+                    FontFamily = new System.Windows.Media.FontFamily("Calibri"),
+                    FontSize = 16
+                };
+
+                doc.Blocks.Add(new Paragraph(new Bold(new Run("Rental Information")))
+                {
+                    FontSize = 22,
+                    TextAlignment = TextAlignment.Center,
+                    Margin = new Thickness(0, 0, 0, 20)
+                });
+
+                var table = new Table();
+                table.Columns.Add(new TableColumn { Width = new GridLength(150) });
+                table.Columns.Add(new TableColumn());
+                var group = new TableRowGroup();
+                table.RowGroups.Add(group);
+
+                void AddRow(string label, string value)
+                {
+                    var row = new TableRow();
+                    row.Cells.Add(new TableCell(new Paragraph(new Run(label))
+                    {
+                        FontWeight = FontWeights.Bold
+                    }));
+                    row.Cells.Add(new TableCell(new Paragraph(new Run(value ?? string.Empty))));
+                    group.Rows.Add(row);
+                }
+
+                AddRow("Rental #:", SelectedRental.RentalID.ToString());
+                AddRow("Tool #:", SelectedRental.ToolNumber);
+                AddRow("Customer:", SelectedRental.CustomerName);
+                AddRow("Rental Date:", SelectedRental.RentalDate.ToString("yyyy-MM-dd HH:mm"));
+                AddRow("Due Date:", SelectedRental.DueDate.ToString("yyyy-MM-dd HH:mm"));
+                AddRow("Return Date:", SelectedRental.ReturnDate?.ToString("yyyy-MM-dd HH:mm") ?? "N/A");
+                AddRow("Status:", SelectedRental.Status ?? string.Empty);
+
+                doc.Blocks.Add(table);
+
+                _dialogService.ShowPrintPreview(doc, $"Rental {SelectedRental.RentalID}", string.Empty);
             }
-
-            AddRow("Rental #:", SelectedRental.RentalID.ToString());
-            AddRow("Tool #:", SelectedRental.ToolNumber);
-            AddRow("Customer:", SelectedRental.CustomerName);
-            AddRow("Rental Date:", SelectedRental.RentalDate.ToString("yyyy-MM-dd HH:mm"));
-            AddRow("Due Date:", SelectedRental.DueDate.ToString("yyyy-MM-dd HH:mm"));
-            AddRow("Return Date:", SelectedRental.ReturnDate?.ToString("yyyy-MM-dd HH:mm") ?? "N/A");
-            AddRow("Status:", SelectedRental.Status ?? string.Empty);
-
-            doc.Blocks.Add(table);
-
-            _dialogService.ShowPrintPreview(doc, $"Rental {SelectedRental.RentalID}", string.Empty);
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to print rental {RentalID}", SelectedRental?.RentalID);
+                _dialogService.ShowInfo($"Failed to print rental: {ex.Message}", "Error");
+            }
         }
 
         async Task DeleteRentalAsync()


### PR DESCRIPTION
## Summary
- wrap `PrintRental` in try/catch and report errors via logger and dialog
- add unit test ensuring PrintRental shows error when preview fails

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689efafe79d08324a05cd14d28c83191