### PR TITLE
Fix cancel switch user reverting to guest

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -85,14 +85,17 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var logger = new StubLogger<MainViewModel>();
 
                 Func<Task<bool>> stubLogin = () => Task.FromResult(false);
-
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
                     new StubFileDialogService(), activityLogService, settingsService, db, dialog, logger, stubLogin);
+
+                var oldUser = new User { UserName = "old", IsAdmin = false };
+                userContext.CurrentUser = oldUser;
 
                 await vm.SwitchUserCommand.ExecuteAsync(null);
 
                 Assert.True(dialog.InfoShown);
                 Assert.Equal("Switch user cancelled.", logger.LastWarning);
+                Assert.Same(oldUser, userContext.CurrentUser);
             }
             finally
             {

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -272,21 +272,24 @@ namespace ToolManagementAppV2.ViewModels
 
             SwitchUserCommand = new AsyncRelayCommand(async () =>
             {
+                var previousUser = _userContext.CurrentUser;
+                _userContext.CurrentUser = null;
                 try
                 {
-                    _userContext.CurrentUser = null;
                     if (await _showLoginWindow())
                     {
                         OpenDashboardCommand.Execute(null);
                     }
                     else
                     {
+                        _userContext.CurrentUser = previousUser;
                         _logger.LogWarning("Switch user cancelled.");
                         _dialogService.ShowInfo("Switch user cancelled.", "Switch User");
                     }
                 }
                 catch (Exception ex)
                 {
+                    _userContext.CurrentUser = previousUser;
                     _logger.LogError(ex, "Switch user failed.");
                     _dialogService.ShowInfo("Failed to switch user.", "Switch User");
                 }


### PR DESCRIPTION
## Summary
- restore previous user when switch user is cancelled
- ensure cancellation test verifies current user is unchanged

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a41ce739f883249e5bdbcf00617072