### PR TITLE
feat: add reusable search bar control

### DIFF
--- a/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
@@ -21,6 +21,7 @@ using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Controls;
 
 namespace ToolManagementAppV2.Tests.Views
 {
@@ -38,7 +39,10 @@ namespace ToolManagementAppV2.Tests.Views
                     var (window, dbPath) = TestHelpers.CreateMainWindow();
                     try
                     {
-                        var textBox = (TextBox)window.FindName("GlobalSearchTextBox");
+                        var searchBar = (SearchBar)window.FindName("GlobalSearchBar");
+                        Assert.NotNull(searchBar);
+
+                        var textBox = (TextBox)searchBar.FindName("SearchTextBox");
                         Assert.NotNull(textBox);
 
                         var vm = Assert.IsType<MainViewModel>(window.DataContext);

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -2,6 +2,7 @@
 <Window x:Class="ToolManagementAppV2.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:ToolManagementAppV2.Controls"
         Title="Tool Management" Width="1280" Height="800" WindowStartupLocation="CenterScreen"
         Background="{StaticResource BackgroundBrush}">
     <DockPanel LastChildFill="True">
@@ -89,12 +90,9 @@
                 <DockPanel>
                     <TextBlock Text="{Binding CurrentPageTitle}" DockPanel.Dock="Left" FontSize="20" FontWeight="SemiBold"/>
                     <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
-                        <TextBox x:Name="GlobalSearchTextBox" Width="260" Text="{Binding GlobalSearchText, UpdateSourceTrigger=PropertyChanged}">
-                            <TextBox.InputBindings>
-                                <KeyBinding Key="Enter" Command="{Binding GlobalSearchCommand}"/>
-                            </TextBox.InputBindings>
-                        </TextBox>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Search" Command="{Binding GlobalSearchCommand}" Margin="8,0,0,0"/>
+                        <controls:SearchBar x:Name="GlobalSearchBar"
+                                            Text="{Binding GlobalSearchText}"
+                                            SearchCommand="{Binding GlobalSearchCommand}"/>
                         <Button x:Name="SwitchUserButton" Style="{StaticResource PrimaryButton}" Content="Switch User" Command="{Binding SwitchUserCommand}" Margin="8,0,0,0"/>
                     </StackPanel>
                 </DockPanel>

--- a/ToolManagementAppV2/Views/Controls/SearchBar.xaml
+++ b/ToolManagementAppV2/Views/Controls/SearchBar.xaml
@@ -1,0 +1,18 @@
+<UserControl x:Class="ToolManagementAppV2.Controls.SearchBar"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="Root">
+    <StackPanel Orientation="Horizontal">
+        <TextBox x:Name="SearchTextBox"
+                 Width="240"
+                 Text="{Binding Text, ElementName=Root, UpdateSourceTrigger=PropertyChanged}">
+            <TextBox.InputBindings>
+                <KeyBinding Key="Enter" Command="{Binding SearchCommand, ElementName=Root}"/>
+            </TextBox.InputBindings>
+        </TextBox>
+        <Button Style="{StaticResource PrimaryButton}"
+                Content="Search"
+                Command="{Binding SearchCommand, ElementName=Root}"
+                Margin="8,0,0,0"/>
+    </StackPanel>
+</UserControl>

--- a/ToolManagementAppV2/Views/Controls/SearchBar.xaml.cs
+++ b/ToolManagementAppV2/Views/Controls/SearchBar.xaml.cs
@@ -1,0 +1,33 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace ToolManagementAppV2.Controls
+{
+    public partial class SearchBar : UserControl
+    {
+        public SearchBar()
+        {
+            InitializeComponent();
+        }
+
+        public string Text
+        {
+            get => (string)GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
+        }
+
+        public static readonly DependencyProperty TextProperty =
+            DependencyProperty.Register(nameof(Text), typeof(string), typeof(SearchBar),
+                new FrameworkPropertyMetadata(string.Empty, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+
+        public ICommand? SearchCommand
+        {
+            get => (ICommand?)GetValue(SearchCommandProperty);
+            set => SetValue(SearchCommandProperty, value);
+        }
+
+        public static readonly DependencyProperty SearchCommandProperty =
+            DependencyProperty.Register(nameof(SearchCommand), typeof(ICommand), typeof(SearchBar));
+    }
+}

--- a/ToolManagementAppV2/Views/RentalHistoryWindow.xaml
+++ b/ToolManagementAppV2/Views/RentalHistoryWindow.xaml
@@ -2,6 +2,7 @@
 <Window x:Class="ToolManagementAppV2.Views.RentalHistoryWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:ToolManagementAppV2.Controls"
         Title="Rental History"
         Width="1100" Height="640"
         WindowStartupLocation="CenterScreen"
@@ -10,10 +11,9 @@
         <Border DockPanel.Dock="Top" Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" Padding="10" CornerRadius="8">
             <DockPanel>
                 <TextBlock Text="Rental History" FontWeight="SemiBold" FontSize="18" DockPanel.Dock="Left"/>
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
-                    <TextBox Width="240" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Search" Command="{Binding SearchCommand}" Margin="8,0,0,0"/>
-                </StackPanel>
+                <controls:SearchBar DockPanel.Dock="Right"
+                                   Text="{Binding SearchText}"
+                                   SearchCommand="{Binding SearchCommand}"/>
             </DockPanel>
         </Border>
 


### PR DESCRIPTION
## Summary
- add reusable `SearchBar` user control exposing `Text` and `SearchCommand`
- replace manual search stacks in `MainWindow` and `RentalHistoryWindow`
- update unit tests for new `SearchBar`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a18b2fa3f88324a9b3b4af5b1dfdee