### PR TITLE
Asynchronous settings loading for avatar selection window

### DIFF
--- a/ToolManagementAppV2.Tests/Views/AvatarSelectionWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/AvatarSelectionWindowTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Views;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Views
+{
+    public class AvatarSelectionWindowTests
+    {
+        [Fact]
+        public void Loaded_SetsTitle_FromSettings()
+        {
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var settings = new StubSettingsService { AppName = "TestApp" };
+                    var logger = new TestLogger<AvatarSelectionWindow>();
+                    var window = new AvatarSelectionWindow(settings, logger);
+
+                    window.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+
+                    Assert.Equal("TestApp – Select Avatar", window.Title);
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+                throw threadException;
+        }
+
+        [Fact]
+        public void Loaded_LogsError_WhenSettingFails()
+        {
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var settings = new FailingSettingsService();
+                    var logger = new TestLogger<AvatarSelectionWindow>();
+                    var window = new AvatarSelectionWindow(settings, logger);
+
+                    var initialTitle = window.Title;
+
+                    window.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+
+                    Assert.Equal(initialTitle, window.Title);
+                    Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error);
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+                throw threadException;
+        }
+
+        class StubSettingsService : ISettingsService
+        {
+            public string? AppName { get; set; }
+
+            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default)
+                => Task.FromResult(AppName);
+
+            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult(new Dictionary<string, string>());
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default)
+                => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult(0);
+            public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+        }
+
+        class FailingSettingsService : ISettingsService
+        {
+            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default)
+                => Task.FromException<string?>(new InvalidOperationException("failure"));
+
+            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult(new Dictionary<string, string>());
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default)
+                => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult(0);
+            public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+        }
+    }
+}
+

--- a/ToolManagementAppV2/Views/AvatarSelectionWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/AvatarSelectionWindow.xaml.cs
@@ -5,6 +5,8 @@ using System.Windows;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Utilities.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 
 namespace ToolManagementAppV2.Views
@@ -15,14 +17,13 @@ namespace ToolManagementAppV2.Views
         public string SelectedAvatarPath => VM.SelectedAvatarPath;
 
         private readonly ISettingsService _settingsService;
+        private readonly ILogger<AvatarSelectionWindow> _logger;
 
-        public AvatarSelectionWindow(ISettingsService settingsService)
+        public AvatarSelectionWindow(ISettingsService settingsService, ILogger<AvatarSelectionWindow>? logger = null)
         {
             InitializeComponent();
             _settingsService = settingsService;
-            var appName = _settingsService.GetSettingAsync("ApplicationName").GetAwaiter().GetResult();
-            if (!string.IsNullOrWhiteSpace(appName))
-                Title = $"{appName} – Select Avatar";
+            _logger = logger ?? NullLogger<AvatarSelectionWindow>.Instance;
 
             var avatarDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "Avatars");
             var avatars = Array.Empty<Uri>();
@@ -34,6 +35,21 @@ namespace ToolManagementAppV2.Views
 
             DataContext = new AvatarSelectionViewModel(avatars, () => DialogResult = true);
             this.DisposeDataContextOnUnload();
+            Loaded += OnLoaded;
+        }
+
+        private async void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var appName = await _settingsService.GetSettingAsync("ApplicationName");
+                if (!string.IsNullOrWhiteSpace(appName))
+                    Title = $"{appName} – Select Avatar";
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load ApplicationName setting");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Load avatar window title asynchronously on `Loaded` event and log failures
- Add tests covering successful title load and logging on failure

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a17cbb56988324a8a915a6489aaec9