### PR TITLE
Use theme styles for search results

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ToolSearchPageBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ToolSearchPageBindingTests.cs
@@ -47,7 +47,8 @@ namespace ToolManagementAppV2.Tests.Tests
                     Assert.Null(ex);
 
                     var template = page.HandToolsList.ItemTemplate;
-                    var grid = Assert.IsType<Grid>(template.LoadContent());
+                    var outer = Assert.IsType<Border>(template.LoadContent());
+                    var grid = Assert.IsType<Grid>(outer.Child);
                     var border = Assert.IsType<Border>(grid.Children[0]);
                     var image = Assert.IsType<Image>(border.Child);
                     var binding = BindingOperations.GetBinding(image, Image.SourceProperty);

--- a/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
@@ -22,7 +22,7 @@ namespace ToolManagementAppV2.Tests.Tests
             Assert.Equal(ScrollBarVisibility.Auto, ScrollViewer.GetHorizontalScrollBarVisibility(page.HandToolsList));
             Assert.Equal(ScrollBarVisibility.Disabled, ScrollViewer.GetVerticalScrollBarVisibility(page.HandToolsList));
             Assert.True(VirtualizingStackPanel.GetIsVirtualizing(page.HandToolsList));
-            Assert.IsType<Grid>(page.HandToolsList.ItemTemplate.LoadContent());
+            Assert.IsType<Border>(page.HandToolsList.ItemTemplate.LoadContent());
 
             var powerPanel = page.PowerToolsList.ItemsPanel.LoadContent();
             var powerStack = Assert.IsType<VirtualizingStackPanel>(powerPanel);

--- a/ToolManagementAppV2/Resources/Templates.xaml
+++ b/ToolManagementAppV2/Resources/Templates.xaml
@@ -17,20 +17,22 @@
         <WrapPanel Orientation="Horizontal" ItemWidth="260" ItemHeight="100"/>
     </ItemsPanelTemplate>
     <DataTemplate x:Key="ToolCardTemplate">
-        <Grid Width="220" Margin="6">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="140"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-            <Border Background="#0e1420" CornerRadius="8" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1">
-                <Image Stretch="UniformToFill"
-                       Source="{Binding ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=tool}"/>
-            </Border>
-            <StackPanel Grid.Row="1" Margin="0,6,0,0">
-                <TextBlock Text="{Binding NameDescription}" FontWeight="SemiBold" FontSize="13"/>
-                <TextBlock Text="{Binding ToolNumber}" Foreground="{StaticResource ForegroundMutedBrush}" FontSize="12"/>
-            </StackPanel>
-        </Grid>
+        <Border Style="{StaticResource Card}" Width="220" Padding="0">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="140"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <Border Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" CornerRadius="8">
+                    <Image Stretch="UniformToFill"
+                           Source="{Binding ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=tool}"/>
+                </Border>
+                <StackPanel Grid.Row="1" Margin="0,6,0,0">
+                    <TextBlock Text="{Binding NameDescription}" FontWeight="SemiBold" FontSize="13"/>
+                    <TextBlock Text="{Binding ToolNumber}" Foreground="{StaticResource ForegroundMutedBrush}" FontSize="12"/>
+                </StackPanel>
+            </Grid>
+        </Border>
     </DataTemplate>
 
     <!-- Shared rental DataGrid columns -->


### PR DESCRIPTION
## Summary
- Use card theme for tool search results so list items match app styling
- Update layout and binding tests for new result template structure

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4349d55548324bc3da1078943c6a1