### PR TITLE
Refactor tool service to async with cancellation support

### DIFF
--- a/ToolManagementAppV2.Tests/Extensions/ToolServiceExtensions.cs
+++ b/ToolManagementAppV2.Tests/Extensions/ToolServiceExtensions.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Data.SQLite;
+using System.Threading;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.ImportExport;
+using ToolModel = ToolManagementAppV2.Models.Domain.Tool;
+
+namespace ToolManagementAppV2.Tests.Extensions
+{
+    public static class ToolServiceExtensions
+    {
+        public static void AddTool(this IToolService service, ToolModel tool) =>
+            service.AddToolAsync(tool).GetAwaiter().GetResult();
+
+        public static void UpdateTool(this IToolService service, ToolModel tool) =>
+            service.UpdateToolAsync(tool).GetAwaiter().GetResult();
+
+        public static void DeleteTool(this IToolService service, int toolID) =>
+            service.DeleteToolAsync(toolID).GetAwaiter().GetResult();
+
+        public static ToolModel? GetToolByID(this IToolService service, int toolID) =>
+            service.GetToolByIDAsync(toolID).GetAwaiter().GetResult();
+
+        public static List<ToolModel> GetAllTools(this IToolService service) =>
+            service.GetAllToolsAsync().GetAwaiter().GetResult();
+
+        public static List<ToolModel> SearchTools(this IToolService service, string? searchText) =>
+            service.SearchToolsAsync(searchText).GetAwaiter().GetResult();
+
+        public static bool ToggleToolCheckOutStatus(this IToolService service, int toolID, string currentUser) =>
+            service.ToggleToolCheckOutStatusAsync(toolID, currentUser).GetAwaiter().GetResult();
+
+        public static List<ToolModel> GetToolsCheckedOutBy(this IToolService service, string userName) =>
+            service.GetToolsCheckedOutByAsync(userName).GetAwaiter().GetResult();
+
+        public static void UpdateToolImage(this IToolService service, int toolID, string imagePath) =>
+            service.UpdateToolImageAsync(toolID, imagePath).GetAwaiter().GetResult();
+
+        public static List<int> ImportToolsFromCsv(this IToolService service, string filePath, IDictionary<string, string> map) =>
+            service.ImportToolsFromCsvAsync(filePath, map, CancellationToken.None).GetAwaiter().GetResult();
+
+        public static void ExportToolsToCsv(this IToolService service, string filePath) =>
+            service.ExportToolsToCsvAsync(filePath, CancellationToken.None).GetAwaiter().GetResult();
+
+        public static ImageImportResult ImportToolImages(this IToolService service, string folderPath, Func<ToolModel, IEnumerable<string>> selector) =>
+            service.ImportToolImagesAsync(folderPath, selector, CancellationToken.None).GetAwaiter().GetResult();
+
+        public static void UpdateToolQuantities(this IToolService service, int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) =>
+            service.UpdateToolQuantitiesAsync(toolID, qtyChange, isRental, conn, tx, CancellationToken.None).GetAwaiter().GetResult();
+    }
+}

--- a/ToolManagementAppV2.Tests/GlobalUsings.cs
+++ b/ToolManagementAppV2.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using ToolManagementAppV2.Tests.Extensions;

--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -370,23 +370,19 @@ namespace ToolManagementAppV2.Tests.Services
 
         class FailingToolService : IToolService
         {
-            public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
             public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
-            public void ExportToolsToCsv(string filePath) => throw new NotImplementedException();
-            public Task ExportToolsToCsvAsync(string filePath) => Task.CompletedTask;
-            public List<ToolModel> GetAllTools() => new();
-            public void AddTool(ToolModel tool) => throw new NotImplementedException();
-            public void UpdateTool(ToolModel tool) => throw new NotImplementedException();
-            public void DeleteTool(int toolID) => throw new NotImplementedException();
-            public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
-            public List<ToolModel> SearchTools(string? searchText) => new();
+            public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+            public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-            public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
-            public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
-            public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
-            public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
-            public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => new();
-            public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null)
+            public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+            public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default)
                 => throw new InvalidOperationException("fail");
         }
     }

--- a/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
@@ -51,32 +51,22 @@ public class ReportServiceSyncTests
         readonly int _delay; readonly List<Tool> _tools;
         public DelayToolService(int delay, int count)
         { _delay = delay; _tools = new List<Tool>(new Tool[count]); }
-        public List<Tool> GetAllTools() => _tools;
-        public Task<List<Tool>> GetAllToolsAsync() => Task.Delay(_delay).ContinueWith(_ => _tools);
-        public void AddTool(Tool tool) => throw new NotImplementedException();
-        public Task AddToolAsync(Tool tool) => throw new NotImplementedException();
-        public void UpdateTool(Tool tool) => throw new NotImplementedException();
-        public Task UpdateToolAsync(Tool tool) => throw new NotImplementedException();
-        public void DeleteTool(int toolID) => throw new NotImplementedException();
-        public Task DeleteToolAsync(int toolID) => throw new NotImplementedException();
-        public Tool GetToolByID(int toolID) => throw new NotImplementedException();
-        public Task<Tool> GetToolByIDAsync(int toolID) => throw new NotImplementedException();
-        public List<Tool> SearchTools(string? searchText) => throw new NotImplementedException();
+
+        public Task<List<Tool>> GetAllToolsAsync(CancellationToken cancellationToken = default) =>
+            Task.Delay(_delay, cancellationToken).ContinueWith(_ => _tools, cancellationToken);
+
+        public Task AddToolAsync(Tool tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateToolAsync(Tool tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<Tool?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<Tool>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
-        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
-        public List<Tool> GetToolsCheckedOutBy(string userName) => throw new NotImplementedException();
-        public Task<List<Tool>> GetToolsCheckedOutByAsync(string userName) => throw new NotImplementedException();
-        public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
-        public Task UpdateToolImageAsync(int toolID, string imagePath) => throw new NotImplementedException();
-        public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
+        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<Tool>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
-        public void ExportToolsToCsv(string filePath) => throw new NotImplementedException();
-        public Task ExportToolsToCsvAsync(string filePath) => throw new NotImplementedException();
-        public ImageImportResult ImportToolImages(string folderPath, Func<Tool, IEnumerable<string>> keySelector) => throw new NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<Tool, IEnumerable<string>> keySelector) => throw new NotImplementedException();
-        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => throw new NotImplementedException();
-        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => throw new NotImplementedException();
+        public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<Tool, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 
     class DelayRentalService : IRentalService

--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -250,6 +250,27 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
+        public async Task SearchToolsAsync_Cancellation_Throws()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                IToolService service = new ToolService(dbService);
+                service.AddTool(new Tool { ToolNumber = "T1" });
+                using var cts = new CancellationTokenSource();
+                var searchTask = service.SearchToolsAsync("T1", cts.Token);
+                cts.Cancel();
+                await Assert.ThrowsAsync<OperationCanceledException>(async () => await searchTask);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public void UpdateTool_DuplicateToolNumber_Throws()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -164,33 +164,24 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public bool ImportCalled { get; private set; }
         public IDictionary<string,string>? MapUsed { get; private set; }
-        public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map)
+        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
             ImportCalled = true;
             MapUsed = map;
-            return new();
+            return Task.FromResult(new List<int>());
         }
-        public System.Threading.Tasks.Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
-        {
-            ImportCalled = true;
-            MapUsed = map;
-            return System.Threading.Tasks.Task.FromResult(new List<int>());
-        }
-        public void ExportToolsToCsv(string filePath) { }
-        public System.Threading.Tasks.Task ExportToolsToCsvAsync(string filePath) => System.Threading.Tasks.Task.CompletedTask;
-        public List<ToolModel> GetAllTools() => new();
-        public void AddTool(ToolModel tool) => throw new NotImplementedException();
-        public void UpdateTool(ToolModel tool) => throw new NotImplementedException();
-        public void DeleteTool(int toolID) => throw new NotImplementedException();
-        public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
-        public List<ToolModel> SearchTools(string? searchText) => new();
+        public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-        public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
-        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
-        public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
-        public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
-        public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => new();
-        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null) => throw new NotImplementedException();
+        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 
     class CapturingCustomerService : ICustomerService
@@ -232,49 +223,41 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
     class StubToolService : IToolService
     {
-        public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => new();
-        public System.Threading.Tasks.Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
-            => System.Threading.Tasks.Task.FromResult(new List<int>());
-        public void ExportToolsToCsv(string filePath) { }
-        public System.Threading.Tasks.Task ExportToolsToCsvAsync(string filePath) => System.Threading.Tasks.Task.CompletedTask;
-        public List<ToolModel> GetAllTools() => new();
-        public void AddTool(ToolModel tool) => throw new NotImplementedException();
-        public void UpdateTool(ToolModel tool) => throw new NotImplementedException();
-        public void DeleteTool(int toolID) => throw new NotImplementedException();
-        public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
-        public List<ToolModel> SearchTools(string? searchText) => new();
+        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
+            => Task.FromResult(new List<int>());
+        public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-        public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
-        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
-        public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
-        public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
-        public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => new();
-        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null) => throw new NotImplementedException();
+        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 
     class CancelableToolService : IToolService
     {
-        public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => new();
-        public async System.Threading.Tasks.Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
+        public async Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
-            await System.Threading.Tasks.Task.Delay(System.Threading.Timeout.Infinite, cancellationToken);
+            await Task.Delay(Timeout.Infinite, cancellationToken);
             return new List<int>();
         }
-        public void ExportToolsToCsv(string filePath) { }
-        public System.Threading.Tasks.Task ExportToolsToCsvAsync(string filePath) => System.Threading.Tasks.Task.CompletedTask;
-        public List<ToolModel> GetAllTools() => new();
-        public void AddTool(ToolModel tool) => throw new NotImplementedException();
-        public void UpdateTool(ToolModel tool) => throw new NotImplementedException();
-        public void DeleteTool(int toolID) => throw new NotImplementedException();
-        public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
-        public List<ToolModel> SearchTools(string? searchText) => new();
+        public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-        public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
-        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
-        public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
-        public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
-        public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => new();
-        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null) => throw new NotImplementedException();
+        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 
     class StubCustomerService : ICustomerService

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -231,52 +231,44 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public bool ImportCalled { get; private set; }
         public bool ExportCalled { get; private set; }
-        public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map)
-        {
-            ImportCalled = true;
-            return new();
-        }
         public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
             ImportCalled = true;
             return Task.FromResult(new List<int>());
         }
-        public void ExportToolsToCsv(string filePath) => ExportCalled = true;
-        public Task ExportToolsToCsvAsync(string filePath) { ExportCalled = true; return Task.CompletedTask; }
-        public List<ToolModel> GetAllTools() => new();
-        public void AddTool(ToolModel tool) => throw new System.NotImplementedException();
-        public void UpdateTool(ToolModel tool) => throw new System.NotImplementedException();
-        public void DeleteTool(int toolID) => throw new System.NotImplementedException();
-        public ToolModel GetToolByID(int toolID) => throw new System.NotImplementedException();
-        public List<ToolModel> SearchTools(string? searchText) => new();
+        public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default)
+        {
+            ExportCalled = true;
+            return Task.CompletedTask;
+        }
+        public Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-        public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new System.NotImplementedException();
-        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new System.NotImplementedException();
-        public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
-        public void UpdateToolImage(int toolID, string imagePath) => throw new System.NotImplementedException();
-        public ImageImportResult ImportToolImages(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector) => new();
-        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => throw new System.NotImplementedException();
+        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
     }
 
     class FailToolService : IToolService
     {
-        public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => throw new System.Exception("fail");
         public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromException<List<int>>(new System.Exception("fail"));
-        public void ExportToolsToCsv(string filePath) => throw new System.Exception("fail");
-        public Task ExportToolsToCsvAsync(string filePath) => Task.FromException(new System.Exception("fail"));
-        public List<ToolModel> GetAllTools() => new();
-        public void AddTool(ToolModel tool) => throw new System.NotImplementedException();
-        public void UpdateTool(ToolModel tool) => throw new System.NotImplementedException();
-        public void DeleteTool(int toolID) => throw new System.NotImplementedException();
-        public ToolModel GetToolByID(int toolID) => throw new System.NotImplementedException();
-        public List<ToolModel> SearchTools(string? searchText) => new();
+        public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.FromException(new System.Exception("fail"));
+        public Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-        public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new System.NotImplementedException();
-        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new System.NotImplementedException();
-        public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
-        public void UpdateToolImage(int toolID, string imagePath) => throw new System.NotImplementedException();
-        public ImageImportResult ImportToolImages(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector) => new();
-        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => throw new System.NotImplementedException();
+        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
     }
 
     class StubRentalService : IRentalService

--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -630,22 +630,10 @@ namespace ToolManagementAppV2.Tests.ViewModels
             readonly List<ToolModel> _tools;
             public CountingToolService(IEnumerable<ToolModel> tools) => _tools = tools.ToList();
 
-            public List<ToolModel> GetAllTools()
-            {
-                GetAllToolsAsyncCalls++;
-                return _tools.ToList();
-            }
-
-            public Task<List<ToolModel>> GetAllToolsAsync()
+            public Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default)
             {
                 GetAllToolsAsyncCalls++;
                 return Task.FromResult(_tools.ToList());
-            }
-
-            public List<ToolModel> SearchTools(string? searchText)
-            {
-                SearchToolsAsyncCalls++;
-                return _tools.ToList();
             }
 
             public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default)
@@ -665,58 +653,34 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 return Task.FromResult(results);
             }
 
-            public void AddTool(ToolModel tool) => throw new NotImplementedException();
-            public Task AddToolAsync(ToolModel tool) => throw new NotImplementedException();
-            public void UpdateTool(ToolModel tool) => throw new NotImplementedException();
-            public Task UpdateToolAsync(ToolModel tool) => throw new NotImplementedException();
-            public void DeleteTool(int toolID) => throw new NotImplementedException();
-            public Task DeleteToolAsync(int toolID) => throw new NotImplementedException();
-            public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
-            public Task<ToolModel> GetToolByIDAsync(int toolID) => throw new NotImplementedException();
-            public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
-            public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
-            public List<ToolModel> GetToolsCheckedOutBy(string userName) => throw new NotImplementedException();
-            public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName) => throw new NotImplementedException();
-            public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
-            public Task UpdateToolImageAsync(int toolID, string imagePath) => throw new NotImplementedException();
-            public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
+            public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
-            public void ExportToolsToCsv(string filePath) => throw new NotImplementedException();
-            public Task ExportToolsToCsvAsync(string filePath) => throw new NotImplementedException();
-            public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => throw new NotImplementedException();
-            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => throw new NotImplementedException();
-            public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => throw new NotImplementedException();
-            public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => throw new NotImplementedException();
+            public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         }
 
         class FailingToolService : IToolService
         {
-            public void AddTool(ToolModel tool) => throw new NotImplementedException();
-            public Task AddToolAsync(ToolModel tool) => throw new NotImplementedException();
-            public void UpdateTool(ToolModel tool) => throw new NotImplementedException();
-            public Task UpdateToolAsync(ToolModel tool) => throw new NotImplementedException();
-            public void DeleteTool(int toolID) => throw new NotImplementedException();
-            public Task DeleteToolAsync(int toolID) => throw new Exception("failure");
-            public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
-            public Task<ToolModel> GetToolByIDAsync(int toolID) => throw new NotImplementedException();
-            public List<ToolModel> GetAllTools() => new();
-            public Task<List<ToolModel>> GetAllToolsAsync() => Task.FromResult(new List<ToolModel>());
-            public List<ToolModel> SearchTools(string? searchText) => new();
+            public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new Exception("failure");
+            public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
             public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-            public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
-            public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
-            public List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
-            public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName) => Task.FromResult(new List<ToolModel>());
-            public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
-            public Task UpdateToolImageAsync(int toolID, string imagePath) => throw new NotImplementedException();
-            public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) => new();
+            public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+            public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
-            public void ExportToolsToCsv(string filePath) { }
-            public Task ExportToolsToCsvAsync(string filePath) => Task.CompletedTask;
-            public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => new();
-            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector) => Task.FromResult(new ImageImportResult());
-            public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => throw new NotImplementedException();
-            public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) => throw new NotImplementedException();
+            public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         }
 
         class CapturingLogger<T> : ILogger<T>

--- a/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
@@ -99,31 +99,23 @@ namespace ToolManagementAppV2.Tests.Views
     class StubToolService : IToolService
     {
         public bool ImportCalled { get; private set; }
-        public System.Collections.Generic.List<int> ImportToolsFromCsv(string filePath, System.Collections.Generic.IDictionary<string, string> map)
+        public Task<System.Collections.Generic.List<int>> ImportToolsFromCsvAsync(string filePath, System.Collections.Generic.IDictionary<string, string> map, CancellationToken cancellationToken)
         {
             ImportCalled = true;
-            return new();
+            return Task.FromResult(new System.Collections.Generic.List<int>());
         }
-        public System.Threading.Tasks.Task<System.Collections.Generic.List<int>> ImportToolsFromCsvAsync(string filePath, System.Collections.Generic.IDictionary<string, string> map, CancellationToken cancellationToken)
-        {
-            ImportCalled = true;
-            return System.Threading.Tasks.Task.FromResult(new System.Collections.Generic.List<int>());
-        }
-        public void ExportToolsToCsv(string filePath) { }
-        public System.Threading.Tasks.Task ExportToolsToCsvAsync(string filePath) => System.Threading.Tasks.Task.CompletedTask;
-        public System.Collections.Generic.List<ToolModel> GetAllTools() => new();
-        public void AddTool(ToolModel tool) => throw new NotImplementedException();
-        public void UpdateTool(ToolModel tool) => throw new NotImplementedException();
-        public void DeleteTool(int toolID) => throw new NotImplementedException();
-        public ToolModel GetToolByID(int toolID) => throw new NotImplementedException();
-        public System.Collections.Generic.List<ToolModel> SearchTools(string? searchText) => new();
+        public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<System.Collections.Generic.List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ToolModel>());
+        public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<System.Collections.Generic.List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ToolModel>());
-        public bool ToggleToolCheckOutStatus(int toolID, string currentUser) => throw new NotImplementedException();
-        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) => throw new NotImplementedException();
-        public System.Collections.Generic.List<ToolModel> GetToolsCheckedOutBy(string userName) => new();
-        public void UpdateToolImage(int toolID, string imagePath) => throw new NotImplementedException();
-        public ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, System.Collections.Generic.IEnumerable<string>> keySelector) => new();
-        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null) => throw new NotImplementedException();
+        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<System.Collections.Generic.List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ToolModel>());
+        public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, System.Collections.Generic.IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 
     class StubCustomerService : ICustomerService

--- a/ToolManagementAppV2/Interfaces/IToolService.cs
+++ b/ToolManagementAppV2/Interfaces/IToolService.cs
@@ -10,34 +10,19 @@ namespace ToolManagementAppV2.Interfaces
 {
     public interface IToolService
     {
-        void AddTool(ToolModel tool);
-        Task AddToolAsync(ToolModel tool);
-        void UpdateTool(ToolModel tool);
-        Task UpdateToolAsync(ToolModel tool);
-        void DeleteTool(int toolID);
-        Task DeleteToolAsync(int toolID);
-        ToolModel GetToolByID(int toolID);
-        Task<ToolModel> GetToolByIDAsync(int toolID);
-        List<ToolModel> GetAllTools();
-        Task<List<ToolModel>> GetAllToolsAsync();
-        List<ToolModel> SearchTools(string? searchText);
+        Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default);
+        Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default);
+        Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default);
+        Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default);
+        Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default);
         Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default);
-        bool ToggleToolCheckOutStatus(int toolID, string currentUser);
-        Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser);
-        List<ToolModel> GetToolsCheckedOutBy(string userName);
-        Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName);
-        void UpdateToolImage(int toolID, string imagePath);
-        Task UpdateToolImageAsync(int toolID, string imagePath);
-        List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map);
+        Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default);
+        Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default);
+        Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default);
         Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken);
-        void ExportToolsToCsv(string filePath);
-        Task ExportToolsToCsvAsync(string filePath);
-        ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector);
-        Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector);
-        void UpdateToolQuantities(int toolID, int qtyChange, bool isRental,
-            SQLiteConnection? conn = null, SQLiteTransaction? tx = null);
+        Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default);
+        Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default);
         Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental,
-            SQLiteConnection? conn = null, SQLiteTransaction? tx = null);
+            SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default);
     }
 }
-

--- a/ToolManagementAppV2/Services/Core/SqliteHelper.cs
+++ b/ToolManagementAppV2/Services/Core/SqliteHelper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SQLite;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ToolManagementAppV2.Services.Core
@@ -98,65 +99,65 @@ namespace ToolManagementAppV2.Services.Core
             return rdr.Read();
         }
 
-        public static async Task<int> ExecuteNonQueryAsync(string connStr, string sql, SQLiteParameter[] parameters = null)
+        public static async Task<int> ExecuteNonQueryAsync(string connStr, string sql, SQLiteParameter[] parameters = null, CancellationToken cancellationToken = default)
         {
             using var conn = new SQLiteConnection(connStr);
-            await conn.OpenAsync();
+            await conn.OpenAsync(cancellationToken);
             using var cmd = new SQLiteCommand(sql, conn);
             if (parameters != null) cmd.Parameters.AddRange(parameters);
-            return await cmd.ExecuteNonQueryAsync();
+            return await cmd.ExecuteNonQueryAsync(cancellationToken);
         }
 
-        public static async Task<int> ExecuteNonQueryAsync(SQLiteConnection conn, SQLiteTransaction tx, string sql, SQLiteParameter[] parameters)
+        public static async Task<int> ExecuteNonQueryAsync(SQLiteConnection conn, SQLiteTransaction tx, string sql, SQLiteParameter[] parameters, CancellationToken cancellationToken = default)
         {
             using var cmd = new SQLiteCommand(sql, conn, tx);
             if (parameters != null) cmd.Parameters.AddRange(parameters);
-            return await cmd.ExecuteNonQueryAsync();
+            return await cmd.ExecuteNonQueryAsync(cancellationToken);
         }
 
-        public static async Task<int> ExecuteNonQueryAsync(SQLiteConnection conn, string sql, SQLiteParameter[] parameters = null)
+        public static async Task<int> ExecuteNonQueryAsync(SQLiteConnection conn, string sql, SQLiteParameter[] parameters = null, CancellationToken cancellationToken = default)
         {
             using var cmd = new SQLiteCommand(sql, conn);
             if (parameters != null) cmd.Parameters.AddRange(parameters);
-            return await cmd.ExecuteNonQueryAsync();
+            return await cmd.ExecuteNonQueryAsync(cancellationToken);
         }
 
-        public static async Task<object> ExecuteScalarAsync(string connStr, string sql, SQLiteParameter[] parameters = null)
+        public static async Task<object> ExecuteScalarAsync(string connStr, string sql, SQLiteParameter[] parameters = null, CancellationToken cancellationToken = default)
         {
             using var conn = new SQLiteConnection(connStr);
-            await conn.OpenAsync();
+            await conn.OpenAsync(cancellationToken);
             using var cmd = new SQLiteCommand(sql, conn);
             if (parameters != null) cmd.Parameters.AddRange(parameters);
-            return await cmd.ExecuteScalarAsync();
+            return await cmd.ExecuteScalarAsync(cancellationToken);
         }
 
-        public static async Task<object> ExecuteScalarAsync(SQLiteConnection conn, string sql, SQLiteParameter[] parameters = null)
+        public static async Task<object> ExecuteScalarAsync(SQLiteConnection conn, string sql, SQLiteParameter[] parameters = null, CancellationToken cancellationToken = default)
         {
             using var cmd = new SQLiteCommand(sql, conn);
             if (parameters != null) cmd.Parameters.AddRange(parameters);
-            return await cmd.ExecuteScalarAsync();
+            return await cmd.ExecuteScalarAsync(cancellationToken);
         }
 
-        public static async Task<List<T>> ExecuteReaderAsync<T>(string connStr, string sql, SQLiteParameter[] parameters, Func<IDataRecord, T> map)
+        public static async Task<List<T>> ExecuteReaderAsync<T>(string connStr, string sql, SQLiteParameter[] parameters, Func<IDataRecord, T> map, CancellationToken cancellationToken = default)
         {
             var list = new List<T>();
             using var conn = new SQLiteConnection(connStr);
-            await conn.OpenAsync();
+            await conn.OpenAsync(cancellationToken);
             using var cmd = new SQLiteCommand(sql, conn);
             if (parameters != null) cmd.Parameters.AddRange(parameters);
-            using var rdr = await cmd.ExecuteReaderAsync();
-            while (await rdr.ReadAsync())
+            using var rdr = await cmd.ExecuteReaderAsync(cancellationToken);
+            while (await rdr.ReadAsync(cancellationToken))
                 list.Add(map(rdr));
             return list;
         }
 
-        public static async Task<List<T>> ExecuteReaderAsync<T>(SQLiteConnection conn, string sql, SQLiteParameter[] parameters, Func<IDataRecord, T> map)
+        public static async Task<List<T>> ExecuteReaderAsync<T>(SQLiteConnection conn, string sql, SQLiteParameter[] parameters, Func<IDataRecord, T> map, CancellationToken cancellationToken = default)
         {
             var list = new List<T>();
             using var cmd = new SQLiteCommand(sql, conn);
             if (parameters != null) cmd.Parameters.AddRange(parameters);
-            using var rdr = await cmd.ExecuteReaderAsync();
-            while (await rdr.ReadAsync())
+            using var rdr = await cmd.ExecuteReaderAsync(cancellationToken);
+            while (await rdr.ReadAsync(cancellationToken))
                 list.Add(map(rdr));
             return list;
         }

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -48,7 +48,7 @@ namespace ToolManagementAppV2.Services.Rentals
                         new SQLiteParameter("@DueDate", dueDate)
                     });
 
-                _toolService?.UpdateToolQuantities(toolID, 1, true, conn, tx);
+                _toolService?.UpdateToolQuantitiesAsync(toolID, 1, true, conn, tx).GetAwaiter().GetResult();
             });
         }
 
@@ -71,7 +71,7 @@ namespace ToolManagementAppV2.Services.Rentals
                         new SQLiteParameter("@RentalID", rentalID)
                     });
 
-                _toolService?.UpdateToolQuantities(toolID, 1, false, conn, tx);
+                _toolService?.UpdateToolQuantitiesAsync(toolID, 1, false, conn, tx).GetAwaiter().GetResult();
             });
         }
 
@@ -108,11 +108,11 @@ namespace ToolManagementAppV2.Services.Rentals
                     // considered overdue and becomes available for others.
                     if (oldDueDate <= DateTime.Today && newDueDate > DateTime.Today)
                     {
-                        _toolService.UpdateToolQuantities(toolID, 1, true, conn, tx);
+                        _toolService.UpdateToolQuantitiesAsync(toolID, 1, true, conn, tx).GetAwaiter().GetResult();
                     }
                     else if (oldDueDate > DateTime.Today && newDueDate <= DateTime.Today)
                     {
-                        _toolService.UpdateToolQuantities(toolID, 1, false, conn, tx);
+                        _toolService.UpdateToolQuantitiesAsync(toolID, 1, false, conn, tx).GetAwaiter().GetResult();
                     }
                 }
             });

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -37,156 +37,54 @@ namespace ToolManagementAppV2.Services.Tools
             _logger = logger ?? NullLogger<ToolService>.Instance;
         }
 
-        static void RunSync(Func<Task> task) => task().GetAwaiter().GetResult();
-        static T RunSync<T>(Func<Task<T>> task) => task().GetAwaiter().GetResult();
-    
-        public List<ToolModel> GetAllTools()
-        {
-            using var conn = _dbService.CreateConnection();
-            return SqliteHelper.ExecuteReader(conn, AllToolsSql, null, MapTool);
-        }
-    
-        public ToolModel GetToolByID(int toolID)
-        {
-            using var conn = _dbService.CreateConnection();
-            return SqliteHelper.ExecuteReader(conn, "SELECT * FROM Tools WHERE ToolID=@ToolID",
-                new[] { new SQLiteParameter("@ToolID", toolID) }, MapTool).FirstOrDefault();
-        }
-    
-        public List<ToolModel> SearchTools(string? searchText)
-        {
-            if (string.IsNullOrWhiteSpace(searchText))
-                return GetAllTools();
-
-            using var conn = _dbService.CreateConnection();
-            var terms = searchText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            var originalCount = terms.Length;
-            if (originalCount > MaxSearchTerms)
-            {
-                _logger.LogInformation(
-                    "Search term limit exceeded; truncating from {OriginalCount} to {Max}",
-                    originalCount, MaxSearchTerms);
-                terms = terms.Take(MaxSearchTerms).ToArray();
-            }
-            var searchable = new[]
-            {
-                "ToolNumber",
-                "NameDescription",
-                "Brand",
-                "PartNumber",
-                "Supplier",
-                "Location",
-                "Notes",
-                "Keywords"
-            };
-
-            var sb = new StringBuilder("SELECT * FROM Tools WHERE ");
-            var parameters = new List<SQLiteParameter>();
-            for (int i = 0; i < terms.Length; i++)
-            {
-                if (i > 0) sb.Append(" AND ");
-                var paramName = $"@p{i}";
-                var likeClause = string.Join(" OR ", searchable.Select(col => $"{col} LIKE {paramName} COLLATE NOCASE"));
-                sb.Append($"(CAST(ToolID AS TEXT) LIKE {paramName} COLLATE NOCASE OR {likeClause})");
-                parameters.Add(new SQLiteParameter(paramName, $"%{terms[i]}%"));
-            }
-
-            return SqliteHelper.ExecuteReader(conn, sb.ToString(), parameters.ToArray(), MapTool);
-        }
-    
-        /// <summary>
-        /// Adds a single tool to the database. ImportToolsFromCsv reuses the
-        /// underlying InsertToolAsync method within a caller-managed transaction when
-        /// performing bulk inserts.
-        /// </summary>
-        public void AddTool(ToolModel tool) =>
-            RunSync(() => AddToolInternalAsync(tool));
-
-        public Task AddToolAsync(ToolModel tool) => AddToolInternalAsync(tool);
-
-        public void UpdateTool(ToolModel tool) =>
-            RunSync(() => UpdateToolInternalAsync(tool));
-
-        public Task UpdateToolAsync(ToolModel tool) => UpdateToolInternalAsync(tool);
-    
-        public void UpdateToolQuantities(int toolID, int qtyChange, bool isRental,
-            SQLiteConnection? conn = null, SQLiteTransaction? tx = null)
-        {
-            if (qtyChange <= 0) throw new ArgumentException("Quantity change must be positive.", nameof(qtyChange));
-            var sql = isRental
-                ? @"UPDATE Tools SET AvailableQuantity = AvailableQuantity - @Q, RentedQuantity = RentedQuantity + @Q WHERE ToolID = @ID AND AvailableQuantity >= @Q"
-                : @"UPDATE Tools SET AvailableQuantity = AvailableQuantity + @Q, RentedQuantity = RentedQuantity - @Q WHERE ToolID = @ID AND RentedQuantity >= @Q";
-            var p = new[]
-            {
-                new SQLiteParameter("@ID", toolID),
-                new SQLiteParameter("@Q", qtyChange)
-            };
-
-            if (conn != null)
-            {
-                int rows = tx != null
-                    ? SqliteHelper.ExecuteNonQuery(conn, tx, sql, p)
-                    : SqliteHelper.ExecuteNonQuery(conn, sql, p);
-                if (rows == 0)
-                {
-                    _logger.LogWarning("Quantity update affected 0 rows for ToolID {ToolID}", toolID);
-                    throw new InvalidOperationException("Quantity update failed.");
-                }
-            }
-            else
-            {
-                using var c = _dbService.CreateConnection();
-                int rows = SqliteHelper.ExecuteNonQuery(c, sql, p);
-                if (rows == 0)
-                {
-                    _logger.LogWarning("Quantity update affected 0 rows for ToolID {ToolID}", toolID);
-                    throw new InvalidOperationException("Quantity update failed.");
-                }
-            }
-        }
-    
-        public void DeleteTool(int toolID) =>
-            RunSync(() => DeleteToolInternalAsync(toolID));
-
-        public Task DeleteToolAsync(int toolID) => DeleteToolInternalAsync(toolID);
-
-        public bool ToggleToolCheckOutStatus(int toolID, string currentUser) =>
-            RunSync(() => ToggleToolCheckOutStatusInternalAsync(toolID, currentUser));
-
-        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser) =>
-            ToggleToolCheckOutStatusInternalAsync(toolID, currentUser);
-    
-        public List<ToolModel> GetToolsCheckedOutBy(string userName)
-        {
-            using var conn = _dbService.CreateConnection();
-            return SqliteHelper.ExecuteReader(conn, "SELECT * FROM Tools WHERE CheckedOutBy=@User AND IsCheckedOut=1",
-                new[] { new SQLiteParameter("@User", userName) }, MapTool);
-        }
-    
-        public void UpdateToolImage(int toolID, string imagePath)
-        {
-            using var conn = _dbService.CreateConnection();
-            SqliteHelper.ExecuteNonQuery(conn, "UPDATE Tools SET ToolImagePath=@Img WHERE ToolID=@ID",
-                new[]
-                {
-                    new SQLiteParameter("@Img", imagePath),
-                    new SQLiteParameter("@ID", toolID)
-                });
-        }
-    
-        public List<int> ImportToolsFromCsv(string filePath, IDictionary<string, string> map) =>
-            RunSync(() => ImportToolsFromCsvInternalAsync(filePath, map, CancellationToken.None));
-
-        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) =>
-            ImportToolsFromCsvInternalAsync(filePath, map, cancellationToken);
-
         static void ValidateQuantity(int quantity)
         {
             if (quantity < 0 || quantity > MaxQuantityOnHand)
                 throw new ArgumentOutOfRangeException(nameof(Tool.QuantityOnHand), $"QuantityOnHand must be between 0 and {MaxQuantityOnHand}.");
         }
 
-        async Task InsertToolAsync(SQLiteConnection conn, SQLiteTransaction? tran, ToolModel tool)
+        public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default)
+            => AddToolInternalAsync(tool, cancellationToken);
+
+        public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default)
+            => UpdateToolInternalAsync(tool, cancellationToken);
+
+        public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default)
+            => DeleteToolInternalAsync(toolID, cancellationToken);
+
+        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default)
+            => ToggleToolCheckOutStatusInternalAsync(toolID, currentUser, cancellationToken);
+
+        public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default)
+        {
+            using var conn = _dbService.CreateConnection();
+            return SqliteHelper.ExecuteReaderAsync(conn,
+                "SELECT * FROM Tools WHERE CheckedOutBy=@User AND IsCheckedOut=1",
+                new[] { new SQLiteParameter("@User", userName) }, MapTool, cancellationToken);
+        }
+
+        public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default)
+        {
+            const string sql = "UPDATE Tools SET ToolImagePath=@Img WHERE ToolID=@ID";
+            var p = new[]
+            {
+                new SQLiteParameter("@Img", imagePath),
+                new SQLiteParameter("@ID", toolID)
+            };
+            using var conn = _dbService.CreateConnection();
+            return SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);
+        }
+
+        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
+            => ImportToolsFromCsvInternalAsync(filePath, map, cancellationToken);
+
+        public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default)
+            => ExportToolsToCsvInternalAsync(filePath, cancellationToken);
+
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default)
+            => Task.Run(() => ImportToolImagesInternal(folderPath, keySelector, cancellationToken), cancellationToken);
+
+        async Task InsertToolAsync(SQLiteConnection conn, SQLiteTransaction? tran, ToolModel tool, CancellationToken cancellationToken)
         {
             ValidateQuantity(tool.QuantityOnHand);
             var p = new[]
@@ -207,27 +105,23 @@ namespace ToolManagementAppV2.Services.Tools
             };
             using var cmd = new SQLiteCommand(UpsertToolCsv, conn, tran);
             cmd.Parameters.AddRange(p);
-            var result = await cmd.ExecuteScalarAsync();
+            var result = await cmd.ExecuteScalarAsync(cancellationToken);
             if (result != null)
                 tool.ToolID = Convert.ToInt32(result);
         }
     
-        public void ExportToolsToCsv(string filePath) =>
-            RunSync(() => ExportToolsToCsvInternalAsync(filePath));
-
-        public Task ExportToolsToCsvAsync(string filePath) =>
-            ExportToolsToCsvInternalAsync(filePath);
-
-        public virtual ImageImportResult ImportToolImages(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector)
+        private ImageImportResult ImportToolImagesInternal(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken)
         {
             var result = new ImageImportResult();
             if (string.IsNullOrWhiteSpace(folderPath) || keySelector == null)
                 return result;
 
-            var tools = GetAllTools();
+            cancellationToken.ThrowIfCancellationRequested();
+            var tools = GetAllToolsAsync(cancellationToken).GetAwaiter().GetResult();
             var groups = new Dictionary<string, List<ToolModel>>(StringComparer.OrdinalIgnoreCase);
             foreach (var tool in tools)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var keys = keySelector(tool);
                 if (keys == null) continue;
                 foreach (var key in keys)
@@ -259,6 +153,7 @@ namespace ToolManagementAppV2.Services.Tools
 
             foreach (var file in Directory.EnumerateFiles(folderPath))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var ext = Path.GetExtension(file);
                 if (!supported.Contains(ext))
                     continue;
@@ -295,7 +190,7 @@ namespace ToolManagementAppV2.Services.Tools
                     }
                 }
                 var relative = $"Images/{Path.GetFileName(dest)}";
-                UpdateToolImage(tool.ToolID, relative);
+                UpdateToolImageAsync(tool.ToolID, relative, cancellationToken).GetAwaiter().GetResult();
                 result.ImportedCount++;
             }
 
@@ -305,7 +200,7 @@ namespace ToolManagementAppV2.Services.Tools
         protected virtual void CopyFile(string sourceFileName, string destFileName)
             => File.Copy(sourceFileName, destFileName, true);
 
-        private async Task<bool> ToolExistsAsync(string toolNumber, int? exceptId = null)
+        private async Task<bool> ToolExistsAsync(string toolNumber, int? exceptId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(toolNumber))
                 return false;
@@ -323,7 +218,7 @@ namespace ToolManagementAppV2.Services.Tools
             }
 
             using var conn = _dbService.CreateConnection();
-            var count = Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql, parameters.ToArray()));
+            var count = Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql, parameters.ToArray(), cancellationToken));
             return count > 0;
         }
     
@@ -348,20 +243,20 @@ namespace ToolManagementAppV2.Services.Tools
             IsPowerTool = (r["IsPowerTool"] is DBNull ? 0 : Convert.ToInt32(r["IsPowerTool"])) == 1
         };
 
-        private async Task AddToolInternalAsync(ToolModel tool)
+        private async Task AddToolInternalAsync(ToolModel tool, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(tool?.ToolNumber))
                 throw new ArgumentException("ToolNumber is required.", nameof(tool));
-            if (await ToolExistsAsync(tool.ToolNumber))
+            if (await ToolExistsAsync(tool.ToolNumber, null, cancellationToken))
                 throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
             ValidateQuantity(tool.QuantityOnHand);
             using var conn = _dbService.CreateConnection();
-            await InsertToolAsync(conn, null, tool);
+            await InsertToolAsync(conn, null, tool, cancellationToken);
         }
 
-        private async Task UpdateToolInternalAsync(ToolModel tool)
+        private async Task UpdateToolInternalAsync(ToolModel tool, CancellationToken cancellationToken)
         {
-            if (await ToolExistsAsync(tool.ToolNumber, tool.ToolID))
+            if (await ToolExistsAsync(tool.ToolNumber, tool.ToolID, cancellationToken))
                 throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
             using var conn = _dbService.CreateConnection();
             ValidateQuantity(tool.QuantityOnHand);
@@ -406,7 +301,7 @@ namespace ToolManagementAppV2.Services.Tools
             };
             try
             {
-                await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+                await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);
             }
             catch (SQLiteException ex)
             {
@@ -415,13 +310,13 @@ namespace ToolManagementAppV2.Services.Tools
             }
         }
 
-        private async Task DeleteToolInternalAsync(int toolID)
+        private async Task DeleteToolInternalAsync(int toolID, CancellationToken cancellationToken)
         {
             using var conn = _dbService.CreateConnection();
             try
             {
                 await SqliteHelper.ExecuteNonQueryAsync(conn, "DELETE FROM Tools WHERE ToolID=@ID",
-                    new[] { new SQLiteParameter("@ID", toolID) });
+                    new[] { new SQLiteParameter("@ID", toolID) }, cancellationToken);
             }
             catch (SQLiteException ex)
             {
@@ -430,18 +325,18 @@ namespace ToolManagementAppV2.Services.Tools
             }
         }
 
-        public async Task<ToolModel> GetToolByIDAsync(int toolID)
+        public async Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default)
         {
             using var conn = _dbService.CreateConnection();
             var list = await SqliteHelper.ExecuteReaderAsync(conn, "SELECT * FROM Tools WHERE ToolID=@ToolID",
-                new[] { new SQLiteParameter("@ToolID", toolID) }, MapTool);
+                new[] { new SQLiteParameter("@ToolID", toolID) }, MapTool, cancellationToken);
             return list.FirstOrDefault();
         }
 
-        public async Task<List<ToolModel>> GetAllToolsAsync()
+        public async Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default)
         {
             using var conn = _dbService.CreateConnection();
-            return await SqliteHelper.ExecuteReaderAsync(conn, AllToolsSql, null, MapTool);
+            return await SqliteHelper.ExecuteReaderAsync(conn, AllToolsSql, null, MapTool, cancellationToken);
         }
 
         public async Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default)
@@ -450,7 +345,7 @@ namespace ToolManagementAppV2.Services.Tools
             if (string.IsNullOrWhiteSpace(searchText))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                return await GetAllToolsAsync();
+                return await GetAllToolsAsync(cancellationToken);
             }
 
             using var conn = _dbService.CreateConnection();
@@ -487,16 +382,16 @@ namespace ToolManagementAppV2.Services.Tools
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            return await SqliteHelper.ExecuteReaderAsync(conn, sb.ToString(), parameters.ToArray(), MapTool);
+            return await SqliteHelper.ExecuteReaderAsync(conn, sb.ToString(), parameters.ToArray(), MapTool, cancellationToken);
         }
 
-        private async Task<bool> ToggleToolCheckOutStatusInternalAsync(int toolID, string currentUser)
+        private async Task<bool> ToggleToolCheckOutStatusInternalAsync(int toolID, string currentUser, CancellationToken cancellationToken)
         {
             using var conn = _dbService.CreateConnection();
             var record = (await SqliteHelper.ExecuteReaderAsync(conn,
                 "SELECT IsCheckedOut, AvailableQuantity FROM Tools WHERE ToolID=@ID",
                 new[] { new SQLiteParameter("@ID", toolID) },
-                r => new { Out = Convert.ToInt32(r["IsCheckedOut"]) == 1, Qty = Convert.ToInt32(r["AvailableQuantity"]) })).FirstOrDefault();
+                r => new { Out = Convert.ToInt32(r["IsCheckedOut"]) == 1, Qty = Convert.ToInt32(r["AvailableQuantity"]) }, cancellationToken)).FirstOrDefault();
 
             if (record == null)
                 throw new InvalidOperationException($"Tool {toolID} not found.");
@@ -522,31 +417,12 @@ namespace ToolManagementAppV2.Services.Tools
                 new SQLiteParameter("@Time", time),
                 new SQLiteParameter("@Q", qtyChange),
                 new SQLiteParameter("@ID", toolID)
-            });
+            }, cancellationToken);
 
             if (rows == 0)
                 throw new InvalidOperationException("Check-out status update failed.");
 
             return true;
-        }
-
-        public async Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName)
-        {
-            using var conn = _dbService.CreateConnection();
-            return await SqliteHelper.ExecuteReaderAsync(conn,
-                "SELECT * FROM Tools WHERE CheckedOutBy=@U", new[] { new SQLiteParameter("@U", userName) }, MapTool);
-        }
-
-        public async Task UpdateToolImageAsync(int toolID, string imagePath)
-        {
-            const string sql = "UPDATE Tools SET ToolImagePath=@Img WHERE ToolID=@ID";
-            var p = new[]
-            {
-                new SQLiteParameter("@Img", imagePath),
-                new SQLiteParameter("@ID", toolID)
-            };
-            using var conn = _dbService.CreateConnection();
-            await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
         }
 
         private async Task<List<int>> ImportToolsFromCsvInternalAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
@@ -556,7 +432,7 @@ namespace ToolManagementAppV2.Services.Tools
             var existingNumbers = new HashSet<string>(
                 await SqliteHelper.ExecuteReaderAsync(conn,
                     "SELECT ToolNumber FROM Tools", null,
-                    r => r.GetString(0)));
+                    r => r.GetString(0), cancellationToken));
 
             using var tran = conn.BeginTransaction();
             try
@@ -567,7 +443,7 @@ namespace ToolManagementAppV2.Services.Tools
                     if (string.IsNullOrWhiteSpace(tool.ToolNumber) ||
                         existingNumbers.Contains(tool.ToolNumber))
                         continue;
-                    await InsertToolAsync(conn, tran, tool);
+                    await InsertToolAsync(conn, tran, tool, cancellationToken);
                     existingNumbers.Add(tool.ToolNumber);
                 }
                 tran.Commit();
@@ -581,16 +457,16 @@ namespace ToolManagementAppV2.Services.Tools
             }
         }
 
-        private async Task ExportToolsToCsvInternalAsync(string filePath)
+        private async Task ExportToolsToCsvInternalAsync(string filePath, CancellationToken cancellationToken)
         {
-            var tools = await GetAllToolsAsync();
+            var tools = await GetAllToolsAsync(cancellationToken);
             await CsvHelperUtil.ExportToolsToCsvAsync(filePath, tools);
         }
 
         public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector)
             => Task.FromResult(ImportToolImages(folderPath, keySelector));
 
-        public async Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null)
+        public async Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default)
         {
             if (qtyChange <= 0) throw new ArgumentException("Quantity change must be positive.", nameof(qtyChange));
             var sql = isRental
@@ -605,8 +481,8 @@ namespace ToolManagementAppV2.Services.Tools
             if (conn != null)
             {
                 int rows = tx != null
-                    ? await SqliteHelper.ExecuteNonQueryAsync(conn, tx, sql, p)
-                    : await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+                    ? await SqliteHelper.ExecuteNonQueryAsync(conn, tx, sql, p, cancellationToken)
+                    : await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);
                 if (rows == 0)
                 {
                     _logger.LogWarning("Quantity update affected 0 rows for ToolID {ToolID}", toolID);
@@ -616,7 +492,7 @@ namespace ToolManagementAppV2.Services.Tools
             else
             {
                 using var c = _dbService.CreateConnection();
-                int rows = await SqliteHelper.ExecuteNonQueryAsync(c, sql, p);
+                int rows = await SqliteHelper.ExecuteNonQueryAsync(c, sql, p, cancellationToken);
                 if (rows == 0)
                 {
                     _logger.LogWarning("Quantity update affected 0 rows for ToolID {ToolID}", toolID);

--- a/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
+using System.Threading;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
@@ -68,16 +69,17 @@ namespace ToolManagementAppV2.ViewModels
                 catch (Exception ex) { _logger.LogError(ex, "Failed to open import/export page"); }
             });
 
-            LoadStats();
+            _ = LoadStatsAsync();
             LoadRecentActivity();
         }
 
-        void LoadStats()
+        async Task LoadStatsAsync()
         {
             try
             {
                 StatCards.Clear();
-                StatCards.Add(new StatCard { Title = "Total Tools", Value = _toolService.GetAllTools().Count.ToString() });
+                var tools = await _toolService.GetAllToolsAsync(CancellationToken.None);
+                StatCards.Add(new StatCard { Title = "Total Tools", Value = tools.Count.ToString() });
                 StatCards.Add(new StatCard { Title = "Active Rentals", Value = _rentalService.GetActiveRentals().Count.ToString() });
                 StatCards.Add(new StatCard { Title = "Total Customers", Value = _customerService.GetAllCustomers().Count.ToString() });
                 StatCards.Add(new StatCard { Title = "Total Users", Value = _userService.GetAllUsers().Count.ToString() });

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -95,7 +95,7 @@ namespace ToolManagementAppV2.ViewModels
             if (string.IsNullOrEmpty(path)) return;
             try
             {
-                await _toolService.ExportToolsToCsvAsync(path);
+                await _toolService.ExportToolsToCsvAsync(path, CancellationToken.None);
                 ImportExportLogs.Add($"Successfully exported tools to {path}.");
             }
             catch (Exception ex)

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -101,7 +101,7 @@ namespace ToolManagementAppV2.ViewModels
         public IAsyncRelayCommand OpenActivityLogsCommand { get; }
         public IRelayCommand OpenReportsCommand { get; }
         public IAsyncRelayCommand OpenImportMappingWindowCommand { get; }
-        public IRelayCommand OpenImageImportMappingWindowCommand { get; }
+        public IAsyncRelayCommand OpenImageImportMappingWindowCommand { get; }
         public IRelayCommand ExitCommand { get; }
         public IAsyncRelayCommand GlobalSearchCommand { get; }
         public IAsyncRelayCommand SwitchUserCommand { get; }
@@ -245,20 +245,7 @@ namespace ToolManagementAppV2.ViewModels
 
             OpenImportMappingWindowCommand = new AsyncRelayCommand(OpenImportMappingWindowAsync);
 
-            OpenImageImportMappingWindowCommand = new RelayCommand(() =>
-            {
-                using var dlg = new Forms.FolderBrowserDialog();
-                if (dlg.ShowDialog() != Forms.DialogResult.OK)
-                    return;
-                var selector = _dialogService.ShowImageImportMapping();
-                if (selector != null)
-                {
-                    var result = _toolService.ImportToolImages(dlg.SelectedPath, selector);
-                    _dialogService.ShowInfo(
-                        $"Imported {result.ImportedCount} images. Unmatched: {result.UnmatchedFiles.Count}, Conflicts: {result.ConflictingFiles.Count}",
-                        "Import Images");
-                }
-            });
+            OpenImageImportMappingWindowCommand = new AsyncRelayCommand(OpenImageImportMappingWindowAsync);
 
             GlobalSearchCommand = new AsyncRelayCommand(GlobalSearchAsync);
 
@@ -370,6 +357,21 @@ namespace ToolManagementAppV2.ViewModels
             {
                 _logger.LogError(ex, "Failed to import tools from CSV");
                 await _dialogService.ShowInfoAsync($"Failed to import tools: {ex.Message}", "Import Tools");
+            }
+        }
+
+        async Task OpenImageImportMappingWindowAsync()
+        {
+            using var dlg = new Forms.FolderBrowserDialog();
+            if (dlg.ShowDialog() != Forms.DialogResult.OK)
+                return;
+            var selector = _dialogService.ShowImageImportMapping();
+            if (selector != null)
+            {
+                var result = await _toolService.ImportToolImagesAsync(dlg.SelectedPath, selector, CancellationToken.None);
+                _dialogService.ShowInfo(
+                    $"Imported {result.ImportedCount} images. Unmatched: {result.UnmatchedFiles.Count}, Conflicts: {result.ConflictingFiles.Count}",
+                    "Import Images");
             }
         }
 


### PR DESCRIPTION
## Summary
- remove synchronous ToolService APIs and expose asynchronous counterparts with CancellationToken support
- propagate cancellation through SqliteHelper and update view models for async calls
- add test coverage for async cancellation and helpers for legacy test calls

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f88371b8483248a3980333cadc09a