### PR TITLE
Add cancel command for importing tools

### DIFF
--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -25,6 +25,7 @@ namespace ToolManagementAppV2.ViewModels
         private readonly ILogger<ImportExportViewModel> _logger;
 
         public IAsyncRelayCommand ImportToolsCommand { get; }
+        public IRelayCommand CancelImportToolsCommand { get; }
         public IAsyncRelayCommand ExportToolsCommand { get; }
         public IAsyncRelayCommand ImportCustomersCommand { get; }
         public IAsyncRelayCommand ExportCustomersCommand { get; }
@@ -54,6 +55,7 @@ namespace ToolManagementAppV2.ViewModels
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<ImportExportViewModel>.Instance;
             ImportToolsCommand = new AsyncRelayCommand(ct => ImportToolsAsync(ct));
+            CancelImportToolsCommand = new RelayCommand(() => ImportToolsCommand.Cancel());
             ExportToolsCommand = new AsyncRelayCommand(ct => ExportToolsAsync(ct));
             ImportCustomersCommand = new AsyncRelayCommand(ct => ImportCustomersAsync(ct));
             ExportCustomersCommand = new AsyncRelayCommand(ct => ExportCustomersAsync(ct));

--- a/ToolManagementAppV2/Views/ImportExportPage.xaml
+++ b/ToolManagementAppV2/Views/ImportExportPage.xaml
@@ -38,7 +38,7 @@
                             Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}" Content="Export Tools CSV" Command="{Binding ExportToolsCommand}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}" Content="Backup Database" Command="{Binding BackupDatabaseCommand}"/>
-                    <Button Style="{StaticResource CompactPrimaryButton}" Content="Cancel Import" Command="{Binding ImportToolsCommand.CancelCommand}" IsEnabled="{Binding ImportToolsCommand.IsRunning}"/>
+                    <Button Style="{StaticResource CompactPrimaryButton}" Content="Cancel Import" Command="{Binding CancelImportToolsCommand}" IsEnabled="{Binding ImportToolsCommand.IsRunning}"/>
 
                 </WrapPanel>
             </StackPanel>


### PR DESCRIPTION
## Summary
- add CancelImportToolsCommand in ImportExportViewModel
- bind Cancel Import button to CancelImportToolsCommand

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a303ca720c8324a5e2304e82e6b519