### PR TITLE
Refactor password hashing and verification

### DIFF
--- a/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
+++ b/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
@@ -65,6 +65,28 @@ namespace ToolManagementAppV2.Tests.Utilities
         }
 
         [Fact]
+        public async Task HashPasswordAsync_ReturnsExpectedHash()
+        {
+            SecurityHelper.SettingsService = null;
+            var saltBytes = Encoding.UTF8.GetBytes("1234567890ABCDEF");
+            var salt = Convert.ToBase64String(saltBytes);
+
+            using var pbkdf2 = new Rfc2898DeriveBytes("secret", saltBytes, 100_000, HashAlgorithmName.SHA256);
+            var expected = Convert.ToBase64String(pbkdf2.GetBytes(32));
+            var actual = await SecurityHelper.HashPasswordAsync("secret", salt);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public async Task VerifyPasswordAsync_ReturnsTrueForValidHash()
+        {
+            SecurityHelper.SettingsService = null;
+            var (hash, salt) = await SecurityHelper.HashPasswordAsync("secret");
+            var result = await SecurityHelper.VerifyPasswordAsync("secret", salt, hash);
+            Assert.True(result);
+        }
+
+        [Fact]
         public void HashPassword_OnlyFetchesIterationsOnceAcrossThreads()
         {
             var settings = new CountingSettingsService(5);

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -124,7 +124,7 @@ namespace ToolManagementAppV2.Services.Users
             }
             else
             {
-                success = SecurityHelper.VerifyPassword(password ?? string.Empty, u.Salt, u.Password);
+                success = await SecurityHelper.VerifyPasswordAsync(password ?? string.Empty, u.Salt, u.Password).ConfigureAwait(false);
             }
 
             if (success)

--- a/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
@@ -36,13 +36,19 @@ namespace ToolManagementAppV2.Utilities.Helpers
 
         public static string HashPassword(string password, out string salt)
         {
-            var result = HashPasswordAsync(password).GetAwaiter().GetResult();
-            salt = result.salt;
-            return result.hash;
+            var saltBytes = new byte[16];
+            RandomNumberGenerator.Fill(saltBytes);
+            salt = Convert.ToBase64String(saltBytes);
+            return HashPassword(password, salt);
         }
 
-        public static string HashPassword(string password, string salt) =>
-            HashPasswordAsync(password, salt).GetAwaiter().GetResult();
+        public static string HashPassword(string password, string salt)
+        {
+            var saltBytes = Convert.FromBase64String(salt);
+            var iterations = GetIterations();
+            using var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, iterations, HashAlgorithmName.SHA256);
+            return Convert.ToBase64String(pbkdf2.GetBytes(32));
+        }
 
         public static async Task<(string hash, string salt)> HashPasswordAsync(string password)
         {
@@ -64,12 +70,14 @@ namespace ToolManagementAppV2.Utilities.Helpers
         public static bool VerifyPassword(string password, string salt, string hash)
         {
             if (string.IsNullOrEmpty(salt) || string.IsNullOrEmpty(hash)) return false;
-            var computed = HashPassword(password, salt);
             try
             {
-                var computedBytes = Convert.FromBase64String(computed);
+                var saltBytes = Convert.FromBase64String(salt);
                 var hashBytes = Convert.FromBase64String(hash);
-                return CryptographicOperations.FixedTimeEquals(computedBytes, hashBytes);
+                var iterations = GetIterations();
+                using var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, iterations, HashAlgorithmName.SHA256);
+                var computed = pbkdf2.GetBytes(32);
+                return CryptographicOperations.FixedTimeEquals(computed, hashBytes);
             }
             catch (FormatException)
             {
@@ -80,12 +88,14 @@ namespace ToolManagementAppV2.Utilities.Helpers
         public static async Task<bool> VerifyPasswordAsync(string password, string salt, string hash)
         {
             if (string.IsNullOrEmpty(salt) || string.IsNullOrEmpty(hash)) return false;
-            var computed = await HashPasswordAsync(password, salt).ConfigureAwait(false);
             try
             {
-                var computedBytes = Convert.FromBase64String(computed);
+                var saltBytes = Convert.FromBase64String(salt);
                 var hashBytes = Convert.FromBase64String(hash);
-                return CryptographicOperations.FixedTimeEquals(computedBytes, hashBytes);
+                var iterations = await GetIterationsAsync().ConfigureAwait(false);
+                using var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, iterations, HashAlgorithmName.SHA256);
+                var computed = pbkdf2.GetBytes(32);
+                return CryptographicOperations.FixedTimeEquals(computed, hashBytes);
             }
             catch (FormatException)
             {

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -221,7 +221,7 @@ namespace ToolManagementAppV2.ViewModels
 
             if (!user.IsAdmin &&
                 (string.IsNullOrWhiteSpace(user.Password) ||
-                 SecurityHelper.VerifyPassword("newpassword", user.Salt, user.Password)))
+                 await SecurityHelper.VerifyPasswordAsync("newpassword", user.Salt, user.Password).ConfigureAwait(false)))
             {
                 if (user.PasswordExpired && !PromptChangePassword(user))
                     return;

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -173,9 +173,9 @@ namespace ToolManagementAppV2.ViewModels
             if (string.IsNullOrWhiteSpace(entered))
             {
                 const string defaultPwd = "changeme";
-                var result = SecurityHelper.HashPasswordAsync(defaultPwd).GetAwaiter().GetResult();
-                newUser.Password = result.hash;
-                newUser.Salt = result.salt;
+                var hash = SecurityHelper.HashPassword(defaultPwd, out var salt);
+                newUser.Password = hash;
+                newUser.Salt = salt;
                 newUser.PasswordExpired = true;
             }
             else


### PR DESCRIPTION
## Summary
- rewrite synchronous password hashing with direct PBKDF2 and expose async verifier
- await password verification in user auth and login flows
- add tests for async hash/verify paths

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a032af58788324a99890986adcf2e4