### PR TITLE
Clear user context before login and fix password change targeting

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -138,6 +138,69 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public async Task SwitchUserCommand_DoesNotAlterPreviousUserPassword()
+        {
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
+
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(db, userContext);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
+
+                var oldUser = new User { UserName = "old", PasswordHash = "OldPass1!" };
+                await userService.AddUserAsync(oldUser);
+                var oldHash = oldUser.PasswordHash;
+                var oldSalt = oldUser.PasswordSalt;
+
+                var newUser = new User { UserName = "new", PasswordHash = "NewPass1!", PasswordExpired = true };
+                await userService.AddUserAsync(newUser);
+
+                userContext.CurrentUser = oldUser;
+
+                Func<Task<bool>> stubLogin = async () =>
+                {
+                    var loginVm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
+                    {
+                        PromptForPasswordAsync = (u, ct) => Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("NewPass1!", false)),
+                        PromptForNewPassword = () => "Changed1!"
+                    };
+                    await loginVm.SelectUserCommand.ExecuteAsync(newUser);
+                    return true;
+                };
+
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                    new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService(), null, stubLogin);
+
+                await vm.SwitchUserCommand.ExecuteAsync(null);
+
+                var oldFromDb = await userService.GetUserByIDAsync(oldUser.UserID);
+                Assert.Equal(oldHash, oldFromDb.PasswordHash);
+                Assert.Equal(oldSalt, oldFromDb.PasswordSalt);
+
+                var authOld = await userService.AuthenticateUserAsync("old", "OldPass1!");
+                Assert.Equal(AuthenticationResult.Success, authOld.Result);
+                var authOldChanged = await userService.AuthenticateUserAsync("old", "Changed1!");
+                Assert.Equal(AuthenticationResult.IncorrectPassword, authOldChanged.Result);
+
+                var authNew = await userService.AuthenticateUserAsync("new", "Changed1!");
+                Assert.Equal(AuthenticationResult.Success, authNew.Result);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 
     class StubFileDialogService : IFileDialogService

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -297,11 +297,9 @@ namespace ToolManagementAppV2.ViewModels
                 return false;
             try
             {
-                // Ensure the current user context is set so the service
-                // authorizes the password change for self-service updates
-                // during first-time login or after a reset.
-                if (_userContext.CurrentUser == null)
-                    _userContext.CurrentUser = user;
+                // Ensure the password change targets the selected user by
+                // resetting the context regardless of any previous login.
+                _userContext.CurrentUser = user;
 
                 var updated = await _userService.ChangeUserPasswordAsync(user.UserID, newPwd);
                 if (!updated)

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -254,6 +254,7 @@ namespace ToolManagementAppV2.ViewModels
             {
                 try
                 {
+                    _userContext.CurrentUser = null;
                     if (await _showLoginWindow())
                     {
                         OpenDashboardCommand.Execute(null);


### PR DESCRIPTION
## Summary
- Reset current user context prior to displaying login to avoid stale state when switching users
- Ensure password changes always apply to the selected account by updating the user context
- Add regression test confirming previous users' passwords remain unchanged after switching

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f0a2efd083249d720318d67572d4