### PR TITLE
Use async API to load activity logs

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -111,7 +111,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void OpenActivityLogsCommand_LoadsLogs()
+        public async Task OpenActivityLogsCommand_LoadsLogsAsync()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -127,7 +127,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var settingsService = new SettingsService(db);
 
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
-                vm.OpenActivityLogsCommand.Execute(null);
+                await vm.OpenActivityLogsCommand.ExecuteAsync(null);
 
                 var page = Assert.IsType<ActivityLogsPage>(vm.CurrentPage);
                 var logsVm = Assert.IsType<ActivityLogsViewModel>(page.DataContext);

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -22,7 +22,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     public class NewPageViewModelTests
     {
         [Fact]
-        public void ActivityLogsViewModel_LoadsLogs()
+        public async Task ActivityLogsViewModel_LoadsLogsAsync()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -31,7 +31,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var service = new ActivityLogService(db);
                 service.LogAction(1, "user", "action");
                 var vm = new ActivityLogsViewModel(service);
-                vm.LoadLogs();
+                await vm.LoadLogsAsync();
                 Assert.NotEmpty(vm.Logs);
             }
             finally

--- a/ToolManagementAppV2/ViewModels/ActivityLogsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ActivityLogsViewModel.cs
@@ -49,7 +49,5 @@ namespace ToolManagementAppV2.ViewModels
                 return false;
             }
         }
-
-        public bool LoadLogs() => LoadLogsAsync().GetAwaiter().GetResult();
     }
 }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -98,7 +98,7 @@ namespace ToolManagementAppV2.ViewModels
         public IAsyncRelayCommand OpenUsersCommand { get; }
         public IRelayCommand OpenSettingsCommand { get; }
         public IRelayCommand OpenImportExportCommand { get; }
-        public IRelayCommand OpenActivityLogsCommand { get; }
+        public IAsyncRelayCommand OpenActivityLogsCommand { get; }
         public IRelayCommand OpenReportsCommand { get; }
         public IAsyncRelayCommand OpenImportMappingWindowCommand { get; }
         public IRelayCommand OpenImageImportMappingWindowCommand { get; }
@@ -230,9 +230,9 @@ namespace ToolManagementAppV2.ViewModels
                 CurrentPage = page;
             });
 
-            OpenActivityLogsCommand = new RelayCommand(() =>
+            OpenActivityLogsCommand = new AsyncRelayCommand(async () =>
             {
-                ActivityLogs.LoadLogs();
+                await ActivityLogs.LoadLogsAsync();
                 var page = new ActivityLogsPage { DataContext = ActivityLogs, Title = "Activity Logs" };
                 CurrentPage = page;
             });


### PR DESCRIPTION
## Summary
- Drop blocking `LoadLogs` method from `ActivityLogsViewModel` and rely on `LoadLogsAsync`
- Make `OpenActivityLogsCommand` asynchronous and load logs without blocking
- Update tests to await async log loading and navigation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f0b27743c8324928379a0201dea79