### PR TITLE
Require password reset for users without credentials

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -434,6 +434,56 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public async Task SelectUserCommand_UserWithoutPassword_PromptsForResetAndDoesNotLogin()
+        {
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
+
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            try
+            {
+                using var dbService = new DatabaseService(dbPath);
+                var userContext = new ApplicationUserContext();
+                var auth = new AuthorizationService(userContext);
+                var userService = new UserService(dbService, userContext, auth);
+                var settingsService = new SettingsService(dbService);
+                await userService.AddUserAsync(new User { UserName = "user", PasswordHash = "Strong1!", IsAdmin = false });
+                using (var conn = dbService.CreateConnection())
+                {
+                    await SqliteHelper.ExecuteNonQueryAsync(conn,
+                        "UPDATE Users SET PasswordHash='', PasswordSalt='' WHERE UserName='user'");
+                }
+
+                bool resetPrompted = false;
+                bool passwordPrompted = false;
+
+                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
+                {
+                    PromptForNewPassword = () => { resetPrompted = true; return null; },
+                    PromptForPasswordAsync = (u, ct) =>
+                    {
+                        passwordPrompted = true;
+                        return Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("dummy", false));
+                    }
+                };
+                await vm.InitializeAsync();
+                bool success = false;
+                vm.LoginSucceeded += (_, __) => success = true;
+
+                await vm.SelectUserCommand.ExecuteAsync(vm.Users.First());
+
+                Assert.True(resetPrompted);
+                Assert.False(passwordPrompted);
+                Assert.False(success);
+                Assert.Null(userContext.CurrentUser);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public async Task SelectUserCommand_AdminWithoutPassword_IgnoresUnauthorized()
         {
             if (System.Windows.Application.Current == null)

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -230,9 +230,17 @@ namespace ToolManagementAppV2.ViewModels
                 }
             }
 
+            if (!user.IsAdmin && string.IsNullOrWhiteSpace(user.PasswordHash))
+            {
+                await _dialogService.ShowInfoAsync("This account has no password. Please reset the password to continue.", "Password Required");
+                if (await PromptChangePasswordAsync(user))
+                    await _dialogService.ShowInfoAsync("Password has been set. Please log in with your new password.", "Password Updated");
+                _userContext.CurrentUser = null;
+                return;
+            }
+
             if (!user.IsAdmin &&
-                (string.IsNullOrWhiteSpace(user.PasswordHash) ||
-                 await SecurityHelper.VerifyPasswordAsync("newpassword", user.PasswordSalt, user.PasswordHash).ConfigureAwait(false)))
+                await SecurityHelper.VerifyPasswordAsync("newpassword", user.PasswordSalt, user.PasswordHash).ConfigureAwait(false))
             {
                 _userContext.CurrentUser = user;
                 if (user.PasswordExpired && !await PromptChangePasswordAsync(user))


### PR DESCRIPTION
## Summary
- require password reset if a user account lacks a password hash
- ensure default placeholder passwords still trigger a change prompt
- add test verifying users missing passwords must reset before logging in

## Testing
- `dotnet test` *(failed: command not found; .NET SDK unavailable in container)*
- `apt-get update` *(failed: 403 Forbidden fetching package lists)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fc2089148324a9c1702efb773cf8