### PR TITLE
Fix switch user by using transient login window

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/DependencyInjectionTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/DependencyInjectionTests.cs
@@ -38,5 +38,17 @@ namespace ToolManagementAppV2.Tests.Tests
             Assert.NotNull(provider.GetService<IMainWindow>());
             Assert.NotNull(provider.GetService<ILoginWindow>());
         }
+
+        [Fact]
+        public void LoginWindow_Is_Transient()
+        {
+            var app = new ToolManagementAppV2.App();
+            var provider = app.Host.Services;
+
+            var first = provider.GetRequiredService<ILoginWindow>();
+            var second = provider.GetRequiredService<ILoginWindow>();
+
+            Assert.NotSame(first, second);
+        }
     }
 }

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -100,7 +100,7 @@ namespace ToolManagementAppV2
                 services.AddTransient<PrintLabelWindow>();
                 services.AddSingleton<IMainWindow>(sp =>
                     new MainWindow(sp.GetRequiredService<IMainViewModel>()));
-                services.AddSingleton<ILoginWindow>(sp =>
+                services.AddTransient<ILoginWindow>(sp =>
                     new LoginWindow(sp.GetRequiredService<ILoginViewModel>()));
             })
             .Build();


### PR DESCRIPTION
## Summary
- make login window transient so user switching creates a fresh instance
- verify login window registration is transient

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1abff6ce8832495a45e8c00d9c3ca