### PR TITLE
Allow specifying initial directory for file dialogs

### DIFF
--- a/ToolManagementAppV2.Tests/TestHelpers.cs
+++ b/ToolManagementAppV2.Tests/TestHelpers.cs
@@ -57,7 +57,7 @@ namespace ToolManagementAppV2.Tests
 
         class StubFileDialogService : IFileDialogService
         {
-            public string OpenFile(string filter) => null;
+            public string OpenFile(string filter, string? initialDirectory = null) => null;
             public string SaveFile(string filter) => null;
         }
 

--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -74,7 +74,7 @@ namespace ToolManagementAppV2.Tests.Tests
 
 class StubFileDialogService : IFileDialogService
 {
-    public string OpenFile(string filter) => null;
+    public string OpenFile(string filter, string? initialDirectory = null) => null;
     public string SaveFile(string filter) => null;
 }
 

--- a/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -27,6 +27,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
             Assert.True(dialog.ShowImportMappingCalled);
             Assert.True(toolSvc.ImportCalled);
+            Assert.Equal(AppContext.BaseDirectory, fileDlg.InitialDirectoryUsed);
             Assert.Equal("ToolNumber", toolSvc.MapUsed!["ToolNumber"]);
             File.Delete(tmp);
         }
@@ -45,6 +46,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
             Assert.True(dialog.ShowImportMappingCalled);
             Assert.True(customerSvc.ImportCalled);
+            Assert.Equal(AppContext.BaseDirectory, fileDlg.InitialDirectoryUsed);
             Assert.Equal("Company", customerSvc.MapUsed!["Company"]);
             File.Delete(tmp);
         }
@@ -133,7 +135,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
     class StubFileDialogService : IFileDialogService
     {
         public string FileToReturn { get; set; } = string.Empty;
-        public string OpenFile(string filter) => FileToReturn;
+        public string? InitialDirectoryUsed { get; private set; }
+        public string OpenFile(string filter, string? initialDirectory = null)
+        {
+            InitialDirectoryUsed = initialDirectory;
+            return FileToReturn;
+        }
         public string SaveFile(string filter) => FileToReturn;
     }
 

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -66,7 +66,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
 class StubFileDialogService : ToolManagementAppV2.Interfaces.IFileDialogService
 {
-    public string OpenFile(string filter) => null;
+    public string OpenFile(string filter, string? initialDirectory = null) => null;
     public string SaveFile(string filter) => null;
 }
 

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelDisposalTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelDisposalTests.cs
@@ -109,7 +109,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
         class StubFileDialogService : IFileDialogService
         {
-            public string OpenFile(string filter) => null;
+            public string OpenFile(string filter, string? initialDirectory = null) => null;
             public string SaveFile(string filter) => null;
         }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelImportMappingTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelImportMappingTests.cs
@@ -74,7 +74,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         class StubFileDialogService : IFileDialogService
         {
             public string? FileToReturn { get; set; }
-            public string OpenFile(string filter) => FileToReturn ?? string.Empty;
+            public string OpenFile(string filter, string? initialDirectory = null) => FileToReturn ?? string.Empty;
             public string SaveFile(string filter) => string.Empty;
         }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -402,7 +402,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 class StubFileDialogService : ToolManagementAppV2.Interfaces.IFileDialogService
 {
     public string FileToOpen;
-    public string OpenFile(string filter) => FileToOpen;
+    public string OpenFile(string filter, string? initialDirectory = null) => FileToOpen;
     public string SaveFile(string filter) => null;
 }
 

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -142,7 +142,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
     class StubFileDialogService : IFileDialogService
     {
-        public string OpenFile(string filter) => null;
+        public string OpenFile(string filter, string? initialDirectory = null) => null;
         public string SaveFile(string filter) => null;
     }
 

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
@@ -113,7 +113,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
     class StubFileDialogService : IFileDialogService
     {
-        public string OpenFile(string filter) => null;
+        public string OpenFile(string filter, string? initialDirectory = null) => null;
         public string SaveFile(string filter) => null;
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -200,7 +200,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     class StubFileDialogService : IFileDialogService
     {
         public string FileToReturn { get; set; } = "path.csv";
-        public string OpenFile(string filter) => FileToReturn;
+        public string OpenFile(string filter, string? initialDirectory = null) => FileToReturn;
         public string SaveFile(string filter) => FileToReturn;
     }
 

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -150,7 +150,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     class StubFileDialogService : ToolManagementAppV2.Interfaces.IFileDialogService
     {
         public string OpenPath { get; set; } = string.Empty;
-        public string? OpenFile(string filter) => OpenPath;
+        public string? OpenFile(string filter, string? initialDirectory = null) => OpenPath;
         public string? SaveFile(string filter) => null;
     }
 

--- a/ToolManagementAppV2.Tests/ViewModels/ToolEditViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolEditViewModelTests.cs
@@ -29,7 +29,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         private class StubFileDialogService : IFileDialogService
         {
             public string? OpenPath { get; set; }
-            public string? OpenFile(string filter) => OpenPath;
+            public string? OpenFile(string filter, string? initialDirectory = null) => OpenPath;
             public string? SaveFile(string filter) => null;
         }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -538,7 +538,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 class StubFileDialogService : IFileDialogService
 {
     public string FileToReturn { get; set; }
-    public string OpenFile(string filter) => FileToReturn;
+    public string OpenFile(string filter, string? initialDirectory = null) => FileToReturn;
     public string SaveFile(string filter) => FileToReturn;
 }
 

--- a/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
@@ -69,7 +69,7 @@ namespace ToolManagementAppV2.Tests.Views
     class StubFileDialogService : IFileDialogService
     {
         public string FileToReturn { get; set; } = string.Empty;
-        public string OpenFile(string filter) => FileToReturn;
+        public string OpenFile(string filter, string? initialDirectory = null) => FileToReturn;
         public string SaveFile(string filter) => FileToReturn;
     }
 

--- a/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
@@ -271,7 +271,7 @@ namespace ToolManagementAppV2.Tests.Views
 
         class StubFileDialogService : IFileDialogService
         {
-            public string OpenFile(string filter) => null;
+            public string OpenFile(string filter, string? initialDirectory = null) => null;
             public string SaveFile(string filter) => null;
         }
 

--- a/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
@@ -135,7 +135,7 @@ namespace ToolManagementAppV2.Tests.Views
     class StubFileDialogService : IFileDialogService
     {
         public string FileToReturn { get; set; }
-        public string OpenFile(string filter) => FileToReturn;
+        public string OpenFile(string filter, string? initialDirectory = null) => FileToReturn;
         public string SaveFile(string filter) => FileToReturn;
     }
 

--- a/ToolManagementAppV2/Interfaces/IFileDialogService.cs
+++ b/ToolManagementAppV2/Interfaces/IFileDialogService.cs
@@ -2,7 +2,7 @@ namespace ToolManagementAppV2.Interfaces
 {
     public interface IFileDialogService
     {
-        string? OpenFile(string filter);
+        string? OpenFile(string filter, string? initialDirectory = null);
         string? SaveFile(string filter);
     }
 }

--- a/ToolManagementAppV2/Services/Core/FileDialogService.cs
+++ b/ToolManagementAppV2/Services/Core/FileDialogService.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Win32;
 using ToolManagementAppV2.Interfaces;
 
@@ -5,12 +6,16 @@ namespace ToolManagementAppV2.Services.Core
 {
     public class FileDialogService : IFileDialogService
     {
-        public string? OpenFile(string filter)
+        public string? OpenFile(string filter, string? initialDirectory = null)
         {
             var dlg = new Microsoft.Win32.OpenFileDialog
             {
                 Filter = filter
             };
+            if (!string.IsNullOrEmpty(initialDirectory))
+            {
+                dlg.InitialDirectory = initialDirectory;
+            }
             return dlg.ShowDialog() == true ? dlg.FileName : null;
         }
 

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -62,7 +62,7 @@ namespace ToolManagementAppV2.ViewModels
 
         async Task ImportToolsAsync(CancellationToken cancellationToken)
         {
-            var path = _fileDialogService.OpenFile("CSV Files|*.csv");
+            var path = _fileDialogService.OpenFile("CSV Files|*.csv", AppContext.BaseDirectory);
             if (string.IsNullOrEmpty(path)) return;
             try
             {
@@ -111,7 +111,7 @@ namespace ToolManagementAppV2.ViewModels
 
         async Task ImportCustomersAsync(CancellationToken cancellationToken)
         {
-            var path = _fileDialogService.OpenFile("CSV Files|*.csv");
+            var path = _fileDialogService.OpenFile("CSV Files|*.csv", AppContext.BaseDirectory);
             if (string.IsNullOrEmpty(path)) return;
             try
             {

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -320,7 +320,7 @@ namespace ToolManagementAppV2.ViewModels
         {
             try
             {
-                var path = _fileDialogService.OpenFile("CSV Files|*.csv");
+                var path = _fileDialogService.OpenFile("CSV Files|*.csv", AppContext.BaseDirectory);
                 if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
                     return;
 


### PR DESCRIPTION
## Summary
- Allow IFileDialogService.OpenFile to take an optional initial directory
- Use AppContext.BaseDirectory when opening CSV files in ImportExportViewModel and MainViewModel
- Capture and assert initial directory in ImportExportViewModel unit tests and update all test stubs

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a193b93e14832499c290e9f0ef077f