### PR TITLE
Center change password window and apply theme colors

### DIFF
--- a/ToolManagementAppV2/Views/ChangePasswordWindow.xaml
+++ b/ToolManagementAppV2/Views/ChangePasswordWindow.xaml
@@ -2,15 +2,25 @@
 <Window x:Class="ToolManagementAppV2.Views.ChangePasswordWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Change Password" SizeToContent="WidthAndHeight" WindowStartupLocation="CenterOwner">
-    <StackPanel Margin="20">
-        <TextBlock Text="New Password"/>
-        <PasswordBox x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged"/>
-        <TextBlock Text="Confirm Password" Margin="0,10,0,0"/>
-        <PasswordBox x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged"/>
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
-            <Button Content="OK" Command="{Binding SaveCommand}" IsDefault="True" Margin="0,0,5,0"/>
-            <Button Content="Cancel" Command="{Binding CancelCommand}" IsCancel="True"/>
+        Title="Change Password"
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterScreen"
+        Background="{StaticResource BackgroundBrush}">
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <TextBlock Grid.Row="0" Text="New Password" HorizontalAlignment="Center" Foreground="{StaticResource ForegroundBrush}"/>
+        <PasswordBox Grid.Row="1" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" HorizontalAlignment="Center"/>
+        <TextBlock Grid.Row="2" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Foreground="{StaticResource ForegroundBrush}"/>
+        <PasswordBox Grid.Row="3" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" HorizontalAlignment="Center"/>
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" Command="{Binding SaveCommand}" IsDefault="True" Margin="0,0,5,0" Foreground="{StaticResource ForegroundBrush}"/>
+            <Button Content="Cancel" Command="{Binding CancelCommand}" IsCancel="True" Foreground="{StaticResource ForegroundBrush}"/>
         </StackPanel>
-    </StackPanel>
+    </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- center ChangePasswordWindow on screen and apply app background
- replace root StackPanel with Grid and center password fields
- apply theme foreground brush to text and buttons for readability

## Testing
- `dotnet test` *(fails: command not found)*
- `dotnet run --project ToolManagementAppV2/ToolManagementAppV2.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f8832bb6c8324a440e20ec8a237a5