### PR TITLE
Add unlock command for user management

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -470,6 +470,20 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public async Task UnlockUserCommand_UnlocksUserAndRefreshesList()
+        {
+            var svc = new InMemoryUserService();
+            await svc.AddUserAsync(new User { UserName = "user1", Password = "pw", LockoutUntil = DateTime.UtcNow.AddMinutes(5) });
+            var vm = new UserManagementViewModel(svc, new StubFileDialogService(), new StubDialogService());
+            await vm.LoadUsersAsync();
+            var user = vm.Users.First();
+            Assert.True(user.IsLocked);
+            await vm.UnlockUserCommand.ExecuteAsync(user);
+            Assert.False(vm.Users.First().IsLocked);
+            Assert.False(svc.Users.First().IsLocked);
+        }
+
+        [Fact]
         public async Task AddUserAsync_CancelledPrompt_DoesNotAddUser()
         {
             var svc = new InMemoryUserService();

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -45,6 +45,7 @@ namespace ToolManagementAppV2.ViewModels
                 {
                     ((AsyncRelayCommand)UpdateUserCommand).NotifyCanExecuteChanged();
                     ((RelayCommand)EditUserCommand).NotifyCanExecuteChanged();
+                    ((AsyncRelayCommand<UserModel>)UnlockUserCommand).NotifyCanExecuteChanged();
                 }
             }
         }
@@ -61,6 +62,7 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand EditUserFromRowCommand { get; }
         public IAsyncRelayCommand<UserModel> ResetPasswordFromRowCommand { get; }
         public IAsyncRelayCommand<UserModel> DeleteUserFromRowCommand { get; }
+        public IAsyncRelayCommand<UserModel> UnlockUserCommand { get; }
 
         public UserManagementViewModel(IUserService userService,
                                        IFileDialogService fileDialogService,
@@ -86,6 +88,7 @@ namespace ToolManagementAppV2.ViewModels
             EditUserFromRowCommand = new RelayCommand<UserModel>(EditUser);
             ResetPasswordFromRowCommand = new AsyncRelayCommand<UserModel>(ResetPasswordFor);
             DeleteUserFromRowCommand = new AsyncRelayCommand<UserModel>(DeleteUserAsync);
+            UnlockUserCommand = new AsyncRelayCommand<UserModel>(UnlockUserAsync, u => u?.IsLocked ?? false);
         }
 
         public async Task LoadUsersAsync()
@@ -360,6 +363,25 @@ namespace ToolManagementAppV2.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to delete user {UserID}", user.UserID);
+            }
+        }
+
+        async Task UnlockUserAsync(UserModel user)
+        {
+            if (user == null) return;
+            try
+            {
+                await _userService.UnlockUserAsync(user.UserID);
+                await LoadUsersAsync();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to unlock users.", "Unauthorized");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to unlock user {UserID}", user.UserID);
+                await _dialogService.ShowInfoAsync($"Failed to unlock user: {ex.Message}", "Error");
             }
         }
     }

--- a/ToolManagementAppV2/Views/UsersPage.xaml
+++ b/ToolManagementAppV2/Views/UsersPage.xaml
@@ -50,6 +50,7 @@
                     <DataGridTextColumn Header="Phone" Binding="{Binding Phone}" Width="140"/>
                     <DataGridTextColumn Header="Mobile" Binding="{Binding Mobile}" Width="140"/>
                     <DataGridCheckBoxColumn Header="Active" Binding="{Binding IsActive}" Width="100"/>
+                    <DataGridCheckBoxColumn Header="Locked" Binding="{Binding IsLocked}" Width="100"/>
                     <DataGridTextColumn Header="Created" Binding="{Binding CreatedAt, StringFormat=\{0:yyyy-MM-dd\}}" Width="140"/>
                 </DataGrid.Columns>
                 <DataGrid.ContextMenu>
@@ -60,6 +61,10 @@
                                                           RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                         <MenuItem Header="Reset Password"
                                   Command="{Binding PlacementTarget.DataContext.ResetPasswordFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                  CommandParameter="{Binding PlacementTarget.SelectedItem,
+                                                          RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                        <MenuItem Header="Unlock"
+                                  Command="{Binding PlacementTarget.DataContext.UnlockUserCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                                   CommandParameter="{Binding PlacementTarget.SelectedItem,
                                                           RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                         <MenuItem Header="Upload Photo"


### PR DESCRIPTION
## Summary
- show locked status in the Users page and add context menu item to unlock accounts
- introduce UnlockUserCommand to refresh users after unlocking and added unit test

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2742cc50483248b471685d0f3f5a3