### PR TITLE
Bind context menu actions to placement target

### DIFF
--- a/ToolManagementAppV2/Views/UsersPage.xaml
+++ b/ToolManagementAppV2/Views/UsersPage.xaml
@@ -56,17 +56,20 @@
                     <ContextMenu>
                         <MenuItem Header="Edit"
                                   Command="{Binding PlacementTarget.DataContext.EditUserFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                                  CommandParameter="{Binding SelectedItem, Source={x:Reference UsersDataGrid}}"/>
+                                  CommandParameter="{Binding PlacementTarget.SelectedItem,
+                                                          RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                         <MenuItem Header="Reset Password"
                                   Command="{Binding PlacementTarget.DataContext.ResetPasswordFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                                  CommandParameter="{Binding SelectedItem, Source={x:Reference UsersDataGrid}}"/>
+                                  CommandParameter="{Binding PlacementTarget.SelectedItem,
+                                                          RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                         <MenuItem Header="Upload Photo"
                                   Command="{Binding PlacementTarget.DataContext.UploadUserPhotoCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                         <MenuItem Header="Update"
                                   Command="{Binding PlacementTarget.DataContext.UpdateUserCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                         <MenuItem Header="Delete"
                                   Command="{Binding PlacementTarget.DataContext.DeleteUserFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                                  CommandParameter="{Binding SelectedItem, Source={x:Reference UsersDataGrid}}"/>
+                                  CommandParameter="{Binding PlacementTarget.SelectedItem,
+                                                          RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                     </ContextMenu>
                 </DataGrid.ContextMenu>
             </DataGrid>


### PR DESCRIPTION
## Summary
- bind UsersPage context menu item parameters to placement target instead of DataGrid reference

## Testing
- `dotnet build` *(command not found: dotnet)*
- `dotnet test` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ae2096fc8324af46f8dc9af09bd9