### PR TITLE
Add reusable error styling and apply across login flows

### DIFF
--- a/ToolManagementAppV2/Resources/Colors.xaml
+++ b/ToolManagementAppV2/Resources/Colors.xaml
@@ -9,6 +9,7 @@
     <Color x:Key="Col.Fg">#E6F0F5</Color>
     <Color x:Key="Col.FgMuted">#93A4B3</Color>
     <Color x:Key="Col.Success">#2ECC71</Color>
+    <Color x:Key="Col.Error">#ff6b6b</Color>
     <SolidColorBrush x:Key="BackgroundBrush" Color="{StaticResource Col.Background}"/>
     <SolidColorBrush x:Key="SurfaceBrush" Color="{StaticResource Col.Surface}"/>
     <SolidColorBrush x:Key="SurfaceAltBrush" Color="{StaticResource Col.SurfaceAlt}"/>
@@ -17,6 +18,7 @@
     <SolidColorBrush x:Key="ForegroundBrush" Color="{StaticResource Col.Fg}"/>
     <SolidColorBrush x:Key="ForegroundMutedBrush" Color="{StaticResource Col.FgMuted}"/>
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource Col.Success}"/>
+    <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource Col.Error}"/>
     <Color x:Key="Col.Accent">gray</Color>
     <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource Col.Accent}"/>
     <Color x:Key="Col.CardBackground">#1F1F1F</Color>

--- a/ToolManagementAppV2/Resources/Styles.xaml
+++ b/ToolManagementAppV2/Resources/Styles.xaml
@@ -35,6 +35,9 @@
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
         <Setter Property="TextWrapping" Value="Wrap"/>
     </Style>
+    <Style x:Key="ErrorTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="Foreground" Value="{StaticResource ErrorBrush}"/>
+    </Style>
     <Style TargetType="TextBox">
         <Setter Property="Background" Value="#141C24"/>
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>

--- a/ToolManagementAppV2/Views/Windows/ChangePasswordWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ChangePasswordWindow.xaml
@@ -20,7 +20,7 @@
         <PasswordBox Grid.Row="1" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
         <TextBlock Grid.Row="2" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Foreground="{StaticResource ForegroundBrush}"/>
         <PasswordBox Grid.Row="3" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
-        <TextBlock Grid.Row="4" Text="{Binding ValidationMessage}" Margin="0,10,0,0" Foreground="Red" HorizontalAlignment="Center"/>
+        <TextBlock Grid.Row="4" Text="{Binding ValidationMessage}" Margin="0,10,0,0" Style="{StaticResource ErrorTextBlock}" HorizontalAlignment="Center"/>
         <controls:DialogButtonBar Grid.Row="5"
                                   LeftButtonText="Cancel"
                                   LeftCommand="{Binding CancelCommand}"

--- a/ToolManagementAppV2/Views/Windows/LoginWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/LoginWindow.xaml
@@ -54,7 +54,7 @@
                                         <RowDefinition Height="80"/>
                                         <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
-                                    <Border Background="#0e1420"
+                                    <Border Background="{StaticResource SurfaceAltBrush}"
                                             CornerRadius="8"
                                             BorderBrush="{StaticResource BorderBrushAlt}"
                                             BorderThickness="1"

--- a/ToolManagementAppV2/Views/Windows/PasswordPromptWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/PasswordPromptWindow.xaml
@@ -68,7 +68,7 @@
 
         <TextBlock x:Name="ErrorTextBlock"
                    Grid.Row="3"
-                   Foreground="#ff6b6b"
+                   Style="{StaticResource ErrorTextBlock}"
                    Visibility="Collapsed"
                    Margin="2,8,0,0"
                    TextWrapping="Wrap"/>

--- a/ToolManagementAppV2/Views/Windows/SetupWizardWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/SetupWizardWindow.xaml
@@ -20,7 +20,7 @@
         <PasswordBox Grid.Row="1" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
         <TextBlock Grid.Row="2" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Foreground="{StaticResource ForegroundBrush}"/>
         <PasswordBox Grid.Row="3" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
-        <TextBlock Grid.Row="4" Text="{Binding ValidationMessage}" Margin="0,10,0,0" Foreground="Red" HorizontalAlignment="Center"/>
+        <TextBlock Grid.Row="4" Text="{Binding ValidationMessage}" Margin="0,10,0,0" Style="{StaticResource ErrorTextBlock}" HorizontalAlignment="Center"/>
         <Button Grid.Row="5" Content="Generate Random" Margin="0,10,0,0" Command="{Binding GenerateCommand}" HorizontalAlignment="Center"/>
         <controls:DialogButtonBar Grid.Row="6"
                                   LeftButtonText="Cancel"


### PR DESCRIPTION
## Summary
- add error color/brush resources
- introduce ErrorTextBlock style based on ErrorBrush
- use SurfaceAltBrush for login user tiles
- apply ErrorTextBlock style to password and setup windows

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a44d3074e88324b8266dcb2e7ab0a9