### PR TITLE
Simplify password validation

### DIFF
--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -233,39 +233,6 @@ public class UserServiceTests
         }
     }
 
-    [Fact]
-    public async Task ChangeUserPasswordAsync_Throws_ForWeakPassword()
-    {
-        var dbPath = Path.GetTempFileName();
-        try
-        {
-            var dbService = new DatabaseService(dbPath);
-            IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            var user = new User { UserName = "weak", PasswordHash = "Strong1!" };
-            await userService.AddUserAsync(user);
-            await Assert.ThrowsAsync<ArgumentException>(() => userService.ChangeUserPasswordAsync(user.UserID, "weak"));
-        }
-        finally
-        {
-            if (File.Exists(dbPath)) File.Delete(dbPath);
-        }
-    }
-
-    [Fact]
-    public async Task AddUserAsync_Throws_ForWeakPassword()
-    {
-        var dbPath = Path.GetTempFileName();
-        try
-        {
-            var dbService = new DatabaseService(dbPath);
-            IUserService userService = new UserService(dbService, new ApplicationUserContext());
-            await Assert.ThrowsAsync<ArgumentException>(() => userService.AddUserAsync(new User { UserName = "weak", PasswordHash = "short" }));
-        }
-        finally
-        {
-            if (File.Exists(dbPath)) File.Delete(dbPath);
-        }
-    }
 
     [Fact]
     public async Task AddUserAsync_Throws_WhenPasswordEmpty()

--- a/ToolManagementAppV2.Tests/Utilities/PasswordValidatorTests.cs
+++ b/ToolManagementAppV2.Tests/Utilities/PasswordValidatorTests.cs
@@ -4,11 +4,10 @@ using Xunit;
 public class PasswordValidatorTests
 {
     [Theory]
-    [InlineData("short", false)]
-    [InlineData("NoDigits!", false)]
-    [InlineData("noupper1!", false)]
-    [InlineData("NOLOWER1!", false)]
-    [InlineData("Valid1!", true)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    [InlineData("pass", true)]
+    [InlineData("123456", true)]
     public void IsValid_ReturnsExpected(string pwd, bool expected)
     {
         var result = PasswordValidator.IsValid(pwd, out _);

--- a/ToolManagementAppV2.Tests/ViewModels/ChangePasswordViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ChangePasswordViewModelTests.cs
@@ -8,8 +8,8 @@ public class ChangePasswordViewModelTests
     {
         bool saved = false;
         var vm = new ChangePasswordViewModel(() => saved = true, () => { });
-        vm.NewPassword = "Valid1!";
-        vm.ConfirmPassword = "Other1!";
+        vm.NewPassword = "abc";
+        vm.ConfirmPassword = "xyz";
         vm.SaveCommand.Execute(null);
         Assert.False(saved);
         Assert.Equal("Passwords do not match.", vm.ValidationMessage);
@@ -20,22 +20,22 @@ public class ChangePasswordViewModelTests
     {
         bool saved = false;
         var vm = new ChangePasswordViewModel(() => saved = true, () => { });
-        vm.NewPassword = "Valid1!";
-        vm.ConfirmPassword = "Valid1!";
+        vm.NewPassword = "simple";
+        vm.ConfirmPassword = "simple";
         vm.SaveCommand.Execute(null);
         Assert.True(saved);
         Assert.True(string.IsNullOrEmpty(vm.ValidationMessage));
     }
 
     [Fact]
-    public void SaveCommand_ShowsError_ForWeakPassword()
+    public void SaveCommand_ShowsError_ForEmptyPassword()
     {
         bool saved = false;
         var vm = new ChangePasswordViewModel(() => saved = true, () => { });
-        vm.NewPassword = "short";
-        vm.ConfirmPassword = "short";
+        vm.NewPassword = string.Empty;
+        vm.ConfirmPassword = string.Empty;
         vm.SaveCommand.Execute(null);
         Assert.False(saved);
-        Assert.False(string.IsNullOrEmpty(vm.ValidationMessage));
+        Assert.Equal("Password cannot be empty.", vm.ValidationMessage);
     }
 }

--- a/ToolManagementAppV2/Utilities/Helpers/PasswordValidator.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/PasswordValidator.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+using System;
 
 namespace ToolManagementAppV2.Utilities.Helpers
 {
@@ -7,19 +7,9 @@ namespace ToolManagementAppV2.Utilities.Helpers
         public static bool IsValid(string password, out string? error)
         {
             error = null;
-            if (string.IsNullOrWhiteSpace(password) || password.Length < 8)
+            if (string.IsNullOrWhiteSpace(password))
             {
-                error = "Password must be at least 8 characters long.";
-                return false;
-            }
-
-            bool hasUpper = password.Any(char.IsUpper);
-            bool hasLower = password.Any(char.IsLower);
-            bool hasDigit = password.Any(char.IsDigit);
-            bool hasSpecial = password.Any(ch => !char.IsLetterOrDigit(ch));
-            if (!(hasUpper && hasLower && hasDigit && hasSpecial))
-            {
-                error = "Password must contain upper, lower, digit, and special characters.";
+                error = "Password cannot be empty.";
                 return false;
             }
 


### PR DESCRIPTION
## Summary
- Replace complex password requirements with a simple non-empty check
- Update password-related view model and utility tests
- Remove weak-password rejection tests from user service

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a2df67ccf083248d9df0608f410c64