### PR TITLE
Add cancellation support to tool searches

### DIFF
--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -380,6 +380,7 @@ namespace ToolManagementAppV2.Tests.Services
             public void DeleteTool(int toolID) => throw new NotImplementedException();
             public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
             public List<ToolModel> SearchTools(string? searchText) => new();
+            public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
             public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
             public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
             public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();

--- a/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
@@ -62,7 +62,7 @@ public class ReportServiceSyncTests
         public Tool GetToolByID(int toolID) => throw new NotImplementedException();
         public Task<Tool> GetToolByIDAsync(int toolID) => throw new NotImplementedException();
         public List<Tool> SearchTools(string? searchText) => throw new NotImplementedException();
-        public Task<List<Tool>> SearchToolsAsync(string? searchText) => throw new NotImplementedException();
+        public Task<List<Tool>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
         public Task ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
         public List<Tool> GetToolsCheckedOutBy(string userName) => throw new NotImplementedException();

--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -8,6 +8,7 @@ using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Interfaces;
 using Xunit;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using ToolManagementAppV2.Tests;
@@ -790,6 +791,25 @@ namespace ToolManagementAppV2.Tests.Services
             finally
             {
                 if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task SearchToolsAsync_Cancelled_Throws()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var svc = new ToolService(dbService);
+                using var cts = new CancellationTokenSource();
+                cts.Cancel();
+                await Assert.ThrowsAsync<OperationCanceledException>(() => svc.SearchToolsAsync("test", cts.Token));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
             }
         }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -183,6 +183,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void DeleteTool(int toolID) => throw new NotImplementedException();
         public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
         public List<ToolModel> SearchTools(string? searchText) => new();
+        public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
         public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
         public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
         public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
@@ -240,6 +241,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void DeleteTool(int toolID) => throw new NotImplementedException();
         public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
         public List<ToolModel> SearchTools(string? searchText) => new();
+        public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
         public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
         public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
         public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
@@ -263,6 +265,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void DeleteTool(int toolID) => throw new NotImplementedException();
         public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
         public List<ToolModel> SearchTools(string? searchText) => new();
+        public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
         public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
         public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
         public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
@@ -290,7 +291,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
                 vm.GlobalSearchText = "Ham";
 
-                await vm.GlobalSearchCommand.ExecuteAsync(null);
+                await vm.GlobalSearchCommand.ExecuteAsync(CancellationToken.None);
 
                 var page = Assert.IsType<ToolSearchPage>(vm.CurrentPage);
                 Assert.Equal("Ham", vm.ToolManagement.SearchText);

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -249,6 +249,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void DeleteTool(int toolID) => throw new System.NotImplementedException();
         public ToolModel GetToolByID(int toolID) => throw new System.NotImplementedException();
         public List<ToolModel> SearchTools(string? searchText) => new();
+        public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
         public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new System.NotImplementedException();
         public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
         public void UpdateToolImage(int toolID, string imagePath) => throw new System.NotImplementedException();
@@ -268,6 +269,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void DeleteTool(int toolID) => throw new System.NotImplementedException();
         public ToolModel GetToolByID(int toolID) => throw new System.NotImplementedException();
         public List<ToolModel> SearchTools(string? searchText) => new();
+        public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
         public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new System.NotImplementedException();
         public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
         public void UpdateToolImage(int toolID, string imagePath) => throw new System.NotImplementedException();

--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -38,7 +38,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw" });
                 vm.SearchTerm = "Ham";
-                await vm.SearchCommand.ExecuteAsync(null);
+                await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
                 Assert.Single(vm.SearchResults);
                 Assert.Equal("Hammer", vm.SearchResults.First().NameDescription);
             }
@@ -64,7 +64,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Hammer", Brand = "BrandB" });
                 vm.SearchTerm = "Hammer BrandA";
-                await vm.SearchCommand.ExecuteAsync(null);
+                await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
                 Assert.Single(vm.SearchResults);
                 Assert.Equal("BrandA", vm.SearchResults.First().Brand);
             }
@@ -90,7 +90,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Cordless Drill", IsPowerTool = true });
                 vm.SearchTerm = string.Empty;
-                await vm.SearchCommand.ExecuteAsync(null);
+                await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
                 Assert.Single(vm.HandTools);
                 Assert.Single(vm.PowerTools);
             }
@@ -116,7 +116,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw", Brand = "BrandB" });
                 vm.SelectedCategory = "BrandA";
-                await vm.SearchCommand.ExecuteAsync(null);
+                await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
                 Assert.Single(vm.SearchResults);
                 Assert.Equal("BrandA", vm.SearchResults.First().Brand);
             }
@@ -559,7 +559,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var toolService = new CountingToolService(tools);
             var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
             vm.SearchTerm = "Ham";
-            await vm.SearchCommand.ExecuteAsync(null);
+            await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
             Assert.Equal(1, toolService.SearchToolsAsyncCalls);
             Assert.Equal(0, toolService.GetAllToolsAsyncCalls);
         }
@@ -574,11 +574,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var toolService = new CountingToolService(tools);
             var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
 
-            await vm.SearchCommand.ExecuteAsync(null);
+            await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
             Assert.Equal(1, toolService.GetAllToolsAsyncCalls);
             Assert.Equal(0, toolService.SearchToolsAsyncCalls);
 
-            await vm.SearchCommand.ExecuteAsync(null);
+            await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
             Assert.Equal(1, toolService.GetAllToolsAsyncCalls);
         }
 
@@ -648,9 +648,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 return _tools.ToList();
             }
 
-            public Task<List<ToolModel>> SearchToolsAsync(string? searchText)
+            public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default)
             {
                 SearchToolsAsyncCalls++;
+                if (cancellationToken.IsCancellationRequested)
+                    return Task.FromCanceled<List<ToolModel>>(cancellationToken);
                 if (string.IsNullOrWhiteSpace(searchText))
                     return Task.FromResult(_tools.ToList());
                 var term = searchText.Trim();
@@ -700,7 +702,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             public List<ToolModel> GetAllTools() => new();
             public Task<List<ToolModel>> GetAllToolsAsync() => Task.FromResult(new List<ToolModel>());
             public List<ToolModel> SearchTools(string? searchText) => new();
-            public Task<List<ToolModel>> SearchToolsAsync(string? searchText) => Task.FromResult(new List<ToolModel>());
+            public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
             public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
             public Task ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
             public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();

--- a/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
@@ -116,6 +116,7 @@ namespace ToolManagementAppV2.Tests.Views
         public void DeleteTool(int toolID) => throw new NotImplementedException();
         public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
         public System.Collections.Generic.List<ToolModel> SearchTools(string? searchText) => new();
+        public Task<System.Collections.Generic.List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ToolModel>());
         public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
         public System.Collections.Generic.List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
         public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();

--- a/ToolManagementAppV2/Interfaces/IToolService.cs
+++ b/ToolManagementAppV2/Interfaces/IToolService.cs
@@ -21,7 +21,7 @@ namespace ToolManagementAppV2.Interfaces
         List<ToolModel> GetAllTools();
         Task<List<ToolModel>> GetAllToolsAsync();
         List<ToolModel> SearchTools(string? searchText);
-        Task<List<ToolModel>> SearchToolsAsync(string? searchText);
+        Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default);
         void ToggleToolCheckOutStatus(int toolID, string currentUser);
         Task ToggleToolCheckOutStatusAsync(int toolID, string currentUser);
         List<ToolModel> GetToolsCheckedOutBy(string userName);

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -430,10 +430,14 @@ namespace ToolManagementAppV2.Services.Tools
             return await SqliteHelper.ExecuteReaderAsync(conn, AllToolsSql, null, MapTool);
         }
 
-        public async Task<List<ToolModel>> SearchToolsAsync(string? searchText)
+        public async Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (string.IsNullOrWhiteSpace(searchText))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
                 return await GetAllToolsAsync();
+            }
 
             using var conn = _dbService.CreateConnection();
             var terms = searchText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
@@ -468,6 +472,7 @@ namespace ToolManagementAppV2.Services.Tools
                 parameters.Add(new SQLiteParameter(paramName, $"%{terms[i]}%"));
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
             return await SqliteHelper.ExecuteReaderAsync(conn, sb.ToString(), parameters.ToArray(), MapTool);
         }
 

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -260,14 +260,7 @@ namespace ToolManagementAppV2.ViewModels
                 }
             });
 
-            GlobalSearchCommand = new AsyncRelayCommand(async () =>
-            {
-                ToolManagement.SearchText = GlobalSearchText;
-                await OpenSearchToolsCommand.ExecuteAsync(null);
-                if (ToolManagement.SearchCommand != null)
-                    await ToolManagement.SearchCommand.ExecuteAsync(null);
-                GlobalSearchText = string.Empty;
-            });
+            GlobalSearchCommand = new AsyncRelayCommand(GlobalSearchAsync);
 
             SwitchUserCommand = new AsyncRelayCommand(async () =>
             {
@@ -366,6 +359,15 @@ namespace ToolManagementAppV2.ViewModels
                 _logger.LogError(ex, "Failed to import tools from CSV");
                 await _dialogService.ShowInfoAsync($"Failed to import tools: {ex.Message}", "Import Tools");
             }
+        }
+
+        async Task GlobalSearchAsync(CancellationToken cancellationToken)
+        {
+            ToolManagement.SearchText = GlobalSearchText;
+            await OpenSearchToolsCommand.ExecuteAsync(null);
+            if (ToolManagement.SearchCommand != null)
+                await ToolManagement.SearchCommand.ExecuteAsync(cancellationToken);
+            GlobalSearchText = string.Empty;
         }
 
         /// <inheritdoc />

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities;
@@ -76,12 +77,15 @@ namespace ToolManagementAppV2.ViewModels
             {
                 if (SetProperty(ref _selectedCategory, value))
                 {
-                    SearchCommand.Execute(null);
+                    _searchCts.Cancel();
+                    _searchCts.Dispose();
+                    _searchCts = new CancellationTokenSource();
+                    SearchCommand.Execute(_searchCts.Token);
                 }
             }
         }
 
-        public IAsyncRelayCommand SearchCommand { get; }
+        public IAsyncRelayCommand<CancellationToken> SearchCommand { get; }
         public IAsyncRelayCommand NewToolCommand { get; }
         public IAsyncRelayCommand EditToolCommand { get; }
         public IAsyncRelayCommand DeleteToolCommand { get; }
@@ -89,6 +93,7 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand ViewDetailsCommand { get; }
 
         readonly IDispatcherTimer _searchDebounceTimer;
+        CancellationTokenSource _searchCts = new();
 
         // Writable for TwoWay binding from XAML. Mirrors SearchTerm and triggers search.
         private string _searchText = string.Empty;
@@ -100,6 +105,7 @@ namespace ToolManagementAppV2.ViewModels
                 if (SetProperty(ref _searchText, value))
                 {
                     SearchTerm = value;
+                    _searchCts.Cancel();
                     _searchDebounceTimer.Stop();
                     _searchDebounceTimer.Start();
                 }
@@ -118,7 +124,7 @@ namespace ToolManagementAppV2.ViewModels
             _rentalService = rentalService;
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<ToolManagementViewModel>.Instance;
-            SearchCommand = new AsyncRelayCommand(FilterToolsAsync);
+            SearchCommand = new AsyncRelayCommand<CancellationToken>(FilterToolsAsync);
             _searchDebounceTimer = searchDebounceTimer ?? new DispatcherTimerWrapper { Interval = TimeSpan.FromMilliseconds(300) };
             _searchDebounceTimer.Tick += OnSearchDebounceTimerTick;
             NewToolCommand = new AsyncRelayCommand(AddToolAsync);
@@ -136,7 +142,9 @@ namespace ToolManagementAppV2.ViewModels
         void OnSearchDebounceTimerTick(object? s, EventArgs e)
         {
             _searchDebounceTimer.Stop();
-            SearchCommand.Execute(null);
+            _searchCts.Dispose();
+            _searchCts = new CancellationTokenSource();
+            SearchCommand.Execute(_searchCts.Token);
         }
 
         bool _suppressToolsChanged;
@@ -163,14 +171,14 @@ namespace ToolManagementAppV2.ViewModels
         /// Invoked by <see cref="SearchCommand"/> whenever the search text or
         /// <see cref="SelectedCategory"/> changes and recomputes <see cref="Categories"/>.
         /// </summary>
-        async Task FilterToolsAsync()
+        async Task FilterToolsAsync(CancellationToken cancellationToken)
         {
             var term = string.IsNullOrWhiteSpace(SearchTerm) ? string.Empty : SearchTerm.Trim();
             IEnumerable<ToolModel> source;
 
             if (!string.IsNullOrEmpty(term))
             {
-                source = await _toolService.SearchToolsAsync(term);
+                source = await _toolService.SearchToolsAsync(term, cancellationToken);
             }
             else
             {
@@ -198,7 +206,7 @@ namespace ToolManagementAppV2.ViewModels
             {
                 await _toolService.AddToolAsync(NewTool);
                 await LoadToolsAsync();
-                await FilterToolsAsync();
+                await FilterToolsAsync(CancellationToken.None);
                 NewTool = new ToolModel();
             }
             catch (InvalidOperationException ex)
@@ -243,7 +251,7 @@ namespace ToolManagementAppV2.ViewModels
 
             await _toolService.UpdateToolAsync(updated);
             await LoadToolsAsync();
-            await FilterToolsAsync();
+            await FilterToolsAsync(CancellationToken.None);
             SelectedTool = Tools.FirstOrDefault(t => t.ToolID == updated.ToolID);
         }
 
@@ -266,7 +274,7 @@ namespace ToolManagementAppV2.ViewModels
             {
                 await _toolService.DeleteToolAsync(SelectedTool.ToolID);
                 await LoadToolsAsync();
-                await FilterToolsAsync();
+                await FilterToolsAsync(CancellationToken.None);
                 SelectedTool = null;
             }
             catch (Exception ex)
@@ -346,6 +354,8 @@ namespace ToolManagementAppV2.ViewModels
         {
             _searchDebounceTimer.Tick -= OnSearchDebounceTimerTick;
             _searchDebounceTimer.Stop();
+            _searchCts.Cancel();
+            _searchCts.Dispose();
             Tools.CollectionChanged -= Tools_CollectionChanged;
         }
     }


### PR DESCRIPTION
## Summary
- add optional CancellationToken parameter to tool search service and interface
- propagate cancellation through global and debounced search commands
- test that cancelled searches throw

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f00f911ec8324b8a6ff753348764f