### PR TITLE
Handle admin password bootstrap without crash

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -285,6 +285,38 @@ namespace ToolManagementAppV2.Tests.ViewModels
             Assert.Null(userContext.CurrentUser);
             Assert.NotNull(logger.LastException);
         }
+
+        [Fact]
+        public async Task SelectUserCommand_AdminWithoutPassword_IgnoresUnauthorized()
+        {
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
+
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            try
+            {
+                using var dbService = new DatabaseService(dbPath);
+                var userContext = new ApplicationUserContext();
+                var auth = new AuthorizationService(userContext);
+                var userService = new UserService(dbService, userContext, auth);
+                var settingsService = new SettingsService(dbService);
+                await userService.AddUserAsync(new User { UserName = "admin", IsAdmin = true });
+
+                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
+                {
+                    PromptForPasswordAsync = (u, ct) => Task.FromResult<PasswordPromptResult?>(null)
+                };
+                await vm.InitializeAsync();
+
+                await vm.SelectUserCommand.ExecuteAsync(vm.Users[0]);
+
+                Assert.Null(userContext.CurrentUser);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
     }
 
     class StubDialogService : IDialogService

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -212,7 +212,15 @@ namespace ToolManagementAppV2.ViewModels
 
             if (user.IsAdmin && string.IsNullOrWhiteSpace(user.Password))
             {
-                await _userService.ChangeUserPasswordAsync(user.UserID, "admin");
+                try
+                {
+                    await _userService.ChangeUserPasswordAsync(user.UserID, "admin");
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    _logger.LogWarning(ex, "Failed to set default password for admin user {UserID}", user.UserID);
+                }
+
                 var refreshed = await _userService.GetUserByIDAsync(user.UserID);
                 if (refreshed != null)
                 {


### PR DESCRIPTION
## Summary
- ignore UnauthorizedAccessException when setting default admin password during login
- add regression test for admin login when password is missing

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a1a4cec4648324bf785c6e09377afe