### PR TITLE
Align tests with unified tool list

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -60,8 +60,8 @@ namespace ToolManagementAppV2.Tests.Tests
 
                 var page = Assert.IsType<ToolSearchPage>(vm.CurrentPage);
                 Assert.Same(vm.ToolManagement, page.DataContext);
-                Assert.Same(vm.ToolManagement.SearchResults, page.ToolsList.ItemsSource);
-                Assert.NotEmpty(vm.ToolManagement.SearchResults);
+                Assert.Same(vm.ToolManagement.Tools, page.ToolsList.ItemsSource);
+                Assert.NotEmpty(vm.ToolManagement.Tools);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Tests/ToolSearchPageBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ToolSearchPageBindingTests.cs
@@ -46,14 +46,17 @@ namespace ToolManagementAppV2.Tests.Tests
                     var ex = Record.Exception(() => page = new ToolSearchPage());
                     Assert.Null(ex);
 
+                    var itemsBinding = BindingOperations.GetBinding(page.ToolsList, ItemsControl.ItemsSourceProperty);
+                    Assert.Equal("Tools", itemsBinding?.Path.Path);
+
                     var template = page.ToolsList.ItemTemplate;
                     var outer = Assert.IsType<Border>(template.LoadContent());
                     var grid = Assert.IsType<Grid>(outer.Child);
                     var border = Assert.IsType<Border>(grid.Children[0]);
                     var image = Assert.IsType<Image>(border.Child);
-                    var binding = BindingOperations.GetBinding(image, Image.SourceProperty);
-                    Assert.NotNull(binding);
-                    Assert.IsType<NullToDefaultImageConverter>(binding!.Converter);
+                    var imageBinding = BindingOperations.GetBinding(image, Image.SourceProperty);
+                    Assert.NotNull(imageBinding);
+                    Assert.IsType<NullToDefaultImageConverter>(imageBinding!.Converter);
 
                     if (createdApp)
                         app.Shutdown();

--- a/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
@@ -12,7 +12,7 @@ namespace ToolManagementAppV2.Tests.Tests
     public class ToolSearchPageLayoutTests
     {
         [Fact]
-        public void ToolsList_UsesHorizontalVirtualizingStackPanel()
+        public void SingleList_UsesHorizontalVirtualizingStackPanel()
         {
             var page = new ToolSearchPage();
 
@@ -26,7 +26,7 @@ namespace ToolManagementAppV2.Tests.Tests
         }
 
         [Fact]
-        public void ToolsList_VirtualizesLargeCollections()
+        public void SingleList_VirtualizesLargeCollections()
         {
             var page = new ToolSearchPage();
             page.ToolsList.ItemsSource = Enumerable.Range(0, 1000)

--- a/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolManagementViewModelTests.cs
@@ -103,32 +103,6 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task SearchCommand_FiltersToolsBySelectedCategory()
-        {
-            var dbPath = Path.GetTempFileName();
-            try
-            {
-                var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
-                var customerService = new CustomerService(db);
-                var rentalService = new RentalService(db);
-                var dialog = new StubDialogService();
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
-                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
-                toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw", Brand = "BrandB" });
-                vm.SelectedCategory = "BrandA";
-                await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
-                Assert.Single(vm.SearchResults);
-                Assert.Equal("BrandA", vm.SearchResults.First().Brand);
-            }
-            finally
-            {
-                if (File.Exists(dbPath))
-                    File.Delete(dbPath);
-            }
-        }
-
-        [Fact]
         public async Task Categories_Update_WhenToolsCollectionChanges()
         {
             var dbPath = Path.GetTempFileName();


### PR DESCRIPTION
## Summary
- remove outdated category-based search test
- assert navigation binds page list to unified `Tools` collection
- verify search page list binds to `Tools` and adjust layout tests for single list

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a43daafa7483249cbd1c3d829337c1