### PR TITLE
Refactor async helpers and settings fallback

### DIFF
--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -356,6 +356,24 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
+        public void GetPasswordIterations_InvalidStoredValue_ReturnsDefault()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var service = new SettingsService(dbService);
+                service.SaveSetting("PasswordIterations", "-5");
+                Assert.Equal(100_000, service.GetPasswordIterations());
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public async Task SaveAndRetrieveSettingAsync()
         {
             var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2/Services/Core/CsvHelperUtil.cs
+++ b/ToolManagementAppV2/Services/Core/CsvHelperUtil.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.VisualBasic.FileIO;
 using System.Linq;
-using System.Threading.Tasks;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Models.ImportExport;
 
@@ -25,8 +24,9 @@ namespace ToolManagementAppV2.Utilities.IO
             using var parser = new TextFieldParser(filePath);
             parser.SetDelimiters(",");
             parser.HasFieldsEnclosedInQuotes = true;
-            return await Task.Run(() =>
-                parser.EndOfData ? Array.Empty<string>() : parser.ReadFields().Select(h => h.Trim()));
+            return await Task.Run(()
+                parser.EndOfData ? Array.Empty<string>() : parser.ReadFields().Select(h => h.Trim())
+            ).ConfigureAwait(false);
         }
 
         public static List<ToolModel> LoadToolsFromCsv(string filePath, IDictionary<string, string> map, out List<int> invalidRows)
@@ -92,7 +92,7 @@ namespace ToolManagementAppV2.Utilities.IO
             File.WriteAllLines(filePath, lines);
         }
 
-        public static Task ExportToolsToCsvAsync(string filePath, List<ToolModel> tools)
+        public static async Task ExportToolsToCsvAsync(string filePath, List<ToolModel> tools)
         {
             var lines = new List<string>
             {
@@ -110,7 +110,7 @@ namespace ToolManagementAppV2.Utilities.IO
                     Quote(t.Notes),
                     Quote(t.QuantityOnHand.ToString()),
                     Quote(t.IsPowerTool ? "1" : "0"))));
-            return File.WriteAllLinesAsync(filePath, lines);
+            await File.WriteAllLinesAsync(filePath, lines).ConfigureAwait(false);
         }
 
         public static List<CustomerModel> LoadCustomersFromCsv(string filePath, IDictionary<string, string> map)

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -284,11 +284,13 @@ namespace ToolManagementAppV2.Services.Core
         /// </summary>
         /// <param name="backupFilePath">Destination path for the backup file.</param>
         /// <param name="cancellationToken">Token to observe for cancellation.</param>
-        public Task BackupDatabaseAsync(string backupFilePath, CancellationToken cancellationToken)
-            => Task.Run(() =>
+        public async Task BackupDatabaseAsync(string backupFilePath, CancellationToken cancellationToken)
+        {
+            await Task.Run(() =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 BackupDatabase(backupFilePath);
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -327,7 +327,7 @@ namespace ToolManagementAppV2.Services.Settings
         public int GetPasswordIterations(CancellationToken cancellationToken = default)
         {
             var value = GetSetting(PasswordIterationsKey, cancellationToken);
-            return int.TryParse(value, out var i) ? i : 100_000;
+            return int.TryParse(value, out var i) && i > 0 ? i : 100_000;
         }
 
         public void SavePasswordIterations(int iterations, CancellationToken cancellationToken = default)
@@ -340,7 +340,7 @@ namespace ToolManagementAppV2.Services.Settings
         public async Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default)
         {
             var value = await GetSettingAsync(PasswordIterationsKey, cancellationToken).ConfigureAwait(false);
-            return int.TryParse(value, out var i) ? i : 100_000;
+            return int.TryParse(value, out var i) && i > 0 ? i : 100_000;
         }
 
         public async Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- Remove duplicate import and adopt `ConfigureAwait(false)` in CSV helper utilities
- Use `ConfigureAwait(false)` for database backups
- Validate password iteration settings and test fallback to defaults

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0734126b0832499332e2cf2630a4a