### PR TITLE
Remove unused SwitchUserButton name

### DIFF
--- a/ToolManagementAppV2.Tests/TestHelpers.cs
+++ b/ToolManagementAppV2.Tests/TestHelpers.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Windows;
+using System.Windows.Media;
 using ToolManagementAppV2;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
@@ -35,6 +37,22 @@ namespace ToolManagementAppV2.Tests
                 fileDialogService, activityLogService, settingsService, db, dialogService);
             var window = new MainWindow(vm, db);
             return (window, dbPath);
+        }
+
+        public static IEnumerable<T> FindVisualChildren<T>(DependencyObject depObj) where T : DependencyObject
+        {
+            if (depObj == null)
+                yield break;
+
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(depObj); i++)
+            {
+                DependencyObject child = VisualTreeHelper.GetChild(depObj, i);
+                if (child is T t)
+                    yield return t;
+
+                foreach (T childOfChild in FindVisualChildren<T>(child))
+                    yield return childOfChild;
+            }
         }
 
         class StubFileDialogService : IFileDialogService

--- a/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
@@ -97,11 +97,12 @@ namespace ToolManagementAppV2.Tests.Views
                     var (window, dbPath) = TestHelpers.CreateMainWindow();
                     try
                     {
-                        var button = (Button)window.FindName("SwitchUserButton");
+                        var button = TestHelpers.FindVisualChildren<Button>(window)
+                            .FirstOrDefault(b => Equals(b.Content, "Switch User"));
                         Assert.NotNull(button);
 
                         var vm = Assert.IsType<MainViewModel>(window.DataContext);
-                        Assert.Same(vm.SwitchUserCommand, button.Command);
+                        Assert.Same(vm.SwitchUserCommand, button!.Command);
                     }
                     finally
                     {
@@ -167,8 +168,9 @@ namespace ToolManagementAppV2.Tests.Views
                         var window = new ToolManagementAppV2.MainWindow(vm, db);
                         try
                         {
-                            var button = (Button)window.FindName("SwitchUserButton");
-                            var cmd = Assert.IsAssignableFrom<IAsyncRelayCommand>(button.Command);
+                            var button = TestHelpers.FindVisualChildren<Button>(window)
+                                .FirstOrDefault(b => Equals(b.Content, "Switch User"));
+                            var cmd = Assert.IsAssignableFrom<IAsyncRelayCommand>(button!.Command);
                             var task = cmd.ExecuteAsync(null);
                             var frame = new DispatcherFrame();
                             task.ContinueWith(_ => frame.Continue = false);

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -93,7 +93,7 @@
                         <controls:SearchBar x:Name="GlobalSearchBar"
                                             Text="{Binding GlobalSearchText}"
                                             SearchCommand="{Binding GlobalSearchCommand}"/>
-                        <Button x:Name="SwitchUserButton" Style="{StaticResource PrimaryButton}" Content="Switch User" Command="{Binding SwitchUserCommand}" Margin="8,0,0,0"/>
+                        <Button Style="{StaticResource PrimaryButton}" Content="Switch User" Command="{Binding SwitchUserCommand}" Margin="8,0,0,0"/>
                     </StackPanel>
                 </DockPanel>
             </Border>


### PR DESCRIPTION
## Summary
- remove SwitchUserButton x:Name from MainWindow
- add helper to locate controls via visual tree for tests
- adjust MainWindow tests to find Switch User button without a name

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a18fe61e588324b020f47c1378fbf9