### PR TITLE
Refactor services to async and enforce admin permissions

### DIFF
--- a/ToolManagementAppV2.Tests/Extensions/UserServiceExtensions.cs
+++ b/ToolManagementAppV2.Tests/Extensions/UserServiceExtensions.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
+
+namespace ToolManagementAppV2.Tests.Extensions
+{
+    public static class UserServiceExtensions
+    {
+        public static List<User> GetAllUsers(this IUserService service) =>
+            service.GetAllUsersAsync().GetAwaiter().GetResult();
+
+        public static User? AuthenticateUser(this IUserService service, string userName, string password) =>
+            service.AuthenticateUserAsync(userName, password).GetAwaiter().GetResult();
+
+        public static void UpdateUser(this IUserService service, User user) =>
+            service.UpdateUserAsync(user).GetAwaiter().GetResult();
+    }
+}

--- a/ToolManagementAppV2.Tests/Services/ReportServiceConcurrencyTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceConcurrencyTests.cs
@@ -18,10 +18,10 @@ using Xunit;
 
 namespace ToolManagementAppV2.Tests.Services;
 
-public class ReportServiceSyncTests
+public class ReportServiceConcurrencyTests
 {
     [Fact]
-    public void GenerateSummaryReportSync_UsesConcurrentAsyncCalls()
+    public async Task GenerateSummaryReportAsync_UsesConcurrentAsyncCalls()
     {
         const int delay = 200;
         var toolService = new DelayToolService(delay, 3);
@@ -33,7 +33,7 @@ public class ReportServiceSyncTests
         var svc = new ReportService(toolService, rentalService, activity, customerService, userService);
 
         var sw = Stopwatch.StartNew();
-        var doc = svc.GenerateSummaryReportSync();
+        var doc = await svc.GenerateSummaryReportAsync();
         sw.Stop();
 
         var text = new TextRange(doc.ContentStart, doc.ContentEnd).Text;
@@ -122,17 +122,14 @@ public class ReportServiceSyncTests
         readonly int _delay; readonly List<User> _users;
         public DelayUserService(int delay, int count)
         { _delay = delay; _users = new List<User>(new User[count]); }
-        public List<User> GetAllUsers() => _users;
         public Task<List<User>> GetAllUsersAsync() => Task.Delay(_delay).ContinueWith(_ => _users);
         public User? GetUserByID(int userID) => throw new NotImplementedException();
         public Task<User?> GetUserByIDAsync(int userID) => throw new NotImplementedException();
-        public User? AuthenticateUser(string userName, string password) => throw new NotImplementedException();
         public Task<User?> AuthenticateUserAsync(string userName, string password) => throw new NotImplementedException();
         public User? GetCurrentUser() => null;
         public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
         public void AddUser(User user) => throw new NotImplementedException();
         public Task AddUserAsync(User user) => throw new NotImplementedException();
-        public void UpdateUser(User user) => throw new NotImplementedException();
         public Task UpdateUserAsync(User user) => throw new NotImplementedException();
         public Task<bool> TryDeleteUserAsync(int userID) => throw new NotImplementedException();
         public bool ChangeUserPassword(int userID, string newPassword) => throw new NotImplementedException();

--- a/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
@@ -62,7 +62,7 @@ namespace ToolManagementAppV2.Tests.Services
 
                 rentalService.RentTool(tool.ToolID, customer.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
-                var task = Task.Run(() => reportService.GenerateSummaryReport().Result);
+                var task = reportService.GenerateSummaryReportAsync();
                 Assert.True(task.Wait(TimeSpan.FromSeconds(5)), "GenerateSummaryReport deadlocked.");
                 var doc = task.Result;
                 var text = new TextRange(doc.ContentStart, doc.ContentEnd).Text;
@@ -126,7 +126,7 @@ namespace ToolManagementAppV2.Tests.Services
 
                 rentalService.RentTool(tool.ToolID, customer.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
-                var doc = await reportService.GenerateSummaryReport();
+                var doc = await reportService.GenerateSummaryReportAsync();
                 var text = new TextRange(doc.ContentStart, doc.ContentEnd).Text;
                 Assert.Contains("Total Tools: 1", text);
                 Assert.Contains("Total Rentals (History): 1", text);

--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.Services
@@ -26,6 +27,42 @@ namespace ToolManagementAppV2.Tests.Services
                 ISettingsService service = new SettingsService(dbService);
 
                 Assert.Throws<ArgumentException>(() => service.SaveSetting(key!, "Value1"));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void SaveSetting_NonAdmin_Throws()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var context = new NonAdminContext();
+                var service = new SettingsService(dbService, context);
+                Assert.Throws<UnauthorizedAccessException>(() => service.SaveSetting("Key", "Value"));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task SaveSettingAsync_NonAdmin_Throws()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var context = new NonAdminContext();
+                var service = new SettingsService(dbService, context);
+                await Assert.ThrowsAsync<UnauthorizedAccessException>(() => service.SaveSettingAsync("Key", "Value"));
             }
             finally
             {
@@ -197,7 +234,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var logs = new List<LogEntry>();
                 using var factory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
                 var logger = factory.CreateLogger<SettingsService>();
-                ISettingsService service = new SettingsService(dbService, logger);
+                ISettingsService service = new SettingsService(dbService, null, logger);
 
                 service.DeleteSetting("MissingKey");
 
@@ -221,7 +258,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var logs = new List<LogEntry>();
                 using var factory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
                 var logger = factory.CreateLogger<SettingsService>();
-                var service = new SettingsService(dbService, logger);
+                var service = new SettingsService(dbService, null, logger);
 
                 var invalid = service.SaveScannerIpAddresses(new[] { "192.168.1.1", "bad", "999.999.999.999" }).ToList();
 
@@ -253,7 +290,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var logs = new List<LogEntry>();
                 using var factory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
                 var logger = factory.CreateLogger<SettingsService>();
-                var service = new SettingsService(dbService, logger);
+                var service = new SettingsService(dbService, null, logger);
 
                 var invalid = service.SaveScannerIpAddresses(new[] { "127.0.0.1", "10.0.0.2" });
                 Assert.Empty(invalid);
@@ -419,6 +456,15 @@ namespace ToolManagementAppV2.Tests.Services
                 if (File.Exists(dbPath))
                     File.Delete(dbPath);
             }
+        }
+
+        class NonAdminContext : IUserContext
+        {
+            public User? CurrentUser { get; set; } = new User { UserName = "u", IsAdmin = false };
+            public event EventHandler<User?>? UserChanged { add { } remove { } }
+            public bool IsAdmin => false;
+            public string UserName => CurrentUser?.UserName ?? "";
+            public string Role => "User";
         }
     }
 }

--- a/ToolManagementAppV2.Tests/Services/UserActiveTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserActiveTests.cs
@@ -5,6 +5,7 @@ using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Tests.Extensions;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.Services

--- a/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
@@ -8,6 +8,7 @@ using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Utilities.Helpers;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Tests.Extensions;
 using Xunit;
 
 public class UserAuthenticationTests

--- a/ToolManagementAppV2.Tests/Services/UserMobileTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserMobileTests.cs
@@ -4,6 +4,7 @@ using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Tests.Extensions;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.Services

--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -6,6 +6,7 @@ using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Helpers;
+using ToolManagementAppV2.Tests.Extensions;
 using Xunit;
 
 public class UserServiceTests
@@ -204,5 +205,33 @@ public class UserServiceTests
         {
             if (File.Exists(dbPath)) File.Delete(dbPath);
         }
+    }
+
+    [Fact]
+    public async Task UpdateUserAsync_NonAdmin_Throws()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            var context = new NonAdminContext();
+            var userService = new UserService(dbService, context);
+            await userService.AddUserAsync(new User { UserName = "u", Password = "p" });
+            var user = (await userService.GetAllUsersAsync())[0];
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(() => userService.UpdateUserAsync(user));
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    class NonAdminContext : IUserContext
+    {
+        public User? CurrentUser { get; set; } = new User { UserName = "u", IsAdmin = false };
+        public event EventHandler<User?>? UserChanged { add { } remove { } }
+        public bool IsAdmin => false;
+        public string UserName => CurrentUser?.UserName ?? "";
+        public string Role => "User";
     }
 }

--- a/ToolManagementAppV2.Tests/Tests/MapUserLoggingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/MapUserLoggingTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
@@ -14,7 +15,7 @@ namespace ToolManagementAppV2.Tests
     public class MapUserLoggingTests
     {
         [Fact]
-        public void GetAllUsers_InvalidPackPath_LogsException()
+        public async Task GetAllUsers_InvalidPackPath_LogsException()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -27,7 +28,7 @@ namespace ToolManagementAppV2.Tests
                 try
                 {
                     service.AddUser(new User { UserName = "u", Password = "p", UserPhotoPath = "pack://application:,,,/Resources/NoImage.png" });
-                    service.GetAllUsers();
+                    await service.GetAllUsersAsync();
                 }
                 finally
                 {
@@ -42,7 +43,7 @@ namespace ToolManagementAppV2.Tests
         }
 
         [Fact]
-        public void GetAllUsers_InvalidFilePath_LogsException()
+        public async Task GetAllUsers_InvalidFilePath_LogsException()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -55,7 +56,7 @@ namespace ToolManagementAppV2.Tests
                 try
                 {
                     service.AddUser(new User { UserName = "u", Password = "p", UserPhotoPath = "invalid|path.png" });
-                    service.GetAllUsers();
+                    await service.GetAllUsersAsync();
                 }
                 finally
                 {

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -16,6 +16,7 @@ using ToolManagementAppV2.Views;
 using Xunit;
 using Microsoft.Extensions.Logging;
 using ToolManagementAppV2.Tests;
+using ToolManagementAppV2.Tests.Extensions;
 
 namespace ToolManagementAppV2.Tests.ViewModels
 {
@@ -314,11 +315,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
             _tcs = tcs;
         }
 
-        public List<User> GetAllUsers() => _users.ToList();
         public Task<List<User>> GetAllUsersAsync() => Task.FromResult(_users.ToList());
         public User? GetUserByID(int userID) => null;
         public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult<User?>(null);
-        public User? AuthenticateUser(string userName, string password) => null;
         public Task<User?> AuthenticateUserAsync(string userName, string password) => Task.FromResult<User?>(null);
         public User? GetCurrentUser() => null;
         public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
@@ -344,11 +343,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
             _users = new List<User> { user };
         }
 
-        public List<User> GetAllUsers() => _users.ToList();
-        public Task<List<User>> GetAllUsersAsync() => Task.FromResult(GetAllUsers());
+        public Task<List<User>> GetAllUsersAsync() => Task.FromResult(_users.ToList());
         public User? GetUserByID(int userID) => _users.FirstOrDefault(u => u.UserID == userID);
         public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult(GetUserByID(userID));
-        public User? AuthenticateUser(string userName, string password) => null;
         public Task<User?> AuthenticateUserAsync(string userName, string password) => Task.FromResult<User?>(null);
         public User? GetCurrentUser() => null;
         public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -355,11 +355,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
     class StubUserService : IUserService
     {
-        public List<User> GetAllUsers() => new();
         public Task<List<User>> GetAllUsersAsync() => Task.FromResult(new List<User>());
         public User? GetUserByID(int userID) => null;
         public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult<User?>(null);
-        public User? AuthenticateUser(string userName, string password) => null;
         public Task<User?> AuthenticateUserAsync(string userName, string password) => Task.FromResult<User?>(null);
         public User? GetCurrentUser() => null;
         public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);

--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -13,6 +13,7 @@ using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.ViewModels.Rental;
 using ToolManagementAppV2.Views;
 using ToolManagementAppV2.Utilities.Helpers;
+using ToolManagementAppV2.Tests.Extensions;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.ViewModels
@@ -568,11 +569,9 @@ class StubDialogService : IDialogService
 class InMemoryUserService : IUserService
 {
     public List<User> Users { get; } = new();
-    public List<User> GetAllUsers() => Users;
     public Task<List<User>> GetAllUsersAsync() => Task.FromResult(Users.ToList());
     public User? GetUserByID(int userID) => Users.FirstOrDefault(u => u.UserID == userID);
     public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult(GetUserByID(userID));
-    public User? AuthenticateUser(string userName, string password) => null;
     public Task<User?> AuthenticateUserAsync(string userName, string password) => Task.FromResult<User?>(null);
     public User? GetCurrentUser() => null;
     public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
@@ -617,11 +616,9 @@ class PromptUserManagementViewModel : UserManagementViewModel
 class FailingUserService : IUserService
 {
     readonly List<User> _users = new();
-    public List<User> GetAllUsers() => _users;
     public Task<List<User>> GetAllUsersAsync() => Task.FromResult(_users);
     public User? GetUserByID(int userID) => _users.FirstOrDefault(u => u.UserID == userID);
     public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult(GetUserByID(userID));
-    public User? AuthenticateUser(string userName, string password) => null;
     public Task<User?> AuthenticateUserAsync(string userName, string password) => Task.FromResult<User?>(null);
     public User? GetCurrentUser() => null;
     public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
@@ -636,11 +633,9 @@ class FailingUserService : IUserService
 
 class GetAllUsersFailingUserService : IUserService
 {
-    public List<User> GetAllUsers() => throw new Exception("load failed");
     public Task<List<User>> GetAllUsersAsync() => Task.FromException<List<User>>(new Exception("load failed"));
     public User? GetUserByID(int userID) => null;
     public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult<User?>(null);
-    public User? AuthenticateUser(string userName, string password) => null;
     public Task<User?> AuthenticateUserAsync(string userName, string password) => Task.FromResult<User?>(null);
     public User? GetCurrentUser() => null;
     public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -65,7 +65,7 @@ namespace ToolManagementAppV2
             var rentalService = new RentalService(db, toolService, loggerFactory.CreateLogger<RentalService>());
             var activityLogService = new ActivityLogService(db, loggerFactory.CreateLogger<ActivityLogService>());
             var fileDialogService = new FileDialogService();
-            var settingsService = new SettingsService(db, loggerFactory.CreateLogger<SettingsService>());
+            var settingsService = new SettingsService(db, userContext, loggerFactory.CreateLogger<SettingsService>());
             SecurityHelper.SettingsService = settingsService;
             IDialogService dialogService = new DialogService(loggerFactory.CreateLogger<DialogService>());
 

--- a/ToolManagementAppV2/Interfaces/IUserService.cs
+++ b/ToolManagementAppV2/Interfaces/IUserService.cs
@@ -7,17 +7,14 @@ namespace ToolManagementAppV2.Interfaces
 {
     public interface IUserService
     {
-        List<User> GetAllUsers();
         Task<List<User>> GetAllUsersAsync();
         User? GetUserByID(int userID);
         Task<User?> GetUserByIDAsync(int userID);
-        User? AuthenticateUser(string userName, string password);
         Task<User?> AuthenticateUserAsync(string userName, string password);
         User? GetCurrentUser();
         Task<User?> GetCurrentUserAsync();
         void AddUser(User user);
         Task AddUserAsync(User user);
-        void UpdateUser(User user);
         Task UpdateUserAsync(User user);
         Task<bool> TryDeleteUserAsync(int userID);
         bool ChangeUserPassword(int userID, string newPassword);

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -12,20 +13,24 @@ namespace ToolManagementAppV2.Services.Settings
     public class SettingsService : ISettingsService
     {
         readonly DatabaseService _dbService;
+        readonly IUserContext _context;
         readonly ILogger<SettingsService> _logger;
         const string UpsertSql = @"
             INSERT INTO Settings (Key, Value) 
             VALUES (@Key, @Value)
             ON CONFLICT(Key) DO UPDATE SET Value = @Value";
 
-        public SettingsService(DatabaseService dbService, ILogger<SettingsService>? logger = null)
+        public SettingsService(DatabaseService dbService, IUserContext? context = null, ILogger<SettingsService>? logger = null)
         {
             _dbService = dbService;
+            _context = context ?? new AdminUserContext();
             _logger = logger ?? NullLogger<SettingsService>.Instance;
         }
 
         public void SaveSetting(string key, string value)
         {
+            if (!_context.IsAdmin)
+                throw new UnauthorizedAccessException("Only administrators can modify settings.");
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentException("Key cannot be null or empty.", nameof(key));
 
@@ -48,6 +53,8 @@ namespace ToolManagementAppV2.Services.Settings
 
         public async Task SaveSettingAsync(string key, string value)
         {
+            if (!_context.IsAdmin)
+                throw new UnauthorizedAccessException("Only administrators can modify settings.");
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentException("Key cannot be null or empty.", nameof(key));
 
@@ -385,6 +392,15 @@ namespace ToolManagementAppV2.Services.Settings
             if (iterations <= 0)
                 throw new ArgumentOutOfRangeException(nameof(iterations));
             await SaveSettingAsync(PasswordIterationsKey, iterations.ToString());
+        }
+
+        class AdminUserContext : IUserContext
+        {
+            public User? CurrentUser { get; set; }
+            public event EventHandler<User?>? UserChanged;
+            public bool IsAdmin => true;
+            public string UserName => CurrentUser?.UserName ?? "Admin";
+            public string Role => "Admin";
         }
     }
 }

--- a/ToolManagementAppV2/Services/Tools/ReportService.cs
+++ b/ToolManagementAppV2/Services/Tools/ReportService.cs
@@ -35,7 +35,7 @@ namespace ToolManagementAppV2.Services.Tools
             _userService = userService;
         }
 
-        public async Task<FlowDocument> GenerateInventoryReport()
+        public async Task<FlowDocument> GenerateInventoryReportAsync()
         {
             var tools = await _toolService.GetAllToolsAsync().ConfigureAwait(false);
             var lines = tools.Select(t =>
@@ -43,10 +43,7 @@ namespace ToolManagementAppV2.Services.Tools
             return BuildReport("Tool Inventory Report", lines);
         }
 
-        public FlowDocument GenerateInventoryReportSync() =>
-            GenerateInventoryReport().GetAwaiter().GetResult();
-
-        public async Task<FlowDocument> GenerateRentalReport(bool activeOnly = true)
+        public async Task<FlowDocument> GenerateRentalReportAsync(bool activeOnly = true)
         {
             var rentals = activeOnly
                 ? await _rentalService.GetActiveRentalsAsync().ConfigureAwait(false)
@@ -60,10 +57,7 @@ namespace ToolManagementAppV2.Services.Tools
             return BuildReport(title, lines);
         }
 
-        public FlowDocument GenerateRentalReportSync(bool activeOnly = true) =>
-            GenerateRentalReport(activeOnly).GetAwaiter().GetResult();
-
-        public async Task<FlowDocument> GenerateActivityLogReport()
+        public async Task<FlowDocument> GenerateActivityLogReportAsync()
         {
             var result = await _activityLogService.GetRecentLogsAsync(100).ConfigureAwait(false);
             var logs = result?.Data ?? new List<ActivityLog>();
@@ -72,10 +66,7 @@ namespace ToolManagementAppV2.Services.Tools
             return BuildReport("Activity Log Report", lines);
         }
 
-        public FlowDocument GenerateActivityLogReportSync() =>
-            GenerateActivityLogReport().GetAwaiter().GetResult();
-
-        public async Task<FlowDocument> GenerateCustomerReport()
+        public async Task<FlowDocument> GenerateCustomerReportAsync()
         {
             var customers = await _customerService.GetAllCustomersAsync().ConfigureAwait(false);
             var lines = customers.Select(c =>
@@ -83,10 +74,7 @@ namespace ToolManagementAppV2.Services.Tools
             return BuildReport("Customer Report", lines);
         }
 
-        public FlowDocument GenerateCustomerReportSync() =>
-            GenerateCustomerReport().GetAwaiter().GetResult();
-
-        public async Task<FlowDocument> GenerateUserReport()
+        public async Task<FlowDocument> GenerateUserReportAsync()
         {
             var users = await _userService.GetAllUsersAsync().ConfigureAwait(false);
             var lines = users.Select(u =>
@@ -94,10 +82,7 @@ namespace ToolManagementAppV2.Services.Tools
             return BuildReport("User Report", lines);
         }
 
-        public FlowDocument GenerateUserReportSync() =>
-            GenerateUserReport().GetAwaiter().GetResult();
-
-        public async Task<FlowDocument> GenerateSummaryReport()
+        public async Task<FlowDocument> GenerateSummaryReportAsync()
         {
             var totalToolsTask = _toolService.GetAllToolsAsync();
             var totalRentalsTask = _rentalService.GetAllRentalsAsync();
@@ -119,27 +104,6 @@ namespace ToolManagementAppV2.Services.Tools
             return BuildReport("Application Summary Report", lines);
         }
 
-        public FlowDocument GenerateSummaryReportSync()
-        {
-            var totalToolsTask = _toolService.GetAllToolsAsync();
-            var totalRentalsTask = _rentalService.GetAllRentalsAsync();
-            var totalActiveRentalsTask = _rentalService.GetActiveRentalsAsync();
-            var totalCustomersTask = _customerService.GetAllCustomersAsync();
-            var totalUsersTask = _userService.GetAllUsersAsync();
-
-            Task.WhenAll(totalToolsTask, totalRentalsTask, totalActiveRentalsTask, totalCustomersTask, totalUsersTask).GetAwaiter().GetResult();
-
-            var lines = new[]
-            {
-                $"Total Tools: {totalToolsTask.Result.Count}",
-                $"Total Rentals (History): {totalRentalsTask.Result.Count}",
-                $"Active Rentals: {totalActiveRentalsTask.Result.Count}",
-                $"Total Customers: {totalCustomersTask.Result.Count}",
-                $"Total Users: {totalUsersTask.Result.Count}"
-            };
-
-            return BuildReport("Application Summary Report", lines);
-        }
 
         FlowDocument BuildReport(string title, IEnumerable<string> lines)
         {

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -25,94 +25,11 @@ namespace ToolManagementAppV2.Services.Users
             _logger = logger ?? NullLogger<UserService>.Instance;
         }
 
-        public List<User> GetAllUsers()
-        {
-            using var conn = _dbService.CreateConnection();
-            const string sql = "SELECT UserID, UserName, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, FailedAttempts, LockoutUntil, PasswordExpired FROM Users";
-            return SqliteHelper.ExecuteReader(conn, sql, null, MapUser);
-        }
-
         public User? GetUserByID(int userID)
         {
             using var conn = _dbService.CreateConnection();
             return SqliteHelper.ExecuteReader(conn, "SELECT * FROM Users WHERE UserID=@ID",
                 new[] { new SQLiteParameter("@ID", userID) }, MapUser).FirstOrDefault();
-        }
-
-        public User? AuthenticateUser(string userName, string password)
-        {
-            using var conn = _dbService.CreateConnection();
-            var users = SqliteHelper.ExecuteReader(conn,
-                "SELECT * FROM Users WHERE UserName=@UserName",
-                new[] { new SQLiteParameter("@UserName", userName) }, MapUser);
-            var u = users.FirstOrDefault();
-            if (u == null) return null;
-            if (u.LockoutUntil.HasValue && u.LockoutUntil > DateTime.UtcNow)
-                return null;
-            if (u.LockoutUntil.HasValue && u.LockoutUntil <= DateTime.UtcNow)
-            {
-                var reset = new[]
-                {
-                    new SQLiteParameter("@Attempts", 0),
-                    new SQLiteParameter("@Lockout", DBNull.Value),
-                    new SQLiteParameter("@ID", u.UserID)
-                };
-                SqliteHelper.ExecuteNonQuery(conn, "UPDATE Users SET FailedAttempts=@Attempts, LockoutUntil=@Lockout WHERE UserID=@ID", reset);
-                u.FailedAttempts = 0;
-                u.LockoutUntil = null;
-            }
-
-            bool success;
-            if (string.IsNullOrWhiteSpace(u.Salt) && SecurityHelper.IsSha256Hash(u.Password))
-            {
-                var legacy = SecurityHelper.ComputeSha256HashLegacy(password ?? string.Empty);
-                success = u.Password == legacy;
-                if (success)
-                {
-                    var upgradedResult = SecurityHelper.HashPasswordAsync(password ?? string.Empty).GetAwaiter().GetResult();
-                    var p = new[]
-                    {
-                        new SQLiteParameter("@Pwd", upgradedResult.hash),
-                        new SQLiteParameter("@Salt", upgradedResult.salt),
-                        new SQLiteParameter("@ID", u.UserID)
-                    };
-                    SqliteHelper.ExecuteNonQuery(conn, "UPDATE Users SET Password=@Pwd, Salt=@Salt WHERE UserID=@ID", p);
-                    u.Password = upgradedResult.hash;
-                    u.Salt = upgradedResult.salt;
-                }
-            }
-            else
-            {
-                success = SecurityHelper.VerifyPassword(password ?? string.Empty, u.Salt, u.Password);
-            }
-
-            if (success)
-            {
-                var reset = new[]
-                {
-                    new SQLiteParameter("@Attempts", 0),
-                    new SQLiteParameter("@Lockout", DBNull.Value),
-                    new SQLiteParameter("@ID", u.UserID)
-                };
-                SqliteHelper.ExecuteNonQuery(conn, "UPDATE Users SET FailedAttempts=@Attempts, LockoutUntil=@Lockout WHERE UserID=@ID", reset);
-                u.FailedAttempts = 0;
-                u.LockoutUntil = null;
-                return u;
-            }
-
-            u.FailedAttempts++;
-            DateTime? lockout = null;
-            if (u.FailedAttempts >= 3)
-                lockout = DateTime.UtcNow.AddMinutes(15);
-            var update = new[]
-            {
-                new SQLiteParameter("@Attempts", u.FailedAttempts),
-                new SQLiteParameter("@Lockout", (object?)lockout ?? DBNull.Value),
-                new SQLiteParameter("@ID", u.UserID)
-            };
-            SqliteHelper.ExecuteNonQuery(conn, "UPDATE Users SET FailedAttempts=@Attempts, LockoutUntil=@Lockout WHERE UserID=@ID", update);
-            u.LockoutUntil = lockout;
-            return null;
         }
 
         public User? GetCurrentUser()
@@ -181,56 +98,6 @@ namespace ToolManagementAppV2.Services.Users
             {
                 throw new InvalidOperationException("A user with the same username already exists.", ex);
             }
-            user.Password = hashed;
-            user.Salt = salt;
-        }
-
-        public void UpdateUser(User user)
-        {
-            const string sql = @"
-                UPDATE Users SET
-                  UserName      = @UserName,
-                  Password      = @Password,
-                  Salt          = @Salt,
-                  UserPhotoPath = @Photo,
-                  IsAdmin       = @Admin,
-                  Email         = @Email,
-                  Phone         = @Phone,
-                  Mobile        = @Mobile,
-                  Address       = @Address,
-                  Role          = @Role,
-                  IsActive      = @IsActive,
-                  PasswordExpired = @PasswordExpired
-                WHERE UserID = @UserID";
-
-            string hashed = user.Password;
-            string salt = user.Salt;
-            if (!string.IsNullOrWhiteSpace(user.Password) && string.IsNullOrWhiteSpace(user.Salt))
-            {
-                var result = SecurityHelper.HashPasswordAsync(user.Password).GetAwaiter().GetResult();
-                hashed = result.hash;
-                salt = result.salt;
-            }
-
-            var p = new[]
-            {
-                new SQLiteParameter("@UserID",   user.UserID),
-                new SQLiteParameter("@UserName", user.UserName),
-                new SQLiteParameter("@Password", hashed),
-                new SQLiteParameter("@Salt",     salt),
-                new SQLiteParameter("@Photo",    (object)user.UserPhotoPath ?? DBNull.Value),
-                new SQLiteParameter("@Admin",    user.IsAdmin ? 1 : 0),
-                new SQLiteParameter("@Email",    (object)user.Email ?? DBNull.Value),
-                new SQLiteParameter("@Phone",    (object)user.Phone ?? DBNull.Value),
-                new SQLiteParameter("@Mobile",   (object)user.Mobile ?? DBNull.Value),
-                new SQLiteParameter("@Address",  (object)user.Address ?? DBNull.Value),
-                new SQLiteParameter("@Role",     (object)user.Role ?? DBNull.Value),
-                new SQLiteParameter("@IsActive", user.IsActive ? 1 : 0),
-                new SQLiteParameter("@PasswordExpired", user.PasswordExpired ? 1 : 0)
-            };
-
-            using var conn = _dbService.CreateConnection();
-            SqliteHelper.ExecuteNonQuery(conn, sql, p);
             user.Password = hashed;
             user.Salt = salt;
         }
@@ -467,6 +334,8 @@ namespace ToolManagementAppV2.Services.Users
 
         public async Task UpdateUserAsync(User user)
         {
+            if (!_context.IsAdmin)
+                throw new UnauthorizedAccessException("Only administrators can update users.");
             const string sql = @"
                 UPDATE Users SET
                   UserName      = @UserName,

--- a/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
@@ -82,7 +82,8 @@ namespace ToolManagementAppV2.ViewModels
                 StatCards.Add(new StatCard { Title = "Total Tools", Value = tools.Count.ToString() });
                 StatCards.Add(new StatCard { Title = "Active Rentals", Value = _rentalService.GetActiveRentals().Count.ToString() });
                 StatCards.Add(new StatCard { Title = "Total Customers", Value = _customerService.GetAllCustomers().Count.ToString() });
-                StatCards.Add(new StatCard { Title = "Total Users", Value = _userService.GetAllUsers().Count.ToString() });
+                var users = await _userService.GetAllUsersAsync();
+                StatCards.Add(new StatCard { Title = "Total Users", Value = users.Count.ToString() });
             }
             catch (Exception ex)
             {

--- a/ToolManagementAppV2/ViewModels/ReportsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ReportsViewModel.cs
@@ -61,13 +61,13 @@ namespace ToolManagementAppV2.ViewModels
         {
             FlowDocument doc = SelectedReport switch
             {
-                "Summary" => await _reportService.GenerateSummaryReport(),
-                "Inventory" => await _reportService.GenerateInventoryReport(),
-                "Activity Log" => await _reportService.GenerateActivityLogReport(),
-                "Customers" => await _reportService.GenerateCustomerReport(),
-                "Users" => await _reportService.GenerateUserReport(),
-                "Active Rentals" => await _reportService.GenerateRentalReport(true),
-                "Full Rental History" => await _reportService.GenerateRentalReport(false),
+                "Summary" => await _reportService.GenerateSummaryReportAsync(),
+                "Inventory" => await _reportService.GenerateInventoryReportAsync(),
+                "Activity Log" => await _reportService.GenerateActivityLogReportAsync(),
+                "Customers" => await _reportService.GenerateCustomerReportAsync(),
+                "Users" => await _reportService.GenerateUserReportAsync(),
+                "Active Rentals" => await _reportService.GenerateRentalReportAsync(true),
+                "Full Rental History" => await _reportService.GenerateRentalReportAsync(false),
                 _ => null
             };
 


### PR DESCRIPTION
## Summary
- convert user and report services to fully async patterns and update consumers
- add admin-only checks for updating users and modifying settings
- extend tests and helpers for async operations and authorization

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a016255c988324b56a2369700c9481