### PR TITLE
Use dependency injection for window services

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/LoginWindowBehaviorTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/LoginWindowBehaviorTests.cs
@@ -8,6 +8,7 @@ using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2;
 using Xunit;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace ToolManagementAppV2.Tests.Tests
 {
@@ -21,7 +22,8 @@ namespace ToolManagementAppV2.Tests.Tests
             var userContext = new ApplicationUserContext();
             var userService = new UserService(db, userContext);
             var settingsService = new SettingsService(db);
-            var vm = new LoginViewModel(userService, settingsService, new DialogService(), userContext);
+            var serviceProvider = new ServiceCollection().BuildServiceProvider();
+            var vm = new LoginViewModel(userService, settingsService, new DialogService(serviceProvider), userContext);
             var window = new LoginWindow(vm);
             Assert.False(window.Topmost);
             window.Close();

--- a/ToolManagementAppV2.Tests/Tests/LoginWindowLayoutTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/LoginWindowLayoutTests.cs
@@ -11,6 +11,7 @@ using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.Services;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace ToolManagementAppV2.Tests.Tests
 {
@@ -24,7 +25,8 @@ namespace ToolManagementAppV2.Tests.Tests
             var userContext = new ApplicationUserContext();
             var userService = new UserService(db, userContext);
             var settingsService = new SettingsService(db);
-            var vm = new LoginViewModel(userService, settingsService, new DialogService(), userContext);
+            var serviceProvider = new ServiceCollection().BuildServiceProvider();
+            var vm = new LoginViewModel(userService, settingsService, new DialogService(serviceProvider), userContext);
             var window = new LoginWindow(vm);
             var panel = window.UsersListBox.ItemsPanel.LoadContent();
             var stackPanel = Assert.IsType<VirtualizingStackPanel>(panel);
@@ -43,7 +45,8 @@ namespace ToolManagementAppV2.Tests.Tests
             var userContext = new ApplicationUserContext();
             var userService = new UserService(db, userContext);
             var settingsService = new SettingsService(db);
-            var vm = new LoginViewModel(userService, settingsService, new DialogService(), userContext);
+            var serviceProvider = new ServiceCollection().BuildServiceProvider();
+            var vm = new LoginViewModel(userService, settingsService, new DialogService(serviceProvider), userContext);
             var window = new LoginWindow(vm);
             window.UsersListBox.ItemsSource = Enumerable.Range(0, 1000)
                 .Select(i => new User { UserID = i, UserName = $"User {i}" })

--- a/ToolManagementAppV2.Tests/Views/DialogServiceAsyncTests.cs
+++ b/ToolManagementAppV2.Tests/Views/DialogServiceAsyncTests.cs
@@ -7,6 +7,7 @@ using System.Windows.Threading;
 using ToolManagementAppV2.Services;
 using ToolManagementAppV2.Views;
 using Xunit;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace ToolManagementAppV2.Tests.Views
 {
@@ -21,7 +22,8 @@ namespace ToolManagementAppV2.Tests.Views
                 try
                 {
                     var app = new System.Windows.Application();
-                    var service = new DialogService();
+                    var serviceProvider = new ServiceCollection().BuildServiceProvider();
+                    var service = new DialogService(serviceProvider);
                     var task = service.ShowInfoAsync("Message", "Title");
                     System.Windows.Application.Current.Dispatcher.BeginInvoke(new Action(() =>
                     {
@@ -52,7 +54,8 @@ namespace ToolManagementAppV2.Tests.Views
                 try
                 {
                     var app = new System.Windows.Application();
-                    var service = new DialogService();
+                    var serviceProvider = new ServiceCollection().BuildServiceProvider();
+                    var service = new DialogService(serviceProvider);
                     var task = service.ShowConfirmationAsync("?", "Confirm");
                     System.Windows.Application.Current.Dispatcher.BeginInvoke(new Action(() =>
                     {

--- a/ToolManagementAppV2.Tests/Views/ScannerStatusWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ScannerStatusWindowTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using ToolManagementAppV2.Views;
+using ToolManagementAppV2.Interfaces;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.Views
@@ -17,7 +18,7 @@ namespace ToolManagementAppV2.Tests.Views
             {
                 try
                 {
-                    var window = new ScannerStatusWindow();
+                    var window = new ScannerStatusWindow(new StubScannerService(), new StubDialogService());
                     window.DataContext = new DisposableVm(() => disposed = true);
                     window.Close();
                 }
@@ -42,6 +43,29 @@ namespace ToolManagementAppV2.Tests.Views
             readonly Action _onDispose;
             public DisposableVm(Action onDispose) => _onDispose = onDispose;
             public void Dispose() => _onDispose();
+        }
+
+        class StubScannerService : IScannerService
+        {
+            public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<ToolManagementAppV2.Models.ScannerDevice>> GetScannerDevicesAsync(System.Threading.CancellationToken cancellationToken)
+                => System.Threading.Tasks.Task.FromResult<System.Collections.Generic.IEnumerable<ToolManagementAppV2.Models.ScannerDevice>>(Array.Empty<ToolManagementAppV2.Models.ScannerDevice>());
+        }
+
+        class StubDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => false;
+            public ToolManagementAppV2.Models.Domain.ToolModel? ShowEditToolDialog(ToolManagementAppV2.Models.Domain.ToolModel tool) => null;
+            public void ShowToolDetails(ToolManagementAppV2.Models.Domain.ToolModel tool) { }
+            public (ToolManagementAppV2.Models.Domain.CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolManagementAppV2.Models.Domain.ToolModel tool, System.Collections.Generic.IEnumerable<ToolManagementAppV2.Models.Domain.CustomerModel> customers) => null;
+            public ToolManagementAppV2.Models.Domain.CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ToolManagementAppV2.Models.Domain.ToolModel tool, System.Collections.Generic.IEnumerable<ToolManagementAppV2.Models.Domain.RentalModel> history) { }
+            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+            public System.Func<ToolManagementAppV2.Models.Domain.ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+            public void ShowScannerStatus() { }
         }
     }
 }

--- a/ToolManagementAppV2.Tests/Views/ToolEditWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ToolEditWindowTests.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Views;
+using ToolManagementAppV2.Services.Core;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.Views
@@ -25,7 +26,7 @@ namespace ToolManagementAppV2.Tests.Views
                     Action onSave = () => window?.Close();
                     Action onCancel = () => window?.Close();
 
-                    window = new ToolEditWindow(tool, onSave, onCancel);
+                    window = new ToolEditWindow(tool, onSave, onCancel, new FileDialogService());
                     window.Closed += (_, __) => closed = true;
 
                     Assert.IsType<ToolEditViewModel>(window.DataContext);
@@ -68,7 +69,7 @@ namespace ToolManagementAppV2.Tests.Views
                     Action onSave = () => window?.Close();
                     Action onCancel = () => window?.Close();
 
-                    window = new ToolEditWindow(tool, onSave, onCancel);
+                    window = new ToolEditWindow(tool, onSave, onCancel, new FileDialogService());
                     window.Closed += (_, __) => closed = true;
 
                     var vm = (ToolEditViewModel)window.DataContext;
@@ -102,7 +103,7 @@ namespace ToolManagementAppV2.Tests.Views
                 Action onSave = () => window?.Close();
                 Action onCancel = () => window?.Close();
 
-                window = new ToolEditWindow(tool, onSave, onCancel);
+                window = new ToolEditWindow(tool, onSave, onCancel, new FileDialogService());
                 window.ShowDialog();
             });
 

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -19,6 +19,8 @@ using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Utilities.Helpers;
+using ToolManagementAppV2.Views;
+using ToolManagementAppV2.Services.Devices;
 
 namespace ToolManagementAppV2
 {
@@ -72,8 +74,14 @@ namespace ToolManagementAppV2
                     services.AddSingleton<IFileDialogService, FileDialogService>();
                     services.AddSingleton<ISettingsService, SettingsService>();
                     services.AddSingleton<IDialogService, DialogService>();
+                    services.AddSingleton<IScannerService, ScannerService>();
                     services.AddSingleton<IMainViewModel, MainViewModel>();
                     services.AddSingleton<ILoginViewModel, LoginViewModel>();
+                    services.AddTransient<ToolEditWindow>();
+                    services.AddTransient<AvatarSelectionWindow>();
+                    services.AddTransient<ScannerStatusWindow>();
+                    services.AddTransient<PasswordPromptWindow>();
+                    services.AddTransient<PrintLabelWindow>();
                     services.AddSingleton<IMainWindow>(sp =>
                         new MainWindow(sp.GetRequiredService<IMainViewModel>()));
                     services.AddSingleton<ILoginWindow>(sp =>

--- a/ToolManagementAppV2/Services/DialogService.cs
+++ b/ToolManagementAppV2/Services/DialogService.cs
@@ -8,6 +8,7 @@ using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.ViewModels.Rental;
 using ToolManagementAppV2.Views;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -15,10 +16,12 @@ namespace ToolManagementAppV2.Services
 {
     public class DialogService : IDialogService
     {
+        readonly IServiceProvider _serviceProvider;
         readonly ILogger<DialogService> _logger;
 
-        public DialogService(ILogger<DialogService>? logger = null)
+        public DialogService(IServiceProvider serviceProvider, ILogger<DialogService>? logger = null)
         {
+            _serviceProvider = serviceProvider;
             _logger = logger ?? NullLogger<DialogService>.Instance;
         }
         public void ShowInfo(string message, string title)
@@ -43,10 +46,11 @@ namespace ToolManagementAppV2.Services
 
         public ToolModel? ShowEditToolDialog(ToolModel tool)
         {
-            ToolEditWindow win = null!;
-            win = new ToolEditWindow(tool,
-                onSave: () => win.DialogResult = true,
-                onCancel: () => win.DialogResult = false);
+            ToolEditWindow? win = null;
+            win = ActivatorUtilities.CreateInstance<ToolEditWindow>(_serviceProvider,
+                tool,
+                (Action)(() => win!.DialogResult = true),
+                (Action)(() => win!.DialogResult = false));
             try { win.Owner = System.Windows.Application.Current?.MainWindow; }
             catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for ToolEditWindow"); }
             try { return win.ShowDialog() == true ? tool : null; }
@@ -161,7 +165,7 @@ namespace ToolManagementAppV2.Services
 
         public void ShowPrintLabelDialog()
         {
-            var win = new PrintLabelWindow(this);
+            var win = _serviceProvider.GetRequiredService<PrintLabelWindow>();
             try { win.Owner = System.Windows.Application.Current?.MainWindow; }
             catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for PrintLabelWindow"); }
             try { win.ShowDialog(); }
@@ -170,7 +174,7 @@ namespace ToolManagementAppV2.Services
 
         public void ShowScannerStatus()
         {
-            var win = new ScannerStatusWindow();
+            var win = _serviceProvider.GetRequiredService<ScannerStatusWindow>();
             try { win.Owner = System.Windows.Application.Current?.MainWindow; }
             catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for ScannerStatusWindow"); }
             try { win.ShowDialog(); }

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -17,6 +17,7 @@ using ToolManagementAppV2.Utilities.Helpers;
 using ToolManagementAppV2.Views;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -35,6 +36,7 @@ namespace ToolManagementAppV2.ViewModels
         readonly IDialogService _dialogService;
         readonly IUserContext _userContext;
         readonly ILogger<LoginViewModel> _logger;
+        readonly IServiceProvider? _serviceProvider;
 
         public ObservableCollection<User> Users { get; } = new();
 
@@ -83,22 +85,25 @@ namespace ToolManagementAppV2.ViewModels
         public Func<User, CancellationToken, Task<PasswordPromptResult?>>? PromptForPasswordAsync { get; set; }
             
 
-        public LoginViewModel(IUserService userService, ISettingsService settingsService, IDialogService dialogService, IUserContext userContext, ILogger<LoginViewModel>? logger = null)
+        public LoginViewModel(IUserService userService, ISettingsService settingsService, IDialogService dialogService, IUserContext userContext, ILogger<LoginViewModel>? logger = null, IServiceProvider? serviceProvider = null)
         {
             _settingsService = settingsService;
             _userService = userService;
             _dialogService = dialogService;
             _userContext = userContext;
             _logger = logger ?? NullLogger<LoginViewModel>.Instance;
+            _serviceProvider = serviceProvider;
 
             SelectUserCommand = new AsyncRelayCommand<User>(OnUserSelected);
 
             PromptForPasswordAsync = (u, ct) =>
             {
-                var prompt = new PasswordPromptWindow(_dialogService)
-                {
-                    SelectedUser = u
-                };
+                PasswordPromptWindow prompt;
+                if (_serviceProvider != null)
+                    prompt = _serviceProvider.GetRequiredService<PasswordPromptWindow>();
+                else
+                    prompt = new PasswordPromptWindow(_dialogService);
+                prompt.SelectedUser = u;
                 var result = prompt.ShowDialog();
                 if (result == true)
                     return Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult(prompt.EnteredPassword, prompt.IsPasswordResetRequested));

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -12,6 +12,7 @@ using ToolManagementAppV2.Utilities.Helpers;
 using ToolManagementAppV2.Views;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -21,6 +22,7 @@ namespace ToolManagementAppV2.ViewModels
         private readonly IFileDialogService _fileDialogService;
         private readonly IDialogService _dialogService;
         private readonly ILogger<UserManagementViewModel> _logger;
+        private readonly IServiceProvider? _serviceProvider;
 
         private List<UserModel> _allUsers = new();
 
@@ -63,12 +65,14 @@ namespace ToolManagementAppV2.ViewModels
         public UserManagementViewModel(IUserService userService,
                                        IFileDialogService fileDialogService,
                                        IDialogService dialogService,
-                                       ILogger<UserManagementViewModel>? logger = null)
+                                       ILogger<UserManagementViewModel>? logger = null,
+                                       IServiceProvider? serviceProvider = null)
         {
             _userService = userService;
             _fileDialogService = fileDialogService;
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<UserManagementViewModel>.Instance;
+            _serviceProvider = serviceProvider;
 
             LoadUsersCommand = new AsyncRelayCommand(LoadUsersAsync);
             UploadUserPhotoCommand = new AsyncRelayCommand(UploadUserPhotoAsync);
@@ -200,7 +204,12 @@ namespace ToolManagementAppV2.ViewModels
             {
                 try
                 {
-                    var prompt = new PasswordPromptWindow(_dialogService) { SelectedUser = newUser };
+                    PasswordPromptWindow prompt;
+                    if (_serviceProvider != null)
+                        prompt = _serviceProvider.GetRequiredService<PasswordPromptWindow>();
+                    else
+                        prompt = new PasswordPromptWindow(_dialogService);
+                    prompt.SelectedUser = newUser;
                     if (prompt.ShowDialog() == true)
                     {
                         password = prompt.EnteredPassword;

--- a/ToolManagementAppV2/Views/AvatarSelectionWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/AvatarSelectionWindow.xaml.cs
@@ -2,8 +2,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Windows;
-using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Utilities.Extensions;
@@ -16,14 +14,13 @@ namespace ToolManagementAppV2.Views
         public AvatarSelectionViewModel VM => (AvatarSelectionViewModel)DataContext;
         public string SelectedAvatarPath => VM.SelectedAvatarPath;
 
-        public AvatarSelectionWindow()
+        private readonly ISettingsService _settingsService;
+
+        public AvatarSelectionWindow(ISettingsService settingsService)
         {
             InitializeComponent();
-
-            var dbPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db");
-            using var dbService = new DatabaseService(dbPath);
-            var settingsService = new SettingsService(dbService);
-            var appName = settingsService.GetSetting("ApplicationName");
+            _settingsService = settingsService;
+            var appName = _settingsService.GetSetting("ApplicationName");
             if (!string.IsNullOrWhiteSpace(appName))
                 Title = $"{appName} – Select Avatar";
 

--- a/ToolManagementAppV2/Views/PasswordPromptWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PasswordPromptWindow.xaml.cs
@@ -3,7 +3,6 @@ using System;
 using System.Windows;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
-using ToolManagementAppV2.Services;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Utilities.Extensions;
 
@@ -13,6 +12,7 @@ namespace ToolManagementAppV2.Views
     {
         private const int MaxAttempts = 2;
         private int _attemptCount;
+        private readonly IDialogService _dialogService;
 
         public PasswordPromptViewModel VM => (PasswordPromptViewModel)DataContext;
         public string EnteredPassword => VM.EnteredPassword;
@@ -35,16 +35,15 @@ namespace ToolManagementAppV2.Views
         public PasswordPromptWindow(IDialogService dialogService)
         {
             InitializeComponent();
+            _dialogService = dialogService;
             DataContext = new PasswordPromptViewModel(
-                dialogService,
+                _dialogService,
                 () => { DialogResult = true; },
                 () => { DialogResult = false; },
                 ShowError);
             this.DisposeDataContextOnUnload();
             Loaded += OnLoaded;
         }
-
-        public PasswordPromptWindow() : this(new DialogService()) { }
 
         private void OnLoaded(object sender, RoutedEventArgs e)
         {

--- a/ToolManagementAppV2/Views/PrintLabelWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/PrintLabelWindow.xaml.cs
@@ -22,13 +22,14 @@ namespace ToolManagementAppV2.Views
     /// </summary>
     public partial class PrintLabelWindow : Window
     {
+        private readonly IDialogService _dialogService;
+
         public PrintLabelWindow(IDialogService dialogService)
         {
             InitializeComponent();
-            DataContext = new PrintLabelViewModel(dialogService, () => Close());
+            _dialogService = dialogService;
+            DataContext = new PrintLabelViewModel(_dialogService, () => Close());
             this.DisposeDataContextOnUnload();
         }
-
-        public PrintLabelWindow() : this(new ToolManagementAppV2.Services.DialogService()) { }
     }
 }

--- a/ToolManagementAppV2/Views/ScannerStatusWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ScannerStatusWindow.xaml.cs
@@ -1,10 +1,5 @@
-using System;
-using System.IO;
 using System.Windows;
-using ToolManagementAppV2.Services.Devices;
-using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Settings;
-using ToolManagementAppV2.Services;
+using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Utilities.Extensions;
 
@@ -12,17 +7,16 @@ namespace ToolManagementAppV2.Views
 {
     public partial class ScannerStatusWindow : Window
     {
-        readonly DatabaseService _ownedDb;
+        private readonly IScannerService _scannerService;
+        private readonly IDialogService _dialogService;
 
-        public ScannerStatusWindow()
+        public ScannerStatusWindow(IScannerService scannerService, IDialogService dialogService)
         {
             InitializeComponent();
-            var dbPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db");
-            _ownedDb = new DatabaseService(dbPath);
-            var settingsService = new SettingsService(_ownedDb);
-            DataContext = new ScannerStatusViewModel(new ScannerService(settingsService), new DialogService());
+            _scannerService = scannerService;
+            _dialogService = dialogService;
+            DataContext = new ScannerStatusViewModel(_scannerService, _dialogService);
             this.DisposeDataContextOnUnload();
-            Closed += (_, __) => _ownedDb.Dispose();
         }
     }
 }

--- a/ToolManagementAppV2/Views/ToolEditWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/ToolEditWindow.xaml.cs
@@ -3,18 +3,20 @@ using System;
 using System.Windows;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.ViewModels;
-using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views
 {
     public partial class ToolEditWindow : Window
     {
-        public ToolEditWindow(ToolModel tool, Action onSave, Action onCancel)
+        private readonly IFileDialogService _fileDialogService;
+
+        public ToolEditWindow(ToolModel tool, Action onSave, Action onCancel, IFileDialogService fileDialogService)
         {
             InitializeComponent();
-            var fileDialog = new FileDialogService();
-            DataContext = new ToolEditViewModel(tool, onSave, onCancel, fileDialog);
+            _fileDialogService = fileDialogService;
+            DataContext = new ToolEditViewModel(tool, onSave, onCancel, _fileDialogService);
             this.DisposeDataContextOnUnload();
         }
     }

--- a/ToolManagementAppV2/Views/UsersEditWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/UsersEditWindow.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Utilities.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace ToolManagementAppV2.Views
 {
@@ -20,7 +21,7 @@ namespace ToolManagementAppV2.Views
         private void BrowseAvatar()
         {
             var vm = (UsersEditViewModel)DataContext;
-            var avatarWin = new AvatarSelectionWindow();
+            var avatarWin = ((App)Application.Current).Host.Services.GetRequiredService<AvatarSelectionWindow>();
 
             try { avatarWin.Owner = this; } catch { }
 


### PR DESCRIPTION
## Summary
- Inject dialog, scanner, file and settings services into UI windows and remove direct DatabaseService usage
- Register windows and scanner service with DI container and resolve them via DialogService or application service provider
- Update view models and tests to create windows through dependency injection

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a030b38d048324a930d4a39660f403