### PR TITLE
Preserve user password data on profile update

### DIFF
--- a/ToolManagementAppV2.Tests/Services/UserPasswordRetentionTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserPasswordRetentionTests.cs
@@ -1,0 +1,48 @@
+using System.IO;
+using System.Linq;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Tests;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Services
+{
+    public class UserPasswordRetentionTests
+    {
+        [Fact]
+        public void UpdateUser_KeepsExistingHashAndSalt_WhenPasswordNotChanged()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                using var db = new DatabaseService(dbPath);
+                IUserService userService = new UserService(db, new ApplicationUserContext());
+
+                var user = new User { UserName = "u", PasswordHash = "Strong1!" };
+                userService.AddUser(user);
+
+                var originalHash = user.PasswordHash;
+                var originalSalt = user.PasswordSalt;
+
+                var loaded = userService.GetAllUsers().First();
+                loaded.Email = "new@example.com";
+
+                userService.UpdateUser(loaded);
+
+                var updated = userService.GetUserByID(loaded.UserID);
+                Assert.NotNull(updated);
+                Assert.Equal(originalHash, updated!.PasswordHash);
+                Assert.Equal(originalSalt, updated.PasswordSalt);
+                Assert.Equal("new@example.com", updated.Email);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}
+

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -238,6 +238,19 @@ namespace ToolManagementAppV2.Services.Users
 
             string hashed = user.PasswordHash;
             string salt = user.PasswordSalt;
+
+            if (string.IsNullOrWhiteSpace(user.PasswordHash) || string.IsNullOrWhiteSpace(user.PasswordSalt))
+            {
+                var existing = await GetUserByIDAsync(user.UserID);
+                if (existing != null)
+                {
+                    if (string.IsNullOrWhiteSpace(user.PasswordHash))
+                        hashed = existing.PasswordHash;
+                    if (string.IsNullOrWhiteSpace(user.PasswordSalt))
+                        salt = existing.PasswordSalt;
+                }
+            }
+
             if (!string.IsNullOrWhiteSpace(user.PasswordHash) && string.IsNullOrWhiteSpace(user.PasswordSalt))
             {
                 var result = await SecurityHelper.HashPasswordAsync(user.PasswordHash).ConfigureAwait(false);

--- a/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/UserManagementViewModel.cs
@@ -259,25 +259,37 @@ namespace ToolManagementAppV2.ViewModels
             Users.ReplaceRange(_allUsers);
         }
 
-        void EditUser(UserModel? user)
+        async void EditUser(UserModel? user)
         {
             if (user == null) return;
 
+            UserModel source = user;
+            try
+            {
+                var loaded = await _userService.GetUserByIDAsync(user.UserID);
+                if (loaded != null)
+                    source = loaded;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve full user record");
+            }
+
             var clone = new UserModel
             {
-                UserID = user.UserID,
-                UserName = user.UserName,
-                PasswordHash = user.PasswordHash,
-                PasswordSalt = user.PasswordSalt,
-                UserPhotoPath = user.UserPhotoPath,
-                IsAdmin = user.IsAdmin,
-                Email = user.Email,
-                Phone = user.Phone,
-                Mobile = user.Mobile,
-                Address = user.Address,
-                Role = user.Role,
-                IsActive = user.IsActive,
-                CreatedAt = user.CreatedAt
+                UserID = source.UserID,
+                UserName = source.UserName,
+                PasswordHash = source.PasswordHash,
+                PasswordSalt = source.PasswordSalt,
+                UserPhotoPath = source.UserPhotoPath,
+                IsAdmin = source.IsAdmin,
+                Email = source.Email,
+                Phone = source.Phone,
+                Mobile = source.Mobile,
+                Address = source.Address,
+                Role = source.Role,
+                IsActive = source.IsActive,
+                CreatedAt = source.CreatedAt
             };
 
             UsersEditWindow? win = null;


### PR DESCRIPTION
## Summary
- ensure EditUser fetches full user record so password hash and salt are available
- avoid overwriting password hash/salt with null on profile updates
- add test confirming password data is preserved when not changed

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f7bbda6483248fbf114e894eb63d