### PR TITLE
Handle missing user photos in login window

### DIFF
--- a/ToolManagementAppV2/Views/LoginWindow.xaml
+++ b/ToolManagementAppV2/Views/LoginWindow.xaml
@@ -58,7 +58,7 @@
                                         BorderBrush="{StaticResource BorderBrushAlt}"
                                         BorderThickness="1"
                                         ClipToBounds="True">
-                                    <Image Stretch="UniformToFill" Source="{Binding UserPhotoPath}"/>
+                                    <Image Stretch="UniformToFill" Source="{Binding UserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"/>
                                 </Border>
                                 <TextBlock Grid.Row="1"
                                            Text="{Binding UserName}"


### PR DESCRIPTION
## Summary
- use NullToDefaultImageConverter in LoginWindow to display a default avatar when user photo path is null or invalid

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a411922483249e7944bc7c0b561c