### PR TITLE
Validate and test company logo path

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Utilities.Helpers;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -69,13 +70,29 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void SaveCompanyLogoCommand_PersistsPath()
         {
             var settings = new StubSettingsService();
+            var expected = PathHelper.GetAbsolutePath("logo.png");
             var vm = new SettingsViewModel(new StubFileDialogService(), settings, new StubDialogService())
             {
                 CompanyLogoPath = "logo.png"
             };
             vm.SaveCompanyLogoCommand.Execute(null);
             Assert.Equal("CompanyLogoPath", settings.SavedKey);
-            Assert.Equal("logo.png", settings.SavedValue);
+            Assert.Equal(expected, settings.SavedValue);
+        }
+
+        [Fact]
+        public void SaveCompanyLogoCommand_InvalidPath_ShowsError()
+        {
+            var settings = new StubSettingsService();
+            var dialog = new StubDialogService();
+            var vm = new SettingsViewModel(new StubFileDialogService(), settings, dialog)
+            {
+                CompanyLogoPath = Path.Combine("..", "logo.png")
+            };
+            vm.SaveCompanyLogoCommand.Execute(null);
+            Assert.Null(settings.SavedKey);
+            Assert.Equal("Selected logo path is invalid.", dialog.LastMessage);
+            Assert.Equal("Invalid Path", dialog.LastTitle);
         }
 
         [Fact]
@@ -156,7 +173,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
     class StubDialogService : IDialogService
     {
-        public void ShowInfo(string message, string title) { }
+        public string? LastMessage { get; private set; }
+        public string? LastTitle { get; private set; }
+        public void ShowInfo(string message, string title)
+        {
+            LastMessage = message;
+            LastTitle = title;
+        }
         public bool ShowConfirmation(string message, string title) => true;
         public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
         public void ShowToolDetails(ToolModel tool) { }

--- a/ToolManagementAppV2.Tests/Views/SettingsPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/SettingsPageTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Views;
@@ -24,6 +25,38 @@ namespace ToolManagementAppV2.Tests.Views
                     };
                     var page = new SettingsPage { DataContext = vm };
                     vm.TestDbCommand.Execute(null);
+                    app.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadException != null)
+                throw threadException;
+        }
+
+        [Fact]
+        public void SaveCompanyLogoCommand_InvalidPath_ShowsError()
+        {
+            Exception? threadException = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new System.Windows.Application();
+                    var settings = new StubSettingsService();
+                    var dialog = new StubDialogService();
+                    var vm = new SettingsViewModel(new StubFileDialogService(), settings, dialog)
+                    {
+                        CompanyLogoPath = Path.Combine("..", "logo.png")
+                    };
+                    var page = new SettingsPage { DataContext = vm };
+                    vm.SaveCompanyLogoCommand.Execute(null);
+                    Assert.Equal("Selected logo path is invalid.", dialog.LastMessage);
                     app.Shutdown();
                 }
                 catch (Exception ex)

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.ObjectModel;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Utilities.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -125,8 +126,14 @@ namespace ToolManagementAppV2.ViewModels
 
         void SaveCompanyLogo()
         {
-            if (!string.IsNullOrWhiteSpace(CompanyLogoPath))
-                _settingsService.SaveSetting("CompanyLogoPath", CompanyLogoPath);
+            var full = PathHelper.GetAbsolutePath(CompanyLogoPath);
+            if (string.IsNullOrEmpty(full))
+            {
+                _dialogService.ShowInfo("Selected logo path is invalid.", "Invalid Path");
+                return;
+            }
+
+            _settingsService.SaveSetting("CompanyLogoPath", full);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Validate the company logo path using `PathHelper.GetAbsolutePath` and show a dialog if invalid.
- Added unit tests for valid and invalid logo paths and a UI test for invalid logo updates.

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f0b297cdc8324b20652a361855dc1