### PR TITLE
Handle dialog service failures in settings test command

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Interfaces;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.ViewModels
@@ -75,6 +76,20 @@ namespace ToolManagementAppV2.Tests.ViewModels
             vm.SaveCompanyLogoCommand.Execute(null);
             Assert.Equal("CompanyLogoPath", settings.SavedKey);
             Assert.Equal("logo.png", settings.SavedValue);
+        }
+
+        [Fact]
+        public void TestDbCommand_LogsError_WhenDialogServiceFails()
+        {
+            var logger = new CapturingLogger<SettingsViewModel>();
+            var vm = new SettingsViewModel(new StubFileDialogService(), new StubSettingsService(), new FailingDialogService(), logger)
+            {
+                ConnectionString = "invalid"
+            };
+            var ex = Record.Exception(() => vm.TestDbCommand.Execute(null));
+            Assert.Null(ex);
+            Assert.NotNull(logger.LastError);
+            Assert.Contains("Failed to display info dialog", logger.LastError);
         }
     }
 
@@ -154,6 +169,40 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
         public void ShowScannerStatus() { }
+    }
+
+    class FailingDialogService : IDialogService
+    {
+        public void ShowInfo(string message, string title) => throw new InvalidOperationException("dialog failure");
+        public bool ShowConfirmation(string message, string title) => false;
+        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+        public void ShowToolDetails(ToolModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+        public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+        public void ShowScannerStatus() { }
+    }
+
+    class CapturingLogger<T> : ILogger<T>
+    {
+        public string? LastError { get; private set; }
+        public IDisposable BeginScope<TState>(TState state) => NullDisposable.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (logLevel == LogLevel.Error)
+                LastError = formatter(state, exception);
+        }
+        private sealed class NullDisposable : IDisposable
+        {
+            public static readonly NullDisposable Instance = new();
+            public void Dispose() { }
+        }
     }
 }
 

--- a/ToolManagementAppV2.Tests/Views/SettingsPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/SettingsPageTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading;
+using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Views;
+using ToolManagementAppV2.Tests.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Views
+{
+    public class SettingsPageTests
+    {
+        [Fact]
+        public void TestDbCommand_ExecutesInUiThread()
+        {
+            Exception? threadException = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new System.Windows.Application();
+                    var vm = new SettingsViewModel(new StubFileDialogService(), new StubSettingsService(), new StubDialogService())
+                    {
+                        ConnectionString = "invalid"
+                    };
+                    var page = new SettingsPage { DataContext = vm };
+                    vm.TestDbCommand.Execute(null);
+                    app.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadException != null)
+                throw threadException;
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -33,7 +33,14 @@ namespace ToolManagementAppV2.ViewModels
             TestDbCommand = new RelayCommand(() =>
             {
                 var success = TestDbConnection(out var message);
-                _dialogService.ShowInfo(message, "Database Connection");
+                try
+                {
+                    _dialogService.ShowInfo(message, "Database Connection");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to display info dialog.");
+                }
             });
             BrowseCompanyLogoCommand = new RelayCommand(BrowseCompanyLogo);
             SaveCompanyLogoCommand = new RelayCommand(SaveCompanyLogo);


### PR DESCRIPTION
## Summary
- handle dialog service exceptions when testing DB connection
- add tests for SettingsViewModel and SettingsPage to cover dialog errors

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689efdad549883248d3121750eeeb26e