### PR TITLE
Initialize failed login attempts for new users

### DIFF
--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -90,6 +90,26 @@ public class UserServiceTests
     }
 
     [Fact]
+    public async Task AddUserAsync_SetsFailedAttemptsToZero()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            var userService = new UserService(dbService, new ApplicationUserContext());
+            var user = new User { UserName = "user1", Password = "pw" };
+            await userService.AddUserAsync(user);
+            var stored = userService.GetUserByID(user.UserID);
+            Assert.NotNull(stored);
+            Assert.Equal(0, stored!.FailedAttempts);
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
     public void ChangeUserPassword_ReturnsFalse_ForInvalidUserID()
     {
         var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -126,9 +126,9 @@ namespace ToolManagementAppV2.Services.Users
         {
             const string sql = @"
                 INSERT INTO Users
-                  (UserName, Password, Salt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, PasswordExpired)
+                  (UserName, Password, Salt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, FailedAttempts, LockoutUntil, PasswordExpired)
                 VALUES
-                  (@UserName,@Password,@Salt,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role,@IsActive,@CreatedAt,@PasswordExpired);
+                  (@UserName,@Password,@Salt,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role,@IsActive,@CreatedAt,@FailedAttempts,@Lockout,@PasswordExpired);
                 SELECT last_insert_rowid();";
 
             using var conn = _dbService.CreateConnection();
@@ -166,6 +166,8 @@ namespace ToolManagementAppV2.Services.Users
                 new SQLiteParameter("@Role",     (object)user.Role ?? DBNull.Value),
                 new SQLiteParameter("@IsActive", user.IsActive ? 1 : 0),
                 new SQLiteParameter("@CreatedAt", user.CreatedAt),
+                new SQLiteParameter("@FailedAttempts", user.FailedAttempts),
+                new SQLiteParameter("@Lockout",    (object?)user.LockoutUntil ?? DBNull.Value),
                 new SQLiteParameter("@PasswordExpired", user.PasswordExpired ? 1 : 0)
             });
             try
@@ -389,9 +391,9 @@ namespace ToolManagementAppV2.Services.Users
         {
             const string sql = @"
                 INSERT INTO Users
-                  (UserName, Password, Salt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, PasswordExpired)
+                  (UserName, Password, Salt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, FailedAttempts, LockoutUntil, PasswordExpired)
                 VALUES
-                  (@UserName,@Password,@Salt,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role,@IsActive,@CreatedAt,@PasswordExpired);
+                  (@UserName,@Password,@Salt,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role,@IsActive,@CreatedAt,@FailedAttempts,@Lockout,@PasswordExpired);
                 SELECT last_insert_rowid();";
 
             using var conn = _dbService.CreateConnection();
@@ -429,6 +431,8 @@ namespace ToolManagementAppV2.Services.Users
                 new SQLiteParameter("@Role",     (object)user.Role ?? DBNull.Value),
                 new SQLiteParameter("@IsActive", user.IsActive ? 1 : 0),
                 new SQLiteParameter("@CreatedAt", user.CreatedAt),
+                new SQLiteParameter("@FailedAttempts", user.FailedAttempts),
+                new SQLiteParameter("@Lockout",    (object?)user.LockoutUntil ?? DBNull.Value),
                 new SQLiteParameter("@PasswordExpired", user.PasswordExpired ? 1 : 0)
             });
             try


### PR DESCRIPTION
## Summary
- avoid NOT NULL constraint when first logging in by explicitly setting FailedAttempts and LockoutUntil on user creation
- add regression test ensuring new users start with zero failed attempts

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f114a691c8324880bc6a1286d8834