### PR TITLE
Handle rental history failures

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
@@ -346,6 +346,34 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public async Task OpenHistory_ShowsDialogOnFailure()
+        {
+            var rentals = new List<Rental>
+            {
+                new Rental
+                {
+                    RentalID = 1,
+                    ToolID = 1,
+                    ToolNumber = "T1",
+                    CustomerID = 1,
+                    CustomerName = "C1",
+                    RentalDate = DateTime.Today,
+                    DueDate = DateTime.Today.AddDays(1),
+                    Status = "Rented"
+                }
+            };
+            var rentalService = new ExceptionRentalService(rentals);
+            var dialog = new StubDialogService();
+            var vm = new ManageRentalsViewModel(rentalService, dialog);
+            await vm.LoadRentalsAsync();
+            vm.SelectedRental = vm.Rentals.First();
+
+            await vm.OpenHistoryCommand.ExecuteAsync(null);
+
+            Assert.Contains("boom", dialog.LastInfoMessage);
+        }
+
+        [Fact]
         public async Task PrintRental_ShowsDialogOnFailure()
         {
             var rentals = new List<Rental>

--- a/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
@@ -205,22 +205,27 @@ namespace ToolManagementAppV2.ViewModels
         {
             if (SelectedRental == null)
                 return;
+
+            List<RentalModel> history;
             try
             {
-                var history = await _rentalService.GetRentalHistoryForToolAsync(SelectedRental.ToolID);
-                var tool = new ToolModel
-                {
-                    ToolID = SelectedRental.ToolID,
-                    ToolNumber = SelectedRental.ToolNumber,
-                    NameDescription = SelectedRental.ToolNumber
-                };
-                _dialogService.ShowRentalHistory(tool, history);
+                history = await _rentalService.GetRentalHistoryForToolAsync(SelectedRental.ToolID);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to open rental history for tool {ToolID}", SelectedRental.ToolID);
                 await _dialogService.ShowInfoAsync($"Failed to load rental history: {ex.Message}", "Error");
+                return;
             }
+
+            var tool = new ToolModel
+            {
+                ToolID = SelectedRental.ToolID,
+                ToolNumber = SelectedRental.ToolNumber,
+                NameDescription = SelectedRental.ToolNumber
+            };
+
+            _dialogService.ShowRentalHistory(tool, history);
         }
 
         void PrintRental()


### PR DESCRIPTION
## Summary
- handle rental history service errors in ManageRentalsViewModel
- test rental history failure handling

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f00e684588324ba36c02ac7ee1b10