### PR TITLE
Handle image copy IO errors

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -812,5 +812,86 @@ namespace ToolManagementAppV2.Tests.Services
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void ImportToolImages_CopyIOException_RecordsConflict()
+        {
+            var dbPath = Path.GetTempFileName();
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            var imgPath = Path.Combine(tempDir, "T1.png");
+            File.WriteAllText(imgPath, "img");
+
+            try
+            {
+                var logs = new List<LogEntry>();
+                using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
+                var dbService = new DatabaseService(dbPath);
+                var svc = new FailingCopyToolService(dbService, loggerFactory.CreateLogger<ToolService>());
+
+                svc.AddTool(new Tool { ToolNumber = "T1" });
+
+                var result = svc.ImportToolImages(tempDir, t => new[] { t.ToolNumber });
+
+                Assert.Equal(0, result.ImportedCount);
+                Assert.Contains(imgPath, result.ConflictingFiles);
+                Assert.Contains(logs, l => l.Level == LogLevel.Error && l.Exception is IOException);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+                if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
+
+                var destDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images");
+                if (Directory.Exists(destDir)) Directory.Delete(destDir, true);
+            }
+        }
+
+        [Fact]
+        public void ImportToolImages_SingleImage_ImportsSuccessfully()
+        {
+            var dbPath = Path.GetTempFileName();
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            var imgPath = Path.Combine(tempDir, "T1.png");
+            File.WriteAllText(imgPath, "img");
+
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var svc = new ToolService(dbService);
+
+                svc.AddTool(new Tool { ToolNumber = "T1" });
+
+                var result = svc.ImportToolImages(tempDir, t => new[] { t.ToolNumber });
+
+                Assert.Equal(1, result.ImportedCount);
+                Assert.Empty(result.ConflictingFiles);
+                Assert.Empty(result.UnmatchedFiles);
+
+                var destDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images");
+                var destFile = Path.Combine(destDir, Path.GetFileName(imgPath));
+                Assert.True(File.Exists(destFile));
+
+                var tool = svc.GetAllTools().Single();
+                Assert.Equal($"Images/{Path.GetFileName(imgPath)}", tool.ToolImagePath);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+                if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
+                var destDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images");
+                if (Directory.Exists(destDir)) Directory.Delete(destDir, true);
+            }
+        }
+
+        private class FailingCopyToolService : ToolService
+        {
+            public FailingCopyToolService(DatabaseService dbService, ILogger<ToolService> logger)
+                : base(dbService, logger) { }
+
+            protected override void CopyFile(string sourceFileName, string destFileName)
+                => throw new IOException("fail");
+        }
     }
 }

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -282,7 +282,18 @@ namespace ToolManagementAppV2.Services.Tools
                 }
                 var dest = Path.Combine(destDir, Path.GetFileName(file));
                 if (!File.Exists(dest))
-                    File.Copy(file, dest, true);
+                {
+                    try
+                    {
+                        CopyFile(file, dest);
+                    }
+                    catch (IOException ex)
+                    {
+                        _logger.LogError(ex, "Failed to copy image from {Source} to {Destination}", file, dest);
+                        result.ConflictingFiles.Add(file);
+                        continue;
+                    }
+                }
                 var relative = $"Images/{Path.GetFileName(dest)}";
                 UpdateToolImage(tool.ToolID, relative);
                 result.ImportedCount++;
@@ -290,7 +301,10 @@ namespace ToolManagementAppV2.Services.Tools
 
             return result;
         }
-    
+
+        protected virtual void CopyFile(string sourceFileName, string destFileName)
+            => File.Copy(sourceFileName, destFileName, true);
+
         private async Task<bool> ToolExistsAsync(string toolNumber, int? exceptId = null)
         {
             if (string.IsNullOrWhiteSpace(toolNumber))


### PR DESCRIPTION
## Summary
- log and record image conflicts when file copy throws IOException
- add tests covering failed and successful image imports

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f0b20a57883249f4e28efef185fdd