### PR TITLE
Centralize shared styles

### DIFF
--- a/ToolManagementAppV2/Resources/Styles.xaml
+++ b/ToolManagementAppV2/Resources/Styles.xaml
@@ -38,6 +38,11 @@
     <Style x:Key="ErrorTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
         <Setter Property="Foreground" Value="{StaticResource ErrorBrush}"/>
     </Style>
+    <Style x:Key="SectionHeader" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="Margin" Value="0,0,0,6"/>
+    </Style>
     <Style TargetType="TextBox">
         <Setter Property="Background" Value="#141C24"/>
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
@@ -211,6 +216,30 @@
     <Style TargetType="Button" x:Key="PrimaryButton" BasedOn="{StaticResource NavButton}">
         <Setter Property="Width" Value="120"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
+    </Style>
+    <Style x:Key="CompactPrimaryButton" TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="MinWidth" Value="220"/>
+        <Setter Property="Padding" Value="10,8"/>
+        <Setter Property="Margin" Value="0,0,8,8"/>
+    </Style>
+    <Style x:Key="LinkButton" TargetType="Button">
+        <Setter Property="Foreground" Value="{StaticResource ForegroundMutedBrush}"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="0"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="ContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <TextBlock Text="{Binding}"
+                               TextDecorations="Underline"
+                               Foreground="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=Foreground}"/>
+                </TextBlock>
+            </DataTemplate>
+        </Setter.Value>
+    </Setter>
     </Style>
     <Style TargetType="Border" x:Key="Card">
         <Setter Property="Background" Value="{StaticResource SurfaceBrush}"/>

--- a/ToolManagementAppV2/Views/Pages/ImportExportPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/ImportExportPage.xaml
@@ -3,20 +3,6 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       Background="{StaticResource BackgroundBrush}">
-    <Page.Resources>
-        <Style x:Key="CompactPrimaryButton" TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
-            <Setter Property="HorizontalAlignment" Value="Left"/>
-            <Setter Property="MinWidth" Value="220"/>
-            <Setter Property="Padding" Value="10,8"/>
-            <Setter Property="Margin" Value="0,0,8,8"/>
-        </Style>
-        <Style x:Key="SectionHeader" TargetType="TextBlock">
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="FontSize" Value="14"/>
-            <Setter Property="Margin" Value="0,0,0,6"/>
-        </Style>
-    </Page.Resources>
-
     <Grid Margin="8">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/ToolManagementAppV2/Views/Pages/SettingsPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/SettingsPage.xaml
@@ -8,7 +8,7 @@
         <StackPanel Margin="8" Orientation="Vertical">
             <Border Style="{StaticResource Card}" Padding="12" Margin="0,0,0,8">
                 <StackPanel Orientation="Vertical">
-                    <TextBlock Text="Database" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                    <TextBlock Text="Database" Style="{StaticResource SectionHeader}"/>
                     <Grid Margin="0,8,0,0">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="200"/>
@@ -24,7 +24,7 @@
 
             <Border Style="{StaticResource Card}" Padding="12" Margin="0,0,0,8">
                 <StackPanel Orientation="Vertical">
-                    <TextBlock Text="General" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                    <TextBlock Text="General" Style="{StaticResource SectionHeader}"/>
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="200"/>
@@ -47,7 +47,7 @@
 
             <Border Style="{StaticResource Card}" Padding="12">
                 <StackPanel Orientation="Vertical">
-                    <TextBlock Text="Branding" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                    <TextBlock Text="Branding" Style="{StaticResource SectionHeader}"/>
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="200"/>

--- a/ToolManagementAppV2/Views/Windows/PasswordPromptWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/PasswordPromptWindow.xaml
@@ -7,26 +7,6 @@
         Width="520" Height="260"
         WindowStartupLocation="CenterScreen"
         Background="{StaticResource BackgroundBrush}">
-    <Window.Resources>
-        <Style x:Key="LinkButton" TargetType="Button">
-            <Setter Property="Foreground" Value="{StaticResource ForegroundMutedBrush}"/>
-            <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="BorderBrush" Value="Transparent"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="0"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="ContentTemplate">
-                <Setter.Value>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding}"
-                                   TextDecorations="Underline"
-                                   Foreground="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=Foreground}"/>
-                    </DataTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-    </Window.Resources>
-
     <Grid Margin="14">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>


### PR DESCRIPTION
## Summary
- centralize LinkButton, CompactPrimaryButton, and SectionHeader styles in Resources/Styles.xaml
- update PasswordPromptWindow, ImportExportPage, and SettingsPage to use centralized styles

## Testing
- `dotnet test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a44ecdec98832483ee679056486764