### PR TITLE
Trim credentials in async authentication

### DIFF
--- a/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
@@ -224,7 +224,7 @@ public class UserAuthenticationTests
             Assert.False(string.IsNullOrWhiteSpace(added.Salt));
             Assert.True(SecurityHelper.VerifyPassword("secret", added.Salt, added.Password));
 
-            var auth = await userService.AuthenticateUserAsync("atest", "secret");
+            var auth = await userService.AuthenticateUserAsync(" atest ", " secret ");
             Assert.Equal(AuthenticationResult.Success, auth.Result);
             Assert.NotNull(auth.User);
         }
@@ -249,7 +249,7 @@ public class UserAuthenticationTests
 
             for (int i = 0; i < 3; i++)
             {
-                var auth = await userService.AuthenticateUserAsync("lockasync", "bad");
+                var auth = await userService.AuthenticateUserAsync(" lockasync ", " bad ");
                 if (i < 2)
                     Assert.Equal(AuthenticationResult.IncorrectPassword, auth.Result);
                 else
@@ -260,7 +260,7 @@ public class UserAuthenticationTests
             Assert.Equal(3, stored.FailedAttempts);
             Assert.NotNull(stored.LockoutUntil);
 
-            var afterLock = await userService.AuthenticateUserAsync("lockasync", "secret");
+            var afterLock = await userService.AuthenticateUserAsync(" lockasync ", " secret ");
             Assert.Equal(AuthenticationResult.LockedOut, afterLock.Result);
         }
         finally
@@ -283,7 +283,7 @@ public class UserAuthenticationTests
             await userService.AddUserAsync(user);
 
             for (int i = 0; i < 3; i++)
-                await userService.AuthenticateUserAsync("areset", "bad");
+                await userService.AuthenticateUserAsync(" areset ", " bad ");
 
             using (var conn = dbService.CreateConnection())
             using (var cmd = new SQLiteCommand("UPDATE Users SET LockoutUntil=@t WHERE UserID=@id", conn))
@@ -293,7 +293,7 @@ public class UserAuthenticationTests
                 cmd.ExecuteNonQuery();
             }
 
-            var auth = await userService.AuthenticateUserAsync("areset", "secret");
+            var auth = await userService.AuthenticateUserAsync(" areset ", " secret ");
             Assert.Equal(AuthenticationResult.Success, auth.Result);
             Assert.NotNull(auth.User);
 

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -79,6 +79,9 @@ namespace ToolManagementAppV2.Services.Users
         {
             using var conn = _dbService.CreateConnection();
 
+            userName = (userName ?? string.Empty).Trim();
+            password = (password ?? string.Empty).Trim();
+
             await SqliteHelper.ExecuteNonQueryAsync(
                 conn,
                 "UPDATE Users SET FailedAttempts=IFNULL(FailedAttempts,0) WHERE FailedAttempts IS NULL"
@@ -110,11 +113,11 @@ namespace ToolManagementAppV2.Services.Users
             bool success;
             if (string.IsNullOrWhiteSpace(u.Salt) && SecurityHelper.IsSha256Hash(u.Password))
             {
-                var legacy = SecurityHelper.ComputeSha256HashLegacy(password ?? string.Empty);
+                var legacy = SecurityHelper.ComputeSha256HashLegacy(password);
                 success = u.Password == legacy;
                 if (success)
                 {
-                    var upgradedResult = await SecurityHelper.HashPasswordAsync(password ?? string.Empty).ConfigureAwait(false);
+                    var upgradedResult = await SecurityHelper.HashPasswordAsync(password).ConfigureAwait(false);
                     var p = new[]
                     {
                 new SQLiteParameter("@Pwd", upgradedResult.hash),
@@ -128,7 +131,7 @@ namespace ToolManagementAppV2.Services.Users
             }
             else
             {
-                success = await SecurityHelper.VerifyPasswordAsync(password ?? string.Empty, u.Salt, u.Password).ConfigureAwait(false);
+                success = await SecurityHelper.VerifyPasswordAsync(password, u.Salt, u.Password).ConfigureAwait(false);
             }
 
             if (success)


### PR DESCRIPTION
## Summary
- sanitize username and password in `AuthenticateUserAsync`
- adjust user authentication tests to pass padded credentials

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a23a6ee0c4832489f3b65cf28043b4