### PR TITLE
Use async iteration initialization in SecurityHelper

### DIFF
--- a/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
+++ b/ToolManagementAppV2.Tests/Utilities/SecurityHelperTests.cs
@@ -25,6 +25,7 @@ namespace ToolManagementAppV2.Tests.Utilities
                 ISettingsService settings = new SettingsService(dbService);
                 settings.SavePasswordIterationsAsync(5).GetAwaiter().GetResult();
                 SecurityHelper.SettingsService = settings;
+                SecurityHelper.GetIterationsAsync().GetAwaiter().GetResult();
 
                 var saltBytes = Encoding.UTF8.GetBytes("1234567890ABCDEF");
                 var salt = Convert.ToBase64String(saltBytes);
@@ -117,6 +118,7 @@ namespace ToolManagementAppV2.Tests.Utilities
         {
             var settings = new CountingSettingsService(5);
             SecurityHelper.SettingsService = settings;
+            SecurityHelper.GetIterationsAsync().GetAwaiter().GetResult();
 
             var saltBytes = Encoding.UTF8.GetBytes("1234567890ABCDEF");
             var salt = Convert.ToBase64String(saltBytes);
@@ -135,6 +137,7 @@ namespace ToolManagementAppV2.Tests.Utilities
         {
             var settings = new AsyncOnlySettingsService(7);
             SecurityHelper.SettingsService = settings;
+            SecurityHelper.GetIterationsAsync().GetAwaiter().GetResult();
 
             var saltBytes = Encoding.UTF8.GetBytes("1234567890ABCDEF");
             var salt = Convert.ToBase64String(saltBytes);

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -120,6 +120,7 @@ namespace ToolManagementAppV2
             var loggerFactory = Host.Services.GetRequiredService<ILoggerFactory>();
             PathHelper.Configure(loggerFactory.CreateLogger("PathHelper"));
             SecurityHelper.SettingsService = Host.Services.GetRequiredService<ISettingsService>();
+            await SecurityHelper.GetIterationsAsync().ConfigureAwait(false);
 
             var main = (Window)Host.Services.GetRequiredService<IMainWindow>();
             Current.MainWindow = main;

--- a/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/SecurityHelper.cs
@@ -12,7 +12,6 @@ namespace ToolManagementAppV2.Utilities.Helpers
         const int DefaultIterations = 100_000;
         static ISettingsService? _settingsService;
         static int _iterationCache;
-        static readonly object _iterLock = new();
         static readonly SemaphoreSlim _iterSemaphore = new(1, 1);
 
         public static ISettingsService? SettingsService
@@ -45,7 +44,7 @@ namespace ToolManagementAppV2.Utilities.Helpers
         public static string HashPassword(string password, string salt)
         {
             var saltBytes = Convert.FromBase64String(salt);
-            var iterations = GetIterations();
+            var iterations = GetCachedIterations();
             using var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, iterations, HashAlgorithmName.SHA256);
             return Convert.ToBase64String(pbkdf2.GetBytes(32));
         }
@@ -74,7 +73,7 @@ namespace ToolManagementAppV2.Utilities.Helpers
             {
                 var saltBytes = Convert.FromBase64String(salt);
                 var hashBytes = Convert.FromBase64String(hash);
-                var iterations = GetIterations();
+                var iterations = GetCachedIterations();
                 using var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, iterations, HashAlgorithmName.SHA256);
                 var computed = pbkdf2.GetBytes(32);
                 return CryptographicOperations.FixedTimeEquals(computed, hashBytes);
@@ -121,32 +120,13 @@ namespace ToolManagementAppV2.Utilities.Helpers
             return sb.ToString();
         }
 
-        static int GetIterations()
+        static int GetCachedIterations()
         {
             var cached = Volatile.Read(ref _iterationCache);
-            if (cached > 0) return cached;
-
-            lock (_iterLock)
-            {
-                cached = _iterationCache;
-                if (cached > 0) return cached;
-
-                int value = DefaultIterations;
-                var svc = _settingsService;
-                if (svc != null)
-                {
-                    value = svc.GetPasswordIterationsAsync().GetAwaiter().GetResult();
-                }
-
-                if (value <= 0)
-                    value = DefaultIterations;
-
-                Volatile.Write(ref _iterationCache, value);
-                return value;
-            }
+            return cached > 0 ? cached : DefaultIterations;
         }
 
-        static async Task<int> GetIterationsAsync()
+        internal static async Task<int> GetIterationsAsync()
         {
             var cached = Volatile.Read(ref _iterationCache);
             if (cached > 0) return cached;


### PR DESCRIPTION
## Summary
- refactor SecurityHelper to cache password iteration counts asynchronously
- preload iteration count at app startup
- adjust tests for async iteration retrieval

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2cdb0aa2c8324a0bcf512a672c033