### PR TITLE
Trim and validate new passwords

### DIFF
--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -192,6 +192,48 @@ public class UserServiceTests
     }
 
     [Fact]
+    public async Task ChangeUserPasswordAsync_TrimsInputBeforeHashing()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+            var user = new User { UserName = "trim", Password = "pw" };
+            await userService.AddUserAsync(user);
+            var result = await userService.ChangeUserPasswordAsync(user.UserID, "  newpass  ");
+            Assert.True(result);
+            var auth = await userService.AuthenticateUserAsync("trim", "newpass");
+            Assert.Equal(AuthenticationResult.Success, auth.Result);
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task ChangeUserPasswordAsync_ReturnsFalse_WhenPasswordIsWhitespace()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+            var user = new User { UserName = "blank", Password = "pw" };
+            await userService.AddUserAsync(user);
+            var result = await userService.ChangeUserPasswordAsync(user.UserID, "   ");
+            Assert.False(result);
+            var auth = await userService.AuthenticateUserAsync("blank", "pw");
+            Assert.Equal(AuthenticationResult.Success, auth.Result);
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
     public void GetAllUsers_DoesNotIncludeSensitiveFields()
     {
         var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -292,15 +292,15 @@ namespace ToolManagementAppV2.Services.Users
         {
             if (_context.CurrentUser?.UserID != userID)
                 _auth.EnsureAdmin();
+
+            newPassword = (newPassword ?? string.Empty).Trim();
+            if (newPassword.Length == 0)
+                return false;
+
             var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt, PasswordExpired=@Expired WHERE UserID=@ID";
-            string hashed = string.Empty;
-            string salt = string.Empty;
-            if (!string.IsNullOrWhiteSpace(newPassword))
-            {
-                var result = await SecurityHelper.HashPasswordAsync(newPassword).ConfigureAwait(false);
-                hashed = result.hash;
-                salt = result.salt;
-            }
+            var result = await SecurityHelper.HashPasswordAsync(newPassword).ConfigureAwait(false);
+            string hashed = result.hash;
+            string salt = result.salt;
 
             var expired = newPassword == "admin" || newPassword == "changeme" || newPassword == "newpassword";
 


### PR DESCRIPTION
## Summary
- Trim new passwords before hashing and reject empty passwords
- Add unit tests covering trimmed input and blank password rejection

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a25b371a4c8324836f1ae522abc39e