### PR TITLE
Include Templates.xaml as WPF page

### DIFF
--- a/ToolManagementAppV2/ToolManagementAppV2.csproj
+++ b/ToolManagementAppV2/ToolManagementAppV2.csproj
@@ -101,7 +101,13 @@
 
  <ItemGroup>
    <Page Remove="Resources\Colors.xaml" />
-   <Page Remove="Resources\Templates.xaml" />
+ </ItemGroup>
+
+ <ItemGroup>
+   <Page Include="Resources\Templates.xaml">
+     <Generator>MSBuild:Compile</Generator>
+     <SubType>Designer</SubType>
+   </Page>
  </ItemGroup>
 
   <ItemGroup>
@@ -241,11 +247,6 @@
     <Content Include="Resources\Avatars\9.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Resource Include="Resources\Templates.xaml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Resource>
     <Resource Include="Resources\DefaultLogo.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Resource>


### PR DESCRIPTION
## Summary
- include Templates.xaml as a compiled WPF Page instead of a loose resource
- remove conflicting Template.xaml removal/override entries from project file

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: command not found)*
- `dotnet build ToolManagementAppV2/ToolManagementAppV2.csproj -p:EnableWindowsTargeting=true` *(fails: command not found)*
- `dotnet run --project ToolManagementAppV2/ToolManagementAppV2.csproj -p:EnableWindowsTargeting=true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1969f8d508324aee18b90537f8c41