### PR TITLE
Ensure converter resources compile with assembly namespace

### DIFF
--- a/ToolManagementAppV2/Resources/Converters.xaml
+++ b/ToolManagementAppV2/Resources/Converters.xaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:conv="clr-namespace:ToolManagementAppV2.Utilities.Converters">
+                    xmlns:conv="clr-namespace:ToolManagementAppV2.Utilities.Converters;assembly=ToolManagementAppV2">
     <conv:NullToDefaultImageConverter x:Key="NullToDefaultImageConverter"/>
     <conv:BooleanToAdminConverter x:Key="BooleanToAdminConverter"/>
 </ResourceDictionary>

--- a/ToolManagementAppV2/ToolManagementAppV2.csproj
+++ b/ToolManagementAppV2/ToolManagementAppV2.csproj
@@ -265,6 +265,7 @@
     </Resource>
     <Resource Include="Resources\Converters.xaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Generator>MSBuild:Compile</Generator>
     </Resource>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Specify assembly in Converters.xaml namespace declaration
- Ensure Converters.xaml compiles to BAML via Generator metadata

## Testing
- ⚠️ `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a19f8a31d08324924d1241ce96300e