### PR TITLE
Rename user password fields to hashed variants

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
@@ -55,7 +55,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var user = new User
                 {
                     UserName = "user",
-                    Password = "pass",
+                    PasswordHash = "pass",
                     IsAdmin = false
                 };
                 userService.AddUser(user);
@@ -119,7 +119,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var user = new User
                 {
                     UserName = "user",
-                    Password = "pass",
+                    PasswordHash = "pass",
                     IsAdmin = false
                 };
                 userService.AddUser(user);

--- a/ToolManagementAppV2.Tests/Services/UserActiveTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserActiveTests.cs
@@ -19,7 +19,7 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 using var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
-                var user = new User { UserName = "u", Password = "p" };
+                var user = new User { UserName = "u", PasswordHash = "p" };
                 userService.AddUser(user);
                 var added = userService.GetAllUsers().First();
                 Assert.True(added.IsActive);
@@ -39,7 +39,7 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 using var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
-                var user = new User { UserName = "u", Password = "p" };
+                var user = new User { UserName = "u", PasswordHash = "p" };
                 userService.AddUser(user);
                 var added = userService.GetAllUsers().First();
                 added.IsActive = false;

--- a/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
@@ -22,14 +22,14 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var user = new User { UserName = "test", Password = "secret", IsAdmin = false };
+            var user = new User { UserName = "test", PasswordHash = "secret", IsAdmin = false };
             userService.AddUser(user);
             var added = userService.GetUserByID(user.UserID)!;
 
-            Assert.NotEqual("secret", added.Password);
-            Assert.False(SecurityHelper.IsSha256Hash(added.Password));
-            Assert.False(string.IsNullOrWhiteSpace(added.Salt));
-            Assert.True(SecurityHelper.VerifyPassword("secret", added.Salt, added.Password));
+            Assert.NotEqual("secret", added.PasswordHash);
+            Assert.False(SecurityHelper.IsSha256Hash(added.PasswordHash));
+            Assert.False(string.IsNullOrWhiteSpace(added.PasswordSalt));
+            Assert.True(SecurityHelper.VerifyPassword("secret", added.PasswordSalt, added.PasswordHash));
 
             var auth = userService.AuthenticateUser("test", "secret");
             Assert.Equal(AuthenticationResult.Success, auth.Result);
@@ -53,7 +53,7 @@ public class UserAuthenticationTests
 
             var legacy = SecurityHelper.ComputeSha256HashLegacy("secret");
             using (var conn = dbService.CreateConnection())
-            using (var cmd = new SQLiteCommand("INSERT INTO Users (UserName, Password, IsAdmin) VALUES (@u,@p,0);", conn))
+            using (var cmd = new SQLiteCommand("INSERT INTO Users (UserName, PasswordHash, IsAdmin) VALUES (@u,@p,0);", conn))
             {
                 cmd.Parameters.AddWithValue("@u", "legacy");
                 cmd.Parameters.AddWithValue("@p", legacy);
@@ -65,9 +65,9 @@ public class UserAuthenticationTests
             Assert.NotNull(auth.User);
 
             var updated = userService.GetUserByID(auth.User!.UserID)!;
-            Assert.False(SecurityHelper.IsSha256Hash(updated.Password));
-            Assert.False(string.IsNullOrWhiteSpace(updated.Salt));
-            Assert.True(SecurityHelper.VerifyPassword("secret", updated.Salt, updated.Password));
+            Assert.False(SecurityHelper.IsSha256Hash(updated.PasswordHash));
+            Assert.False(string.IsNullOrWhiteSpace(updated.PasswordSalt));
+            Assert.True(SecurityHelper.VerifyPassword("secret", updated.PasswordSalt, updated.PasswordHash));
         }
         finally
         {
@@ -85,11 +85,11 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var user = new User { UserName = "emptysalt", Password = "secret", IsAdmin = false };
+            var user = new User { UserName = "emptysalt", PasswordHash = "secret", IsAdmin = false };
             userService.AddUser(user);
 
             using (var conn = dbService.CreateConnection())
-            using (var cmd = new SQLiteCommand("UPDATE Users SET Salt='' WHERE UserID=@ID", conn))
+            using (var cmd = new SQLiteCommand("UPDATE Users SET PasswordSalt='' WHERE UserID=@ID", conn))
             {
                 cmd.Parameters.AddWithValue("@ID", user.UserID);
                 cmd.ExecuteNonQuery();
@@ -115,7 +115,7 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var user = new User { UserName = "lock", Password = "secret", IsAdmin = false };
+            var user = new User { UserName = "lock", PasswordHash = "secret", IsAdmin = false };
             userService.AddUser(user);
 
             for (int i = 0; i < 3; i++)
@@ -151,7 +151,7 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var user = new User { UserName = "reset", Password = "secret", IsAdmin = false };
+            var user = new User { UserName = "reset", PasswordHash = "secret", IsAdmin = false };
             userService.AddUser(user);
 
             for (int i = 0; i < 3; i++)
@@ -190,7 +190,7 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var user = new User { UserName = "flag", Password = "secret", IsAdmin = false };
+            var user = new User { UserName = "flag", PasswordHash = "secret", IsAdmin = false };
             userService.AddUser(user);
 
             userService.ChangeUserPassword(user.UserID, "admin");
@@ -217,14 +217,14 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var user = new User { UserName = "atest", Password = "secret", IsAdmin = false };
+            var user = new User { UserName = "atest", PasswordHash = "secret", IsAdmin = false };
             userService.AddUser(user);
             var added = userService.GetUserByID(user.UserID)!;
 
-            Assert.NotEqual("secret", added.Password);
-            Assert.False(SecurityHelper.IsSha256Hash(added.Password));
-            Assert.False(string.IsNullOrWhiteSpace(added.Salt));
-            Assert.True(SecurityHelper.VerifyPassword("secret", added.Salt, added.Password));
+            Assert.NotEqual("secret", added.PasswordHash);
+            Assert.False(SecurityHelper.IsSha256Hash(added.PasswordHash));
+            Assert.False(string.IsNullOrWhiteSpace(added.PasswordSalt));
+            Assert.True(SecurityHelper.VerifyPassword("secret", added.PasswordSalt, added.PasswordHash));
 
             var auth = await userService.AuthenticateUserAsync(" atest ", " secret ");
             Assert.Equal(AuthenticationResult.Success, auth.Result);
@@ -246,7 +246,7 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var user = new User { UserName = "lockasync", Password = "secret", IsAdmin = false };
+            var user = new User { UserName = "lockasync", PasswordHash = "secret", IsAdmin = false };
             userService.AddUser(user);
 
             for (int i = 0; i < 3; i++)
@@ -282,7 +282,7 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var user = new User { UserName = "areset", Password = "secret", IsAdmin = false };
+            var user = new User { UserName = "areset", PasswordHash = "secret", IsAdmin = false };
             await userService.AddUserAsync(user);
 
             for (int i = 0; i < 3; i++)

--- a/ToolManagementAppV2.Tests/Services/UserDeletionTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserDeletionTests.cs
@@ -19,7 +19,7 @@ public class UserDeletionTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var admin = new User { UserName = "admin", Password = "pw", IsAdmin = true };
+            var admin = new User { UserName = "admin", PasswordHash = "pw", IsAdmin = true };
             await userService.AddUserAsync(admin);
 
             var added = (await userService.GetAllUsersAsync()).First();

--- a/ToolManagementAppV2.Tests/Services/UserMobileTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserMobileTests.cs
@@ -19,7 +19,7 @@ namespace ToolManagementAppV2.Tests.Services
                 using var dbService = new DatabaseService(dbPath);
                 IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-                var user = new User { UserName = "u", Password = "p", Mobile = "111" };
+                var user = new User { UserName = "u", PasswordHash = "p", Mobile = "111" };
                 userService.AddUser(user);
 
                 var added = userService.GetAllUsers().First();
@@ -41,7 +41,7 @@ namespace ToolManagementAppV2.Tests.Services
                 using var dbService = new DatabaseService(dbPath);
                 IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-                var user = new User { UserName = "u", Password = "p", Mobile = "1" };
+                var user = new User { UserName = "u", PasswordHash = "p", Mobile = "1" };
                 userService.AddUser(user);
                 var added = userService.GetAllUsers().First();
 

--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -30,7 +30,7 @@ public class UserServiceTests
             var ctx = new StubUserContext { CurrentUser = new User { UserName = "seed", IsAdmin = false } };
             var auth = new AuthorizationService(ctx);
             var userService = new UserService(dbService, ctx, auth);
-            var admin = new User { UserName = "admin", Password = "pw", IsAdmin = true };
+            var admin = new User { UserName = "admin", PasswordHash = "pw", IsAdmin = true };
             await userService.AddUserAsync(admin);
             Assert.NotEqual(0, admin.UserID);
         }
@@ -50,9 +50,9 @@ public class UserServiceTests
             var ctx = new StubUserContext { CurrentUser = new User { UserName = "seed", IsAdmin = false } };
             var auth = new AuthorizationService(ctx);
             var userService = new UserService(dbService, ctx, auth);
-            var admin = new User { UserName = "admin", Password = "pw", IsAdmin = true };
+            var admin = new User { UserName = "admin", PasswordHash = "pw", IsAdmin = true };
             await userService.AddUserAsync(admin);
-            await Assert.ThrowsAsync<UnauthorizedAccessException>(() => userService.AddUserAsync(new User { UserName = "user", Password = "pw" }));
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(() => userService.AddUserAsync(new User { UserName = "user", PasswordHash = "pw" }));
         }
         finally
         {
@@ -67,7 +67,7 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var admin = new User { UserName = "admin", Password = "pw", IsAdmin = true };
+            var admin = new User { UserName = "admin", PasswordHash = "pw", IsAdmin = true };
             await userService.AddUserAsync(admin);
             var result = await userService.TryDeleteUserAsync(admin.UserID);
             Assert.False(result);
@@ -87,8 +87,8 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var admin1 = new User { UserName = "admin1", Password = "pw", IsAdmin = true };
-            var admin2 = new User { UserName = "admin2", Password = "pw", IsAdmin = true };
+            var admin1 = new User { UserName = "admin1", PasswordHash = "pw", IsAdmin = true };
+            var admin2 = new User { UserName = "admin2", PasswordHash = "pw", IsAdmin = true };
             await userService.AddUserAsync(admin1);
             await userService.AddUserAsync(admin2);
             var result = await userService.TryDeleteUserAsync(admin1.UserID);
@@ -110,8 +110,8 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            userService.AddUser(new User { UserName = "dup", Password = "pw" });
-            var ex = Assert.Throws<InvalidOperationException>(() => userService.AddUser(new User { UserName = "dup", Password = "pw" }));
+            userService.AddUser(new User { UserName = "dup", PasswordHash = "pw" });
+            var ex = Assert.Throws<InvalidOperationException>(() => userService.AddUser(new User { UserName = "dup", PasswordHash = "pw" }));
             Assert.Contains("username", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
@@ -128,8 +128,8 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             var userService = new UserService(dbService, new ApplicationUserContext());
-            await userService.AddUserAsync(new User { UserName = "dup", Password = "pw" });
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => userService.AddUserAsync(new User { UserName = "dup", Password = "pw" }));
+            await userService.AddUserAsync(new User { UserName = "dup", PasswordHash = "pw" });
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => userService.AddUserAsync(new User { UserName = "dup", PasswordHash = "pw" }));
             Assert.Contains("username", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
@@ -146,7 +146,7 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             var userService = new UserService(dbService, new ApplicationUserContext());
-            var user = new User { UserName = "user1", Password = "pw" };
+            var user = new User { UserName = "user1", PasswordHash = "pw" };
             await userService.AddUserAsync(user);
             var stored = userService.GetUserByID(user.UserID);
             Assert.NotNull(stored);
@@ -200,7 +200,7 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var user = new User { UserName = "trim", Password = "pw" };
+            var user = new User { UserName = "trim", PasswordHash = "pw" };
             await userService.AddUserAsync(user);
             var result = await userService.ChangeUserPasswordAsync(user.UserID, "  newpass  ");
             Assert.True(result);
@@ -221,7 +221,7 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var user = new User { UserName = "blank", Password = "pw" };
+            var user = new User { UserName = "blank", PasswordHash = "pw" };
             await userService.AddUserAsync(user);
             var result = await userService.ChangeUserPasswordAsync(user.UserID, "   ");
             Assert.False(result);
@@ -242,7 +242,7 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var user = new User { UserName = "locked", Password = "pw" };
+            var user = new User { UserName = "locked", PasswordHash = "pw" };
             await userService.AddUserAsync(user);
 
             await userService.AuthenticateUserAsync("locked", "bad");
@@ -276,7 +276,7 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var user = new User { UserName = "lock", Password = "pw" };
+            var user = new User { UserName = "lock", PasswordHash = "pw" };
             await userService.AddUserAsync(user);
 
             await userService.AuthenticateUserAsync("lock", "bad");
@@ -311,7 +311,7 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var user = new User { UserName = "nulltest", Password = "pw" };
+            var user = new User { UserName = "nulltest", PasswordHash = "pw" };
             await userService.AddUserAsync(user);
 
             using (var conn = dbService.CreateConnection())
@@ -343,11 +343,11 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            userService.AddUser(new User { UserName = "list", Password = "pw", Salt = "s" });
+            userService.AddUser(new User { UserName = "list", PasswordHash = "pw", PasswordSalt = "s" });
             var users = userService.GetAllUsers();
             var user = users[0];
-            Assert.Null(user.Password);
-            Assert.Null(user.Salt);
+            Assert.Null(user.PasswordHash);
+            Assert.Null(user.PasswordSalt);
         }
         finally
         {
@@ -363,11 +363,11 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             var userService = new UserService(dbService, new ApplicationUserContext());
-            await userService.AddUserAsync(new User { UserName = "list", Password = "pw", Salt = "s" });
+            await userService.AddUserAsync(new User { UserName = "list", PasswordHash = "pw", PasswordSalt = "s" });
             var users = await userService.GetAllUsersAsync();
             var user = users[0];
-            Assert.Null(user.Password);
-            Assert.Null(user.Salt);
+            Assert.Null(user.PasswordHash);
+            Assert.Null(user.PasswordSalt);
         }
         finally
         {
@@ -384,13 +384,13 @@ public class UserServiceTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
             var hash = SecurityHelper.HashPassword("secret", out var salt);
-            var user = new User { UserName = "prehashed", Password = hash, Salt = salt, PasswordExpired = true };
+            var user = new User { UserName = "prehashed", PasswordHash = hash, PasswordSalt = salt, PasswordExpired = true };
             userService.AddUser(user);
             var fetched = userService.GetUserByID(user.UserID)!;
-            Assert.Equal(hash, fetched.Password);
-            Assert.Equal(salt, fetched.Salt);
+            Assert.Equal(hash, fetched.PasswordHash);
+            Assert.Equal(salt, fetched.PasswordSalt);
             Assert.True(fetched.PasswordExpired);
-            Assert.True(SecurityHelper.VerifyPassword("secret", fetched.Salt, fetched.Password));
+            Assert.True(SecurityHelper.VerifyPassword("secret", fetched.PasswordSalt, fetched.PasswordHash));
         }
         finally
         {

--- a/ToolManagementAppV2.Tests/Tests/MapUserLoggingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/MapUserLoggingTests.cs
@@ -26,7 +26,7 @@ namespace ToolManagementAppV2.Tests
                 PathHelper.Configure(factory.CreateLogger<PathHelper>());
                 try
                 {
-                    service.AddUser(new User { UserName = "u", Password = "p", UserPhotoPath = "pack://application:,,,/Resources/NoImage.png" });
+                    service.AddUser(new User { UserName = "u", PasswordHash = "p", UserPhotoPath = "pack://application:,,,/Resources/NoImage.png" });
                     service.GetAllUsers();
                 }
                 finally
@@ -54,7 +54,7 @@ namespace ToolManagementAppV2.Tests
                 PathHelper.Configure(factory.CreateLogger<PathHelper>());
                 try
                 {
-                    service.AddUser(new User { UserName = "u", Password = "p", UserPhotoPath = "invalid|path.png" });
+                    service.AddUser(new User { UserName = "u", PasswordHash = "p", UserPhotoPath = "invalid|path.png" });
                     service.GetAllUsers();
                 }
                 finally

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -97,7 +97,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var auth = new AuthorizationService(userContext);
                 var userService = new UserService(dbService, userContext, auth);
                 var settingsService = new SettingsService(dbService);
-                userService.AddUser(new User { UserName = "user", Password = "newpassword", IsAdmin = false });
+                userService.AddUser(new User { UserName = "user", PasswordHash = "newpassword", IsAdmin = false });
 
                 var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext);
                 await vm.InitializeAsync();
@@ -130,7 +130,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var auth = new AuthorizationService(userContext);
                 var userService = new UserService(dbService, userContext, auth);
                 var settingsService = new SettingsService(dbService);
-                var user = new User { UserName = "user", Password = "newpassword", IsAdmin = false, PasswordExpired = true };
+                var user = new User { UserName = "user", PasswordHash = "newpassword", IsAdmin = false, PasswordExpired = true };
                 userService.AddUser(user);
 
                 var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
@@ -146,7 +146,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 Assert.True(success);
                 var updated = userService.GetUserByID(user.UserID)!;
                 Assert.False(updated.PasswordExpired);
-                Assert.True(SecurityHelper.VerifyPassword("changed", updated.Salt, updated.Password));
+                Assert.True(SecurityHelper.VerifyPassword("changed", updated.PasswordSalt, updated.PasswordHash));
             }
             finally
             {
@@ -168,7 +168,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var auth = new AuthorizationService(userContext);
                 var userService = new UserService(dbService, userContext, auth);
                 var settingsService = new SettingsService(dbService);
-                var admin = new User { UserName = "admin", Password = "secret", IsAdmin = true, PasswordExpired = true };
+                var admin = new User { UserName = "admin", PasswordHash = "secret", IsAdmin = true, PasswordExpired = true };
                 userService.AddUser(admin);
 
                 var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
@@ -186,7 +186,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 Assert.True(success);
                 var updated = userService.GetUserByID(admin.UserID)!;
                 Assert.False(updated.PasswordExpired);
-                Assert.True(SecurityHelper.VerifyPassword("changed", updated.Salt, updated.Password));
+                Assert.True(SecurityHelper.VerifyPassword("changed", updated.PasswordSalt, updated.PasswordHash));
             }
             finally
             {
@@ -207,7 +207,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(dbService, userContext);
                 var settingsService = new SettingsService(dbService);
-                userService.AddUser(new User { UserName = "admin", Password = "secret", IsAdmin = true });
+                userService.AddUser(new User { UserName = "admin", PasswordHash = "secret", IsAdmin = true });
 
                 var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
                 {
@@ -242,7 +242,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(dbService, userContext);
                 var settingsService = new SettingsService(dbService);
-                userService.AddUser(new User { UserName = "admin", Password = "secret", IsAdmin = true });
+                userService.AddUser(new User { UserName = "admin", PasswordHash = "secret", IsAdmin = true });
 
                 var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
                 {
@@ -312,7 +312,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 new System.Windows.Application();
 
             var hashed = SecurityHelper.HashPassword("newpassword", out var salt);
-            var user = new User { UserID = 1, UserName = "user", Password = hashed, Salt = salt, IsAdmin = false, PasswordExpired = true };
+            var user = new User { UserID = 1, UserName = "user", PasswordHash = hashed, PasswordSalt = salt, IsAdmin = false, PasswordExpired = true };
             var userService = new ThrowingUserService(user);
             var settingsService = new StubSettingsService();
             var dialog = new CapturingDialogService();
@@ -353,8 +353,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 {
                     UserID = 1,
                     UserName = "admin",
-                    Password = result.hash,
-                    Salt = result.salt,
+                    PasswordHash = result.hash,
+                    PasswordSalt = result.salt,
                     IsAdmin = true,
                     PasswordExpired = true
                 };
@@ -418,7 +418,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 new System.Windows.Application();
 
             var hashed = SecurityHelper.HashPassword("secret", out var salt);
-            var dbUser = new User { UserID = 1, UserName = "admin", Password = hashed, Salt = salt, IsAdmin = true };
+            var dbUser = new User { UserID = 1, UserName = "admin", PasswordHash = hashed, PasswordSalt = salt, IsAdmin = true };
             var userService = new OmittingPasswordUserService(dbUser);
             var settingsService = new StubSettingsService();
             var userContext = new ApplicationUserContext();
@@ -452,7 +452,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var userService = new UserService(dbService, userContext, auth);
                 var settingsService = new SettingsService(dbService);
                 var lockout = DateTime.UtcNow.AddMinutes(15);
-                await userService.AddUserAsync(new User { UserName = "locked", Password = "newpassword", LockoutUntil = lockout });
+                await userService.AddUserAsync(new User { UserName = "locked", PasswordHash = "newpassword", LockoutUntil = lockout });
 
                 var dialog = new CapturingDialogService();
                 var vm = new LoginViewModel(userService, settingsService, dialog, userContext)
@@ -574,7 +574,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
         public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password)
             => Task.FromResult(
-                userName == _dbUser.UserName && SecurityHelper.VerifyPassword(password, _dbUser.Salt, _dbUser.Password)
+                userName == _dbUser.UserName && SecurityHelper.VerifyPassword(password, _dbUser.PasswordSalt, _dbUser.PasswordHash)
                     ? (AuthenticationResult.Success, (User?)_dbUser)
                     : (AuthenticationResult.IncorrectPassword, (User?)null));
 

--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -29,7 +29,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
-                userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                userService.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
                 await vm.LoadUsersAsync();
                 vm.SelectedUser = vm.Users.First();
                 vm.SelectedUser.Email = "test@example.com";
@@ -52,7 +52,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task UpdateUserCommand_ShowsErrorOnFailure()
         {
             var svc = new FailingUserService();
-            svc.AddUser(new User { UserID = 1, UserName = "user1", Password = "pw" });
+            svc.AddUser(new User { UserID = 1, UserName = "user1", PasswordHash = "pw" });
             var dialog = new StubDialogService();
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), dialog);
             await vm.LoadUsersAsync();
@@ -68,7 +68,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task EditUserAsync_PersistsChanges()
         {
             var svc = new InMemoryUserService();
-            svc.AddUser(new User { UserName = "user1", Password = "pw" });
+            svc.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
             var dialog = new StubDialogService();
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), dialog);
             await vm.LoadUsersAsync();
@@ -79,8 +79,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 UserID = user.UserID,
                 UserName = user.UserName,
-                Password = user.Password,
-                Salt = user.Salt,
+                PasswordHash = user.PasswordHash,
+                PasswordSalt = user.PasswordSalt,
                 UserPhotoPath = user.UserPhotoPath,
                 IsAdmin = user.IsAdmin,
                 Email = "edited@example.com",
@@ -125,7 +125,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task EditUserAsync_ShowsErrorOnFailure()
         {
             var svc = new FailingUserService();
-            svc.AddUser(new User { UserID = 1, UserName = "user1", Password = "pw" });
+            svc.AddUser(new User { UserID = 1, UserName = "user1", PasswordHash = "pw" });
             var dialog = new StubDialogService();
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), dialog);
             await vm.LoadUsersAsync();
@@ -136,8 +136,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 UserID = user.UserID,
                 UserName = user.UserName,
-                Password = user.Password,
-                Salt = user.Salt,
+                PasswordHash = user.PasswordHash,
+                PasswordSalt = user.PasswordSalt,
                 UserPhotoPath = user.UserPhotoPath,
                 IsAdmin = user.IsAdmin,
                 Email = "edited@example.com",
@@ -185,7 +185,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var fileSvc = new StubFileDialogService { FileToReturn = "path/to/image.png" };
                 var vm = new UserManagementViewModel(userService, fileSvc, new StubDialogService());
-                userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                userService.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
                 await vm.LoadUsersAsync();
                 vm.SelectedUser = vm.Users.First();
                 await vm.UploadUserPhotoCommand.ExecuteAsync(null);
@@ -215,7 +215,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var fileSvc = new StubFileDialogService { FileToReturn = Path.Combine("..", "outside.png") };
                 var dialog = new StubDialogService();
                 var vm = new UserManagementViewModel(userService, fileSvc, dialog);
-                userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                userService.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
                 await vm.LoadUsersAsync();
                 vm.SelectedUser = vm.Users.First();
                 await vm.UploadUserPhotoCommand.ExecuteAsync(null);
@@ -244,7 +244,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var fileSvc = new StubFileDialogService { FileToReturn = "img.png" };
                 var vm = new UserManagementViewModel(userService, fileSvc, new StubDialogService());
-                userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                userService.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
                 await vm.LoadUsersAsync();
                 vm.SelectedUser = vm.Users.First();
 
@@ -273,7 +273,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task CommandsDisabledWhenNoUserSelected()
         {
             var svc = new InMemoryUserService();
-            await svc.AddUserAsync(new User { UserName = "user1", Password = "pw" });
+            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "pw" });
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), new StubDialogService());
             await vm.LoadUsersAsync();
             Assert.False(vm.UpdateUserCommand.CanExecute(null));
@@ -287,8 +287,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task LoadUsersAsync_LoadsUsers()
         {
             var svc = new InMemoryUserService();
-            await svc.AddUserAsync(new User { UserName = "user1", Password = "pw" });
-            await svc.AddUserAsync(new User { UserName = "user2", Password = "pw" });
+            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "pw" });
+            await svc.AddUserAsync(new User { UserName = "user2", PasswordHash = "pw" });
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), new StubDialogService());
             await vm.LoadUsersAsync();
             Assert.Equal(2, vm.Users.Count);
@@ -317,14 +317,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
             await vm.AddUserAsync();
             Assert.Single(vm.Users);
             Assert.Single(svc.Users);
-            Assert.Equal("pw", svc.Users[0].Password);
+            Assert.Equal("pw", svc.Users[0].PasswordHash);
         }
 
         [Fact]
         public async Task AddUserAsync_SkipsExistingNameFromService()
         {
             var svc = new InMemoryUserService();
-            await svc.AddUserAsync(new User { UserName = "user1", Password = "pw" });
+            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "pw" });
             var vm = new PromptUserManagementViewModel(svc, "pw");
             await vm.AddUserAsync();
 
@@ -338,8 +338,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task AddUserAsync_FindsFirstAvailableNumber()
         {
             var svc = new InMemoryUserService();
-            await svc.AddUserAsync(new User { UserName = "user1", Password = "pw" });
-            await svc.AddUserAsync(new User { UserName = "user3", Password = "pw" });
+            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "pw" });
+            await svc.AddUserAsync(new User { UserName = "user3", PasswordHash = "pw" });
             var vm = new PromptUserManagementViewModel(svc, "pw");
             await vm.AddUserAsync();
 
@@ -357,8 +357,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             await vm.AddUserAsync();
             var user = svc.Users.Single();
             Assert.True(user.PasswordExpired);
-            Assert.False(string.IsNullOrEmpty(user.Password));
-            Assert.NotEqual("changeme", user.Password);
+            Assert.False(string.IsNullOrEmpty(user.PasswordHash));
+            Assert.NotEqual("changeme", user.PasswordHash);
         }
 
         [Fact]
@@ -368,7 +368,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var vm = new PromptUserManagementViewModel(svc, "");
             await vm.AddUserAsync();
             var user = svc.Users.Single();
-            Assert.False(string.IsNullOrEmpty(user.Salt));
+            Assert.False(string.IsNullOrEmpty(user.PasswordSalt));
         }
 
         [Fact]
@@ -379,7 +379,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             await vm.AddUserAsync();
             var user = svc.Users.Single();
             Assert.False(user.PasswordExpired);
-            Assert.Equal("secret", user.Password);
+            Assert.Equal("secret", user.PasswordHash);
         }
 
         [Fact]
@@ -392,14 +392,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var dialog = new StubDialogService();
                 var vm = new UserManagementViewModel(userService, new StubFileDialogService(), dialog);
-                userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                userService.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
                 await vm.LoadUsersAsync();
                 var user = vm.Users.First();
                 var original = userService.GetUserByID(user.UserID)!;
-                var oldPwd = original.Password;
+                var oldPwd = original.PasswordHash;
                 await vm.ResetPasswordFromRowCommand.ExecuteAsync(user);
                 var updated = userService.GetUserByID(user.UserID)!;
-                Assert.NotEqual(oldPwd, updated.Password);
+                Assert.NotEqual(oldPwd, updated.PasswordHash);
                 Assert.True(updated.PasswordExpired);
                 Assert.Equal("Password Reset", dialog.LastInfoTitle);
                 Assert.Equal("Password has been reset. The user must change it at next login.", dialog.LastInfoMessage);
@@ -415,8 +415,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task SearchAndClearUsers_WorkAsExpected()
         {
             var svc = new InMemoryUserService();
-            await svc.AddUserAsync(new User { UserName = "alice", Password = "pw" });
-            await svc.AddUserAsync(new User { UserName = "bob", Password = "pw" });
+            await svc.AddUserAsync(new User { UserName = "alice", PasswordHash = "pw" });
+            await svc.AddUserAsync(new User { UserName = "bob", PasswordHash = "pw" });
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), new StubDialogService());
             await vm.LoadUsersAsync();
 
@@ -433,8 +433,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task DeleteUserFromRowCommand_RemovesUser()
         {
             var svc = new InMemoryUserService();
-            await svc.AddUserAsync(new User { UserName = "user1", Password = "pw" });
-            await svc.AddUserAsync(new User { UserName = "user2", Password = "pw" });
+            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "pw" });
+            await svc.AddUserAsync(new User { UserName = "user2", PasswordHash = "pw" });
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), new StubDialogService());
             await vm.LoadUsersAsync();
             var toDelete = vm.Users.First();
@@ -447,7 +447,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task DeleteUserFromRowCommand_FailureDoesNotRemoveUser()
         {
             var svc = new FailingUserService();
-            svc.AddUser(new User { UserName = "user1", Password = "pw" });
+            svc.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), new StubDialogService());
             await vm.LoadUsersAsync();
             var toDelete = vm.Users.First();
@@ -459,7 +459,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task DeleteUserFromRowCommand_FailureShowsInfo()
         {
             var svc = new FailingUserService();
-            svc.AddUser(new User { UserName = "user1", Password = "pw" });
+            svc.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
             var dialog = new StubDialogService();
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), dialog);
             await vm.LoadUsersAsync();
@@ -473,7 +473,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task UnlockUserCommand_UnlocksUserAndRefreshesList()
         {
             var svc = new InMemoryUserService();
-            await svc.AddUserAsync(new User { UserName = "user1", Password = "pw", LockoutUntil = DateTime.UtcNow.AddMinutes(5) });
+            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "pw", LockoutUntil = DateTime.UtcNow.AddMinutes(5) });
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), new StubDialogService());
             await vm.LoadUsersAsync();
             var user = vm.Users.First();
@@ -490,7 +490,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             await svc.AddUserAsync(new User
             {
                 UserName = "user1",
-                Password = "pw",
+                PasswordHash = "pw",
                 FailedAttempts = 5,
                 LockoutUntil = DateTime.UtcNow.AddMinutes(5)
             });

--- a/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
@@ -61,7 +61,7 @@ namespace ToolManagementAppV2.Tests.Views
                         IUserService userService = new UserService(db, new ApplicationUserContext());
                         var fileSvc = new StubFileDialogService { FileToReturn = "img.png" };
                         var vm = new UserManagementViewModel(userService, fileSvc, new StubDialogService());
-                        userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                        userService.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
                         vm.LoadUsers();
                         vm.SelectedUser = vm.Users.First();
                         vm.SelectedUser.Email = "user@example.com";
@@ -121,8 +121,8 @@ namespace ToolManagementAppV2.Tests.Views
                         var db = new DatabaseService(dbPath);
                         IUserService userService = new UserService(db, new ApplicationUserContext());
                         var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
-                        userService.AddUser(new User { UserName = "user1", Password = "pw" });
-                        userService.AddUser(new User { UserName = "user2", Password = "pw" });
+                        userService.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
+                        userService.AddUser(new User { UserName = "user2", PasswordHash = "pw" });
                         vm.LoadUsers();
 
                         var page = new UsersPage(vm);
@@ -175,7 +175,7 @@ namespace ToolManagementAppV2.Tests.Views
                         var db = new DatabaseService(dbPath);
                         IUserService userService = new UserService(db, new ApplicationUserContext());
                         var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
-                        userService.AddUser(new User { UserName = "user1", Password = "pw" });
+                        userService.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
                         vm.LoadUsers();
 
                         var page = new UsersPage(vm);

--- a/ToolManagementAppV2/Models/Domain/User.cs
+++ b/ToolManagementAppV2/Models/Domain/User.cs
@@ -11,11 +11,11 @@ namespace ToolManagementAppV2.Models.Domain
         private string _userName;
         public string UserName { get => _userName; set => SetProperty(ref _userName, value); }
 
-        private string _password;
-        public string Password { get => _password; set => SetProperty(ref _password, value); }
+        private string _passwordHash;
+        public string PasswordHash { get => _passwordHash; set => SetProperty(ref _passwordHash, value); }
 
-        private string _salt;
-        public string Salt { get => _salt; set => SetProperty(ref _salt, value); }
+        private string _passwordSalt;
+        public string PasswordSalt { get => _passwordSalt; set => SetProperty(ref _passwordSalt, value); }
 
         private string _userPhotoPath;
         public string UserPhotoPath { get => _userPhotoPath; set => SetProperty(ref _userPhotoPath, value); }

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -54,8 +54,8 @@ namespace ToolManagementAppV2.Services.Core
             {
                 EnsureIndex(conn, "Tools", "Keywords");
             }
-            EnsureColumn("Users", "Password", "TEXT");
-            EnsureColumn("Users", "Salt", "TEXT");
+            EnsureColumn("Users", "PasswordHash", "TEXT");
+            EnsureColumn("Users", "PasswordSalt", "TEXT");
             EnsureColumn("Users", "Email", "TEXT");
             EnsureColumn("Users", "Phone", "TEXT");
             EnsureColumn("Users", "Mobile", "TEXT");
@@ -125,8 +125,8 @@ namespace ToolManagementAppV2.Services.Core
                     UserID INTEGER PRIMARY KEY AUTOINCREMENT,
                     UserName TEXT NOT NULL,
                     UserPhotoPath TEXT,
-                    Password TEXT,
-                    Salt TEXT,
+                    PasswordHash TEXT,
+                    PasswordSalt TEXT,
                     IsAdmin INTEGER NOT NULL DEFAULT 0,
                     Email TEXT,
                     Phone TEXT,

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -43,8 +43,8 @@ namespace ToolManagementAppV2.Services.Users
             {
                 UserID = rdr["UserID"] != DBNull.Value ? Convert.ToInt32(rdr["UserID"]) : 0,
                 UserName = rdr["UserName"].ToString(),
-                Password = HasColumn("Password") && rdr["Password"] != DBNull.Value ? rdr["Password"].ToString() : null,
-                Salt = HasColumn("Salt") && rdr["Salt"] != DBNull.Value ? rdr["Salt"].ToString() : null,
+                PasswordHash = HasColumn("PasswordHash") && rdr["PasswordHash"] != DBNull.Value ? rdr["PasswordHash"].ToString() : null,
+                PasswordSalt = HasColumn("PasswordSalt") && rdr["PasswordSalt"] != DBNull.Value ? rdr["PasswordSalt"].ToString() : null,
                 UserPhotoPath = rdr["UserPhotoPath"]?.ToString(),
                 IsAdmin = rdr["IsAdmin"] != DBNull.Value && Convert.ToInt32(rdr["IsAdmin"]) == 1,
                 Email = rdr["Email"]?.ToString(),
@@ -105,10 +105,10 @@ namespace ToolManagementAppV2.Services.Users
             }
 
             bool success;
-            if (string.IsNullOrWhiteSpace(u.Salt) && SecurityHelper.IsSha256Hash(u.Password))
+            if (string.IsNullOrWhiteSpace(u.PasswordSalt) && SecurityHelper.IsSha256Hash(u.PasswordHash))
             {
                 var legacy = SecurityHelper.ComputeSha256HashLegacy(password);
-                success = u.Password == legacy;
+                success = u.PasswordHash == legacy;
                 if (success)
                 {
                     var upgradedResult = await SecurityHelper.HashPasswordAsync(password).ConfigureAwait(false);
@@ -118,14 +118,14 @@ namespace ToolManagementAppV2.Services.Users
                 new SQLiteParameter("@Salt", upgradedResult.salt),
                 new SQLiteParameter("@ID", u.UserID)
             };
-                    await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET Password=@Pwd, Salt=@Salt WHERE UserID=@ID", p);
-                    u.Password = upgradedResult.hash;
-                    u.Salt = upgradedResult.salt;
+                    await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET PasswordHash=@Pwd, PasswordSalt=@Salt WHERE UserID=@ID", p);
+                    u.PasswordHash = upgradedResult.hash;
+                    u.PasswordSalt = upgradedResult.salt;
                 }
             }
             else
             {
-                success = await SecurityHelper.VerifyPasswordAsync(password, u.Salt, u.Password).ConfigureAwait(false);
+                success = await SecurityHelper.VerifyPasswordAsync(password, u.PasswordSalt, u.PasswordHash).ConfigureAwait(false);
             }
 
             if (success)
@@ -168,9 +168,9 @@ namespace ToolManagementAppV2.Services.Users
                 _auth.EnsureAdmin();
             const string sql = @"
                 INSERT INTO Users
-                  (UserName, Password, Salt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, FailedAttempts, LockoutUntil, PasswordExpired)
+                  (UserName, PasswordHash, PasswordSalt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, FailedAttempts, LockoutUntil, PasswordExpired)
                 VALUES
-                  (@UserName,@Password,@Salt,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role,@IsActive,@CreatedAt,@FailedAttempts,@Lockout,@PasswordExpired);
+                  (@UserName,@PasswordHash,@PasswordSalt,@Photo,@Admin,@Email,@Phone,@Mobile,@Address,@Role,@IsActive,@CreatedAt,@FailedAttempts,@Lockout,@PasswordExpired);
                 SELECT last_insert_rowid();";
 
             using var conn = _dbService.CreateConnection();
@@ -178,17 +178,17 @@ namespace ToolManagementAppV2.Services.Users
 
             string hashed = string.Empty;
             string salt = string.Empty;
-            if (!string.IsNullOrWhiteSpace(user.Password))
+            if (!string.IsNullOrWhiteSpace(user.PasswordHash))
             {
-                if (!string.IsNullOrWhiteSpace(user.Salt) &&
-                    IsBase64String(user.Password) && IsBase64String(user.Salt))
+                if (!string.IsNullOrWhiteSpace(user.PasswordSalt) &&
+                    IsBase64String(user.PasswordHash) && IsBase64String(user.PasswordSalt))
                 {
-                    hashed = user.Password;
-                    salt = user.Salt;
+                    hashed = user.PasswordHash;
+                    salt = user.PasswordSalt;
                 }
                 else
                 {
-                    var result = await SecurityHelper.HashPasswordAsync(user.Password).ConfigureAwait(false);
+                    var result = await SecurityHelper.HashPasswordAsync(user.PasswordHash).ConfigureAwait(false);
                     hashed = result.hash;
                     salt = result.salt;
                 }
@@ -199,8 +199,8 @@ namespace ToolManagementAppV2.Services.Users
             cmd.Parameters.AddRange(new[]
             {
                 new SQLiteParameter("@UserName", user.UserName),
-                new SQLiteParameter("@Password", hashed),
-                new SQLiteParameter("@Salt",     salt),
+                new SQLiteParameter("@PasswordHash", hashed),
+                new SQLiteParameter("@PasswordSalt",     salt),
                 new SQLiteParameter("@Photo",    (object)user.UserPhotoPath ?? DBNull.Value),
                 new SQLiteParameter("@Admin",    user.IsAdmin ? 1 : 0),
                 new SQLiteParameter("@Email",    (object)user.Email ?? DBNull.Value),
@@ -223,8 +223,8 @@ namespace ToolManagementAppV2.Services.Users
             {
                 throw new InvalidOperationException("A user with the same username already exists.", ex);
             }
-            user.Password = hashed;
-            user.Salt = salt;
+            user.PasswordHash = hashed;
+            user.PasswordSalt = salt;
         }
 
         public async Task UpdateUserAsync(User user)
@@ -233,8 +233,8 @@ namespace ToolManagementAppV2.Services.Users
             const string sql = @"
                 UPDATE Users SET
                   UserName      = @UserName,
-                  Password      = @Password,
-                  Salt          = @Salt,
+                  PasswordHash  = @PasswordHash,
+                  PasswordSalt  = @PasswordSalt,
                   UserPhotoPath = @Photo,
                   IsAdmin       = @Admin,
                   Email         = @Email,
@@ -245,11 +245,11 @@ namespace ToolManagementAppV2.Services.Users
                   IsActive      = @IsActive
                 WHERE UserID = @UserID";
 
-            string hashed = user.Password;
-            string salt = user.Salt;
-            if (!string.IsNullOrWhiteSpace(user.Password) && string.IsNullOrWhiteSpace(user.Salt))
+            string hashed = user.PasswordHash;
+            string salt = user.PasswordSalt;
+            if (!string.IsNullOrWhiteSpace(user.PasswordHash) && string.IsNullOrWhiteSpace(user.PasswordSalt))
             {
-                var result = await SecurityHelper.HashPasswordAsync(user.Password).ConfigureAwait(false);
+                var result = await SecurityHelper.HashPasswordAsync(user.PasswordHash).ConfigureAwait(false);
                 hashed = result.hash;
                 salt = result.salt;
             }
@@ -258,8 +258,8 @@ namespace ToolManagementAppV2.Services.Users
             {
                 new SQLiteParameter("@UserID",   user.UserID),
                 new SQLiteParameter("@UserName", user.UserName),
-                new SQLiteParameter("@Password", hashed),
-                new SQLiteParameter("@Salt",     salt),
+                new SQLiteParameter("@PasswordHash", hashed),
+                new SQLiteParameter("@PasswordSalt",     salt),
                 new SQLiteParameter("@Photo",    (object)user.UserPhotoPath ?? DBNull.Value),
                 new SQLiteParameter("@Admin",    user.IsAdmin ? 1 : 0),
                 new SQLiteParameter("@Email",    (object)user.Email ?? DBNull.Value),
@@ -272,8 +272,8 @@ namespace ToolManagementAppV2.Services.Users
 
             using var conn = _dbService.CreateConnection();
             await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
-            user.Password = hashed;
-            user.Salt = salt;
+            user.PasswordHash = hashed;
+            user.PasswordSalt = salt;
         }
 
         public async Task<bool> ChangeUserPasswordAsync(int userID, string newPassword)
@@ -285,7 +285,7 @@ namespace ToolManagementAppV2.Services.Users
             if (newPassword.Length == 0)
                 return false;
 
-            var sql = "UPDATE Users SET Password=@Pwd, Salt=@Salt, PasswordExpired=@Expired WHERE UserID=@ID";
+            var sql = "UPDATE Users SET PasswordHash=@Pwd, PasswordSalt=@Salt, PasswordExpired=@Expired WHERE UserID=@ID";
             var result = await SecurityHelper.HashPasswordAsync(newPassword).ConfigureAwait(false);
             string hashed = result.hash;
             string salt = result.salt;

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -184,8 +184,8 @@ namespace ToolManagementAppV2.ViewModels
                 var admin = new User
                 {
                     UserName = "admin",
-                    Password = result.hash,
-                    Salt = result.salt,
+                    PasswordHash = result.hash,
+                    PasswordSalt = result.salt,
                     IsAdmin = true,
                     PasswordExpired = true
                 };
@@ -215,7 +215,7 @@ namespace ToolManagementAppV2.ViewModels
             if (dbUser == null) return;
             user = dbUser;
 
-            if (user.IsAdmin && string.IsNullOrWhiteSpace(user.Password))
+            if (user.IsAdmin && string.IsNullOrWhiteSpace(user.PasswordHash))
             {
                 try
                 {
@@ -229,15 +229,15 @@ namespace ToolManagementAppV2.ViewModels
                 var refreshed = await _userService.GetUserByIDAsync(user.UserID);
                 if (refreshed != null)
                 {
-                    user.Password = refreshed.Password;
-                    user.Salt = refreshed.Salt;
+                    user.PasswordHash = refreshed.PasswordHash;
+                    user.PasswordSalt = refreshed.PasswordSalt;
                     user.PasswordExpired = refreshed.PasswordExpired;
                 }
             }
 
             if (!user.IsAdmin &&
-                (string.IsNullOrWhiteSpace(user.Password) ||
-                 await SecurityHelper.VerifyPasswordAsync("newpassword", user.Salt, user.Password).ConfigureAwait(false)))
+                (string.IsNullOrWhiteSpace(user.PasswordHash) ||
+                 await SecurityHelper.VerifyPasswordAsync("newpassword", user.PasswordSalt, user.PasswordHash).ConfigureAwait(false)))
             {
                 _userContext.CurrentUser = user;
                 if (user.PasswordExpired && !await PromptChangePasswordAsync(user))
@@ -265,8 +265,8 @@ namespace ToolManagementAppV2.ViewModels
                     var refreshed = await _userService.GetUserByIDAsync(user.UserID);
                     if (refreshed != null)
                     {
-                        user.Password = refreshed.Password;
-                        user.Salt = refreshed.Salt;
+                        user.PasswordHash = refreshed.PasswordHash;
+                        user.PasswordSalt = refreshed.PasswordSalt;
                         user.PasswordExpired = refreshed.PasswordExpired;
                     }
                     await LoadUsersCommand.ExecuteAsync(null);
@@ -328,8 +328,8 @@ namespace ToolManagementAppV2.ViewModels
             var refreshed = await _userService.GetUserByIDAsync(user.UserID);
             if (refreshed != null)
             {
-                user.Password = refreshed.Password;
-                user.Salt = refreshed.Salt;
+                user.PasswordHash = refreshed.PasswordHash;
+                user.PasswordSalt = refreshed.PasswordSalt;
                 user.PasswordExpired = refreshed.PasswordExpired;
             }
             return true;

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -185,13 +185,13 @@ namespace ToolManagementAppV2.ViewModels
             {
                 const string defaultPwd = "changeme";
                 var hash = SecurityHelper.HashPassword(defaultPwd, out var salt);
-                newUser.Password = hash;
-                newUser.Salt = salt;
+                newUser.PasswordHash = hash;
+                newUser.PasswordSalt = salt;
                 newUser.PasswordExpired = true;
             }
             else
             {
-                newUser.Password = entered;
+                newUser.PasswordHash = entered;
             }
 
             try
@@ -270,8 +270,8 @@ namespace ToolManagementAppV2.ViewModels
             {
                 UserID = user.UserID,
                 UserName = user.UserName,
-                Password = user.Password,
-                Salt = user.Salt,
+                PasswordHash = user.PasswordHash,
+                PasswordSalt = user.PasswordSalt,
                 UserPhotoPath = user.UserPhotoPath,
                 IsAdmin = user.IsAdmin,
                 Email = user.Email,
@@ -326,8 +326,8 @@ namespace ToolManagementAppV2.ViewModels
                 {
                     refreshed.PasswordExpired = true;
                     await _userService.UpdateUserAsync(refreshed);
-                    user.Password = refreshed.Password;
-                    user.Salt = refreshed.Salt;
+                    user.PasswordHash = refreshed.PasswordHash;
+                    user.PasswordSalt = refreshed.PasswordSalt;
                     user.PasswordExpired = true;
                 }
                 _dialogService.ShowInfo("Password has been reset. The user must change it at next login.", "Password Reset");


### PR DESCRIPTION
## Summary
- rename `Password` to `PasswordHash` and `Salt` to `PasswordSalt`
- update database mappings and service logic for new names
- adjust view models and tests to use hashed field names

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b00f08808324a987dff1eedb2c20