### PR TITLE
Make Locked column read-only

### DIFF
--- a/ToolManagementAppV2/Views/UsersPage.xaml
+++ b/ToolManagementAppV2/Views/UsersPage.xaml
@@ -50,7 +50,7 @@
                     <DataGridTextColumn Header="Phone" Binding="{Binding Phone}" Width="140"/>
                     <DataGridTextColumn Header="Mobile" Binding="{Binding Mobile}" Width="140"/>
                     <DataGridCheckBoxColumn Header="Active" Binding="{Binding IsActive}" Width="100"/>
-                    <DataGridCheckBoxColumn Header="Locked" Binding="{Binding IsLocked}" Width="100"/>
+                    <DataGridCheckBoxColumn Header="Locked" Binding="{Binding IsLocked, Mode=OneWay}" IsReadOnly="True" Width="100"/>
                     <DataGridTextColumn Header="Created" Binding="{Binding CreatedAt, StringFormat=\{0:yyyy-MM-dd\}}" Width="140"/>
                 </DataGrid.Columns>
                 <DataGrid.ContextMenu>


### PR DESCRIPTION
## Summary
- make Locked checkbox column read-only and one-way bound so UI can't toggle lock state

## Testing
- `dotnet test` *(fails: command not found - dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e5649e6483248012404c7fb82e3c