### PR TITLE
Apply virtualized DataGrid styling across views

### DIFF
--- a/ToolManagementAppV2/Views/Pages/ReportsPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/ReportsPage.xaml
@@ -15,7 +15,11 @@
             </StackPanel>
         </Border>
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
-            <DataGrid ItemsSource="{Binding ReportResults}" AutoGenerateColumns="True" IsReadOnly="True"/>
+            <DataGrid ItemsSource="{Binding ReportResults}"
+                      AutoGenerateColumns="True"
+                      IsReadOnly="True"
+                      Style="{StaticResource VirtualizedDataGridStyle}"
+                      ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}"/>
         </Border>
     </Grid>
 </Page>

--- a/ToolManagementAppV2/Views/Pages/ScannerStatusPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/ScannerStatusPage.xaml
@@ -21,7 +21,11 @@
             </Border>
 
             <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0" Margin="0,8,0,0">
-                <DataGrid ItemsSource="{Binding Devices}" AutoGenerateColumns="False" IsReadOnly="True">
+                <DataGrid ItemsSource="{Binding Devices}"
+                          AutoGenerateColumns="False"
+                          IsReadOnly="True"
+                          Style="{StaticResource VirtualizedDataGridStyle}"
+                          ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
                         <DataGridTextColumn Header="IP" Binding="{Binding Ip}" Width="180"/>

--- a/ToolManagementAppV2/Views/Windows/ImportMappingWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ImportMappingWindow.xaml
@@ -18,7 +18,9 @@
                       HeadersVisibility="Column"
                       CanUserAddRows="False"
                       CanUserDeleteRows="False"
-                      IsReadOnly="False">
+                      IsReadOnly="False"
+                      Style="{StaticResource VirtualizedDataGridStyle}"
+                      ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="Property" Binding="{Binding PropertyName}" IsReadOnly="True" Width="2*"/>
                     <DataGridTemplateColumn Header="CSV Column" Width="3*">

--- a/ToolManagementAppV2/Views/Windows/PrintLabelWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/PrintLabelWindow.xaml
@@ -31,7 +31,11 @@
         </Border>
 
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0" Margin="0,8,0,8">
-            <DataGrid ItemsSource="{Binding Items}" AutoGenerateColumns="False" IsReadOnly="True">
+            <DataGrid ItemsSource="{Binding Items}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      Style="{StaticResource VirtualizedDataGridStyle}"
+                      ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="Tool #" Binding="{Binding ToolNumber}" Width="120"/>
                     <DataGridTextColumn Header="Name" Binding="{Binding NameDescription}" Width="*"/>

--- a/ToolManagementAppV2/Views/Windows/ScannerStatusWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ScannerStatusWindow.xaml
@@ -24,7 +24,11 @@
             </Border>
 
             <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0" Margin="0,8,0,0">
-                <DataGrid ItemsSource="{Binding Devices}" AutoGenerateColumns="False" IsReadOnly="True">
+                <DataGrid ItemsSource="{Binding Devices}"
+                          AutoGenerateColumns="False"
+                          IsReadOnly="True"
+                          Style="{StaticResource VirtualizedDataGridStyle}"
+                          ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
                         <DataGridTextColumn Header="IP" Binding="{Binding Ip}" Width="180"/>


### PR DESCRIPTION
## Summary
- Apply `VirtualizedDataGridStyle` to DataGrids in reports, scanner status, label printing, scanner status window, and import mapping views
- Ensure DataGrid column headers use the global `DataGridColumnHeader` style

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a454308b94832495ee9d0583b0da0b