### PR TITLE
Ensure login window remains above main window

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/LoginWindowBehaviorTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/LoginWindowBehaviorTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Tests
+{
+    public class LoginWindowBehaviorTests
+    {
+        [Fact]
+        public void LoginWindow_IsTopmost()
+        {
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            using var db = new DatabaseService(dbPath);
+            var userContext = new ApplicationUserContext();
+            var userService = new UserService(db, userContext);
+            var settingsService = new SettingsService(db);
+            var window = new LoginWindow(userContext, userService, settingsService);
+            Assert.True(window.Topmost);
+            window.Close();
+        }
+    }
+}

--- a/ToolManagementAppV2/Views/LoginWindow.xaml
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml
@@ -6,6 +6,7 @@
         Width="900" Height="560"
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
+        Topmost="True"
         Background="{StaticResource BackgroundBrush}">
     <Window.InputBindings>
         <KeyBinding Key="Enter" Command="{Binding SelectUserCommand}" CommandParameter="{Binding SelectedUser}"/>


### PR DESCRIPTION
## Summary
- ensure login window remains on top by setting Topmost property
- add unit test verifying login window is topmost

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689f11203ac0832484578b744501d744