### PR TITLE
Deduplicate scanner IPs and merge statuses

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ScannerServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ScannerServiceTests.cs
@@ -62,6 +62,29 @@ namespace ToolManagementAppV2.Tests.Services
                 if (File.Exists(dbPath)) File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public async Task GetScannerDevicesAsync_DeduplicatesIps()
+        {
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var settings = new SettingsService(db);
+                settings.SaveScannerIpAddresses(new[] { "127.0.0.1", "127.0.0.1" });
+
+                var service = new ScannerService(settings);
+
+                var devices = await service.GetScannerDevicesAsync(CancellationToken.None);
+                var list = devices.ToList();
+                Assert.Single(list);
+                Assert.Equal("127.0.0.1", list[0].Ip);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
         [Fact]
         public async Task GetScannerDevicesAsync_HonorsCancellation()
         {

--- a/ToolManagementAppV2.Tests/Tests/ScannerIntegrationTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ScannerIntegrationTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Devices;
+using ToolManagementAppV2.Services.Settings;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Tests
+{
+    public class ScannerIntegrationTests
+    {
+        [Fact]
+        public async Task GetScannerDevicesAsync_ScansLocalhost()
+        {
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var settings = new SettingsService(db);
+                settings.SaveScannerIpAddresses(new[] { "127.0.0.1" });
+
+                var service = new ScannerService(settings);
+                var devices = await service.GetScannerDevicesAsync(CancellationToken.None);
+                var device = Assert.Single(devices);
+                Assert.Equal("127.0.0.1", device.Ip);
+                Assert.Equal("Online", device.Status);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+    }
+}
+

--- a/ToolManagementAppV2/Services/Devices/ScannerService.cs
+++ b/ToolManagementAppV2/Services/Devices/ScannerService.cs
@@ -27,7 +27,7 @@ namespace ToolManagementAppV2.Services.Devices
             cancellationToken.ThrowIfCancellationRequested();
 
             using var semaphore = new SemaphoreSlim(5);
-            var tasks = _settingsService.GetScannerIpAddresses().Select(async ip =>
+            var tasks = _settingsService.GetScannerIpAddresses().Distinct().Select(async ip =>
             {
                 await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try
@@ -59,7 +59,22 @@ namespace ToolManagementAppV2.Services.Devices
                 }
             });
 
-            return await Task.WhenAll(tasks).ConfigureAwait(false);
+            var devices = await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            // Merge statuses for any duplicate IPs
+            return devices
+                .GroupBy(d => d.Ip)
+                .Select(g =>
+                {
+                    var device = g.First();
+                    if (g.Any(d => d.Status == "Online"))
+                        device.Status = "Online";
+                    else if (g.Any(d => d.Status == "Offline"))
+                        device.Status = "Offline";
+                    else
+                        device.Status = "Error";
+                    return device;
+                });
         }
     }
 }


### PR DESCRIPTION
## Summary
- avoid redundant pings by de-duplicating scanner IPs and merging statuses for duplicate entries
- add unit test ensuring duplicate IPs are condensed
- add integration test verifying scanner status for localhost

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689efdbe5fe08324b281c50ea9d51e89