### PR TITLE
Fix user context menu binding

### DIFF
--- a/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Windows.Controls;
 using System.Reflection;
 using System.Collections.Generic;
+using System.IO;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
@@ -128,6 +129,60 @@ namespace ToolManagementAppV2.Tests.Views
             {
                 if (System.IO.File.Exists(dbPath))
                     System.IO.File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public void ContextMenuEditCommand_BindsSelectedItem()
+        {
+            var dbPath = Path.GetTempFileName();
+            Exception? threadException = null;
+
+            try
+            {
+                var thread = new Thread(() =>
+                {
+                    try
+                    {
+                        var db = new DatabaseService(dbPath);
+                        IUserService userService = new UserService(db, new ApplicationUserContext());
+                        var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
+                        userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                        vm.LoadUsers();
+
+                        var page = new UsersPage { DataContext = vm };
+                        var grid = (Grid)page.Content;
+                        var dataGrid = (DataGrid)((Border)grid.Children[1]).Child;
+
+                        dataGrid.SelectedItem = vm.Users.First();
+                        dataGrid.ContextMenu.PlacementTarget = dataGrid;
+                        dataGrid.ContextMenu.IsOpen = true;
+
+                        var editItem = (MenuItem)dataGrid.ContextMenu.Items[0];
+
+                        Assert.Equal(vm.Users.First(), editItem.CommandParameter);
+
+                        dataGrid.ContextMenu.IsOpen = false;
+                    }
+                    catch (Exception ex)
+                    {
+                        threadException = ex;
+                    }
+                });
+
+                thread.SetApartmentState(ApartmentState.STA);
+                thread.Start();
+                thread.Join();
+
+                if (threadException != null)
+                {
+                    throw threadException;
+                }
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
             }
         }
     }

--- a/ToolManagementAppV2/Views/UsersPage.xaml
+++ b/ToolManagementAppV2/Views/UsersPage.xaml
@@ -26,7 +26,8 @@
         </Border>
 
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
-            <DataGrid ItemsSource="{Binding Users}"
+            <DataGrid x:Name="UsersDataGrid"
+                      ItemsSource="{Binding Users}"
                       SelectedItem="{Binding SelectedUser}"
                       IsReadOnly="True"
                       AutoGenerateColumns="False"
@@ -53,11 +54,19 @@
                 </DataGrid.Columns>
                 <DataGrid.ContextMenu>
                     <ContextMenu>
-                        <MenuItem Header="Edit" Command="{Binding PlacementTarget.DataContext.EditUserFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
-                        <MenuItem Header="Reset Password" Command="{Binding PlacementTarget.DataContext.ResetPasswordFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
-                        <MenuItem Header="Upload Photo" Command="{Binding PlacementTarget.DataContext.UploadUserPhotoCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                        <MenuItem Header="Update" Command="{Binding PlacementTarget.DataContext.UpdateUserCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                        <MenuItem Header="Delete" Command="{Binding PlacementTarget.DataContext.DeleteUserFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
+                        <MenuItem Header="Edit"
+                                  Command="{Binding PlacementTarget.DataContext.EditUserFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                  CommandParameter="{Binding SelectedItem, Source={x:Reference UsersDataGrid}}"/>
+                        <MenuItem Header="Reset Password"
+                                  Command="{Binding PlacementTarget.DataContext.ResetPasswordFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                  CommandParameter="{Binding SelectedItem, Source={x:Reference UsersDataGrid}}"/>
+                        <MenuItem Header="Upload Photo"
+                                  Command="{Binding PlacementTarget.DataContext.UploadUserPhotoCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                        <MenuItem Header="Update"
+                                  Command="{Binding PlacementTarget.DataContext.UpdateUserCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                        <MenuItem Header="Delete"
+                                  Command="{Binding PlacementTarget.DataContext.DeleteUserFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                  CommandParameter="{Binding SelectedItem, Source={x:Reference UsersDataGrid}}"/>
                     </ContextMenu>
                 </DataGrid.ContextMenu>
             </DataGrid>


### PR DESCRIPTION
## Summary
- Fix UsersPage context menu bindings by referencing DataGrid via x:Reference
- Add regression test to ensure context menu binds SelectedItem

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1aa451b588324b5fb0ef8c9addf07