### PR TITLE
Use async SQLite calls with cancellation support

### DIFF
--- a/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
+++ b/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
@@ -143,34 +143,34 @@ namespace ToolManagementAppV2.Tests.Utilities
 
             public int Counter => _counter;
 
-            public int GetPasswordIterations()
+            public int GetPasswordIterations(CancellationToken cancellationToken = default)
             {
                 Interlocked.Increment(ref _counter);
                 return _iterations;
             }
 
-            public Task<int> GetPasswordIterationsAsync()
+            public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default)
             {
                 Interlocked.Increment(ref _counter);
                 return Task.FromResult(_iterations);
             }
 
-            public void SaveSetting(string key, string value) => throw new NotImplementedException();
-            public Task SaveSettingAsync(string key, string value) => throw new NotImplementedException();
-            public string? GetSetting(string key) => throw new NotImplementedException();
-            public Task<string?> GetSettingAsync(string key) => throw new NotImplementedException();
-            public Dictionary<string, string> GetAllSettings() => throw new NotImplementedException();
-            public Task<Dictionary<string, string>> GetAllSettingsAsync() => throw new NotImplementedException();
-            public void UpdateSettings(Dictionary<string, string> settings) => throw new NotImplementedException();
-            public Task UpdateSettingsAsync(Dictionary<string, string> settings) => throw new NotImplementedException();
-            public void DeleteSetting(string key) => throw new NotImplementedException();
-            public Task DeleteSettingAsync(string key) => throw new NotImplementedException();
-            public IEnumerable<string> GetScannerIpAddresses() => throw new NotImplementedException();
-            public Task<IEnumerable<string>> GetScannerIpAddressesAsync() => throw new NotImplementedException();
-            public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses) => throw new NotImplementedException();
-            public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses) => throw new NotImplementedException();
-            public void SavePasswordIterations(int iterations) => throw new NotImplementedException();
-            public Task SavePasswordIterationsAsync(int iterations) => throw new NotImplementedException();
+            public void SaveSetting(string key, string value, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public string? GetSetting(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Dictionary<string, string> GetAllSettings(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public void UpdateSettings(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public void DeleteSetting(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public IEnumerable<string> GetScannerIpAddresses(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public void SavePasswordIterations(int iterations, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         }
 
         class AsyncOnlySettingsService : ISettingsService
@@ -179,25 +179,25 @@ namespace ToolManagementAppV2.Tests.Utilities
 
             public AsyncOnlySettingsService(int iterations) => _iterations = iterations;
 
-            public int GetPasswordIterations() => 0;
-            public Task<int> GetPasswordIterationsAsync() => Task.FromResult(_iterations);
+            public int GetPasswordIterations(CancellationToken cancellationToken = default) => 0;
+            public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(_iterations);
 
-            public void SaveSetting(string key, string value) => throw new NotImplementedException();
-            public Task SaveSettingAsync(string key, string value) => throw new NotImplementedException();
-            public string? GetSetting(string key) => throw new NotImplementedException();
-            public Task<string?> GetSettingAsync(string key) => throw new NotImplementedException();
-            public Dictionary<string, string> GetAllSettings() => throw new NotImplementedException();
-            public Task<Dictionary<string, string>> GetAllSettingsAsync() => throw new NotImplementedException();
-            public void UpdateSettings(Dictionary<string, string> settings) => throw new NotImplementedException();
-            public Task UpdateSettingsAsync(Dictionary<string, string> settings) => throw new NotImplementedException();
-            public void DeleteSetting(string key) => throw new NotImplementedException();
-            public Task DeleteSettingAsync(string key) => throw new NotImplementedException();
-            public IEnumerable<string> GetScannerIpAddresses() => throw new NotImplementedException();
-            public Task<IEnumerable<string>> GetScannerIpAddressesAsync() => throw new NotImplementedException();
-            public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses) => throw new NotImplementedException();
-            public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses) => throw new NotImplementedException();
-            public void SavePasswordIterations(int iterations) => throw new NotImplementedException();
-            public Task SavePasswordIterationsAsync(int iterations) => throw new NotImplementedException();
+            public void SaveSetting(string key, string value, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public string? GetSetting(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Dictionary<string, string> GetAllSettings(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public void UpdateSettings(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public void DeleteSetting(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public IEnumerable<string> GetScannerIpAddresses(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public void SavePasswordIterations(int iterations, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         }
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Interfaces;
@@ -159,48 +160,48 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public string SavedValue { get; private set; }
         public string? GetSettingValue { get; set; } = string.Empty;
 
-        public void SaveSetting(string key, string value)
+        public void SaveSetting(string key, string value, CancellationToken cancellationToken = default)
         {
             SavedKey = key;
             SavedValue = value;
         }
 
-        public string? GetSetting(string key) => GetSettingValue;
-        public Dictionary<string, string> GetAllSettings() => new();
-        public void UpdateSettings(Dictionary<string, string> settings) { }
-        public void DeleteSetting(string key) { }
+        public string? GetSetting(string key, CancellationToken cancellationToken = default) => GetSettingValue;
+        public Dictionary<string, string> GetAllSettings(CancellationToken cancellationToken = default) => new();
+        public void UpdateSettings(Dictionary<string, string> settings, CancellationToken cancellationToken = default) { }
+        public void DeleteSetting(string key, CancellationToken cancellationToken = default) { }
         public IEnumerable<string> ScannerIps { get; set; } = Array.Empty<string>();
-        public IEnumerable<string> GetScannerIpAddresses() => ScannerIps;
-        public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses)
+        public IEnumerable<string> GetScannerIpAddresses(CancellationToken cancellationToken = default) => ScannerIps;
+        public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default)
         {
             ScannerIps = ipAddresses ?? Array.Empty<string>();
             return Array.Empty<string>();
         }
         public int PasswordIterations { get; set; } = 100_000;
-        public int GetPasswordIterations() => PasswordIterations;
-        public void SavePasswordIterations(int iterations) => PasswordIterations = iterations;
+        public int GetPasswordIterations(CancellationToken cancellationToken = default) => PasswordIterations;
+        public void SavePasswordIterations(int iterations, CancellationToken cancellationToken = default) => PasswordIterations = iterations;
 
-        public Task SaveSettingAsync(string key, string value)
+        public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
         {
             SaveSetting(key, value);
             return Task.CompletedTask;
         }
-        public Task<string?> GetSettingAsync(string key) => Task.FromResult(GetSetting(key));
-        public Task<Dictionary<string, string>> GetAllSettingsAsync() => Task.FromResult(GetAllSettings());
-        public Task UpdateSettingsAsync(Dictionary<string, string> settings)
+        public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult(GetSetting(key));
+        public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(GetAllSettings());
+        public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
         {
             UpdateSettings(settings);
             return Task.CompletedTask;
         }
-        public Task DeleteSettingAsync(string key)
+        public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
         {
             DeleteSetting(key);
             return Task.CompletedTask;
         }
-        public Task<IEnumerable<string>> GetScannerIpAddressesAsync() => Task.FromResult(GetScannerIpAddresses());
-        public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses) => Task.FromResult(SaveScannerIpAddresses(ipAddresses));
-        public Task<int> GetPasswordIterationsAsync() => Task.FromResult(GetPasswordIterations());
-        public Task SavePasswordIterationsAsync(int iterations)
+        public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => Task.FromResult(GetScannerIpAddresses());
+        public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => Task.FromResult(SaveScannerIpAddresses(ipAddresses));
+        public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(GetPasswordIterations());
+        public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default)
         {
             SavePasswordIterations(iterations);
             return Task.CompletedTask;

--- a/ToolManagementAppV2/Interfaces/ISettingsService.cs
+++ b/ToolManagementAppV2/Interfaces/ISettingsService.cs
@@ -1,29 +1,30 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ToolManagementAppV2.Interfaces
 {
     public interface ISettingsService
     {
-        void SaveSetting(string key, string value);
-        string? GetSetting(string key);
-        Dictionary<string, string> GetAllSettings();
-        void UpdateSettings(Dictionary<string, string> settings);
-        void DeleteSetting(string key);
-        Task SaveSettingAsync(string key, string value);
-        Task<string?> GetSettingAsync(string key);
-        Task<Dictionary<string, string>> GetAllSettingsAsync();
-        Task UpdateSettingsAsync(Dictionary<string, string> settings);
-        Task DeleteSettingAsync(string key);
-        IEnumerable<string> GetScannerIpAddresses();
-        IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses);
-        Task<IEnumerable<string>> GetScannerIpAddressesAsync();
-        Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses);
+        void SaveSetting(string key, string value, CancellationToken cancellationToken = default);
+        string? GetSetting(string key, CancellationToken cancellationToken = default);
+        Dictionary<string, string> GetAllSettings(CancellationToken cancellationToken = default);
+        void UpdateSettings(Dictionary<string, string> settings, CancellationToken cancellationToken = default);
+        void DeleteSetting(string key, CancellationToken cancellationToken = default);
+        Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default);
+        Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default);
+        Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default);
+        Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default);
+        Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default);
+        IEnumerable<string> GetScannerIpAddresses(CancellationToken cancellationToken = default);
+        IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default);
+        Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default);
+        Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default);
 
         // Password hashing configuration
-        int GetPasswordIterations();
-        void SavePasswordIterations(int iterations);
-        Task<int> GetPasswordIterationsAsync();
-        Task SavePasswordIterationsAsync(int iterations);
+        int GetPasswordIterations(CancellationToken cancellationToken = default);
+        void SavePasswordIterations(int iterations, CancellationToken cancellationToken = default);
+        Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default);
+        Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default);
     }
 }

--- a/ToolManagementAppV2/Services/Devices/ScannerService.cs
+++ b/ToolManagementAppV2/Services/Devices/ScannerService.cs
@@ -27,7 +27,7 @@ namespace ToolManagementAppV2.Services.Devices
             cancellationToken.ThrowIfCancellationRequested();
 
             using var semaphore = new SemaphoreSlim(5);
-            var tasks = _settingsService.GetScannerIpAddresses().Distinct().Select(async ip =>
+            var tasks = _settingsService.GetScannerIpAddresses(cancellationToken).Distinct().Select(async ip =>
             {
                 await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Data.SQLite;
 using System;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Interfaces;
@@ -24,7 +25,10 @@ namespace ToolManagementAppV2.Services.Settings
             _logger = logger ?? NullLogger<SettingsService>.Instance;
         }
 
-        public void SaveSetting(string key, string value)
+        public void SaveSetting(string key, string value, CancellationToken cancellationToken = default)
+            => SaveSettingAsync(key, value, cancellationToken).GetAwaiter().GetResult();
+
+        public async Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentException("Key cannot be null or empty.", nameof(key));
@@ -37,7 +41,17 @@ namespace ToolManagementAppV2.Services.Settings
                     new SQLiteParameter("@Value", value)
                 };
                 using var conn = _dbService.CreateConnection();
-                SqliteHelper.ExecuteNonQuery(conn, UpsertSql, p);
+                await SqliteHelper.ExecuteNonQueryAsync(conn, UpsertSql, p, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "Saving setting {Key} canceled or timed out", key);
+                throw;
+            }
+            catch (SQLiteException ex) when (ex.ResultCode == SQLiteErrorCode.Busy)
+            {
+                _logger.LogWarning(ex, "Saving setting {Key} timed out", key);
+                throw;
             }
             catch (Exception ex)
             {
@@ -46,56 +60,29 @@ namespace ToolManagementAppV2.Services.Settings
             }
         }
 
-        public async Task SaveSettingAsync(string key, string value)
-        {
-            if (string.IsNullOrWhiteSpace(key))
-                throw new ArgumentException("Key cannot be null or empty.", nameof(key));
+        public string? GetSetting(string key, CancellationToken cancellationToken = default)
+            => GetSettingAsync(key, cancellationToken).GetAwaiter().GetResult();
 
-            try
-            {
-                var p = new[]
-                {
-                    new SQLiteParameter("@Key", key),
-                    new SQLiteParameter("@Value", value)
-                };
-                using var conn = _dbService.CreateConnection();
-                await SqliteHelper.ExecuteNonQueryAsync(conn, UpsertSql, p);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to save setting {Key}", key);
-                throw new InvalidOperationException($"Failed to save setting '{key}'.", ex);
-            }
-        }
-
-        public string? GetSetting(string key)
+        public async Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default)
         {
             try
             {
                 const string sql = "SELECT Value FROM Settings WHERE Key = @Key";
                 using var conn = _dbService.CreateConnection();
-                using var cmd = new SQLiteCommand(sql, conn);
-                cmd.Parameters.AddWithValue("@Key", key);
-                return cmd.ExecuteScalar()?.ToString();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to retrieve setting {Key}", key);
-                throw new InvalidOperationException($"Failed to retrieve setting '{key}'.", ex);
-            }
-        }
-
-        public async Task<string?> GetSettingAsync(string key)
-        {
-            try
-            {
-                const string sql = "SELECT Value FROM Settings WHERE Key = @Key";
-                using var conn = _dbService.CreateConnection();
-                using var cmd = new SQLiteCommand(sql, conn);
-                cmd.Parameters.AddWithValue("@Key", key);
-                var result = await cmd.ExecuteScalarAsync();
+                var p = new[] { new SQLiteParameter("@Key", key) };
+                var result = await SqliteHelper.ExecuteScalarAsync(conn, sql, p, cancellationToken).ConfigureAwait(false);
                 return result?.ToString();
             }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "Retrieving setting {Key} canceled or timed out", key);
+                throw;
+            }
+            catch (SQLiteException ex) when (ex.ResultCode == SQLiteErrorCode.Busy)
+            {
+                _logger.LogWarning(ex, "Retrieving setting {Key} timed out", key);
+                throw;
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to retrieve setting {Key}", key);
@@ -103,27 +90,10 @@ namespace ToolManagementAppV2.Services.Settings
             }
         }
 
-        public Dictionary<string, string> GetAllSettings()
-        {
-            try
-            {
-                var dict = new Dictionary<string, string>();
-                const string sql = "SELECT Key, Value FROM Settings";
-                using var conn = _dbService.CreateConnection();
-                using var cmd = new SQLiteCommand(sql, conn);
-                using var rdr = cmd.ExecuteReader();
-                while (rdr.Read())
-                    dict[rdr["Key"].ToString()] = rdr["Value"].ToString();
-                return dict;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to retrieve all settings");
-                throw new InvalidOperationException("Failed to retrieve all settings.", ex);
-            }
-        }
+        public Dictionary<string, string> GetAllSettings(CancellationToken cancellationToken = default)
+            => GetAllSettingsAsync(cancellationToken).GetAwaiter().GetResult();
 
-        public async Task<Dictionary<string, string>> GetAllSettingsAsync()
+        public async Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default)
         {
             try
             {
@@ -131,10 +101,20 @@ namespace ToolManagementAppV2.Services.Settings
                 const string sql = "SELECT Key, Value FROM Settings";
                 using var conn = _dbService.CreateConnection();
                 using var cmd = new SQLiteCommand(sql, conn);
-                using var rdr = await cmd.ExecuteReaderAsync();
-                while (await rdr.ReadAsync())
+                using var rdr = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                while (await rdr.ReadAsync(cancellationToken).ConfigureAwait(false))
                     dict[rdr["Key"].ToString()] = rdr["Value"].ToString();
                 return dict;
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "Retrieving all settings canceled or timed out");
+                throw;
+            }
+            catch (SQLiteException ex) when (ex.ResultCode == SQLiteErrorCode.Busy)
+            {
+                _logger.LogWarning(ex, "Retrieving all settings timed out");
+                throw;
             }
             catch (Exception ex)
             {
@@ -153,7 +133,10 @@ namespace ToolManagementAppV2.Services.Settings
         /// <exception cref="InvalidOperationException">
         /// Thrown when a transaction cannot be started. The original exception is propagated to the caller.
         /// </exception>
-        public void UpdateSettings(Dictionary<string, string> settings)
+        public void UpdateSettings(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
+            => UpdateSettingsAsync(settings, cancellationToken).GetAwaiter().GetResult();
+
+        public async Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
         {
             if (settings == null)
                 throw new ArgumentNullException(nameof(settings));
@@ -175,9 +158,21 @@ namespace ToolManagementAppV2.Services.Settings
                         new SQLiteParameter("@Key", kv.Key),
                         new SQLiteParameter("@Value", kv.Value)
                     };
-                    SqliteHelper.ExecuteNonQuery(conn, tx, UpsertSql, p);
+                    await SqliteHelper.ExecuteNonQueryAsync(conn, tx, UpsertSql, p, cancellationToken).ConfigureAwait(false);
                 }
                 tx.Commit();
+            }
+            catch (OperationCanceledException ex)
+            {
+                tx.Rollback();
+                _logger.LogWarning(ex, "Updating settings canceled or timed out");
+                throw;
+            }
+            catch (SQLiteException ex) when (ex.ResultCode == SQLiteErrorCode.Busy)
+            {
+                tx.Rollback();
+                _logger.LogWarning(ex, "Updating settings timed out");
+                throw;
             }
             catch (Exception ex)
             {
@@ -187,68 +182,29 @@ namespace ToolManagementAppV2.Services.Settings
             }
         }
 
-        public async Task UpdateSettingsAsync(Dictionary<string, string> settings)
-        {
-            if (settings == null)
-                throw new ArgumentNullException(nameof(settings));
+        public void DeleteSetting(string key, CancellationToken cancellationToken = default)
+            => DeleteSettingAsync(key, cancellationToken).GetAwaiter().GetResult();
 
-            foreach (var kv in settings)
-            {
-                if (string.IsNullOrWhiteSpace(kv.Key))
-                    throw new ArgumentException("Key cannot be null or empty.", nameof(settings));
-            }
-
-            using var conn = _dbService.CreateConnection();
-            using var tx = conn.BeginTransaction();
-            try
-            {
-                foreach (var kv in settings)
-                {
-                    var p = new[]
-                    {
-                        new SQLiteParameter("@Key", kv.Key),
-                        new SQLiteParameter("@Value", kv.Value)
-                    };
-                    await SqliteHelper.ExecuteNonQueryAsync(conn, tx, UpsertSql, p);
-                }
-                tx.Commit();
-            }
-            catch (Exception ex)
-            {
-                tx.Rollback();
-                _logger.LogError(ex, "Failed to update settings");
-                throw new InvalidOperationException("Failed to update settings.", ex);
-            }
-        }
-
-        public void DeleteSetting(string key)
+        public async Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
         {
             try
             {
                 const string sql = "DELETE FROM Settings WHERE Key = @Key";
                 var p = new[] { new SQLiteParameter("@Key", key) };
                 using var conn = _dbService.CreateConnection();
-                var affected = SqliteHelper.ExecuteNonQuery(conn, sql, p);
+                var affected = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken).ConfigureAwait(false);
                 if (affected == 0)
                     _logger.LogWarning("No setting found for key {Key}", key);
             }
-            catch (Exception ex)
+            catch (OperationCanceledException ex)
             {
-                _logger.LogError(ex, "Failed to delete setting {Key}", key);
-                throw new InvalidOperationException($"Failed to delete setting '{key}'.", ex);
+                _logger.LogWarning(ex, "Deleting setting {Key} canceled or timed out", key);
+                throw;
             }
-        }
-
-        public async Task DeleteSettingAsync(string key)
-        {
-            try
+            catch (SQLiteException ex) when (ex.ResultCode == SQLiteErrorCode.Busy)
             {
-                const string sql = "DELETE FROM Settings WHERE Key = @Key";
-                var p = new[] { new SQLiteParameter("@Key", key) };
-                using var conn = _dbService.CreateConnection();
-                var affected = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
-                if (affected == 0)
-                    _logger.LogWarning("No setting found for key {Key}", key);
+                _logger.LogWarning(ex, "Deleting setting {Key} timed out", key);
+                throw;
             }
             catch (Exception ex)
             {
@@ -260,9 +216,9 @@ namespace ToolManagementAppV2.Services.Settings
         const string ScannerIpKey = "ScannerIpAddresses";
         const string PasswordIterationsKey = "PasswordIterations";
 
-        public IEnumerable<string> GetScannerIpAddresses()
+        public IEnumerable<string> GetScannerIpAddresses(CancellationToken cancellationToken = default)
         {
-            var value = GetSetting(ScannerIpKey);
+            var value = GetSetting(ScannerIpKey, cancellationToken);
             if (string.IsNullOrWhiteSpace(value))
                 return Array.Empty<string>();
 
@@ -276,9 +232,9 @@ namespace ToolManagementAppV2.Services.Settings
             return valid;
         }
 
-        public async Task<IEnumerable<string>> GetScannerIpAddressesAsync()
+        public async Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default)
         {
-            var value = await GetSettingAsync(ScannerIpKey);
+            var value = await GetSettingAsync(ScannerIpKey, cancellationToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(value))
                 return Array.Empty<string>();
 
@@ -292,11 +248,11 @@ namespace ToolManagementAppV2.Services.Settings
             return valid;
         }
 
-        public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses)
+        public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default)
         {
             if (ipAddresses == null)
             {
-                DeleteSetting(ScannerIpKey);
+                DeleteSetting(ScannerIpKey, cancellationToken);
                 return Array.Empty<string>();
             }
 
@@ -316,21 +272,21 @@ namespace ToolManagementAppV2.Services.Settings
             if (valid.Count > 0)
             {
                 var value = string.Join(';', valid);
-                SaveSetting(ScannerIpKey, value);
+                SaveSetting(ScannerIpKey, value, cancellationToken);
             }
             else
             {
-                DeleteSetting(ScannerIpKey);
+                DeleteSetting(ScannerIpKey, cancellationToken);
             }
 
             return invalid;
         }
 
-        public async Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses)
+        public async Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default)
         {
             if (ipAddresses == null)
             {
-                await DeleteSettingAsync(ScannerIpKey);
+                await DeleteSettingAsync(ScannerIpKey, cancellationToken).ConfigureAwait(false);
                 return Array.Empty<string>();
             }
 
@@ -350,41 +306,41 @@ namespace ToolManagementAppV2.Services.Settings
             if (valid.Count > 0)
             {
                 var value = string.Join(';', valid);
-                await SaveSettingAsync(ScannerIpKey, value);
+                await SaveSettingAsync(ScannerIpKey, value, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                await DeleteSettingAsync(ScannerIpKey);
+                await DeleteSettingAsync(ScannerIpKey, cancellationToken).ConfigureAwait(false);
             }
 
             return invalid;
         }
 
         // Password hashing configuration
-        public int GetPasswordIterations()
+        public int GetPasswordIterations(CancellationToken cancellationToken = default)
         {
-            var value = GetSetting(PasswordIterationsKey);
+            var value = GetSetting(PasswordIterationsKey, cancellationToken);
             return int.TryParse(value, out var i) ? i : 100_000;
         }
 
-        public void SavePasswordIterations(int iterations)
+        public void SavePasswordIterations(int iterations, CancellationToken cancellationToken = default)
         {
             if (iterations <= 0)
                 throw new ArgumentOutOfRangeException(nameof(iterations));
-            SaveSetting(PasswordIterationsKey, iterations.ToString());
+            SaveSetting(PasswordIterationsKey, iterations.ToString(), cancellationToken);
         }
 
-        public async Task<int> GetPasswordIterationsAsync()
+        public async Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default)
         {
-            var value = await GetSettingAsync(PasswordIterationsKey);
+            var value = await GetSettingAsync(PasswordIterationsKey, cancellationToken).ConfigureAwait(false);
             return int.TryParse(value, out var i) ? i : 100_000;
         }
 
-        public async Task SavePasswordIterationsAsync(int iterations)
+        public async Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default)
         {
             if (iterations <= 0)
                 throw new ArgumentOutOfRangeException(nameof(iterations));
-            await SaveSettingAsync(PasswordIterationsKey, iterations.ToString());
+            await SaveSettingAsync(PasswordIterationsKey, iterations.ToString(), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/ToolManagementAppV2/Services/Users/ActivityLogService.cs
+++ b/ToolManagementAppV2/Services/Users/ActivityLogService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SQLite;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -22,7 +23,10 @@ namespace ToolManagementAppV2.Services.Users
             _logger = logger ?? NullLogger<ActivityLogService>.Instance;
         }
 
-        public virtual Result LogAction(int userID, string userName, string action)
+        public virtual Result LogAction(int userID, string userName, string action, CancellationToken cancellationToken = default)
+            => LogActionAsync(userID, userName, action, cancellationToken).GetAwaiter().GetResult();
+
+        public virtual async Task<Result> LogActionAsync(int userID, string userName, string action, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -36,8 +40,18 @@ namespace ToolManagementAppV2.Services.Users
                     new SQLiteParameter("@Action",   action)
                 };
                 using var conn = _dbService.CreateConnection();
-                SqliteHelper.ExecuteNonQuery(conn, sql, p);
+                await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken).ConfigureAwait(false);
                 return new Result(true);
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "Logging action {Action} canceled or timed out", action);
+                return new Result(false, "Operation canceled");
+            }
+            catch (SQLiteException ex) when (ex.ResultCode == SQLiteErrorCode.Busy)
+            {
+                _logger.LogWarning(ex, "Logging action {Action} timed out", action);
+                return new Result(false, ex.Message);
             }
             catch (Exception ex)
             {
@@ -46,7 +60,10 @@ namespace ToolManagementAppV2.Services.Users
             }
         }
 
-        public virtual Result<List<ActivityLog>> GetRecentLogs(int count = 50)
+        public virtual Result<List<ActivityLog>> GetRecentLogs(int count = 50, CancellationToken cancellationToken = default)
+            => GetRecentLogsAsync(count, cancellationToken).GetAwaiter().GetResult();
+
+        public virtual async Task<Result<List<ActivityLog>>> GetRecentLogsAsync(int count = 50, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -56,8 +73,18 @@ namespace ToolManagementAppV2.Services.Users
                      LIMIT @Count";
                 var p = new[] { new SQLiteParameter("@Count", count) };
                 using var conn = _dbService.CreateConnection();
-                var logs = SqliteHelper.ExecuteReader(conn, sql, p, MapLog);
+                var logs = await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapLog, cancellationToken).ConfigureAwait(false);
                 return new Result<List<ActivityLog>>(logs, true);
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "Retrieving recent activity logs canceled or timed out");
+                return new Result<List<ActivityLog>>(null, false, "Operation canceled");
+            }
+            catch (SQLiteException ex) when (ex.ResultCode == SQLiteErrorCode.Busy)
+            {
+                _logger.LogWarning(ex, "Retrieving recent activity logs timed out");
+                return new Result<List<ActivityLog>>(null, false, ex.Message);
             }
             catch (Exception ex)
             {
@@ -66,27 +93,10 @@ namespace ToolManagementAppV2.Services.Users
             }
         }
 
-        public virtual async Task<Result<List<ActivityLog>>> GetRecentLogsAsync(int count = 50)
-        {
-            try
-            {
-                const string sql = @"
-                    SELECT * FROM ActivityLogs
-                     ORDER BY Timestamp DESC
-                     LIMIT @Count";
-                var p = new[] { new SQLiteParameter("@Count", count) };
-                using var conn = _dbService.CreateConnection();
-                var logs = await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapLog);
-                return new Result<List<ActivityLog>>(logs, true);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to retrieve recent activity logs");
-                return new Result<List<ActivityLog>>(null, false, ex.Message);
-            }
-        }
+        public virtual Result PurgeOldLogs(DateTime threshold, CancellationToken cancellationToken = default)
+            => PurgeOldLogsAsync(threshold, cancellationToken).GetAwaiter().GetResult();
 
-        public virtual Result PurgeOldLogs(DateTime threshold)
+        public virtual async Task<Result> PurgeOldLogsAsync(DateTime threshold, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -95,8 +105,18 @@ namespace ToolManagementAppV2.Services.Users
                      WHERE Timestamp < @Threshold";
                 var p = new[] { new SQLiteParameter("@Threshold", threshold) };
                 using var conn = _dbService.CreateConnection();
-                SqliteHelper.ExecuteNonQuery(conn, sql, p);
+                await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken).ConfigureAwait(false);
                 return new Result(true);
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "Purging logs prior to {Threshold} canceled or timed out", threshold);
+                return new Result(false, "Operation canceled");
+            }
+            catch (SQLiteException ex) when (ex.ResultCode == SQLiteErrorCode.Busy)
+            {
+                _logger.LogWarning(ex, "Purging logs prior to {Threshold} timed out", threshold);
+                return new Result(false, ex.Message);
             }
             catch (Exception ex)
             {

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -113,16 +113,16 @@ namespace ToolManagementAppV2.ViewModels
             LoadUsersCommand = new AsyncRelayCommand(LoadUsersAsync);
         }
 
-        public async Task InitializeAsync()
+        public async Task InitializeAsync(CancellationToken cancellationToken = default)
         {
-            CompanyLogo = await LoadLogoAsync();
-            WindowTitle = await GetWindowTitleAsync();
+            CompanyLogo = await LoadLogoAsync(cancellationToken);
+            WindowTitle = await GetWindowTitleAsync(cancellationToken);
             await LoadUsersCommand.ExecuteAsync(null);
         }
 
-        async Task<BitmapImage> LoadLogoAsync()
+        async Task<BitmapImage> LoadLogoAsync(CancellationToken cancellationToken)
         {
-            var logoPath = await _settingsService.GetSettingAsync("CompanyLogoPath");
+            var logoPath = await _settingsService.GetSettingAsync("CompanyLogoPath", cancellationToken);
             Uri logoUri;
             if (!string.IsNullOrWhiteSpace(logoPath))
             {
@@ -159,9 +159,9 @@ namespace ToolManagementAppV2.ViewModels
             return bitmap;
         }
 
-        async Task<string> GetWindowTitleAsync()
+        async Task<string> GetWindowTitleAsync(CancellationToken cancellationToken)
         {
-            var appName = await _settingsService.GetSettingAsync("ApplicationName");
+            var appName = await _settingsService.GetSettingAsync("ApplicationName", cancellationToken);
             return !string.IsNullOrWhiteSpace(appName)
                 ? $"{appName} – Login"
                 : "Tool Inventory Management – Login";


### PR DESCRIPTION
## Summary
- add CancellationToken parameters to settings APIs and switch to async SQLite helper methods
- propagate cancellation tokens from view models and scanner service
- improve logging for cancellations and timeouts in settings and activity log operations

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0454054648324b6d35769dbaf9015