### PR TITLE
Add dialog message text style and apply to dialog windows

### DIFF
--- a/ToolManagementAppV2/Resources/Styles.xaml
+++ b/ToolManagementAppV2/Resources/Styles.xaml
@@ -51,6 +51,10 @@
         <Setter Property="FontSize" Value="16"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
     </Style>
+    <Style x:Key="DialogMessageTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="16"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+    </Style>
     <Style TargetType="TextBox">
         <Setter Property="Background" Value="#141C24"/>
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>

--- a/ToolManagementAppV2/Views/Windows/ConfirmDialogWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ConfirmDialogWindow.xaml
@@ -13,7 +13,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Border Style="{StaticResource Card}">
-            <TextBlock Text="{Binding Message}" FontSize="16" TextWrapping="Wrap"/>
+            <TextBlock Text="{Binding Message}" Style="{StaticResource DialogMessageTextBlock}"/>
         </Border>
         <controls:DialogButtonBar Grid.Row="1"
                                   LeftButtonText="No"

--- a/ToolManagementAppV2/Views/Windows/InfoDialogWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/InfoDialogWindow.xaml
@@ -12,7 +12,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Border Style="{StaticResource Card}">
-            <TextBlock Text="{Binding Message}" FontSize="16" TextWrapping="Wrap"/>
+            <TextBlock Text="{Binding Message}" Style="{StaticResource DialogMessageTextBlock}"/>
         </Border>
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
             <Button Style="{StaticResource PrimaryButton}" Content="OK" Command="{Binding OkCommand}"/>


### PR DESCRIPTION
## Summary
- add DialogMessageTextBlock style for dialog message TextBlocks
- use DialogMessageTextBlock style in info and confirm dialog windows

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a457334f248324a64a00f9794e67c3