### PR TITLE
feat: add reusable dialog button bar

### DIFF
--- a/ToolManagementAppV2/Views/ChangePasswordWindow.xaml
+++ b/ToolManagementAppV2/Views/ChangePasswordWindow.xaml
@@ -2,6 +2,7 @@
 <Window x:Class="ToolManagementAppV2.Views.ChangePasswordWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:ToolManagementAppV2.Controls"
         Title="Change Password"
         SizeToContent="WidthAndHeight"
         WindowStartupLocation="CenterScreen"
@@ -18,9 +19,10 @@
         <PasswordBox Grid.Row="1" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" HorizontalAlignment="Center"/>
         <TextBlock Grid.Row="2" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Foreground="{StaticResource ForegroundBrush}"/>
         <PasswordBox Grid.Row="3" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" HorizontalAlignment="Center"/>
-        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
-            <Button Content="OK" Command="{Binding SaveCommand}" IsDefault="True" Margin="0,0,5,0" Foreground="{StaticResource ForegroundBrush}"/>
-            <Button Content="Cancel" Command="{Binding CancelCommand}" IsCancel="True" Foreground="{StaticResource ForegroundBrush}"/>
-        </StackPanel>
+        <controls:DialogButtonBar Grid.Row="4"
+                                  LeftButtonText="Cancel"
+                                  LeftCommand="{Binding CancelCommand}"
+                                  RightButtonText="OK"
+                                  RightCommand="{Binding SaveCommand}"/>
     </Grid>
 </Window>

--- a/ToolManagementAppV2/Views/ConfirmDialogWindow.xaml
+++ b/ToolManagementAppV2/Views/ConfirmDialogWindow.xaml
@@ -2,6 +2,7 @@
 <Window x:Class="ToolManagementAppV2.Views.ConfirmDialogWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:ToolManagementAppV2.Controls"
         Title="Confirm"
         Width="480" Height="220"
         WindowStartupLocation="CenterScreen"
@@ -14,9 +15,10 @@
         <Border Style="{StaticResource Card}">
             <TextBlock Text="{Binding Message}" FontSize="16" TextWrapping="Wrap"/>
         </Border>
-        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Style="{StaticResource PrimaryButton}" Content="No" Command="{Binding CancelCommand}"/>
-            <Button Style="{StaticResource PrimaryButton}" Content="Yes" Command="{Binding OkCommand}" Margin="8,0,0,0"/>
-        </StackPanel>
+        <controls:DialogButtonBar Grid.Row="1"
+                                  LeftButtonText="No"
+                                  LeftCommand="{Binding CancelCommand}"
+                                  RightButtonText="Yes"
+                                  RightCommand="{Binding OkCommand}"/>
     </Grid>
 </Window>

--- a/ToolManagementAppV2/Views/Controls/DialogButtonBar.xaml
+++ b/ToolManagementAppV2/Views/Controls/DialogButtonBar.xaml
@@ -1,0 +1,15 @@
+<UserControl x:Class="ToolManagementAppV2.Controls.DialogButtonBar"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+        <Button Style="{StaticResource PrimaryButton}"
+                Content="{Binding LeftButtonText, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                Command="{Binding LeftCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                IsCancel="True"/>
+        <Button Style="{StaticResource PrimaryButton}"
+                Content="{Binding RightButtonText, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                Command="{Binding RightCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                Margin="8,0,0,0"
+                IsDefault="True"/>
+    </StackPanel>
+</UserControl>

--- a/ToolManagementAppV2/Views/Controls/DialogButtonBar.xaml.cs
+++ b/ToolManagementAppV2/Views/Controls/DialogButtonBar.xaml.cs
@@ -1,0 +1,46 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace ToolManagementAppV2.Controls
+{
+    public partial class DialogButtonBar : UserControl
+    {
+        public DialogButtonBar()
+        {
+            InitializeComponent();
+        }
+
+        public string LeftButtonText
+        {
+            get => (string)GetValue(LeftButtonTextProperty);
+            set => SetValue(LeftButtonTextProperty, value);
+        }
+        public static readonly DependencyProperty LeftButtonTextProperty =
+            DependencyProperty.Register(nameof(LeftButtonText), typeof(string), typeof(DialogButtonBar), new PropertyMetadata("Cancel"));
+
+        public string RightButtonText
+        {
+            get => (string)GetValue(RightButtonTextProperty);
+            set => SetValue(RightButtonTextProperty, value);
+        }
+        public static readonly DependencyProperty RightButtonTextProperty =
+            DependencyProperty.Register(nameof(RightButtonText), typeof(string), typeof(DialogButtonBar), new PropertyMetadata("OK"));
+
+        public ICommand? LeftCommand
+        {
+            get => (ICommand?)GetValue(LeftCommandProperty);
+            set => SetValue(LeftCommandProperty, value);
+        }
+        public static readonly DependencyProperty LeftCommandProperty =
+            DependencyProperty.Register(nameof(LeftCommand), typeof(ICommand), typeof(DialogButtonBar));
+
+        public ICommand? RightCommand
+        {
+            get => (ICommand?)GetValue(RightCommandProperty);
+            set => SetValue(RightCommandProperty, value);
+        }
+        public static readonly DependencyProperty RightCommandProperty =
+            DependencyProperty.Register(nameof(RightCommand), typeof(ICommand), typeof(DialogButtonBar));
+    }
+}

--- a/ToolManagementAppV2/Views/ImageImportMappingWindow.xaml
+++ b/ToolManagementAppV2/Views/ImageImportMappingWindow.xaml
@@ -2,6 +2,7 @@
 <Window x:Class="ToolManagementAppV2.Views.ImageImportMappingWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:ToolManagementAppV2.Controls"
         Title="Import Tool Pictures"
         Width="600" Height="220"
         WindowStartupLocation="CenterScreen"
@@ -18,16 +19,10 @@
             </StackPanel>
         </Border>
 
-        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Style="{StaticResource PrimaryButton}"
-                    Content="OK"
-                    Width="140"
-                    Command="{Binding OkCommand}"/>
-            <Button Style="{StaticResource PrimaryButton}"
-                    Content="Cancel"
-                    Width="140"
-                    Margin="8,0,0,0"
-                    Command="{Binding CancelCommand}"/>
-        </StackPanel>
+        <controls:DialogButtonBar DockPanel.Dock="Bottom"
+                                  LeftButtonText="Cancel"
+                                  LeftCommand="{Binding CancelCommand}"
+                                  RightButtonText="OK"
+                                  RightCommand="{Binding OkCommand}"/>
     </DockPanel>
 </Window>

--- a/ToolManagementAppV2/Views/ImportMappingWindow.xaml
+++ b/ToolManagementAppV2/Views/ImportMappingWindow.xaml
@@ -2,6 +2,7 @@
 <Window x:Class="ToolManagementAppV2.Views.ImportMappingWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:ToolManagementAppV2.Controls"
         Title="Import Mapping"
         Width="1200" Height="700"
         WindowStartupLocation="CenterScreen"
@@ -38,16 +39,10 @@
             </DataGrid>
         </Border>
 
-        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Style="{StaticResource PrimaryButton}"
-                    Content="OK"
-                    Width="140"
-                    Command="{Binding OkCommand}"/>
-            <Button Style="{StaticResource PrimaryButton}"
-                    Content="Cancel"
-                    Width="140"
-                    Margin="8,0,0,0"
-                    Command="{Binding CancelCommand}"/>
-        </StackPanel>
+        <controls:DialogButtonBar DockPanel.Dock="Bottom"
+                                  LeftButtonText="Cancel"
+                                  LeftCommand="{Binding CancelCommand}"
+                                  RightButtonText="OK"
+                                  RightCommand="{Binding OkCommand}"/>
     </DockPanel>
 </Window>

--- a/ToolManagementAppV2/Views/PasswordPromptWindow.xaml
+++ b/ToolManagementAppV2/Views/PasswordPromptWindow.xaml
@@ -2,6 +2,7 @@
 <Window x:Class="ToolManagementAppV2.Views.PasswordPromptWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:ToolManagementAppV2.Controls"
         Title="Enter Password"
         Width="520" Height="260"
         WindowStartupLocation="CenterScreen"
@@ -72,16 +73,10 @@
                    Margin="2,8,0,0"
                    TextWrapping="Wrap"/>
 
-        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
-            <Button Style="{StaticResource PrimaryButton}"
-                    Content="Cancel"
-                    Command="{Binding CancelCommand}"
-                    IsCancel="True"/>
-            <Button Style="{StaticResource PrimaryButton}"
-                    Content="OK"
-                    Margin="8,0,0,0"
-                    Command="{Binding OkCommand}"
-                    IsDefault="True"/>
-        </StackPanel>
+        <controls:DialogButtonBar Grid.Row="4"
+                                  LeftButtonText="Cancel"
+                                  LeftCommand="{Binding CancelCommand}"
+                                  RightButtonText="OK"
+                                  RightCommand="{Binding OkCommand}"/>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- add `DialogButtonBar` control exposing button texts and commands for dialogs
- use `DialogButtonBar` in ChangePassword, PasswordPrompt, ImageImportMapping, ImportMapping, and ConfirmDialog windows

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a1891a95a88324b8e2c52f4e7f9804