### PR TITLE
Refactor password iteration retrieval to async

### DIFF
--- a/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
+++ b/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
@@ -99,6 +99,19 @@ namespace ToolManagementAppV2.Tests.Utilities
             SecurityHelper.SettingsService = null;
         }
 
+        [Fact]
+        public void HashPasswordAsync_DoesNotDeadlock()
+        {
+            var settings = new AsyncOnlySettingsService(7);
+            SecurityHelper.SettingsService = settings;
+
+            var task = SecurityHelper.HashPasswordAsync("secret");
+            var completed = task.Wait(1000);
+            Assert.True(completed, "HashPasswordAsync timed out, possible deadlock.");
+
+            SecurityHelper.SettingsService = null;
+        }
+
         class CountingSettingsService : ISettingsService
         {
             int _counter;

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -69,16 +69,16 @@ namespace ToolManagementAppV2.Services.Users
                 success = u.Password == legacy;
                 if (success)
                 {
-                    var upgraded = SecurityHelper.HashPassword(password ?? string.Empty, out var salt);
+                    var upgradedResult = SecurityHelper.HashPasswordAsync(password ?? string.Empty).GetAwaiter().GetResult();
                     var p = new[]
                     {
-                        new SQLiteParameter("@Pwd", upgraded),
-                        new SQLiteParameter("@Salt", salt),
+                        new SQLiteParameter("@Pwd", upgradedResult.hash),
+                        new SQLiteParameter("@Salt", upgradedResult.salt),
                         new SQLiteParameter("@ID", u.UserID)
                     };
                     SqliteHelper.ExecuteNonQuery(conn, "UPDATE Users SET Password=@Pwd, Salt=@Salt WHERE UserID=@ID", p);
-                    u.Password = upgraded;
-                    u.Salt = salt;
+                    u.Password = upgradedResult.hash;
+                    u.Salt = upgradedResult.salt;
                 }
             }
             else
@@ -146,7 +146,9 @@ namespace ToolManagementAppV2.Services.Users
                 }
                 else
                 {
-                    hashed = SecurityHelper.HashPassword(user.Password, out salt);
+                    var result = SecurityHelper.HashPasswordAsync(user.Password).GetAwaiter().GetResult();
+                    hashed = result.hash;
+                    salt = result.salt;
                 }
             }
 
@@ -205,7 +207,9 @@ namespace ToolManagementAppV2.Services.Users
             string salt = user.Salt;
             if (!string.IsNullOrWhiteSpace(user.Password) && string.IsNullOrWhiteSpace(user.Salt))
             {
-                hashed = SecurityHelper.HashPassword(user.Password, out salt);
+                var result = SecurityHelper.HashPasswordAsync(user.Password).GetAwaiter().GetResult();
+                hashed = result.hash;
+                salt = result.salt;
             }
 
             var p = new[]
@@ -238,7 +242,9 @@ namespace ToolManagementAppV2.Services.Users
             string salt = string.Empty;
             if (!string.IsNullOrWhiteSpace(newPassword))
             {
-                hashed = SecurityHelper.HashPassword(newPassword, out salt);
+                var result = SecurityHelper.HashPasswordAsync(newPassword).GetAwaiter().GetResult();
+                hashed = result.hash;
+                salt = result.salt;
             }
 
             var expired = newPassword == "admin" || newPassword == "changeme" || newPassword == "newpassword";
@@ -342,16 +348,16 @@ namespace ToolManagementAppV2.Services.Users
                 success = u.Password == legacy;
                 if (success)
                 {
-                    var upgraded = SecurityHelper.HashPassword(password ?? string.Empty, out var salt);
+                    var upgradedResult = await SecurityHelper.HashPasswordAsync(password ?? string.Empty).ConfigureAwait(false);
                     var p = new[]
                     {
-                new SQLiteParameter("@Pwd", upgraded),
-                new SQLiteParameter("@Salt", salt),
+                new SQLiteParameter("@Pwd", upgradedResult.hash),
+                new SQLiteParameter("@Salt", upgradedResult.salt),
                 new SQLiteParameter("@ID", u.UserID)
             };
                     await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET Password=@Pwd, Salt=@Salt WHERE UserID=@ID", p);
-                    u.Password = upgraded;
-                    u.Salt = salt;
+                    u.Password = upgradedResult.hash;
+                    u.Salt = upgradedResult.salt;
                 }
             }
             else
@@ -420,7 +426,9 @@ namespace ToolManagementAppV2.Services.Users
                 }
                 else
                 {
-                    hashed = SecurityHelper.HashPassword(user.Password, out salt);
+                    var result = await SecurityHelper.HashPasswordAsync(user.Password).ConfigureAwait(false);
+                    hashed = result.hash;
+                    salt = result.salt;
                 }
             }
 
@@ -478,7 +486,9 @@ namespace ToolManagementAppV2.Services.Users
             string salt = user.Salt;
             if (!string.IsNullOrWhiteSpace(user.Password) && string.IsNullOrWhiteSpace(user.Salt))
             {
-                hashed = SecurityHelper.HashPassword(user.Password, out salt);
+                var result = await SecurityHelper.HashPasswordAsync(user.Password).ConfigureAwait(false);
+                hashed = result.hash;
+                salt = result.salt;
             }
 
             var p = new[]
@@ -510,7 +520,9 @@ namespace ToolManagementAppV2.Services.Users
             string salt = string.Empty;
             if (!string.IsNullOrWhiteSpace(newPassword))
             {
-                hashed = SecurityHelper.HashPassword(newPassword, out salt);
+                var result = await SecurityHelper.HashPasswordAsync(newPassword).ConfigureAwait(false);
+                hashed = result.hash;
+                salt = result.salt;
             }
 
             var expired = newPassword == "admin" || newPassword == "changeme" || newPassword == "newpassword";

--- a/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
@@ -13,6 +13,7 @@ namespace ToolManagementAppV2.Utilities.Helpers
         static ISettingsService? _settingsService;
         static int _iterationCache;
         static readonly object _iterLock = new();
+        static readonly SemaphoreSlim _iterSemaphore = new(1, 1);
 
         public static ISettingsService? SettingsService
         {
@@ -35,16 +36,28 @@ namespace ToolManagementAppV2.Utilities.Helpers
 
         public static string HashPassword(string password, out string salt)
         {
-            var saltBytes = new byte[16];
-            RandomNumberGenerator.Fill(saltBytes);
-            salt = Convert.ToBase64String(saltBytes);
-            return HashPassword(password, salt);
+            var result = HashPasswordAsync(password).GetAwaiter().GetResult();
+            salt = result.salt;
+            return result.hash;
         }
 
-        public static string HashPassword(string password, string salt)
+        public static string HashPassword(string password, string salt) =>
+            HashPasswordAsync(password, salt).GetAwaiter().GetResult();
+
+        public static async Task<(string hash, string salt)> HashPasswordAsync(string password)
+        {
+            var saltBytes = new byte[16];
+            RandomNumberGenerator.Fill(saltBytes);
+            var salt = Convert.ToBase64String(saltBytes);
+            var hash = await HashPasswordAsync(password, salt).ConfigureAwait(false);
+            return (hash, salt);
+        }
+
+        public static async Task<string> HashPasswordAsync(string password, string salt)
         {
             var saltBytes = Convert.FromBase64String(salt);
-            using var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, GetIterations(), HashAlgorithmName.SHA256);
+            var iterations = await GetIterationsAsync().ConfigureAwait(false);
+            using var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, iterations, HashAlgorithmName.SHA256);
             return Convert.ToBase64String(pbkdf2.GetBytes(32));
         }
 
@@ -52,6 +65,22 @@ namespace ToolManagementAppV2.Utilities.Helpers
         {
             if (string.IsNullOrEmpty(salt) || string.IsNullOrEmpty(hash)) return false;
             var computed = HashPassword(password, salt);
+            try
+            {
+                var computedBytes = Convert.FromBase64String(computed);
+                var hashBytes = Convert.FromBase64String(hash);
+                return CryptographicOperations.FixedTimeEquals(computedBytes, hashBytes);
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+        }
+
+        public static async Task<bool> VerifyPasswordAsync(string password, string salt, string hash)
+        {
+            if (string.IsNullOrEmpty(salt) || string.IsNullOrEmpty(hash)) return false;
+            var computed = await HashPasswordAsync(password, salt).ConfigureAwait(false);
             try
             {
                 var computedBytes = Convert.FromBase64String(computed);
@@ -97,13 +126,6 @@ namespace ToolManagementAppV2.Utilities.Helpers
                 if (svc != null)
                 {
                     value = svc.GetPasswordIterations();
-                    if (value <= 0)
-                    {
-                        value = svc.GetPasswordIterationsAsync()
-                            .ConfigureAwait(false)
-                            .GetAwaiter()
-                            .GetResult();
-                    }
                 }
 
                 if (value <= 0)
@@ -111,6 +133,36 @@ namespace ToolManagementAppV2.Utilities.Helpers
 
                 Volatile.Write(ref _iterationCache, value);
                 return value;
+            }
+        }
+
+        static async Task<int> GetIterationsAsync()
+        {
+            var cached = Volatile.Read(ref _iterationCache);
+            if (cached > 0) return cached;
+
+            await _iterSemaphore.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                cached = _iterationCache;
+                if (cached > 0) return cached;
+
+                int value = DefaultIterations;
+                var svc = _settingsService;
+                if (svc != null)
+                {
+                    value = await svc.GetPasswordIterationsAsync().ConfigureAwait(false);
+                }
+
+                if (value <= 0)
+                    value = DefaultIterations;
+
+                Volatile.Write(ref _iterationCache, value);
+                return value;
+            }
+            finally
+            {
+                _iterSemaphore.Release();
             }
         }
     }

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -171,12 +171,12 @@ namespace ToolManagementAppV2.ViewModels
                     "No users exist. A default admin account will be created (username: admin, password: admin).",
                     "Setup");
 
-                var hashed = SecurityHelper.HashPassword("admin", out var salt);
+                var result = await SecurityHelper.HashPasswordAsync("admin").ConfigureAwait(false);
                 var admin = new User
                 {
                     UserName = "admin",
-                    Password = hashed,
-                    Salt = salt,
+                    Password = result.hash,
+                    Salt = result.salt,
                     IsAdmin = true,
                     PasswordExpired = true
                 };

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -169,8 +169,9 @@ namespace ToolManagementAppV2.ViewModels
             if (string.IsNullOrWhiteSpace(entered))
             {
                 const string defaultPwd = "changeme";
-                newUser.Password = SecurityHelper.HashPassword(defaultPwd, out var salt);
-                newUser.Salt = salt;
+                var result = SecurityHelper.HashPasswordAsync(defaultPwd).GetAwaiter().GetResult();
+                newUser.Password = result.hash;
+                newUser.Salt = result.salt;
                 newUser.PasswordExpired = true;
             }
             else


### PR DESCRIPTION
## Summary
- Refactor SecurityHelper to cache iterations from sync and async settings and expose async hashing helpers
- Update password hashing across services and view models to use async helpers
- Add unit test ensuring async settings loading does not deadlock

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a0139e47f083249873113ce3bd4be2