### PR TITLE
Enforce plaintext password hashing

### DIFF
--- a/ToolManagementAppV2.Tests/AsyncServiceExtensions.cs
+++ b/ToolManagementAppV2.Tests/AsyncServiceExtensions.cs
@@ -75,14 +75,7 @@ public static class AsyncServiceExtensions
     public static User? GetCurrentUser(this IUserService svc)
         => svc.GetCurrentUserAsync().GetAwaiter().GetResult();
     public static void AddUser(this IUserService svc, User user)
-    {
-        if (!string.IsNullOrWhiteSpace(user.PasswordHash) && string.IsNullOrWhiteSpace(user.PasswordSalt))
-        {
-            user.PasswordHash = SecurityHelper.HashPassword(user.PasswordHash, out var salt);
-            user.PasswordSalt = salt;
-        }
-        svc.AddUserAsync(user).GetAwaiter().GetResult();
-    }
+        => svc.AddUserAsync(user).GetAwaiter().GetResult();
     public static void UpdateUser(this IUserService svc, User user)
         => svc.UpdateUserAsync(user).GetAwaiter().GetResult();
     public static bool ChangeUserPassword(this IUserService svc, int id, string newPassword)

--- a/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
@@ -55,7 +55,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var user = new User
                 {
                     UserName = "user",
-                    PasswordHash = "pass",
+                    PasswordHash = "Strong1!",
                     IsAdmin = false
                 };
                 userService.AddUser(user);
@@ -119,7 +119,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var user = new User
                 {
                     UserName = "user",
-                    PasswordHash = "pass",
+                    PasswordHash = "Strong1!",
                     IsAdmin = false
                 };
                 userService.AddUser(user);

--- a/ToolManagementAppV2.Tests/Services/UserActiveTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserActiveTests.cs
@@ -19,7 +19,7 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 using var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
-                var user = new User { UserName = "u", PasswordHash = "p" };
+                var user = new User { UserName = "u", PasswordHash = "Strong1!" };
                 userService.AddUser(user);
                 var added = userService.GetAllUsers().First();
                 Assert.True(added.IsActive);
@@ -39,7 +39,7 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 using var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
-                var user = new User { UserName = "u", PasswordHash = "p" };
+                var user = new User { UserName = "u", PasswordHash = "Strong1!" };
                 userService.AddUser(user);
                 var added = userService.GetAllUsers().First();
                 added.IsActive = false;

--- a/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
@@ -51,7 +51,7 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var legacy = SecurityHelper.ComputeSha256HashLegacy("secret");
+            var legacy = SecurityHelper.ComputeSha256HashLegacy("Strong1!");
             using (var conn = dbService.CreateConnection())
             using (var cmd = new SQLiteCommand("INSERT INTO Users (UserName, PasswordHash, IsAdmin) VALUES (@u,@p,0);", conn))
             {
@@ -60,14 +60,14 @@ public class UserAuthenticationTests
                 cmd.ExecuteNonQuery();
             }
 
-            var auth = userService.AuthenticateUser("legacy", "secret");
+            var auth = userService.AuthenticateUser("legacy", "Strong1!");
             Assert.Equal(AuthenticationResult.Success, auth.Result);
             Assert.NotNull(auth.User);
 
             var updated = userService.GetUserByID(auth.User!.UserID)!;
             Assert.False(SecurityHelper.IsSha256Hash(updated.PasswordHash));
             Assert.False(string.IsNullOrWhiteSpace(updated.PasswordSalt));
-            Assert.True(SecurityHelper.VerifyPassword("secret", updated.PasswordSalt, updated.PasswordHash));
+            Assert.True(SecurityHelper.VerifyPassword("Strong1!", updated.PasswordSalt, updated.PasswordHash));
         }
         finally
         {
@@ -85,7 +85,7 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var user = new User { UserName = "emptysalt", PasswordHash = "secret", IsAdmin = false };
+            var user = new User { UserName = "emptysalt", PasswordHash = "Strong1!", IsAdmin = false };
             userService.AddUser(user);
 
             using (var conn = dbService.CreateConnection())
@@ -95,7 +95,7 @@ public class UserAuthenticationTests
                 cmd.ExecuteNonQuery();
             }
 
-            var auth = userService.AuthenticateUser("emptysalt", "secret");
+            var auth = userService.AuthenticateUser("emptysalt", "Strong1!");
             Assert.Equal(AuthenticationResult.IncorrectPassword, auth.Result);
             Assert.Null(auth.User);
         }
@@ -115,7 +115,7 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var user = new User { UserName = "lock", PasswordHash = "secret", IsAdmin = false };
+            var user = new User { UserName = "lock", PasswordHash = "Strong1!", IsAdmin = false };
             userService.AddUser(user);
 
             for (int i = 0; i < 3; i++)
@@ -133,7 +133,7 @@ public class UserAuthenticationTests
             Assert.Equal(DateTimeKind.Utc, stored.LockoutUntil!.Value.Kind);
             Assert.True(stored.IsLocked);
 
-            var afterLock = userService.AuthenticateUser("lock", "secret");
+            var afterLock = userService.AuthenticateUser("lock", "Strong1!");
             Assert.Equal(AuthenticationResult.LockedOut, afterLock.Result);
         }
         finally
@@ -152,7 +152,7 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var user = new User { UserName = "reset", PasswordHash = "secret", IsAdmin = false };
+            var user = new User { UserName = "reset", PasswordHash = "Strong1!", IsAdmin = false };
             userService.AddUser(user);
 
             for (int i = 0; i < 3; i++)
@@ -166,7 +166,7 @@ public class UserAuthenticationTests
                 cmd.ExecuteNonQuery();
             }
 
-            var auth = userService.AuthenticateUser("reset", "secret");
+            var auth = userService.AuthenticateUser("reset", "Strong1!");
             Assert.Equal(AuthenticationResult.Success, auth.Result);
             Assert.NotNull(auth.User);
 
@@ -183,7 +183,7 @@ public class UserAuthenticationTests
     }
 
     [Fact]
-    public void ChangeUserPassword_SetsPasswordExpiredFlag()
+    public void ChangeUserPassword_Throws_ForDefaultPassword()
     {
         var dbPath = Path.GetTempFileName();
         try
@@ -191,16 +191,10 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var user = new User { UserName = "flag", PasswordHash = "secret", IsAdmin = false };
+            var user = new User { UserName = "flag", PasswordHash = "Strong1!", IsAdmin = false };
             userService.AddUser(user);
 
-            userService.ChangeUserPassword(user.UserID, "admin");
-            var updated = userService.GetAllUsers().First();
-            Assert.True(updated.PasswordExpired);
-
-            userService.ChangeUserPassword(user.UserID, "newpass");
-            updated = userService.GetAllUsers().First();
-            Assert.False(updated.PasswordExpired);
+            Assert.Throws<ArgumentException>(() => userService.ChangeUserPassword(user.UserID, "admin"));
         }
         finally
         {
@@ -218,16 +212,16 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var user = new User { UserName = "atest", PasswordHash = "secret", IsAdmin = false };
+            var user = new User { UserName = "atest", PasswordHash = "Strong1!", IsAdmin = false };
             userService.AddUser(user);
             var added = userService.GetUserByID(user.UserID)!;
 
-            Assert.NotEqual("secret", added.PasswordHash);
+            Assert.NotEqual("Strong1!", added.PasswordHash);
             Assert.False(SecurityHelper.IsSha256Hash(added.PasswordHash));
             Assert.False(string.IsNullOrWhiteSpace(added.PasswordSalt));
-            Assert.True(SecurityHelper.VerifyPassword("secret", added.PasswordSalt, added.PasswordHash));
+            Assert.True(SecurityHelper.VerifyPassword("Strong1!", added.PasswordSalt, added.PasswordHash));
 
-            var auth = await userService.AuthenticateUserAsync(" atest ", " secret ");
+            var auth = await userService.AuthenticateUserAsync(" atest ", " Strong1! ");
             Assert.Equal(AuthenticationResult.Success, auth.Result);
             Assert.NotNull(auth.User);
         }
@@ -247,7 +241,7 @@ public class UserAuthenticationTests
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-            var user = new User { UserName = "lockasync", PasswordHash = "secret", IsAdmin = false };
+            var user = new User { UserName = "lockasync", PasswordHash = "Strong1!", IsAdmin = false };
             userService.AddUser(user);
 
             for (int i = 0; i < 3; i++)
@@ -265,7 +259,7 @@ public class UserAuthenticationTests
             Assert.Equal(DateTimeKind.Utc, stored.LockoutUntil!.Value.Kind);
             Assert.True(stored.IsLocked);
 
-            var afterLock = await userService.AuthenticateUserAsync(" lockasync ", " secret ");
+            var afterLock = await userService.AuthenticateUserAsync(" lockasync ", " Strong1! ");
             Assert.Equal(AuthenticationResult.LockedOut, afterLock.Result);
         }
         finally
@@ -298,7 +292,7 @@ public class UserAuthenticationTests
                 cmd.ExecuteNonQuery();
             }
 
-            var auth = await userService.AuthenticateUserAsync(" areset ", " secret ");
+            var auth = await userService.AuthenticateUserAsync(" areset ", " Strong1! ");
             Assert.Equal(AuthenticationResult.Success, auth.Result);
             Assert.NotNull(auth.User);
 

--- a/ToolManagementAppV2.Tests/Services/UserMobileTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserMobileTests.cs
@@ -19,7 +19,7 @@ namespace ToolManagementAppV2.Tests.Services
                 using var dbService = new DatabaseService(dbPath);
                 IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-                var user = new User { UserName = "u", PasswordHash = "p", Mobile = "111" };
+                var user = new User { UserName = "u", PasswordHash = "Strong1!", Mobile = "111" };
                 userService.AddUser(user);
 
                 var added = userService.GetAllUsers().First();
@@ -41,7 +41,7 @@ namespace ToolManagementAppV2.Tests.Services
                 using var dbService = new DatabaseService(dbPath);
                 IUserService userService = new UserService(dbService, new ApplicationUserContext());
 
-                var user = new User { UserName = "u", PasswordHash = "p", Mobile = "1" };
+                var user = new User { UserName = "u", PasswordHash = "Strong1!", Mobile = "1" };
                 userService.AddUser(user);
                 var added = userService.GetAllUsers().First();
 

--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -110,8 +110,8 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            userService.AddUser(new User { UserName = "dup", PasswordHash = "pw" });
-            var ex = Assert.Throws<InvalidOperationException>(() => userService.AddUser(new User { UserName = "dup", PasswordHash = "pw" }));
+            userService.AddUser(new User { UserName = "dup", PasswordHash = "Strong1!" });
+            var ex = Assert.Throws<InvalidOperationException>(() => userService.AddUser(new User { UserName = "dup", PasswordHash = "Strong1!" }));
             Assert.Contains("username", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
@@ -268,6 +268,22 @@ public class UserServiceTests
     }
 
     [Fact]
+    public async Task AddUserAsync_Throws_WhenPasswordEmpty()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            var userService = new UserService(dbService, new ApplicationUserContext());
+            await Assert.ThrowsAsync<ArgumentException>(() => userService.AddUserAsync(new User { UserName = "nopass" }));
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
     public async Task UnlockUserAsync_ResetsFailedAttemptsAndLockout()
     {
         var dbPath = Path.GetTempFileName();
@@ -378,8 +394,7 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var hash = SecurityHelper.HashPassword("Strong1!", out var salt);
-            userService.AddUser(new User { UserName = "list", PasswordHash = hash, PasswordSalt = salt });
+            userService.AddUser(new User { UserName = "list", PasswordHash = "Strong1!" });
             var users = userService.GetAllUsers();
             var user = users[0];
             Assert.Null(user.PasswordHash);
@@ -399,8 +414,7 @@ public class UserServiceTests
         {
             var dbService = new DatabaseService(dbPath);
             var userService = new UserService(dbService, new ApplicationUserContext());
-            var hash = SecurityHelper.HashPassword("Strong1!", out var salt);
-            await userService.AddUserAsync(new User { UserName = "list", PasswordHash = hash, PasswordSalt = salt });
+            await userService.AddUserAsync(new User { UserName = "list", PasswordHash = "Strong1!" });
             var users = await userService.GetAllUsersAsync();
             var user = users[0];
             Assert.Null(user.PasswordHash);
@@ -413,21 +427,18 @@ public class UserServiceTests
     }
 
     [Fact]
-    public void AddUser_UsesPreHashedPassword_WhenProvided()
+    public void AddUser_HashesPassword_WhenProvided()
     {
         var dbPath = Path.GetTempFileName();
         try
         {
             var dbService = new DatabaseService(dbPath);
             IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var hash = SecurityHelper.HashPassword("secret", out var salt);
-            var user = new User { UserName = "prehashed", PasswordHash = hash, PasswordSalt = salt, PasswordExpired = true };
+            var user = new User { UserName = "prehashed", PasswordHash = "Strong1!", PasswordExpired = true };
             userService.AddUser(user);
             var fetched = userService.GetUserByID(user.UserID)!;
-            Assert.Equal(hash, fetched.PasswordHash);
-            Assert.Equal(salt, fetched.PasswordSalt);
+            Assert.True(SecurityHelper.VerifyPassword("Strong1!", fetched.PasswordSalt, fetched.PasswordHash));
             Assert.True(fetched.PasswordExpired);
-            Assert.True(SecurityHelper.VerifyPassword("secret", fetched.PasswordSalt, fetched.PasswordHash));
         }
         finally
         {

--- a/ToolManagementAppV2.Tests/Tests/MapUserLoggingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/MapUserLoggingTests.cs
@@ -26,7 +26,7 @@ namespace ToolManagementAppV2.Tests
                 PathHelper.Configure(factory.CreateLogger<PathHelper>());
                 try
                 {
-                    service.AddUser(new User { UserName = "u", PasswordHash = "p", UserPhotoPath = "pack://application:,,,/Resources/NoImage.png" });
+                    service.AddUser(new User { UserName = "u", PasswordHash = "Strong1!", UserPhotoPath = "pack://application:,,,/Resources/NoImage.png" });
                     service.GetAllUsers();
                 }
                 finally
@@ -54,7 +54,7 @@ namespace ToolManagementAppV2.Tests
                 PathHelper.Configure(factory.CreateLogger<PathHelper>());
                 try
                 {
-                    service.AddUser(new User { UserName = "u", PasswordHash = "p", UserPhotoPath = "invalid|path.png" });
+                    service.AddUser(new User { UserName = "u", PasswordHash = "Strong1!", UserPhotoPath = "invalid|path.png" });
                     service.GetAllUsers();
                 }
                 finally

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -36,11 +36,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var userContext = new ApplicationUserContext();
                 var auth = new AuthorizationService(userContext);
                 var userService = new UserService(dbService, userContext, auth);
-                await userService.AddUserAsync(new User { UserName = "admin", PasswordHash = "x", IsAdmin = true });
+                await userService.AddUserAsync(new User { UserName = "admin", PasswordHash = "Strong1!", IsAdmin = true });
                 var settingsService = new SettingsService(dbService);
                 await settingsService.SaveSettingAsync("ApplicationName", "TestApp");
 
-                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext);
+                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
+                {
+                    PromptForPasswordAsync = (u, ct) => Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("Strong1!", false))
+                };
                 await vm.InitializeAsync();
 
                 Assert.Equal("TestApp – Login", vm.WindowTitle);
@@ -102,7 +105,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var auth = new AuthorizationService(userContext);
                 var userService = new UserService(dbService, userContext, auth);
                 var settingsService = new SettingsService(dbService);
-                userService.AddUser(new User { UserName = "user", PasswordHash = "newpassword", IsAdmin = false });
+                userService.AddUser(new User { UserName = "user", PasswordHash = "Strong1!", IsAdmin = false });
 
                 var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext);
                 await vm.InitializeAsync();
@@ -135,12 +138,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var auth = new AuthorizationService(userContext);
                 var userService = new UserService(dbService, userContext, auth);
                 var settingsService = new SettingsService(dbService);
-                var user = new User { UserName = "user", PasswordHash = "newpassword", IsAdmin = false, PasswordExpired = true };
+                var user = new User { UserName = "user", PasswordHash = "Strong1!", IsAdmin = false, PasswordExpired = true };
                 userService.AddUser(user);
 
                 var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
                 {
-                    PromptForNewPassword = () => "changed"
+                    PromptForNewPassword = () => "Changed1!",
+                    PromptForPasswordAsync = (u, ct) => Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("Strong1!", false))
                 };
                 await vm.InitializeAsync();
                 bool success = false;
@@ -151,7 +155,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 Assert.True(success);
                 var updated = userService.GetUserByID(user.UserID)!;
                 Assert.False(updated.PasswordExpired);
-                Assert.True(SecurityHelper.VerifyPassword("changed", updated.PasswordSalt, updated.PasswordHash));
+                Assert.True(SecurityHelper.VerifyPassword("Changed1!", updated.PasswordSalt, updated.PasswordHash));
             }
             finally
             {
@@ -173,14 +177,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var auth = new AuthorizationService(userContext);
                 var userService = new UserService(dbService, userContext, auth);
                 var settingsService = new SettingsService(dbService);
-                var admin = new User { UserName = "admin", PasswordHash = "secret", IsAdmin = true, PasswordExpired = true };
+                var admin = new User { UserName = "admin", PasswordHash = "Strong1!", IsAdmin = true, PasswordExpired = true };
                 userService.AddUser(admin);
 
                 var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
                 {
                     PromptForPasswordAsync = (u, ct) =>
-                        Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("secret", false)),
-                    PromptForNewPassword = () => "changed"
+                        Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("Strong1!", false)),
+                    PromptForNewPassword = () => "Changed1!"
                 };
                 await vm.InitializeAsync();
                 bool success = false;
@@ -191,7 +195,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 Assert.True(success);
                 var updated = userService.GetUserByID(admin.UserID)!;
                 Assert.False(updated.PasswordExpired);
-                Assert.True(SecurityHelper.VerifyPassword("changed", updated.PasswordSalt, updated.PasswordHash));
+                Assert.True(SecurityHelper.VerifyPassword("Changed1!", updated.PasswordSalt, updated.PasswordHash));
             }
             finally
             {
@@ -212,12 +216,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(dbService, userContext);
                 var settingsService = new SettingsService(dbService);
-                userService.AddUser(new User { UserName = "admin", PasswordHash = "secret", IsAdmin = true });
+                userService.AddUser(new User { UserName = "admin", PasswordHash = "Strong1!", IsAdmin = true });
 
                 var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
                 {
                     PromptForPasswordAsync = (u, ct) =>
-                        Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("secret", false))
+                        Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("Strong1!", false))
                 };
                 await vm.InitializeAsync();
                 bool success = false;
@@ -247,14 +251,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(dbService, userContext);
                 var settingsService = new SettingsService(dbService);
-                userService.AddUser(new User { UserName = "admin", PasswordHash = "secret", IsAdmin = true });
+                userService.AddUser(new User { UserName = "admin", PasswordHash = "Strong1!", IsAdmin = true });
 
                 var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
                 {
                     PromptForPasswordAsync = async (u, ct) =>
                     {
                         await Task.Delay(TimeSpan.FromSeconds(5), ct);
-                        return new PasswordPromptResult("secret", false);
+                        return new PasswordPromptResult("Strong1!", false);
                     }
                 };
                 await vm.InitializeAsync();
@@ -327,7 +331,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             if (System.Windows.Application.Current == null)
                 new System.Windows.Application();
 
-            var hashed = SecurityHelper.HashPassword("newpassword", out var salt);
+            var hashed = SecurityHelper.HashPassword("Strong1!", out var salt);
             var user = new User { UserID = 1, UserName = "user", PasswordHash = hashed, PasswordSalt = salt, IsAdmin = false, PasswordExpired = true };
             var userService = new ThrowingUserService(user);
             var settingsService = new StubSettingsService();
@@ -337,7 +341,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
             var vm = new LoginViewModel(userService, settingsService, dialog, userContext, logger)
             {
-                PromptForNewPassword = () => "changed"
+                PromptForNewPassword = () => "Changed1!",
+                PromptForPasswordAsync = (u, ct) => Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("Strong1!", false))
             };
             await vm.LoadUsersCommand.ExecuteAsync(null);
 
@@ -364,13 +369,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var settingsService = new SettingsService(dbService);
                 SecurityHelper.SettingsService = settingsService;
 
-                var result = await SecurityHelper.HashPasswordAsync("admin");
                 var admin = new User
                 {
                     UserID = 1,
                     UserName = "admin",
-                    PasswordHash = result.hash,
-                    PasswordSalt = result.salt,
+                    PasswordHash = "Strong1!",
                     IsAdmin = true,
                     PasswordExpired = true
                 };
@@ -378,7 +381,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
                 {
-                    PromptForNewPassword = () => "changed"
+                    PromptForNewPassword = () => "Changed1!"
                 };
 
                 var method = typeof(LoginViewModel).GetMethod("PromptChangePasswordAsync", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -386,7 +389,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var ok = await task;
 
                 Assert.True(ok);
-                var authResult = await userService.AuthenticateUserAsync("admin", "changed");
+                var authResult = await userService.AuthenticateUserAsync("admin", "Changed1!");
                 Assert.Equal(AuthenticationResult.Success, authResult.Result);
             }
             finally
@@ -409,7 +412,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var auth = new AuthorizationService(userContext);
                 var userService = new UserService(dbService, userContext, auth);
                 var settingsService = new SettingsService(dbService);
-                await userService.AddUserAsync(new User { UserName = "admin", IsAdmin = true });
+                await userService.AddUserAsync(new User { UserName = "admin", PasswordHash = "Strong1!", IsAdmin = true });
+                using (var conn = dbService.CreateConnection())
+                {
+                    await SqliteHelper.ExecuteNonQueryAsync(conn,
+                        "UPDATE Users SET PasswordHash='', PasswordSalt='' WHERE UserName='admin'");
+                }
 
                 var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
                 {
@@ -433,7 +441,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             if (System.Windows.Application.Current == null)
                 new System.Windows.Application();
 
-            var hashed = SecurityHelper.HashPassword("secret", out var salt);
+            var hashed = SecurityHelper.HashPassword("Strong1!", out var salt);
             var dbUser = new User { UserID = 1, UserName = "admin", PasswordHash = hashed, PasswordSalt = salt, IsAdmin = true };
             var userService = new OmittingPasswordUserService(dbUser);
             var settingsService = new StubSettingsService();
@@ -441,7 +449,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
             var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
             {
-                PromptForPasswordAsync = (u, ct) => Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("secret", false))
+                PromptForPasswordAsync = (u, ct) => Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("Strong1!", false))
             };
             await vm.LoadUsersCommand.ExecuteAsync(null);
             bool success = false;
@@ -473,7 +481,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var dialog = new CapturingDialogService();
                 var vm = new LoginViewModel(userService, settingsService, dialog, userContext)
                 {
-                    PromptForPasswordAsync = (u, ct) => Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("secret", false))
+                    PromptForPasswordAsync = (u, ct) => Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("Strong1!", false))
                 };
                 await vm.InitializeAsync();
 

--- a/ToolManagementAppV2.Tests/ViewModels/ReportsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ReportsViewModelTests.cs
@@ -39,7 +39,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 rentalService.RentTool(tool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
-                var user = new User { UserName = "user" };
+                var user = new User { UserName = "user", PasswordHash = "Strong1!" };
                 userService.AddUser(user);
 
                 var vm = new ReportsViewModel(reportService);

--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -29,7 +29,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var db = new DatabaseService(dbPath);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
-                userService.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
+                userService.AddUser(new User { UserName = "user1", PasswordHash = "Strong1!" });
                 await vm.LoadUsersAsync();
                 vm.SelectedUser = vm.Users.First();
                 vm.SelectedUser.Email = "test@example.com";
@@ -52,7 +52,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task UpdateUserCommand_ShowsErrorOnFailure()
         {
             var svc = new FailingUserService();
-            svc.AddUser(new User { UserID = 1, UserName = "user1", PasswordHash = "pw" });
+            svc.AddUser(new User { UserID = 1, UserName = "user1", PasswordHash = "Strong1!" });
             var dialog = new StubDialogService();
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), dialog);
             await vm.LoadUsersAsync();
@@ -68,7 +68,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task EditUserAsync_PersistsChanges()
         {
             var svc = new InMemoryUserService();
-            svc.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
+            svc.AddUser(new User { UserName = "user1", PasswordHash = "Strong1!" });
             var dialog = new StubDialogService();
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), dialog);
             await vm.LoadUsersAsync();
@@ -125,7 +125,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task EditUserAsync_ShowsErrorOnFailure()
         {
             var svc = new FailingUserService();
-            svc.AddUser(new User { UserID = 1, UserName = "user1", PasswordHash = "pw" });
+            svc.AddUser(new User { UserID = 1, UserName = "user1", PasswordHash = "Strong1!" });
             var dialog = new StubDialogService();
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), dialog);
             await vm.LoadUsersAsync();
@@ -185,7 +185,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var fileSvc = new StubFileDialogService { FileToReturn = "path/to/image.png" };
                 var vm = new UserManagementViewModel(userService, fileSvc, new StubDialogService());
-                userService.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
+                userService.AddUser(new User { UserName = "user1", PasswordHash = "Strong1!" });
                 await vm.LoadUsersAsync();
                 vm.SelectedUser = vm.Users.First();
                 await vm.UploadUserPhotoCommand.ExecuteAsync(null);
@@ -215,7 +215,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var fileSvc = new StubFileDialogService { FileToReturn = Path.Combine("..", "outside.png") };
                 var dialog = new StubDialogService();
                 var vm = new UserManagementViewModel(userService, fileSvc, dialog);
-                userService.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
+                userService.AddUser(new User { UserName = "user1", PasswordHash = "Strong1!" });
                 await vm.LoadUsersAsync();
                 vm.SelectedUser = vm.Users.First();
                 await vm.UploadUserPhotoCommand.ExecuteAsync(null);
@@ -244,7 +244,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var fileSvc = new StubFileDialogService { FileToReturn = "img.png" };
                 var vm = new UserManagementViewModel(userService, fileSvc, new StubDialogService());
-                userService.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
+                userService.AddUser(new User { UserName = "user1", PasswordHash = "Strong1!" });
                 await vm.LoadUsersAsync();
                 vm.SelectedUser = vm.Users.First();
 
@@ -313,11 +313,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task AddUserAsync_AddsUser()
         {
             var svc = new InMemoryUserService();
-            var vm = new PromptUserManagementViewModel(svc, "pw");
+            var vm = new PromptUserManagementViewModel(svc, "Strong1!");
             await vm.AddUserAsync();
             Assert.Single(vm.Users);
             Assert.Single(svc.Users);
-            Assert.Equal("pw", svc.Users[0].PasswordHash);
+            Assert.Equal("Strong1!", svc.Users[0].PasswordHash);
         }
 
         [Fact]
@@ -325,7 +325,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var svc = new InMemoryUserService();
             await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "Strong1!" });
-            var vm = new PromptUserManagementViewModel(svc, "pw");
+            var vm = new PromptUserManagementViewModel(svc, "Strong1!");
             await vm.AddUserAsync();
 
             Assert.Equal(2, svc.Users.Count);
@@ -340,7 +340,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var svc = new InMemoryUserService();
             await svc.AddUserAsync(new User { UserName = "user1", PasswordHash = "Strong1!" });
             await svc.AddUserAsync(new User { UserName = "user3", PasswordHash = "Strong1!" });
-            var vm = new PromptUserManagementViewModel(svc, "pw");
+            var vm = new PromptUserManagementViewModel(svc, "Strong1!");
             await vm.AddUserAsync();
 
             Assert.Equal(3, svc.Users.Count);
@@ -375,11 +375,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task AddUserAsync_WithEnteredPassword_DoesNotExpire()
         {
             var svc = new InMemoryUserService();
-            var vm = new PromptUserManagementViewModel(svc, "secret");
+            var vm = new PromptUserManagementViewModel(svc, "Strong1!");
             await vm.AddUserAsync();
             var user = svc.Users.Single();
             Assert.False(user.PasswordExpired);
-            Assert.Equal("secret", user.PasswordHash);
+            Assert.Equal("Strong1!", user.PasswordHash);
         }
 
         [Fact]
@@ -392,7 +392,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 var dialog = new StubDialogService();
                 var vm = new UserManagementViewModel(userService, new StubFileDialogService(), dialog);
-                userService.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
+                userService.AddUser(new User { UserName = "user1", PasswordHash = "Strong1!" });
                 await vm.LoadUsersAsync();
                 var user = vm.Users.First();
                 var original = userService.GetUserByID(user.UserID)!;
@@ -447,7 +447,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task DeleteUserFromRowCommand_FailureDoesNotRemoveUser()
         {
             var svc = new FailingUserService();
-            svc.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
+            svc.AddUser(new User { UserName = "user1", PasswordHash = "Strong1!" });
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), new StubDialogService());
             await vm.LoadUsersAsync();
             var toDelete = vm.Users.First();
@@ -459,7 +459,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public async Task DeleteUserFromRowCommand_FailureShowsInfo()
         {
             var svc = new FailingUserService();
-            svc.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
+            svc.AddUser(new User { UserName = "user1", PasswordHash = "Strong1!" });
             var dialog = new StubDialogService();
             var vm = new UserManagementViewModel(svc, new StubFileDialogService(), dialog);
             await vm.LoadUsersAsync();

--- a/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
@@ -61,7 +61,7 @@ namespace ToolManagementAppV2.Tests.Views
                         IUserService userService = new UserService(db, new ApplicationUserContext());
                         var fileSvc = new StubFileDialogService { FileToReturn = "img.png" };
                         var vm = new UserManagementViewModel(userService, fileSvc, new StubDialogService());
-                        userService.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
+                        userService.AddUser(new User { UserName = "user1", PasswordHash = "Strong1!" });
                         vm.LoadUsers();
                         vm.SelectedUser = vm.Users.First();
                         vm.SelectedUser.Email = "user@example.com";
@@ -121,8 +121,8 @@ namespace ToolManagementAppV2.Tests.Views
                         var db = new DatabaseService(dbPath);
                         IUserService userService = new UserService(db, new ApplicationUserContext());
                         var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
-                        userService.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
-                        userService.AddUser(new User { UserName = "user2", PasswordHash = "pw" });
+                        userService.AddUser(new User { UserName = "user1", PasswordHash = "Strong1!" });
+                        userService.AddUser(new User { UserName = "user2", PasswordHash = "Strong1!" });
                         vm.LoadUsers();
 
                         var page = new UsersPage(vm);
@@ -175,7 +175,7 @@ namespace ToolManagementAppV2.Tests.Views
                         var db = new DatabaseService(dbPath);
                         IUserService userService = new UserService(db, new ApplicationUserContext());
                         var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
-                        userService.AddUser(new User { UserName = "user1", PasswordHash = "pw" });
+                        userService.AddUser(new User { UserName = "user1", PasswordHash = "Strong1!" });
                         vm.LoadUsers();
 
                         var page = new UsersPage(vm);

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -181,25 +181,15 @@ namespace ToolManagementAppV2.Services.Users
             using var conn = _dbService.CreateConnection();
             using var cmd = new SQLiteCommand(sql, conn);
 
-            string hashed = string.Empty;
-            string salt = string.Empty;
-            if (!string.IsNullOrWhiteSpace(user.PasswordHash))
-            {
-                if (!string.IsNullOrWhiteSpace(user.PasswordSalt) &&
-                    IsBase64String(user.PasswordHash) && IsBase64String(user.PasswordSalt))
-                {
-                    hashed = user.PasswordHash;
-                    salt = user.PasswordSalt;
-                }
-                else
-                {
-                    if (!PasswordValidator.IsValid(user.PasswordHash, out var error))
-                        throw new ArgumentException(error, nameof(user.PasswordHash));
-                    var result = await SecurityHelper.HashPasswordAsync(user.PasswordHash).ConfigureAwait(false);
-                    hashed = result.hash;
-                    salt = result.salt;
-                }
-            }
+            var password = (user.PasswordHash ?? string.Empty).Trim();
+            if (string.IsNullOrEmpty(password))
+                throw new ArgumentException("Password cannot be empty.", nameof(user.PasswordHash));
+            if (!PasswordValidator.IsValid(password, out var error))
+                throw new ArgumentException(error, nameof(user.PasswordHash));
+
+            var result = await SecurityHelper.HashPasswordAsync(password).ConfigureAwait(false);
+            string hashed = result.hash;
+            string salt = result.salt;
 
             if (user.CreatedAt == default)
                 user.CreatedAt = DateTime.UtcNow;
@@ -351,11 +341,5 @@ namespace ToolManagementAppV2.Services.Users
             return true;
         }
 
-        static bool IsBase64String(string input)
-        {
-            if (string.IsNullOrWhiteSpace(input)) return false;
-            Span<byte> buffer = new Span<byte>(new byte[input.Length]);
-            return Convert.TryFromBase64String(input, buffer, out _);
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Require non-empty plaintext passwords in `UserService.AddUserAsync` and always hash via `SecurityHelper`
- Simplify test `AddUser` helper to delegate hashing to the service
- Update and expand unit tests to cover validation failures

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d190159883249c0db052698ad07c