### PR TITLE
refactor: ensure dispatcher for async dialogs

### DIFF
--- a/ToolManagementAppV2/Interfaces/IDialogService.cs
+++ b/ToolManagementAppV2/Interfaces/IDialogService.cs
@@ -12,15 +12,15 @@ namespace ToolManagementAppV2.Interfaces
         void ShowInfo(string message, string title);
         Task ShowInfoAsync(string message, string title) =>
             System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowInfo(message, title)).Task
-            ?? Task.Run(() => ShowInfo(message, title));
+            ?? Task.CompletedTask;
         bool ShowConfirmation(string message, string title);
         Task<bool> ShowConfirmationAsync(string message, string title) =>
             System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowConfirmation(message, title)).Task
-            ?? Task.FromResult(ShowConfirmation(message, title));
+            ?? Task.FromResult(false);
         ToolModel? ShowEditToolDialog(ToolModel tool);
         Task<ToolModel?> ShowEditToolDialogAsync(ToolModel tool) =>
             System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowEditToolDialog(tool)).Task
-            ?? Task.FromResult(ShowEditToolDialog(tool));
+            ?? Task.FromResult<ToolModel?>(null);
         void ShowToolDetails(ToolModel tool);
         (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers);
         CustomerModel? ShowAddCustomerDialog();

--- a/ToolManagementAppV2/Services/DialogService.cs
+++ b/ToolManagementAppV2/Services/DialogService.cs
@@ -30,9 +30,15 @@ namespace ToolManagementAppV2.Services
             dialog.ShowDialog();
         }
 
-        public Task ShowInfoAsync(string message, string title) =>
-            System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowInfo(message, title)).Task
-            ?? Task.Run(() => ShowInfo(message, title));
+        public Task ShowInfoAsync(string message, string title)
+        {
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher != null)
+                return dispatcher.InvokeAsync(() => ShowInfo(message, title)).Task;
+
+            _logger.LogWarning("No dispatcher available for ShowInfoAsync; dialog not shown.");
+            return Task.CompletedTask;
+        }
 
         public bool ShowConfirmation(string message, string title)
         {
@@ -40,9 +46,15 @@ namespace ToolManagementAppV2.Services
             return dialog.ShowDialog() == true;
         }
 
-        public Task<bool> ShowConfirmationAsync(string message, string title) =>
-            System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowConfirmation(message, title)).Task
-            ?? Task.FromResult(ShowConfirmation(message, title));
+        public Task<bool> ShowConfirmationAsync(string message, string title)
+        {
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher != null)
+                return dispatcher.InvokeAsync(() => ShowConfirmation(message, title)).Task;
+
+            _logger.LogWarning("No dispatcher available for ShowConfirmationAsync; returning false.");
+            return Task.FromResult(false);
+        }
 
         public ToolModel? ShowEditToolDialog(ToolModel tool)
         {
@@ -57,9 +69,15 @@ namespace ToolManagementAppV2.Services
             catch (Exception ex) { _logger.LogError(ex, "Failed to show ToolEditWindow"); return null; }
         }
 
-        public Task<ToolModel?> ShowEditToolDialogAsync(ToolModel tool) =>
-            System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowEditToolDialog(tool)).Task
-            ?? Task.FromResult(ShowEditToolDialog(tool));
+        public Task<ToolModel?> ShowEditToolDialogAsync(ToolModel tool)
+        {
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher != null)
+                return dispatcher.InvokeAsync(() => ShowEditToolDialog(tool)).Task;
+
+            _logger.LogWarning("No dispatcher available for ShowEditToolDialogAsync; returning null.");
+            return Task.FromResult<ToolModel?>(null);
+        }
 
         public void ShowToolDetails(ToolModel tool)
         {


### PR DESCRIPTION
## Summary
- require a dispatcher for dialog service async methods
- avoid Task.Run fallback and log when no dispatcher

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a18fdf5c3c832482a88b71bc5af71f