### PR TITLE
Handle null failed attempts in password change

### DIFF
--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using System.Data.SQLite;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
@@ -260,6 +261,37 @@ public class UserServiceTests
             Assert.NotNull(updated);
             Assert.Equal(0, updated!.FailedAttempts);
             Assert.Null(updated.LockoutUntil);
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task ChangeUserPasswordAsync_AllowsNullFailedAttempts()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+            var user = new User { UserName = "nulltest", Password = "pw" };
+            await userService.AddUserAsync(user);
+
+            using (var conn = dbService.CreateConnection())
+            {
+                await SqliteHelper.ExecuteNonQueryAsync(conn,
+                    "UPDATE Users SET FailedAttempts=NULL WHERE UserID=@ID",
+                    new[] { new SQLiteParameter("@ID", user.UserID) });
+            }
+
+            var changed = await userService.ChangeUserPasswordAsync(user.UserID, "newpass");
+            Assert.True(changed);
+
+            var updated = userService.GetUserByID(user.UserID);
+            Assert.NotNull(updated);
+            Assert.Equal(0, updated!.FailedAttempts);
         }
         finally
         {

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -297,7 +297,7 @@ namespace ToolManagementAppV2.Services.Users
             if (newPassword.Length == 0)
                 return false;
 
-            var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt, PasswordExpired=@Expired, FailedAttempts=@Attempts, LockoutUntil=@Lockout WHERE UserID=@ID";
+            var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt, PasswordExpired=@Expired, FailedAttempts=IFNULL(@Attempts,0), LockoutUntil=@Lockout WHERE UserID=@ID";
             var result = await SecurityHelper.HashPasswordAsync(newPassword).ConfigureAwait(false);
             string hashed = result.hash;
             string salt = result.salt;
@@ -309,7 +309,7 @@ namespace ToolManagementAppV2.Services.Users
                 new SQLiteParameter("@Pwd", hashed),
                 new SQLiteParameter("@Salt", salt),
                 new SQLiteParameter("@Expired", expired ? 1 : 0),
-                new SQLiteParameter("@Attempts", 0),
+                new SQLiteParameter("@Attempts", DbType.Int32) { Value = 0 },
                 new SQLiteParameter("@Lockout", DBNull.Value),
                 new SQLiteParameter("@ID",  userID)
             };


### PR DESCRIPTION
## Summary
- guard ChangeUserPasswordAsync against null FailedAttempts and bind Attempts param as Int32
- add regression test covering null FailedAttempts when resetting password

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a26974e614832480c46aa3e54c3808