### PR TITLE
Ensure first user becomes admin automatically

### DIFF
--- a/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/Users/UserServiceTests.cs
@@ -21,7 +21,7 @@ public class UserServiceTests
     }
 
     [Fact]
-    public async Task AddUserAsync_AllowsSeedingAdminWithoutAuthorization()
+    public async Task AddUserAsync_PromotesFirstUserToAdmin()
     {
         var dbPath = Path.GetTempFileName();
         try
@@ -30,9 +30,13 @@ public class UserServiceTests
             var ctx = new StubUserContext { CurrentUser = new User { UserName = "seed", IsAdmin = false } };
             var auth = new AuthorizationService(ctx);
             var userService = new UserService(dbService, ctx, auth);
-            var admin = new User { UserName = "admin", PasswordHash = "Strong1!", IsAdmin = true };
-            await userService.AddUserAsync(admin);
-            Assert.NotEqual(0, admin.UserID);
+            var first = new User { UserName = "admin", PasswordHash = "Strong1!", IsAdmin = false };
+            await userService.AddUserAsync(first);
+            Assert.NotEqual(0, first.UserID);
+            Assert.True(first.IsAdmin);
+            var stored = userService.GetUserByID(first.UserID);
+            Assert.NotNull(stored);
+            Assert.True(stored!.IsAdmin);
         }
         finally
         {
@@ -50,9 +54,11 @@ public class UserServiceTests
             var ctx = new StubUserContext { CurrentUser = new User { UserName = "seed", IsAdmin = false } };
             var auth = new AuthorizationService(ctx);
             var userService = new UserService(dbService, ctx, auth);
-            var admin = new User { UserName = "admin", PasswordHash = "Strong1!", IsAdmin = true };
+            var admin = new User { UserName = "admin", PasswordHash = "Strong1!", IsAdmin = false };
             await userService.AddUserAsync(admin);
-            await Assert.ThrowsAsync<UnauthorizedAccessException>(() => userService.AddUserAsync(new User { UserName = "user", PasswordHash = "Strong1!" }));
+            Assert.True(admin.IsAdmin);
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                () => userService.AddUserAsync(new User { UserName = "user", PasswordHash = "Strong1!" }));
         }
         finally
         {

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -198,8 +198,15 @@ namespace ToolManagementAppV2.Services.Users
         public async Task AddUserAsync(User user)
         {
             var existingUsers = await GetAllUsersAsync();
-            if (existingUsers.Count > 0)
+            if (existingUsers.Count == 0)
+            {
+                // Seed first user as an administrator regardless of input flag
+                user.IsAdmin = true;
+            }
+            else
+            {
                 _auth.EnsureAdmin();
+            }
             const string sql = @"
                 INSERT INTO Users
                   (UserName, PasswordHash, PasswordSalt, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, FailedAttempts, LockoutUntil, PasswordExpired)


### PR DESCRIPTION
## Summary
- Make the first registered user an admin automatically
- Ensure subsequent users still require admin privileges
- Add tests covering initial admin promotion and authorization enforcement

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e07ccf6483249fccacdf6c53dca3