### PR TITLE
refactor: rename token param in LoadRecentActivityAsync

### DIFF
--- a/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
@@ -98,12 +98,12 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        internal async Task LoadRecentActivityAsync(CancellationToken cancellationToken)
+        internal async Task LoadRecentActivityAsync(CancellationToken token)
         {
             try
             {
                 RecentActivity.Clear();
-                var result = await _activityLogService.GetRecentLogsAsync(10, cancellationToken).ConfigureAwait(false);
+                var result = await _activityLogService.GetRecentLogsAsync(10, token).ConfigureAwait(false);
                 if (!result.Success || result.Value == null)
                 {
                     _logger.LogError("Failed to load recent activity: {Error}", result.ErrorMessage);


### PR DESCRIPTION
## Summary
- rename cancellation token parameter in `LoadRecentActivityAsync`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1625bc7ec832493336a00b947863f