### PR TITLE
Ensure converters load before templates

### DIFF
--- a/ToolManagementAppV2.Tests/Views/ToolSearchPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ToolSearchPageTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading;
+using ToolManagementAppV2.Views;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.Views
+{
+    public class ToolSearchPageTests
+    {
+        [Fact]
+        public void Constructor_LoadsWithoutException()
+        {
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    if (System.Windows.Application.Current == null)
+                        new System.Windows.Application();
+                    var page = new ToolSearchPage();
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+            {
+                throw threadException;
+            }
+        }
+    }
+}
+

--- a/ToolManagementAppV2/App.xaml
+++ b/ToolManagementAppV2/App.xaml
@@ -8,8 +8,8 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/Colors.xaml"/>
                 <ResourceDictionary Source="Resources/Styles.xaml"/>
-                <ResourceDictionary Source="Resources/Templates.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
+                <ResourceDictionary Source="Resources/Templates.xaml"/>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>


### PR DESCRIPTION
## Summary
- Fix `App.xaml` resource loading order so converters precede templates
- Add unit test verifying `ToolSearchPage` initializes without errors

## Testing
- ⚠️ `dotnet test` *(missing `dotnet` command in container)*


------
https://chatgpt.com/codex/tasks/task_e_68a41e0c981883248691d357c052ff13