### PR TITLE
feat: async csv and image import improvements

### DIFF
--- a/ToolManagementAppV2.Tests/Extensions/ToolServiceExtensions.cs
+++ b/ToolManagementAppV2.Tests/Extensions/ToolServiceExtensions.cs
@@ -44,7 +44,7 @@ namespace ToolManagementAppV2.Tests.Extensions
             service.ExportToolsToCsvAsync(filePath, CancellationToken.None).GetAwaiter().GetResult();
 
         public static ImageImportResult ImportToolImages(this IToolService service, string folderPath, Func<ToolModel, IEnumerable<string>> selector) =>
-            service.ImportToolImagesAsync(folderPath, selector, CancellationToken.None).GetAwaiter().GetResult();
+            service.ImportToolImagesAsync(folderPath, selector, null, CancellationToken.None).GetAwaiter().GetResult();
 
         public static void UpdateToolQuantities(this IToolService service, int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) =>
             service.UpdateToolQuantitiesAsync(toolID, qtyChange, isRental, conn, tx, CancellationToken.None).GetAwaiter().GetResult();

--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -381,7 +381,7 @@ namespace ToolManagementAppV2.Tests.Services
             public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
             public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
             public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default)
                 => throw new InvalidOperationException("fail");
         }

--- a/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
@@ -65,7 +65,7 @@ public class ReportServiceAsyncTests
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
         public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<Tool, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<Tool, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 

--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -7,6 +7,7 @@ using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Tools;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models.ImportExport;
 using Xunit;
 using System.Threading;
 using System.Threading.Tasks;
@@ -909,12 +910,48 @@ namespace ToolManagementAppV2.Tests.Services
             }
         }
 
+        [Fact]
+        public async Task ImportToolImagesAsync_RespectsCancellation()
+        {
+            var dbPath = Path.GetTempFileName();
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            var img1 = Path.Combine(tempDir, "T1.png");
+            var img2 = Path.Combine(tempDir, "T2.png");
+            File.WriteAllText(img1, "img");
+            File.WriteAllText(img2, "img");
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var svc = new ToolService(dbService);
+                svc.AddTool(new Tool { ToolNumber = "T1" });
+                svc.AddTool(new Tool { ToolNumber = "T2" });
+
+                var cts = new CancellationTokenSource();
+                var progress = new Progress<ImageImportProgress>(p =>
+                {
+                    if (p.Processed == 1)
+                        cts.Cancel();
+                });
+
+                await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                    svc.ImportToolImagesAsync(tempDir, t => new[] { t.ToolNumber }, progress, cts.Token));
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+                if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
+                var destDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images");
+                if (Directory.Exists(destDir)) Directory.Delete(destDir, true);
+            }
+        }
+
         private class FailingCopyToolService : ToolService
         {
             public FailingCopyToolService(DatabaseService dbService, ILogger<ToolService> logger)
                 : base(dbService, logger) { }
 
-            protected override void CopyFile(string sourceFileName, string destFileName)
+            protected override Task CopyFileAsync(string sourceFileName, string destFileName, CancellationToken cancellationToken)
                 => throw new IOException("fail");
         }
     }

--- a/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
@@ -74,6 +74,29 @@ public class CsvImportTests
     }
 
     [Fact]
+    public async Task LoadToolsFromCsvAsync_RespectsCancellation()
+    {
+        var csv = string.Join('\n',
+            "ToolNumber,NameDescription",
+            "T1,Hammer");
+        var path = Path.GetTempFileName();
+        File.WriteAllText(path, csv);
+
+        var map = new Dictionary<string, string>
+        {
+            {"ToolNumber", "ToolNumber"},
+            {"NameDescription", "NameDescription"}
+        };
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => CsvHelperUtil.LoadToolsFromCsvAsync(path, map, cts.Token));
+
+        if (File.Exists(path)) File.Delete(path);
+    }
+
+    [Fact]
     public async System.Threading.Tasks.Task ImportToolsFromCsvAsync_SkipsInvalidRows()
     {
         var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -180,7 +180,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 
@@ -235,7 +235,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 
@@ -256,7 +256,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -250,7 +250,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
     }
 
@@ -267,7 +267,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
     }
 

--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -677,7 +677,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
             public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         }
 
@@ -694,7 +694,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
             public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
             public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         }
 

--- a/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
@@ -114,7 +114,7 @@ namespace ToolManagementAppV2.Tests.Views
         public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<System.Collections.Generic.List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ToolModel>());
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, System.Collections.Generic.IEnumerable<string>> keySelector, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, System.Collections.Generic.IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 

--- a/ToolManagementAppV2/Interfaces/IToolService.cs
+++ b/ToolManagementAppV2/Interfaces/IToolService.cs
@@ -21,7 +21,7 @@ namespace ToolManagementAppV2.Interfaces
         Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default);
         Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken);
         Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default);
-        Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default);
+        Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default);
         Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental,
             SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default);
     }

--- a/ToolManagementAppV2/Models/DTOs/ImageImportProgress.cs
+++ b/ToolManagementAppV2/Models/DTOs/ImageImportProgress.cs
@@ -1,0 +1,8 @@
+namespace ToolManagementAppV2.Models.ImportExport
+{
+    public class ImageImportProgress
+    {
+        public int Processed { get; set; }
+        public int Total { get; set; }
+    }
+}

--- a/ToolManagementAppV2/Services/Core/CsvHelperUtil.cs
+++ b/ToolManagementAppV2/Services/Core/CsvHelperUtil.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualBasic.FileIO;
 using System.Linq;
@@ -71,6 +72,16 @@ namespace ToolManagementAppV2.Utilities.IO
             return list;
         }
 
+        public static async Task<(List<ToolModel> Tools, List<int> InvalidRows)> LoadToolsFromCsvAsync(
+            string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default)
+        {
+            return await Task.Run(() =>
+            {
+                var tools = LoadToolsFromCsv(filePath, map, out var invalid);
+                return (tools, invalid);
+            }, cancellationToken).ConfigureAwait(false);
+        }
+
         public static void ExportToolsToCsv(string filePath, List<ToolModel> tools)
         {
             var lines = new List<string>
@@ -139,6 +150,10 @@ namespace ToolManagementAppV2.Utilities.IO
 
             return list;
         }
+
+        public static async Task<List<CustomerModel>> LoadCustomersFromCsvAsync(string filePath, IDictionary<string, string> map,
+            CancellationToken cancellationToken = default)
+            => await Task.Run(() => LoadCustomersFromCsv(filePath, map), cancellationToken).ConfigureAwait(false);
 
 
         public static void ExportCustomersToCsv(string filePath, List<CustomerModel> customers)

--- a/ToolManagementAppV2/Services/Customers/CustomerService.cs
+++ b/ToolManagementAppV2/Services/Customers/CustomerService.cs
@@ -177,7 +177,7 @@ namespace ToolManagementAppV2.Services.Customers
 
         async Task<CustomerImportResult> ImportCustomersFromCsvInternalAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
-            var customers = CsvHelperUtil.LoadCustomersFromCsv(filePath, map);
+            var customers = await CsvHelperUtil.LoadCustomersFromCsvAsync(filePath, map, cancellationToken);
             var result = new CustomerImportResult();
             using var conn = _dbService.CreateConnection();
             using var tran = conn.BeginTransaction();

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -100,10 +100,10 @@ namespace ToolManagementAppV2.Services.Tools
         public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default)
             => ExportToolsToCsvInternalAsync(filePath, cancellationToken);
 
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken = default)
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
-            return ImportToolImagesInternalAsync(folderPath, keySelector, cancellationToken);
+            return ImportToolImagesInternalAsync(folderPath, keySelector, progress, cancellationToken);
         }
 
         async Task InsertToolAsync(SQLiteConnection conn, SQLiteTransaction? tran, ToolModel tool, CancellationToken cancellationToken)
@@ -132,7 +132,7 @@ namespace ToolManagementAppV2.Services.Tools
                 tool.ToolID = Convert.ToInt32(result);
         }
     
-        private async Task<ImageImportResult> ImportToolImagesInternalAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, CancellationToken cancellationToken)
+        private async Task<ImageImportResult> ImportToolImagesInternalAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress, CancellationToken cancellationToken)
         {
             var result = new ImageImportResult();
             if (string.IsNullOrWhiteSpace(folderPath) || keySelector == null)
@@ -173,7 +173,10 @@ namespace ToolManagementAppV2.Services.Tools
 
             var supported = new HashSet<string>(new[] { ".png", ".jpg", ".jpeg", ".bmp", ".gif" }, StringComparer.OrdinalIgnoreCase);
 
-            foreach (var file in Directory.EnumerateFiles(folderPath))
+            var files = await Task.Run(() => Directory.EnumerateFiles(folderPath).ToList(), cancellationToken);
+            var total = files.Count;
+            var processed = 0;
+            foreach (var file in files)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var ext = Path.GetExtension(file);
@@ -202,7 +205,7 @@ namespace ToolManagementAppV2.Services.Tools
                 {
                     try
                     {
-                        CopyFile(file, dest);
+                        await CopyFileAsync(file, dest, cancellationToken);
                     }
                     catch (IOException ex)
                     {
@@ -214,13 +217,19 @@ namespace ToolManagementAppV2.Services.Tools
                 var relative = $"Images/{Path.GetFileName(dest)}";
                 await UpdateToolImageAsync(tool.ToolID, relative, cancellationToken);
                 result.ImportedCount++;
+                processed++;
+                progress?.Report(new ImageImportProgress { Processed = processed, Total = total });
             }
 
             return result;
         }
 
-        protected virtual void CopyFile(string sourceFileName, string destFileName)
-            => File.Copy(sourceFileName, destFileName, true);
+        protected virtual async Task CopyFileAsync(string sourceFileName, string destFileName, CancellationToken cancellationToken)
+        {
+            await using var source = new FileStream(sourceFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, true);
+            await using var destination = new FileStream(destFileName, FileMode.Create, FileAccess.Write, FileShare.None, 81920, true);
+            await source.CopyToAsync(destination, cancellationToken);
+        }
 
         private async Task<bool> ToolExistsAsync(string toolNumber, int? exceptId = null, CancellationToken cancellationToken = default)
         {
@@ -449,7 +458,7 @@ namespace ToolManagementAppV2.Services.Tools
 
         private async Task<List<int>> ImportToolsFromCsvInternalAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
-            var tools = CsvHelperUtil.LoadToolsFromCsv(filePath, map, out var invalidRows);
+            var (tools, invalidRows) = await CsvHelperUtil.LoadToolsFromCsvAsync(filePath, map, cancellationToken);
             using var conn = _dbService.CreateConnection();
             var existingNumbers = new HashSet<string>(
                 await SqliteHelper.ExecuteReaderAsync(conn,

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using ToolManagementAppV2.Utilities.IO;
 using ToolManagementAppV2.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
+using ToolManagementAppV2.Models.ImportExport;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -367,7 +368,9 @@ namespace ToolManagementAppV2.ViewModels
             var selector = _dialogService.ShowImageImportMapping();
             if (selector != null)
             {
-                var result = await _toolService.ImportToolImagesAsync(dlg.SelectedPath, selector, cancellationToken);
+                var progress = new Progress<ImageImportProgress>(p =>
+                    _logger.LogInformation("Imported {Processed}/{Total} images", p.Processed, p.Total));
+                var result = await _toolService.ImportToolImagesAsync(dlg.SelectedPath, selector, progress, cancellationToken);
                 _dialogService.ShowInfo(
                     $"Imported {result.ImportedCount} images. Unmatched: {result.UnmatchedFiles.Count}, Conflicts: {result.ConflictingFiles.Count}",
                     "Import Images");


### PR DESCRIPTION
## Summary
- add async CSV parsing helpers
- make tool image import fully asynchronous with progress
- wire progress through view models and services

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0eaea8b448324a7e1bc27a2512bea