### PR TITLE
Notify users on invalid file paths

### DIFF
--- a/ToolManagementAppV2.Tests/Services/PrinterTests.cs
+++ b/ToolManagementAppV2.Tests/Services/PrinterTests.cs
@@ -6,6 +6,10 @@ using System.Threading.Tasks;
 using System.Windows.Documents;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.ViewModels;
+using CustomerModel = ToolManagementAppV2.Models.Domain.Customer;
+using RentalModel = ToolManagementAppV2.Models.Domain.Rental;
 using Xunit;
 using ToolModel = ToolManagementAppV2.Models.Domain.Tool;
 
@@ -26,6 +30,37 @@ namespace ToolManagementAppV2.Tests.Services
             public void SavePasswordIterations(int iterations) { }
         }
 
+        private class InvalidLogoSettingsService : ISettingsService
+        {
+            public void SaveSetting(string key, string value) { }
+            public string? GetSetting(string key) => ".." + System.IO.Path.DirectorySeparatorChar + "logo.png";
+            public Dictionary<string, string> GetAllSettings() => new();
+            public void UpdateSettings(Dictionary<string, string> settings) { }
+            public void DeleteSetting(string key) { }
+            public IEnumerable<string> GetScannerIpAddresses() => Enumerable.Empty<string>();
+            public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses) => Enumerable.Empty<string>();
+            public int GetPasswordIterations() => 0;
+            public void SavePasswordIterations(int iterations) { }
+        }
+
+        private class StubDialogService : IDialogService
+        {
+            public string? LastInfoMessage { get; private set; }
+            public void ShowInfo(string message, string title) => LastInfoMessage = message;
+            public bool ShowConfirmation(string message, string title) => false;
+            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+            public void ShowToolDetails(ToolModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+            public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+            public void ShowScannerStatus() { }
+        }
+
         [Fact]
         public async Task BuildDocumentIncrementallyAsync_ProcessesAllTools()
         {
@@ -41,6 +76,17 @@ namespace ToolManagementAppV2.Tests.Services
             var doc = await task;
 
             Assert.Equal(1 + 120, doc.Blocks.Count);
+        }
+
+        [Fact]
+        public void LoadCompanyLogoPath_InvalidPath_NotifiesUser()
+        {
+            var dialog = new StubDialogService();
+            var printer = new Printer(new InvalidLogoSettingsService(), dialog);
+            var method = typeof(Printer).GetMethod("LoadCompanyLogoPath", BindingFlags.NonPublic | BindingFlags.Instance);
+            var result = (string?)method.Invoke(printer, null);
+            Assert.Null(result);
+            Assert.Equal("Company logo path is invalid.", dialog.LastInfoMessage);
         }
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -212,7 +212,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var fileSvc = new StubFileDialogService { FileToReturn = Path.Combine("..", "outside.png") };
-                var vm = new UserManagementViewModel(userService, fileSvc, new StubDialogService());
+                var dialog = new StubDialogService();
+                var vm = new UserManagementViewModel(userService, fileSvc, dialog);
                 userService.AddUser(new User { UserName = "user1", Password = "pw" });
                 await vm.LoadUsersAsync();
                 vm.SelectedUser = vm.Users.First();
@@ -223,6 +224,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var allUsers = (System.Collections.Generic.List<User>)field!.GetValue(vm);
                 Assert.Null(vm.Users.First().UserPhotoPath);
                 Assert.Null(allUsers.First().UserPhotoPath);
+                Assert.Equal("Selected file path is invalid.", dialog.LastInfoMessage);
             }
             finally
             {

--- a/ToolManagementAppV2/Services/Tools/Printer.cs
+++ b/ToolManagementAppV2/Services/Tools/Printer.cs
@@ -20,10 +20,20 @@ namespace ToolManagementAppV2.Services.Tools
     public class Printer
     {
         private readonly ISettingsService _settingsService;
+        private readonly IDialogService? _dialogService;
 
-        public Printer(ISettingsService settingsService)
+        public Printer(ISettingsService settingsService, IDialogService? dialogService = null)
         {
             _settingsService = settingsService;
+            _dialogService = dialogService;
+        }
+
+        void Notify(string message, string title)
+        {
+            if (_dialogService != null)
+                _dialogService.ShowInfo(message, title);
+            else
+                MessageBox.Show(message, title);
         }
 
         /// <summary>
@@ -54,10 +64,14 @@ namespace ToolManagementAppV2.Services.Tools
             try
             {
                 var full = Utilities.Helpers.PathHelper.GetAbsolutePath(path, true);
-                return !string.IsNullOrEmpty(full) && File.Exists(full) ? full : null;
+                if (!string.IsNullOrEmpty(full) && File.Exists(full))
+                    return full;
+                Notify("Company logo path is invalid.", "Invalid Path");
+                return null;
             }
             catch (InvalidOperationException)
             {
+                Notify("Company logo path is invalid.", "Invalid Path");
                 return null;
             }
         }
@@ -217,10 +231,14 @@ namespace ToolManagementAppV2.Services.Tools
             }
             catch (InvalidOperationException)
             {
+                Notify("Image path is invalid.", "Invalid Path");
                 return new Border { Width = 120, Height = 120, CornerRadius = new CornerRadius(10) };
             }
-            if (string.IsNullOrEmpty(full))
+            if (string.IsNullOrEmpty(full) || !File.Exists(full))
+            {
+                Notify("Image path is invalid.", "Invalid Path");
                 return new Border { Width = 120, Height = 120, CornerRadius = new CornerRadius(10) };
+            }
 
             var bmp = new BitmapImage();
             bmp.BeginInit();
@@ -252,10 +270,14 @@ namespace ToolManagementAppV2.Services.Tools
             }
             catch (InvalidOperationException)
             {
+                Notify("Logo path is invalid.", "Invalid Path");
                 return;
             }
             if (string.IsNullOrEmpty(full) || !File.Exists(full))
+            {
+                Notify("Logo path is invalid.", "Invalid Path");
                 return;
+            }
             var bmp = new BitmapImage();
             bmp.BeginInit();
             bmp.CacheOption = BitmapCacheOption.OnLoad;

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -120,12 +120,19 @@ namespace ToolManagementAppV2.ViewModels
                 try
                 {
                     var full = PathHelper.GetAbsolutePath(logoPath, true);
-                    logoUri = !string.IsNullOrEmpty(full) && File.Exists(full)
-                        ? new Uri(full)
-                        : new Uri("pack://application:,,,/Resources/DefaultLogo.png");
+                    if (!string.IsNullOrEmpty(full) && File.Exists(full))
+                    {
+                        logoUri = new Uri(full);
+                    }
+                    else
+                    {
+                        await _dialogService.ShowInfoAsync("Company logo path is invalid; using default logo.", "Invalid Path");
+                        logoUri = new Uri("pack://application:,,,/Resources/DefaultLogo.png");
+                    }
                 }
                 catch (InvalidOperationException)
                 {
+                    await _dialogService.ShowInfoAsync("Company logo path is invalid; using default logo.", "Invalid Path");
                     logoUri = new Uri("pack://application:,,,/Resources/DefaultLogo.png");
                 }
             }

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -102,7 +102,11 @@ namespace ToolManagementAppV2.ViewModels
             if (SelectedUser == null) return;
             var path = _fileDialogService.OpenFile("Image Files|*.png;*.jpg;*.jpeg;*.bmp|All Files|*.*");
             var full = PathHelper.GetAbsolutePath(path);
-            if (string.IsNullOrEmpty(full)) return;
+            if (string.IsNullOrEmpty(full))
+            {
+                await _dialogService.ShowInfoAsync("Selected file path is invalid.", "Invalid Path");
+                return;
+            }
 
             SelectedUser.UserPhotoPath = full;
             try

--- a/ToolManagementAppV2/Views/PrintPreviewWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PrintPreviewWindow.xaml.cs
@@ -54,10 +54,11 @@ namespace ToolManagementAppV2.Views
                     var full = Utilities.Helpers.PathHelper.GetAbsolutePath(path, true);
                     if (!string.IsNullOrEmpty(full) && File.Exists(full))
                         return new Uri(full, UriKind.Absolute);
+                    MessageBox.Show("Logo path is invalid.", "Invalid Path");
                 }
                 catch (InvalidOperationException)
                 {
-                    // fall through to default
+                    MessageBox.Show("Logo path is invalid.", "Invalid Path");
                 }
             }
             return new Uri("pack://application:,,,/Resources/DefaultLogo.png");


### PR DESCRIPTION
## Summary
- Alert when uploading a user photo with an invalid path
- Warn about invalid logo paths in login and printing workflows
- Validate printer image paths and surface errors

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689efdabc6f48324a4f6493b9ae436d5