### PR TITLE
Add global exception handling and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ This project adheres to the rules in `AGENTS.md`, including:
 - Running `dotnet test` before commits and updating tests for new functionality.
 - Summarizing changes and referencing test results in pull requests.
 
+### Error Handling
+Global exception handlers are wired in `App.xaml.cs` for dispatcher, domain, and background task errors. These handlers log through `ILogger<App>`/Serilog and notify users via `IDialogService`, marking exceptions as handled when possible to keep the application running.
+
 ### Resource Management
 `DatabaseService` implements `IDisposable` and should be disposed when no longer in use.
 `MainWindow` requires a `MainViewModel` and optionally an owned `DatabaseService`. Pass the

--- a/ToolManagementAppV2.Tests/Tests/AppUnhandledExceptionTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/AppUnhandledExceptionTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ToolManagementAppV2;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Tests;
+using ToolManagementAppV2.Models;
+using ToolManagementAppV2.ViewModels;
+using System.Windows.Documents;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Tests
+{
+    public class AppUnhandledExceptionTests
+    {
+        [Fact]
+        public void DispatcherException_LogsAndShowsDialog()
+        {
+            Exception? threadException = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var logs = new List<LogEntry>();
+                    var dialog = new RecordingDialogService();
+
+                    var host = Host.CreateDefaultBuilder()
+                        .ConfigureServices(services =>
+                        {
+                            services.AddSingleton<IDialogService>(dialog);
+                        })
+                        .ConfigureLogging(b =>
+                        {
+                            b.ClearProviders();
+                            b.AddProvider(new ListLoggerProvider(logs));
+                        })
+                        .Build();
+
+                    var app = new App(host);
+                    app.HandleDispatcherException(new InvalidOperationException("boom"));
+
+                    Assert.Single(logs);
+                    Assert.Equal(1, dialog.InfoCount);
+                    app.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadException != null)
+                throw threadException;
+        }
+
+        [Fact]
+        public void TaskException_LogsAndShowsDialog()
+        {
+            Exception? threadException = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var logs = new List<LogEntry>();
+                    var dialog = new RecordingDialogService();
+
+                    var host = Host.CreateDefaultBuilder()
+                        .ConfigureServices(services =>
+                        {
+                            services.AddSingleton<IDialogService>(dialog);
+                        })
+                        .ConfigureLogging(b =>
+                        {
+                            b.ClearProviders();
+                            b.AddProvider(new ListLoggerProvider(logs));
+                        })
+                        .Build();
+
+                    var app = new App(host);
+                    app.HandleTaskException(new AggregateException(new InvalidOperationException("boom")));
+
+                    Assert.Single(logs);
+                    Assert.Equal(1, dialog.InfoCount);
+                    app.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadException != null)
+                throw threadException;
+        }
+
+        private class RecordingDialogService : IDialogService
+        {
+            public int InfoCount { get; private set; }
+            public void ShowInfo(string message, string title) => InfoCount++;
+            public bool ShowConfirmation(string message, string title) => false;
+            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+            public void ShowToolDetails(ToolModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+            public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+            public void ShowScannerStatus() { }
+        }
+    }
+}
+

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Threading;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -27,68 +28,81 @@ namespace ToolManagementAppV2
     public partial class App : System.Windows.Application
     {
         public IHost Host { get; }
+        private readonly ILogger<App> _logger;
+        private readonly IDialogService _dialogService;
 
-        public App()
+        public App() : this(BuildHost()) { }
+
+        internal App(IHost host)
         {
-            Host = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
-                .ConfigureLogging((context, logging) =>
-                {
-                    var logsDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
-                        context.Configuration["Logging:Directory"] ?? "Logs");
-                    Directory.CreateDirectory(logsDir);
-                    var logFile = Path.Combine(logsDir, "app-.log");
+            Host = host;
+            _logger = Host.Services.GetRequiredService<ILogger<App>>();
+            _dialogService = Host.Services.GetRequiredService<IDialogService>();
 
-                    Log.Logger = new LoggerConfiguration()
-                        .MinimumLevel.Debug()
-                        .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-                        .Enrich.FromLogContext()
-                        .WriteTo.Async(w => w.File(
-                            path: logFile,
-                            rollingInterval: RollingInterval.Day,
-                            retainedFileCountLimit: 14,
-                            shared: true,
-                            encoding: Encoding.UTF8))
-                        .CreateLogger();
-
-                    logging.ClearProviders();
-                    logging.AddSerilog(Log.Logger, dispose: true);
-                })
-                .ConfigureServices((context, services) =>
-                {
-                    services.AddSingleton<DatabaseService>(sp =>
-                    {
-                        var config = sp.GetRequiredService<IConfiguration>();
-                        var logger = sp.GetRequiredService<ILogger<DatabaseService>>();
-                        var dbPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
-                            config["Database:Path"] ?? "tool_inventory.db");
-                        return new DatabaseService(dbPath, logger);
-                    });
-                    services.AddSingleton<IDatabaseService>(sp => sp.GetRequiredService<DatabaseService>());
-                    services.AddSingleton<IDatabaseBackupService>(sp => sp.GetRequiredService<DatabaseService>());
-                    services.AddSingleton<IUserContext, ApplicationUserContext>();
-                    services.AddSingleton<IToolService, ToolService>();
-                    services.AddSingleton<ICustomerService, CustomerService>();
-                    services.AddSingleton<IUserService, UserService>();
-                    services.AddSingleton<IRentalService, RentalService>();
-                    services.AddSingleton<ActivityLogService>();
-                    services.AddSingleton<IFileDialogService, FileDialogService>();
-                    services.AddSingleton<ISettingsService, SettingsService>();
-                    services.AddSingleton<IDialogService, DialogService>();
-                    services.AddSingleton<IScannerService, ScannerService>();
-                    services.AddSingleton<IMainViewModel, MainViewModel>();
-                    services.AddSingleton<ILoginViewModel, LoginViewModel>();
-                    services.AddTransient<ToolEditWindow>();
-                    services.AddTransient<AvatarSelectionWindow>();
-                    services.AddTransient<ScannerStatusWindow>();
-                    services.AddTransient<PasswordPromptWindow>();
-                    services.AddTransient<PrintLabelWindow>();
-                    services.AddSingleton<IMainWindow>(sp =>
-                        new MainWindow(sp.GetRequiredService<IMainViewModel>()));
-                    services.AddSingleton<ILoginWindow>(sp =>
-                        new LoginWindow(sp.GetRequiredService<ILoginViewModel>()));
-                })
-                .Build();
+            DispatcherUnhandledException += (s, e) => HandleDispatcherException(e.Exception, e);
+            AppDomain.CurrentDomain.UnhandledException += (s, e) =>
+                HandleDomainException(e.ExceptionObject as Exception ?? new Exception("Unknown"), e);
+            TaskScheduler.UnobservedTaskException += (s, e) => HandleTaskException(e.Exception, e);
         }
+
+        private static IHost BuildHost() => Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
+            .ConfigureLogging((context, logging) =>
+            {
+                var logsDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
+                    context.Configuration["Logging:Directory"] ?? "Logs");
+                Directory.CreateDirectory(logsDir);
+                var logFile = Path.Combine(logsDir, "app-.log");
+
+                Log.Logger = new LoggerConfiguration()
+                    .MinimumLevel.Debug()
+                    .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+                    .Enrich.FromLogContext()
+                    .WriteTo.Async(w => w.File(
+                        path: logFile,
+                        rollingInterval: RollingInterval.Day,
+                        retainedFileCountLimit: 14,
+                        shared: true,
+                        encoding: Encoding.UTF8))
+                    .CreateLogger();
+
+                logging.ClearProviders();
+                logging.AddSerilog(Log.Logger, dispose: true);
+            })
+            .ConfigureServices((context, services) =>
+            {
+                services.AddSingleton<DatabaseService>(sp =>
+                {
+                    var config = sp.GetRequiredService<IConfiguration>();
+                    var logger = sp.GetRequiredService<ILogger<DatabaseService>>();
+                    var dbPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
+                        config["Database:Path"] ?? "tool_inventory.db");
+                    return new DatabaseService(dbPath, logger);
+                });
+                services.AddSingleton<IDatabaseService>(sp => sp.GetRequiredService<DatabaseService>());
+                services.AddSingleton<IDatabaseBackupService>(sp => sp.GetRequiredService<DatabaseService>());
+                services.AddSingleton<IUserContext, ApplicationUserContext>();
+                services.AddSingleton<IToolService, ToolService>();
+                services.AddSingleton<ICustomerService, CustomerService>();
+                services.AddSingleton<IUserService, UserService>();
+                services.AddSingleton<IRentalService, RentalService>();
+                services.AddSingleton<ActivityLogService>();
+                services.AddSingleton<IFileDialogService, FileDialogService>();
+                services.AddSingleton<ISettingsService, SettingsService>();
+                services.AddSingleton<IDialogService, DialogService>();
+                services.AddSingleton<IScannerService, ScannerService>();
+                services.AddSingleton<IMainViewModel, MainViewModel>();
+                services.AddSingleton<ILoginViewModel, LoginViewModel>();
+                services.AddTransient<ToolEditWindow>();
+                services.AddTransient<AvatarSelectionWindow>();
+                services.AddTransient<ScannerStatusWindow>();
+                services.AddTransient<PasswordPromptWindow>();
+                services.AddTransient<PrintLabelWindow>();
+                services.AddSingleton<IMainWindow>(sp =>
+                    new MainWindow(sp.GetRequiredService<IMainViewModel>()));
+                services.AddSingleton<ILoginWindow>(sp =>
+                    new LoginWindow(sp.GetRequiredService<ILoginViewModel>()));
+            })
+            .Build();
 
         [STAThread]
         public static async Task Main()
@@ -143,6 +157,26 @@ namespace ToolManagementAppV2
             if (main.WindowState == WindowState.Minimized) main.WindowState = WindowState.Normal;
             main.Activate();
             main.Focus();
+        }
+
+        internal void HandleDispatcherException(Exception ex, DispatcherUnhandledExceptionEventArgs? e = null)
+        {
+            _logger.LogError(ex, "Unhandled dispatcher exception");
+            _dialogService.ShowInfo("An unexpected error occurred. Please try again.", "Error");
+            if (e != null) e.Handled = true;
+        }
+
+        internal void HandleDomainException(Exception ex, UnhandledExceptionEventArgs? e = null)
+        {
+            _logger.LogError(ex, "Unhandled domain exception");
+            _dialogService.ShowInfo("An unexpected error occurred. The application may need to close.", "Error");
+        }
+
+        internal void HandleTaskException(AggregateException ex, UnobservedTaskExceptionEventArgs? e = null)
+        {
+            _logger.LogError(ex, "Unobserved task exception");
+            _dialogService.ShowInfo("An unexpected background error occurred.", "Error");
+            if (e != null) e.SetObserved();
         }
 
         protected override void OnExit(ExitEventArgs e)


### PR DESCRIPTION
## Summary
- subscribe to dispatcher, domain and task-level exception events to log and notify users
- add unit tests for dispatcher and background task exceptions
- document new exception handling approach

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a04fd6f7688324a4f6f13465f2b649