### PR TITLE
Add configurable auto logout

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelAutoLogoutTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelAutoLogoutTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.ViewModels;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class MainViewModelAutoLogoutTests
+    {
+        [Fact]
+        public void TimerTick_InvokesSwitchUser()
+        {
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
+
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(db, userContext);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
+                settingsService.SaveAutoLogoutMinutesAsync(1).GetAwaiter().GetResult();
+
+                var timer = new TestDispatcherTimer();
+                var loginCalled = false;
+                Func<Task<bool>> login = () => { loginCalled = true; return Task.FromResult(true); };
+
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                    new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService(), null, login, timer);
+
+                Assert.True(timer.IsEnabled);
+
+                timer.RaiseTick();
+
+                Assert.True(loginCalled);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        class TestDispatcherTimer : IDispatcherTimer
+        {
+            public event EventHandler Tick;
+            public TimeSpan Interval { get; set; }
+            public bool IsEnabled { get; private set; }
+            public void Start() => IsEnabled = true;
+            public void Stop() => IsEnabled = false;
+            public void RaiseTick()
+            {
+                if (IsEnabled)
+                    Tick?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        class StubFileDialogService : IFileDialogService
+        {
+            public string OpenFile(string filter, string? initialDirectory = null) => null;
+            public string SaveFile(string filter) => null;
+        }
+
+        class StubDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => false;
+            public ToolManagementAppV2.Models.Domain.ToolModel? ShowEditToolDialog(ToolManagementAppV2.Models.Domain.ToolModel tool) => null;
+            public void ShowToolDetails(ToolManagementAppV2.Models.Domain.ToolModel tool) { }
+            public (ToolManagementAppV2.Models.Domain.CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolManagementAppV2.Models.Domain.ToolModel tool, System.Collections.Generic.IEnumerable<ToolManagementAppV2.Models.Domain.CustomerModel> customers) => null;
+            public ToolManagementAppV2.Models.Domain.CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ToolManagementAppV2.Models.Domain.ToolModel tool, System.Collections.Generic.IEnumerable<ToolManagementAppV2.Models.Domain.RentalModel> history) { }
+            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+            public Func<ToolManagementAppV2.Models.Domain.ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+            public void ShowScannerStatus() { }
+        }
+    }
+}

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -125,6 +125,17 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public void AutoLogoutMinutes_LoadsAndSaves()
+        {
+            var settings = new StubSettingsService { AutoLogoutMinutes = 5 };
+            var vm = new SettingsViewModel(new StubFileDialogService(), settings, new StubDialogService());
+            Assert.Equal(5, vm.AutoLogoutMinutes);
+
+            vm.AutoLogoutMinutes = 10;
+            Assert.Equal(10, settings.AutoLogoutMinutes);
+        }
+
+        [Fact]
         public void PasswordIterations_AboveLimit_PersistsClampedValue()
         {
             var path = System.IO.Path.GetTempFileName();
@@ -161,6 +172,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public string? GetSettingValue { get; set; } = string.Empty;
         public IEnumerable<string> ScannerIps { get; set; } = Array.Empty<string>();
         public int PasswordIterations { get; set; } = 100_000;
+        public int AutoLogoutMinutes { get; set; }
 
         public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
         {
@@ -188,6 +200,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default)
         {
             PasswordIterations = iterations;
+            return Task.CompletedTask;
+        }
+        public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(AutoLogoutMinutes);
+        public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default)
+        {
+            AutoLogoutMinutes = minutes;
             return Task.CompletedTask;
         }
     }

--- a/ToolManagementAppV2.Tests/Views/AvatarSelectionWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/AvatarSelectionWindowTests.cs
@@ -100,6 +100,10 @@ namespace ToolManagementAppV2.Tests.Views
                 => Task.FromResult(0);
             public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
+            public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult(0);
+            public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
         }
 
         class FailingSettingsService : ISettingsService
@@ -122,6 +126,10 @@ namespace ToolManagementAppV2.Tests.Views
             public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default)
                 => Task.FromResult(0);
             public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult(0);
+            public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
         }
     }

--- a/ToolManagementAppV2/Interfaces/ISettingsService.cs
+++ b/ToolManagementAppV2/Interfaces/ISettingsService.cs
@@ -17,5 +17,9 @@ namespace ToolManagementAppV2.Interfaces
         // Password hashing configuration
         Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default);
         Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default);
+
+        // Auto logout configuration
+        Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default);
+        Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default);
     }
 }

--- a/ToolManagementAppV2/MainWindow.xaml.cs
+++ b/ToolManagementAppV2/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System;
 using System.Windows;
 using ToolManagementAppV2.Utilities.Extensions;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.ViewModels;
 
 namespace ToolManagementAppV2
 {
@@ -26,6 +27,13 @@ namespace ToolManagementAppV2
             this.DisposeDataContextOnUnload();
 
             Closed += (_, __) => _ownedDb?.Dispose();
+
+            if (viewModel is MainViewModel vm)
+            {
+                MouseMove += (_, __) => vm.ResetAutoLogoutTimer();
+                KeyDown += (_, __) => vm.ResetAutoLogoutTimer();
+                MouseDown += (_, __) => vm.ResetAutoLogoutTimer();
+            }
         }
 
         void IMainWindow.Activate() => base.Activate();

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -206,6 +206,7 @@ namespace ToolManagementAppV2.Services.Settings
 
         const string ScannerIpKey = "ScannerIpAddresses";
         const string PasswordIterationsKey = "PasswordIterations";
+        const string AutoLogoutMinutesKey = "AutoLogoutMinutes";
 
         public async Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default)
         {
@@ -271,6 +272,20 @@ namespace ToolManagementAppV2.Services.Settings
             if (iterations <= 0)
                 throw new ArgumentOutOfRangeException(nameof(iterations));
             await SaveSettingAsync(PasswordIterationsKey, iterations.ToString(), cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default)
+        {
+            var value = await GetSettingAsync(AutoLogoutMinutesKey, cancellationToken).ConfigureAwait(false);
+            return int.TryParse(value, out var i) && i >= 0 ? i : 0;
+        }
+
+        public async Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default)
+        {
+            _auth.EnsureAdmin();
+            if (minutes < 0)
+                throw new ArgumentOutOfRangeException(nameof(minutes));
+            await SaveSettingAsync(AutoLogoutMinutesKey, minutes.ToString(), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -23,6 +23,7 @@ using ToolManagementAppV2.Utilities.IO;
 using ToolManagementAppV2.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using ToolManagementAppV2.Models.ImportExport;
+using ToolManagementAppV2.Utilities;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -39,6 +40,8 @@ namespace ToolManagementAppV2.ViewModels
         readonly IDialogService _dialogService;
         readonly ILogger<MainViewModel> _logger;
         readonly Func<Task<bool>> _showLoginWindow;
+        readonly IDispatcherTimer _autoLogoutTimer;
+        int _autoLogoutMinutes;
 
         EventHandler<User?>? _userContextChangedHandler;
         PropertyChangedEventHandler? _toolManagementPropertyChangedHandler;
@@ -85,6 +88,15 @@ namespace ToolManagementAppV2.ViewModels
 
         public ToolModel? SelectedTool => ToolManagement.SelectedTool;
 
+        public void ResetAutoLogoutTimer()
+        {
+            if (_autoLogoutMinutes > 0)
+            {
+                _autoLogoutTimer.Stop();
+                _autoLogoutTimer.Start();
+            }
+        }
+
         public void RefreshCurrentUser()
         {
             OnPropertyChanged(nameof(IsCurrentUserAdmin));
@@ -123,7 +135,8 @@ namespace ToolManagementAppV2.ViewModels
                              IDatabaseBackupService databaseService,
                              IDialogService dialogService,
                              ILogger<MainViewModel>? logger = null,
-                             Func<Task<bool>>? showLoginWindow = null)
+                             Func<Task<bool>>? showLoginWindow = null,
+                             IDispatcherTimer? autoLogoutTimer = null)
         {
             _toolService = toolService;
             _userService = userService;
@@ -163,6 +176,10 @@ namespace ToolManagementAppV2.ViewModels
             Reports = new ReportsViewModel(new ReportService(toolService, rentalService, activityLogService, customerService, userService));
             ActivityLogs = new ActivityLogsViewModel(activityLogService);
             Settings = new SettingsViewModel(_fileDialogService, _settingsService, _dialogService);
+            _autoLogoutTimer = autoLogoutTimer ?? new DispatcherTimerWrapper();
+            _autoLogoutTimer.Tick += OnAutoLogoutTimerTick;
+            Settings.PropertyChanged += Settings_PropertyChanged;
+            UpdateAutoLogoutTimer();
 
             OpenDashboardCommand = new RelayCommand(() =>
             {
@@ -320,6 +337,33 @@ namespace ToolManagementAppV2.ViewModels
             OpenDashboardCommand.Execute(null);
         }
 
+        void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(SettingsViewModel.AutoLogoutMinutes))
+                UpdateAutoLogoutTimer();
+        }
+
+        void UpdateAutoLogoutTimer()
+        {
+            _autoLogoutMinutes = Settings.AutoLogoutMinutes;
+            if (_autoLogoutMinutes > 0)
+            {
+                _autoLogoutTimer.Interval = TimeSpan.FromMinutes(_autoLogoutMinutes);
+                _autoLogoutTimer.Stop();
+                _autoLogoutTimer.Start();
+            }
+            else if (_autoLogoutTimer.IsEnabled)
+            {
+                _autoLogoutTimer.Stop();
+            }
+        }
+
+        async void OnAutoLogoutTimerTick(object? s, EventArgs e)
+        {
+            _autoLogoutTimer.Stop();
+            await SwitchUserCommand.ExecuteAsync(null);
+        }
+
         async Task OpenImportMappingWindowAsync(CancellationToken cancellationToken)
         {
             try
@@ -395,6 +439,9 @@ namespace ToolManagementAppV2.ViewModels
                 ToolManagement.PropertyChanged -= _toolManagementPropertyChangedHandler;
                 _toolManagementPropertyChangedHandler = null;
             }
+            Settings.PropertyChanged -= Settings_PropertyChanged;
+            _autoLogoutTimer.Tick -= OnAutoLogoutTimerTick;
+            _autoLogoutTimer.Stop();
             ToolManagement.Dispose();
         }
     }

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -33,6 +33,7 @@ namespace ToolManagementAppV2.ViewModels
             ThemeOptions = new ObservableCollection<string> { "Light", "Dark" };
             _theme = ThemeOptions[0];
             _passwordIterations = _settingsService.GetPasswordIterationsAsync().GetAwaiter().GetResult();
+            _autoLogoutMinutes = _settingsService.GetAutoLogoutMinutesAsync().GetAwaiter().GetResult();
             TestDbCommand = new RelayCommand(() =>
             {
                 var success = TestDbConnection(out var message);
@@ -126,6 +127,38 @@ namespace ToolManagementAppV2.ViewModels
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to save password iterations.");
+                }
+            }
+        }
+
+        private int _autoLogoutMinutes;
+        public int AutoLogoutMinutes
+        {
+            get => _autoLogoutMinutes;
+            set => SetAutoLogoutMinutesAsync(value).GetAwaiter().GetResult();
+        }
+
+        async Task SetAutoLogoutMinutesAsync(int value, CancellationToken token = default)
+        {
+            if (value < 0) return;
+            if (SetProperty(ref _autoLogoutMinutes, value))
+            {
+                try
+                {
+                    await _settingsService.SaveAutoLogoutMinutesAsync(value, token).ConfigureAwait(false);
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    _logger.LogWarning(ex, "Unauthorized to change auto logout minutes.");
+                    _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+                }
+                catch (OperationCanceledException ex)
+                {
+                    _logger.LogInformation(ex, "Saving auto logout minutes was canceled.");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to save auto logout minutes.");
                 }
             }
         }

--- a/ToolManagementAppV2/Views/SettingsPage.xaml
+++ b/ToolManagementAppV2/Views/SettingsPage.xaml
@@ -33,11 +33,14 @@
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
                         <TextBlock Text="Theme" VerticalAlignment="Center"/>
                         <ComboBox Grid.Column="1" SelectedItem="{Binding Theme}" ItemsSource="{Binding ThemeOptions}" Margin="8,0,0,0"/>
                         <TextBlock Grid.Row="1" Text="Password Iterations" VerticalAlignment="Center"/>
                         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding PasswordIterations}" Margin="8,0,0,0" PreviewTextInput="PasswordIterationsBox_PreviewTextInput"/>
+                        <TextBlock Grid.Row="2" Text="Auto-logout (minutes)" VerticalAlignment="Center"/>
+                        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding AutoLogoutMinutes}" Margin="8,0,0,0" PreviewTextInput="AutoLogoutMinutesBox_PreviewTextInput"/>
                     </Grid>
                 </StackPanel>
             </Border>

--- a/ToolManagementAppV2/Views/SettingsPage.xaml.cs
+++ b/ToolManagementAppV2/Views/SettingsPage.xaml.cs
@@ -17,5 +17,12 @@ namespace ToolManagementAppV2.Views
             var proposed = textBox.Text.Insert(textBox.SelectionStart, e.Text);
             e.Handled = !int.TryParse(proposed, out var value) || value <= 0;
         }
+
+        void AutoLogoutMinutesBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
+        {
+            var textBox = (TextBox)sender;
+            var proposed = textBox.Text.Insert(textBox.SelectionStart, e.Text);
+            e.Handled = !int.TryParse(proposed, out var value) || value < 0;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add settings service APIs to persist auto logout timeout
- expose AutoLogoutMinutes in Settings UI and view model
- implement idle timer to auto switch users and tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ff9518948324a8b54e6ea1e1e526