### PR TITLE
Enable layout rounding for nav ScrollViewer

### DIFF
--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -19,7 +19,10 @@
                     <TextBlock Text="{Binding CurrentPageTitle}" FontSize="12" Foreground="{StaticResource ForegroundMutedBrush}" Margin="0,4,0,0"/>
                 </StackPanel>
 
-                <ScrollViewer Grid.Row="1" PreviewMouseWheel="LeftNavScrollViewer_PreviewMouseWheel">
+                <ScrollViewer Grid.Row="1"
+                              PreviewMouseWheel="LeftNavScrollViewer_PreviewMouseWheel"
+                              SnapsToDevicePixels="True"
+                              UseLayoutRounding="True">
                     <StackPanel Orientation="Vertical" Margin="12,0,12,8">
                         <TextBlock Text="Operations" Foreground="{StaticResource ForegroundMutedBrush}" Margin="6,8,6,2"/>
                         <Button Style="{StaticResource NavButton}" Content="Dashboard" Command="{Binding OpenDashboardCommand}"/>

--- a/ToolManagementAppV2/Resources/Styles.xaml
+++ b/ToolManagementAppV2/Resources/Styles.xaml
@@ -20,6 +20,8 @@
         <Setter Property="VerticalScrollBarVisibility" Value="Auto"/>
         <Setter Property="HorizontalScrollBarVisibility" Value="Disabled"/>
         <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
     </Style>
     <Style TargetType="Frame">
         <Setter Property="NavigationUIVisibility" Value="Hidden"/>


### PR DESCRIPTION
## Summary
- align navigation ScrollViewer to device pixels for sharper rendering
- set global ScrollViewer style to snap to device pixels and use layout rounding

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a30c6e7f0c83249386f63a0a46d3e7