### PR TITLE
Add parameterless constructors to ILogger-based converters

### DIFF
--- a/ToolManagementAppV2/Utilities/Converters/BooleanToAdminConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/BooleanToAdminConverter.cs
@@ -11,6 +11,8 @@ namespace ToolManagementAppV2.Utilities.Converters
     {
         private readonly ILogger<BooleanToAdminConverter> _logger;
 
+        public BooleanToAdminConverter() : this(null) { }
+
         public BooleanToAdminConverter(ILogger<BooleanToAdminConverter>? logger = null)
             => _logger = logger ?? NullLogger<BooleanToAdminConverter>.Instance;
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/ToolManagementAppV2/Utilities/Converters/CheckOutStatusConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/CheckOutStatusConverter.cs
@@ -11,6 +11,8 @@ namespace ToolManagementAppV2.Utilities.Converters
     {
         private readonly ILogger<CheckOutStatusConverter> _logger;
 
+        public CheckOutStatusConverter() : this(null) { }
+
         public CheckOutStatusConverter(ILogger<CheckOutStatusConverter>? logger = null)
             => _logger = logger ?? NullLogger<CheckOutStatusConverter>.Instance;
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/ToolManagementAppV2/Utilities/Converters/NonEmptyStringToBoolConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/NonEmptyStringToBoolConverter.cs
@@ -11,6 +11,8 @@ namespace ToolManagementAppV2.Utilities.Converters
     {
         private readonly ILogger<NonEmptyStringToBoolConverter> _logger;
 
+        public NonEmptyStringToBoolConverter() : this(null) { }
+
         public NonEmptyStringToBoolConverter(ILogger<NonEmptyStringToBoolConverter>? logger = null)
             => _logger = logger ?? NullLogger<NonEmptyStringToBoolConverter>.Instance;
 

--- a/ToolManagementAppV2/Utilities/Converters/NullToBooleanConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/NullToBooleanConverter.cs
@@ -16,6 +16,8 @@ namespace ToolManagementAppV2.Utilities.Converters
     {
         private readonly ILogger<NullToBooleanConverter> _logger;
 
+        public NullToBooleanConverter() : this(null) { }
+
         public NullToBooleanConverter(ILogger<NullToBooleanConverter>? logger = null)
             => _logger = logger ?? NullLogger<NullToBooleanConverter>.Instance;
         /// <summary>

--- a/ToolManagementAppV2/Utilities/Converters/NullToDefaultImageConverter.cs
+++ b/ToolManagementAppV2/Utilities/Converters/NullToDefaultImageConverter.cs
@@ -21,6 +21,8 @@ namespace ToolManagementAppV2.Utilities.Converters
         private static readonly ConcurrentQueue<string> _cacheOrder = new ConcurrentQueue<string>();
         private readonly ILogger<NullToDefaultImageConverter> _logger;
 
+        public NullToDefaultImageConverter() : this(null) { }
+
         public NullToDefaultImageConverter(ILogger<NullToDefaultImageConverter>? logger = null)
         {
             _logger = logger ?? NullLogger<NullToDefaultImageConverter>.Instance;


### PR DESCRIPTION
## Summary
- Provide parameterless constructor delegating to logger-based constructor in NullToDefaultImageConverter to avoid XAML instantiation issues
- Add same pattern to BooleanToAdminConverter
- Extend pattern to other ILogger-dependent converters to ensure consistent behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f15ffd6c083248006172885e36860