### PR TITLE
Ensure UTC handling for lockout timestamps

### DIFF
--- a/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
@@ -130,6 +130,7 @@ public class UserAuthenticationTests
             var stored = userService.GetAllUsers().First();
             Assert.Equal(3, stored.FailedAttempts);
             Assert.NotNull(stored.LockoutUntil);
+            Assert.Equal(DateTimeKind.Utc, stored.LockoutUntil!.Value.Kind);
             Assert.True(stored.IsLocked);
 
             var afterLock = userService.AuthenticateUser("lock", "secret");
@@ -160,7 +161,7 @@ public class UserAuthenticationTests
             using (var conn = dbService.CreateConnection())
             using (var cmd = new SQLiteCommand("UPDATE Users SET LockoutUntil=@t WHERE UserID=@id", conn))
             {
-                cmd.Parameters.AddWithValue("@t", DateTime.UtcNow.AddMinutes(-1));
+                cmd.Parameters.AddWithValue("@t", DateTime.UtcNow.AddMinutes(-1).ToString("o"));
                 cmd.Parameters.AddWithValue("@id", user.UserID);
                 cmd.ExecuteNonQuery();
             }
@@ -261,6 +262,7 @@ public class UserAuthenticationTests
             var stored = userService.GetAllUsers().First(u => u.UserName == "lockasync");
             Assert.Equal(3, stored.FailedAttempts);
             Assert.NotNull(stored.LockoutUntil);
+            Assert.Equal(DateTimeKind.Utc, stored.LockoutUntil!.Value.Kind);
             Assert.True(stored.IsLocked);
 
             var afterLock = await userService.AuthenticateUserAsync(" lockasync ", " secret ");
@@ -291,7 +293,7 @@ public class UserAuthenticationTests
             using (var conn = dbService.CreateConnection())
             using (var cmd = new SQLiteCommand("UPDATE Users SET LockoutUntil=@t WHERE UserID=@id", conn))
             {
-                cmd.Parameters.AddWithValue("@t", DateTime.UtcNow.AddMinutes(-1));
+                cmd.Parameters.AddWithValue("@t", DateTime.UtcNow.AddMinutes(-1).ToString("o"));
                 cmd.Parameters.AddWithValue("@id", user.UserID);
                 cmd.ExecuteNonQuery();
             }

--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -286,6 +286,7 @@ public class UserServiceTests
             Assert.NotNull(locked);
             Assert.True(locked!.FailedAttempts >= 3);
             Assert.NotNull(locked.LockoutUntil);
+            Assert.Equal(DateTimeKind.Utc, locked.LockoutUntil!.Value.Kind);
 
             await userService.UnlockUserAsync(user.UserID);
 
@@ -320,6 +321,7 @@ public class UserServiceTests
             Assert.NotNull(locked);
             Assert.True(locked!.FailedAttempts >= 3);
             Assert.NotNull(locked.LockoutUntil);
+            Assert.Equal(DateTimeKind.Utc, locked.LockoutUntil!.Value.Kind);
 
             var changed = await userService.ChangeUserPasswordAsync(user.UserID, "Newpass1!");
             Assert.True(changed);

--- a/ToolManagementAppV2/Models/Domain/User.cs
+++ b/ToolManagementAppV2/Models/Domain/User.cs
@@ -48,9 +48,13 @@ namespace ToolManagementAppV2.Models.Domain
         public int FailedAttempts { get => _failedAttempts; set => SetProperty(ref _failedAttempts, value); }
 
         private DateTime? _lockoutUntil;
-        public DateTime? LockoutUntil { get => _lockoutUntil; set => SetProperty(ref _lockoutUntil, value); }
+        public DateTime? LockoutUntil
+        {
+            get => _lockoutUntil;
+            set => SetProperty(ref _lockoutUntil, value?.ToUniversalTime());
+        }
 
-        public bool IsLocked => LockoutUntil > DateTime.UtcNow;
+        public bool IsLocked => LockoutUntil?.ToUniversalTime() > DateTime.UtcNow;
 
         private bool _passwordExpired;
         public bool PasswordExpired { get => _passwordExpired; set => SetProperty(ref _passwordExpired, value); }

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
+using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ToolManagementAppV2.Services.Users;
@@ -69,9 +70,9 @@ namespace ToolManagementAppV2.Services.Rentals
             RentalID = Convert.ToInt32(r["RentalID"]),
             ToolID = Convert.ToInt32(r["ToolID"]),
             CustomerID = Convert.ToInt32(r["CustomerID"]),
-            RentalDate = Convert.ToDateTime(r["RentalDate"]),
-            DueDate = Convert.ToDateTime(r["DueDate"]),
-            ReturnDate = r["ReturnDate"] is DBNull ? null : Convert.ToDateTime(r["ReturnDate"]),
+            RentalDate = DateTime.Parse(r["RentalDate"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+            DueDate = DateTime.Parse(r["DueDate"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+            ReturnDate = r["ReturnDate"] is DBNull ? null : DateTime.Parse(r["ReturnDate"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
             Status = r["Status"].ToString(),
             ToolNumber = r["ToolNumber"].ToString(),
             CustomerName = r["Company"].ToString(),
@@ -152,7 +153,7 @@ namespace ToolManagementAppV2.Services.Rentals
                     throw new InvalidOperationException("Unable to extend rental. Rental not found or already returned.");
 
                 int toolID = Convert.ToInt32(reader["ToolID"]);
-                DateTime oldDueDate = Convert.ToDateTime(reader["DueDate"]);
+                DateTime oldDueDate = DateTime.Parse(reader["DueDate"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
 
                 var updateCmd = new SQLiteCommand(
                     "UPDATE Rentals SET DueDate=@NewDueDate WHERE RentalID=@RentalID AND Status='Rented'",

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -12,6 +12,7 @@ using ToolManagementAppV2.Utilities.IO;
 using ToolManagementAppV2.Models.ImportExport;
 using ToolManagementAppV2.Interfaces;
 using System.Text;
+using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ToolManagementAppV2.Services.Users;
@@ -273,11 +274,15 @@ namespace ToolManagementAppV2.Services.Tools
             QuantityOnHand = r["AvailableQuantity"] is DBNull ? 0 : Convert.ToInt32(r["AvailableQuantity"]),
             RentedQuantity = r["RentedQuantity"] is DBNull ? 0 : Convert.ToInt32(r["RentedQuantity"]),
             Supplier = r["Supplier"].ToString(),
-            PurchasedDate = r["PurchasedDate"] is DBNull ? (DateTime?)null : Convert.ToDateTime(r["PurchasedDate"]),
+            PurchasedDate = r["PurchasedDate"] is DBNull
+                ? (DateTime?)null
+                : DateTime.Parse(r["PurchasedDate"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
             Notes = r["Notes"].ToString(),
             IsCheckedOut = (r["IsCheckedOut"] is DBNull ? 0 : Convert.ToInt32(r["IsCheckedOut"])) == 1,
             CheckedOutBy = r["CheckedOutBy"].ToString(),
-            CheckedOutTime = r["CheckedOutTime"] is DBNull ? (DateTime?)null : Convert.ToDateTime(r["CheckedOutTime"]),
+            CheckedOutTime = r["CheckedOutTime"] is DBNull
+                ? (DateTime?)null
+                : DateTime.Parse(r["CheckedOutTime"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
             ToolImagePath = r["ToolImagePath"]?.ToString(),
             Keywords = r["Keywords"]?.ToString(),
             IsPowerTool = (r["IsPowerTool"] is DBNull ? 0 : Convert.ToInt32(r["IsPowerTool"])) == 1

--- a/ToolManagementAppV2/Services/Users/ActivityLogService.cs
+++ b/ToolManagementAppV2/Services/Users/ActivityLogService.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
+using System.Globalization;
 
 namespace ToolManagementAppV2.Services.Users
 {
@@ -123,7 +124,7 @@ namespace ToolManagementAppV2.Services.Users
                 LogID = Convert.ToInt32(r["LogID"]),
                 UserName = r["UserName"].ToString(),
                 Action = r["Action"].ToString(),
-                Timestamp = Convert.ToDateTime(r["Timestamp"])
+                Timestamp = DateTime.Parse(r["Timestamp"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal)
             };
 
             log.UserID = r["UserID"] == DBNull.Value

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -8,6 +8,7 @@ using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Utilities.Helpers;
 using ToolManagementAppV2.Interfaces;
 using System.Linq;
+using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -53,9 +54,13 @@ namespace ToolManagementAppV2.Services.Users
                 Address = rdr["Address"]?.ToString(),
                 Role = rdr["Role"]?.ToString(),
                 IsActive = rdr["IsActive"] != DBNull.Value && Convert.ToInt32(rdr["IsActive"]) == 1,
-                CreatedAt = rdr["CreatedAt"] == DBNull.Value ? DateTime.MinValue : Convert.ToDateTime(rdr["CreatedAt"]),
+                CreatedAt = rdr["CreatedAt"] == DBNull.Value
+                    ? DateTime.MinValue
+                    : DateTime.Parse(rdr["CreatedAt"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
                 FailedAttempts = rdr["FailedAttempts"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["FailedAttempts"]),
-                LockoutUntil = rdr["LockoutUntil"] == DBNull.Value ? null : Convert.ToDateTime(rdr["LockoutUntil"]),
+                LockoutUntil = rdr["LockoutUntil"] == DBNull.Value
+                    ? null
+                    : DateTime.Parse(rdr["LockoutUntil"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
                 PasswordExpired = rdr["PasswordExpired"] != DBNull.Value && Convert.ToInt32(rdr["PasswordExpired"]) == 1
             };
         }
@@ -143,7 +148,7 @@ namespace ToolManagementAppV2.Services.Users
             var update = new[]
             {
         new SQLiteParameter("@Attempts", u.FailedAttempts),
-        new SQLiteParameter("@Lockout", (object?)lockout ?? DBNull.Value),
+        new SQLiteParameter("@Lockout", (object?)lockout?.ToString("o") ?? DBNull.Value),
         new SQLiteParameter("@ID", u.UserID)
     };
             await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET FailedAttempts=IFNULL(@Attempts,0), LockoutUntil=@Lockout WHERE UserID=@ID", update);
@@ -213,7 +218,7 @@ namespace ToolManagementAppV2.Services.Users
                 new SQLiteParameter("@IsActive", user.IsActive ? 1 : 0),
                 new SQLiteParameter("@CreatedAt", user.CreatedAt),
                 new SQLiteParameter("@FailedAttempts", user.FailedAttempts),
-                new SQLiteParameter("@Lockout",    (object?)user.LockoutUntil ?? DBNull.Value),
+                new SQLiteParameter("@Lockout",    (object?)user.LockoutUntil?.ToUniversalTime().ToString("o") ?? DBNull.Value),
                 new SQLiteParameter("@PasswordExpired", user.PasswordExpired ? 1 : 0)
             });
             try


### PR DESCRIPTION
## Summary
- Normalize `LockoutUntil` using UTC and ISO 8601 storage
- Replace `Convert.ToDateTime` with UTC-aware parsing across services
- Update tests to verify UTC lockout logic

## Testing
- ⚠️ `dotnet test` *(missing `dotnet` runtime; attempted to install but package sources returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c9aff8488324992b91d360d82c2b