### PR TITLE
Add parameterless InitializeAsync wrapper

### DIFF
--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -113,7 +113,10 @@ namespace ToolManagementAppV2.ViewModels
             LoadUsersCommand = new AsyncRelayCommand(LoadUsersAsync);
         }
 
-        public async Task InitializeAsync(CancellationToken cancellationToken = default)
+        public Task InitializeAsync()
+            => InitializeAsync(default);
+
+        public async Task InitializeAsync(CancellationToken cancellationToken)
         {
             CompanyLogo = await LoadLogoAsync(cancellationToken);
             WindowTitle = await GetWindowTitleAsync(cancellationToken);


### PR DESCRIPTION
## Summary
- Add parameterless `InitializeAsync` method delegating to cancellation token overload in `LoginViewModel`
- Remove default parameter from existing overload

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a04b15f9648324baabac8e4ae72bd5