### PR TITLE
Use themed heading style for avatar selection window

### DIFF
--- a/ToolManagementAppV2/Views/Windows/AvatarSelectionWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/AvatarSelectionWindow.xaml
@@ -10,7 +10,7 @@
         <!-- HEADER -->
         <Border DockPanel.Dock="Top" Background="{DynamicResource AccentBrush}" Padding="10">
             <TextBlock Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}"
-                       FontWeight="Bold" FontSize="20" Margin="10" />
+                       Style="{StaticResource HeadingTextBlock}" Margin="10" />
         </Border>
 
         <!-- AVATAR GRID -->


### PR DESCRIPTION
## Summary
- apply shared `HeadingTextBlock` style to avatar selection window header for consistent theming

## Testing
- `dotnet test` *(fails: command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_68a4588c3ca08324abe4df104fcf4fa1