### PR TITLE
Reset lockout state when changing password

### DIFF
--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -234,6 +234,40 @@ public class UserServiceTests
     }
 
     [Fact]
+    public async Task ChangeUserPasswordAsync_ResetsFailedAttemptsAndLockout()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+            var user = new User { UserName = "lock", Password = "pw" };
+            await userService.AddUserAsync(user);
+
+            await userService.AuthenticateUserAsync("lock", "bad");
+            await userService.AuthenticateUserAsync("lock", "bad");
+            await userService.AuthenticateUserAsync("lock", "bad");
+
+            var locked = userService.GetUserByID(user.UserID);
+            Assert.NotNull(locked);
+            Assert.True(locked!.FailedAttempts >= 3);
+            Assert.NotNull(locked.LockoutUntil);
+
+            var changed = await userService.ChangeUserPasswordAsync(user.UserID, "newpass");
+            Assert.True(changed);
+
+            var updated = userService.GetUserByID(user.UserID);
+            Assert.NotNull(updated);
+            Assert.Equal(0, updated!.FailedAttempts);
+            Assert.Null(updated.LockoutUntil);
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
     public void GetAllUsers_DoesNotIncludeSensitiveFields()
     {
         var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -297,7 +297,7 @@ namespace ToolManagementAppV2.Services.Users
             if (newPassword.Length == 0)
                 return false;
 
-            var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt, PasswordExpired=@Expired WHERE UserID=@ID";
+            var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt, PasswordExpired=@Expired, FailedAttempts=@Attempts, LockoutUntil=@Lockout WHERE UserID=@ID";
             var result = await SecurityHelper.HashPasswordAsync(newPassword).ConfigureAwait(false);
             string hashed = result.hash;
             string salt = result.salt;
@@ -309,6 +309,8 @@ namespace ToolManagementAppV2.Services.Users
                 new SQLiteParameter("@Pwd", hashed),
                 new SQLiteParameter("@Salt", salt),
                 new SQLiteParameter("@Expired", expired ? 1 : 0),
+                new SQLiteParameter("@Attempts", 0),
+                new SQLiteParameter("@Lockout", DBNull.Value),
                 new SQLiteParameter("@ID",  userID)
             };
             using var conn = _dbService.CreateConnection();


### PR DESCRIPTION
## Summary
- Reset failed attempts and clear lockout when a user's password is changed
- Test that password change clears failed-attempt counters and lockout timestamp

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a26048f84883249e480649909b4397