### PR TITLE
Return success flag when toggling tool checkout status

### DIFF
--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -381,7 +381,8 @@ namespace ToolManagementAppV2.Tests.Services
             public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
             public List<ToolModel> SearchTools(string? searchText) => new();
             public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-            public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+            public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+            public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
             public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
             public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
             public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => new();

--- a/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
@@ -63,8 +63,8 @@ public class ReportServiceSyncTests
         public Task<Tool> GetToolByIDAsync(int toolID) => throw new NotImplementedException();
         public List<Tool> SearchTools(string? searchText) => throw new NotImplementedException();
         public Task<List<Tool>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
-        public Task ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
+        public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
         public List<Tool> GetToolsCheckedOutBy(string userName) => throw new NotImplementedException();
         public Task<List<Tool>> GetToolsCheckedOutByAsync(string userName) => throw new NotImplementedException();
         public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();

--- a/ToolManagementAppV2.Tests/Services/ToolCheckOutTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolCheckOutTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using ToolManagementAppV2.Models.Domain;
@@ -19,8 +20,9 @@ namespace ToolManagementAppV2.Tests.Services
                 var service = new ToolService(new DatabaseService(db));
                 service.AddTool(new Tool { ToolNumber = "T1", QuantityOnHand = 0 });
                 var tool = service.GetAllTools().First();
-                service.ToggleToolCheckOutStatus(tool.ToolID, "u");
+                var result = service.ToggleToolCheckOutStatus(tool.ToolID, "u");
                 var updated = service.GetToolByID(tool.ToolID);
+                Assert.False(result);
                 Assert.False(updated.IsCheckedOut);
                 Assert.Equal(0, updated.QuantityOnHand);
             }
@@ -39,14 +41,31 @@ namespace ToolManagementAppV2.Tests.Services
                 IToolService svc = new ToolService(new DatabaseService(db));
                 svc.AddTool(new Tool { ToolNumber = "T2", QuantityOnHand = 1 });
                 var tool = svc.GetAllTools().First();
-                svc.ToggleToolCheckOutStatus(tool.ToolID, "u");
+                var first = svc.ToggleToolCheckOutStatus(tool.ToolID, "u");
                 var outTool = svc.GetToolByID(tool.ToolID);
+                Assert.True(first);
                 Assert.True(outTool.IsCheckedOut);
                 Assert.Equal(0, outTool.QuantityOnHand);
-                svc.ToggleToolCheckOutStatus(tool.ToolID, "u");
+                var second = svc.ToggleToolCheckOutStatus(tool.ToolID, "u");
                 var back = svc.GetToolByID(tool.ToolID);
+                Assert.True(second);
                 Assert.False(back.IsCheckedOut);
                 Assert.Equal(1, back.QuantityOnHand);
+            }
+            finally
+            {
+                if (File.Exists(db)) File.Delete(db);
+            }
+        }
+
+        [Fact]
+        public void ToggleCheckOut_Nonexistent_Throws()
+        {
+            var db = Path.GetTempFileName();
+            try
+            {
+                var service = new ToolService(new DatabaseService(db));
+                Assert.Throws<InvalidOperationException>(() => service.ToggleToolCheckOutStatus(42, "u"));
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -739,8 +739,10 @@ namespace ToolManagementAppV2.Tests.Services
                 var tool = svc.GetAllTools().Single();
 
                 var before = DateTime.UtcNow;
-                svc.ToggleToolCheckOutStatus(tool.ToolID, "user");
+                var result = svc.ToggleToolCheckOutStatus(tool.ToolID, "user");
                 var after = DateTime.UtcNow;
+
+                Assert.True(result);
 
                 var updated = svc.GetToolByID(tool.ToolID);
                 Assert.True(updated.IsCheckedOut);
@@ -783,8 +785,9 @@ namespace ToolManagementAppV2.Tests.Services
                 var svc = new ToolService(dbService);
                 await svc.AddToolAsync(new Tool { ToolNumber = "T2", QuantityOnHand = 1 });
                 var tool = (await svc.GetAllToolsAsync()).Single();
-                await svc.ToggleToolCheckOutStatusAsync(tool.ToolID, "u");
+                var success = await svc.ToggleToolCheckOutStatusAsync(tool.ToolID, "u");
                 var updated = await svc.GetToolByIDAsync(tool.ToolID);
+                Assert.True(success);
                 Assert.True(updated.IsCheckedOut);
                 Assert.Equal(0, updated.QuantityOnHand);
             }

--- a/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Models.ImportExport;
@@ -184,7 +185,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
         public List<ToolModel> SearchTools(string? searchText) => new();
         public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-        public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+        public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
         public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
         public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
         public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => new();
@@ -242,7 +244,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
         public List<ToolModel> SearchTools(string? searchText) => new();
         public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-        public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+        public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
         public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
         public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
         public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => new();
@@ -266,7 +269,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
         public List<ToolModel> SearchTools(string? searchText) => new();
         public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-        public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+        public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
         public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
         public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
         public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => new();

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -250,7 +250,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public ToolModel GetToolByID(int toolID) => throw new System.NotImplementedException();
         public List<ToolModel> SearchTools(string? searchText) => new();
         public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-        public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new System.NotImplementedException();
+        public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new System.NotImplementedException();
+        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new System.NotImplementedException();
         public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
         public void UpdateToolImage(int toolID, string imagePath) => throw new System.NotImplementedException();
         public ImageImportResult ImportToolImages(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector) => new();
@@ -270,7 +271,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public ToolModel GetToolByID(int toolID) => throw new System.NotImplementedException();
         public List<ToolModel> SearchTools(string? searchText) => new();
         public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-        public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new System.NotImplementedException();
+        public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new System.NotImplementedException();
+        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new System.NotImplementedException();
         public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
         public void UpdateToolImage(int toolID, string imagePath) => throw new System.NotImplementedException();
         public ImageImportResult ImportToolImages(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector) => new();

--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -673,8 +673,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             public Task DeleteToolAsync(int toolID) => throw new NotImplementedException();
             public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
             public Task<ToolModel> GetToolByIDAsync(int toolID) => throw new NotImplementedException();
-            public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
-            public Task ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
+            public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+            public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
             public List<ToolModel> GetToolsCheckedOutBy(string userName) => throw new NotImplementedException();
             public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName) => throw new NotImplementedException();
             public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
@@ -703,8 +703,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             public Task<List<ToolModel>> GetAllToolsAsync() => Task.FromResult(new List<ToolModel>());
             public List<ToolModel> SearchTools(string? searchText) => new();
             public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-            public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
-            public Task ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
+            public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+            public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
             public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
             public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName) => Task.FromResult(new List<ToolModel>());
             public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();

--- a/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Controls;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
@@ -117,7 +118,8 @@ namespace ToolManagementAppV2.Tests.Views
         public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
         public System.Collections.Generic.List<ToolModel> SearchTools(string? searchText) => new();
         public Task<System.Collections.Generic.List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ToolModel>());
-        public void ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+        public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
+        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
         public System.Collections.Generic.List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
         public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
         public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, System.Collections.Generic.IEnumerable<string>> keySelector) => new();

--- a/ToolManagementAppV2/Interfaces/IToolService.cs
+++ b/ToolManagementAppV2/Interfaces/IToolService.cs
@@ -22,8 +22,8 @@ namespace ToolManagementAppV2.Interfaces
         Task<List<ToolModel>> GetAllToolsAsync();
         List<ToolModel> SearchTools(string? searchText);
         Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default);
-        void ToggleToolCheckOutStatus(int toolID, string currentUser);
-        Task ToggleToolCheckOutStatusAsync(int toolID, string currentUser);
+        bool ToggleToolCheckOutStatus(int toolID, string currentUser);
+        Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser);
         List<ToolModel> GetToolsCheckedOutBy(string userName);
         Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName);
         void UpdateToolImage(int toolID, string imagePath);

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -150,10 +150,10 @@ namespace ToolManagementAppV2.Services.Tools
 
         public Task DeleteToolAsync(int toolID) => DeleteToolInternalAsync(toolID);
 
-        public void ToggleToolCheckOutStatus(int toolID, string currentUser) =>
+        public bool ToggleToolCheckOutStatus(int toolID, string currentUser) =>
             RunSync(() => ToggleToolCheckOutStatusInternalAsync(toolID, currentUser));
 
-        public Task ToggleToolCheckOutStatusAsync(int toolID, string currentUser) =>
+        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) =>
             ToggleToolCheckOutStatusInternalAsync(toolID, currentUser);
     
         public List<ToolModel> GetToolsCheckedOutBy(string userName)
@@ -476,7 +476,7 @@ namespace ToolManagementAppV2.Services.Tools
             return await SqliteHelper.ExecuteReaderAsync(conn, sb.ToString(), parameters.ToArray(), MapTool);
         }
 
-        private async Task ToggleToolCheckOutStatusInternalAsync(int toolID, string currentUser)
+        private async Task<bool> ToggleToolCheckOutStatusInternalAsync(int toolID, string currentUser)
         {
             using var conn = _dbService.CreateConnection();
             var record = (await SqliteHelper.ExecuteReaderAsync(conn,
@@ -488,14 +488,14 @@ namespace ToolManagementAppV2.Services.Tools
                 throw new InvalidOperationException($"Tool {toolID} not found.");
 
             if (!record.Out && record.Qty <= 0)
-                return;
+                return false;
 
             var newStatus = record.Out ? 0 : 1;
             var time = record.Out ? (object)DBNull.Value : DateTime.UtcNow;
             var by = record.Out ? (object)DBNull.Value : currentUser;
             var qtyChange = record.Out ? 1 : -1;
 
-            await SqliteHelper.ExecuteNonQueryAsync(conn, @"
+            var rows = await SqliteHelper.ExecuteNonQueryAsync(conn, @"
                 UPDATE Tools SET
                   IsCheckedOut = @Out,
                   CheckedOutBy = @By,
@@ -509,6 +509,11 @@ namespace ToolManagementAppV2.Services.Tools
                 new SQLiteParameter("@Q", qtyChange),
                 new SQLiteParameter("@ID", toolID)
             });
+
+            if (rows == 0)
+                throw new InvalidOperationException("Check-out status update failed.");
+
+            return true;
         }
 
         public async Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName)


### PR DESCRIPTION
## Summary
- Have tool checkout toggle return bool and throw on failed updates
- Update interface and callers to handle new result
- Add tests for toggling existing tools and missing records

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f0b226ee083248f9c10b715d16b89