### PR TITLE
feat: centralize header text styles

### DIFF
--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -17,7 +17,7 @@
                 <StackPanel Orientation="Vertical" Margin="16,16,16,8">
                     <StackPanel Orientation="Horizontal">
                         <Image Source="{Binding CompanyLogoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=logo}" Width="36" Height="36" Margin="0,0,8,0"/>
-                        <TextBlock Text="Tool Management" FontSize="18" FontWeight="SemiBold"/>
+                        <TextBlock Text="Tool Management" Style="{StaticResource HeadingTextBlock}"/>
                     </StackPanel>
                     <TextBlock Text="{Binding CurrentPageTitle}" FontSize="12" Foreground="{StaticResource ForegroundMutedBrush}" Margin="0,4,0,0"/>
                 </StackPanel>

--- a/ToolManagementAppV2/Resources/Styles.xaml
+++ b/ToolManagementAppV2/Resources/Styles.xaml
@@ -43,6 +43,14 @@
         <Setter Property="FontSize" Value="14"/>
         <Setter Property="Margin" Value="0,0,0,6"/>
     </Style>
+    <Style x:Key="HeadingTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="18"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+    </Style>
+    <Style x:Key="SubheadingTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="16"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+    </Style>
     <Style TargetType="TextBox">
         <Setter Property="Background" Value="#141C24"/>
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>

--- a/ToolManagementAppV2/Views/Pages/DashboardPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/DashboardPage.xaml
@@ -9,7 +9,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <TextBlock Text="Overview" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,8"/>
+        <TextBlock Text="Overview" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
         <ItemsControl Grid.Row="1" ItemsSource="{Binding StatCards}" ItemTemplate="{StaticResource StatCardTemplate}" ItemsPanel="{StaticResource WrapPanelItems}"/>
         <Grid Grid.Row="2" Margin="0,16,0,0">
             <Grid.ColumnDefinitions>
@@ -18,7 +18,7 @@
             </Grid.ColumnDefinitions>
             <Border Style="{StaticResource Card}" Grid.Column="0">
                 <StackPanel>
-                    <TextBlock Text="Recent Activity" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                    <TextBlock Text="Recent Activity" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
                     <ListView ItemsSource="{Binding RecentActivity}"
                               VirtualizingPanel.IsVirtualizing="True"
                               VirtualizingPanel.VirtualizationMode="Recycling">
@@ -32,7 +32,7 @@
             </Border>
             <Border Style="{StaticResource Card}" Grid.Column="1">
                 <StackPanel>
-                    <TextBlock Text="Quick Actions" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                    <TextBlock Text="Quick Actions" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
                     <WrapPanel>
                         <Button Style="{StaticResource PrimaryButton}" Content="New Tool" Command="{Binding NewToolCommand}" Margin="0,0,8,8"/>
                         <Button Style="{StaticResource PrimaryButton}" Content="Rent Tool" Command="{Binding OpenRentalsCommand}" Margin="0,0,8,8"/>

--- a/ToolManagementAppV2/Views/Pages/ManageToolsPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/ManageToolsPage.xaml
@@ -12,7 +12,7 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <TextBlock Text="Tools" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                <TextBlock Text="Tools" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
 
                 <DataGrid Grid.Row="1"
                           ItemsSource="{Binding Tools}"

--- a/ToolManagementAppV2/Views/Pages/ScannerStatusPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/ScannerStatusPage.xaml
@@ -5,7 +5,7 @@
       Background="{StaticResource BackgroundBrush}">
     <DockPanel Margin="10">
         <Border DockPanel.Dock="Top" Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" Padding="10" CornerRadius="8">
-            <TextBlock Text="Scanner Status" FontWeight="SemiBold" FontSize="18"/>
+            <TextBlock Text="Scanner Status" Style="{StaticResource HeadingTextBlock}"/>
         </Border>
         <Grid>
             <Grid.RowDefinitions>

--- a/ToolManagementAppV2/Views/Windows/ImportMappingWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ImportMappingWindow.xaml
@@ -9,7 +9,7 @@
         Background="{StaticResource BackgroundBrush}">
     <DockPanel Margin="10">
         <Border DockPanel.Dock="Top" Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" Padding="10" CornerRadius="8">
-            <TextBlock Text="Map CSV Columns to Fields" FontWeight="SemiBold" FontSize="18"/>
+            <TextBlock Text="Map CSV Columns to Fields" Style="{StaticResource HeadingTextBlock}"/>
         </Border>
 
         <Border Style="{StaticResource Card}" Margin="0,8,0,8" DockPanel.Dock="Top">

--- a/ToolManagementAppV2/Views/Windows/LoginWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/LoginWindow.xaml
@@ -27,7 +27,7 @@
             <DockPanel LastChildFill="False">
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
                     <Image Source="{Binding CompanyLogo}" Width="36" Height="36" Margin="0,0,10,0"/>
-                    <TextBlock Text="{Binding WindowTitle}" FontSize="18" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Binding WindowTitle}" Style="{StaticResource HeadingTextBlock}" VerticalAlignment="Center"/>
                 </StackPanel>
                 <TextBlock DockPanel.Dock="Right" Foreground="{StaticResource ForegroundMutedBrush}" VerticalAlignment="Center"
                            Text="Select your account to continue"/>

--- a/ToolManagementAppV2/Views/Windows/PasswordPromptWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/PasswordPromptWindow.xaml
@@ -17,8 +17,7 @@
         </Grid.RowDefinitions>
 
         <TextBlock x:Name="PromptTextBlock"
-                   FontSize="16"
-                   FontWeight="SemiBold"
+                   Style="{StaticResource SubheadingTextBlock}"
                    Margin="0,0,0,8"/>
 
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="10">

--- a/ToolManagementAppV2/Views/Windows/PrintPreviewWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/PrintPreviewWindow.xaml
@@ -20,8 +20,7 @@
                            Stretch="Uniform"
                            Margin="0,0,8,0"/>
                     <TextBlock x:Name="PreviewTitle"
-                               FontWeight="SemiBold"
-                               FontSize="18"
+                               Style="{StaticResource HeadingTextBlock}"
                                VerticalAlignment="Center"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">

--- a/ToolManagementAppV2/Views/Windows/RentToolPopupWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/RentToolPopupWindow.xaml
@@ -8,7 +8,7 @@
         Background="{StaticResource BackgroundBrush}">
     <DockPanel Margin="10">
         <Border DockPanel.Dock="Top" Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" Padding="10" CornerRadius="8">
-            <TextBlock Text="Rent Tool" FontWeight="SemiBold" FontSize="18"/>
+            <TextBlock Text="Rent Tool" Style="{StaticResource HeadingTextBlock}"/>
         </Border>
 
         <Border Style="{StaticResource Card}" Margin="0,8,0,8">

--- a/ToolManagementAppV2/Views/Windows/RentalHistoryWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/RentalHistoryWindow.xaml
@@ -10,7 +10,7 @@
     <DockPanel Margin="10">
         <Border DockPanel.Dock="Top" Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" Padding="10" CornerRadius="8">
             <DockPanel>
-                <TextBlock Text="Rental History" FontWeight="SemiBold" FontSize="18" DockPanel.Dock="Left"/>
+                <TextBlock Text="Rental History" Style="{StaticResource HeadingTextBlock}" DockPanel.Dock="Left"/>
                 <controls:SearchBar DockPanel.Dock="Right"
                                    Text="{Binding SearchText}"
                                    SearchCommand="{Binding SearchCommand}"/>

--- a/ToolManagementAppV2/Views/Windows/ScannerStatusWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ScannerStatusWindow.xaml
@@ -8,7 +8,7 @@
         Background="{StaticResource BackgroundBrush}">
     <DockPanel Margin="10">
         <Border DockPanel.Dock="Top" Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" Padding="10" CornerRadius="8">
-            <TextBlock Text="Scanner Status" FontWeight="SemiBold" FontSize="18"/>
+            <TextBlock Text="Scanner Status" Style="{StaticResource HeadingTextBlock}"/>
         </Border>
         <Grid>
             <Grid.RowDefinitions>

--- a/ToolManagementAppV2/Views/Windows/UsersEditWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/UsersEditWindow.xaml
@@ -12,7 +12,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <TextBlock Text="{Binding Title}" FontSize="18" FontWeight="SemiBold" Margin="0,0,0,8"/>
+        <TextBlock Text="{Binding Title}" Style="{StaticResource HeadingTextBlock}" Margin="0,0,0,8"/>
 
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>


### PR DESCRIPTION
## Summary
- add `HeadingTextBlock` and `SubheadingTextBlock` styles for shared header formatting
- refactor page and window headers to use shared text styles instead of inline font settings

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a4522ceb608324b52ca77e84739f35