### PR TITLE
Add user unlock helper and IsLocked flag

### DIFF
--- a/ToolManagementAppV2.Tests/AsyncServiceExtensions.cs
+++ b/ToolManagementAppV2.Tests/AsyncServiceExtensions.cs
@@ -79,4 +79,6 @@ public static class AsyncServiceExtensions
         => svc.UpdateUserAsync(user).GetAwaiter().GetResult();
     public static bool ChangeUserPassword(this IUserService svc, int id, string newPassword)
         => svc.ChangeUserPasswordAsync(id, newPassword).GetAwaiter().GetResult();
+    public static void UnlockUser(this IUserService svc, int id)
+        => svc.UnlockUserAsync(id).GetAwaiter().GetResult();
 }

--- a/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
@@ -139,5 +139,6 @@ public class ReportServiceAsyncTests
         public Task<bool> TryDeleteUserAsync(int userID) => throw new NotImplementedException();
         public bool ChangeUserPassword(int userID, string newPassword) => throw new NotImplementedException();
         public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => throw new NotImplementedException();
+        public Task UnlockUserAsync(int userId) => throw new NotImplementedException();
     }
 }

--- a/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
@@ -130,6 +130,7 @@ public class UserAuthenticationTests
             var stored = userService.GetAllUsers().First();
             Assert.Equal(3, stored.FailedAttempts);
             Assert.NotNull(stored.LockoutUntil);
+            Assert.True(stored.IsLocked);
 
             var afterLock = userService.AuthenticateUser("lock", "secret");
             Assert.Equal(AuthenticationResult.LockedOut, afterLock.Result);
@@ -171,6 +172,7 @@ public class UserAuthenticationTests
             var stored = userService.GetAllUsers().First(u => u.UserName == "reset");
             Assert.Equal(0, stored.FailedAttempts);
             Assert.Null(stored.LockoutUntil);
+            Assert.False(stored.IsLocked);
         }
         finally
         {
@@ -259,6 +261,7 @@ public class UserAuthenticationTests
             var stored = userService.GetAllUsers().First(u => u.UserName == "lockasync");
             Assert.Equal(3, stored.FailedAttempts);
             Assert.NotNull(stored.LockoutUntil);
+            Assert.True(stored.IsLocked);
 
             var afterLock = await userService.AuthenticateUserAsync(" lockasync ", " secret ");
             Assert.Equal(AuthenticationResult.LockedOut, afterLock.Result);
@@ -300,6 +303,7 @@ public class UserAuthenticationTests
             var stored = (await userService.GetAllUsersAsync()).First(u => u.UserName == "areset");
             Assert.Equal(0, stored.FailedAttempts);
             Assert.Null(stored.LockoutUntil);
+            Assert.False(stored.IsLocked);
         }
         finally
         {

--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -261,6 +261,7 @@ public class UserServiceTests
             Assert.NotNull(updated);
             Assert.Equal(0, updated!.FailedAttempts);
             Assert.Null(updated.LockoutUntil);
+            Assert.False(updated.IsLocked);
         }
         finally
         {
@@ -292,6 +293,7 @@ public class UserServiceTests
             var updated = userService.GetUserByID(user.UserID);
             Assert.NotNull(updated);
             Assert.Equal(0, updated!.FailedAttempts);
+            Assert.False(updated.IsLocked);
         }
         finally
         {

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -519,6 +519,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task<bool> TryDeleteUserAsync(int userID) => Task.FromResult(false);
         public bool ChangeUserPassword(int userID, string newPassword) => false;
         public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => Task.FromResult(false);
+        public Task UnlockUserAsync(int userId) => Task.CompletedTask;
     }
 
     class ThrowingUserService : IUserService
@@ -549,6 +550,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task<bool> TryDeleteUserAsync(int userID) => Task.FromResult(false);
         public bool ChangeUserPassword(int userID, string newPassword) => throw new InvalidOperationException();
         public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => throw new InvalidOperationException();
+        public Task UnlockUserAsync(int userId) => Task.CompletedTask;
     }
 
     class OmittingPasswordUserService : IUserService
@@ -585,6 +587,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             ChangePasswordCalled = true;
             return Task.FromResult(true);
         }
+        public Task UnlockUserAsync(int userId) => Task.CompletedTask;
     }
 
     class CapturingDialogService : IDialogService

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -372,5 +372,6 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task<bool> TryDeleteUserAsync(int userID) => Task.FromResult(false);
         public bool ChangeUserPassword(int userID, string newPassword) => false;
         public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => Task.FromResult(false);
+        public Task UnlockUserAsync(int userId) => Task.CompletedTask;
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -597,6 +597,16 @@ class InMemoryUserService : IUserService
     }
     public bool ChangeUserPassword(int userID, string newPassword) => false;
     public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => Task.FromResult(false);
+    public Task UnlockUserAsync(int userId)
+    {
+        var user = Users.FirstOrDefault(u => u.UserID == userId);
+        if (user != null)
+        {
+            user.FailedAttempts = 0;
+            user.LockoutUntil = null;
+        }
+        return Task.CompletedTask;
+    }
 }
 
 class PromptUserManagementViewModel : UserManagementViewModel
@@ -633,6 +643,7 @@ class FailingUserService : IUserService
     public Task<bool> TryDeleteUserAsync(int userID) => Task.FromResult(false);
     public bool ChangeUserPassword(int userID, string newPassword) => false;
     public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => Task.FromResult(false);
+    public Task UnlockUserAsync(int userId) => Task.CompletedTask;
 }
 
 class GetAllUsersFailingUserService : IUserService
@@ -652,6 +663,7 @@ class GetAllUsersFailingUserService : IUserService
     public Task<bool> TryDeleteUserAsync(int userID) => Task.FromResult(false);
     public bool ChangeUserPassword(int userID, string newPassword) => false;
     public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => Task.FromResult(false);
+    public Task UnlockUserAsync(int userId) => Task.CompletedTask;
 }
 
 class CancelPromptUserManagementViewModel : UserManagementViewModel

--- a/ToolManagementAppV2/Interfaces/IUserService.cs
+++ b/ToolManagementAppV2/Interfaces/IUserService.cs
@@ -15,6 +15,7 @@ namespace ToolManagementAppV2.Interfaces
         Task UpdateUserAsync(User user);
         Task<bool> TryDeleteUserAsync(int userID);
         Task<bool> ChangeUserPasswordAsync(int userID, string newPassword);
+        Task UnlockUserAsync(int userId);
     }
 }
 

--- a/ToolManagementAppV2/Models/Domain/User.cs
+++ b/ToolManagementAppV2/Models/Domain/User.cs
@@ -50,6 +50,8 @@ namespace ToolManagementAppV2.Models.Domain
         private DateTime? _lockoutUntil;
         public DateTime? LockoutUntil { get => _lockoutUntil; set => SetProperty(ref _lockoutUntil, value); }
 
+        public bool IsLocked => LockoutUntil > DateTime.UtcNow;
+
         private bool _passwordExpired;
         public bool PasswordExpired { get => _passwordExpired; set => SetProperty(ref _passwordExpired, value); }
     }

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -99,13 +99,7 @@ namespace ToolManagementAppV2.Services.Users
 
             if (u.LockoutUntil.HasValue && u.LockoutUntil <= DateTime.UtcNow)
             {
-                var reset = new[]
-                {
-            new SQLiteParameter("@Attempts", 0),
-            new SQLiteParameter("@Lockout", DBNull.Value),
-            new SQLiteParameter("@ID", u.UserID)
-        };
-                await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET FailedAttempts=IFNULL(@Attempts,0), LockoutUntil=@Lockout WHERE UserID=@ID", reset);
+                await UnlockUserAsync(u.UserID);
                 u.FailedAttempts = 0;
                 u.LockoutUntil = null;
             }
@@ -136,13 +130,7 @@ namespace ToolManagementAppV2.Services.Users
 
             if (success)
             {
-                var reset = new[]
-                {
-            new SQLiteParameter("@Attempts", 0),
-            new SQLiteParameter("@Lockout", DBNull.Value),
-            new SQLiteParameter("@ID", u.UserID)
-        };
-                await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET FailedAttempts=IFNULL(@Attempts,0), LockoutUntil=@Lockout WHERE UserID=@ID", reset);
+                await UnlockUserAsync(u.UserID);
                 u.FailedAttempts = 0;
                 u.LockoutUntil = null;
                 return (AuthenticationResult.Success, u);
@@ -297,7 +285,7 @@ namespace ToolManagementAppV2.Services.Users
             if (newPassword.Length == 0)
                 return false;
 
-            var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt, PasswordExpired=@Expired, FailedAttempts=IFNULL(@Attempts,0), LockoutUntil=@Lockout WHERE UserID=@ID";
+            var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt, PasswordExpired=@Expired WHERE UserID=@ID";
             var result = await SecurityHelper.HashPasswordAsync(newPassword).ConfigureAwait(false);
             string hashed = result.hash;
             string salt = result.salt;
@@ -309,15 +297,28 @@ namespace ToolManagementAppV2.Services.Users
                 new SQLiteParameter("@Pwd", hashed),
                 new SQLiteParameter("@Salt", salt),
                 new SQLiteParameter("@Expired", expired ? 1 : 0),
-                new SQLiteParameter("@Attempts", DbType.Int32) { Value = 0 },
-                new SQLiteParameter("@Lockout", DBNull.Value),
                 new SQLiteParameter("@ID",  userID)
             };
             using var conn = _dbService.CreateConnection();
             int rows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
             if (rows == 0)
                 _logger.LogWarning("Password update affected 0 rows for UserID {UserID}", userID);
+            if (rows > 0)
+                await UnlockUserAsync(userID);
             return rows > 0;
+        }
+
+        public async Task UnlockUserAsync(int userId)
+        {
+            var p = new[]
+            {
+                new SQLiteParameter("@Attempts", 0),
+                new SQLiteParameter("@Lockout", DBNull.Value),
+                new SQLiteParameter("@ID", userId)
+            };
+            using var conn = _dbService.CreateConnection();
+            await SqliteHelper.ExecuteNonQueryAsync(conn,
+                "UPDATE Users SET FailedAttempts=IFNULL(@Attempts,0), LockoutUntil=@Lockout WHERE UserID=@ID", p);
         }
 
         async Task DeleteUserInternalAsync(int userID)


### PR DESCRIPTION
## Summary
- expose `IsLocked` flag on `User` based on lockout timestamp
- add `UnlockUserAsync` and use it from authentication and password resets
- cover new lockout logic in tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a26d036afc8324b967e37a58dd0286