### PR TITLE
Fix tool image binding and window command reference

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ToolCardTemplateBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ToolCardTemplateBindingTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using ToolManagementAppV2.Utilities.Converters;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Tests
+{
+    public class ToolCardTemplateBindingTests
+    {
+        [Fact]
+        public void ToolCardTemplate_UsesNullToDefaultImageConverter()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var dict = new ResourceDictionary
+                    {
+                        Source = new Uri("pack://application:,,,/Resources/Templates.xaml", UriKind.Absolute)
+                    };
+                    var template = Assert.IsType<DataTemplate>(dict["ToolCardTemplate"]);
+                    var grid = Assert.IsType<Grid>(template.LoadContent());
+                    var border = Assert.IsType<Border>(grid.Children[0]);
+                    var image = Assert.IsType<Image>(border.Child);
+                    var binding = BindingOperations.GetBinding(image, Image.SourceProperty);
+                    Assert.NotNull(binding);
+                    Assert.IsType<NullToDefaultImageConverter>(binding!.Converter);
+                    Assert.Equal("tool", binding.ConverterParameter);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null)
+            {
+                throw threadEx;
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2/Resources/Templates.xaml
+++ b/ToolManagementAppV2/Resources/Templates.xaml
@@ -23,7 +23,8 @@
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <Border Background="#0e1420" CornerRadius="8" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1">
-                <Image Stretch="UniformToFill" Source="{Binding ToolImagePath}"/>
+                <Image Stretch="UniformToFill"
+                       Source="{Binding ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=tool}"/>
             </Border>
             <StackPanel Grid.Row="1" Margin="0,6,0,0">
                 <TextBlock Text="{Binding NameDescription}" FontWeight="SemiBold" FontSize="13"/>

--- a/ToolManagementAppV2/Views/ImportExportPage.xaml
+++ b/ToolManagementAppV2/Views/ImportExportPage.xaml
@@ -34,8 +34,8 @@
                 <TextBlock Text="Tools" Style="{StaticResource SectionHeader}" />
                 <WrapPanel>
                     <Button Style="{StaticResource CompactPrimaryButton}" Content="Import Tools CSV" Command="{Binding ImportToolsCommand}"/>
-                    <Button Style="{StaticResource CompactPrimaryButton}" Content="Import Tool Images" Command="{Binding DataContext.OpenImageImportMappingWindowCommand, RelativeSource={RelativeSource AncestorType=Frame}}"
-                            Visibility="{Binding DataContext.IsCurrentUserAdmin, RelativeSource={RelativeSource AncestorType=Frame}, Converter={StaticResource BoolToVis}}"/>
+                    <Button Style="{StaticResource CompactPrimaryButton}" Content="Import Tool Images" Command="{Binding DataContext.OpenImageImportMappingWindowCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                            Visibility="{Binding DataContext.IsCurrentUserAdmin, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource BoolToVis}}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}" Content="Export Tools CSV" Command="{Binding ExportToolsCommand}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}" Content="Backup Database" Command="{Binding BackupDatabaseCommand}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}" Content="Cancel Import" Command="{Binding CancelImportToolsCommand}" IsEnabled="{Binding ImportToolsCommand.IsRunning}"/>


### PR DESCRIPTION
## Summary
- apply default image converter for tool cards to prevent binding errors
- reference window DataContext for Import Export commands
- test tool card template uses NullToDefaultImageConverter

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a30ae53898832496d00e9242479b41