### PR TITLE
Handle semicolons in SQLite backup paths with connection string builder

### DIFF
--- a/ToolManagementAppV2.Tests/Services/DatabaseBackupTests.cs
+++ b/ToolManagementAppV2.Tests/Services/DatabaseBackupTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ToolManagementAppV2.Services.Core;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Services
+{
+    public class DatabaseBackupTests
+    {
+        [Fact]
+        public async Task BackupDatabase_PathWithSemicolon_DoesNotThrow()
+        {
+            var dbPath = Path.GetTempFileName();
+            var backupPath1 = Path.Combine(Path.GetTempPath(), $"backup;{Guid.NewGuid():N}.db");
+            var backupPath2 = Path.Combine(Path.GetTempPath(), $"backup;{Guid.NewGuid():N}.db");
+            try
+            {
+                var service = new DatabaseService(dbPath);
+
+                var ex1 = Record.Exception(() => service.BackupDatabase(backupPath1));
+                Assert.Null(ex1);
+                Assert.True(File.Exists(backupPath1));
+
+                var ex2 = await Record.ExceptionAsync(() => service.BackupDatabaseAsync(backupPath2, CancellationToken.None));
+                Assert.Null(ex2);
+                Assert.True(File.Exists(backupPath2));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+                if (File.Exists(backupPath1))
+                    File.Delete(backupPath1);
+                if (File.Exists(backupPath2))
+                    File.Delete(backupPath2);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -263,7 +263,14 @@ namespace ToolManagementAppV2.Services.Core
             try
             {
                 using var source = CreateConnection();
-                using var destination = new SQLiteConnection($"Data Source={backupFilePath};Version=3;Pooling=True;Cache=Shared;");
+                var builder = new SQLiteConnectionStringBuilder
+                {
+                    DataSource = backupFilePath,
+                    Version = 3,
+                    Pooling = true
+                };
+                builder["Cache"] = "Shared";
+                using var destination = new SQLiteConnection(builder.ToString());
                 destination.Open();
 
                 source.BackupDatabase(destination, "main", "main", -1, null, 0);
@@ -280,13 +287,11 @@ namespace ToolManagementAppV2.Services.Core
         /// </summary>
         /// <param name="backupFilePath">Destination path for the backup file.</param>
         /// <param name="cancellationToken">Token to observe for cancellation.</param>
-        public async Task BackupDatabaseAsync(string backupFilePath, CancellationToken cancellationToken)
-        {
-            await Task.Run(() =>
+        public Task BackupDatabaseAsync(string backupFilePath, CancellationToken cancellationToken)
+            => Task.Run(() =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 BackupDatabase(backupFilePath);
-            }, cancellationToken).ConfigureAwait(false);
-        }
+            }, cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
- Build backup connection strings with `SQLiteConnectionStringBuilder` to handle special characters
- Simplify async backup helper and add unit test ensuring semicolon paths work

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a306a1beec832483fe086e6cd20768