### PR TITLE
Propagate user context change events to update UI

### DIFF
--- a/ToolManagementAppV2.Tests/Services/Users/ApplicationUserContextTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/ApplicationUserContextTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Windows;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Users;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Services.Users
+{
+    public class ApplicationUserContextTests
+    {
+        [Fact]
+        public void SettingCurrentUser_RaisesUserChanged()
+        {
+            if (Application.Current == null)
+                new Application();
+
+            var context = new ApplicationUserContext();
+            User? raisedUser = null;
+            context.UserChanged += (_, u) => raisedUser = u;
+
+            var user = new User { UserName = "test" };
+            context.CurrentUser = user;
+
+            Assert.Equal(user, raisedUser);
+        }
+
+        [Fact]
+        public void SettingCurrentUserToNull_RaisesUserChanged()
+        {
+            if (Application.Current == null)
+                new Application();
+
+            var context = new ApplicationUserContext();
+            context.CurrentUser = new User { UserName = "x" };
+            User? raisedUser = null;
+            context.UserChanged += (_, u) => raisedUser = u;
+
+            context.CurrentUser = null;
+
+            Assert.Null(raisedUser);
+        }
+    }
+}

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -18,7 +18,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     public class MainViewModelCurrentUserTests
     {
         [Fact]
-        public void RefreshCurrentUser_RaisesPropertyChanged()
+        public void UserContextChange_RaisesPropertyChanged()
         {
             if (System.Windows.Application.Current == null)
                 new System.Windows.Application();
@@ -45,14 +45,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 };
 
                 userContext.CurrentUser = new User { UserName = "admin", IsAdmin = true };
-                vm.RefreshCurrentUser();
 
                 Assert.True(raised);
                 Assert.True(vm.IsCurrentUserAdmin);
 
                 raised = false;
                 userContext.CurrentUser = new User { UserName = "user", IsAdmin = false };
-                vm.RefreshCurrentUser();
 
                 Assert.True(raised);
                 Assert.False(vm.IsCurrentUserAdmin);

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -48,7 +48,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService(), null, stubLogin);
 
                 userContext.CurrentUser = new User { UserName = "old", IsAdmin = false };
-                vm.RefreshCurrentUser();
+                Assert.Equal("old", vm.CurrentUserName);
+                Assert.False(vm.IsCurrentUserAdmin);
 
                 await vm.SwitchUserCommand.ExecuteAsync(null);
 

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -91,9 +91,6 @@ namespace ToolManagementAppV2
                 return;
             }
 
-            if (main.DataContext is MainViewModel vm)
-                vm.RefreshCurrentUser();
-
             if (main.WindowState == WindowState.Minimized) main.WindowState = WindowState.Normal;
             main.Activate();
             main.Focus();

--- a/ToolManagementAppV2/Interfaces/IUserContext.cs
+++ b/ToolManagementAppV2/Interfaces/IUserContext.cs
@@ -1,3 +1,4 @@
+using System;
 using ToolManagementAppV2.Models.Domain;
 
 namespace ToolManagementAppV2.Interfaces
@@ -5,6 +6,8 @@ namespace ToolManagementAppV2.Interfaces
     public interface IUserContext
     {
         User? CurrentUser { get; set; }
+
+        event EventHandler<User?>? UserChanged;
 
         bool IsAdmin { get; }
 

--- a/ToolManagementAppV2/Services/Users/ApplicationUserContext.cs
+++ b/ToolManagementAppV2/Services/Users/ApplicationUserContext.cs
@@ -8,6 +8,8 @@ namespace ToolManagementAppV2.Services.Users
     {
         const string Key = "CurrentUser";
 
+        public event EventHandler<User?>? UserChanged;
+
         public User? CurrentUser
         {
             get => System.Windows.Application.Current?.Properties[Key] as User;
@@ -18,6 +20,8 @@ namespace ToolManagementAppV2.Services.Users
                     System.Windows.Application.Current.Properties.Remove(Key);
                 else
                     System.Windows.Application.Current.Properties[Key] = value;
+
+                UserChanged?.Invoke(this, value);
             }
         }
 

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -38,6 +38,7 @@ namespace ToolManagementAppV2.ViewModels
         readonly ILogger<MainViewModel> _logger;
         readonly Func<Task<bool>> _showLoginWindow;
 
+        EventHandler<User?>? _userContextChangedHandler;
         PropertyChangedEventHandler? _toolManagementPropertyChangedHandler;
 
         public ToolManagementViewModel ToolManagement { get; }
@@ -143,6 +144,9 @@ namespace ToolManagementAppV2.ViewModels
                     await lvm.InitializeAsync();
                 return login.ShowDialog() == true;
             });
+
+            _userContextChangedHandler = (_, _) => RefreshCurrentUser();
+            _userContext.UserChanged += _userContextChangedHandler;
 
             ToolManagement = new ToolManagementViewModel(toolService, customerService, rentalService, _dialogService);
             _toolManagementPropertyChangedHandler = (s, e) =>
@@ -269,7 +273,6 @@ namespace ToolManagementAppV2.ViewModels
             {
                 if (await _showLoginWindow())
                 {
-                    RefreshCurrentUser();
                     OpenDashboardCommand.Execute(null);
                 }
                 else
@@ -368,6 +371,12 @@ namespace ToolManagementAppV2.ViewModels
         /// <inheritdoc />
         public void Dispose()
         {
+            if (_userContextChangedHandler != null)
+            {
+                _userContext.UserChanged -= _userContextChangedHandler;
+                _userContextChangedHandler = null;
+            }
+
             if (_toolManagementPropertyChangedHandler != null)
             {
                 ToolManagement.PropertyChanged -= _toolManagementPropertyChangedHandler;


### PR DESCRIPTION
## Summary
- fire `UserChanged` event when `ApplicationUserContext.CurrentUser` updates
- subscribe `MainViewModel` to `UserChanged` instead of manual refresh calls
- add unit and integration tests around user switching

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689efdba4930832485144204c242a153