### PR TITLE
Handle multiple disposal in ToolManagementViewModel

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -619,7 +619,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             Assert.True(timer.IsEnabled);
 
             vm.Dispose();
-
+            var ex = Record.Exception(() => vm.Dispose());
+            Assert.Null(ex);
             Assert.False(timer.IsEnabled);
         }
 

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -97,6 +97,9 @@ namespace ToolManagementAppV2.ViewModels
         readonly IDispatcherTimer _searchDebounceTimer;
         CancellationTokenSource _searchCts = new();
 
+        bool _suppressToolsChanged;
+        bool _disposed;
+
         // Writable for TwoWay binding from XAML. Mirrors SearchTerm and triggers search.
         private string _searchText = string.Empty;
         public string SearchText
@@ -149,8 +152,6 @@ namespace ToolManagementAppV2.ViewModels
             _searchCts = new CancellationTokenSource();
             SearchCommand.Execute(_searchCts.Token);
         }
-
-        bool _suppressToolsChanged;
 
         public async Task LoadToolsAsync()
         {
@@ -404,10 +405,23 @@ namespace ToolManagementAppV2.ViewModels
         /// <inheritdoc />
         public void Dispose()
         {
+            if (_disposed)
+                return;
+            _disposed = true;
+
             _searchDebounceTimer.Tick -= OnSearchDebounceTimerTick;
             _searchDebounceTimer.Stop();
-            _searchCts.Cancel();
-            _searchCts.Dispose();
+
+            var cts = Interlocked.Exchange(ref _searchCts, null!);
+            try
+            {
+                cts?.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            cts?.Dispose();
+
             Tools.CollectionChanged -= Tools_CollectionChanged;
         }
     }


### PR DESCRIPTION
## Summary
- guard ToolManagementViewModel disposal with a private flag
- safely cancel and dispose search token source using Interlocked
- test disposing ToolManagementViewModel multiple times without exceptions

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a1d28fbc8324a96a67d5c6c29edd