### PR TITLE
style: add dropdown item style

### DIFF
--- a/ToolManagementAppV2/Resources/Styles.xaml
+++ b/ToolManagementAppV2/Resources/Styles.xaml
@@ -42,6 +42,19 @@
         <Setter Property="Height" Value="34"/>
         <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
     </Style>
+    <Style x:Key="DropdownItemStyle" TargetType="ComboBoxItem">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
+        <Setter Property="Padding" Value="8,4"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="#243142"/>
+            </Trigger>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Background" Value="#1E2936"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
     <Style TargetType="ComboBox">
         <Setter Property="Background" Value="#141C24"/>
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
@@ -50,6 +63,7 @@
         <Setter Property="Padding" Value="8,4"/>
         <Setter Property="Height" Value="34"/>
         <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Setter Property="ItemContainerStyle" Value="{StaticResource DropdownItemStyle}"/>
     </Style>
     <Style TargetType="PasswordBox">
         <Setter Property="Background" Value="#141C24"/>


### PR DESCRIPTION
## Summary
- Add `DropdownItemStyle` for ComboBox items with hover and selection states
- Apply `DropdownItemStyle` via `ItemContainerStyle` on global ComboBox style
- Verified no ComboBoxes override `ItemContainerStyle` in views

## Testing
- `dotnet test` *(fails: `dotnet` not found)*
- `apt-get update` *(fails: repositories not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f45e614c8324aeb1a1cfbbd4106a