### PR TITLE
Add activity logging to core services

### DIFF
--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -14,11 +14,21 @@ using ToolManagementAppV2.Interfaces;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.Tests;
 
 namespace ToolManagementAppV2.Tests.Services
 {
     public class RentalServiceTests
     {
+        class StubUserContext : IUserContext
+        {
+            public User? CurrentUser { get; set; }
+            public event EventHandler<User?>? UserChanged;
+            public bool IsAdmin => CurrentUser?.IsAdmin ?? false;
+            public string UserName => CurrentUser?.UserName ?? string.Empty;
+            public string Role => CurrentUser?.Role ?? string.Empty;
+        }
         [Fact]
         public void GetRentalHistoryForTool_ReturnsHistory()
         {
@@ -360,6 +370,37 @@ namespace ToolManagementAppV2.Tests.Services
                 var toolAfter = toolService.GetToolByID(tool.ToolID);
                 Assert.Equal(0, toolAfter.QuantityOnHand);
                 Assert.Equal(1, toolAfter.RentedQuantity);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task RentToolAsync_LogsActivity()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var ctx = new StubUserContext { CurrentUser = new User { UserID = 1, UserName = "tester", IsAdmin = true } };
+                var auth = new AllowAllAuthorizationService();
+                var logService = new ActivityLogService(db);
+                var toolService = new ToolService(db, auth, null, logService, ctx);
+                var customerService = new CustomerService(db, auth);
+                var rentalService = new RentalService(db, auth, toolService, null, logService, ctx);
+
+                await toolService.AddToolAsync(new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, RentedQuantity = 0 });
+                await customerService.AddCustomerAsync(new Customer { Company = "Acme" });
+                var tool = (await toolService.GetAllToolsAsync()).First();
+                var cust = (await customerService.GetAllCustomersAsync()).First();
+
+                await rentalService.RentToolAsync(tool.ToolID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+
+                var logs = await logService.GetRecentLogsAsync();
+                Assert.Contains(logs.Value, l => l.Action.Contains("Rented tool"));
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -13,11 +13,20 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using ToolManagementAppV2.Tests;
+using ToolManagementAppV2.Services.Users;
 
 namespace ToolManagementAppV2.Tests.Services
 {
     public class ToolServiceTests
     {
+        class StubUserContext : IUserContext
+        {
+            public User? CurrentUser { get; set; }
+            public event EventHandler<User?>? UserChanged;
+            public bool IsAdmin => CurrentUser?.IsAdmin ?? false;
+            public string UserName => CurrentUser?.UserName ?? string.Empty;
+            public string Role => CurrentUser?.Role ?? string.Empty;
+        }
         [Fact]
         public void SearchTools_WithNull_ReturnsAllTools()
         {
@@ -103,7 +112,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var logs = new List<LogEntry>();
                 using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
                 var dbService = new DatabaseService(dbPath);
-                var service = new ToolService(dbService, loggerFactory.CreateLogger<ToolService>());
+                var service = new ToolService(dbService, logger: loggerFactory.CreateLogger<ToolService>());
 
                 service.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
 
@@ -349,7 +358,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var logs = new List<LogEntry>();
                 using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
                 var dbService = new DatabaseService(dbPath);
-                var service = new ToolService(dbService, loggerFactory.CreateLogger<ToolService>());
+                var service = new ToolService(dbService, logger: loggerFactory.CreateLogger<ToolService>());
 
                 service.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
                 var tool = service.GetAllTools().First();
@@ -454,7 +463,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var logs = new List<LogEntry>();
                 using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
                 var db = new DatabaseService(dbPath);
-                var svc = new ToolService(db, loggerFactory.CreateLogger<ToolService>());
+                var svc = new ToolService(db, logger: loggerFactory.CreateLogger<ToolService>());
                 svc.AddTool(new Tool { ToolNumber = "T1", NameDescription = "A" });
 
                 var result = svc.ImportToolImages(imgDir, t => new[] { t.ToolNumber });
@@ -650,7 +659,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var logs = new List<LogEntry>();
                 using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
                 var dbService = new DatabaseService(dbPath);
-                IToolService service = new ToolService(dbService, loggerFactory.CreateLogger<ToolService>());
+                IToolService service = new ToolService(dbService, logger: loggerFactory.CreateLogger<ToolService>());
 
                 service.AddTool(new Tool
                 {
@@ -946,6 +955,27 @@ namespace ToolManagementAppV2.Tests.Services
                 if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
                 var destDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images");
                 if (Directory.Exists(destDir)) Directory.Delete(destDir, true);
+            }
+        }
+
+        [Fact]
+        public async Task AddToolAsync_LogsActivity()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var ctx = new StubUserContext { CurrentUser = new User { UserID = 1, UserName = "tester", IsAdmin = true } };
+                var auth = new AllowAllAuthorizationService();
+                var logService = new ActivityLogService(dbService);
+                var svc = new ToolService(dbService, auth, null, logService, ctx);
+                await svc.AddToolAsync(new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, RentedQuantity = 0 });
+                var logs = await logService.GetRecentLogsAsync();
+                Assert.Contains(logs.Value, l => l.Action.Contains("Added tool"));
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
             }
         }
 

--- a/ToolManagementAppV2.Tests/Services/UserLoggingTests.cs
+++ b/ToolManagementAppV2.Tests/Services/UserLoggingTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using ToolManagementAppV2.Models;
+using ToolManagementAppV2.Models.Domain;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Users;
+using Xunit;
+
+public class UserLoggingTests
+{
+    [Fact]
+    public async Task AuthenticateUserAsync_LogsActivity()
+    {
+        var dbPath = Path.GetTempFileName();
+        try
+        {
+            var dbService = new DatabaseService(dbPath);
+            var ctx = new ApplicationUserContext();
+            var logService = new ActivityLogService(dbService);
+            var userService = new UserService(dbService, ctx, null, null, logService);
+            await userService.AddUserAsync(new User { UserName = "log", PasswordHash = "Strong1!" });
+            var auth = await userService.AuthenticateUserAsync("log", "Strong1!");
+            Assert.Equal(AuthenticationResult.Success, auth.Result);
+            var logs = await logService.GetRecentLogsAsync();
+            Assert.Contains(logs.Value, l => l.Action.Contains("User login"));
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+}
+

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -20,13 +20,17 @@ namespace ToolManagementAppV2.Services.Rentals
         private readonly IToolService? _toolService;
         private readonly ILogger<RentalService> _logger;
         private readonly IAuthorizationService _auth;
+        private readonly ActivityLogService? _activityLog;
+        private readonly IUserContext? _context;
 
-        public RentalService(DatabaseService dbService, IAuthorizationService? authorizationService = null, IToolService? toolService = null, ILogger<RentalService>? logger = null)
+        public RentalService(DatabaseService dbService, IAuthorizationService? authorizationService = null, IToolService? toolService = null, ILogger<RentalService>? logger = null, ActivityLogService? activityLogService = null, IUserContext? userContext = null)
         {
             _dbService = dbService ?? throw new ArgumentNullException(nameof(dbService));
             _auth = authorizationService ?? new NoOpAuthorizationService();
             _toolService = toolService; // may be null if inventory sync not desired
             _logger = logger ?? NullLogger<RentalService>.Instance;
+            _activityLog = activityLogService;
+            _context = userContext;
         }
 
         async Task ExecuteWithTransactionAsync(Func<SQLiteConnection, SQLiteTransaction, Task> action, Func<Task>? postCommitAction = null)
@@ -112,6 +116,11 @@ namespace ToolManagementAppV2.Services.Rentals
                 if (_toolService != null)
                     await _toolService.UpdateToolQuantitiesAsync(toolID, 1, true, conn, tx);
             });
+            if (_activityLog != null)
+            {
+                var user = _context?.CurrentUser;
+                await _activityLog.LogActionAsync(user?.UserID ?? 0, user?.UserName ?? string.Empty, $"Rented tool {toolID} to customer {customerID}").ConfigureAwait(false);
+            }
         }
 
         public async Task ReturnToolAsync(int rentalID, DateTime returnDate)
@@ -137,6 +146,11 @@ namespace ToolManagementAppV2.Services.Rentals
                 if (_toolService != null)
                     await _toolService.UpdateToolQuantitiesAsync(toolID, 1, false, conn, tx);
             });
+            if (_activityLog != null)
+            {
+                var user = _context?.CurrentUser;
+                await _activityLog.LogActionAsync(user?.UserID ?? 0, user?.UserName ?? string.Empty, $"Returned rental {rentalID}").ConfigureAwait(false);
+            }
         }
 
         public async Task ExtendRentalAsync(int rentalID, DateTime newDueDate)
@@ -171,6 +185,11 @@ namespace ToolManagementAppV2.Services.Rentals
                         await _toolService.UpdateToolQuantitiesAsync(toolID, 1, false, conn, tx);
                 }
             });
+            if (_activityLog != null)
+            {
+                var user = _context?.CurrentUser;
+                await _activityLog.LogActionAsync(user?.UserID ?? 0, user?.UserName ?? string.Empty, $"Extended rental {rentalID}").ConfigureAwait(false);
+            }
         }
 
         public async Task DeleteRentalAsync(int rentalID)
@@ -181,6 +200,11 @@ namespace ToolManagementAppV2.Services.Rentals
             using var conn = _dbService.CreateConnection();
             if (await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p) == 0)
                 throw new InvalidOperationException("Rental not found.");
+            if (_activityLog != null)
+            {
+                var user = _context?.CurrentUser;
+                await _activityLog.LogActionAsync(user?.UserID ?? 0, user?.UserName ?? string.Empty, $"Deleted rental {rentalID}").ConfigureAwait(false);
+            }
         }
 
         public async Task<List<Rental>> GetActiveRentalsAsync()

--- a/ToolManagementAppV2/Services/Tools/ToolService.cs
+++ b/ToolManagementAppV2/Services/Tools/ToolService.cs
@@ -33,12 +33,16 @@ namespace ToolManagementAppV2.Services.Tools
     
         readonly ILogger<ToolService> _logger;
         readonly IAuthorizationService _auth;
+        readonly ActivityLogService? _activityLog;
+        readonly IUserContext? _context;
 
-        public ToolService(DatabaseService dbService, IAuthorizationService? authorizationService = null, ILogger<ToolService>? logger = null)
+        public ToolService(DatabaseService dbService, IAuthorizationService? authorizationService = null, ILogger<ToolService>? logger = null, ActivityLogService? activityLogService = null, IUserContext? userContext = null)
         {
             _dbService = dbService;
             _auth = authorizationService ?? new NoOpAuthorizationService();
             _logger = logger ?? NullLogger<ToolService>.Instance;
+            _activityLog = activityLogService;
+            _context = userContext;
         }
 
         static void ValidateQuantity(int quantity)
@@ -47,28 +51,49 @@ namespace ToolManagementAppV2.Services.Tools
                 throw new ArgumentOutOfRangeException(nameof(Tool.QuantityOnHand), $"QuantityOnHand must be between 0 and {MaxQuantityOnHand}.");
         }
 
-        public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default)
+        public async Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
-            return AddToolInternalAsync(tool, cancellationToken);
+            await AddToolInternalAsync(tool, cancellationToken).ConfigureAwait(false);
+            if (_activityLog != null)
+            {
+                var user = _context?.CurrentUser;
+                await _activityLog.LogActionAsync(user?.UserID ?? 0, user?.UserName ?? string.Empty, $"Added tool {tool.ToolNumber}", cancellationToken).ConfigureAwait(false);
+            }
         }
 
-        public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default)
+        public async Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
-            return UpdateToolInternalAsync(tool, cancellationToken);
+            await UpdateToolInternalAsync(tool, cancellationToken).ConfigureAwait(false);
+            if (_activityLog != null)
+            {
+                var user = _context?.CurrentUser;
+                await _activityLog.LogActionAsync(user?.UserID ?? 0, user?.UserName ?? string.Empty, $"Updated tool {tool.ToolNumber}", cancellationToken).ConfigureAwait(false);
+            }
         }
 
-        public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default)
+        public async Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
-            return DeleteToolInternalAsync(toolID, cancellationToken);
+            await DeleteToolInternalAsync(toolID, cancellationToken).ConfigureAwait(false);
+            if (_activityLog != null)
+            {
+                var user = _context?.CurrentUser;
+                await _activityLog.LogActionAsync(user?.UserID ?? 0, user?.UserName ?? string.Empty, $"Deleted tool {toolID}", cancellationToken).ConfigureAwait(false);
+            }
         }
 
-        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default)
+        public async Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
-            return ToggleToolCheckOutStatusInternalAsync(toolID, currentUser, cancellationToken);
+            var result = await ToggleToolCheckOutStatusInternalAsync(toolID, currentUser, cancellationToken).ConfigureAwait(false);
+            if (result && _activityLog != null)
+            {
+                int userId = _context?.CurrentUser?.UserID ?? 0;
+                await _activityLog.LogActionAsync(userId, currentUser, $"Toggled tool {toolID} check-out status", cancellationToken).ConfigureAwait(false);
+            }
+            return result;
         }
 
         public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default)

--- a/ToolManagementAppV2/Services/Users/UserService.cs
+++ b/ToolManagementAppV2/Services/Users/UserService.cs
@@ -20,13 +20,15 @@ namespace ToolManagementAppV2.Services.Users
         readonly IUserContext _context;
         readonly ILogger<UserService> _logger;
         readonly IAuthorizationService _auth;
+        readonly ActivityLogService? _activityLog;
 
-        public UserService(DatabaseService dbService, IUserContext context, IAuthorizationService? authorizationService = null, ILogger<UserService>? logger = null)
+        public UserService(DatabaseService dbService, IUserContext context, IAuthorizationService? authorizationService = null, ILogger<UserService>? logger = null, ActivityLogService? activityLogService = null)
         {
             _dbService = dbService;
             _context = context;
             _auth = authorizationService ?? new NoOpAuthorizationService();
             _logger = logger ?? NullLogger<UserService>.Instance;
+            _activityLog = activityLogService;
         }
 
 
@@ -145,7 +147,13 @@ namespace ToolManagementAppV2.Services.Users
                 success = await SecurityHelper.VerifyPasswordAsync(password, u.PasswordSalt, u.PasswordHash).ConfigureAwait(false);
             }
 
-            return success ? (AuthenticationResult.Success, u) : (AuthenticationResult.IncorrectPassword, null);
+            if (success)
+            {
+                if (_activityLog != null)
+                    await _activityLog.LogActionAsync(u.UserID, u.UserName ?? string.Empty, "User login").ConfigureAwait(false);
+                return (AuthenticationResult.Success, u);
+            }
+            return (AuthenticationResult.IncorrectPassword, null);
         }
 
 


### PR DESCRIPTION
## Summary
- log user authentication events through ActivityLogService
- log tool add/update/delete and checkout toggles
- log rental operations and add unit tests for logging

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a441a8b9688324918a44c088f4135b