### PR TITLE
Handle password change errors

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -14,6 +14,7 @@ using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Helpers;
 using ToolManagementAppV2.Views;
 using Xunit;
+using Microsoft.Extensions.Logging;
 
 namespace ToolManagementAppV2.Tests.ViewModels
 {
@@ -226,6 +227,33 @@ namespace ToolManagementAppV2.Tests.ViewModels
             Assert.Single(vm.Users);
             Assert.Equal("admin", vm.Users[0].UserName);
         }
+
+        [Fact]
+        public async Task PromptChangePassword_ShowsError_WhenServiceFails()
+        {
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
+
+            var hashed = SecurityHelper.HashPassword("newpassword", out var salt);
+            var user = new User { UserID = 1, UserName = "user", Password = hashed, Salt = salt, IsAdmin = false, PasswordExpired = true };
+            var userService = new ThrowingUserService(user);
+            var settingsService = new StubSettingsService();
+            var dialog = new CapturingDialogService();
+            var userContext = new ApplicationUserContext();
+            var logger = new CapturingLogger<LoginViewModel>();
+
+            var vm = new LoginViewModel(userService, settingsService, dialog, userContext, logger)
+            {
+                PromptForNewPassword = () => "changed"
+            };
+            await vm.LoadUsersCommand.ExecuteAsync(null);
+
+            await vm.SelectUserCommand.ExecuteAsync(vm.Users[0]);
+
+            Assert.True(dialog.InfoShown);
+            Assert.Null(userContext.CurrentUser);
+            Assert.NotNull(logger.LastException);
+        }
     }
 
     class StubDialogService : IDialogService
@@ -274,5 +302,71 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task<bool> TryDeleteUserAsync(int userID) => Task.FromResult(false);
         public bool ChangeUserPassword(int userID, string newPassword) => false;
         public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => Task.FromResult(false);
+    }
+
+    class ThrowingUserService : IUserService
+    {
+        readonly List<User> _users;
+
+        public ThrowingUserService(User user)
+        {
+            _users = new List<User> { user };
+        }
+
+        public List<User> GetAllUsers() => _users.ToList();
+        public Task<List<User>> GetAllUsersAsync() => Task.FromResult(GetAllUsers());
+        public User? GetUserByID(int userID) => _users.FirstOrDefault(u => u.UserID == userID);
+        public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult(GetUserByID(userID));
+        public User? AuthenticateUser(string userName, string password) => null;
+        public Task<User?> AuthenticateUserAsync(string userName, string password) => Task.FromResult<User?>(null);
+        public User? GetCurrentUser() => null;
+        public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
+        public void AddUser(User user) => _users.Add(user);
+        public Task AddUserAsync(User user)
+        {
+            _users.Add(user);
+            return Task.CompletedTask;
+        }
+        public void UpdateUser(User user) { }
+        public Task UpdateUserAsync(User user) => Task.CompletedTask;
+        public Task<bool> TryDeleteUserAsync(int userID) => Task.FromResult(false);
+        public bool ChangeUserPassword(int userID, string newPassword) => throw new InvalidOperationException();
+        public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => throw new InvalidOperationException();
+    }
+
+    class CapturingDialogService : IDialogService
+    {
+        public bool InfoShown { get; private set; }
+        public void ShowInfo(string message, string title) => InfoShown = true;
+        public bool ShowConfirmation(string message, string title) => true;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+        public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
+    }
+
+    class CapturingLogger<T> : ILogger<T>
+    {
+        public Exception? LastException { get; private set; }
+        public IDisposable BeginScope<TState>(TState state) => NullDisposable.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (logLevel == LogLevel.Error)
+                LastException = exception;
+        }
+
+        sealed class NullDisposable : IDisposable
+        {
+            public static readonly NullDisposable Instance = new();
+            public void Dispose() { }
+        }
     }
 }

--- a/ToolManagementAppV2.Tests/Views/PasswordPromptWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/PasswordPromptWindowTests.cs
@@ -44,6 +44,41 @@ namespace ToolManagementAppV2.Tests.Views
             }
         }
 
+        [Fact]
+        public void ResetPasswordCommand_DoesNotSetFlag_WhenCancelled()
+        {
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var dialog = new StubDialogService { ConfirmationResult = false };
+                    var window = new PasswordPromptWindow(dialog)
+                    {
+                        SelectedUser = new User { IsAdmin = true }
+                    };
+
+                    window.VM.ResetPasswordCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+
+                    Assert.False(window.IsPasswordResetRequested);
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+            {
+                throw threadException;
+            }
+        }
+
         private class StubDialogService : IDialogService
         {
             public bool ConfirmationResult { get; set; }

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -15,6 +15,8 @@ using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Utilities.Extensions;
 using ToolManagementAppV2.Utilities.Helpers;
 using ToolManagementAppV2.Views;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -32,6 +34,7 @@ namespace ToolManagementAppV2.ViewModels
         readonly ISettingsService _settingsService;
         readonly IDialogService _dialogService;
         readonly IUserContext _userContext;
+        readonly ILogger<LoginViewModel> _logger;
 
         public ObservableCollection<User> Users { get; } = new();
 
@@ -80,12 +83,13 @@ namespace ToolManagementAppV2.ViewModels
         public Func<User, CancellationToken, Task<PasswordPromptResult?>>? PromptForPasswordAsync { get; set; }
             
 
-        public LoginViewModel(IUserService userService, ISettingsService settingsService, IDialogService dialogService, IUserContext userContext)
+        public LoginViewModel(IUserService userService, ISettingsService settingsService, IDialogService dialogService, IUserContext userContext, ILogger<LoginViewModel>? logger = null)
         {
             _settingsService = settingsService;
             _userService = userService;
             _dialogService = dialogService;
             _userContext = userContext;
+            _logger = logger ?? NullLogger<LoginViewModel>.Instance;
 
             SelectUserCommand = new AsyncRelayCommand<User>(OnUserSelected);
 
@@ -257,7 +261,16 @@ namespace ToolManagementAppV2.ViewModels
             var newPwd = PromptForNewPassword?.Invoke();
             if (string.IsNullOrWhiteSpace(newPwd))
                 return false;
-            _userService.ChangeUserPassword(user.UserID, newPwd);
+            try
+            {
+                _userService.ChangeUserPassword(user.UserID, newPwd);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to change password for user {UserID}", user.UserID);
+                _dialogService.ShowInfo("Failed to update password.", "Error");
+                return false;
+            }
             var refreshed = _userService.GetUserByID(user.UserID);
             if (refreshed != null)
             {


### PR DESCRIPTION
## Summary
- add logging to LoginViewModel password change failures
- cover password change failure and reset cancel scenarios with tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689efdcf7c2083249df92b8f4a7b7b37