### PR TITLE
Fix password change workflow during login

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -32,7 +32,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 using var dbService = new DatabaseService(dbPath);
                 var userContext = new ApplicationUserContext();
-                var userService = new UserService(dbService, userContext);
+                var auth = new AuthorizationService(userContext);
+                var userService = new UserService(dbService, userContext, auth);
                 var settingsService = new SettingsService(dbService);
                 await settingsService.SaveSettingAsync("ApplicationName", "TestApp");
 
@@ -60,7 +61,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 using var dbService = new DatabaseService(dbPath);
                 var userContext = new ApplicationUserContext();
-                var userService = new UserService(dbService, userContext);
+                var auth = new AuthorizationService(userContext);
+                var userService = new UserService(dbService, userContext, auth);
                 var settingsService = new SettingsService(dbService);
 
                 var logs = new List<LogEntry>();
@@ -90,7 +92,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 using var dbService = new DatabaseService(dbPath);
                 var userContext = new ApplicationUserContext();
-                var userService = new UserService(dbService, userContext);
+                var auth = new AuthorizationService(userContext);
+                var userService = new UserService(dbService, userContext, auth);
                 var settingsService = new SettingsService(dbService);
                 userService.AddUser(new User { UserName = "user", Password = "newpassword", IsAdmin = false });
 
@@ -122,7 +125,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 using var dbService = new DatabaseService(dbPath);
                 var userContext = new ApplicationUserContext();
-                var userService = new UserService(dbService, userContext);
+                var auth = new AuthorizationService(userContext);
+                var userService = new UserService(dbService, userContext, auth);
                 var settingsService = new SettingsService(dbService);
                 var user = new User { UserName = "user", Password = "newpassword", IsAdmin = false, PasswordExpired = true };
                 userService.AddUser(user);
@@ -139,6 +143,46 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 Assert.True(success);
                 var updated = userService.GetUserByID(user.UserID)!;
+                Assert.False(updated.PasswordExpired);
+                Assert.True(SecurityHelper.VerifyPassword("changed", updated.Salt, updated.Password));
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task SelectUserCommand_PromptsForPasswordChange_WhenAdminExpired()
+        {
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
+
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            try
+            {
+                using var dbService = new DatabaseService(dbPath);
+                var userContext = new ApplicationUserContext();
+                var auth = new AuthorizationService(userContext);
+                var userService = new UserService(dbService, userContext, auth);
+                var settingsService = new SettingsService(dbService);
+                var admin = new User { UserName = "admin", Password = "secret", IsAdmin = true, PasswordExpired = true };
+                userService.AddUser(admin);
+
+                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
+                {
+                    PromptForPasswordAsync = (u, ct) =>
+                        Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("secret", false)),
+                    PromptForNewPassword = () => "changed"
+                };
+                await vm.InitializeAsync();
+                bool success = false;
+                vm.LoginSucceeded += (_, __) => success = true;
+
+                await vm.SelectUserCommand.ExecuteAsync(vm.Users.First());
+
+                Assert.True(success);
+                var updated = userService.GetUserByID(admin.UserID)!;
                 Assert.False(updated.PasswordExpired);
                 Assert.True(SecurityHelper.VerifyPassword("changed", updated.Salt, updated.Password));
             }

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -283,7 +283,8 @@ namespace ToolManagementAppV2.Services.Users
 
         public async Task<bool> ChangeUserPasswordAsync(int userID, string newPassword)
         {
-            _auth.EnsureAdmin();
+            if (_context.CurrentUser?.UserID != userID)
+                _auth.EnsureAdmin();
             var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt, PasswordExpired=@Expired WHERE UserID=@ID";
             string hashed = string.Empty;
             string salt = string.Empty;

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -234,9 +234,12 @@ namespace ToolManagementAppV2.ViewModels
                 (string.IsNullOrWhiteSpace(user.Password) ||
                  await SecurityHelper.VerifyPasswordAsync("newpassword", user.Salt, user.Password).ConfigureAwait(false)))
             {
-                if (user.PasswordExpired && !await PromptChangePasswordAsync(user))
-                    return;
                 _userContext.CurrentUser = user;
+                if (user.PasswordExpired && !await PromptChangePasswordAsync(user))
+                {
+                    _userContext.CurrentUser = null;
+                    return;
+                }
                 LoginSucceeded?.Invoke(this, EventArgs.Empty);
                 return;
             }
@@ -274,9 +277,12 @@ namespace ToolManagementAppV2.ViewModels
                 }
             }
 
-            if (credential.PasswordExpired && !await PromptChangePasswordAsync(credential))
-                return;
             _userContext.CurrentUser = credential;
+            if (credential.PasswordExpired && !await PromptChangePasswordAsync(credential))
+            {
+                _userContext.CurrentUser = null;
+                return;
+            }
             LoginSucceeded?.Invoke(this, EventArgs.Empty);
         }
 


### PR DESCRIPTION
## Summary
- Set current user before invoking password change prompts
- Allow users to change their own password without admin rights
- Add tests verifying password change success for admin and non-admin logins

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a7f688c48324ad85a21d65dbe6e9