### PR TITLE
Use dynamic resource for image converter

### DIFF
--- a/ToolManagementAppV2/Resources/Templates.xaml
+++ b/ToolManagementAppV2/Resources/Templates.xaml
@@ -24,7 +24,7 @@
             </Grid.RowDefinitions>
             <Border Background="#0e1420" CornerRadius="8" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1">
                 <Image Stretch="UniformToFill"
-                       Source="{Binding ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=tool}"/>
+                       Source="{Binding ToolImagePath, Converter={DynamicResource NullToDefaultImageConverter}, ConverterParameter=tool}"/>
             </Border>
             <StackPanel Grid.Row="1" Margin="0,6,0,0">
                 <TextBlock Text="{Binding NameDescription}" FontWeight="SemiBold" FontSize="13"/>


### PR DESCRIPTION
## Summary
- Resolve dynamic resource lookup for NullToDefaultImageConverter in ToolCardTemplate

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a41fc66cf88324a81ccb99ba57285a