### PR TITLE
Display current user avatar in header

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -37,23 +37,31 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
 
-                bool raised = false;
+                bool adminRaised = false;
+                bool photoRaised = false;
                 vm.PropertyChanged += (s, e) =>
                 {
                     if (e.PropertyName == nameof(MainViewModel.IsCurrentUserAdmin))
-                        raised = true;
+                        adminRaised = true;
+                    if (e.PropertyName == nameof(MainViewModel.CurrentUserPhotoPath))
+                        photoRaised = true;
                 };
 
-                userContext.CurrentUser = new User { UserName = "admin", IsAdmin = true };
+                userContext.CurrentUser = new User { UserName = "admin", IsAdmin = true, UserPhotoPath = "img1.png" };
 
-                Assert.True(raised);
+                Assert.True(adminRaised);
+                Assert.True(photoRaised);
                 Assert.True(vm.IsCurrentUserAdmin);
+                Assert.Equal("img1.png", vm.CurrentUserPhotoPath);
 
-                raised = false;
-                userContext.CurrentUser = new User { UserName = "user", IsAdmin = false };
+                adminRaised = false;
+                photoRaised = false;
+                userContext.CurrentUser = new User { UserName = "user", IsAdmin = false, UserPhotoPath = "img2.png" };
 
-                Assert.True(raised);
+                Assert.True(adminRaised);
+                Assert.True(photoRaised);
                 Assert.False(vm.IsCurrentUserAdmin);
+                Assert.Equal("img2.png", vm.CurrentUserPhotoPath);
             }
             finally
             {

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -88,9 +88,13 @@
                 <DockPanel>
                     <TextBlock Text="{Binding CurrentPageTitle}" DockPanel.Dock="Left" FontSize="20" FontWeight="SemiBold"/>
                     <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
+                        <Border Width="32" Height="32" CornerRadius="16" ClipToBounds="True" Margin="0,0,8,0">
+                            <Image Source="{Binding CurrentUserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}" Stretch="UniformToFill"/>
+                        </Border>
+                        <TextBlock Text="{Binding CurrentUserName}" VerticalAlignment="Center" Margin="0,0,8,0"/>
                         <controls:SearchBar x:Name="GlobalSearchBar"
                                             Text="{Binding GlobalSearchText}"
-                                            SearchCommand="{Binding GlobalSearchCommand}"/>
+                                            SearchCommand="{Binding GlobalSearchCommand}" Margin="8,0,0,0"/>
                         <Button Style="{StaticResource PrimaryButton}" Content="Switch User" Command="{Binding SwitchUserCommand}" Margin="8,0,0,0"/>
                     </StackPanel>
                 </DockPanel>

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -83,6 +83,8 @@ namespace ToolManagementAppV2.ViewModels
 
         public string CurrentUserRole => _userContext.Role;
 
+        public string? CurrentUserPhotoPath => _userContext.CurrentUser?.UserPhotoPath;
+
         public ToolModel? SelectedTool => ToolManagement.SelectedTool;
 
         public void RefreshCurrentUser()
@@ -90,6 +92,7 @@ namespace ToolManagementAppV2.ViewModels
             OnPropertyChanged(nameof(IsCurrentUserAdmin));
             OnPropertyChanged(nameof(CurrentUserName));
             OnPropertyChanged(nameof(CurrentUserRole));
+            OnPropertyChanged(nameof(CurrentUserPhotoPath));
         }
 
         public IRelayCommand OpenDashboardCommand { get; }


### PR DESCRIPTION
## Summary
- Expose current user photo path in `MainViewModel` and refresh bindings on user switch
- Show user avatar and name in the main window header using `NullToDefaultImageConverter`
- Update tests to ensure user photo path updates when the active user changes

## Testing
- `dotnet test` *(fails: command not found; .NET SDK unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ff9260cc8324bddba78d84d5aa8e