### PR TITLE
Remove sync activity log methods and update callers

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ActivityLogServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ActivityLogServiceTests.cs
@@ -12,7 +12,7 @@ namespace ToolManagementAppV2.Tests.Services
     public class ActivityLogServiceTests
     {
         [Fact]
-        public void LogAction_ReturnsFailure_WhenTableMissing()
+        public async Task LogAction_ReturnsFailure_WhenTableMissing()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -23,7 +23,7 @@ namespace ToolManagementAppV2.Tests.Services
                     cmd.ExecuteNonQuery();
 
                 var service = new ActivityLogService(db);
-                var result = service.LogAction(1, "user", "action");
+                var result = await service.LogActionAsync(1, "user", "action");
                 Assert.False(result.Success);
                 Assert.NotNull(result.ErrorMessage);
             }
@@ -34,7 +34,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void GetRecentLogs_ReturnsFailure_WhenTableMissing()
+        public async Task GetRecentLogs_ReturnsFailure_WhenTableMissing()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -45,7 +45,7 @@ namespace ToolManagementAppV2.Tests.Services
                     cmd.ExecuteNonQuery();
 
                 var service = new ActivityLogService(db);
-                var result = service.GetRecentLogs();
+                var result = await service.GetRecentLogsAsync();
                 Assert.False(result.Success);
                 Assert.NotNull(result.ErrorMessage);
             }
@@ -63,7 +63,7 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 using var db = new DatabaseService(dbPath);
                 var service = new ActivityLogService(db);
-                var logResult = service.LogAction(1, "user", "action");
+                var logResult = await service.LogActionAsync(1, "user", "action");
                 Assert.True(logResult.Success);
 
                 var recent = await service.GetRecentLogsAsync();

--- a/ToolManagementAppV2.Tests/ViewModels/ActivityLogsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ActivityLogsViewModelTests.cs
@@ -20,7 +20,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 var service = new ActivityLogService(db);
-                service.LogAction(1, "user", "action");
+                await service.LogActionAsync(1, "user", "action");
                 var vm = new ActivityLogsViewModel(service);
                 await vm.RefreshCommand.ExecutionTask;
                 Assert.Single(vm.Logs);
@@ -40,11 +40,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 var service = new ActivityLogService(db);
-                service.LogAction(1, "user", "first");
+                await service.LogActionAsync(1, "user", "first");
                 var vm = new ActivityLogsViewModel(service);
                 await vm.RefreshCommand.ExecutionTask;
                 Assert.Single(vm.Logs);
-                service.LogAction(1, "user", "second");
+                await service.LogActionAsync(1, "user", "second");
                 Assert.Single(vm.Logs);
                 await vm.RefreshCommand.ExecuteAsync(null);
                 Assert.Equal(2, vm.Logs.Count);

--- a/ToolManagementAppV2.Tests/ViewModels/DashboardViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/DashboardViewModelTests.cs
@@ -10,13 +10,14 @@ using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace ToolManagementAppV2.Tests.ViewModels
 {
     public class DashboardViewModelTests
     {
         [Fact]
-        public void Constructor_LoadsStatsAndActivity_AndCommandsExecute()
+        public async Task Constructor_LoadsStatsAndActivity_AndCommandsExecute()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -27,7 +28,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
-                activityLogService.LogAction(1, "user", "action");
+                await activityLogService.LogActionAsync(1, "user", "action");
 
                 bool newTool = false, rentals = false, import = false;
 
@@ -41,6 +42,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     new RelayCommand(() => rentals = true),
                     new RelayCommand(() => import = true));
 
+                await Task.Delay(50);
                 Assert.NotEmpty(vm.StatCards);
                 Assert.NotEmpty(vm.RecentActivity);
 

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -118,7 +118,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 var activityLogService = new ActivityLogService(db);
-                activityLogService.LogAction(1, "user", "action");
+                await activityLogService.LogActionAsync(1, "user", "action");
                 IToolService toolService = new ToolService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -29,7 +29,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 var service = new ActivityLogService(db);
-                service.LogAction(1, "user", "action");
+                await service.LogActionAsync(1, "user", "action");
                 var vm = new ActivityLogsViewModel(service);
                 await vm.LoadLogsAsync();
                 Assert.NotEmpty(vm.Logs);

--- a/ToolManagementAppV2/Services/Users/ActivityLogService.cs
+++ b/ToolManagementAppV2/Services/Users/ActivityLogService.cs
@@ -23,9 +23,6 @@ namespace ToolManagementAppV2.Services.Users
             _logger = logger ?? NullLogger<ActivityLogService>.Instance;
         }
 
-        public virtual Result LogAction(int userID, string userName, string action, CancellationToken cancellationToken = default)
-            => LogActionAsync(userID, userName, action, cancellationToken).GetAwaiter().GetResult();
-
         public virtual async Task<Result> LogActionAsync(int userID, string userName, string action, CancellationToken cancellationToken = default)
         {
             try
@@ -60,9 +57,6 @@ namespace ToolManagementAppV2.Services.Users
             }
         }
 
-        public virtual Result<List<ActivityLog>> GetRecentLogs(int count = 50, CancellationToken cancellationToken = default)
-            => GetRecentLogsAsync(count, cancellationToken).GetAwaiter().GetResult();
-
         public virtual async Task<Result<List<ActivityLog>>> GetRecentLogsAsync(int count = 50, CancellationToken cancellationToken = default)
         {
             try
@@ -92,9 +86,6 @@ namespace ToolManagementAppV2.Services.Users
                 return new Result<List<ActivityLog>>(null, false, ex.Message);
             }
         }
-
-        public virtual Result PurgeOldLogs(DateTime threshold, CancellationToken cancellationToken = default)
-            => PurgeOldLogsAsync(threshold, cancellationToken).GetAwaiter().GetResult();
 
         public virtual async Task<Result> PurgeOldLogsAsync(DateTime threshold, CancellationToken cancellationToken = default)
         {

--- a/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
@@ -71,7 +71,7 @@ namespace ToolManagementAppV2.ViewModels
             });
 
             _ = LoadStatsAsync(CancellationToken.None);
-            LoadRecentActivity();
+            _ = LoadRecentActivityAsync(CancellationToken.None);
         }
 
         internal async Task LoadStatsAsync(CancellationToken cancellationToken)
@@ -98,12 +98,12 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        void LoadRecentActivity()
+        internal async Task LoadRecentActivityAsync(CancellationToken cancellationToken)
         {
             try
             {
                 RecentActivity.Clear();
-                var result = _activityLogService.GetRecentLogs(10);
+                var result = await _activityLogService.GetRecentLogsAsync(10, cancellationToken).ConfigureAwait(false);
                 if (!result.Success || result.Value == null)
                 {
                     _logger.LogError("Failed to load recent activity: {Error}", result.ErrorMessage);
@@ -111,6 +111,10 @@ namespace ToolManagementAppV2.ViewModels
                 }
                 foreach (var log in result.Value)
                     RecentActivity.Add(log);
+            }
+            catch (OperationCanceledException)
+            {
+                // Swallow cancellations quietly.
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- drop synchronous ActivityLogService wrappers
- load recent activity via async pattern in DashboardViewModel
- adjust tests to await ActivityLogService async methods

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a136908e408324a51137e8b09dcfae