### PR TITLE
Remove Topmost attribute from login window and adjust tests

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/LoginWindowBehaviorTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/LoginWindowBehaviorTests.cs
@@ -12,7 +12,7 @@ namespace ToolManagementAppV2.Tests.Tests
     public class LoginWindowBehaviorTests
     {
         [Fact]
-        public void LoginWindow_IsTopmost()
+        public void LoginWindow_IsNotTopmost()
         {
             var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
             using var db = new DatabaseService(dbPath);
@@ -20,7 +20,7 @@ namespace ToolManagementAppV2.Tests.Tests
             var userService = new UserService(db, userContext);
             var settingsService = new SettingsService(db);
             var window = new LoginWindow(userContext, userService, settingsService);
-            Assert.True(window.Topmost);
+            Assert.False(window.Topmost);
             window.Close();
         }
     }

--- a/ToolManagementAppV2/Views/LoginWindow.xaml
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml
@@ -6,7 +6,6 @@
         Width="900" Height="560"
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
-        Topmost="True"
         Background="{StaticResource BackgroundBrush}">
     <Window.InputBindings>
         <KeyBinding Key="Enter" Command="{Binding SelectUserCommand}" CommandParameter="{Binding SelectedUser}"/>


### PR DESCRIPTION
## Summary
- remove Topmost attribute from LoginWindow so it no longer stays above other windows
- update LoginWindowBehaviorTests to ensure window is not topmost

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f131ff0e48324ba21f84b1adb8686