### PR TITLE
Add cancellation tokens across customer flows

### DIFF
--- a/ToolManagementAppV2.Tests/AsyncServiceExtensions.cs
+++ b/ToolManagementAppV2.Tests/AsyncServiceExtensions.cs
@@ -25,22 +25,22 @@ public static class AsyncServiceExtensions
         => svc.SearchToolsAsync(text, token).GetAwaiter().GetResult();
 
     // CustomerService wrappers
-    public static void AddCustomer(this ICustomerService svc, Customer customer)
-        => svc.AddCustomerAsync(customer).GetAwaiter().GetResult();
-    public static void UpdateCustomer(this ICustomerService svc, Customer customer)
-        => svc.UpdateCustomerAsync(customer).GetAwaiter().GetResult();
-    public static void DeleteCustomer(this ICustomerService svc, int id)
-        => svc.DeleteCustomerAsync(id).GetAwaiter().GetResult();
-    public static Customer GetCustomerByID(this ICustomerService svc, int id)
-        => svc.GetCustomerByIDAsync(id).GetAwaiter().GetResult();
-    public static List<Customer> GetAllCustomers(this ICustomerService svc)
-        => svc.GetAllCustomersAsync().GetAwaiter().GetResult();
-    public static List<Customer> SearchCustomers(this ICustomerService svc, string term)
-        => svc.SearchCustomersAsync(term).GetAwaiter().GetResult();
-    public static CustomerImportResult ImportCustomersFromCsv(this ICustomerService svc, string path, IDictionary<string,string> map)
-        => svc.ImportCustomersFromCsvAsync(path, map).GetAwaiter().GetResult();
-    public static void ExportCustomersToCsv(this ICustomerService svc, string path)
-        => svc.ExportCustomersToCsvAsync(path).GetAwaiter().GetResult();
+    public static void AddCustomer(this ICustomerService svc, Customer customer, CancellationToken token = default)
+        => svc.AddCustomerAsync(customer, token).GetAwaiter().GetResult();
+    public static void UpdateCustomer(this ICustomerService svc, Customer customer, CancellationToken token = default)
+        => svc.UpdateCustomerAsync(customer, token).GetAwaiter().GetResult();
+    public static void DeleteCustomer(this ICustomerService svc, int id, CancellationToken token = default)
+        => svc.DeleteCustomerAsync(id, token).GetAwaiter().GetResult();
+    public static Customer GetCustomerByID(this ICustomerService svc, int id, CancellationToken token = default)
+        => svc.GetCustomerByIDAsync(id, token).GetAwaiter().GetResult();
+    public static List<Customer> GetAllCustomers(this ICustomerService svc, CancellationToken token = default)
+        => svc.GetAllCustomersAsync(token).GetAwaiter().GetResult();
+    public static List<Customer> SearchCustomers(this ICustomerService svc, string term, CancellationToken token = default)
+        => svc.SearchCustomersAsync(term, token).GetAwaiter().GetResult();
+    public static CustomerImportResult ImportCustomersFromCsv(this ICustomerService svc, string path, IDictionary<string,string> map, CancellationToken token = default)
+        => svc.ImportCustomersFromCsvAsync(path, map, token).GetAwaiter().GetResult();
+    public static void ExportCustomersToCsv(this ICustomerService svc, string path, CancellationToken token = default)
+        => svc.ExportCustomersToCsvAsync(path, token).GetAwaiter().GetResult();
 
     // RentalService wrappers
     public static void RentTool(this IRentalService svc, int toolID, int customerID, DateTime rentalDate, DateTime dueDate)

--- a/ToolManagementAppV2.Tests/Services/CustomerServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/CustomerServiceTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using ToolManagementAppV2.Models.ImportExport;
 using Microsoft.Extensions.Logging;
 using ToolManagementAppV2.Tests;
+using System.Threading;
 
 namespace ToolManagementAppV2.Tests.Services
 {
@@ -205,6 +206,51 @@ namespace ToolManagementAppV2.Tests.Services
             }
             finally
             {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task GetAllCustomersAsync_RespectsCancellation()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var service = new CustomerService(dbService);
+                var cts = new CancellationTokenSource();
+                cts.Cancel();
+                await Assert.ThrowsAsync<OperationCanceledException>(() => service.GetAllCustomersAsync(cts.Token));
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task ImportCustomersFromCsvAsync_RespectsCancellation()
+        {
+            var dbPath = Path.GetTempFileName();
+            var csvPath = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(csvPath, "Company,Contact,Phone\nAcme,John,1\nBeta,Jane,2");
+                var dbService = new DatabaseService(dbPath);
+                var service = new CustomerService(dbService);
+                var map = new Dictionary<string, string>
+                {
+                    {"Company", "Company"},
+                    {"Contact", "Contact"},
+                    {"Phone", "Phone"}
+                };
+                var cts = new CancellationTokenSource();
+                cts.Cancel();
+                await Assert.ThrowsAsync<OperationCanceledException>(() => service.ImportCustomersFromCsvAsync(csvPath, map, cts.Token));
+            }
+            finally
+            {
+                if (File.Exists(csvPath)) File.Delete(csvPath);
                 if (File.Exists(dbPath)) File.Delete(dbPath);
             }
         }

--- a/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
@@ -100,21 +100,21 @@ public class ReportServiceAsyncTests
         public DelayCustomerService(int delay, int count)
         { _delay = delay; _customers = new List<Customer>(new Customer[count]); }
         public List<Customer> GetAllCustomers() => _customers;
-        public Task<List<Customer>> GetAllCustomersAsync() => Task.Delay(_delay).ContinueWith(_ => _customers);
+        public Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => Task.Delay(_delay, cancellationToken).ContinueWith(_ => _customers, cancellationToken);
         public void AddCustomer(Customer customer) => throw new NotImplementedException();
-        public Task AddCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void UpdateCustomer(Customer customer) => throw new NotImplementedException();
-        public Task UpdateCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void DeleteCustomer(int customerID) => throw new NotImplementedException();
-        public Task DeleteCustomerAsync(int customerID) => throw new NotImplementedException();
+        public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Customer GetCustomerByID(int customerID) => throw new NotImplementedException();
-        public Task<Customer> GetCustomerByIDAsync(int customerID) => throw new NotImplementedException();
+        public Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public List<Customer> SearchCustomers(string searchTerm) => throw new NotImplementedException();
-        public Task<List<Customer>> SearchCustomersAsync(string searchTerm) => throw new NotImplementedException();
+        public Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public CustomerImportResult ImportCustomersFromCsv(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
-        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map) => throw new NotImplementedException();
+        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void ExportCustomersToCsv(string filePath) => throw new NotImplementedException();
-        public Task ExportCustomersToCsvAsync(string filePath) => throw new NotImplementedException();
+        public Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 
     class DelayUserService : IUserService

--- a/ToolManagementAppV2.Tests/ViewModels/DashboardViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/DashboardViewModelTests.cs
@@ -9,6 +9,7 @@ using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
+using System.Threading;
 
 namespace ToolManagementAppV2.Tests.ViewModels
 {
@@ -93,6 +94,33 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     nullParam == "openImportExportCommand" ? null : importCmd));
 
                 Assert.Equal(nullParam, ex.ParamName);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task LoadStatsAsync_CanBeCancelled()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                IUserService userService = new UserService(db, new ApplicationUserContext());
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+                var vm = new DashboardViewModel(toolService, rentalService, customerService, userService, activityLogService,
+                    new RelayCommand(() => { }), new RelayCommand(() => { }), new RelayCommand(() => { }));
+                vm.StatCards.Clear();
+                var cts = new CancellationTokenSource();
+                cts.Cancel();
+                await vm.LoadStatsAsync(cts.Token);
+                Assert.Empty(vm.StatCards);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -196,24 +196,24 @@ namespace ToolManagementAppV2.Tests.ViewModels
             return new CustomerImportResult();
         }
         public void ExportCustomersToCsv(string filePath) => ExportCalled = true;
-        public System.Threading.Tasks.Task ExportCustomersToCsvAsync(string filePath)
+        public System.Threading.Tasks.Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default)
         {
             ExportCalled = true;
             return System.Threading.Tasks.Task.CompletedTask;
         }
         public void AddCustomer(Customer customer) => throw new NotImplementedException();
-        public System.Threading.Tasks.Task AddCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void UpdateCustomer(Customer customer) => throw new NotImplementedException();
-        public System.Threading.Tasks.Task UpdateCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void DeleteCustomer(int customerID) => throw new NotImplementedException();
-        public System.Threading.Tasks.Task DeleteCustomerAsync(int customerID) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Customer GetCustomerByID(int customerID) => throw new NotImplementedException();
-        public System.Threading.Tasks.Task<Customer> GetCustomerByIDAsync(int customerID) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public List<Customer> GetAllCustomers() => new();
-        public System.Threading.Tasks.Task<List<Customer>> GetAllCustomersAsync() => System.Threading.Tasks.Task.FromResult(new List<Customer>());
+        public System.Threading.Tasks.Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.FromResult(new List<Customer>());
         public List<Customer> SearchCustomers(string searchTerm) => new();
-        public System.Threading.Tasks.Task<List<Customer>> SearchCustomersAsync(string searchTerm) => System.Threading.Tasks.Task.FromResult(new List<Customer>());
-        public System.Threading.Tasks.Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map)
+        public System.Threading.Tasks.Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.FromResult(new List<Customer>());
+        public System.Threading.Tasks.Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default)
         {
             ImportCalled = true;
             MapUsed = map;
@@ -264,40 +264,40 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public CustomerImportResult ImportCustomersFromCsv(string filePath, IDictionary<string, string> map) => new CustomerImportResult();
         public void ExportCustomersToCsv(string filePath) { }
-        public System.Threading.Tasks.Task ExportCustomersToCsvAsync(string filePath) => System.Threading.Tasks.Task.CompletedTask;
+        public System.Threading.Tasks.Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.CompletedTask;
         public void AddCustomer(Customer customer) => throw new NotImplementedException();
-        public System.Threading.Tasks.Task AddCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void UpdateCustomer(Customer customer) => throw new NotImplementedException();
-        public System.Threading.Tasks.Task UpdateCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void DeleteCustomer(int customerID) => throw new NotImplementedException();
-        public System.Threading.Tasks.Task DeleteCustomerAsync(int customerID) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Customer GetCustomerByID(int customerID) => throw new NotImplementedException();
-        public System.Threading.Tasks.Task<Customer> GetCustomerByIDAsync(int customerID) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public List<Customer> GetAllCustomers() => new();
-        public System.Threading.Tasks.Task<List<Customer>> GetAllCustomersAsync() => System.Threading.Tasks.Task.FromResult(new List<Customer>());
+        public System.Threading.Tasks.Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.FromResult(new List<Customer>());
         public List<Customer> SearchCustomers(string searchTerm) => new();
-        public System.Threading.Tasks.Task<List<Customer>> SearchCustomersAsync(string searchTerm) => System.Threading.Tasks.Task.FromResult(new List<Customer>());
-        public System.Threading.Tasks.Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map) => System.Threading.Tasks.Task.FromResult(new CustomerImportResult());
+        public System.Threading.Tasks.Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.FromResult(new List<Customer>());
+        public System.Threading.Tasks.Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.FromResult(new CustomerImportResult());
     }
 
     class FailCustomerService : ICustomerService
     {
         public CustomerImportResult ImportCustomersFromCsv(string filePath, IDictionary<string, string> map) => new CustomerImportResult();
         public void ExportCustomersToCsv(string filePath) => throw new System.Exception("fail");
-        public System.Threading.Tasks.Task ExportCustomersToCsvAsync(string filePath) => System.Threading.Tasks.Task.FromException(new System.Exception("fail"));
+        public System.Threading.Tasks.Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.FromException(new System.Exception("fail"));
         public void AddCustomer(Customer customer) => throw new NotImplementedException();
-        public System.Threading.Tasks.Task AddCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void UpdateCustomer(Customer customer) => throw new NotImplementedException();
-        public System.Threading.Tasks.Task UpdateCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void DeleteCustomer(int customerID) => throw new NotImplementedException();
-        public System.Threading.Tasks.Task DeleteCustomerAsync(int customerID) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Customer GetCustomerByID(int customerID) => throw new NotImplementedException();
-        public System.Threading.Tasks.Task<Customer> GetCustomerByIDAsync(int customerID) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public List<Customer> GetAllCustomers() => new();
-        public System.Threading.Tasks.Task<List<Customer>> GetAllCustomersAsync() => System.Threading.Tasks.Task.FromResult(new List<Customer>());
+        public System.Threading.Tasks.Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.FromResult(new List<Customer>());
         public List<Customer> SearchCustomers(string searchTerm) => new();
-        public System.Threading.Tasks.Task<List<Customer>> SearchCustomersAsync(string searchTerm) => System.Threading.Tasks.Task.FromResult(new List<Customer>());
-        public System.Threading.Tasks.Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map) => System.Threading.Tasks.Task.FromResult(new CustomerImportResult());
+        public System.Threading.Tasks.Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.FromResult(new List<Customer>());
+        public System.Threading.Tasks.Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.FromResult(new CustomerImportResult());
     }
 
     class StubDatabaseBackupService : IDatabaseBackupService

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -293,24 +293,24 @@ namespace ToolManagementAppV2.Tests.ViewModels
             return new CustomerImportResult();
         }
         public void ExportCustomersToCsv(string filePath) => ExportCalled = true;
-        public Task ExportCustomersToCsvAsync(string filePath)
+        public Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default)
         {
             ExportCalled = true;
             return Task.CompletedTask;
         }
         public void AddCustomer(Customer customer) => throw new System.NotImplementedException();
-        public Task AddCustomerAsync(Customer customer) => throw new System.NotImplementedException();
+        public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public void UpdateCustomer(Customer customer) => throw new System.NotImplementedException();
-        public Task UpdateCustomerAsync(Customer customer) => throw new System.NotImplementedException();
+        public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public void DeleteCustomer(int customerID) => throw new System.NotImplementedException();
-        public Task DeleteCustomerAsync(int customerID) => throw new System.NotImplementedException();
+        public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Customer GetCustomerByID(int customerID) => throw new System.NotImplementedException();
-        public Task<Customer> GetCustomerByIDAsync(int customerID) => throw new System.NotImplementedException();
+        public Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public List<Customer> GetAllCustomers() => new();
-        public Task<List<Customer>> GetAllCustomersAsync() => Task.FromResult(new List<Customer>());
+        public Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
         public List<Customer> SearchCustomers(string searchTerm) => new();
-        public Task<List<Customer>> SearchCustomersAsync(string searchTerm) => Task.FromResult(new List<Customer>());
-        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map)
+        public Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
+        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default)
         {
             ImportCalled = true;
             return Task.FromResult(new CustomerImportResult());
@@ -320,21 +320,21 @@ namespace ToolManagementAppV2.Tests.ViewModels
     class FailCustomerService : ICustomerService
     {
         public CustomerImportResult ImportCustomersFromCsv(string filePath, IDictionary<string, string> map) => throw new System.Exception("fail");
-        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map) => throw new System.Exception("fail");
+        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default) => throw new System.Exception("fail");
         public void ExportCustomersToCsv(string filePath) => throw new System.Exception("fail");
-        public Task ExportCustomersToCsvAsync(string filePath) => throw new System.Exception("fail");
+        public Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new System.Exception("fail");
         public void AddCustomer(Customer customer) => throw new System.NotImplementedException();
-        public Task AddCustomerAsync(Customer customer) => throw new System.NotImplementedException();
+        public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public void UpdateCustomer(Customer customer) => throw new System.NotImplementedException();
-        public Task UpdateCustomerAsync(Customer customer) => throw new System.NotImplementedException();
+        public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public void DeleteCustomer(int customerID) => throw new System.NotImplementedException();
-        public Task DeleteCustomerAsync(int customerID) => throw new System.NotImplementedException();
+        public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Customer GetCustomerByID(int customerID) => throw new System.NotImplementedException();
-        public Task<Customer> GetCustomerByIDAsync(int customerID) => throw new System.NotImplementedException();
+        public Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public List<Customer> GetAllCustomers() => new();
-        public Task<List<Customer>> GetAllCustomersAsync() => Task.FromResult(new List<Customer>());
+        public Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
         public List<Customer> SearchCustomers(string searchTerm) => new();
-        public Task<List<Customer>> SearchCustomersAsync(string searchTerm) => Task.FromResult(new List<Customer>());
+        public Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
     }
 
     class StubDatabaseBackupService : IDatabaseBackupService

--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -623,6 +623,21 @@ namespace ToolManagementAppV2.Tests.ViewModels
             Assert.False(timer.IsEnabled);
         }
 
+        [Fact]
+        public async Task SearchCommand_CanBeCancelled()
+        {
+            var tools = new List<ToolModel>
+            {
+                new Tool { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" }
+            };
+            var toolService = new CountingToolService(tools);
+            var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
+            vm.SearchTerm = "Ham";
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(() => vm.SearchCommand.ExecuteAsync(cts.Token));
+        }
+
         class CountingToolService : IToolService
         {
             public int GetAllToolsAsyncCalls { get; private set; }

--- a/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
@@ -122,20 +122,20 @@ namespace ToolManagementAppV2.Tests.Views
     {
         public CustomerImportResult ImportCustomersFromCsv(string filePath, System.Collections.Generic.IDictionary<string, string> map) => new CustomerImportResult();
         public void ExportCustomersToCsv(string filePath) { }
-        public System.Threading.Tasks.Task ExportCustomersToCsvAsync(string filePath) => System.Threading.Tasks.Task.CompletedTask;
+        public System.Threading.Tasks.Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.CompletedTask;
         public void AddCustomer(Customer customer) => throw new NotImplementedException();
-        public System.Threading.Tasks.Task AddCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void UpdateCustomer(Customer customer) => throw new NotImplementedException();
-        public System.Threading.Tasks.Task UpdateCustomerAsync(Customer customer) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void DeleteCustomer(int customerID) => throw new NotImplementedException();
-        public System.Threading.Tasks.Task DeleteCustomerAsync(int customerID) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Customer GetCustomerByID(int customerID) => throw new NotImplementedException();
-        public System.Threading.Tasks.Task<Customer> GetCustomerByIDAsync(int customerID) => throw new NotImplementedException();
+        public System.Threading.Tasks.Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public System.Collections.Generic.List<Customer> GetAllCustomers() => new();
-        public System.Threading.Tasks.Task<System.Collections.Generic.List<Customer>> GetAllCustomersAsync() => System.Threading.Tasks.Task.FromResult(new System.Collections.Generic.List<Customer>());
+        public System.Threading.Tasks.Task<System.Collections.Generic.List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.FromResult(new System.Collections.Generic.List<Customer>());
         public System.Collections.Generic.List<Customer> SearchCustomers(string searchTerm) => new();
-        public System.Threading.Tasks.Task<System.Collections.Generic.List<Customer>> SearchCustomersAsync(string searchTerm) => System.Threading.Tasks.Task.FromResult(new System.Collections.Generic.List<Customer>());
-        public System.Threading.Tasks.Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, System.Collections.Generic.IDictionary<string, string> map) => System.Threading.Tasks.Task.FromResult(new CustomerImportResult());
+        public System.Threading.Tasks.Task<System.Collections.Generic.List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.FromResult(new System.Collections.Generic.List<Customer>());
+        public System.Threading.Tasks.Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, System.Collections.Generic.IDictionary<string, string> map, CancellationToken cancellationToken = default) => System.Threading.Tasks.Task.FromResult(new CustomerImportResult());
     }
 
     class StubDatabaseBackupService : IDatabaseBackupService

--- a/ToolManagementAppV2/Interfaces/ICustomerService.cs
+++ b/ToolManagementAppV2/Interfaces/ICustomerService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
@@ -8,14 +9,14 @@ namespace ToolManagementAppV2.Interfaces
 {
     public interface ICustomerService
     {
-        Task AddCustomerAsync(Customer customer);
-        Task UpdateCustomerAsync(Customer customer);
-        Task DeleteCustomerAsync(int customerID);
-        Task<Customer> GetCustomerByIDAsync(int customerID);
-        Task<List<Customer>> GetAllCustomersAsync();
-        Task<List<Customer>> SearchCustomersAsync(string searchTerm);
-        Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map);
-        Task ExportCustomersToCsvAsync(string filePath);
+        Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default);
+        Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default);
+        Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default);
+        Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default);
+        Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default);
+        Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default);
+        Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default);
+        Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default);
     }
 }
 

--- a/ToolManagementAppV2/Services/Customers/CustomerService.cs
+++ b/ToolManagementAppV2/Services/Customers/CustomerService.cs
@@ -30,41 +30,41 @@ namespace ToolManagementAppV2.Services.Customers
             _logger = logger ?? NullLogger<CustomerService>.Instance;
         }
 
-        public Task AddCustomerAsync(CustomerModel customer)
+        public Task AddCustomerAsync(CustomerModel customer, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
-            return AddCustomerInternalAsync(customer, CancellationToken.None);
+            return AddCustomerInternalAsync(customer, cancellationToken);
         }
 
-        public Task UpdateCustomerAsync(CustomerModel customer)
+        public Task UpdateCustomerAsync(CustomerModel customer, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
-            return UpdateCustomerInternalAsync(customer, CancellationToken.None);
+            return UpdateCustomerInternalAsync(customer, cancellationToken);
         }
 
-        public Task DeleteCustomerAsync(int customerID)
+        public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
-            return DeleteCustomerInternalAsync(customerID, CancellationToken.None);
+            return DeleteCustomerInternalAsync(customerID, cancellationToken);
         }
 
-        public Task<CustomerModel> GetCustomerByIDAsync(int customerID) =>
-            GetCustomerByIDInternalAsync(customerID, CancellationToken.None);
+        public Task<CustomerModel> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) =>
+            GetCustomerByIDInternalAsync(customerID, cancellationToken);
 
-        public Task<List<CustomerModel>> GetAllCustomersAsync() =>
-            GetAllCustomersInternalAsync(CancellationToken.None);
+        public Task<List<CustomerModel>> GetAllCustomersAsync(CancellationToken cancellationToken = default) =>
+            GetAllCustomersInternalAsync(cancellationToken);
 
-        public Task<List<CustomerModel>> SearchCustomersAsync(string searchTerm) =>
-            SearchCustomersInternalAsync(searchTerm, CancellationToken.None);
+        public Task<List<CustomerModel>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) =>
+            SearchCustomersInternalAsync(searchTerm, cancellationToken);
 
-        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map)
+        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
-            return ImportCustomersFromCsvInternalAsync(filePath, map, CancellationToken.None);
+            return ImportCustomersFromCsvInternalAsync(filePath, map, cancellationToken);
         }
 
-        public Task ExportCustomersToCsvAsync(string filePath) =>
-            ExportCustomersToCsvInternalAsync(filePath, CancellationToken.None);
+        public Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default) =>
+            ExportCustomersToCsvInternalAsync(filePath, cancellationToken);
 
         async Task AddCustomerInternalAsync(CustomerModel customer, CancellationToken cancellationToken)
         {

--- a/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
 using System.Threading;
+using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
@@ -69,23 +70,27 @@ namespace ToolManagementAppV2.ViewModels
                 catch (Exception ex) { _logger.LogError(ex, "Failed to open import/export page"); }
             });
 
-            _ = LoadStatsAsync();
+            _ = LoadStatsAsync(CancellationToken.None);
             LoadRecentActivity();
         }
 
-        async Task LoadStatsAsync()
+        internal async Task LoadStatsAsync(CancellationToken cancellationToken)
         {
             try
             {
                 StatCards.Clear();
-                var tools = await _toolService.GetAllToolsAsync(CancellationToken.None);
+                var tools = await _toolService.GetAllToolsAsync(cancellationToken);
                 StatCards.Add(new StatCard { Title = "Total Tools", Value = tools.Count.ToString() });
                 var activeRentals = await _rentalService.GetActiveRentalsAsync();
-                var customers = await _customerService.GetAllCustomersAsync();
+                var customers = await _customerService.GetAllCustomersAsync(cancellationToken);
                 var users = await _userService.GetAllUsersAsync();
                 StatCards.Add(new StatCard { Title = "Active Rentals", Value = activeRentals.Count.ToString() });
                 StatCards.Add(new StatCard { Title = "Total Customers", Value = customers.Count.ToString() });
                 StatCards.Add(new StatCard { Title = "Total Users", Value = users.Count.ToString() });
+            }
+            catch (OperationCanceledException)
+            {
+                // Swallow cancellations quietly.
             }
             catch (Exception ex)
             {

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -53,11 +53,11 @@ namespace ToolManagementAppV2.ViewModels
             _databaseService = databaseService;
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<ImportExportViewModel>.Instance;
-            ImportToolsCommand = new AsyncRelayCommand(ImportToolsAsync);
-            ExportToolsCommand = new AsyncRelayCommand(ExportToolsAsync);
-            ImportCustomersCommand = new AsyncRelayCommand(ImportCustomersAsync);
-            ExportCustomersCommand = new AsyncRelayCommand(ExportCustomersAsync);
-            BackupDatabaseCommand = new AsyncRelayCommand(BackupDatabaseAsync);
+            ImportToolsCommand = new AsyncRelayCommand(ct => ImportToolsAsync(ct));
+            ExportToolsCommand = new AsyncRelayCommand(ct => ExportToolsAsync(ct));
+            ImportCustomersCommand = new AsyncRelayCommand(ct => ImportCustomersAsync(ct));
+            ExportCustomersCommand = new AsyncRelayCommand(ct => ExportCustomersAsync(ct));
+            BackupDatabaseCommand = new AsyncRelayCommand(ct => BackupDatabaseAsync(ct));
         }
 
         async Task ImportToolsAsync(CancellationToken cancellationToken)
@@ -89,14 +89,18 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        async Task ExportToolsAsync()
+        async Task ExportToolsAsync(CancellationToken cancellationToken)
         {
             var path = _fileDialogService.SaveFile("CSV Files|*.csv");
             if (string.IsNullOrEmpty(path)) return;
             try
             {
-                await _toolService.ExportToolsToCsvAsync(path, CancellationToken.None);
+                await _toolService.ExportToolsToCsvAsync(path, cancellationToken);
                 ImportExportLogs.Add($"Successfully exported tools to {path}.");
+            }
+            catch (OperationCanceledException)
+            {
+                ImportExportLogs.Add("Tool export was cancelled.");
             }
             catch (Exception ex)
             {
@@ -105,7 +109,7 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        async Task ImportCustomersAsync()
+        async Task ImportCustomersAsync(CancellationToken cancellationToken)
         {
             var path = _fileDialogService.OpenFile("CSV Files|*.csv");
             if (string.IsNullOrEmpty(path)) return;
@@ -116,10 +120,14 @@ namespace ToolManagementAppV2.ViewModels
                 var map = _dialogService.ShowImportMapping(headers, properties);
                 if (map == null)
                     return;
-                var result = await _customerService.ImportCustomersFromCsvAsync(path, map);
+                var result = await _customerService.ImportCustomersFromCsvAsync(path, map, cancellationToken);
                 ImportExportLogs.Add($"Successfully imported customers from {path}. Imported {result.ImportedCount} customers.");
                 foreach (var msg in result.SkippedRows)
                     ImportExportLogs.Add($"Skipped {msg}");
+            }
+            catch (OperationCanceledException)
+            {
+                ImportExportLogs.Add("Customer import was cancelled.");
             }
             catch (Exception ex)
             {
@@ -128,14 +136,18 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        async Task ExportCustomersAsync()
+        async Task ExportCustomersAsync(CancellationToken cancellationToken)
         {
             var path = _fileDialogService.SaveFile("CSV Files|*.csv");
             if (string.IsNullOrEmpty(path)) return;
             try
             {
-                await _customerService.ExportCustomersToCsvAsync(path);
+                await _customerService.ExportCustomersToCsvAsync(path, cancellationToken);
                 ImportExportLogs.Add($"Successfully exported customers to {path}.");
+            }
+            catch (OperationCanceledException)
+            {
+                ImportExportLogs.Add("Customer export was cancelled.");
             }
             catch (Exception ex)
             {

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -242,11 +242,11 @@ namespace ToolManagementAppV2.ViewModels
                 CurrentPage = page;
             });
 
-            OpenImportMappingWindowCommand = new AsyncRelayCommand(OpenImportMappingWindowAsync);
+            OpenImportMappingWindowCommand = new AsyncRelayCommand(ct => OpenImportMappingWindowAsync(ct));
 
-            OpenImageImportMappingWindowCommand = new AsyncRelayCommand(OpenImageImportMappingWindowAsync);
+            OpenImageImportMappingWindowCommand = new AsyncRelayCommand(ct => OpenImageImportMappingWindowAsync(ct));
 
-            GlobalSearchCommand = new AsyncRelayCommand(GlobalSearchAsync);
+            GlobalSearchCommand = new AsyncRelayCommand(ct => GlobalSearchAsync(ct));
 
             SwitchUserCommand = new AsyncRelayCommand(async () =>
             {
@@ -324,7 +324,7 @@ namespace ToolManagementAppV2.ViewModels
             OpenDashboardCommand.Execute(null);
         }
 
-        async Task OpenImportMappingWindowAsync()
+        async Task OpenImportMappingWindowAsync(CancellationToken cancellationToken)
         {
             try
             {
@@ -345,7 +345,7 @@ namespace ToolManagementAppV2.ViewModels
                         string.Join(", ", headers),
                         mappingString);
                     await _dialogService.ShowInfoAsync("Importing tools...", "Import Tools");
-                    var invalid = await _toolService.ImportToolsFromCsvAsync(path, map, CancellationToken.None);
+                    var invalid = await _toolService.ImportToolsFromCsvAsync(path, map, cancellationToken);
                     var msg = invalid.Count == 0
                         ? "Successfully imported tools."
                         : $"Imported with {invalid.Count} invalid rows.";
@@ -359,7 +359,7 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        async Task OpenImageImportMappingWindowAsync()
+        async Task OpenImageImportMappingWindowAsync(CancellationToken cancellationToken)
         {
             using var dlg = new Forms.FolderBrowserDialog();
             if (dlg.ShowDialog() != Forms.DialogResult.OK)
@@ -367,7 +367,7 @@ namespace ToolManagementAppV2.ViewModels
             var selector = _dialogService.ShowImageImportMapping();
             if (selector != null)
             {
-                var result = await _toolService.ImportToolImagesAsync(dlg.SelectedPath, selector, CancellationToken.None);
+                var result = await _toolService.ImportToolImagesAsync(dlg.SelectedPath, selector, cancellationToken);
                 _dialogService.ShowInfo(
                     $"Imported {result.ImportedCount} images. Unmatched: {result.UnmatchedFiles.Count}, Conflicts: {result.ConflictingFiles.Count}",
                     "Import Images");

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -127,10 +127,10 @@ namespace ToolManagementAppV2.ViewModels
             SearchCommand = new AsyncRelayCommand<CancellationToken>(FilterToolsAsync);
             _searchDebounceTimer = searchDebounceTimer ?? new DispatcherTimerWrapper { Interval = TimeSpan.FromMilliseconds(300) };
             _searchDebounceTimer.Tick += OnSearchDebounceTimerTick;
-            NewToolCommand = new AsyncRelayCommand(AddToolAsync);
-            EditToolCommand = new AsyncRelayCommand(EditToolAsync, () => SelectedTool != null);
-            DeleteToolCommand = new AsyncRelayCommand(DeleteToolAsync);
-            OpenRentalsCommand = new AsyncRelayCommand(OpenRentalsAsync, () => SelectedTool != null);
+            NewToolCommand = new AsyncRelayCommand(ct => AddToolAsync(ct));
+            EditToolCommand = new AsyncRelayCommand(ct => EditToolAsync(ct), () => SelectedTool != null);
+            DeleteToolCommand = new AsyncRelayCommand(ct => DeleteToolAsync(ct));
+            OpenRentalsCommand = new AsyncRelayCommand(ct => OpenRentalsAsync(ct), () => SelectedTool != null);
             ViewDetailsCommand = new RelayCommand(ViewDetails, () => SelectedTool != null);
             // Ensure no duplicate event subscriptions when the view model is
             // constructed multiple times or the collection persists across
@@ -200,14 +200,18 @@ namespace ToolManagementAppV2.ViewModels
             LoadCategories(source, suppressSearch: true);
         }
 
-        async Task AddToolAsync()
+        async Task AddToolAsync(CancellationToken cancellationToken)
         {
             try
             {
-                await _toolService.AddToolAsync(NewTool);
+                await _toolService.AddToolAsync(NewTool, cancellationToken);
                 await LoadToolsAsync();
-                await FilterToolsAsync(CancellationToken.None);
+                await FilterToolsAsync(cancellationToken);
                 NewTool = new ToolModel();
+            }
+            catch (OperationCanceledException)
+            {
+                // Ignore cancellation
             }
             catch (UnauthorizedAccessException)
             {
@@ -225,7 +229,7 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        async Task EditToolAsync()
+        async Task EditToolAsync(CancellationToken cancellationToken)
         {
             if (SelectedTool == null) return;
 
@@ -255,10 +259,14 @@ namespace ToolManagementAppV2.ViewModels
 
             try
             {
-                await _toolService.UpdateToolAsync(updated);
+                await _toolService.UpdateToolAsync(updated, cancellationToken);
                 await LoadToolsAsync();
-                await FilterToolsAsync(CancellationToken.None);
+                await FilterToolsAsync(cancellationToken);
                 SelectedTool = Tools.FirstOrDefault(t => t.ToolID == updated.ToolID);
+            }
+            catch (OperationCanceledException)
+            {
+                // Ignore cancellation
             }
             catch (UnauthorizedAccessException)
             {
@@ -272,7 +280,7 @@ namespace ToolManagementAppV2.ViewModels
             _dialogService.ShowToolDetails(SelectedTool);
         }
 
-        async Task DeleteToolAsync()
+        async Task DeleteToolAsync(CancellationToken cancellationToken)
         {
             if (SelectedTool == null) return;
             var confirm = await _dialogService.ShowConfirmationAsync(
@@ -283,10 +291,14 @@ namespace ToolManagementAppV2.ViewModels
 
             try
             {
-                await _toolService.DeleteToolAsync(SelectedTool.ToolID);
+                await _toolService.DeleteToolAsync(SelectedTool.ToolID, cancellationToken);
                 await LoadToolsAsync();
-                await FilterToolsAsync(CancellationToken.None);
+                await FilterToolsAsync(cancellationToken);
                 SelectedTool = null;
+            }
+            catch (OperationCanceledException)
+            {
+                // Ignore cancellation
             }
             catch (UnauthorizedAccessException)
             {
@@ -299,13 +311,13 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        async Task OpenRentalsAsync()
+        async Task OpenRentalsAsync(CancellationToken cancellationToken)
         {
             if (SelectedTool == null) return;
 
             try
             {
-                var customers = await _customerService.GetAllCustomersAsync();
+                var customers = await _customerService.GetAllCustomersAsync(cancellationToken);
                 var result = _dialogService.ShowRentToolDialog(SelectedTool, customers);
                 if (result != null)
                 {
@@ -316,6 +328,10 @@ namespace ToolManagementAppV2.ViewModels
                         dueDate);
                     await LoadToolsAsync();
                 }
+            }
+            catch (OperationCanceledException)
+            {
+                // Ignore cancellation
             }
             catch (UnauthorizedAccessException)
             {


### PR DESCRIPTION
## Summary
- add `CancellationToken` support to customer service API and interface
- propagate and handle tokens through dashboard, tool management, import/export, and main view models
- add cancellation-focused unit tests for customer operations and view model commands

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a05ce630e08324b7f44667d4d77b3f