### PR TITLE
Inject view model into UsersPage and allow null misconfiguration

### DIFF
--- a/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
@@ -18,6 +18,34 @@ namespace ToolManagementAppV2.Tests.Views
     public class UsersPageTests
     {
         [Fact]
+        public void Constructor_AllowsNullDataContext()
+        {
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var page = new UsersPage(null);
+                    Assert.Null(page.ViewModel);
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+            {
+                throw threadException;
+            }
+        }
+
+        [Fact]
         public void ButtonsExecuteCommandsAndUpdateCollections()
         {
             var dbPath = System.IO.Path.GetTempFileName();
@@ -38,7 +66,7 @@ namespace ToolManagementAppV2.Tests.Views
                         vm.SelectedUser = vm.Users.First();
                         vm.SelectedUser.Email = "user@example.com";
 
-                        var page = new UsersPage { DataContext = vm };
+                        var page = new UsersPage(vm);
                         var updateBtn = (Button)page.FindName("UpdateUserButton");
                         var uploadBtn = (Button)page.FindName("UploadPhotoButton");
 
@@ -97,7 +125,7 @@ namespace ToolManagementAppV2.Tests.Views
                         userService.AddUser(new User { UserName = "user2", Password = "pw" });
                         vm.LoadUsers();
 
-                        var page = new UsersPage { DataContext = vm };
+                        var page = new UsersPage(vm);
                         var grid = (Grid)page.Content;
                         var dataGrid = (DataGrid)((Border)grid.Children[1]).Child;
 
@@ -150,7 +178,7 @@ namespace ToolManagementAppV2.Tests.Views
                         userService.AddUser(new User { UserName = "user1", Password = "pw" });
                         vm.LoadUsers();
 
-                        var page = new UsersPage { DataContext = vm };
+                        var page = new UsersPage(vm);
                         var grid = (Grid)page.Content;
                         var dataGrid = (DataGrid)((Border)grid.Children[1]).Child;
 

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -203,12 +203,7 @@ namespace ToolManagementAppV2.ViewModels
             OpenUsersCommand = new AsyncRelayCommand(async () =>
             {
                 await UserManagement.LoadUsersAsync();
-                var page = new UsersPage
-                {
-                    // UsersPage expects a UserManagementViewModel as its DataContext
-                    DataContext = UserManagement,
-                    Title = "Users"
-                };
+                var page = new UsersPage(UserManagement) { Title = "Users" };
                 CurrentPage = page;
             });
 

--- a/ToolManagementAppV2/Views/UsersPage.xaml.cs
+++ b/ToolManagementAppV2/Views/UsersPage.xaml.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Windows.Controls;
 using ToolManagementAppV2.ViewModels;
 
@@ -10,17 +9,17 @@ namespace ToolManagementAppV2.Views
     /// </summary>
     public partial class UsersPage : Page
     {
-        public UsersPage()
+        public UsersPage(UserManagementViewModel? viewModel)
         {
+            DataContext = viewModel;
             InitializeComponent();
         }
 
         /// <summary>
         /// Convenience accessor for the strongly typed view model.
-        /// Throws if the DataContext is not correctly set.
+        /// Returns null if the DataContext is not correctly set.
         /// </summary>
-        public UserManagementViewModel ViewModel =>
-            DataContext as UserManagementViewModel
-            ?? throw new InvalidOperationException("UsersPage requires a UserManagementViewModel DataContext.");
+        public UserManagementViewModel? ViewModel =>
+            DataContext as UserManagementViewModel;
     }
 }


### PR DESCRIPTION
## Summary
- Inject `UserManagementViewModel` via `UsersPage` constructor and expose nullable `ViewModel` property
- Create Users page with injected view model in `MainViewModel`'s `OpenUsersCommand`
- Add regression test ensuring `UsersPage` can be constructed without a data context

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a295872eac832490b80dc2c95240c5