### PR TITLE
Use awaited results in summary report

### DIFF
--- a/ToolManagementAppV2/Services/Tools/ReportService.cs
+++ b/ToolManagementAppV2/Services/Tools/ReportService.cs
@@ -90,15 +90,26 @@ namespace ToolManagementAppV2.Services.Tools
             var totalCustomersTask = _customerService.GetAllCustomersAsync();
             var totalUsersTask = _userService.GetAllUsersAsync();
 
-            await Task.WhenAll(totalToolsTask, totalRentalsTask, totalActiveRentalsTask, totalCustomersTask, totalUsersTask).ConfigureAwait(false);
+            await Task.WhenAll(
+                totalToolsTask,
+                totalRentalsTask,
+                totalActiveRentalsTask,
+                totalCustomersTask,
+                totalUsersTask).ConfigureAwait(false);
+
+            var totalTools = await totalToolsTask.ConfigureAwait(false);
+            var totalRentals = await totalRentalsTask.ConfigureAwait(false);
+            var totalActiveRentals = await totalActiveRentalsTask.ConfigureAwait(false);
+            var totalCustomers = await totalCustomersTask.ConfigureAwait(false);
+            var totalUsers = await totalUsersTask.ConfigureAwait(false);
 
             var lines = new[]
             {
-                $"Total Tools: {totalToolsTask.Result.Count}",
-                $"Total Rentals (History): {totalRentalsTask.Result.Count}",
-                $"Active Rentals: {totalActiveRentalsTask.Result.Count}",
-                $"Total Customers: {totalCustomersTask.Result.Count}",
-                $"Total Users: {totalUsersTask.Result.Count}"
+                $"Total Tools: {totalTools.Count}",
+                $"Total Rentals (History): {totalRentals.Count}",
+                $"Active Rentals: {totalActiveRentals.Count}",
+                $"Total Customers: {totalCustomers.Count}",
+                $"Total Users: {totalUsers.Count}"
             };
 
             return BuildReport("Application Summary Report", lines);


### PR DESCRIPTION
## Summary
- Await summary report tasks and store the results before composing the report

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a17e4c0e7883248406812216c912c8