### PR TITLE
Copy external company logos locally

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Interfaces;
-using ToolManagementAppV2.Utilities.Helpers;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -68,17 +67,54 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void SaveCompanyLogoCommand_PersistsPath()
+        public void SaveCompanyLogoCommand_PersistsRelativePath()
         {
             var settings = new StubSettingsService();
-            var expected = PathHelper.GetAbsolutePath("logo.png");
-            var vm = new SettingsViewModel(new StubFileDialogService(), settings, new StubDialogService())
+            var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+            var file = Path.Combine(baseDir, "logo.png");
+            File.WriteAllText(file, "data");
+            try
             {
-                CompanyLogoPath = "logo.png"
-            };
-            vm.SaveCompanyLogoCommand.ExecuteAsync(null).GetAwaiter().GetResult();
-            Assert.Equal("CompanyLogoPath", settings.SavedKey);
-            Assert.Equal(expected, settings.SavedValue);
+                var vm = new SettingsViewModel(new StubFileDialogService(), settings, new StubDialogService())
+                {
+                    CompanyLogoPath = file
+                };
+                var expected = Path.GetRelativePath(baseDir, file);
+                vm.SaveCompanyLogoCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+                Assert.Equal("CompanyLogoPath", settings.SavedKey);
+                Assert.Equal(expected, settings.SavedValue);
+                Assert.Equal(expected, vm.CompanyLogoPath);
+            }
+            finally
+            {
+                if (File.Exists(file)) File.Delete(file);
+            }
+        }
+
+        [Fact]
+        public void SaveCompanyLogoCommand_CopiesExternalFile()
+        {
+            var settings = new StubSettingsService();
+            var external = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".png");
+            File.WriteAllText(external, "data");
+            try
+            {
+                var vm = new SettingsViewModel(new StubFileDialogService(), settings, new StubDialogService())
+                {
+                    CompanyLogoPath = external
+                };
+                vm.SaveCompanyLogoCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+                var expected = Path.Combine("Assets", "CompanyLogo", Path.GetFileName(external));
+                Assert.Equal(expected, settings.SavedValue);
+                Assert.Equal(expected, vm.CompanyLogoPath);
+                Assert.True(File.Exists(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, expected)));
+            }
+            finally
+            {
+                if (File.Exists(external)) File.Delete(external);
+                var copied = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets", "CompanyLogo", Path.GetFileName(external));
+                if (File.Exists(copied)) File.Delete(copied);
+            }
         }
 
         [Fact]

--- a/ToolManagementAppV2.Tests/Views/SettingsPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/SettingsPageTests.cs
@@ -56,12 +56,56 @@ namespace ToolManagementAppV2.Tests.Views
                     };
                     var page = new SettingsPage { DataContext = vm };
                     vm.SaveCompanyLogoCommand.Execute(null);
+                    vm.SaveCompanyLogoCommand.ExecutionTask?.GetAwaiter().GetResult();
                     Assert.Equal("Selected logo path is invalid.", dialog.LastMessage);
                     app.Shutdown();
                 }
                 catch (Exception ex)
                 {
                     threadException = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadException != null)
+                throw threadException;
+        }
+
+        [Fact]
+        public void SaveCompanyLogoCommand_CopiesExternalFile()
+        {
+            Exception? threadException = null;
+            var thread = new Thread(() =>
+            {
+                string? external = null;
+                try
+                {
+                    var app = new System.Windows.Application();
+                    var settings = new StubSettingsService();
+                    external = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".png");
+                    File.WriteAllText(external, "data");
+                    var vm = new SettingsViewModel(new StubFileDialogService(), settings, new StubDialogService())
+                    {
+                        CompanyLogoPath = external
+                    };
+                    var page = new SettingsPage { DataContext = vm };
+                    vm.SaveCompanyLogoCommand.Execute(null);
+                    vm.SaveCompanyLogoCommand.ExecutionTask?.GetAwaiter().GetResult();
+                    var expected = Path.Combine("Assets", "CompanyLogo", Path.GetFileName(external));
+                    Assert.Equal(expected, settings.SavedValue);
+                    Assert.True(File.Exists(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, expected)));
+                    app.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+                finally
+                {
+                    if (external != null && File.Exists(external)) File.Delete(external);
+                    var copied = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets", "CompanyLogo", Path.GetFileName(external));
+                    if (File.Exists(copied)) File.Delete(copied);
                 }
             });
             thread.SetApartmentState(ApartmentState.STA);

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -2,11 +2,11 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Utilities.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -195,29 +195,72 @@ namespace ToolManagementAppV2.ViewModels
 
         async Task SaveCompanyLogoAsync(CancellationToken token = default)
         {
-            var full = PathHelper.GetAbsolutePath(CompanyLogoPath);
-            if (string.IsNullOrEmpty(full))
+            if (string.IsNullOrWhiteSpace(CompanyLogoPath))
             {
                 _dialogService.ShowInfo("Selected logo path is invalid.", "Invalid Path");
                 return;
             }
 
+            string baseDir = Path.GetFullPath(AppDomain.CurrentDomain.BaseDirectory);
+            string fullInputPath;
+
             try
             {
-                await _settingsService.SaveSettingAsync("CompanyLogoPath", full, token).ConfigureAwait(false);
+                fullInputPath = Path.GetFullPath(CompanyLogoPath);
             }
-            catch (UnauthorizedAccessException ex)
+            catch
             {
-                _logger.LogWarning(ex, "Unauthorized to change settings.");
-                _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+                _dialogService.ShowInfo("Selected logo path is invalid.", "Invalid Path");
+                return;
             }
-            catch (OperationCanceledException ex)
+
+            if (!File.Exists(fullInputPath))
             {
-                _logger.LogInformation(ex, "Saving company logo was canceled.");
+                _dialogService.ShowInfo("Selected logo path is invalid.", "Invalid Path");
+                return;
+            }
+
+            string relativePath;
+            try
+            {
+                if (!fullInputPath.StartsWith(baseDir, StringComparison.OrdinalIgnoreCase))
+                {
+                    var assetsDir = Path.Combine(baseDir, "Assets", "CompanyLogo");
+                    Directory.CreateDirectory(assetsDir);
+                    var fileName = Path.GetFileName(fullInputPath);
+                    var destPath = Path.Combine(assetsDir, fileName);
+                    File.Copy(fullInputPath, destPath, true);
+                    relativePath = Path.GetRelativePath(baseDir, destPath);
+                }
+                else
+                {
+                    relativePath = Path.GetRelativePath(baseDir, fullInputPath);
+                }
+
+                CompanyLogoPath = relativePath;
+
+                try
+                {
+                    await _settingsService.SaveSettingAsync("CompanyLogoPath", relativePath, token).ConfigureAwait(false);
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    _logger.LogWarning(ex, "Unauthorized to change settings.");
+                    _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+                }
+                catch (OperationCanceledException ex)
+                {
+                    _logger.LogInformation(ex, "Saving company logo was canceled.");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to save company logo path.");
+                }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to save company logo path.");
+                _logger.LogError(ex, "Failed to copy company logo.");
+                _dialogService.ShowInfo("Failed to save company logo.", "Error");
             }
         }
     }


### PR DESCRIPTION
## Summary
- copy company logo files into `Assets/CompanyLogo` when selected from outside the app directory
- store company logo paths as relative paths in settings
- add unit and UI tests for saving external company logos

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a42a7f9ef483249a66ed637cd85108