### PR TITLE
Remove tool categorization collections

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -76,7 +76,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task SearchCommand_SortsResultsIntoCategories()
+        public async Task SearchCommand_ReturnsAllTools_WhenNoSearchTerm()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -91,8 +91,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Cordless Drill", IsPowerTool = true });
                 vm.SearchTerm = string.Empty;
                 await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
-                Assert.Single(vm.HandTools);
-                Assert.Single(vm.PowerTools);
+                Assert.Equal(2, vm.SearchResults.Count);
+                Assert.Contains(vm.SearchResults, t => t.NameDescription == "Hammer");
+                Assert.Contains(vm.SearchResults, t => t.NameDescription == "Cordless Drill");
             }
             finally
             {

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -26,8 +26,6 @@ namespace ToolManagementAppV2.ViewModels
 
         public ObservableCollection<ToolModel> Tools { get; } = new();
         public ObservableCollection<ToolModel> SearchResults { get; } = new();
-        public ObservableCollection<ToolModel> HandTools { get; } = new();
-        public ObservableCollection<ToolModel> PowerTools { get; } = new();
 
         /// <summary>
         /// List of available tool categories derived from distinct brands
@@ -161,7 +159,6 @@ namespace ToolManagementAppV2.ViewModels
                 var all = await _toolService.GetAllToolsAsync();
                 Tools.ReplaceRange(all);
                 SearchResults.ReplaceRange(all);
-                CategorizeTools(all);
                 LoadCategories(Tools);
             }
             finally
@@ -200,7 +197,6 @@ namespace ToolManagementAppV2.ViewModels
             }
 
             SearchResults.ReplaceRange(source);
-            CategorizeTools(source);
             LoadCategories(source, suppressSearch: true);
         }
 
@@ -363,14 +359,6 @@ namespace ToolManagementAppV2.ViewModels
                 await _dialogService.ShowInfoAsync($"Failed to rent tool: {ex.Message}", "Error");
             }
         }
-
-        void CategorizeTools(IEnumerable<ToolModel> tools)
-        {
-            HandTools.ReplaceRange(tools.Where(t => !IsPowerTool(t)));
-            PowerTools.ReplaceRange(tools.Where(IsPowerTool));
-        }
-
-        static bool IsPowerTool(ToolModel tool) => tool?.IsPowerTool == true;
 
         void LoadCategories(IEnumerable<ToolModel> tools, bool suppressSearch = false)
         {


### PR DESCRIPTION
## Summary
- remove HandTools and PowerTools collections and related categorization logic
- rely solely on SearchResults for displaying tools
- adjust tests to reflect new search behavior

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a43bb72cc88324a780d004ca543310