### PR TITLE
Add authorization enforcement to services

### DIFF
--- a/ToolManagementAppV2.Tests/AllowAllAuthorizationService.cs
+++ b/ToolManagementAppV2.Tests/AllowAllAuthorizationService.cs
@@ -1,0 +1,9 @@
+using ToolManagementAppV2.Interfaces;
+
+namespace ToolManagementAppV2.Tests
+{
+    public class AllowAllAuthorizationService : IAuthorizationService
+    {
+        public void EnsureAdmin() { }
+    }
+}

--- a/ToolManagementAppV2.Tests/Services/AuthorizationServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/AuthorizationServiceTests.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.Extensions.Logging.Abstractions;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Users;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Services
+{
+    public class AuthorizationServiceTests
+    {
+        class StubUserContext : IUserContext
+        {
+            public User? CurrentUser { get; set; }
+            public event EventHandler<User?>? UserChanged;
+            public bool IsAdmin => CurrentUser?.IsAdmin ?? false;
+            public string UserName => CurrentUser?.UserName ?? string.Empty;
+            public string Role => CurrentUser?.Role ?? string.Empty;
+        }
+
+        [Fact]
+        public void EnsureAdmin_NonAdmin_Throws()
+        {
+            var ctx = new StubUserContext { CurrentUser = new User { UserName = "user", IsAdmin = false } };
+            var svc = new AuthorizationService(ctx, NullLogger<AuthorizationService>.Instance);
+            Assert.Throws<UnauthorizedAccessException>(() => svc.EnsureAdmin());
+        }
+
+        [Fact]
+        public void EnsureAdmin_Admin_DoesNotThrow()
+        {
+            var ctx = new StubUserContext { CurrentUser = new User { UserName = "admin", IsAdmin = true } };
+            var svc = new AuthorizationService(ctx, NullLogger<AuthorizationService>.Instance);
+            svc.EnsureAdmin();
+        }
+    }
+}

--- a/ToolManagementAppV2.Tests/TestHelpers.cs
+++ b/ToolManagementAppV2.Tests/TestHelpers.cs
@@ -21,14 +21,15 @@ namespace ToolManagementAppV2.Tests
         {
             var dbPath = Path.GetTempFileName();
             var db = new DatabaseService(dbPath);
-            var toolService = new ToolService(db);
-            var customerService = new CustomerService(db);
+            var auth = new AllowAllAuthorizationService();
+            var toolService = new ToolService(db, auth);
+            var customerService = new CustomerService(db, auth);
             var userContext = new ApplicationUserContext();
-            var userService = new UserService(db, userContext);
-            var rentalService = new RentalService(db, toolService);
+            var userService = new UserService(db, userContext, auth);
+            var rentalService = new RentalService(db, auth, toolService);
             var activityLogService = new ActivityLogService(db);
             var fileDialogService = new StubFileDialogService();
-            var settingsService = new SettingsService(db);
+            var settingsService = new SettingsService(db, auth);
             var dialogService = new StubDialogService();
             var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
                 fileDialogService, activityLogService, settingsService, db, dialogService);

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -81,6 +81,7 @@ namespace ToolManagementAppV2
                 services.AddSingleton<IDatabaseService>(sp => sp.GetRequiredService<DatabaseService>());
                 services.AddSingleton<IDatabaseBackupService>(sp => sp.GetRequiredService<DatabaseService>());
                 services.AddSingleton<IUserContext, ApplicationUserContext>();
+                services.AddSingleton<IAuthorizationService, AuthorizationService>();
                 services.AddSingleton<IToolService, ToolService>();
                 services.AddSingleton<ICustomerService, CustomerService>();
                 services.AddSingleton<IUserService, UserService>();

--- a/ToolManagementAppV2/Interfaces/IAuthorizationService.cs
+++ b/ToolManagementAppV2/Interfaces/IAuthorizationService.cs
@@ -1,0 +1,7 @@
+namespace ToolManagementAppV2.Interfaces
+{
+    public interface IAuthorizationService
+    {
+        void EnsureAdmin();
+    }
+}

--- a/ToolManagementAppV2/Services/Customers/CustomerService.cs
+++ b/ToolManagementAppV2/Services/Customers/CustomerService.cs
@@ -13,6 +13,7 @@ using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Models.ImportExport;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Utilities.IO;
+using ToolManagementAppV2.Services.Users;
 
 namespace ToolManagementAppV2.Services.Customers
 {
@@ -20,21 +21,32 @@ namespace ToolManagementAppV2.Services.Customers
     {
         readonly DatabaseService _dbService;
         readonly ILogger<CustomerService> _logger;
+        readonly IAuthorizationService _auth;
 
-        public CustomerService(DatabaseService dbService, ILogger<CustomerService>? logger = null)
+        public CustomerService(DatabaseService dbService, IAuthorizationService? authorizationService = null, ILogger<CustomerService>? logger = null)
         {
             _dbService = dbService;
+            _auth = authorizationService ?? new NoOpAuthorizationService();
             _logger = logger ?? NullLogger<CustomerService>.Instance;
         }
 
-        public Task AddCustomerAsync(CustomerModel customer) =>
-            AddCustomerInternalAsync(customer, CancellationToken.None);
+        public Task AddCustomerAsync(CustomerModel customer)
+        {
+            _auth.EnsureAdmin();
+            return AddCustomerInternalAsync(customer, CancellationToken.None);
+        }
 
-        public Task UpdateCustomerAsync(CustomerModel customer) =>
-            UpdateCustomerInternalAsync(customer, CancellationToken.None);
+        public Task UpdateCustomerAsync(CustomerModel customer)
+        {
+            _auth.EnsureAdmin();
+            return UpdateCustomerInternalAsync(customer, CancellationToken.None);
+        }
 
-        public Task DeleteCustomerAsync(int customerID) =>
-            DeleteCustomerInternalAsync(customerID, CancellationToken.None);
+        public Task DeleteCustomerAsync(int customerID)
+        {
+            _auth.EnsureAdmin();
+            return DeleteCustomerInternalAsync(customerID, CancellationToken.None);
+        }
 
         public Task<CustomerModel> GetCustomerByIDAsync(int customerID) =>
             GetCustomerByIDInternalAsync(customerID, CancellationToken.None);
@@ -45,8 +57,11 @@ namespace ToolManagementAppV2.Services.Customers
         public Task<List<CustomerModel>> SearchCustomersAsync(string searchTerm) =>
             SearchCustomersInternalAsync(searchTerm, CancellationToken.None);
 
-        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map) =>
-            ImportCustomersFromCsvInternalAsync(filePath, map, CancellationToken.None);
+        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map)
+        {
+            _auth.EnsureAdmin();
+            return ImportCustomersFromCsvInternalAsync(filePath, map, CancellationToken.None);
+        }
 
         public Task ExportCustomersToCsvAsync(string filePath) =>
             ExportCustomersToCsvInternalAsync(filePath, CancellationToken.None);

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -9,6 +9,7 @@ using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using ToolManagementAppV2.Services.Users;
 
 namespace ToolManagementAppV2.Services.Rentals
 {
@@ -17,10 +18,12 @@ namespace ToolManagementAppV2.Services.Rentals
         private readonly DatabaseService _dbService;
         private readonly IToolService? _toolService;
         private readonly ILogger<RentalService> _logger;
+        private readonly IAuthorizationService _auth;
 
-        public RentalService(DatabaseService dbService, IToolService? toolService = null, ILogger<RentalService>? logger = null)
+        public RentalService(DatabaseService dbService, IAuthorizationService? authorizationService = null, IToolService? toolService = null, ILogger<RentalService>? logger = null)
         {
             _dbService = dbService ?? throw new ArgumentNullException(nameof(dbService));
+            _auth = authorizationService ?? new NoOpAuthorizationService();
             _toolService = toolService; // may be null if inventory sync not desired
             _logger = logger ?? NullLogger<RentalService>.Instance;
         }
@@ -83,6 +86,7 @@ namespace ToolManagementAppV2.Services.Rentals
 
         public async Task RentToolAsync(int toolID, int customerID, DateTime rentalDate, DateTime dueDate)
         {
+            _auth.EnsureAdmin();
             await ExecuteWithTransactionAsync(async (conn, tx) =>
             {
                 var availCmd = new SQLiteCommand(
@@ -111,6 +115,7 @@ namespace ToolManagementAppV2.Services.Rentals
 
         public async Task ReturnToolAsync(int rentalID, DateTime returnDate)
         {
+            _auth.EnsureAdmin();
             await ExecuteWithTransactionAsync(async (conn, tx) =>
             {
                 var selCmd = new SQLiteCommand(
@@ -135,6 +140,7 @@ namespace ToolManagementAppV2.Services.Rentals
 
         public async Task ExtendRentalAsync(int rentalID, DateTime newDueDate)
         {
+            _auth.EnsureAdmin();
             await ExecuteWithTransactionAsync(async (conn, tx) =>
             {
                 var selectCmd = new SQLiteCommand(
@@ -168,6 +174,7 @@ namespace ToolManagementAppV2.Services.Rentals
 
         public async Task DeleteRentalAsync(int rentalID)
         {
+            _auth.EnsureAdmin();
             const string sql = "DELETE FROM Rentals WHERE RentalID = @RentalID";
             var p = new[] { new SQLiteParameter("@RentalID", rentalID) };
             using var conn = _dbService.CreateConnection();

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -7,6 +7,7 @@ using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using ToolManagementAppV2.Services.Users;
 
 namespace ToolManagementAppV2.Services.Settings
 {
@@ -14,14 +15,16 @@ namespace ToolManagementAppV2.Services.Settings
     {
         readonly DatabaseService _dbService;
         readonly ILogger<SettingsService> _logger;
+        readonly IAuthorizationService _auth;
         const string UpsertSql = @"
             INSERT INTO Settings (Key, Value) 
             VALUES (@Key, @Value)
             ON CONFLICT(Key) DO UPDATE SET Value = @Value";
 
-        public SettingsService(DatabaseService dbService, ILogger<SettingsService>? logger = null)
+        public SettingsService(DatabaseService dbService, IAuthorizationService? authorizationService = null, ILogger<SettingsService>? logger = null)
         {
             _dbService = dbService;
+            _auth = authorizationService ?? new NoOpAuthorizationService();
             _logger = logger ?? NullLogger<SettingsService>.Instance;
         }
 
@@ -30,6 +33,7 @@ namespace ToolManagementAppV2.Services.Settings
 
         public async Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
         {
+            _auth.EnsureAdmin();
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentException("Key cannot be null or empty.", nameof(key));
 
@@ -138,6 +142,7 @@ namespace ToolManagementAppV2.Services.Settings
 
         public async Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
         {
+            _auth.EnsureAdmin();
             if (settings == null)
                 throw new ArgumentNullException(nameof(settings));
 
@@ -187,6 +192,7 @@ namespace ToolManagementAppV2.Services.Settings
 
         public async Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
         {
+            _auth.EnsureAdmin();
             try
             {
                 const string sql = "DELETE FROM Settings WHERE Key = @Key";
@@ -284,6 +290,7 @@ namespace ToolManagementAppV2.Services.Settings
 
         public async Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default)
         {
+            _auth.EnsureAdmin();
             if (ipAddresses == null)
             {
                 await DeleteSettingAsync(ScannerIpKey, cancellationToken).ConfigureAwait(false);
@@ -338,6 +345,7 @@ namespace ToolManagementAppV2.Services.Settings
 
         public async Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default)
         {
+            _auth.EnsureAdmin();
             if (iterations <= 0)
                 throw new ArgumentOutOfRangeException(nameof(iterations));
             await SaveSettingAsync(PasswordIterationsKey, iterations.ToString(), cancellationToken).ConfigureAwait(false);

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -14,6 +14,7 @@ using ToolManagementAppV2.Interfaces;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using ToolManagementAppV2.Services.Users;
 
 namespace ToolManagementAppV2.Services.Tools
 {
@@ -30,10 +31,12 @@ namespace ToolManagementAppV2.Services.Tools
         const int MaxSearchTerms = 10;
     
         readonly ILogger<ToolService> _logger;
+        readonly IAuthorizationService _auth;
 
-        public ToolService(DatabaseService dbService, ILogger<ToolService>? logger = null)
+        public ToolService(DatabaseService dbService, IAuthorizationService? authorizationService = null, ILogger<ToolService>? logger = null)
         {
             _dbService = dbService;
+            _auth = authorizationService ?? new NoOpAuthorizationService();
             _logger = logger ?? NullLogger<ToolService>.Instance;
         }
 
@@ -44,16 +47,28 @@ namespace ToolManagementAppV2.Services.Tools
         }
 
         public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default)
-            => AddToolInternalAsync(tool, cancellationToken);
+        {
+            _auth.EnsureAdmin();
+            return AddToolInternalAsync(tool, cancellationToken);
+        }
 
         public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default)
-            => UpdateToolInternalAsync(tool, cancellationToken);
+        {
+            _auth.EnsureAdmin();
+            return UpdateToolInternalAsync(tool, cancellationToken);
+        }
 
         public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default)
-            => DeleteToolInternalAsync(toolID, cancellationToken);
+        {
+            _auth.EnsureAdmin();
+            return DeleteToolInternalAsync(toolID, cancellationToken);
+        }
 
         public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default)
-            => ToggleToolCheckOutStatusInternalAsync(toolID, currentUser, cancellationToken);
+        {
+            _auth.EnsureAdmin();
+            return ToggleToolCheckOutStatusInternalAsync(toolID, currentUser, cancellationToken);
+        }
 
         public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default)
         {
@@ -65,6 +80,7 @@ namespace ToolManagementAppV2.Services.Tools
 
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default)
         {
+            _auth.EnsureAdmin();
             const string sql = "UPDATE Tools SET ToolImagePath=@Img WHERE ToolID=@ID";
             var p = new[]
             {
@@ -76,13 +92,19 @@ namespace ToolManagementAppV2.Services.Tools
         }
 
         public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
-            => ImportToolsFromCsvInternalAsync(filePath, map, cancellationToken);
+        {
+            _auth.EnsureAdmin();
+            return ImportToolsFromCsvInternalAsync(filePath, map, cancellationToken);
+        }
 
         public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default)
             => ExportToolsToCsvInternalAsync(filePath, cancellationToken);
 
         public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default)
-            => ImportToolImagesInternalAsync(folderPath, keySelector, cancellationToken);
+        {
+            _auth.EnsureAdmin();
+            return ImportToolImagesInternalAsync(folderPath, keySelector, cancellationToken);
+        }
 
         async Task InsertToolAsync(SQLiteConnection conn, SQLiteTransaction? tran, ToolModel tool, CancellationToken cancellationToken)
         {

--- a/ToolManagementAppV2/Services/Users/AuthorizationService.cs
+++ b/ToolManagementAppV2/Services/Users/AuthorizationService.cs
@@ -1,0 +1,28 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using ToolManagementAppV2.Interfaces;
+
+namespace ToolManagementAppV2.Services.Users
+{
+    public class AuthorizationService : IAuthorizationService
+    {
+        private readonly IUserContext _userContext;
+        private readonly ILogger<AuthorizationService> _logger;
+
+        public AuthorizationService(IUserContext userContext, ILogger<AuthorizationService>? logger = null)
+        {
+            _userContext = userContext;
+            _logger = logger ?? NullLogger<AuthorizationService>.Instance;
+        }
+
+        public void EnsureAdmin()
+        {
+            if (!_userContext.IsAdmin)
+            {
+                _logger.LogWarning("Unauthorized access attempt by {User}", _userContext.UserName);
+                throw new UnauthorizedAccessException("Admin privileges required.");
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/Services/Users/NoOpAuthorizationService.cs
+++ b/ToolManagementAppV2/Services/Users/NoOpAuthorizationService.cs
@@ -1,0 +1,9 @@
+using ToolManagementAppV2.Interfaces;
+
+namespace ToolManagementAppV2.Services.Users
+{
+    public class NoOpAuthorizationService : IAuthorizationService
+    {
+        public void EnsureAdmin() { }
+    }
+}

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -17,11 +17,13 @@ namespace ToolManagementAppV2.Services.Users
         readonly DatabaseService _dbService;
         readonly IUserContext _context;
         readonly ILogger<UserService> _logger;
+        readonly IAuthorizationService _auth;
 
-        public UserService(DatabaseService dbService, IUserContext context, ILogger<UserService>? logger = null)
+        public UserService(DatabaseService dbService, IUserContext context, IAuthorizationService? authorizationService = null, ILogger<UserService>? logger = null)
         {
             _dbService = dbService;
             _context = context;
+            _auth = authorizationService ?? new NoOpAuthorizationService();
             _logger = logger ?? NullLogger<UserService>.Instance;
         }
 
@@ -166,6 +168,7 @@ namespace ToolManagementAppV2.Services.Users
 
         public async Task AddUserAsync(User user)
         {
+            _auth.EnsureAdmin();
             const string sql = @"
                 INSERT INTO Users
                   (UserName, Password, Salt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, FailedAttempts, LockoutUntil, PasswordExpired)
@@ -229,6 +232,7 @@ namespace ToolManagementAppV2.Services.Users
 
         public async Task UpdateUserAsync(User user)
         {
+            _auth.EnsureAdmin();
             const string sql = @"
                 UPDATE Users SET
                   UserName      = @UserName,
@@ -277,6 +281,7 @@ namespace ToolManagementAppV2.Services.Users
 
         public async Task<bool> ChangeUserPasswordAsync(int userID, string newPassword)
         {
+            _auth.EnsureAdmin();
             var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt, PasswordExpired=@Expired WHERE UserID=@ID";
             string hashed = string.Empty;
             string salt = string.Empty;
@@ -312,6 +317,7 @@ namespace ToolManagementAppV2.Services.Users
 
         public async Task<bool> TryDeleteUserAsync(int userID)
         {
+            _auth.EnsureAdmin();
             var user = await GetUserByIDAsync(userID);
             if (user == null) return false;
             if (user.IsAdmin)

--- a/ToolManagementAppV2/ViewModels/CustomerManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/CustomerManagementViewModel.cs
@@ -91,9 +91,16 @@ namespace ToolManagementAppV2.ViewModels
             var customer = _dialogService.ShowAddCustomerDialog();
             if (customer == null) return;
 
-            await _customerService.AddCustomerAsync(customer);
-            await LoadCustomersAsync();
-            ClearNewCustomerFields();
+            try
+            {
+                await _customerService.AddCustomerAsync(customer);
+                await LoadCustomersAsync();
+                ClearNewCustomerFields();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to add customers.", "Unauthorized");
+            }
         }
 
         async Task UpdateCustomerAsync()
@@ -110,8 +117,15 @@ namespace ToolManagementAppV2.ViewModels
                 Address = NewCustomerAddress
             };
 
-            await _customerService.UpdateCustomerAsync(updated);
-            await LoadCustomersAsync();
+            try
+            {
+                await _customerService.UpdateCustomerAsync(updated);
+                await LoadCustomersAsync();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to update customers.", "Unauthorized");
+            }
         }
 
         async Task SearchCustomersAsync()
@@ -146,9 +160,16 @@ namespace ToolManagementAppV2.ViewModels
             if (SelectedCustomer == null)
                 return;
 
-            await _customerService.DeleteCustomerAsync(SelectedCustomer.CustomerID);
-            await SearchCustomersAsync();
-            SelectedCustomer = null;
+            try
+            {
+                await _customerService.DeleteCustomerAsync(SelectedCustomer.CustomerID);
+                await SearchCustomersAsync();
+                SelectedCustomer = null;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to delete customers.", "Unauthorized");
+            }
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
@@ -177,6 +177,10 @@ namespace ToolManagementAppV2.ViewModels
                 await _rentalService.ReturnToolAsync(SelectedRental.RentalID, DateTime.Today);
                 await LoadRentalsAsync();
             }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to check in rentals.", "Unauthorized");
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to check in rental {RentalID}", SelectedRental.RentalID);
@@ -193,6 +197,10 @@ namespace ToolManagementAppV2.ViewModels
                 var newDueDate = SelectedRental.DueDate.AddDays(7);
                 await _rentalService.ExtendRentalAsync(SelectedRental.RentalID, newDueDate);
                 await LoadRentalsAsync();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to extend rentals.", "Unauthorized");
             }
             catch (Exception ex)
             {
@@ -295,6 +303,10 @@ namespace ToolManagementAppV2.ViewModels
                 _allRentals.Remove(rentalToDelete);
                 Rentals.Remove(rentalToDelete);
                 SelectedRental = null;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to delete rentals.", "Unauthorized");
             }
             catch (Exception ex)
             {

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -104,7 +104,16 @@ namespace ToolManagementAppV2.ViewModels
                     }
                 }
                 if (SetProperty(ref _passwordIterations, newValue))
-                    _settingsService.SavePasswordIterations(newValue);
+                {
+                    try
+                    {
+                        _settingsService.SavePasswordIterations(newValue);
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+                    }
+                }
             }
         }
 
@@ -147,7 +156,14 @@ namespace ToolManagementAppV2.ViewModels
                 return;
             }
 
-            _settingsService.SaveSetting("CompanyLogoPath", full);
+            try
+            {
+                _settingsService.SaveSetting("CompanyLogoPath", full);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+            }
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -209,6 +209,10 @@ namespace ToolManagementAppV2.ViewModels
                 await FilterToolsAsync(CancellationToken.None);
                 NewTool = new ToolModel();
             }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to add tools.", "Unauthorized");
+            }
             catch (InvalidOperationException ex)
             {
                 _logger.LogError(ex, "Failed to add tool due to invalid operation");
@@ -249,10 +253,17 @@ namespace ToolManagementAppV2.ViewModels
             var updated = await _dialogService.ShowEditToolDialogAsync(clone);
             if (updated == null) return;
 
-            await _toolService.UpdateToolAsync(updated);
-            await LoadToolsAsync();
-            await FilterToolsAsync(CancellationToken.None);
-            SelectedTool = Tools.FirstOrDefault(t => t.ToolID == updated.ToolID);
+            try
+            {
+                await _toolService.UpdateToolAsync(updated);
+                await LoadToolsAsync();
+                await FilterToolsAsync(CancellationToken.None);
+                SelectedTool = Tools.FirstOrDefault(t => t.ToolID == updated.ToolID);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to update tools.", "Unauthorized");
+            }
         }
 
         void ViewDetails()
@@ -276,6 +287,10 @@ namespace ToolManagementAppV2.ViewModels
                 await LoadToolsAsync();
                 await FilterToolsAsync(CancellationToken.None);
                 SelectedTool = null;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to delete tools.", "Unauthorized");
             }
             catch (Exception ex)
             {
@@ -301,6 +316,10 @@ namespace ToolManagementAppV2.ViewModels
                         dueDate);
                     await LoadToolsAsync();
                 }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to rent tools.", "Unauthorized");
             }
             catch (Exception ex)
             {

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -122,6 +122,10 @@ namespace ToolManagementAppV2.ViewModels
                 var idx = Users.IndexOf(SelectedUser);
                 if (idx >= 0) Users[idx] = SelectedUser;
             }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to update users.", "Unauthorized");
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to update user photo");
@@ -139,6 +143,10 @@ namespace ToolManagementAppV2.ViewModels
                 if (idxAll >= 0) _allUsers[idxAll] = SelectedUser;
                 var idx = Users.IndexOf(SelectedUser);
                 if (idx >= 0) Users[idx] = SelectedUser;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to update users.", "Unauthorized");
             }
             catch (Exception ex)
             {
@@ -189,6 +197,10 @@ namespace ToolManagementAppV2.ViewModels
                 _allUsers.Add(newUser);
                 Users.Add(newUser);
                 SelectedUser = newUser;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to add users.", "Unauthorized");
             }
             catch (Exception ex)
             {
@@ -282,6 +294,10 @@ namespace ToolManagementAppV2.ViewModels
                         if (ReferenceEquals(SelectedUser, user)) SelectedUser = clone;
                         win.DialogResult = true;
                     }
+                    catch (UnauthorizedAccessException)
+                    {
+                        _dialogService.ShowInfo("You are not authorized to update users.", "Unauthorized");
+                    }
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, "Failed to update user");
@@ -299,17 +315,24 @@ namespace ToolManagementAppV2.ViewModels
         {
             if (user == null) return;
             var newPassword = SecurityHelper.GeneratePassword();
-            await _userService.ChangeUserPasswordAsync(user.UserID, newPassword);
-            var refreshed = await _userService.GetUserByIDAsync(user.UserID);
-            if (refreshed != null)
+            try
             {
-                refreshed.PasswordExpired = true;
-                await _userService.UpdateUserAsync(refreshed);
-                user.Password = refreshed.Password;
-                user.Salt = refreshed.Salt;
-                user.PasswordExpired = true;
+                await _userService.ChangeUserPasswordAsync(user.UserID, newPassword);
+                var refreshed = await _userService.GetUserByIDAsync(user.UserID);
+                if (refreshed != null)
+                {
+                    refreshed.PasswordExpired = true;
+                    await _userService.UpdateUserAsync(refreshed);
+                    user.Password = refreshed.Password;
+                    user.Salt = refreshed.Salt;
+                    user.PasswordExpired = true;
+                }
+                _dialogService.ShowInfo("Password has been reset. The user must change it at next login.", "Password Reset");
             }
-            _dialogService.ShowInfo("Password has been reset. The user must change it at next login.", "Password Reset");
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to reset passwords.", "Unauthorized");
+            }
         }
 
         async Task DeleteUserAsync(UserModel user)
@@ -329,6 +352,10 @@ namespace ToolManagementAppV2.ViewModels
                     _logger.LogWarning("Failed to delete user {UserID}", user.UserID);
                     await _dialogService.ShowInfoAsync("Failed to delete user.", "Error");
                 }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to delete users.", "Unauthorized");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- add `IAuthorizationService` with `EnsureAdmin` and implementation with warning logs
- gate mutating service methods through `EnsureAdmin`
- surface authorization failures in view models and register service in DI

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a058cb18e4832491b114e0d6043306