### PR TITLE
Use single tools list in search page

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -60,8 +60,8 @@ namespace ToolManagementAppV2.Tests.Tests
 
                 var page = Assert.IsType<ToolSearchPage>(vm.CurrentPage);
                 Assert.Same(vm.ToolManagement, page.DataContext);
-                Assert.Same(vm.ToolManagement.HandTools, page.HandToolsList.ItemsSource);
-                Assert.NotEmpty(vm.ToolManagement.HandTools);
+                Assert.Same(vm.ToolManagement.SearchResults, page.ToolsList.ItemsSource);
+                Assert.NotEmpty(vm.ToolManagement.SearchResults);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Tests/ToolSearchPageBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ToolSearchPageBindingTests.cs
@@ -13,7 +13,7 @@ namespace ToolManagementAppV2.Tests.Tests
     public class ToolSearchPageBindingTests
     {
         [Fact]
-        public void HandToolsList_UsesNullToDefaultImageConverter()
+        public void ToolsList_UsesNullToDefaultImageConverter()
         {
             Exception? threadEx = null;
             var thread = new Thread(() =>
@@ -46,7 +46,7 @@ namespace ToolManagementAppV2.Tests.Tests
                     var ex = Record.Exception(() => page = new ToolSearchPage());
                     Assert.Null(ex);
 
-                    var template = page.HandToolsList.ItemTemplate;
+                    var template = page.ToolsList.ItemTemplate;
                     var outer = Assert.IsType<Border>(template.LoadContent());
                     var grid = Assert.IsType<Grid>(outer.Child);
                     var border = Assert.IsType<Border>(grid.Children[0]);

--- a/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
@@ -12,54 +12,36 @@ namespace ToolManagementAppV2.Tests.Tests
     public class ToolSearchPageLayoutTests
     {
         [Fact]
-        public void ToolLists_UseHorizontalVirtualizingStackPanel()
+        public void ToolsList_UsesHorizontalVirtualizingStackPanel()
         {
             var page = new ToolSearchPage();
 
-            var handPanel = page.HandToolsList.ItemsPanel.LoadContent();
-            var handStack = Assert.IsType<VirtualizingStackPanel>(handPanel);
-            Assert.Equal(Orientation.Horizontal, handStack.Orientation);
-            Assert.Equal(ScrollBarVisibility.Auto, ScrollViewer.GetHorizontalScrollBarVisibility(page.HandToolsList));
-            Assert.Equal(ScrollBarVisibility.Disabled, ScrollViewer.GetVerticalScrollBarVisibility(page.HandToolsList));
-            Assert.True(VirtualizingStackPanel.GetIsVirtualizing(page.HandToolsList));
-            Assert.IsType<Border>(page.HandToolsList.ItemTemplate.LoadContent());
-
-            var powerPanel = page.PowerToolsList.ItemsPanel.LoadContent();
-            var powerStack = Assert.IsType<VirtualizingStackPanel>(powerPanel);
-            Assert.Equal(Orientation.Horizontal, powerStack.Orientation);
-            Assert.Equal(ScrollBarVisibility.Auto, ScrollViewer.GetHorizontalScrollBarVisibility(page.PowerToolsList));
-            Assert.Equal(ScrollBarVisibility.Disabled, ScrollViewer.GetVerticalScrollBarVisibility(page.PowerToolsList));
-            Assert.True(VirtualizingStackPanel.GetIsVirtualizing(page.PowerToolsList));
+            var panel = page.ToolsList.ItemsPanel.LoadContent();
+            var stack = Assert.IsType<VirtualizingStackPanel>(panel);
+            Assert.Equal(Orientation.Horizontal, stack.Orientation);
+            Assert.Equal(ScrollBarVisibility.Auto, ScrollViewer.GetHorizontalScrollBarVisibility(page.ToolsList));
+            Assert.Equal(ScrollBarVisibility.Disabled, ScrollViewer.GetVerticalScrollBarVisibility(page.ToolsList));
+            Assert.True(VirtualizingStackPanel.GetIsVirtualizing(page.ToolsList));
+            Assert.IsType<Border>(page.ToolsList.ItemTemplate.LoadContent());
         }
 
         [Fact]
-        public void ToolLists_VirtualizeLargeCollections()
+        public void ToolsList_VirtualizesLargeCollections()
         {
             var page = new ToolSearchPage();
-            page.HandToolsList.ItemsSource = Enumerable.Range(0, 1000)
+            page.ToolsList.ItemsSource = Enumerable.Range(0, 1000)
                 .Select(i => new Tool { ToolID = i, NameDescription = $"Tool {i}" })
                 .ToList();
-            page.PowerToolsList.ItemsSource = Enumerable.Range(0, 1000)
-                .Select(i => new Tool { ToolID = i, NameDescription = $"Power {i}" })
-                .ToList();
 
-            page.HandToolsList.Measure(new Size(800, 300));
-            page.HandToolsList.Arrange(new Rect(0, 0, 800, 300));
-            page.HandToolsList.UpdateLayout();
+            page.ToolsList.Measure(new Size(800, 300));
+            page.ToolsList.Arrange(new Rect(0, 0, 800, 300));
+            page.ToolsList.UpdateLayout();
 
-            page.PowerToolsList.Measure(new Size(800, 300));
-            page.PowerToolsList.Arrange(new Rect(0, 0, 800, 300));
-            page.PowerToolsList.UpdateLayout();
+            Assert.NotNull(page.ToolsList.ItemContainerGenerator.ContainerFromIndex(0));
+            Assert.Null(page.ToolsList.ItemContainerGenerator.ContainerFromIndex(999));
 
-            Assert.NotNull(page.HandToolsList.ItemContainerGenerator.ContainerFromIndex(0));
-            Assert.Null(page.HandToolsList.ItemContainerGenerator.ContainerFromIndex(999));
-            Assert.NotNull(page.PowerToolsList.ItemContainerGenerator.ContainerFromIndex(0));
-            Assert.Null(page.PowerToolsList.ItemContainerGenerator.ContainerFromIndex(999));
-
-            var handFirst = (FrameworkElement)page.HandToolsList.ItemContainerGenerator.ContainerFromIndex(0);
-            var powerFirst = (FrameworkElement)page.PowerToolsList.ItemContainerGenerator.ContainerFromIndex(0);
-            Assert.True(handFirst.ActualWidth > 0 && handFirst.ActualHeight > 0);
-            Assert.True(powerFirst.ActualWidth > 0 && powerFirst.ActualHeight > 0);
+            var first = (FrameworkElement)page.ToolsList.ItemContainerGenerator.ContainerFromIndex(0);
+            Assert.True(first.ActualWidth > 0 && first.ActualHeight > 0);
         }
 
         [Fact]

--- a/ToolManagementAppV2/Views/ToolSearchPage.xaml
+++ b/ToolManagementAppV2/Views/ToolSearchPage.xaml
@@ -7,7 +7,6 @@
     <Grid Margin="8">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Border Style="{StaticResource Card}">
@@ -25,36 +24,19 @@
                 <Button Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Search" Command="{Binding SearchCommand}" Margin="8,0,0,0"/>
             </Grid>
         </Border>
-        <TextBlock Grid.Row="1" Text="Hand Tools" Margin="4,8,0,4" FontWeight="SemiBold"/>
-        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Auto">
-            <StackPanel>
-                <ListBox x:Name="HandToolsList"
-                         ItemsSource="{Binding HandTools}"
-                         ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                         ScrollViewer.VerticalScrollBarVisibility="Disabled"
-                         VirtualizingPanel.IsVirtualizing="True"
-                         VirtualizingPanel.VirtualizationMode="Recycling"
-                         Margin="0,0,0,12" ItemTemplate="{StaticResource ToolCardTemplate}" av:ItemsSource="{av:SampleData ItemCount=5}">
-                    <ListBox.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <VirtualizingStackPanel Orientation="Horizontal"/>
-                        </ItemsPanelTemplate>
-                    </ListBox.ItemsPanel>
-                </ListBox>
-                <TextBlock Text="Power Tools" Margin="4,0,0,4" FontWeight="SemiBold"/>
-                <ListBox x:Name="PowerToolsList"
-                         ItemsSource="{Binding PowerTools}"
-                         ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                         ScrollViewer.VerticalScrollBarVisibility="Disabled"
-                         VirtualizingPanel.IsVirtualizing="True"
-                         VirtualizingPanel.VirtualizationMode="Recycling" ItemTemplate="{StaticResource ToolCardTemplate}" av:ItemsSource="{av:SampleData ItemCount=5}">
-                    <ListBox.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <VirtualizingStackPanel Orientation="Horizontal"/>
-                        </ItemsPanelTemplate>
-                    </ListBox.ItemsPanel>
-                </ListBox>
-            </StackPanel>
-        </ScrollViewer>
+        <ListBox x:Name="ToolsList" Grid.Row="1"
+                 ItemsSource="{Binding SearchResults}"
+                 ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                 ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                 VirtualizingPanel.IsVirtualizing="True"
+                 VirtualizingPanel.VirtualizationMode="Recycling"
+                 ItemTemplate="{StaticResource ToolCardTemplate}"
+                 av:ItemsSource="{av:SampleData ItemCount=5}">
+            <ListBox.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel Orientation="Horizontal"/>
+                </ItemsPanelTemplate>
+            </ListBox.ItemsPanel>
+        </ListBox>
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- Simplify tool search UI to use one horizontally virtualized list bound to search results
- Align tests with unified tools list

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a438f746bc8324865c570672e3349e