### PR TITLE
Handle inactive users during authentication

### DIFF
--- a/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserAuthenticationTests.cs
@@ -157,4 +157,26 @@ public class UserAuthenticationTests
         }
     }
 
+    [Fact]
+    public async Task AuthenticateUserAsync_ReturnsInactive_WhenUserInactive()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            IUserService userService = new UserService(dbService, new ApplicationUserContext());
+
+            await userService.AddUserAsync(new User { UserName = "inactive", PasswordHash = "Strong1!", IsAdmin = false, IsActive = false });
+
+            var auth = await userService.AuthenticateUserAsync("inactive", "Strong1!");
+            Assert.Equal(AuthenticationResult.Inactive, auth.Result);
+            Assert.Null(auth.User);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
 }

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -87,6 +87,35 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public async Task LoadUsersAsync_FiltersInactiveUsers()
+        {
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
+
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            try
+            {
+                using var dbService = new DatabaseService(dbPath);
+                var userContext = new ApplicationUserContext();
+                var auth = new AuthorizationService(userContext);
+                var userService = new UserService(dbService, userContext, auth);
+                var settingsService = new SettingsService(dbService);
+                await userService.AddUserAsync(new User { UserName = "active", PasswordHash = "Strong1!", IsAdmin = false, IsActive = true });
+                await userService.AddUserAsync(new User { UserName = "inactive", PasswordHash = "Strong1!", IsAdmin = false, IsActive = false });
+
+                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext);
+                await vm.LoadUsersCommand.ExecuteAsync(null);
+
+                Assert.Single(vm.Users);
+                Assert.Equal("active", vm.Users[0].UserName);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public async Task SelectUserCommand_SetsCurrentUser()
         {
             if (System.Windows.Application.Current == null)

--- a/ToolManagementAppV2/Models/AuthenticationResult.cs
+++ b/ToolManagementAppV2/Models/AuthenticationResult.cs
@@ -3,6 +3,7 @@ namespace ToolManagementAppV2.Models
     public enum AuthenticationResult
     {
         Success,
-        IncorrectPassword
+        IncorrectPassword,
+        Inactive
     }
 }

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -119,6 +119,7 @@ namespace ToolManagementAppV2.Services.Users
 
             var u = users.FirstOrDefault();
             if (u == null) return (AuthenticationResult.IncorrectPassword, null);
+            if (!u.IsActive) return (AuthenticationResult.Inactive, null);
 
             bool success;
             if (string.IsNullOrWhiteSpace(u.PasswordSalt) && SecurityHelper.IsSha256Hash(u.PasswordHash))

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -188,7 +189,7 @@ namespace ToolManagementAppV2.ViewModels
                 users = await _userService.GetAllUsersAsync();
             }
 
-            Users.ReplaceRange(users);
+            Users.ReplaceRange(users.Where(u => u.IsActive));
         }
 
         /// <summary>
@@ -275,6 +276,9 @@ namespace ToolManagementAppV2.ViewModels
                     case AuthenticationResult.IncorrectPassword:
                         await _dialogService.ShowInfoAsync("Incorrect password. Please try again.", "Login Failed");
                         continue;
+                    case AuthenticationResult.Inactive:
+                        await _dialogService.ShowInfoAsync("User is inactive. Please contact an administrator.", "Login Failed");
+                        return;
                     case AuthenticationResult.Success:
                         credential = authResult.User;
                         break;


### PR DESCRIPTION
## Summary
- Return `Inactive` when authenticating disabled users and filter inactive accounts from login view
- Show an error when an inactive account tries to sign in
- Add tests ensuring inactive accounts are hidden and cannot authenticate

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f9f46e10832489ef7eceb0facd03