### PR TITLE
Implement reusable password validation and surface errors

### DIFF
--- a/ToolManagementAppV2.Tests/AsyncServiceExtensions.cs
+++ b/ToolManagementAppV2.Tests/AsyncServiceExtensions.cs
@@ -5,6 +5,7 @@ using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Models.ImportExport;
+using ToolManagementAppV2.Utilities.Helpers;
 
 namespace ToolManagementAppV2.Tests;
 
@@ -74,7 +75,14 @@ public static class AsyncServiceExtensions
     public static User? GetCurrentUser(this IUserService svc)
         => svc.GetCurrentUserAsync().GetAwaiter().GetResult();
     public static void AddUser(this IUserService svc, User user)
-        => svc.AddUserAsync(user).GetAwaiter().GetResult();
+    {
+        if (!string.IsNullOrWhiteSpace(user.PasswordHash) && string.IsNullOrWhiteSpace(user.PasswordSalt))
+        {
+            user.PasswordHash = SecurityHelper.HashPassword(user.PasswordHash, out var salt);
+            user.PasswordSalt = salt;
+        }
+        svc.AddUserAsync(user).GetAwaiter().GetResult();
+    }
     public static void UpdateUser(this IUserService svc, User user)
         => svc.UpdateUserAsync(user).GetAwaiter().GetResult();
     public static bool ChangeUserPassword(this IUserService svc, int id, string newPassword)

--- a/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 public class UserAuthenticationTests
 {
     [Fact]
-    public void AuthenticateUser_HashesPassword()
+    public async Task AuthenticateUser_HashesPassword()
     {
         var dbPath = Path.GetTempFileName();
         try
@@ -22,16 +22,16 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var user = new User { UserName = "test", PasswordHash = "secret", IsAdmin = false };
-            userService.AddUser(user);
+            var user = new User { UserName = "test", PasswordHash = "Strong1!", IsAdmin = false };
+            await userService.AddUserAsync(user);
             var added = userService.GetUserByID(user.UserID)!;
 
-            Assert.NotEqual("secret", added.PasswordHash);
+            Assert.NotEqual("Strong1!", added.PasswordHash);
             Assert.False(SecurityHelper.IsSha256Hash(added.PasswordHash));
             Assert.False(string.IsNullOrWhiteSpace(added.PasswordSalt));
-            Assert.True(SecurityHelper.VerifyPassword("secret", added.PasswordSalt, added.PasswordHash));
+            Assert.True(SecurityHelper.VerifyPassword("Strong1!", added.PasswordSalt, added.PasswordHash));
 
-            var auth = userService.AuthenticateUser("test", "secret");
+            var auth = userService.AuthenticateUser("test", "Strong1!");
             Assert.Equal(AuthenticationResult.Success, auth.Result);
             Assert.NotNull(auth.User);
         }
@@ -282,7 +282,7 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var user = new User { UserName = "areset", PasswordHash = "secret", IsAdmin = false };
+            var user = new User { UserName = "areset", PasswordHash = "Strong1!", IsAdmin = false };
             await userService.AddUserAsync(user);
 
             for (int i = 0; i < 3; i++)

--- a/ToolManagementAppV2.Tests/Services/UserDeletionTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserDeletionTests.cs
@@ -19,7 +19,7 @@ public class UserDeletionTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var admin = new User { UserName = "admin", PasswordHash = "pw", IsAdmin = true };
+            var admin = new User { UserName = "admin", PasswordHash = "Strong1!", IsAdmin = true };
             await userService.AddUserAsync(admin);
 
             var added = (await userService.GetAllUsersAsync()).First();

--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -30,7 +30,7 @@ public class UserServiceTests
             var ctx = new StubUserContext { CurrentUser = new User { UserName = "seed", IsAdmin = false } };
             var auth = new AuthorizationService(ctx);
             var userService = new UserService(dbService, ctx, auth);
-            var admin = new User { UserName = "admin", PasswordHash = "pw", IsAdmin = true };
+            var admin = new User { UserName = "admin", PasswordHash = "Strong1!", IsAdmin = true };
             await userService.AddUserAsync(admin);
             Assert.NotEqual(0, admin.UserID);
         }
@@ -50,9 +50,9 @@ public class UserServiceTests
             var ctx = new StubUserContext { CurrentUser = new User { UserName = "seed", IsAdmin = false } };
             var auth = new AuthorizationService(ctx);
             var userService = new UserService(dbService, ctx, auth);
-            var admin = new User { UserName = "admin", PasswordHash = "pw", IsAdmin = true };
+            var admin = new User { UserName = "admin", PasswordHash = "Strong1!", IsAdmin = true };
             await userService.AddUserAsync(admin);
-            await Assert.ThrowsAsync<UnauthorizedAccessException>(() => userService.AddUserAsync(new User { UserName = "user", PasswordHash = "pw" }));
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(() => userService.AddUserAsync(new User { UserName = "user", PasswordHash = "Strong1!" }));
         }
         finally
         {
@@ -67,7 +67,7 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var admin = new User { UserName = "admin", PasswordHash = "pw", IsAdmin = true };
+            var admin = new User { UserName = "admin", PasswordHash = "Strong1!", IsAdmin = true };
             await userService.AddUserAsync(admin);
             var result = await userService.TryDeleteUserAsync(admin.UserID);
             Assert.False(result);
@@ -87,8 +87,8 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var admin1 = new User { UserName = "admin1", PasswordHash = "pw", IsAdmin = true };
-            var admin2 = new User { UserName = "admin2", PasswordHash = "pw", IsAdmin = true };
+            var admin1 = new User { UserName = "admin1", PasswordHash = "Strong1!", IsAdmin = true };
+            var admin2 = new User { UserName = "admin2", PasswordHash = "Strong1!", IsAdmin = true };
             await userService.AddUserAsync(admin1);
             await userService.AddUserAsync(admin2);
             var result = await userService.TryDeleteUserAsync(admin1.UserID);
@@ -128,8 +128,8 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             var userService = new UserService(dbService, new ApplicationUserContext());
-            await userService.AddUserAsync(new User { UserName = "dup", PasswordHash = "pw" });
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => userService.AddUserAsync(new User { UserName = "dup", PasswordHash = "pw" }));
+            await userService.AddUserAsync(new User { UserName = "dup", PasswordHash = "Strong1!" });
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => userService.AddUserAsync(new User { UserName = "dup", PasswordHash = "Strong1!" }));
             Assert.Contains("username", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
@@ -146,7 +146,7 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             var userService = new UserService(dbService, new ApplicationUserContext());
-            var user = new User { UserName = "user1", PasswordHash = "pw" };
+            var user = new User { UserName = "user1", PasswordHash = "Strong1!" };
             await userService.AddUserAsync(user);
             var stored = userService.GetUserByID(user.UserID);
             Assert.NotNull(stored);
@@ -166,7 +166,7 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var result = userService.ChangeUserPassword(9999, "newpass");
+            var result = userService.ChangeUserPassword(9999, "Newpass1!");
             Assert.False(result);
         }
         finally
@@ -183,7 +183,7 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var result = await userService.ChangeUserPasswordAsync(9999, "newpass");
+            var result = await userService.ChangeUserPasswordAsync(9999, "Newpass1!");
             Assert.False(result);
         }
         finally
@@ -200,11 +200,11 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var user = new User { UserName = "trim", PasswordHash = "pw" };
+            var user = new User { UserName = "trim", PasswordHash = "Strong1!" };
             await userService.AddUserAsync(user);
-            var result = await userService.ChangeUserPasswordAsync(user.UserID, "  newpass  ");
+            var result = await userService.ChangeUserPasswordAsync(user.UserID, "  Newpass1!  ");
             Assert.True(result);
-            var auth = await userService.AuthenticateUserAsync("trim", "newpass");
+            var auth = await userService.AuthenticateUserAsync("trim", "Newpass1!");
             Assert.Equal(AuthenticationResult.Success, auth.Result);
         }
         finally
@@ -214,19 +214,52 @@ public class UserServiceTests
     }
 
     [Fact]
-    public async Task ChangeUserPasswordAsync_ReturnsFalse_WhenPasswordIsWhitespace()
+    public async Task ChangeUserPasswordAsync_Throws_WhenPasswordIsWhitespace()
     {
         var dbPath = Path.GetTempFileName();
         try
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var user = new User { UserName = "blank", PasswordHash = "pw" };
+            var user = new User { UserName = "blank", PasswordHash = "Strong1!" };
             await userService.AddUserAsync(user);
-            var result = await userService.ChangeUserPasswordAsync(user.UserID, "   ");
-            Assert.False(result);
-            var auth = await userService.AuthenticateUserAsync("blank", "pw");
+            await Assert.ThrowsAsync<ArgumentException>(() => userService.ChangeUserPasswordAsync(user.UserID, "   "));
+            var auth = await userService.AuthenticateUserAsync("blank", "Strong1!");
             Assert.Equal(AuthenticationResult.Success, auth.Result);
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task ChangeUserPasswordAsync_Throws_ForWeakPassword()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+            var user = new User { UserName = "weak", PasswordHash = "Strong1!" };
+            await userService.AddUserAsync(user);
+            await Assert.ThrowsAsync<ArgumentException>(() => userService.ChangeUserPasswordAsync(user.UserID, "weak"));
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task AddUserAsync_Throws_ForWeakPassword()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+            await Assert.ThrowsAsync<ArgumentException>(() => userService.AddUserAsync(new User { UserName = "weak", PasswordHash = "short" }));
         }
         finally
         {
@@ -242,7 +275,7 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var user = new User { UserName = "locked", PasswordHash = "pw" };
+            var user = new User { UserName = "locked", PasswordHash = "Strong1!" };
             await userService.AddUserAsync(user);
 
             await userService.AuthenticateUserAsync("locked", "bad");
@@ -276,7 +309,7 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var user = new User { UserName = "lock", PasswordHash = "pw" };
+            var user = new User { UserName = "lock", PasswordHash = "Strong1!" };
             await userService.AddUserAsync(user);
 
             await userService.AuthenticateUserAsync("lock", "bad");
@@ -288,7 +321,7 @@ public class UserServiceTests
             Assert.True(locked!.FailedAttempts >= 3);
             Assert.NotNull(locked.LockoutUntil);
 
-            var changed = await userService.ChangeUserPasswordAsync(user.UserID, "newpass");
+            var changed = await userService.ChangeUserPasswordAsync(user.UserID, "Newpass1!");
             Assert.True(changed);
 
             var updated = userService.GetUserByID(user.UserID);
@@ -311,7 +344,7 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var user = new User { UserName = "nulltest", PasswordHash = "pw" };
+            var user = new User { UserName = "nulltest", PasswordHash = "Strong1!" };
             await userService.AddUserAsync(user);
 
             using (var conn = dbService.CreateConnection())
@@ -321,7 +354,7 @@ public class UserServiceTests
                     new[] { new SQLiteParameter("@ID", user.UserID) });
             }
 
-            var changed = await userService.ChangeUserPasswordAsync(user.UserID, "newpass");
+            var changed = await userService.ChangeUserPasswordAsync(user.UserID, "Newpass1!");
             Assert.True(changed);
 
             var updated = userService.GetUserByID(user.UserID);
@@ -343,7 +376,8 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            userService.AddUser(new User { UserName = "list", PasswordHash = "pw", PasswordSalt = "s" });
+            var hash = SecurityHelper.HashPassword("Strong1!", out var salt);
+            userService.AddUser(new User { UserName = "list", PasswordHash = hash, PasswordSalt = salt });
             var users = userService.GetAllUsers();
             var user = users[0];
             Assert.Null(user.PasswordHash);
@@ -363,7 +397,8 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             var userService = new UserService(dbService, new ApplicationUserContext());
-            await userService.AddUserAsync(new User { UserName = "list", PasswordHash = "pw", PasswordSalt = "s" });
+            var hash = SecurityHelper.HashPassword("Strong1!", out var salt);
+            await userService.AddUserAsync(new User { UserName = "list", PasswordHash = hash, PasswordSalt = salt });
             var users = await userService.GetAllUsersAsync();
             var user = users[0];
             Assert.Null(user.PasswordHash);

--- a/ToolManagementAppV2.Tests/Utilities/PasswordValidatorTests.cs
+++ b/ToolManagementAppV2.Tests/Utilities/PasswordValidatorTests.cs
@@ -1,0 +1,17 @@
+using ToolManagementAppV2.Utilities.Helpers;
+using Xunit;
+
+public class PasswordValidatorTests
+{
+    [Theory]
+    [InlineData("short", false)]
+    [InlineData("NoDigits!", false)]
+    [InlineData("noupper1!", false)]
+    [InlineData("NOLOWER1!", false)]
+    [InlineData("Valid1!", true)]
+    public void IsValid_ReturnsExpected(string pwd, bool expected)
+    {
+        var result = PasswordValidator.IsValid(pwd, out _);
+        Assert.Equal(expected, result);
+    }
+}

--- a/ToolManagementAppV2.Tests/ViewModels/ChangePasswordViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ChangePasswordViewModelTests.cs
@@ -1,0 +1,41 @@
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+public class ChangePasswordViewModelTests
+{
+    [Fact]
+    public void SaveCommand_ShowsError_OnMismatch()
+    {
+        bool saved = false;
+        var vm = new ChangePasswordViewModel(() => saved = true, () => { });
+        vm.NewPassword = "Valid1!";
+        vm.ConfirmPassword = "Other1!";
+        vm.SaveCommand.Execute(null);
+        Assert.False(saved);
+        Assert.Equal("Passwords do not match.", vm.ValidationMessage);
+    }
+
+    [Fact]
+    public void SaveCommand_CallsSave_WhenValid()
+    {
+        bool saved = false;
+        var vm = new ChangePasswordViewModel(() => saved = true, () => { });
+        vm.NewPassword = "Valid1!";
+        vm.ConfirmPassword = "Valid1!";
+        vm.SaveCommand.Execute(null);
+        Assert.True(saved);
+        Assert.True(string.IsNullOrEmpty(vm.ValidationMessage));
+    }
+
+    [Fact]
+    public void SaveCommand_ShowsError_ForWeakPassword()
+    {
+        bool saved = false;
+        var vm = new ChangePasswordViewModel(() => saved = true, () => { });
+        vm.NewPassword = "short";
+        vm.ConfirmPassword = "short";
+        vm.SaveCommand.Execute(null);
+        Assert.False(saved);
+        Assert.False(string.IsNullOrEmpty(vm.ValidationMessage));
+    }
+}

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -452,7 +452,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var userService = new UserService(dbService, userContext, auth);
                 var settingsService = new SettingsService(dbService);
                 var lockout = DateTime.UtcNow.AddMinutes(15);
-                await userService.AddUserAsync(new User { UserName = "locked", PasswordHash = "newpassword", LockoutUntil = lockout });
+                await userService.AddUserAsync(new User { UserName = "locked", PasswordHash = "Strong1!", LockoutUntil = lockout });
 
                 var dialog = new CapturingDialogService();
                 var vm = new LoginViewModel(userService, settingsService, dialog, userContext)

--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -273,7 +273,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task CommandsDisabledWhenNoUserSelected()
         {
             var svc = new InMemoryUserService();
-            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "pw" });
+            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "Strong1!" });
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), new StubDialogService());
             await vm.LoadUsersAsync();
             Assert.False(vm.UpdateUserCommand.CanExecute(null));
@@ -287,8 +287,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task LoadUsersAsync_LoadsUsers()
         {
             var svc = new InMemoryUserService();
-            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "pw" });
-            await svc.AddUserAsync(new User { UserName = "user2", PasswordHash = "pw" });
+            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "Strong1!" });
+            await svc.AddUserAsync(new User { UserName = "user2", PasswordHash = "Strong1!" });
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), new StubDialogService());
             await vm.LoadUsersAsync();
             Assert.Equal(2, vm.Users.Count);
@@ -324,7 +324,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task AddUserAsync_SkipsExistingNameFromService()
         {
             var svc = new InMemoryUserService();
-            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "pw" });
+            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "Strong1!" });
             var vm = new PromptUserManagementViewModel(svc, "pw");
             await vm.AddUserAsync();
 
@@ -338,8 +338,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task AddUserAsync_FindsFirstAvailableNumber()
         {
             var svc = new InMemoryUserService();
-            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "pw" });
-            await svc.AddUserAsync(new User { UserName = "user3", PasswordHash = "pw" });
+            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "Strong1!" });
+            await svc.AddUserAsync(new User { UserName = "user3", PasswordHash = "Strong1!" });
             var vm = new PromptUserManagementViewModel(svc, "pw");
             await vm.AddUserAsync();
 
@@ -415,8 +415,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task SearchAndClearUsers_WorkAsExpected()
         {
             var svc = new InMemoryUserService();
-            await svc.AddUserAsync(new User { UserName = "alice", PasswordHash = "pw" });
-            await svc.AddUserAsync(new User { UserName = "bob", PasswordHash = "pw" });
+            await svc.AddUserAsync(new User { UserName = "alice", PasswordHash = "Strong1!" });
+            await svc.AddUserAsync(new User { UserName = "bob", PasswordHash = "Strong1!" });
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), new StubDialogService());
             await vm.LoadUsersAsync();
 
@@ -433,8 +433,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task DeleteUserFromRowCommand_RemovesUser()
         {
             var svc = new InMemoryUserService();
-            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "pw" });
-            await svc.AddUserAsync(new User { UserName = "user2", PasswordHash = "pw" });
+            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "Strong1!" });
+            await svc.AddUserAsync(new User { UserName = "user2", PasswordHash = "Strong1!" });
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), new StubDialogService());
             await vm.LoadUsersAsync();
             var toDelete = vm.Users.First();
@@ -473,7 +473,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task UnlockUserCommand_UnlocksUserAndRefreshesList()
         {
             var svc = new InMemoryUserService();
-            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "pw", LockoutUntil = DateTime.UtcNow.AddMinutes(5) });
+            await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "Strong1!", LockoutUntil = DateTime.UtcNow.AddMinutes(5) });
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), new StubDialogService());
             await vm.LoadUsersAsync();
             var user = vm.Users.First();
@@ -490,7 +490,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             await svc.AddUserAsync(new User
             {
                 UserName = "user1",
-                PasswordHash = "pw",
+                PasswordHash = "Strong1!",
                 FailedAttempts = 5,
                 LockoutUntil = DateTime.UtcNow.AddMinutes(5)
             });

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -188,6 +188,8 @@ namespace ToolManagementAppV2.Services.Users
                 }
                 else
                 {
+                    if (!PasswordValidator.IsValid(user.PasswordHash, out var error))
+                        throw new ArgumentException(error, nameof(user.PasswordHash));
                     var result = await SecurityHelper.HashPasswordAsync(user.PasswordHash).ConfigureAwait(false);
                     hashed = result.hash;
                     salt = result.salt;
@@ -282,8 +284,8 @@ namespace ToolManagementAppV2.Services.Users
                 _auth.EnsureAdmin();
 
             newPassword = (newPassword ?? string.Empty).Trim();
-            if (newPassword.Length == 0)
-                return false;
+            if (!PasswordValidator.IsValid(newPassword, out var error))
+                throw new ArgumentException(error, nameof(newPassword));
 
             var sql = "UPDATE Users SET PasswordHash=@Pwd, PasswordSalt=@Salt, PasswordExpired=@Expired WHERE UserID=@ID";
             var result = await SecurityHelper.HashPasswordAsync(newPassword).ConfigureAwait(false);

--- a/ToolManagementAppV2/Utilities/Helpers/PasswordValidator.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/PasswordValidator.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+
+namespace ToolManagementAppV2.Utilities.Helpers
+{
+    public static class PasswordValidator
+    {
+        public static bool IsValid(string password, out string? error)
+        {
+            error = null;
+            if (string.IsNullOrWhiteSpace(password) || password.Length < 8)
+            {
+                error = "Password must be at least 8 characters long.";
+                return false;
+            }
+
+            bool hasUpper = password.Any(char.IsUpper);
+            bool hasLower = password.Any(char.IsLower);
+            bool hasDigit = password.Any(char.IsDigit);
+            bool hasSpecial = password.Any(ch => !char.IsLetterOrDigit(ch));
+            if (!(hasUpper && hasLower && hasDigit && hasSpecial))
+            {
+                error = "Password must contain upper, lower, digit, and special characters.";
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/ChangePasswordViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ChangePasswordViewModel.cs
@@ -1,13 +1,40 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
+using ToolManagementAppV2.Utilities.Helpers;
 
 namespace ToolManagementAppV2.ViewModels
 {
     public class ChangePasswordViewModel : ObservableObject
     {
-        public string NewPassword { get; set; } = string.Empty;
-        public string ConfirmPassword { get; set; } = string.Empty;
+        string _newPassword = string.Empty;
+        public string NewPassword
+        {
+            get => _newPassword;
+            set
+            {
+                if (SetProperty(ref _newPassword, value))
+                    ValidationMessage = string.Empty;
+            }
+        }
+
+        string _confirmPassword = string.Empty;
+        public string ConfirmPassword
+        {
+            get => _confirmPassword;
+            set
+            {
+                if (SetProperty(ref _confirmPassword, value))
+                    ValidationMessage = string.Empty;
+            }
+        }
+
+        string _validationMessage = string.Empty;
+        public string ValidationMessage
+        {
+            get => _validationMessage;
+            private set => SetProperty(ref _validationMessage, value);
+        }
 
         public IRelayCommand SaveCommand { get; }
         public IRelayCommand CancelCommand { get; }
@@ -16,8 +43,20 @@ namespace ToolManagementAppV2.ViewModels
         {
             SaveCommand = new RelayCommand(() =>
             {
-                if (!string.IsNullOrWhiteSpace(NewPassword) && NewPassword == ConfirmPassword)
-                    onSave();
+                if (!PasswordValidator.IsValid(NewPassword, out var error))
+                {
+                    ValidationMessage = error!;
+                    return;
+                }
+
+                if (NewPassword != ConfirmPassword)
+                {
+                    ValidationMessage = "Passwords do not match.";
+                    return;
+                }
+
+                ValidationMessage = string.Empty;
+                onSave();
             });
             CancelCommand = new RelayCommand(onCancel);
         }

--- a/ToolManagementAppV2/Views/ChangePasswordWindow.xaml
+++ b/ToolManagementAppV2/Views/ChangePasswordWindow.xaml
@@ -14,12 +14,14 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0" Text="New Password" HorizontalAlignment="Center" Foreground="{StaticResource ForegroundBrush}"/>
         <PasswordBox Grid.Row="1" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
         <TextBlock Grid.Row="2" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Foreground="{StaticResource ForegroundBrush}"/>
         <PasswordBox Grid.Row="3" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
-        <controls:DialogButtonBar Grid.Row="4"
+        <TextBlock Grid.Row="4" Text="{Binding ValidationMessage}" Margin="0,10,0,0" Foreground="Red" HorizontalAlignment="Center"/>
+        <controls:DialogButtonBar Grid.Row="5"
                                   LeftButtonText="Cancel"
                                   LeftCommand="{Binding CancelCommand}"
                                   RightButtonText="OK"


### PR DESCRIPTION
## Summary
- add `PasswordValidator` helper for consistent password rules
- validate and show errors in `ChangePasswordViewModel` and window
- enforce password rules when adding users or changing passwords

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c400c69c832488e7af6bd978f570