### PR TITLE
Specify System.Windows.Application to avoid ambiguity

### DIFF
--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -24,7 +24,7 @@ using ToolManagementAppV2.Services.Devices;
 
 namespace ToolManagementAppV2
 {
-    public partial class App : Application
+    public partial class App : System.Windows.Application
     {
         public IHost Host { get; }
 


### PR DESCRIPTION
## Summary
- Qualify App's base class as System.Windows.Application to avoid type ambiguity

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a04dff435c83248c8a1191220c1427