### PR TITLE
Streamline tool listing by using SearchResults

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -60,8 +60,8 @@ namespace ToolManagementAppV2.Tests.Tests
 
                 var page = Assert.IsType<ToolSearchPage>(vm.CurrentPage);
                 Assert.Same(vm.ToolManagement, page.DataContext);
-                Assert.Same(vm.ToolManagement.HandTools, page.HandToolsList.ItemsSource);
-                Assert.NotEmpty(vm.ToolManagement.HandTools);
+                Assert.Same(vm.ToolManagement.SearchResults, page.SearchResultsList.ItemsSource);
+                Assert.NotEmpty(vm.ToolManagement.SearchResults);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Tests/ToolSearchPageBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ToolSearchPageBindingTests.cs
@@ -13,7 +13,7 @@ namespace ToolManagementAppV2.Tests.Tests
     public class ToolSearchPageBindingTests
     {
         [Fact]
-        public void HandToolsList_UsesNullToDefaultImageConverter()
+        public void SearchResultsList_UsesNullToDefaultImageConverter()
         {
             Exception? threadEx = null;
             var thread = new Thread(() =>
@@ -46,7 +46,7 @@ namespace ToolManagementAppV2.Tests.Tests
                     var ex = Record.Exception(() => page = new ToolSearchPage());
                     Assert.Null(ex);
 
-                    var template = page.HandToolsList.ItemTemplate;
+                    var template = page.SearchResultsList.ItemTemplate;
                     var outer = Assert.IsType<Border>(template.LoadContent());
                     var grid = Assert.IsType<Grid>(outer.Child);
                     var border = Assert.IsType<Border>(grid.Children[0]);

--- a/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
@@ -12,54 +12,36 @@ namespace ToolManagementAppV2.Tests.Tests
     public class ToolSearchPageLayoutTests
     {
         [Fact]
-        public void ToolLists_UseHorizontalVirtualizingStackPanel()
+        public void ToolList_UsesHorizontalVirtualizingStackPanel()
         {
             var page = new ToolSearchPage();
 
-            var handPanel = page.HandToolsList.ItemsPanel.LoadContent();
-            var handStack = Assert.IsType<VirtualizingStackPanel>(handPanel);
-            Assert.Equal(Orientation.Horizontal, handStack.Orientation);
-            Assert.Equal(ScrollBarVisibility.Auto, ScrollViewer.GetHorizontalScrollBarVisibility(page.HandToolsList));
-            Assert.Equal(ScrollBarVisibility.Disabled, ScrollViewer.GetVerticalScrollBarVisibility(page.HandToolsList));
-            Assert.True(VirtualizingStackPanel.GetIsVirtualizing(page.HandToolsList));
-            Assert.IsType<Border>(page.HandToolsList.ItemTemplate.LoadContent());
-
-            var powerPanel = page.PowerToolsList.ItemsPanel.LoadContent();
-            var powerStack = Assert.IsType<VirtualizingStackPanel>(powerPanel);
-            Assert.Equal(Orientation.Horizontal, powerStack.Orientation);
-            Assert.Equal(ScrollBarVisibility.Auto, ScrollViewer.GetHorizontalScrollBarVisibility(page.PowerToolsList));
-            Assert.Equal(ScrollBarVisibility.Disabled, ScrollViewer.GetVerticalScrollBarVisibility(page.PowerToolsList));
-            Assert.True(VirtualizingStackPanel.GetIsVirtualizing(page.PowerToolsList));
+            var panel = page.SearchResultsList.ItemsPanel.LoadContent();
+            var stack = Assert.IsType<VirtualizingStackPanel>(panel);
+            Assert.Equal(Orientation.Horizontal, stack.Orientation);
+            Assert.Equal(ScrollBarVisibility.Auto, ScrollViewer.GetHorizontalScrollBarVisibility(page.SearchResultsList));
+            Assert.Equal(ScrollBarVisibility.Disabled, ScrollViewer.GetVerticalScrollBarVisibility(page.SearchResultsList));
+            Assert.True(VirtualizingStackPanel.GetIsVirtualizing(page.SearchResultsList));
+            Assert.IsType<Border>(page.SearchResultsList.ItemTemplate.LoadContent());
         }
 
         [Fact]
-        public void ToolLists_VirtualizeLargeCollections()
+        public void ToolList_VirtualizesLargeCollections()
         {
             var page = new ToolSearchPage();
-            page.HandToolsList.ItemsSource = Enumerable.Range(0, 1000)
+            page.SearchResultsList.ItemsSource = Enumerable.Range(0, 1000)
                 .Select(i => new Tool { ToolID = i, NameDescription = $"Tool {i}" })
                 .ToList();
-            page.PowerToolsList.ItemsSource = Enumerable.Range(0, 1000)
-                .Select(i => new Tool { ToolID = i, NameDescription = $"Power {i}" })
-                .ToList();
 
-            page.HandToolsList.Measure(new Size(800, 300));
-            page.HandToolsList.Arrange(new Rect(0, 0, 800, 300));
-            page.HandToolsList.UpdateLayout();
+            page.SearchResultsList.Measure(new Size(800, 300));
+            page.SearchResultsList.Arrange(new Rect(0, 0, 800, 300));
+            page.SearchResultsList.UpdateLayout();
 
-            page.PowerToolsList.Measure(new Size(800, 300));
-            page.PowerToolsList.Arrange(new Rect(0, 0, 800, 300));
-            page.PowerToolsList.UpdateLayout();
+            Assert.NotNull(page.SearchResultsList.ItemContainerGenerator.ContainerFromIndex(0));
+            Assert.Null(page.SearchResultsList.ItemContainerGenerator.ContainerFromIndex(999));
 
-            Assert.NotNull(page.HandToolsList.ItemContainerGenerator.ContainerFromIndex(0));
-            Assert.Null(page.HandToolsList.ItemContainerGenerator.ContainerFromIndex(999));
-            Assert.NotNull(page.PowerToolsList.ItemContainerGenerator.ContainerFromIndex(0));
-            Assert.Null(page.PowerToolsList.ItemContainerGenerator.ContainerFromIndex(999));
-
-            var handFirst = (FrameworkElement)page.HandToolsList.ItemContainerGenerator.ContainerFromIndex(0);
-            var powerFirst = (FrameworkElement)page.PowerToolsList.ItemContainerGenerator.ContainerFromIndex(0);
-            Assert.True(handFirst.ActualWidth > 0 && handFirst.ActualHeight > 0);
-            Assert.True(powerFirst.ActualWidth > 0 && powerFirst.ActualHeight > 0);
+            var first = (FrameworkElement)page.SearchResultsList.ItemContainerGenerator.ContainerFromIndex(0);
+            Assert.True(first.ActualWidth > 0 && first.ActualHeight > 0);
         }
 
         [Fact]

--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -76,7 +76,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task SearchCommand_SortsResultsIntoCategories()
+        public async Task SearchCommand_PopulatesSearchResults()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -91,8 +91,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Cordless Drill", IsPowerTool = true });
                 vm.SearchTerm = string.Empty;
                 await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
-                Assert.Single(vm.HandTools);
-                Assert.Single(vm.PowerTools);
+                Assert.Equal(2, vm.SearchResults.Count);
             }
             finally
             {

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -26,8 +26,6 @@ namespace ToolManagementAppV2.ViewModels
 
         public ObservableCollection<ToolModel> Tools { get; } = new();
         public ObservableCollection<ToolModel> SearchResults { get; } = new();
-        public ObservableCollection<ToolModel> HandTools { get; } = new();
-        public ObservableCollection<ToolModel> PowerTools { get; } = new();
 
         /// <summary>
         /// List of available tool categories derived from distinct brands
@@ -161,7 +159,6 @@ namespace ToolManagementAppV2.ViewModels
                 var all = await _toolService.GetAllToolsAsync();
                 Tools.ReplaceRange(all);
                 SearchResults.ReplaceRange(all);
-                CategorizeTools(all);
                 LoadCategories(Tools);
             }
             finally
@@ -200,7 +197,6 @@ namespace ToolManagementAppV2.ViewModels
             }
 
             SearchResults.ReplaceRange(source);
-            CategorizeTools(source);
             LoadCategories(source, suppressSearch: true);
         }
 
@@ -363,14 +359,6 @@ namespace ToolManagementAppV2.ViewModels
                 await _dialogService.ShowInfoAsync($"Failed to rent tool: {ex.Message}", "Error");
             }
         }
-
-        void CategorizeTools(IEnumerable<ToolModel> tools)
-        {
-            HandTools.ReplaceRange(tools.Where(t => !IsPowerTool(t)));
-            PowerTools.ReplaceRange(tools.Where(IsPowerTool));
-        }
-
-        static bool IsPowerTool(ToolModel tool) => tool?.IsPowerTool == true;
 
         void LoadCategories(IEnumerable<ToolModel> tools, bool suppressSearch = false)
         {

--- a/ToolManagementAppV2/Views/ToolSearchPage.xaml
+++ b/ToolManagementAppV2/Views/ToolSearchPage.xaml
@@ -25,36 +25,21 @@
                 <Button Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Search" Command="{Binding SearchCommand}" Margin="8,0,0,0"/>
             </Grid>
         </Border>
-        <TextBlock Grid.Row="1" Text="Hand Tools" Margin="4,8,0,4" FontWeight="SemiBold"/>
+        <TextBlock Grid.Row="1" Text="Tools" Margin="4,8,0,4" FontWeight="SemiBold"/>
         <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Auto">
-            <StackPanel>
-                <ListBox x:Name="HandToolsList"
-                         ItemsSource="{Binding HandTools}"
-                         ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                         ScrollViewer.VerticalScrollBarVisibility="Disabled"
-                         VirtualizingPanel.IsVirtualizing="True"
-                         VirtualizingPanel.VirtualizationMode="Recycling"
-                         Margin="0,0,0,12" ItemTemplate="{StaticResource ToolCardTemplate}" av:ItemsSource="{av:SampleData ItemCount=5}">
-                    <ListBox.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <VirtualizingStackPanel Orientation="Horizontal"/>
-                        </ItemsPanelTemplate>
-                    </ListBox.ItemsPanel>
-                </ListBox>
-                <TextBlock Text="Power Tools" Margin="4,0,0,4" FontWeight="SemiBold"/>
-                <ListBox x:Name="PowerToolsList"
-                         ItemsSource="{Binding PowerTools}"
-                         ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                         ScrollViewer.VerticalScrollBarVisibility="Disabled"
-                         VirtualizingPanel.IsVirtualizing="True"
-                         VirtualizingPanel.VirtualizationMode="Recycling" ItemTemplate="{StaticResource ToolCardTemplate}" av:ItemsSource="{av:SampleData ItemCount=5}">
-                    <ListBox.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <VirtualizingStackPanel Orientation="Horizontal"/>
-                        </ItemsPanelTemplate>
-                    </ListBox.ItemsPanel>
-                </ListBox>
-            </StackPanel>
+            <ListBox x:Name="SearchResultsList"
+                     ItemsSource="{Binding SearchResults}"
+                     ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                     ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                     VirtualizingPanel.IsVirtualizing="True"
+                     VirtualizingPanel.VirtualizationMode="Recycling"
+                     ItemTemplate="{StaticResource ToolCardTemplate}" av:ItemsSource="{av:SampleData ItemCount=5}">
+                <ListBox.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel Orientation="Horizontal"/>
+                    </ItemsPanelTemplate>
+                </ListBox.ItemsPanel>
+            </ListBox>
         </ScrollViewer>
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- drop HandTools/PowerTools collections and related categorization logic
- show a single SearchResults list on the tool search page
- update tests for consolidated tool list

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a43941c04c8324b13526486e9ed590