### PR TITLE
Show dialog when user deletion fails

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -442,6 +442,20 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public async Task DeleteUserFromRowCommand_FailureShowsInfo()
+        {
+            var svc = new FailingUserService();
+            svc.AddUser(new User { UserName = "user1", Password = "pw" });
+            var dialog = new StubDialogService();
+            var vm = new UserManagementViewModel(svc, new StubFileDialogService(), dialog);
+            await vm.LoadUsersAsync();
+            var toDelete = vm.Users.First();
+            await vm.DeleteUserFromRowCommand.ExecuteAsync(toDelete);
+            Assert.Equal("Failed to delete user.", dialog.LastInfoMessage);
+            Assert.Equal("Error", dialog.LastInfoTitle);
+        }
+
+        [Fact]
         public async Task AddUserAsync_CancelledPrompt_DoesNotAddUser()
         {
             var svc = new InMemoryUserService();

--- a/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
@@ -76,6 +76,60 @@ namespace ToolManagementAppV2.Tests.Views
                     System.IO.File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void ContextMenuDeleteCommand_RemovesUser()
+        {
+            var dbPath = System.IO.Path.GetTempFileName();
+            Exception? threadException = null;
+
+            try
+            {
+                var thread = new Thread(() =>
+                {
+                    try
+                    {
+                        var db = new DatabaseService(dbPath);
+                        IUserService userService = new UserService(db, new ApplicationUserContext());
+                        var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
+                        userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                        userService.AddUser(new User { UserName = "user2", Password = "pw" });
+                        vm.LoadUsers();
+
+                        var page = new UsersPage { DataContext = vm };
+                        var grid = (Grid)page.Content;
+                        var dataGrid = (DataGrid)((Border)grid.Children[1]).Child;
+
+                        dataGrid.SelectedItem = vm.Users.First();
+                        var deleteItem = (MenuItem)dataGrid.ContextMenu.Items[4];
+
+                        Assert.Equal(vm.DeleteUserFromRowCommand, deleteItem.Command);
+                        deleteItem.Command.Execute(dataGrid.SelectedItem);
+
+                        Assert.Single(vm.Users);
+                        Assert.Equal("user2", vm.Users.First().UserName);
+                    }
+                    catch (Exception ex)
+                    {
+                        threadException = ex;
+                    }
+                });
+
+                thread.SetApartmentState(ApartmentState.STA);
+                thread.Start();
+                thread.Join();
+
+                if (threadException != null)
+                {
+                    throw threadException;
+                }
+            }
+            finally
+            {
+                if (System.IO.File.Exists(dbPath))
+                    System.IO.File.Delete(dbPath);
+            }
+        }
     }
 
     class StubFileDialogService : IFileDialogService

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -316,6 +316,7 @@ namespace ToolManagementAppV2.ViewModels
                 else
                 {
                     _logger.LogWarning("Failed to delete user {UserID}", user.UserID);
+                    await _dialogService.ShowInfoAsync("Failed to delete user.", "Error");
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- Inform users when deletion of a user fails
- Cover user deletion failures with new unit test
- Exercise user deletion via page context menu in UI tests

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689f0b2eae208324964bd1c31139b735