### PR TITLE
Fix admin password update after reset

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -17,6 +17,7 @@ using ToolManagementAppV2.Views;
 using Xunit;
 using Microsoft.Extensions.Logging;
 using ToolManagementAppV2.Tests;
+using System.Reflection;
 
 namespace ToolManagementAppV2.Tests.ViewModels
 {
@@ -329,6 +330,53 @@ namespace ToolManagementAppV2.Tests.ViewModels
             Assert.True(dialog.InfoShown);
             Assert.Null(userContext.CurrentUser);
             Assert.NotNull(logger.LastException);
+        }
+
+        [Fact]
+        public async Task PromptChangePassword_SetsCurrentUserWhenNull()
+        {
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
+
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            try
+            {
+                using var dbService = new DatabaseService(dbPath);
+                var userContext = new ApplicationUserContext();
+                var auth = new AuthorizationService(userContext);
+                var userService = new UserService(dbService, userContext, auth);
+                var settingsService = new SettingsService(dbService);
+                SecurityHelper.SettingsService = settingsService;
+
+                var result = await SecurityHelper.HashPasswordAsync("admin");
+                var admin = new User
+                {
+                    UserID = 1,
+                    UserName = "admin",
+                    Password = result.hash,
+                    Salt = result.salt,
+                    IsAdmin = true,
+                    PasswordExpired = true
+                };
+                await userService.AddUserAsync(admin);
+
+                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
+                {
+                    PromptForNewPassword = () => "changed"
+                };
+
+                var method = typeof(LoginViewModel).GetMethod("PromptChangePasswordAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+                var task = (Task<bool>)method.Invoke(vm, new object[] { admin });
+                var ok = await task;
+
+                Assert.True(ok);
+                var authResult = await userService.AuthenticateUserAsync("admin", "changed");
+                Assert.Equal(AuthenticationResult.Success, authResult.Result);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
         }
 
         [Fact]

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -306,7 +306,18 @@ namespace ToolManagementAppV2.ViewModels
                 return false;
             try
             {
-                await _userService.ChangeUserPasswordAsync(user.UserID, newPwd);
+                // Ensure the current user context is set so the service
+                // authorizes the password change for self-service updates
+                // during first-time login or after a reset.
+                if (_userContext.CurrentUser == null)
+                    _userContext.CurrentUser = user;
+
+                var updated = await _userService.ChangeUserPasswordAsync(user.UserID, newPwd);
+                if (!updated)
+                {
+                    await _dialogService.ShowInfoAsync("Failed to update password.", "Error");
+                    return false;
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- ensure login flow sets user context before changing password and verify update result
- add regression test for password change when current user context is unset

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a2661c3d0083248d002db2b37ba2e4