### PR TITLE
Ensure secondary windows close on user switch

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Windows;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
@@ -58,6 +59,60 @@ namespace ToolManagementAppV2.Tests.ViewModels
             }
             finally
             {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task SwitchUserCommand_ClosesNonMainWindows()
+        {
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
+            System.Windows.Application.Current.ShutdownMode = ShutdownMode.OnExplicitShutdown;
+            var main = new Window();
+            System.Windows.Application.Current.MainWindow = main;
+            main.Show();
+            var w1 = new Window();
+            w1.Show();
+            var w2 = new Window();
+            w2.Show();
+
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var toolService = new ToolService(db);
+                var userContext = new ApplicationUserContext();
+                var userService = new UserService(db, userContext);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
+                var dialog = new StubDialogService();
+
+                Func<Task<bool>> stubLogin = () =>
+                {
+                    userContext.CurrentUser = new User { UserName = "new", IsAdmin = true };
+                    return Task.FromResult(true);
+                };
+
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                    new StubFileDialogService(), activityLogService, settingsService, db, dialog, null, stubLogin);
+
+                await vm.SwitchUserCommand.ExecuteAsync(null);
+
+                Assert.False(w1.IsVisible);
+                Assert.False(w2.IsVisible);
+                Assert.True(main.IsVisible);
+                Assert.Single(System.Windows.Application.Current.Windows.Cast<Window>());
+            }
+            finally
+            {
+                w1.Close();
+                w2.Close();
+                main.Close();
+                System.Windows.Application.Current.Shutdown();
                 if (File.Exists(dbPath))
                     File.Delete(dbPath);
             }

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -114,6 +114,16 @@ namespace ToolManagementAppV2.ViewModels
             OnPropertyChanged(nameof(CurrentUserPhotoPath));
         }
 
+        void CloseNonMainWindows()
+        {
+            var main = Application.Current.MainWindow;
+            foreach (Window window in Application.Current.Windows.Cast<Window>().ToList())
+            {
+                if (window != main)
+                    window.Close();
+            }
+        }
+
         public IRelayCommand OpenDashboardCommand { get; }
         public IAsyncRelayCommand OpenSearchToolsCommand { get; }
         public IAsyncRelayCommand OpenManageToolsCommand { get; }
@@ -284,6 +294,7 @@ namespace ToolManagementAppV2.ViewModels
             {
                 var previousUser = _userContext.CurrentUser;
                 _userContext.CurrentUser = null;
+                CloseNonMainWindows();
                 try
                 {
                     if (await _showLoginWindow())


### PR DESCRIPTION
## Summary
- add `CloseNonMainWindows` helper to shut down all windows except the main window
- invoke helper in `SwitchUserCommand` prior to opening login dialog
- add unit test confirming non-main windows close when switching users

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a44186035c8324af7d1568b1a5b44a