### PR TITLE
Add first-run setup wizard for secure admin password

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -36,6 +36,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var userContext = new ApplicationUserContext();
                 var auth = new AuthorizationService(userContext);
                 var userService = new UserService(dbService, userContext, auth);
+                await userService.AddUserAsync(new User { UserName = "admin", PasswordHash = "x", IsAdmin = true });
                 var settingsService = new SettingsService(dbService);
                 await settingsService.SaveSettingAsync("ApplicationName", "TestApp");
 
@@ -53,7 +54,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task LoadUsersAsync_SeedsAdmin_LogsInformation()
+        public async Task LoadUsersAsync_UsesSetupWizard_WhenNoUsers()
         {
             if (System.Windows.Application.Current == null)
                 new System.Windows.Application();
@@ -72,10 +73,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(provider));
                 var logger = loggerFactory.CreateLogger<LoginViewModel>();
 
-                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext, logger);
+                var dialog = new CapturingDialogService();
+                var setup = new StubSetupWizard("Str0ngP@ss!", true);
+                var vm = new LoginViewModel(userService, settingsService, dialog, userContext, logger, null, setup);
                 await vm.LoadUsersCommand.ExecuteAsync(null);
 
+                Assert.True(setup.Invoked);
                 Assert.Contains(logs, l => l.Level == LogLevel.Information && l.Message.Contains("admin"));
+                Assert.Contains("Str0ngP@ss!", dialog.LastMessage);
             }
             finally
             {
@@ -282,27 +287,38 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task LoadUsersAsync_AwaitsAdminCreation()
+        public async Task LoadUsersAsync_AwaitsSetupWizard()
         {
             if (System.Windows.Application.Current == null)
                 new System.Windows.Application();
 
-            var tcs = new TaskCompletionSource<bool>();
-            var userService = new AwaitableUserService(tcs);
-            var settingsService = new StubSettingsService();
-            var userContext = new ApplicationUserContext();
-            var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext);
+            var tcs = new TaskCompletionSource<SetupWizardResult?>();
+            var setup = new AwaitableSetupWizard(tcs.Task);
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            try
+            {
+                using var dbService = new DatabaseService(dbPath);
+                var userContext = new ApplicationUserContext();
+                var auth = new AuthorizationService(userContext);
+                var userService = new UserService(dbService, userContext, auth);
+                var settingsService = new SettingsService(dbService);
+                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext, null, null, setup);
 
-            var loadTask = vm.LoadUsersCommand.ExecuteAsync(null);
+                var loadTask = vm.LoadUsersCommand.ExecuteAsync(null);
 
-            await Task.Delay(50);
-            Assert.False(loadTask.IsCompleted);
+                await Task.Delay(50);
+                Assert.False(loadTask.IsCompleted);
 
-            tcs.SetResult(true);
-            await loadTask;
+                tcs.SetResult(new SetupWizardResult("Str0ngP@ss!", false));
+                await loadTask;
 
-            Assert.Single(vm.Users);
-            Assert.Equal("admin", vm.Users[0].UserName);
+                Assert.Single(vm.Users);
+                Assert.Equal("admin", vm.Users[0].UserName);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
         }
 
         [Fact]
@@ -490,37 +506,6 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void ShowScannerStatus() { }
     }
 
-    class AwaitableUserService : IUserService
-    {
-        readonly TaskCompletionSource<bool> _tcs;
-        readonly List<User> _users = new();
-
-        public AwaitableUserService(TaskCompletionSource<bool> tcs)
-        {
-            _tcs = tcs;
-        }
-
-        public List<User> GetAllUsers() => _users.ToList();
-        public Task<List<User>> GetAllUsersAsync() => Task.FromResult(_users.ToList());
-        public User? GetUserByID(int userID) => null;
-        public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult<User?>(null);
-        public User? AuthenticateUser(string userName, string password) => null;
-        public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.IncorrectPassword, null));
-        public User? GetCurrentUser() => null;
-        public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
-        public void AddUser(User user) => _users.Add(user);
-        public async Task AddUserAsync(User user)
-        {
-            await _tcs.Task;
-            _users.Add(user);
-        }
-        public void UpdateUser(User user) { }
-        public Task UpdateUserAsync(User user) => Task.CompletedTask;
-        public Task<bool> TryDeleteUserAsync(int userID) => Task.FromResult(false);
-        public bool ChangeUserPassword(int userID, string newPassword) => false;
-        public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => Task.FromResult(false);
-        public Task UnlockUserAsync(int userId) => Task.CompletedTask;
-    }
 
     class ThrowingUserService : IUserService
     {
@@ -588,6 +573,33 @@ namespace ToolManagementAppV2.Tests.ViewModels
             return Task.FromResult(true);
         }
         public Task UnlockUserAsync(int userId) => Task.CompletedTask;
+    }
+
+    class StubSetupWizard : ISetupWizard
+    {
+        readonly SetupWizardResult _result;
+        public bool Invoked { get; private set; }
+        public StubSetupWizard(string password, bool isRandom = false)
+        {
+            _result = new SetupWizardResult(password, isRandom);
+        }
+
+        public Task<SetupWizardResult?> RunAsync()
+        {
+            Invoked = true;
+            return Task.FromResult<SetupWizardResult?>(_result);
+        }
+    }
+
+    class AwaitableSetupWizard : ISetupWizard
+    {
+        readonly Task<SetupWizardResult?> _task;
+        public AwaitableSetupWizard(Task<SetupWizardResult?> task)
+        {
+            _task = task;
+        }
+
+        public Task<SetupWizardResult?> RunAsync() => _task;
     }
 
     class CapturingDialogService : IDialogService

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -22,6 +22,7 @@ using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Utilities.Helpers;
 using ToolManagementAppV2.Views;
 using ToolManagementAppV2.Services.Devices;
+using ToolManagementAppV2.Interfaces;
 
 namespace ToolManagementAppV2
 {
@@ -97,6 +98,8 @@ namespace ToolManagementAppV2
                 services.AddTransient<AvatarSelectionWindow>();
                 services.AddTransient<ScannerStatusWindow>();
                 services.AddTransient<PasswordPromptWindow>();
+                services.AddTransient<ISetupWizard, SetupWizardWindow>();
+                services.AddTransient<SetupWizardWindow>();
                 services.AddTransient<PrintLabelWindow>();
                 services.AddSingleton<IMainWindow>(sp =>
                     new MainWindow(sp.GetRequiredService<IMainViewModel>()));

--- a/ToolManagementAppV2/Interfaces/ISetupWizard.cs
+++ b/ToolManagementAppV2/Interfaces/ISetupWizard.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace ToolManagementAppV2.Interfaces
+{
+    public interface ISetupWizard
+    {
+        Task<SetupWizardResult?> RunAsync();
+    }
+
+    public record SetupWizardResult(string Password, bool IsRandom);
+}

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -38,6 +38,7 @@ namespace ToolManagementAppV2.ViewModels
         readonly IUserContext _userContext;
         readonly ILogger<LoginViewModel> _logger;
         readonly IServiceProvider? _serviceProvider;
+        readonly ISetupWizard? _setupWizard;
 
         public ObservableCollection<User> Users { get; } = new();
 
@@ -86,7 +87,7 @@ namespace ToolManagementAppV2.ViewModels
         public Func<User, CancellationToken, Task<PasswordPromptResult?>>? PromptForPasswordAsync { get; set; }
             
 
-        public LoginViewModel(IUserService userService, ISettingsService settingsService, IDialogService dialogService, IUserContext userContext, ILogger<LoginViewModel>? logger = null, IServiceProvider? serviceProvider = null)
+        public LoginViewModel(IUserService userService, ISettingsService settingsService, IDialogService dialogService, IUserContext userContext, ILogger<LoginViewModel>? logger = null, IServiceProvider? serviceProvider = null, ISetupWizard? setupWizard = null)
         {
             _settingsService = settingsService;
             _userService = userService;
@@ -94,6 +95,7 @@ namespace ToolManagementAppV2.ViewModels
             _userContext = userContext;
             _logger = logger ?? NullLogger<LoginViewModel>.Instance;
             _serviceProvider = serviceProvider;
+            _setupWizard = setupWizard;
 
             SelectUserCommand = new AsyncRelayCommand<User>(OnUserSelected);
 
@@ -174,23 +176,30 @@ namespace ToolManagementAppV2.ViewModels
         async Task LoadUsersAsync()
         {
             var users = await _userService.GetAllUsersAsync();
-            if (users.Count == 0)
+            if (users.Count == 0 && _setupWizard != null)
             {
-                await _dialogService.ShowInfoAsync(
-                    "No users exist. A default admin account will be created (username: admin, password: admin).",
-                    "Setup");
+                var result = await _setupWizard.RunAsync();
+                if (result == null || string.IsNullOrWhiteSpace(result.Password))
+                    return;
 
-                var result = await SecurityHelper.HashPasswordAsync("admin").ConfigureAwait(false);
+                if (!PasswordValidator.IsValid(result.Password, out var error))
+                {
+                    await _dialogService.ShowInfoAsync(error!, "Invalid Password");
+                    return;
+                }
+
+                var hash = await SecurityHelper.HashPasswordAsync(result.Password).ConfigureAwait(false);
                 var admin = new User
                 {
                     UserName = "admin",
-                    PasswordHash = result.hash,
-                    PasswordSalt = result.salt,
-                    IsAdmin = true,
-                    PasswordExpired = true
+                    PasswordHash = hash.hash,
+                    PasswordSalt = hash.salt,
+                    IsAdmin = true
                 };
                 await _userService.AddUserAsync(admin);
-                _logger.LogInformation("Seeded admin user {UserName}", admin.UserName);
+                _logger.LogInformation("Created admin user {UserName}", admin.UserName);
+                if (result.IsRandom)
+                    await _dialogService.ShowInfoAsync($"Generated admin password: {result.Password}", "Setup");
                 users = await _userService.GetAllUsersAsync();
             }
 

--- a/ToolManagementAppV2/ViewModels/SetupWizardViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SetupWizardViewModel.cs
@@ -1,0 +1,33 @@
+using CommunityToolkit.Mvvm.Input;
+using System;
+using ToolManagementAppV2.Utilities.Helpers;
+
+namespace ToolManagementAppV2.ViewModels
+{
+    public class SetupWizardViewModel : ChangePasswordViewModel
+    {
+        readonly Action<string> _onGenerated;
+        bool _isRandom;
+        public bool IsRandom
+        {
+            get => _isRandom;
+            private set => SetProperty(ref _isRandom, value);
+        }
+
+        public IRelayCommand GenerateCommand { get; }
+
+        public SetupWizardViewModel(Action onSave, Action onCancel, Action<string> onGenerated)
+            : base(onSave, onCancel)
+        {
+            _onGenerated = onGenerated;
+            GenerateCommand = new RelayCommand(() =>
+            {
+                var pwd = SecurityHelper.GeneratePassword(16);
+                NewPassword = pwd;
+                ConfirmPassword = pwd;
+                IsRandom = true;
+                _onGenerated(pwd);
+            });
+        }
+    }
+}

--- a/ToolManagementAppV2/Views/SetupWizardWindow.xaml
+++ b/ToolManagementAppV2/Views/SetupWizardWindow.xaml
@@ -1,0 +1,31 @@
+<Window x:Class="ToolManagementAppV2.Views.SetupWizardWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:ToolManagementAppV2.Controls"
+        Title="Initial Setup"
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterScreen"
+        Background="{StaticResource BackgroundBrush}">
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <TextBlock Grid.Row="0" Text="Admin Password" HorizontalAlignment="Center" Foreground="{StaticResource ForegroundBrush}"/>
+        <PasswordBox Grid.Row="1" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
+        <TextBlock Grid.Row="2" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Foreground="{StaticResource ForegroundBrush}"/>
+        <PasswordBox Grid.Row="3" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
+        <TextBlock Grid.Row="4" Text="{Binding ValidationMessage}" Margin="0,10,0,0" Foreground="Red" HorizontalAlignment="Center"/>
+        <Button Grid.Row="5" Content="Generate Random" Margin="0,10,0,0" Command="{Binding GenerateCommand}" HorizontalAlignment="Center"/>
+        <controls:DialogButtonBar Grid.Row="6"
+                                  LeftButtonText="Cancel"
+                                  LeftCommand="{Binding CancelCommand}"
+                                  RightButtonText="OK"
+                                  RightCommand="{Binding SaveCommand}"/>
+    </Grid>
+</Window>

--- a/ToolManagementAppV2/Views/SetupWizardWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/SetupWizardWindow.xaml.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Utilities.Extensions;
+using ToolManagementAppV2.ViewModels;
+
+namespace ToolManagementAppV2.Views
+{
+    public partial class SetupWizardWindow : Window, ISetupWizard, IDisposable
+    {
+        bool _disposed;
+        readonly SetupWizardViewModel _viewModel;
+
+        public SetupWizardWindow()
+        {
+            InitializeComponent();
+            _viewModel = new SetupWizardViewModel(() => DialogResult = true, () => DialogResult = false, pwd =>
+            {
+                NewPasswordBox.Password = pwd;
+                ConfirmPasswordBox.Password = pwd;
+            });
+            DataContext = _viewModel;
+            this.DisposeDataContextOnUnload();
+        }
+
+        void NewPasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
+            => _viewModel.NewPassword = ((PasswordBox)sender).Password;
+
+        void ConfirmPasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
+            => _viewModel.ConfirmPassword = ((PasswordBox)sender).Password;
+
+        public Task<SetupWizardResult?> RunAsync()
+        {
+            var result = ShowDialog() == true ? new SetupWizardResult(_viewModel.NewPassword, _viewModel.IsRandom) : null;
+            return Task.FromResult(result);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Remove automatic admin seeding in login logic and prompt setup wizard when no users exist
- Add setup wizard UI with random password generation option and display
- Register setup wizard and update tests for new behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2cf9d0bf88324858376ea067a0d7c