### PR TITLE
Log import mapping selections

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelImportMappingTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelImportMappingTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class MainViewModelImportMappingTests
+    {
+        [Fact]
+        public async Task OpenImportMappingWindowAsync_LogsSelectedHeadersAndMapping()
+        {
+            var dbPath = Path.GetTempFileName();
+            var csvPath = Path.GetTempFileName();
+            File.WriteAllText(csvPath, "ToolNumber\n");
+            var logs = new List<LogEntry>();
+            try
+            {
+                using var factory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(db, userContext);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
+                var fileDlg = new StubFileDialogService { FileToReturn = csvPath };
+                var dialog = new StubDialogService { MapToReturn = new Dictionary<string,string>{{"ToolNumber","ToolNumber"}} };
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                    fileDlg, activityLogService, settingsService, db, dialog,
+                    logger: factory.CreateLogger<MainViewModel>());
+
+                await vm.OpenImportMappingWindowCommand.ExecuteAsync(null);
+
+                Assert.Contains(logs, l => l.Message.Contains("Import mapping selected") && l.Message.Contains("ToolNumber -> ToolNumber"));
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+                if (File.Exists(csvPath)) File.Delete(csvPath);
+            }
+        }
+
+        class StubDialogService : IDialogService
+        {
+            public Dictionary<string,string>? MapToReturn { get; set; }
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => false;
+            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+            public void ShowToolDetails(ToolModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => MapToReturn;
+            public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+            public void ShowScannerStatus() { }
+        }
+
+        class StubFileDialogService : IFileDialogService
+        {
+            public string? FileToReturn { get; set; }
+            public string OpenFile(string filter) => FileToReturn ?? string.Empty;
+            public string SaveFile(string filter) => string.Empty;
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -353,6 +353,10 @@ namespace ToolManagementAppV2.ViewModels
                 var map = _dialogService.ShowImportMapping(headers, properties);
                 if (map != null)
                 {
+                    var mappingString = string.Join(", ", map.Select(kvp => $"{kvp.Key} -> {kvp.Value}"));
+                    _logger.LogInformation("Import mapping selected. Headers: {Headers}. Map: {Map}",
+                        string.Join(", ", headers),
+                        mappingString);
                     await _dialogService.ShowInfoAsync("Importing tools...", "Import Tools");
                     var invalid = await _toolService.ImportToolsFromCsvAsync(path, map, CancellationToken.None);
                     var msg = invalid.Count == 0


### PR DESCRIPTION
## Summary
- log selected CSV headers and property mapping when importing tools
- test that import mapping info is logged

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689f00f5b7288324890112ab6aef1f2b