### PR TITLE
Use auth result object

### DIFF
--- a/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
@@ -96,7 +96,7 @@ public class UserAuthenticationTests
             }
 
             var auth = userService.AuthenticateUser("emptysalt", "secret");
-            Assert.Equal(AuthenticationResult.Failed, auth.Result);
+            Assert.Equal(AuthenticationResult.IncorrectPassword, auth.Result);
             Assert.Null(auth.User);
         }
         finally
@@ -122,7 +122,7 @@ public class UserAuthenticationTests
             {
                 var auth = userService.AuthenticateUser("lock", "bad");
                 if (i < 2)
-                    Assert.Equal(AuthenticationResult.Failed, auth.Result);
+                    Assert.Equal(AuthenticationResult.IncorrectPassword, auth.Result);
                 else
                     Assert.Equal(AuthenticationResult.LockedOut, auth.Result);
             }
@@ -251,7 +251,7 @@ public class UserAuthenticationTests
             {
                 var auth = await userService.AuthenticateUserAsync("lockasync", "bad");
                 if (i < 2)
-                    Assert.Equal(AuthenticationResult.Failed, auth.Result);
+                    Assert.Equal(AuthenticationResult.IncorrectPassword, auth.Result);
                 else
                     Assert.Equal(AuthenticationResult.LockedOut, auth.Result);
             }
@@ -262,6 +262,44 @@ public class UserAuthenticationTests
 
             var afterLock = await userService.AuthenticateUserAsync("lockasync", "secret");
             Assert.Equal(AuthenticationResult.LockedOut, afterLock.Result);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task AuthenticateUserAsync_ResetAfterSuccess()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+
+            var user = new User { UserName = "areset", Password = "secret", IsAdmin = false };
+            await userService.AddUserAsync(user);
+
+            for (int i = 0; i < 3; i++)
+                await userService.AuthenticateUserAsync("areset", "bad");
+
+            using (var conn = dbService.CreateConnection())
+            using (var cmd = new SQLiteCommand("UPDATE Users SET LockoutUntil=@t WHERE UserID=@id", conn))
+            {
+                cmd.Parameters.AddWithValue("@t", DateTime.UtcNow.AddMinutes(-1));
+                cmd.Parameters.AddWithValue("@id", user.UserID);
+                cmd.ExecuteNonQuery();
+            }
+
+            var auth = await userService.AuthenticateUserAsync("areset", "secret");
+            Assert.Equal(AuthenticationResult.Success, auth.Result);
+            Assert.NotNull(auth.User);
+
+            var stored = (await userService.GetAllUsersAsync()).First(u => u.UserName == "areset");
+            Assert.Equal(0, stored.FailedAttempts);
+            Assert.Null(stored.LockoutUntil);
         }
         finally
         {

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -457,7 +457,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public User? GetUserByID(int userID) => null;
         public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult<User?>(null);
         public User? AuthenticateUser(string userName, string password) => null;
-        public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.Failed, null));
+        public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.IncorrectPassword, null));
         public User? GetCurrentUser() => null;
         public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
         public void AddUser(User user) => _users.Add(user);
@@ -487,7 +487,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public User? GetUserByID(int userID) => _users.FirstOrDefault(u => u.UserID == userID);
         public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult(GetUserByID(userID));
         public User? AuthenticateUser(string userName, string password) => null;
-        public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.Failed, null));
+        public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.IncorrectPassword, null));
         public User? GetCurrentUser() => null;
         public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
         public void AddUser(User user) => _users.Add(user);
@@ -526,7 +526,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             => Task.FromResult(
                 userName == _dbUser.UserName && SecurityHelper.VerifyPassword(password, _dbUser.Salt, _dbUser.Password)
                     ? (AuthenticationResult.Success, (User?)_dbUser)
-                    : (AuthenticationResult.Failed, (User?)null));
+                    : (AuthenticationResult.IncorrectPassword, (User?)null));
 
         public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
         public Task AddUserAsync(User user) => Task.CompletedTask;

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -362,7 +362,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public User? GetUserByID(int userID) => null;
         public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult<User?>(null);
         public User? AuthenticateUser(string userName, string password) => null;
-        public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.Failed, null));
+        public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.IncorrectPassword, null));
         public User? GetCurrentUser() => null;
         public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
         public void AddUser(User user) { }

--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -574,7 +574,7 @@ class InMemoryUserService : IUserService
     public User? GetUserByID(int userID) => Users.FirstOrDefault(u => u.UserID == userID);
     public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult(GetUserByID(userID));
     public User? AuthenticateUser(string userName, string password) => null;
-    public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.Failed, null));
+    public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.IncorrectPassword, null));
     public User? GetCurrentUser() => null;
     public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
     public void AddUser(User user)
@@ -623,7 +623,7 @@ class FailingUserService : IUserService
     public User? GetUserByID(int userID) => _users.FirstOrDefault(u => u.UserID == userID);
     public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult(GetUserByID(userID));
     public User? AuthenticateUser(string userName, string password) => null;
-    public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.Failed, null));
+    public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.IncorrectPassword, null));
     public User? GetCurrentUser() => null;
     public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
     public void AddUser(User user) => _users.Add(user);
@@ -642,7 +642,7 @@ class GetAllUsersFailingUserService : IUserService
     public User? GetUserByID(int userID) => null;
     public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult<User?>(null);
     public User? AuthenticateUser(string userName, string password) => null;
-    public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.Failed, null));
+    public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.IncorrectPassword, null));
     public User? GetCurrentUser() => null;
     public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
     public void AddUser(User user) { }

--- a/ToolManagementAppV2/Models/AuthenticationResult.cs
+++ b/ToolManagementAppV2/Models/AuthenticationResult.cs
@@ -3,7 +3,7 @@ namespace ToolManagementAppV2.Models
     public enum AuthenticationResult
     {
         Success,
-        Failed,
+        IncorrectPassword,
         LockedOut
     }
 }

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -89,7 +89,7 @@ namespace ToolManagementAppV2.Services.Users
                 new[] { new SQLiteParameter("@UserName", userName) }, MapUser);
 
             var u = users.FirstOrDefault();
-            if (u == null) return (AuthenticationResult.Failed, null);
+            if (u == null) return (AuthenticationResult.IncorrectPassword, null);
 
             if (u.LockoutUntil.HasValue && u.LockoutUntil > DateTime.UtcNow)
                 return (AuthenticationResult.LockedOut, u);
@@ -159,7 +159,7 @@ namespace ToolManagementAppV2.Services.Users
             u.LockoutUntil = lockout;
             return (u.LockoutUntil.HasValue && u.LockoutUntil > DateTime.UtcNow)
                 ? (AuthenticationResult.LockedOut, u)
-                : (AuthenticationResult.Failed, null);
+                : (AuthenticationResult.IncorrectPassword, null);
         }
 
 

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -276,16 +276,17 @@ namespace ToolManagementAppV2.ViewModels
                 }
 
                 var authResult = await _userService.AuthenticateUserAsync(user.UserName, promptResult.Password);
-                if (authResult.Result == AuthenticationResult.LockedOut)
+                switch (authResult.Result)
                 {
-                    await _dialogService.ShowInfoAsync($"Account locked until {authResult.User?.LockoutUntil}.", "Login Failed");
-                    return;
-                }
-
-                credential = authResult.User;
-                if (credential == null)
-                {
-                    await _dialogService.ShowInfoAsync("Incorrect password. Please try again.", "Login Failed");
+                    case AuthenticationResult.LockedOut:
+                        await _dialogService.ShowInfoAsync($"Account locked until {authResult.User?.LockoutUntil}.", "Login Failed");
+                        return;
+                    case AuthenticationResult.IncorrectPassword:
+                        await _dialogService.ShowInfoAsync("Incorrect password. Please try again.", "Login Failed");
+                        continue;
+                    case AuthenticationResult.Success:
+                        credential = authResult.User;
+                        break;
                 }
             }
 


### PR DESCRIPTION
## Summary
- Return an `AuthenticationResult` enum from `UserService` to indicate success, incorrect password, or lockout
- Handle new authentication outcomes in `LoginViewModel` and show lockout message
- Expand unit tests for lockout messaging and lockout reset on successful login

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b3bcbc908324a5ee58538094021d