### PR TITLE
Fix Keywords index creation in DatabaseService

### DIFF
--- a/ToolManagementAppV2.Tests/Services/DatabaseIndexTests.cs
+++ b/ToolManagementAppV2.Tests/Services/DatabaseIndexTests.cs
@@ -17,6 +17,7 @@ namespace ToolManagementAppV2.Tests.Services
                 Assert.True(SqliteHelper.IndexExists(db.ConnectionString, "idx_Users_UserName"));
                 Assert.True(SqliteHelper.IndexExists(db.ConnectionString, "idx_Customers_Contact"));
                 Assert.True(SqliteHelper.IndexExists(db.ConnectionString, "idx_Rentals_ToolID_CustomerID"));
+                Assert.True(SqliteHelper.IndexExists(db.ConnectionString, "idx_Tools_Keywords"));
             }
             finally
             {

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -49,6 +49,11 @@ namespace ToolManagementAppV2.Services.Core
             EnsureColumn("Tools", "Keywords", "TEXT");
             EnsureColumn("Tools", "IsPowerTool", "INTEGER", "0");
             EnsureColumn("Tools", "IsCheckedOut", "INTEGER", "0");
+            // Ensure indexes that depend on newly added columns
+            using (var conn = CreateConnection())
+            {
+                EnsureIndex(conn, "Tools", "Keywords");
+            }
             EnsureColumn("Users", "Password", "TEXT");
             EnsureColumn("Users", "Salt", "TEXT");
             EnsureColumn("Users", "Email", "TEXT");
@@ -176,7 +181,6 @@ namespace ToolManagementAppV2.Services.Core
             EnsureIndex(conn, "Tools", "Supplier");
             EnsureIndex(conn, "Tools", "Location");
             EnsureIndex(conn, "Tools", "Notes");
-            EnsureIndex(conn, "Tools", "Keywords");
             // Ensure each user has a unique username
             EnsureIndex(conn, "Users", "UserName", true);
             EnsureIndex(conn, "Customers", "Contact");


### PR DESCRIPTION
## Summary
- ensure keyword index is created only after adding the column
- cover Tools Keywords index in tests

## Testing
- `dotnet test` *(fails: command not found - dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689f0f9feca88324b98211e97f421249