### PR TITLE
Log seeded admin user with info log

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -15,6 +15,7 @@ using ToolManagementAppV2.Utilities.Helpers;
 using ToolManagementAppV2.Views;
 using Xunit;
 using Microsoft.Extensions.Logging;
+using ToolManagementAppV2.Tests;
 
 namespace ToolManagementAppV2.Tests.ViewModels
 {
@@ -41,6 +42,36 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 Assert.Equal("TestApp – Login", vm.WindowTitle);
                 Assert.NotNull(vm.CompanyLogo);
                 Assert.NotEmpty(vm.Users);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task LoadUsersAsync_SeedsAdmin_LogsInformation()
+        {
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
+
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            try
+            {
+                using var dbService = new DatabaseService(dbPath);
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(dbService, userContext);
+                var settingsService = new SettingsService(dbService);
+
+                var logs = new List<LogEntry>();
+                using var provider = new ListLoggerProvider(logs);
+                using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(provider));
+                var logger = loggerFactory.CreateLogger<LoginViewModel>();
+
+                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext, logger);
+                await vm.LoadUsersCommand.ExecuteAsync(null);
+
+                Assert.Contains(logs, l => l.Level == LogLevel.Information && l.Message.Contains("admin"));
             }
             finally
             {

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -181,6 +181,7 @@ namespace ToolManagementAppV2.ViewModels
                     PasswordExpired = true
                 };
                 await _userService.AddUserAsync(admin);
+                _logger.LogInformation("Seeded admin user {UserName}", admin.UserName);
                 users = await _userService.GetAllUsersAsync();
             }
 


### PR DESCRIPTION
## Summary
- log an information message with the username when the default admin user is seeded
- add unit test verifying admin seeding logs at information level

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f00e4cfcc832497ec5aa952a0a345