### PR TITLE
Fix Import Tool Images command binding

### DIFF
--- a/ToolManagementAppV2/Views/ImportExportPage.xaml
+++ b/ToolManagementAppV2/Views/ImportExportPage.xaml
@@ -34,8 +34,8 @@
                 <TextBlock Text="Tools" Style="{StaticResource SectionHeader}" />
                 <WrapPanel>
                     <Button Style="{StaticResource CompactPrimaryButton}" Content="Import Tools CSV" Command="{Binding ImportToolsCommand}"/>
-                    <Button Style="{StaticResource CompactPrimaryButton}" Content="Import Tool Images" Command="{Binding DataContext.OpenImageImportMappingWindowCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                            Visibility="{Binding DataContext.IsCurrentUserAdmin, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource BoolToVis}}"/>
+                    <Button Style="{StaticResource CompactPrimaryButton}" Content="Import Tool Images" Command="{Binding DataContext.OpenImageImportMappingWindowCommand, RelativeSource={RelativeSource AncestorType=Frame}}"
+                            Visibility="{Binding DataContext.IsCurrentUserAdmin, RelativeSource={RelativeSource AncestorType=Frame}, Converter={StaticResource BoolToVis}}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}" Content="Export Tools CSV" Command="{Binding ExportToolsCommand}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}" Content="Backup Database" Command="{Binding BackupDatabaseCommand}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}" Content="Cancel Import" Command="{Binding CancelImportToolsCommand}" IsEnabled="{Binding ImportToolsCommand.IsRunning}"/>


### PR DESCRIPTION
## Summary
- ensure Import Tool Images button finds its command and visibility via Frame ancestor

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a3069702a08324bd2e0bc3b3c79adf