### PR TITLE
Fix customers contact binding and add grid test

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/CustomersPageBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CustomersPageBindingTests.cs
@@ -40,6 +40,35 @@ namespace ToolManagementAppV2.Tests.Tests
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public async System.Threading.Tasks.Task DataGrid_ShowsContactNames()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var customerService = new CustomerService(db);
+                // Add a customer with a contact name
+                customerService.AddCustomer(new CustomerModel { Company = "ACME", Contact = "John Doe" });
+                var vm = new CustomerManagementViewModel(customerService, new StubDialogService());
+                await vm.LoadCustomersAsync();
+
+                var page = new CustomersPage { DataContext = vm };
+                var grid = (Grid)page.Content;
+                var border = (Border)grid.Children[1];
+                var dataGrid = (DataGrid)border.Child;
+
+                dataGrid.UpdateLayout();
+                var cell = (TextBlock)dataGrid.Columns[1].GetCellContent(dataGrid.Items[0]);
+                Assert.Equal("John Doe", cell.Text);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 
     class StubDialogService : IDialogService

--- a/ToolManagementAppV2/Views/CustomersPage.xaml
+++ b/ToolManagementAppV2/Views/CustomersPage.xaml
@@ -19,7 +19,7 @@
             <DataGrid ItemsSource="{Binding Customers}" SelectedItem="{Binding SelectedCustomer}" IsReadOnly="True">
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="Company" Binding="{Binding Company}" Width="*"/>
-                    <DataGridTextColumn Header="Contact" Binding="{Binding ContactName}" Width="220"/>
+                    <DataGridTextColumn Header="Contact" Binding="{Binding Contact}" Width="220"/>
                     <DataGridTextColumn Header="Phone" Binding="{Binding Phone}" Width="180"/>
                     <DataGridTextColumn Header="Email" Binding="{Binding Email}" Width="240"/>
                 </DataGrid.Columns>


### PR DESCRIPTION
## Summary
- Bind Customers grid to `Contact` instead of `ContactName`
- Add UI test verifying contact names render in grid

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a0139440688324a9e05939435400d1