### PR TITLE
Handle locked-out accounts during authentication

### DIFF
--- a/ToolManagementAppV2.Tests/AsyncServiceExtensions.cs
+++ b/ToolManagementAppV2.Tests/AsyncServiceExtensions.cs
@@ -69,7 +69,7 @@ public static class AsyncServiceExtensions
         => svc.GetAllUsersAsync().GetAwaiter().GetResult();
     public static User? GetUserByID(this IUserService svc, int id)
         => svc.GetUserByIDAsync(id).GetAwaiter().GetResult();
-    public static User? AuthenticateUser(this IUserService svc, string userName, string password)
+    public static (AuthenticationResult Result, User? User) AuthenticateUser(this IUserService svc, string userName, string password)
         => svc.AuthenticateUserAsync(userName, password).GetAwaiter().GetResult();
     public static User? GetCurrentUser(this IUserService svc)
         => svc.GetCurrentUserAsync().GetAwaiter().GetResult();

--- a/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows.Documents;
 using System.Data.SQLite;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Models.ImportExport;
 using ToolManagementAppV2.Services.Core;
@@ -128,7 +129,7 @@ public class ReportServiceAsyncTests
         public User? GetUserByID(int userID) => throw new NotImplementedException();
         public Task<User?> GetUserByIDAsync(int userID) => throw new NotImplementedException();
         public User? AuthenticateUser(string userName, string password) => throw new NotImplementedException();
-        public Task<User?> AuthenticateUserAsync(string userName, string password) => throw new NotImplementedException();
+        public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => throw new NotImplementedException();
         public User? GetCurrentUser() => null;
         public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
         public void AddUser(User user) => throw new NotImplementedException();

--- a/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Data.SQLite;
 using System.Threading.Tasks;
+using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
@@ -31,7 +32,8 @@ public class UserAuthenticationTests
             Assert.True(SecurityHelper.VerifyPassword("secret", added.Salt, added.Password));
 
             var auth = userService.AuthenticateUser("test", "secret");
-            Assert.NotNull(auth);
+            Assert.Equal(AuthenticationResult.Success, auth.Result);
+            Assert.NotNull(auth.User);
         }
         finally
         {
@@ -59,9 +61,10 @@ public class UserAuthenticationTests
             }
 
             var auth = userService.AuthenticateUser("legacy", "secret");
-            Assert.NotNull(auth);
+            Assert.Equal(AuthenticationResult.Success, auth.Result);
+            Assert.NotNull(auth.User);
 
-            var updated = userService.GetUserByID(auth!.UserID)!;
+            var updated = userService.GetUserByID(auth.User!.UserID)!;
             Assert.False(SecurityHelper.IsSha256Hash(updated.Password));
             Assert.False(string.IsNullOrWhiteSpace(updated.Salt));
             Assert.True(SecurityHelper.VerifyPassword("secret", updated.Salt, updated.Password));
@@ -93,7 +96,8 @@ public class UserAuthenticationTests
             }
 
             var auth = userService.AuthenticateUser("emptysalt", "secret");
-            Assert.Null(auth);
+            Assert.Equal(AuthenticationResult.Failed, auth.Result);
+            Assert.Null(auth.User);
         }
         finally
         {
@@ -117,7 +121,10 @@ public class UserAuthenticationTests
             for (int i = 0; i < 3; i++)
             {
                 var auth = userService.AuthenticateUser("lock", "bad");
-                Assert.Null(auth);
+                if (i < 2)
+                    Assert.Equal(AuthenticationResult.Failed, auth.Result);
+                else
+                    Assert.Equal(AuthenticationResult.LockedOut, auth.Result);
             }
 
             var stored = userService.GetAllUsers().First();
@@ -125,7 +132,7 @@ public class UserAuthenticationTests
             Assert.NotNull(stored.LockoutUntil);
 
             var afterLock = userService.AuthenticateUser("lock", "secret");
-            Assert.Null(afterLock);
+            Assert.Equal(AuthenticationResult.LockedOut, afterLock.Result);
         }
         finally
         {
@@ -147,7 +154,7 @@ public class UserAuthenticationTests
             userService.AddUser(user);
 
             for (int i = 0; i < 3; i++)
-                userService.AuthenticateUser("reset", "bad");
+            userService.AuthenticateUser("reset", "bad");
 
             using (var conn = dbService.CreateConnection())
             using (var cmd = new SQLiteCommand("UPDATE Users SET LockoutUntil=@t WHERE UserID=@id", conn))
@@ -158,7 +165,8 @@ public class UserAuthenticationTests
             }
 
             var auth = userService.AuthenticateUser("reset", "secret");
-            Assert.NotNull(auth);
+            Assert.Equal(AuthenticationResult.Success, auth.Result);
+            Assert.NotNull(auth.User);
 
             var stored = userService.GetAllUsers().First(u => u.UserName == "reset");
             Assert.Equal(0, stored.FailedAttempts);
@@ -217,7 +225,8 @@ public class UserAuthenticationTests
             Assert.True(SecurityHelper.VerifyPassword("secret", added.Salt, added.Password));
 
             var auth = await userService.AuthenticateUserAsync("atest", "secret");
-            Assert.NotNull(auth);
+            Assert.Equal(AuthenticationResult.Success, auth.Result);
+            Assert.NotNull(auth.User);
         }
         finally
         {
@@ -241,7 +250,10 @@ public class UserAuthenticationTests
             for (int i = 0; i < 3; i++)
             {
                 var auth = await userService.AuthenticateUserAsync("lockasync", "bad");
-                Assert.Null(auth);
+                if (i < 2)
+                    Assert.Equal(AuthenticationResult.Failed, auth.Result);
+                else
+                    Assert.Equal(AuthenticationResult.LockedOut, auth.Result);
             }
 
             var stored = userService.GetAllUsers().First(u => u.UserName == "lockasync");
@@ -249,7 +261,7 @@ public class UserAuthenticationTests
             Assert.NotNull(stored.LockoutUntil);
 
             var afterLock = await userService.AuthenticateUserAsync("lockasync", "secret");
-            Assert.Null(afterLock);
+            Assert.Equal(AuthenticationResult.LockedOut, afterLock.Result);
         }
         finally
         {

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Windows;
 using System.Threading.Tasks;
 using System.Threading;
+using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
@@ -387,6 +388,41 @@ namespace ToolManagementAppV2.Tests.ViewModels
             Assert.True(success);
             Assert.False(userService.ChangePasswordCalled);
         }
+
+        [Fact]
+        public async Task SelectUserCommand_ShowsLockoutMessage_WhenAccountLocked()
+        {
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
+
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            try
+            {
+                using var dbService = new DatabaseService(dbPath);
+                var userContext = new ApplicationUserContext();
+                var auth = new AuthorizationService(userContext);
+                var userService = new UserService(dbService, userContext, auth);
+                var settingsService = new SettingsService(dbService);
+                var lockout = DateTime.UtcNow.AddMinutes(15);
+                await userService.AddUserAsync(new User { UserName = "locked", Password = "newpassword", LockoutUntil = lockout });
+
+                var dialog = new CapturingDialogService();
+                var vm = new LoginViewModel(userService, settingsService, dialog, userContext)
+                {
+                    PromptForPasswordAsync = (u, ct) => Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("secret", false))
+                };
+                await vm.InitializeAsync();
+
+                await vm.SelectUserCommand.ExecuteAsync(vm.Users.First());
+
+                Assert.True(dialog.InfoShown);
+                Assert.Contains(lockout.ToString(), dialog.LastMessage);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
     }
 
     class StubDialogService : IDialogService
@@ -421,7 +457,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public User? GetUserByID(int userID) => null;
         public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult<User?>(null);
         public User? AuthenticateUser(string userName, string password) => null;
-        public Task<User?> AuthenticateUserAsync(string userName, string password) => Task.FromResult<User?>(null);
+        public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.Failed, null));
         public User? GetCurrentUser() => null;
         public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
         public void AddUser(User user) => _users.Add(user);
@@ -451,7 +487,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public User? GetUserByID(int userID) => _users.FirstOrDefault(u => u.UserID == userID);
         public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult(GetUserByID(userID));
         public User? AuthenticateUser(string userName, string password) => null;
-        public Task<User?> AuthenticateUserAsync(string userName, string password) => Task.FromResult<User?>(null);
+        public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.Failed, null));
         public User? GetCurrentUser() => null;
         public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
         public void AddUser(User user) => _users.Add(user);
@@ -486,11 +522,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task<User?> GetUserByIDAsync(int userID)
             => Task.FromResult(userID == _dbUser.UserID ? _dbUser : null);
 
-        public Task<User?> AuthenticateUserAsync(string userName, string password)
+        public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password)
             => Task.FromResult(
                 userName == _dbUser.UserName && SecurityHelper.VerifyPassword(password, _dbUser.Salt, _dbUser.Password)
-                    ? _dbUser
-                    : null);
+                    ? (AuthenticationResult.Success, (User?)_dbUser)
+                    : (AuthenticationResult.Failed, (User?)null));
 
         public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
         public Task AddUserAsync(User user) => Task.CompletedTask;
@@ -506,7 +542,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
     class CapturingDialogService : IDialogService
     {
         public bool InfoShown { get; private set; }
-        public void ShowInfo(string message, string title) => InfoShown = true;
+        public string? LastMessage { get; private set; }
+        public void ShowInfo(string message, string title)
+        {
+            InfoShown = true;
+            LastMessage = message;
+        }
         public bool ShowConfirmation(string message, string title) => true;
         public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
         public void ShowToolDetails(ToolModel tool) { }

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -362,7 +362,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public User? GetUserByID(int userID) => null;
         public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult<User?>(null);
         public User? AuthenticateUser(string userName, string password) => null;
-        public Task<User?> AuthenticateUserAsync(string userName, string password) => Task.FromResult<User?>(null);
+        public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.Failed, null));
         public User? GetCurrentUser() => null;
         public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
         public void AddUser(User user) { }

--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
@@ -573,7 +574,7 @@ class InMemoryUserService : IUserService
     public User? GetUserByID(int userID) => Users.FirstOrDefault(u => u.UserID == userID);
     public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult(GetUserByID(userID));
     public User? AuthenticateUser(string userName, string password) => null;
-    public Task<User?> AuthenticateUserAsync(string userName, string password) => Task.FromResult<User?>(null);
+    public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.Failed, null));
     public User? GetCurrentUser() => null;
     public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
     public void AddUser(User user)
@@ -622,7 +623,7 @@ class FailingUserService : IUserService
     public User? GetUserByID(int userID) => _users.FirstOrDefault(u => u.UserID == userID);
     public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult(GetUserByID(userID));
     public User? AuthenticateUser(string userName, string password) => null;
-    public Task<User?> AuthenticateUserAsync(string userName, string password) => Task.FromResult<User?>(null);
+    public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.Failed, null));
     public User? GetCurrentUser() => null;
     public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
     public void AddUser(User user) => _users.Add(user);
@@ -641,7 +642,7 @@ class GetAllUsersFailingUserService : IUserService
     public User? GetUserByID(int userID) => null;
     public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult<User?>(null);
     public User? AuthenticateUser(string userName, string password) => null;
-    public Task<User?> AuthenticateUserAsync(string userName, string password) => Task.FromResult<User?>(null);
+    public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.Failed, null));
     public User? GetCurrentUser() => null;
     public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
     public void AddUser(User user) { }

--- a/ToolManagementAppV2/Interfaces/IUserService.cs
+++ b/ToolManagementAppV2/Interfaces/IUserService.cs
@@ -9,7 +9,7 @@ namespace ToolManagementAppV2.Interfaces
     {
         Task<List<User>> GetAllUsersAsync();
         Task<User?> GetUserByIDAsync(int userID);
-        Task<User?> AuthenticateUserAsync(string userName, string password);
+        Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password);
         Task<User?> GetCurrentUserAsync();
         Task AddUserAsync(User user);
         Task UpdateUserAsync(User user);

--- a/ToolManagementAppV2/Models/AuthenticationResult.cs
+++ b/ToolManagementAppV2/Models/AuthenticationResult.cs
@@ -1,0 +1,9 @@
+namespace ToolManagementAppV2.Models
+{
+    public enum AuthenticationResult
+    {
+        Success,
+        Failed,
+        LockedOut
+    }
+}

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -2,6 +2,7 @@
 using System.Data.SQLite;
 using System.Data;
 using System.Threading.Tasks;
+using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Utilities.Helpers;
@@ -74,7 +75,7 @@ namespace ToolManagementAppV2.Services.Users
             return list.FirstOrDefault();
         }
 
-        public async Task<User?> AuthenticateUserAsync(string userName, string password)
+        public async Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password)
         {
             using var conn = _dbService.CreateConnection();
 
@@ -88,9 +89,10 @@ namespace ToolManagementAppV2.Services.Users
                 new[] { new SQLiteParameter("@UserName", userName) }, MapUser);
 
             var u = users.FirstOrDefault();
-            if (u == null) return null;
+            if (u == null) return (AuthenticationResult.Failed, null);
 
-            if (u.LockoutUntil.HasValue && u.LockoutUntil > DateTime.UtcNow) return null;
+            if (u.LockoutUntil.HasValue && u.LockoutUntil > DateTime.UtcNow)
+                return (AuthenticationResult.LockedOut, u);
 
             if (u.LockoutUntil.HasValue && u.LockoutUntil <= DateTime.UtcNow)
             {
@@ -140,7 +142,7 @@ namespace ToolManagementAppV2.Services.Users
                 await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET FailedAttempts=IFNULL(@Attempts,0), LockoutUntil=@Lockout WHERE UserID=@ID", reset);
                 u.FailedAttempts = 0;
                 u.LockoutUntil = null;
-                return u;
+                return (AuthenticationResult.Success, u);
             }
 
             u.FailedAttempts = Math.Max(0, u.FailedAttempts) + 1;
@@ -155,7 +157,9 @@ namespace ToolManagementAppV2.Services.Users
     };
             await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET FailedAttempts=IFNULL(@Attempts,0), LockoutUntil=@Lockout WHERE UserID=@ID", update);
             u.LockoutUntil = lockout;
-            return null;
+            return (u.LockoutUntil.HasValue && u.LockoutUntil > DateTime.UtcNow)
+                ? (AuthenticationResult.LockedOut, u)
+                : (AuthenticationResult.Failed, null);
         }
 
 

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -9,6 +9,7 @@ using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media.Imaging;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.Services.Users;
@@ -274,7 +275,14 @@ namespace ToolManagementAppV2.ViewModels
                     continue;
                 }
 
-                credential = await _userService.AuthenticateUserAsync(user.UserName, promptResult.Password);
+                var authResult = await _userService.AuthenticateUserAsync(user.UserName, promptResult.Password);
+                if (authResult.Result == AuthenticationResult.LockedOut)
+                {
+                    await _dialogService.ShowInfoAsync($"Account locked until {authResult.User?.LockoutUntil}.", "Login Failed");
+                    return;
+                }
+
+                credential = authResult.User;
                 if (credential == null)
                 {
                     await _dialogService.ShowInfoAsync("Incorrect password. Please try again.", "Login Failed");


### PR DESCRIPTION
## Summary
- Add `AuthenticationResult` enum and return authentication status from `AuthenticateUserAsync`
- Detect `LockedOut` status in `LoginViewModel` and show lockout message
- Add unit test ensuring lockout message appears and update existing tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b1fcbc7c8324a31b946691c15bee