### PR TITLE
Apply primary button style to wizard/edit windows

### DIFF
--- a/ToolManagementAppV2/Views/Windows/SetupWizardWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/SetupWizardWindow.xaml
@@ -21,7 +21,7 @@
         <TextBlock Grid.Row="2" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Foreground="{StaticResource ForegroundBrush}"/>
         <PasswordBox Grid.Row="3" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
         <TextBlock Grid.Row="4" Text="{Binding ValidationMessage}" Margin="0,10,0,0" Style="{StaticResource ErrorTextBlock}" HorizontalAlignment="Center"/>
-        <Button Grid.Row="5" Content="Generate Random" Margin="0,10,0,0" Command="{Binding GenerateCommand}" HorizontalAlignment="Center"/>
+        <Button Grid.Row="5" Content="Generate Random" Style="{StaticResource PrimaryButton}" Margin="0,10,0,0" Command="{Binding GenerateCommand}" HorizontalAlignment="Center"/>
         <controls:DialogButtonBar Grid.Row="6"
                                   LeftButtonText="Cancel"
                                   LeftCommand="{Binding CancelCommand}"

--- a/ToolManagementAppV2/Views/Windows/ToolEditWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ToolEditWindow.xaml
@@ -52,8 +52,8 @@
                 <Image Width="100" Height="100" Stretch="Uniform"
                        Source="{Binding Tool.ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=tool}"/>
                 <StackPanel Orientation="Vertical" Margin="8,0,0,0">
-                    <Button Content="Browse" Width="75" Command="{Binding BrowseImageCommand}"/>
-                    <Button Content="Remove" Width="75" Margin="0,4,0,0" Command="{Binding RemoveImageCommand}"/>
+                    <Button Content="Browse" Style="{StaticResource PrimaryButton}" Width="75" Command="{Binding BrowseImageCommand}"/>
+                    <Button Content="Remove" Style="{StaticResource PrimaryButton}" Width="75" Margin="0,4,0,0" Command="{Binding RemoveImageCommand}"/>
                 </StackPanel>
             </StackPanel>
 


### PR DESCRIPTION
## Summary
- apply PrimaryButton style to browse/remove tool image buttons
- apply PrimaryButton style to setup wizard's Generate Random button

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a45096bf44832494a6b71fc8fbfc08