### PR TITLE
Allow seeding admin without authorization

### DIFF
--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -10,6 +10,54 @@ using Xunit;
 
 public class UserServiceTests
 {
+    class StubUserContext : IUserContext
+    {
+        public User? CurrentUser { get; set; }
+        public event EventHandler<User?>? UserChanged;
+        public bool IsAdmin => CurrentUser?.IsAdmin ?? false;
+        public string UserName => CurrentUser?.UserName ?? string.Empty;
+        public string Role => CurrentUser?.Role ?? string.Empty;
+    }
+
+    [Fact]
+    public async Task AddUserAsync_AllowsSeedingAdminWithoutAuthorization()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            var ctx = new StubUserContext { CurrentUser = new User { UserName = "seed", IsAdmin = false } };
+            var auth = new AuthorizationService(ctx);
+            var userService = new UserService(dbService, ctx, auth);
+            var admin = new User { UserName = "admin", Password = "pw", IsAdmin = true };
+            await userService.AddUserAsync(admin);
+            Assert.NotEqual(0, admin.UserID);
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task AddUserAsync_RequiresAdminAfterSeeding()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            var ctx = new StubUserContext { CurrentUser = new User { UserName = "seed", IsAdmin = false } };
+            var auth = new AuthorizationService(ctx);
+            var userService = new UserService(dbService, ctx, auth);
+            var admin = new User { UserName = "admin", Password = "pw", IsAdmin = true };
+            await userService.AddUserAsync(admin);
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(() => userService.AddUserAsync(new User { UserName = "user", Password = "pw" }));
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
     [Fact]
     public async Task TryDeleteUserAsync_ReturnsFalse_WhenDeletingOnlyAdmin()
     {

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -168,7 +168,9 @@ namespace ToolManagementAppV2.Services.Users
 
         public async Task AddUserAsync(User user)
         {
-            _auth.EnsureAdmin();
+            var existingUsers = await GetAllUsersAsync();
+            if (existingUsers.Count > 0)
+                _auth.EnsureAdmin();
             const string sql = @"
                 INSERT INTO Users
                   (UserName, Password, Salt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, FailedAttempts, LockoutUntil, PasswordExpired)


### PR DESCRIPTION
## Summary
- Skip admin authorization when adding the first user.
- Add tests covering admin seeding and enforcement of admin requirement for subsequent users.

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a1a0ca2e20832496bc703d3d54fa82