### PR TITLE
Auto-generate missing tool numbers

### DIFF
--- a/ToolManagementAppV2.Tests/AsyncServiceExtensions.cs
+++ b/ToolManagementAppV2.Tests/AsyncServiceExtensions.cs
@@ -23,6 +23,8 @@ public static class AsyncServiceExtensions
         => svc.GetAllToolsAsync(token).GetAwaiter().GetResult();
     public static List<Tool> SearchTools(this IToolService svc, string? text, CancellationToken token = default)
         => svc.SearchToolsAsync(text, token).GetAwaiter().GetResult();
+    public static string GenerateNextToolNumber(this IToolService svc, CancellationToken token = default)
+        => svc.GenerateNextToolNumberAsync(token).GetAwaiter().GetResult();
 
     // CustomerService wrappers
     public static void AddCustomer(this ICustomerService svc, Customer customer, CancellationToken token = default)

--- a/ToolManagementAppV2.Tests/Extensions/ToolServiceExtensions.cs
+++ b/ToolManagementAppV2.Tests/Extensions/ToolServiceExtensions.cs
@@ -27,6 +27,8 @@ namespace ToolManagementAppV2.Tests.Extensions
 
         public static List<ToolModel> SearchTools(this IToolService service, string? searchText) =>
             service.SearchToolsAsync(searchText).GetAwaiter().GetResult();
+        public static string GenerateNextToolNumber(this IToolService service) =>
+            service.GenerateNextToolNumberAsync().GetAwaiter().GetResult();
 
         public static bool ToggleToolCheckOutStatus(this IToolService service, int toolID, string currentUser) =>
             service.ToggleToolCheckOutStatusAsync(toolID, currentUser).GetAwaiter().GetResult();

--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -384,6 +384,7 @@ namespace ToolManagementAppV2.Tests.Services
             public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
             public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default)
                 => throw new InvalidOperationException("fail");
+            public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
         }
     }
 }

--- a/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
@@ -67,6 +67,7 @@ public class ReportServiceAsyncTests
         public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<Tool, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 
     class DelayRentalService : IRentalService

--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -232,7 +232,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void AddTool_NullToolNumber_ThrowsArgumentException()
+        public void AddTool_BlankToolNumber_GeneratesNumber()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -241,7 +241,10 @@ namespace ToolManagementAppV2.Tests.Services
                 IToolService service = new ToolService(dbService);
 
                 var tool = new Tool { ToolNumber = "" };
-                Assert.Throws<ArgumentException>(() => service.AddTool(tool));
+                service.AddTool(tool);
+
+                Assert.Equal("T1", tool.ToolNumber);
+                Assert.Single(service.GetAllTools());
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -189,6 +189,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 
     class CapturingCustomerService : ICustomerService
@@ -244,6 +245,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 
     class CancelableToolService : IToolService
@@ -265,6 +267,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 
     class StubCustomerService : ICustomerService

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -252,6 +252,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 
     class FailToolService : IToolService
@@ -269,6 +270,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 
     class StubRentalService : IRentalService

--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -680,6 +680,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
         }
 
         class FailingToolService : IToolService
@@ -697,6 +698,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
             public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
         }
 
         class CapturingLogger<T> : ILogger<T>

--- a/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
@@ -116,6 +116,7 @@ namespace ToolManagementAppV2.Tests.Views
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, System.Collections.Generic.IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 
     class StubCustomerService : ICustomerService

--- a/ToolManagementAppV2/Interfaces/IToolService.cs
+++ b/ToolManagementAppV2/Interfaces/IToolService.cs
@@ -22,6 +22,7 @@ namespace ToolManagementAppV2.Interfaces
         Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken);
         Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default);
         Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default);
+        Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default);
         Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental,
             SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default);
     }

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -106,6 +106,15 @@ namespace ToolManagementAppV2.Services.Tools
             return ImportToolImagesInternalAsync(folderPath, keySelector, progress, cancellationToken);
         }
 
+        public async Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default)
+        {
+            const string sql = "SELECT IFNULL(MAX(CAST(SUBSTR(ToolNumber, 2) AS INTEGER)), 0) FROM Tools WHERE ToolNumber LIKE 'T%'";
+            using var conn = _dbService.CreateConnection();
+            var result = await SqliteHelper.ExecuteScalarAsync(conn, sql, null, cancellationToken);
+            var max = result == null || result == DBNull.Value ? 0 : Convert.ToInt32(result);
+            return $"T{max + 1}";
+        }
+
         async Task InsertToolAsync(SQLiteConnection conn, SQLiteTransaction? tran, ToolModel tool, CancellationToken cancellationToken)
         {
             ValidateQuantity(tool.QuantityOnHand);
@@ -277,7 +286,7 @@ namespace ToolManagementAppV2.Services.Tools
         private async Task AddToolInternalAsync(ToolModel tool, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(tool?.ToolNumber))
-                throw new ArgumentException("ToolNumber is required.", nameof(tool));
+                tool.ToolNumber = await GenerateNextToolNumberAsync(cancellationToken);
             if (await ToolExistsAsync(tool.ToolNumber, null, cancellationToken))
                 throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
             ValidateQuantity(tool.QuantityOnHand);

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -208,6 +208,8 @@ namespace ToolManagementAppV2.ViewModels
         {
             try
             {
+                if (string.IsNullOrWhiteSpace(NewTool.ToolNumber))
+                    NewTool.ToolNumber = await _toolService.GenerateNextToolNumberAsync(cancellationToken);
                 await _toolService.AddToolAsync(NewTool, cancellationToken);
                 await LoadToolsAsync();
                 await FilterToolsAsync(cancellationToken);


### PR DESCRIPTION
## Summary
- add `GenerateNextToolNumberAsync` to compute the next available tool identifier
- assign generated numbers when adding tools without a number and expose in view model
- update tests to verify automatic tool numbering

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a1af1cb7448324b10468671fc02122