### PR TITLE
Add unlock user tests

### DIFF
--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -235,6 +235,40 @@ public class UserServiceTests
     }
 
     [Fact]
+    public async Task UnlockUserAsync_ResetsFailedAttemptsAndLockout()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+            var user = new User { UserName = "locked", Password = "pw" };
+            await userService.AddUserAsync(user);
+
+            await userService.AuthenticateUserAsync("locked", "bad");
+            await userService.AuthenticateUserAsync("locked", "bad");
+            await userService.AuthenticateUserAsync("locked", "bad");
+
+            var locked = userService.GetUserByID(user.UserID);
+            Assert.NotNull(locked);
+            Assert.True(locked!.FailedAttempts >= 3);
+            Assert.NotNull(locked.LockoutUntil);
+
+            await userService.UnlockUserAsync(user.UserID);
+
+            var unlocked = userService.GetUserByID(user.UserID);
+            Assert.NotNull(unlocked);
+            Assert.Equal(0, unlocked!.FailedAttempts);
+            Assert.Null(unlocked.LockoutUntil);
+            Assert.False(unlocked.IsLocked);
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
     public async Task ChangeUserPasswordAsync_ResetsFailedAttemptsAndLockout()
     {
         var dbPath = Path.GetTempFileName();

--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -484,6 +484,34 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public async Task UnlockUserCommand_ClearsLockAndUpdatesCollection()
+        {
+            var svc = new InMemoryUserService();
+            await svc.AddUserAsync(new User
+            {
+                UserName = "user1",
+                Password = "pw",
+                FailedAttempts = 5,
+                LockoutUntil = DateTime.UtcNow.AddMinutes(5)
+            });
+            var vm = new UserManagementViewModel(svc, new StubFileDialogService(), new StubDialogService());
+            await vm.LoadUsersAsync();
+            var model = vm.Users.First();
+            Assert.True(model.IsLocked);
+            Assert.Equal(5, model.FailedAttempts);
+
+            await vm.UnlockUserCommand.ExecuteAsync(model);
+
+            var refreshed = vm.Users.First();
+            Assert.False(refreshed.IsLocked);
+            Assert.Equal(0, refreshed.FailedAttempts);
+            var serviceUser = svc.Users.First();
+            Assert.False(serviceUser.IsLocked);
+            Assert.Equal(0, serviceUser.FailedAttempts);
+            Assert.Null(serviceUser.LockoutUntil);
+        }
+
+        [Fact]
         public async Task AddUserAsync_CancelledPrompt_DoesNotAddUser()
         {
             var svc = new InMemoryUserService();


### PR DESCRIPTION
## Summary
- test `UnlockUserAsync` resets failed attempts and lockout
- verify `UnlockUserCommand` clears lock state and refreshes collection

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2765eaea88324a25f722ebd86183a