### PR TITLE
Restore default WPF page item inclusion

### DIFF
--- a/ToolManagementAppV2/ToolManagementAppV2.csproj
+++ b/ToolManagementAppV2/ToolManagementAppV2.csproj
@@ -7,7 +7,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableDefaultPageItems>false</EnableDefaultPageItems>
   </PropertyGroup>
 
   <ItemGroup>
@@ -51,6 +50,15 @@
     <Page Remove="Views\Settings\**" />
     <Page Remove="Views\Tool\**" />
     <Page Remove="Views\User\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Page Include="Views/**/*.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Compile Include="Views/**/*.xaml.cs">
+      <DependentUpon>%(Filename)</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- remove `EnableDefaultPageItems` to allow default inclusion of WPF pages
- explicitly include view XAML files and their code-behind so partial classes generate

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a19b0b94b88324902f367ab1efdb4c