### PR TITLE
Remove redundant view includes from project file

### DIFF
--- a/ToolManagementAppV2/ToolManagementAppV2.csproj
+++ b/ToolManagementAppV2/ToolManagementAppV2.csproj
@@ -53,15 +53,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Page Include="Views/**/*.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Compile Include="Views/**/*.xaml.cs">
-      <DependentUpon>%(Filename)</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
     <None Remove="Resources\Avatars\1.png" />
     <None Remove="Resources\Avatars\10.png" />
     <None Remove="Resources\Avatars\11.png" />
@@ -113,7 +104,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Page Include="Resources\Templates.xaml">
+    <Page Update="Resources\Templates.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>


### PR DESCRIPTION
## Summary
- rely on SDK defaults by removing explicit View XAML/Page includes
- convert Resources/Templates.xaml to use Update metadata instead of explicit Include

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a19c7aab4c8324a4b29990ded17a00