### PR TITLE
Add reusable DataGrid virtualization style

### DIFF
--- a/ToolManagementAppV2/Resources/Styles.xaml
+++ b/ToolManagementAppV2/Resources/Styles.xaml
@@ -132,6 +132,12 @@
         <Setter Property="AutoGenerateColumns" Value="False"/>
         <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
     </Style>
+    <Style x:Key="VirtualizedDataGridStyle" TargetType="DataGrid" BasedOn="{StaticResource {x:Type DataGrid}}">
+        <Setter Property="EnableRowVirtualization" Value="True"/>
+        <Setter Property="EnableColumnVirtualization" Value="True"/>
+        <Setter Property="VirtualizingPanel.IsVirtualizing" Value="True"/>
+        <Setter Property="VirtualizingPanel.VirtualizationMode" Value="Recycling"/>
+    </Style>
     <Style TargetType="ProgressBar">
         <Setter Property="Height" Value="8"/>
         <Setter Property="Foreground" Value="{StaticResource SuccessBrush}"/>

--- a/ToolManagementAppV2/Views/ActivityLogsPage.xaml
+++ b/ToolManagementAppV2/Views/ActivityLogsPage.xaml
@@ -16,7 +16,7 @@
         </Border>
 
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
-            <DataGrid ItemsSource="{Binding Logs}" IsReadOnly="True" AutoGenerateColumns="False" EnableRowVirtualization="True" EnableColumnVirtualization="True" VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling">
+            <DataGrid ItemsSource="{Binding Logs}" IsReadOnly="True" AutoGenerateColumns="False" Style="{StaticResource VirtualizedDataGridStyle}">
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="Timestamp"
                                          Binding="{Binding Timestamp, StringFormat={}{0:yyyy-MM-dd HH:mm}}"

--- a/ToolManagementAppV2/Views/CustomersPage.xaml
+++ b/ToolManagementAppV2/Views/CustomersPage.xaml
@@ -16,7 +16,7 @@
             </StackPanel>
         </Border>
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
-            <DataGrid ItemsSource="{Binding Customers}" SelectedItem="{Binding SelectedCustomer}" IsReadOnly="True" AutoGenerateColumns="False" EnableRowVirtualization="True" EnableColumnVirtualization="True" VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling">
+            <DataGrid ItemsSource="{Binding Customers}" SelectedItem="{Binding SelectedCustomer}" IsReadOnly="True" AutoGenerateColumns="False" Style="{StaticResource VirtualizedDataGridStyle}">
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="Company" Binding="{Binding Company}" Width="*"/>
                     <DataGridTextColumn Header="Contact" Binding="{Binding Contact}" Width="220"/>

--- a/ToolManagementAppV2/Views/ImportExportPage.xaml
+++ b/ToolManagementAppV2/Views/ImportExportPage.xaml
@@ -19,7 +19,7 @@
             </WrapPanel>
         </Border>
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
-            <DataGrid ItemsSource="{Binding ImportExportLogs}" IsReadOnly="True" AutoGenerateColumns="False" EnableRowVirtualization="True" EnableColumnVirtualization="True" VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling">
+            <DataGrid ItemsSource="{Binding ImportExportLogs}" IsReadOnly="True" AutoGenerateColumns="False" Style="{StaticResource VirtualizedDataGridStyle}">
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="Message" Binding="{Binding}" />
                 </DataGrid.Columns>

--- a/ToolManagementAppV2/Views/ManageRentalsPage.xaml
+++ b/ToolManagementAppV2/Views/ManageRentalsPage.xaml
@@ -19,10 +19,7 @@
                       SelectedItem="{Binding SelectedRental}"
                       IsReadOnly="True"
                       AutoGenerateColumns="False"
-                      EnableRowVirtualization="True"
-                      EnableColumnVirtualization="True"
-                      VirtualizingPanel.IsVirtualizing="True"
-                      VirtualizingPanel.VirtualizationMode="Recycling">
+                      Style="{StaticResource VirtualizedDataGridStyle}">
                 <DataGrid.Columns>
                     <StaticResource ResourceKey="RentalIdColumn"/>
                     <StaticResource ResourceKey="RentalToolNumberColumn"/>

--- a/ToolManagementAppV2/Views/RentalHistoryWindow.xaml
+++ b/ToolManagementAppV2/Views/RentalHistoryWindow.xaml
@@ -22,10 +22,7 @@
                       SelectedItem="{Binding SelectedEntry}"
                       IsReadOnly="True"
                       AutoGenerateColumns="False"
-                      EnableRowVirtualization="True"
-                      EnableColumnVirtualization="True"
-                      VirtualizingPanel.IsVirtualizing="True"
-                      VirtualizingPanel.VirtualizationMode="Recycling">
+                      Style="{StaticResource VirtualizedDataGridStyle}">
                 <DataGrid.Columns>
                     <StaticResource ResourceKey="RentalIdColumn"/>
                     <StaticResource ResourceKey="RentalToolNumberColumn"/>

--- a/ToolManagementAppV2/Views/UsersPage.xaml
+++ b/ToolManagementAppV2/Views/UsersPage.xaml
@@ -32,10 +32,7 @@
                       AutoGenerateColumns="False"
                       SelectionMode="Single"
                       CanUserAddRows="False"
-                      EnableRowVirtualization="True"
-                      EnableColumnVirtualization="True"
-                      VirtualizingPanel.IsVirtualizing="True"
-                      VirtualizingPanel.VirtualizationMode="Recycling">
+                      Style="{StaticResource VirtualizedDataGridStyle}">
                 <DataGrid.Columns>
                     <DataGridTemplateColumn Header="Avatar" Width="60">
                         <DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
## Summary
- add `VirtualizedDataGridStyle` centralizing DataGrid virtualization settings
- apply shared style to DataGrids on rentals, customers, logs, import/export, history, and users pages

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a18c92b5f883248d93ae46c4dbc411