### PR TITLE
Auto-create admin user when no accounts exist

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -57,7 +57,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task LoadUsersAsync_UsesSetupWizard_WhenNoUsers()
+        public async Task LoadUsersAsync_CreatesAdminUser_WhenNoUsers()
         {
             if (System.Windows.Application.Current == null)
                 new System.Windows.Application();
@@ -71,19 +71,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var userService = new UserService(dbService, userContext, auth);
                 var settingsService = new SettingsService(dbService);
 
-                var logs = new List<LogEntry>();
-                using var provider = new ListLoggerProvider(logs);
-                using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(provider));
-                var logger = loggerFactory.CreateLogger<LoginViewModel>();
-
-                var dialog = new CapturingDialogService();
-                var setup = new StubSetupWizard("Str0ngP@ss!", true);
-                var vm = new LoginViewModel(userService, settingsService, dialog, userContext, logger, null, setup);
+                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext);
                 await vm.LoadUsersCommand.ExecuteAsync(null);
 
-                Assert.True(setup.Invoked);
-                Assert.Contains(logs, l => l.Level == LogLevel.Information && l.Message.Contains("admin"));
-                Assert.Contains("Str0ngP@ss!", dialog.LastMessage);
+                Assert.Single(vm.Users);
+                var admin = vm.Users[0];
+                Assert.Equal("admin", admin.UserName);
+                Assert.True(admin.IsAdmin);
+                Assert.True(admin.PasswordExpired);
             }
             finally
             {
@@ -288,41 +283,6 @@ namespace ToolManagementAppV2.Tests.ViewModels
             win.Dispose();
 
             Assert.True(closed);
-        }
-
-        [Fact]
-        public async Task LoadUsersAsync_AwaitsSetupWizard()
-        {
-            if (System.Windows.Application.Current == null)
-                new System.Windows.Application();
-
-            var tcs = new TaskCompletionSource<SetupWizardResult?>();
-            var setup = new AwaitableSetupWizard(tcs.Task);
-            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
-            try
-            {
-                using var dbService = new DatabaseService(dbPath);
-                var userContext = new ApplicationUserContext();
-                var auth = new AuthorizationService(userContext);
-                var userService = new UserService(dbService, userContext, auth);
-                var settingsService = new SettingsService(dbService);
-                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext, null, null, setup);
-
-                var loadTask = vm.LoadUsersCommand.ExecuteAsync(null);
-
-                await Task.Delay(50);
-                Assert.False(loadTask.IsCompleted);
-
-                tcs.SetResult(new SetupWizardResult("Str0ngP@ss!", false));
-                await loadTask;
-
-                Assert.Single(vm.Users);
-                Assert.Equal("admin", vm.Users[0].UserName);
-            }
-            finally
-            {
-                if (File.Exists(dbPath)) File.Delete(dbPath);
-            }
         }
 
         [Fact]
@@ -581,33 +541,6 @@ namespace ToolManagementAppV2.Tests.ViewModels
             return Task.FromResult(true);
         }
         public Task UnlockUserAsync(int userId) => Task.CompletedTask;
-    }
-
-    class StubSetupWizard : ISetupWizard
-    {
-        readonly SetupWizardResult _result;
-        public bool Invoked { get; private set; }
-        public StubSetupWizard(string password, bool isRandom = false)
-        {
-            _result = new SetupWizardResult(password, isRandom);
-        }
-
-        public Task<SetupWizardResult?> RunAsync()
-        {
-            Invoked = true;
-            return Task.FromResult<SetupWizardResult?>(_result);
-        }
-    }
-
-    class AwaitableSetupWizard : ISetupWizard
-    {
-        readonly Task<SetupWizardResult?> _task;
-        public AwaitableSetupWizard(Task<SetupWizardResult?> task)
-        {
-            _task = task;
-        }
-
-        public Task<SetupWizardResult?> RunAsync() => _task;
     }
 
     class CapturingDialogService : IDialogService

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -38,7 +38,6 @@ namespace ToolManagementAppV2.ViewModels
         readonly IUserContext _userContext;
         readonly ILogger<LoginViewModel> _logger;
         readonly IServiceProvider? _serviceProvider;
-        readonly ISetupWizard? _setupWizard;
 
         public ObservableCollection<User> Users { get; } = new();
 
@@ -87,7 +86,7 @@ namespace ToolManagementAppV2.ViewModels
         public Func<User, CancellationToken, Task<PasswordPromptResult?>>? PromptForPasswordAsync { get; set; }
             
 
-        public LoginViewModel(IUserService userService, ISettingsService settingsService, IDialogService dialogService, IUserContext userContext, ILogger<LoginViewModel>? logger = null, IServiceProvider? serviceProvider = null, ISetupWizard? setupWizard = null)
+        public LoginViewModel(IUserService userService, ISettingsService settingsService, IDialogService dialogService, IUserContext userContext, ILogger<LoginViewModel>? logger = null, IServiceProvider? serviceProvider = null)
         {
             _settingsService = settingsService;
             _userService = userService;
@@ -95,7 +94,6 @@ namespace ToolManagementAppV2.ViewModels
             _userContext = userContext;
             _logger = logger ?? NullLogger<LoginViewModel>.Instance;
             _serviceProvider = serviceProvider;
-            _setupWizard = setupWizard;
 
             SelectUserCommand = new AsyncRelayCommand<User>(OnUserSelected);
 
@@ -176,30 +174,17 @@ namespace ToolManagementAppV2.ViewModels
         async Task LoadUsersAsync()
         {
             var users = await _userService.GetAllUsersAsync();
-            if (users.Count == 0 && _setupWizard != null)
+            if (users.Count == 0)
             {
-                var result = await _setupWizard.RunAsync();
-                if (result == null || string.IsNullOrWhiteSpace(result.Password))
-                    return;
-
-                if (!PasswordValidator.IsValid(result.Password, out var error))
-                {
-                    await _dialogService.ShowInfoAsync(error!, "Invalid Password");
-                    return;
-                }
-
-                var hash = await SecurityHelper.HashPasswordAsync(result.Password).ConfigureAwait(false);
                 var admin = new User
                 {
                     UserName = "admin",
-                    PasswordHash = hash.hash,
-                    PasswordSalt = hash.salt,
-                    IsAdmin = true
+                    PasswordHash = "admin",
+                    IsAdmin = true,
+                    PasswordExpired = true
                 };
                 await _userService.AddUserAsync(admin);
                 _logger.LogInformation("Created admin user {UserName}", admin.UserName);
-                if (result.IsRandom)
-                    await _dialogService.ShowInfoAsync($"Generated admin password: {result.Password}", "Setup");
                 users = await _userService.GetAllUsersAsync();
             }
 


### PR DESCRIPTION
## Summary
- drop setup wizard dependency from login
- seed default admin account with expired password when user table is empty
- add test to verify default admin creation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e2d34d688324bf0f7300a3ed485e