### PR TITLE
Handle errors when switching users

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -100,6 +100,44 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public async Task SwitchUserCommand_ShowsError_WhenLoginThrows()
+        {
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
+
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(db, userContext);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
+
+                var dialog = new StubDialogService();
+                var logger = new StubLogger<MainViewModel>();
+
+                Func<Task<bool>> stubLogin = () => throw new InvalidOperationException("boom");
+
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                    new StubFileDialogService(), activityLogService, settingsService, db, dialog, logger, stubLogin);
+
+                await vm.SwitchUserCommand.ExecuteAsync(null);
+
+                Assert.True(dialog.InfoShown);
+                Assert.Equal("Switch user failed.", logger.LastError);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 
     class StubFileDialogService : IFileDialogService
@@ -129,6 +167,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     class StubLogger<T> : ILogger<T>
     {
         public string? LastWarning { get; private set; }
+        public string? LastError { get; private set; }
 
         public IDisposable BeginScope<TState>(TState state) => NullDisposable.Instance;
         public bool IsEnabled(LogLevel logLevel) => true;
@@ -136,6 +175,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             if (logLevel == LogLevel.Warning)
                 LastWarning = formatter(state, exception);
+            if (logLevel == LogLevel.Error)
+                LastError = formatter(state, exception);
         }
 
         private sealed class NullDisposable : IDisposable

--- a/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Windows.Controls;
@@ -14,6 +15,12 @@ using CommunityToolkit.Mvvm.Input;
 using System.Threading.Tasks;
 using System.Windows;
 using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Interfaces;
 
 namespace ToolManagementAppV2.Tests.Views
 {
@@ -116,6 +123,86 @@ namespace ToolManagementAppV2.Tests.Views
         }
 
         [Fact]
+        public void SwitchUserButton_UpdatesCurrentUser()
+        {
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    if (System.Windows.Application.Current == null)
+                        new System.Windows.Application();
+
+                    var dbPath = Path.GetTempFileName();
+                    try
+                    {
+                        var db = new DatabaseService(dbPath);
+                        var toolService = new ToolService(db);
+                        var userContext = new ApplicationUserContext();
+                        var userService = new UserService(db, userContext);
+                        var customerService = new CustomerService(db);
+                        var rentalService = new RentalService(db, toolService);
+                        var activityLogService = new ActivityLogService(db);
+                        var settingsService = new SettingsService(db);
+                        var dialog = new StubDialogService();
+                        var fileDialog = new StubFileDialogService();
+
+                        var newUser = new User { UserName = "newuser", IsAdmin = true };
+                        Func<Task<bool>> stubLogin = () =>
+                        {
+                            userContext.CurrentUser = newUser;
+                            return Task.FromResult(true);
+                        };
+
+                        var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                            fileDialog, activityLogService, settingsService, db, dialog, null, stubLogin);
+
+                        userContext.CurrentUser = new User { UserName = "old", IsAdmin = false };
+
+                        var window = new ToolManagementAppV2.MainWindow(vm, db);
+                        try
+                        {
+                            var button = (Button)window.FindName("SwitchUserButton");
+                            var cmd = Assert.IsAssignableFrom<IAsyncRelayCommand>(button.Command);
+                            var task = cmd.ExecuteAsync(null);
+                            var frame = new DispatcherFrame();
+                            task.ContinueWith(_ => frame.Continue = false);
+                            Dispatcher.PushFrame(frame);
+
+                            Assert.Equal("newuser", vm.CurrentUserName);
+                            Assert.True(vm.IsCurrentUserAdmin);
+                        }
+                        finally
+                        {
+                            window.Close();
+                            db.Dispose();
+                            if (File.Exists(dbPath))
+                                File.Delete(dbPath);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        threadException = ex;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+            {
+                throw threadException;
+            }
+        }
+
+        [Fact]
         public void RentalHistoryButton_BoundToSelectedTool()
         {
             Exception? threadException = null;
@@ -174,6 +261,29 @@ namespace ToolManagementAppV2.Tests.Views
                 }
             }
             return null;
+        }
+
+        class StubFileDialogService : IFileDialogService
+        {
+            public string OpenFile(string filter) => null;
+            public string SaveFile(string filter) => null;
+        }
+
+        class StubDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => false;
+            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+            public void ShowToolDetails(ToolModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+            public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+            public void ShowScannerStatus() { }
         }
 
         [Fact]

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -271,14 +271,22 @@ namespace ToolManagementAppV2.ViewModels
 
             SwitchUserCommand = new AsyncRelayCommand(async () =>
             {
-                if (await _showLoginWindow())
+                try
                 {
-                    OpenDashboardCommand.Execute(null);
+                    if (await _showLoginWindow())
+                    {
+                        OpenDashboardCommand.Execute(null);
+                    }
+                    else
+                    {
+                        _logger.LogWarning("Switch user cancelled.");
+                        _dialogService.ShowInfo("Switch user cancelled.", "Switch User");
+                    }
                 }
-                else
+                catch (Exception ex)
                 {
-                    _logger.LogWarning("Switch user cancelled.");
-                    _dialogService.ShowInfo("Switch user cancelled.", "Switch User");
+                    _logger.LogError(ex, "Switch user failed.");
+                    _dialogService.ShowInfo("Failed to switch user.", "Switch User");
                 }
             });
 


### PR DESCRIPTION
## Summary
- Guard user-switching against login failures
- Add unit test for login exceptions
- Add UI test verifying user switch

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f00f9c6308324b434fb66db1f7638