### PR TITLE
Add extension for default ComboBox style

### DIFF
--- a/ToolManagementAppV2/Utilities/Extensions/ComboBoxExtensions.cs
+++ b/ToolManagementAppV2/Utilities/Extensions/ComboBoxExtensions.cs
@@ -1,0 +1,36 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace ToolManagementAppV2.Utilities.Extensions
+{
+    /// <summary>
+    /// Extension helpers for working with <see cref="ComboBox"/> controls.
+    /// </summary>
+    public static class ComboBoxExtensions
+    {
+        /// <summary>
+        /// Applies the application's default <see cref="Style"/> to the provided <see cref="ComboBox"/>.
+        /// </summary>
+        /// <param name="comboBox">The <see cref="ComboBox"/> to style.</param>
+        public static void ApplyDefaultStyle(this ComboBox comboBox)
+        {
+            if (comboBox is null) return;
+
+            var styleReference = Application.Current?.FindResource(typeof(ComboBox));
+            if (styleReference is Style style)
+                comboBox.Style = style;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ComboBox"/> with the application's default style applied.
+        /// </summary>
+        /// <returns>A newly created, styled <see cref="ComboBox"/>.</returns>
+        public static ComboBox CreateWithDefaultStyle()
+        {
+            var comboBox = new ComboBox();
+            comboBox.ApplyDefaultStyle();
+            return comboBox;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ComboBoxExtensions to apply the application's default style to ComboBox controls

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fdbd43c083248cc14ed0c5ab2daf