### PR TITLE
Optimize summary report generation

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Documents;
+using System.Data.SQLite;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Models.ImportExport;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Services.Customers;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Services;
+
+public class ReportServiceSyncTests
+{
+    [Fact]
+    public void GenerateSummaryReportSync_UsesConcurrentAsyncCalls()
+    {
+        const int delay = 200;
+        var toolService = new DelayToolService(delay, 3);
+        var rentalService = new DelayRentalService(delay, 5, 2);
+        var customerService = new DelayCustomerService(delay, 4);
+        var userService = new DelayUserService(delay, 1);
+        using var db = new DatabaseService(Path.GetTempFileName());
+        var activity = new ActivityLogService(db);
+        var svc = new ReportService(toolService, rentalService, activity, customerService, userService);
+
+        var sw = Stopwatch.StartNew();
+        var doc = svc.GenerateSummaryReportSync();
+        sw.Stop();
+
+        var text = new TextRange(doc.ContentStart, doc.ContentEnd).Text;
+        Assert.Contains("Total Tools: 3", text);
+        Assert.Contains("Total Rentals (History): 5", text);
+        Assert.Contains("Active Rentals: 2", text);
+        Assert.Contains("Total Customers: 4", text);
+        Assert.Contains("Total Users: 1", text);
+
+        Assert.True(sw.ElapsedMilliseconds < delay * 3, $"Expected < {delay * 3}ms but was {sw.ElapsedMilliseconds}ms");
+    }
+
+    class DelayToolService : IToolService
+    {
+        readonly int _delay; readonly List<Tool> _tools;
+        public DelayToolService(int delay, int count)
+        { _delay = delay; _tools = new List<Tool>(new Tool[count]); }
+        public List<Tool> GetAllTools() => _tools;
+        public Task<List<Tool>> GetAllToolsAsync() => Task.Delay(_delay).ContinueWith(_ => _tools);
+        public void AddTool(Tool tool) => throw new NotImplementedException();
+        public Task AddToolAsync(Tool tool) => throw new NotImplementedException();
+        public void UpdateTool(Tool tool) => throw new NotImplementedException();
+        public Task UpdateToolAsync(Tool tool) => throw new NotImplementedException();
+        public void DeleteTool(int toolID) => throw new NotImplementedException();
+        public Task DeleteToolAsync(int toolID) => throw new NotImplementedException();
+        public Tool GetToolByID(int toolID) => throw new NotImplementedException();
+        public Task<Tool> GetToolByIDAsync(int toolID) => throw new NotImplementedException();
+        public List<Tool> SearchTools(string? searchText) => throw new NotImplementedException();
+        public Task<List<Tool>> SearchToolsAsync(string? searchText) => throw new NotImplementedException();
+        public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+        public Task ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
+        public List<Tool> GetToolsCheckedOutBy(string userName) => throw new NotImplementedException();
+        public Task<List<Tool>> GetToolsCheckedOutByAsync(string userName) => throw new NotImplementedException();
+        public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
+        public Task UpdateToolImageAsync(int toolID, string imagePath) => throw new NotImplementedException();
+        public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
+        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public void ExportToolsToCsv(string filePath) => throw new NotImplementedException();
+        public Task ExportToolsToCsvAsync(string filePath) => throw new NotImplementedException();
+        public ImageImportResult ImportToolImages(string folderPath, Func<Tool, IEnumerable<string>> keySelector) => throw new NotImplementedException();
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<Tool, IEnumerable<string>> keySelector) => throw new NotImplementedException();
+        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => throw new NotImplementedException();
+        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => throw new NotImplementedException();
+    }
+
+    class DelayRentalService : IRentalService
+    {
+        readonly int _delay; readonly List<Rental> _all; readonly List<Rental> _active;
+        public DelayRentalService(int delay, int allCount, int activeCount)
+        { _delay = delay; _all = new List<Rental>(new Rental[allCount]); _active = _all.GetRange(0, activeCount); }
+        public List<Rental> GetAllRentals() => _all;
+        public Task<List<Rental>> GetAllRentalsAsync() => Task.Delay(_delay).ContinueWith(_ => _all);
+        public List<Rental> GetActiveRentals() => _active;
+        public Task<List<Rental>> GetActiveRentalsAsync() => Task.Delay(_delay).ContinueWith(_ => _active);
+        public void RentTool(int toolID, int customerID, DateTime rentalDate, DateTime dueDate) => throw new NotImplementedException();
+        public Task RentToolAsync(int toolID, int customerID, DateTime rentalDate, DateTime dueDate) => throw new NotImplementedException();
+        public void ReturnTool(int rentalID, DateTime returnDate) => throw new NotImplementedException();
+        public Task ReturnToolAsync(int rentalID, DateTime returnDate) => throw new NotImplementedException();
+        public void ExtendRental(int rentalID, DateTime newDueDate) => throw new NotImplementedException();
+        public Task ExtendRentalAsync(int rentalID, DateTime newDueDate) => throw new NotImplementedException();
+        public void DeleteRental(int rentalID) => throw new NotImplementedException();
+        public Task DeleteRentalAsync(int rentalID) => throw new NotImplementedException();
+        public List<Rental> GetOverdueRentals() => throw new NotImplementedException();
+        public Task<List<Rental>> GetOverdueRentalsAsync() => throw new NotImplementedException();
+        public List<Rental> GetRentalHistoryForTool(int toolID) => throw new NotImplementedException();
+        public Task<List<Rental>> GetRentalHistoryForToolAsync(int toolID) => throw new NotImplementedException();
+        public List<Rental> GetRentalHistoryForCustomer(int customerID) => throw new NotImplementedException();
+        public Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID) => throw new NotImplementedException();
+    }
+
+    class DelayCustomerService : ICustomerService
+    {
+        readonly int _delay; readonly List<Customer> _customers;
+        public DelayCustomerService(int delay, int count)
+        { _delay = delay; _customers = new List<Customer>(new Customer[count]); }
+        public List<Customer> GetAllCustomers() => _customers;
+        public Task<List<Customer>> GetAllCustomersAsync() => Task.Delay(_delay).ContinueWith(_ => _customers);
+        public void AddCustomer(Customer customer) => throw new NotImplementedException();
+        public Task AddCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public void UpdateCustomer(Customer customer) => throw new NotImplementedException();
+        public Task UpdateCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public void DeleteCustomer(int customerID) => throw new NotImplementedException();
+        public Task DeleteCustomerAsync(int customerID) => throw new NotImplementedException();
+        public Customer GetCustomerByID(int customerID) => throw new NotImplementedException();
+        public Task<Customer> GetCustomerByIDAsync(int customerID) => throw new NotImplementedException();
+        public List<Customer> SearchCustomers(string searchTerm) => throw new NotImplementedException();
+        public Task<List<Customer>> SearchCustomersAsync(string searchTerm) => throw new NotImplementedException();
+        public CustomerImportResult ImportCustomersFromCsv(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
+        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
+        public void ExportCustomersToCsv(string filePath) => throw new NotImplementedException();
+        public Task ExportCustomersToCsvAsync(string filePath) => throw new NotImplementedException();
+    }
+
+    class DelayUserService : IUserService
+    {
+        readonly int _delay; readonly List<User> _users;
+        public DelayUserService(int delay, int count)
+        { _delay = delay; _users = new List<User>(new User[count]); }
+        public List<User> GetAllUsers() => _users;
+        public Task<List<User>> GetAllUsersAsync() => Task.Delay(_delay).ContinueWith(_ => _users);
+        public User? GetUserByID(int userID) => throw new NotImplementedException();
+        public Task<User?> GetUserByIDAsync(int userID) => throw new NotImplementedException();
+        public User? AuthenticateUser(string userName, string password) => throw new NotImplementedException();
+        public Task<User?> AuthenticateUserAsync(string userName, string password) => throw new NotImplementedException();
+        public User? GetCurrentUser() => null;
+        public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
+        public void AddUser(User user) => throw new NotImplementedException();
+        public Task AddUserAsync(User user) => throw new NotImplementedException();
+        public void UpdateUser(User user) => throw new NotImplementedException();
+        public Task UpdateUserAsync(User user) => throw new NotImplementedException();
+        public Task<bool> TryDeleteUserAsync(int userID) => throw new NotImplementedException();
+        public bool ChangeUserPassword(int userID, string newPassword) => throw new NotImplementedException();
+        public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => throw new NotImplementedException();
+    }
+}

--- a/ToolManagementAppV2/Services/Tools/ReportService.cs
+++ b/ToolManagementAppV2/Services/Tools/ReportService.cs
@@ -106,26 +106,39 @@ namespace ToolManagementAppV2.Services.Tools
 
             await Task.WhenAll(totalToolsTask, totalRentalsTask, totalActiveRentalsTask, totalCustomersTask, totalUsersTask).ConfigureAwait(false);
 
-            var totalTools = await totalToolsTask;
-            var totalRentals = await totalRentalsTask;
-            var totalActiveRentals = await totalActiveRentalsTask;
-            var totalCustomers = await totalCustomersTask;
-            var totalUsers = await totalUsersTask;
-
             var lines = new[]
             {
-                $"Total Tools: {totalTools.Count}",
-                $"Total Rentals (History): {totalRentals.Count}",
-                $"Active Rentals: {totalActiveRentals.Count}",
-                $"Total Customers: {totalCustomers.Count}",
-                $"Total Users: {totalUsers.Count}"
+                $"Total Tools: {totalToolsTask.Result.Count}",
+                $"Total Rentals (History): {totalRentalsTask.Result.Count}",
+                $"Active Rentals: {totalActiveRentalsTask.Result.Count}",
+                $"Total Customers: {totalCustomersTask.Result.Count}",
+                $"Total Users: {totalUsersTask.Result.Count}"
             };
 
             return BuildReport("Application Summary Report", lines);
         }
 
-        public FlowDocument GenerateSummaryReportSync() =>
-            GenerateSummaryReport().GetAwaiter().GetResult();
+        public FlowDocument GenerateSummaryReportSync()
+        {
+            var totalToolsTask = _toolService.GetAllToolsAsync();
+            var totalRentalsTask = _rentalService.GetAllRentalsAsync();
+            var totalActiveRentalsTask = _rentalService.GetActiveRentalsAsync();
+            var totalCustomersTask = _customerService.GetAllCustomersAsync();
+            var totalUsersTask = _userService.GetAllUsersAsync();
+
+            Task.WhenAll(totalToolsTask, totalRentalsTask, totalActiveRentalsTask, totalCustomersTask, totalUsersTask).GetAwaiter().GetResult();
+
+            var lines = new[]
+            {
+                $"Total Tools: {totalToolsTask.Result.Count}",
+                $"Total Rentals (History): {totalRentalsTask.Result.Count}",
+                $"Active Rentals: {totalActiveRentalsTask.Result.Count}",
+                $"Total Customers: {totalCustomersTask.Result.Count}",
+                $"Total Users: {totalUsersTask.Result.Count}"
+            };
+
+            return BuildReport("Application Summary Report", lines);
+        }
 
         FlowDocument BuildReport(string title, IEnumerable<string> lines)
         {


### PR DESCRIPTION
## Summary
- Parallelize summary report data fetching with `Task.WhenAll`
- Expose concurrent logic in sync summary report variant
- Add test validating sync report concurrency and correctness

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689efdb62d8c8324b471af9fb6386173