### PR TITLE
Refactor settings service to async-only API

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ScannerServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ScannerServiceTests.cs
@@ -20,7 +20,7 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 var db = new DatabaseService(dbPath);
                 var settings = new SettingsService(db);
-                settings.SaveScannerIpAddresses(new[] { "127.0.0.1" });
+                await settings.SaveScannerIpAddressesAsync(new[] { "127.0.0.1" });
 
                 var service = new ScannerService(settings);
 
@@ -47,7 +47,7 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 var db = new DatabaseService(dbPath);
                 var settings = new SettingsService(db);
-                settings.SaveScannerIpAddresses(new[] { "127.0.0.1", "127.0.0.2" });
+                await settings.SaveScannerIpAddressesAsync(new[] { "127.0.0.1", "127.0.0.2" });
 
                 var service = new ScannerService(settings);
 
@@ -71,7 +71,7 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 var db = new DatabaseService(dbPath);
                 var settings = new SettingsService(db);
-                settings.SaveScannerIpAddresses(new[] { "127.0.0.1", "127.0.0.1" });
+                await settings.SaveScannerIpAddressesAsync(new[] { "127.0.0.1", "127.0.0.1" });
 
                 var service = new ScannerService(settings);
 
@@ -93,7 +93,7 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 var db = new DatabaseService(dbPath);
                 var settings = new SettingsService(db);
-                settings.SaveScannerIpAddresses(new[] { "127.0.0.1" });
+                await settings.SaveScannerIpAddressesAsync(new[] { "127.0.0.1" });
 
                 var service = new ScannerService(settings);
 

--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -25,7 +25,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 ISettingsService service = new SettingsService(dbService);
 
-                Assert.Throws<ArgumentException>(() => service.SaveSetting(key!, "Value1"));
+                Assert.Throws<ArgumentException>(() => service.SaveSettingAsync(key!, "Value1").GetAwaiter().GetResult());
             }
             finally
             {
@@ -44,7 +44,7 @@ namespace ToolManagementAppV2.Tests.Services
                 ISettingsService service = new SettingsService(dbService);
 
                 var settings = new Dictionary<string, string> { [""] = "Value1" };
-                Assert.Throws<ArgumentException>(() => service.UpdateSettings(settings));
+                Assert.Throws<ArgumentException>(() => service.UpdateSettingsAsync(settings).GetAwaiter().GetResult());
             }
             finally
             {
@@ -62,7 +62,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 ISettingsService service = new SettingsService(dbService);
 
-                Assert.Throws<ArgumentNullException>(() => service.UpdateSettings(null!));
+                Assert.Throws<ArgumentNullException>(() => service.UpdateSettingsAsync(null!).GetAwaiter().GetResult());
             }
             finally
             {
@@ -87,7 +87,7 @@ namespace ToolManagementAppV2.Tests.Services
                 }
 
                 var settings = new Dictionary<string, string> { ["Key1"] = "Value1" };
-                Assert.Throws<InvalidOperationException>(() => service.UpdateSettings(settings));
+                Assert.Throws<InvalidOperationException>(() => service.UpdateSettingsAsync(settings).GetAwaiter().GetResult());
             }
             finally
             {
@@ -111,7 +111,7 @@ namespace ToolManagementAppV2.Tests.Services
                     cmd.ExecuteNonQuery();
                 }
 
-                Assert.Throws<InvalidOperationException>(() => service.SaveSetting("Key1", "Value1"));
+                Assert.Throws<InvalidOperationException>(() => service.SaveSettingAsync("Key1", "Value1").GetAwaiter().GetResult());
             }
             finally
             {
@@ -135,7 +135,7 @@ namespace ToolManagementAppV2.Tests.Services
                     cmd.ExecuteNonQuery();
                 }
 
-                Assert.Throws<InvalidOperationException>(() => service.GetSetting("Key1"));
+                Assert.Throws<InvalidOperationException>(() => service.GetSettingAsync("Key1").GetAwaiter().GetResult());
             }
             finally
             {
@@ -153,7 +153,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 ISettingsService service = new SettingsService(dbService);
 
-                var result = service.GetSetting("NonExistentKey");
+                var result = service.GetSettingAsync("NonExistentKey").GetAwaiter().GetResult();
                 Assert.Null(result);
             }
             finally
@@ -178,7 +178,7 @@ namespace ToolManagementAppV2.Tests.Services
                     cmd.ExecuteNonQuery();
                 }
 
-                Assert.Throws<InvalidOperationException>(() => service.DeleteSetting("Key1"));
+                Assert.Throws<InvalidOperationException>(() => service.DeleteSettingAsync("Key1").GetAwaiter().GetResult());
             }
             finally
             {
@@ -199,7 +199,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var logger = factory.CreateLogger<SettingsService>();
                 ISettingsService service = new SettingsService(dbService, logger);
 
-                service.DeleteSetting("MissingKey");
+                service.DeleteSettingAsync("MissingKey").GetAwaiter().GetResult();
 
                 Assert.Single(logs);
                 Assert.Equal(LogLevel.Warning, logs[0].Level);
@@ -223,11 +223,11 @@ namespace ToolManagementAppV2.Tests.Services
                 var logger = factory.CreateLogger<SettingsService>();
                 var service = new SettingsService(dbService, logger);
 
-                var invalid = service.SaveScannerIpAddresses(new[] { "192.168.1.1", "bad", "999.999.999.999" }).ToList();
+                var invalid = service.SaveScannerIpAddressesAsync(new[] { "192.168.1.1", "bad", "999.999.999.999" }).GetAwaiter().GetResult().ToList();
 
                 Assert.Equal(new[] { "bad", "999.999.999.999" }, invalid);
 
-                var saved = service.GetScannerIpAddresses().ToList();
+                var saved = service.GetScannerIpAddressesAsync().GetAwaiter().GetResult().ToList();
                 Assert.Single(saved);
                 Assert.Equal("192.168.1.1", saved[0]);
 
@@ -255,10 +255,10 @@ namespace ToolManagementAppV2.Tests.Services
                 var logger = factory.CreateLogger<SettingsService>();
                 var service = new SettingsService(dbService, logger);
 
-                var invalid = service.SaveScannerIpAddresses(new[] { "127.0.0.1", "10.0.0.2" });
+                var invalid = service.SaveScannerIpAddressesAsync(new[] { "127.0.0.1", "10.0.0.2" }).GetAwaiter().GetResult();
                 Assert.Empty(invalid);
 
-                var saved = service.GetScannerIpAddresses().ToList();
+                var saved = service.GetScannerIpAddressesAsync().GetAwaiter().GetResult().ToList();
                 Assert.Equal(2, saved.Count);
                 Assert.Contains("127.0.0.1", saved);
                 Assert.Contains("10.0.0.2", saved);
@@ -283,12 +283,12 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 var service = new SettingsService(dbService);
 
-                service.SaveScannerIpAddresses(new[] { "192.168.0.1" });
-                Assert.Single(service.GetScannerIpAddresses());
+                service.SaveScannerIpAddressesAsync(new[] { "192.168.0.1" }).GetAwaiter().GetResult();
+                Assert.Single(service.GetScannerIpAddressesAsync().GetAwaiter().GetResult());
 
-                var invalid = service.SaveScannerIpAddresses(input).ToList();
+                var invalid = service.SaveScannerIpAddressesAsync(input).GetAwaiter().GetResult().ToList();
                 Assert.Empty(invalid);
-                Assert.Empty(service.GetScannerIpAddresses());
+                Assert.Empty(service.GetScannerIpAddressesAsync().GetAwaiter().GetResult());
             }
             finally
             {
@@ -306,7 +306,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 ISettingsService service = new SettingsService(dbService);
 
-                var iterations = service.GetPasswordIterations();
+                var iterations = service.GetPasswordIterationsAsync().GetAwaiter().GetResult();
                 Assert.Equal(100_000, iterations);
             }
             finally
@@ -325,8 +325,8 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 ISettingsService service = new SettingsService(dbService);
 
-                service.SavePasswordIterations(50_000);
-                Assert.Equal(50_000, service.GetPasswordIterations());
+                service.SavePasswordIterationsAsync(50_000).GetAwaiter().GetResult();
+                Assert.Equal(50_000, service.GetPasswordIterationsAsync().GetAwaiter().GetResult());
             }
             finally
             {
@@ -346,7 +346,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 ISettingsService service = new SettingsService(dbService);
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => service.SavePasswordIterations(iterations));
+                Assert.Throws<ArgumentOutOfRangeException>(() => service.SavePasswordIterationsAsync(iterations).GetAwaiter().GetResult());
             }
             finally
             {
@@ -363,8 +363,8 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 var dbService = new DatabaseService(dbPath);
                 var service = new SettingsService(dbService);
-                service.SaveSetting("PasswordIterations", "-5");
-                Assert.Equal(100_000, service.GetPasswordIterations());
+                service.SaveSettingAsync("PasswordIterations", "-5").GetAwaiter().GetResult();
+                Assert.Equal(100_000, service.GetPasswordIterationsAsync().GetAwaiter().GetResult());
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Tests/ScannerIntegrationTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ScannerIntegrationTests.cs
@@ -19,7 +19,7 @@ namespace ToolManagementAppV2.Tests.Tests
             {
                 var db = new DatabaseService(dbPath);
                 var settings = new SettingsService(db);
-                settings.SaveScannerIpAddresses(new[] { "127.0.0.1" });
+                await settings.SaveScannerIpAddressesAsync(new[] { "127.0.0.1" });
 
                 var service = new ScannerService(settings);
                 var devices = await service.GetScannerDevicesAsync(CancellationToken.None);

--- a/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
+++ b/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
@@ -23,7 +23,7 @@ namespace ToolManagementAppV2.Tests.Utilities
             {
                 var dbService = new DatabaseService(dbPath);
                 ISettingsService settings = new SettingsService(dbService);
-                settings.SavePasswordIterations(5);
+                settings.SavePasswordIterationsAsync(5).GetAwaiter().GetResult();
                 SecurityHelper.SettingsService = settings;
 
                 var saltBytes = Encoding.UTF8.GetBytes("1234567890ABCDEF");
@@ -143,33 +143,18 @@ namespace ToolManagementAppV2.Tests.Utilities
 
             public int Counter => _counter;
 
-            public int GetPasswordIterations(CancellationToken cancellationToken = default)
-            {
-                Interlocked.Increment(ref _counter);
-                return _iterations;
-            }
-
             public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default)
             {
                 Interlocked.Increment(ref _counter);
                 return Task.FromResult(_iterations);
             }
-
-            public void SaveSetting(string key, string value, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public string? GetSetting(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Dictionary<string, string> GetAllSettings(CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public void UpdateSettings(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public void DeleteSetting(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public IEnumerable<string> GetScannerIpAddresses(CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public void SavePasswordIterations(int iterations, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         }
 
@@ -178,25 +163,15 @@ namespace ToolManagementAppV2.Tests.Utilities
             readonly int _iterations;
 
             public AsyncOnlySettingsService(int iterations) => _iterations = iterations;
-
-            public int GetPasswordIterations(CancellationToken cancellationToken = default) => 0;
             public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(_iterations);
 
-            public void SaveSetting(string key, string value, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public string? GetSetting(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Dictionary<string, string> GetAllSettings(CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public void UpdateSettings(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public void DeleteSetting(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public IEnumerable<string> GetScannerIpAddresses(CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public void SavePasswordIterations(int iterations, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
@@ -59,7 +59,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 var settings = new SettingsService(db);
-                settings.SaveScannerIpAddresses(new[] { "127.0.0.1" });
+                await settings.SaveScannerIpAddressesAsync(new[] { "127.0.0.1" });
                 var svc = new ScannerService(settings);
                 var vm = new ScannerStatusViewModel(svc, new StubDialogService());
                 await vm.RefreshCommand.ExecuteAsync(null);

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -137,7 +137,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 vm.PasswordIterations = 2_000_000;
 
-                Assert.Equal(1_000_000, settings.GetPasswordIterations());
+                Assert.Equal(1_000_000, settings.GetPasswordIterationsAsync().GetAwaiter().GetResult());
             }
             finally
             {
@@ -159,51 +159,35 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public string SavedKey { get; private set; }
         public string SavedValue { get; private set; }
         public string? GetSettingValue { get; set; } = string.Empty;
-
-        public void SaveSetting(string key, string value, CancellationToken cancellationToken = default)
-        {
-            SavedKey = key;
-            SavedValue = value;
-        }
-
-        public string? GetSetting(string key, CancellationToken cancellationToken = default) => GetSettingValue;
-        public Dictionary<string, string> GetAllSettings(CancellationToken cancellationToken = default) => new();
-        public void UpdateSettings(Dictionary<string, string> settings, CancellationToken cancellationToken = default) { }
-        public void DeleteSetting(string key, CancellationToken cancellationToken = default) { }
         public IEnumerable<string> ScannerIps { get; set; } = Array.Empty<string>();
-        public IEnumerable<string> GetScannerIpAddresses(CancellationToken cancellationToken = default) => ScannerIps;
-        public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default)
-        {
-            ScannerIps = ipAddresses ?? Array.Empty<string>();
-            return Array.Empty<string>();
-        }
         public int PasswordIterations { get; set; } = 100_000;
-        public int GetPasswordIterations(CancellationToken cancellationToken = default) => PasswordIterations;
-        public void SavePasswordIterations(int iterations, CancellationToken cancellationToken = default) => PasswordIterations = iterations;
 
         public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
         {
-            SaveSetting(key, value);
+            SavedKey = key;
+            SavedValue = value;
             return Task.CompletedTask;
         }
-        public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult(GetSetting(key));
-        public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(GetAllSettings());
+        public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default)
+            => Task.FromResult(GetSettingValue);
+        public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new Dictionary<string, string>());
         public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
-        {
-            UpdateSettings(settings);
-            return Task.CompletedTask;
-        }
+            => Task.CompletedTask;
         public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+        public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(ScannerIps);
+        public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default)
         {
-            DeleteSetting(key);
-            return Task.CompletedTask;
+            ScannerIps = ipAddresses ?? Array.Empty<string>();
+            return Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
         }
-        public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => Task.FromResult(GetScannerIpAddresses());
-        public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => Task.FromResult(SaveScannerIpAddresses(ipAddresses));
-        public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(GetPasswordIterations());
+        public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(PasswordIterations);
         public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default)
         {
-            SavePasswordIterations(iterations);
+            PasswordIterations = iterations;
             return Task.CompletedTask;
         }
     }

--- a/ToolManagementAppV2/Interfaces/ISettingsService.cs
+++ b/ToolManagementAppV2/Interfaces/ISettingsService.cs
@@ -6,24 +6,15 @@ namespace ToolManagementAppV2.Interfaces
 {
     public interface ISettingsService
     {
-        void SaveSetting(string key, string value, CancellationToken cancellationToken = default);
-        string? GetSetting(string key, CancellationToken cancellationToken = default);
-        Dictionary<string, string> GetAllSettings(CancellationToken cancellationToken = default);
-        void UpdateSettings(Dictionary<string, string> settings, CancellationToken cancellationToken = default);
-        void DeleteSetting(string key, CancellationToken cancellationToken = default);
         Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default);
         Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default);
         Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default);
         Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default);
         Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default);
-        IEnumerable<string> GetScannerIpAddresses(CancellationToken cancellationToken = default);
-        IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default);
         Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default);
         Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default);
 
         // Password hashing configuration
-        int GetPasswordIterations(CancellationToken cancellationToken = default);
-        void SavePasswordIterations(int iterations, CancellationToken cancellationToken = default);
         Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default);
         Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default);
     }

--- a/ToolManagementAppV2/Services/Devices/ScannerService.cs
+++ b/ToolManagementAppV2/Services/Devices/ScannerService.cs
@@ -27,7 +27,8 @@ namespace ToolManagementAppV2.Services.Devices
             cancellationToken.ThrowIfCancellationRequested();
 
             using var semaphore = new SemaphoreSlim(5);
-            var tasks = _settingsService.GetScannerIpAddresses(cancellationToken).Distinct().Select(async ip =>
+            var ips = (await _settingsService.GetScannerIpAddressesAsync(cancellationToken).ConfigureAwait(false)).Distinct();
+            var tasks = ips.Select(async ip =>
             {
                 await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -28,9 +28,6 @@ namespace ToolManagementAppV2.Services.Settings
             _logger = logger ?? NullLogger<SettingsService>.Instance;
         }
 
-        public void SaveSetting(string key, string value, CancellationToken cancellationToken = default)
-            => SaveSettingAsync(key, value, cancellationToken).GetAwaiter().GetResult();
-
         public async Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
@@ -64,9 +61,6 @@ namespace ToolManagementAppV2.Services.Settings
             }
         }
 
-        public string? GetSetting(string key, CancellationToken cancellationToken = default)
-            => GetSettingAsync(key, cancellationToken).GetAwaiter().GetResult();
-
         public async Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default)
         {
             try
@@ -93,9 +87,6 @@ namespace ToolManagementAppV2.Services.Settings
                 throw new InvalidOperationException($"Failed to retrieve setting '{key}'.", ex);
             }
         }
-
-        public Dictionary<string, string> GetAllSettings(CancellationToken cancellationToken = default)
-            => GetAllSettingsAsync(cancellationToken).GetAwaiter().GetResult();
 
         public async Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default)
         {
@@ -137,9 +128,6 @@ namespace ToolManagementAppV2.Services.Settings
         /// <exception cref="InvalidOperationException">
         /// Thrown when a transaction cannot be started. The original exception is propagated to the caller.
         /// </exception>
-        public void UpdateSettings(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
-            => UpdateSettingsAsync(settings, cancellationToken).GetAwaiter().GetResult();
-
         public async Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
@@ -187,9 +175,6 @@ namespace ToolManagementAppV2.Services.Settings
             }
         }
 
-        public void DeleteSetting(string key, CancellationToken cancellationToken = default)
-            => DeleteSettingAsync(key, cancellationToken).GetAwaiter().GetResult();
-
         public async Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
@@ -222,22 +207,6 @@ namespace ToolManagementAppV2.Services.Settings
         const string ScannerIpKey = "ScannerIpAddresses";
         const string PasswordIterationsKey = "PasswordIterations";
 
-        public IEnumerable<string> GetScannerIpAddresses(CancellationToken cancellationToken = default)
-        {
-            var value = GetSetting(ScannerIpKey, cancellationToken);
-            if (string.IsNullOrWhiteSpace(value))
-                return Array.Empty<string>();
-
-            var valid = new List<string>();
-            foreach (var ip in value.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-            {
-                if (IPAddress.TryParse(ip, out _))
-                    valid.Add(ip);
-            }
-
-            return valid;
-        }
-
         public async Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default)
         {
             var value = await GetSettingAsync(ScannerIpKey, cancellationToken).ConfigureAwait(false);
@@ -252,40 +221,6 @@ namespace ToolManagementAppV2.Services.Settings
             }
 
             return valid;
-        }
-
-        public IEnumerable<string> SaveScannerIpAddresses(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default)
-        {
-            if (ipAddresses == null)
-            {
-                DeleteSetting(ScannerIpKey, cancellationToken);
-                return Array.Empty<string>();
-            }
-
-            var valid = new List<string>();
-            var invalid = new List<string>();
-            foreach (var ip in ipAddresses)
-            {
-                if (IPAddress.TryParse(ip, out _))
-                    valid.Add(ip);
-                else
-                    invalid.Add(ip);
-            }
-
-            if (invalid.Count > 0)
-                _logger.LogWarning("Ignoring invalid IP addresses: {InvalidIps}", string.Join(", ", invalid));
-
-            if (valid.Count > 0)
-            {
-                var value = string.Join(';', valid);
-                SaveSetting(ScannerIpKey, value, cancellationToken);
-            }
-            else
-            {
-                DeleteSetting(ScannerIpKey, cancellationToken);
-            }
-
-            return invalid;
         }
 
         public async Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default)
@@ -324,19 +259,6 @@ namespace ToolManagementAppV2.Services.Settings
         }
 
         // Password hashing configuration
-        public int GetPasswordIterations(CancellationToken cancellationToken = default)
-        {
-            var value = GetSetting(PasswordIterationsKey, cancellationToken);
-            return int.TryParse(value, out var i) && i > 0 ? i : 100_000;
-        }
-
-        public void SavePasswordIterations(int iterations, CancellationToken cancellationToken = default)
-        {
-            if (iterations <= 0)
-                throw new ArgumentOutOfRangeException(nameof(iterations));
-            SaveSetting(PasswordIterationsKey, iterations.ToString(), cancellationToken);
-        }
-
         public async Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default)
         {
             var value = await GetSettingAsync(PasswordIterationsKey, cancellationToken).ConfigureAwait(false);

--- a/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
@@ -135,7 +135,7 @@ namespace ToolManagementAppV2.Utilities.Helpers
                 var svc = _settingsService;
                 if (svc != null)
                 {
-                    value = svc.GetPasswordIterations();
+                    value = svc.GetPasswordIterationsAsync().GetAwaiter().GetResult();
                 }
 
                 if (value <= 0)

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -24,13 +24,13 @@ namespace ToolManagementAppV2.ViewModels
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<SettingsViewModel>.Instance;
 
-            var logoPath = _settingsService.GetSetting("CompanyLogoPath");
+            var logoPath = _settingsService.GetSettingAsync("CompanyLogoPath").GetAwaiter().GetResult();
             if (!string.IsNullOrWhiteSpace(logoPath))
                 CompanyLogoPath = logoPath;
 
             ThemeOptions = new ObservableCollection<string> { "Light", "Dark" };
             _theme = ThemeOptions[0];
-            _passwordIterations = _settingsService.GetPasswordIterations();
+            _passwordIterations = _settingsService.GetPasswordIterationsAsync().GetAwaiter().GetResult();
             TestDbCommand = new RelayCommand(() =>
             {
                 var success = TestDbConnection(out var message);
@@ -107,7 +107,7 @@ namespace ToolManagementAppV2.ViewModels
                 {
                     try
                     {
-                        _settingsService.SavePasswordIterations(newValue);
+                        _settingsService.SavePasswordIterationsAsync(newValue).GetAwaiter().GetResult();
                     }
                     catch (UnauthorizedAccessException)
                     {
@@ -158,7 +158,7 @@ namespace ToolManagementAppV2.ViewModels
 
             try
             {
-                _settingsService.SaveSetting("CompanyLogoPath", full);
+                _settingsService.SaveSettingAsync("CompanyLogoPath", full).GetAwaiter().GetResult();
             }
             catch (UnauthorizedAccessException)
             {

--- a/ToolManagementAppV2/Views/AvatarSelectionWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/AvatarSelectionWindow.xaml.cs
@@ -20,7 +20,7 @@ namespace ToolManagementAppV2.Views
         {
             InitializeComponent();
             _settingsService = settingsService;
-            var appName = _settingsService.GetSetting("ApplicationName");
+            var appName = _settingsService.GetSettingAsync("ApplicationName").GetAwaiter().GetResult();
             if (!string.IsNullOrWhiteSpace(appName))
                 Title = $"{appName} – Select Avatar";
 


### PR DESCRIPTION
## Summary
- Remove synchronous APIs from `ISettingsService` and `SettingsService`
- Update consumers to use async settings methods
- Adjust tests and helpers for the async-only settings API

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a16cf94c708324851dcba5ff30022f