### PR TITLE
Refactor startup to OnStartup override

### DIFF
--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -105,26 +105,10 @@ namespace ToolManagementAppV2
             })
             .Build();
 
-        [STAThread]
-        public static async Task Main()
+        protected async override void OnStartup(StartupEventArgs e)
         {
-            var app = new App();
-            try
-            {
-                await app.StartAsync();
-                app.Run();
-            }
-            catch (Exception ex)
-            {
-                var logger = app.Host.Services.GetRequiredService<ILogger<App>>();
-                logger.LogCritical(ex, "Application failed to start");
-            }
-            finally
-            {
-                await app.Host.StopAsync();
-                app.Host.Dispose();
-                Log.CloseAndFlush();
-            }
+            await StartAsync();
+            base.OnStartup(e);
         }
 
         public async Task StartAsync()
@@ -182,6 +166,8 @@ namespace ToolManagementAppV2
 
         protected override void OnExit(ExitEventArgs e)
         {
+            Host.StopAsync().GetAwaiter().GetResult();
+            Host.Dispose();
             Log.CloseAndFlush();
             base.OnExit(e);
         }


### PR DESCRIPTION
## Summary
- Refactor WPF App startup by replacing custom Main entry point with an async OnStartup override that awaits StartAsync
- Ensure host lifecycle is disposed on application exit

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a06f580bf88324a19d7eb66d66e05d