### PR TITLE
Handle errors in OpenUsers command

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
@@ -86,6 +86,40 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public async Task OpenUsersCommand_ShowsError_WhenGetAllUsersFails()
+        {
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
+
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var userContext = new ApplicationUserContext();
+                IUserService userService = new GetAllUsersFailingUserService();
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
+                var dialog = new StubDialogService();
+
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                    new StubFileDialogService(), activityLogService, settingsService, db, dialog);
+
+                var ex = await Record.ExceptionAsync(() => vm.OpenUsersCommand.ExecuteAsync(null));
+
+                Assert.Null(ex);
+                Assert.True(dialog.InfoShown);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 
     class StubDialogService : IDialogService

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -202,9 +202,17 @@ namespace ToolManagementAppV2.ViewModels
 
             OpenUsersCommand = new AsyncRelayCommand(async () =>
             {
-                await UserManagement.LoadUsersAsync();
-                var page = new UsersPage(UserManagement) { Title = "Users" };
-                CurrentPage = page;
+                try
+                {
+                    await UserManagement.LoadUsersAsync();
+                    var page = new UsersPage(UserManagement) { Title = "Users" };
+                    CurrentPage = page;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to open users page");
+                    _dialogService.ShowInfo($"Failed to open users page: {ex.Message}", "Users");
+                }
             });
 
             OpenSettingsCommand = new RelayCommand(() =>


### PR DESCRIPTION
## Summary
- guard OpenUsers command with try/catch to log and notify failures
- add test for OpenUsersCommand error handling when user service fails

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a29d08d89c832497b3283e2e1216db