### PR TITLE
Clamp password iterations with user notification

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -91,6 +91,42 @@ namespace ToolManagementAppV2.Tests.ViewModels
             Assert.NotNull(logger.LastError);
             Assert.Contains("Failed to display info dialog", logger.LastError);
         }
+
+        [Fact]
+        public void PasswordIterations_AboveLimit_IsClampedAndNotifies()
+        {
+            var settings = new StubSettingsService();
+            var dialog = new StubDialogService();
+            var vm = new SettingsViewModel(new StubFileDialogService(), settings, dialog);
+
+            vm.PasswordIterations = 2_000_000;
+
+            Assert.Equal(1_000_000, vm.PasswordIterations);
+            Assert.Equal(1_000_000, settings.PasswordIterations);
+            Assert.NotNull(dialog.LastInfoMessage);
+        }
+
+        [Fact]
+        public void PasswordIterations_AboveLimit_PersistsClampedValue()
+        {
+            var path = System.IO.Path.GetTempFileName();
+            try
+            {
+                var db = new ToolManagementAppV2.Services.Core.DatabaseService(path);
+                var settings = new ToolManagementAppV2.Services.Settings.SettingsService(db);
+                var dialog = new StubDialogService();
+                var vm = new SettingsViewModel(new StubFileDialogService(), settings, dialog);
+
+                vm.PasswordIterations = 2_000_000;
+
+                Assert.Equal(1_000_000, settings.GetPasswordIterations());
+            }
+            finally
+            {
+                if (System.IO.File.Exists(path)) System.IO.File.Delete(path);
+            }
+        }
+
     }
 
     class StubFileDialogService : ToolManagementAppV2.Interfaces.IFileDialogService
@@ -156,7 +192,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
     class StubDialogService : IDialogService
     {
-        public void ShowInfo(string message, string title) { }
+        public string? LastInfoMessage { get; private set; }
+        public string? LastInfoTitle { get; private set; }
+        public void ShowInfo(string message, string title)
+        {
+            LastInfoMessage = message;
+            LastInfoTitle = title;
+        }
         public bool ShowConfirmation(string message, string title) => true;
         public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
         public void ShowToolDetails(ToolModel tool) { }

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -82,14 +82,28 @@ namespace ToolManagementAppV2.ViewModels
         }
 
         private int _passwordIterations;
+        const int MaxPasswordIterations = 1_000_000;
         public int PasswordIterations
         {
             get => _passwordIterations;
             set
             {
                 if (value <= 0) return;
-                if (SetProperty(ref _passwordIterations, value))
-                    _settingsService.SavePasswordIterations(value);
+                var newValue = value;
+                if (value > MaxPasswordIterations)
+                {
+                    newValue = MaxPasswordIterations;
+                    try
+                    {
+                        _dialogService.ShowInfo($"Password iterations cannot exceed {MaxPasswordIterations} and have been set to {MaxPasswordIterations}.", "Password Iterations");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to display info dialog.");
+                    }
+                }
+                if (SetProperty(ref _passwordIterations, newValue))
+                    _settingsService.SavePasswordIterations(newValue);
             }
         }
 


### PR DESCRIPTION
## Summary
- cap password iterations at one million and alert the user when exceeded
- add unit and integration tests ensuring password iterations clamp and persist

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f0b2c2c10832494f753a644b1a270