### PR TITLE
refactor: centralize text styles

### DIFF
--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -19,7 +19,7 @@
                         <Image Source="{Binding CompanyLogoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=logo}" Width="36" Height="36" Margin="0,0,8,0"/>
                         <TextBlock Text="Tool Management" Style="{StaticResource HeadingTextBlock}"/>
                     </StackPanel>
-                    <TextBlock Text="{Binding CurrentPageTitle}" FontSize="12" Foreground="{StaticResource ForegroundMutedBrush}" Margin="0,4,0,0"/>
+                        <TextBlock Text="{Binding CurrentPageTitle}" Style="{StaticResource CaptionTextBlock}" Margin="0,4,0,0"/>
                 </StackPanel>
 
                 <ScrollViewer Grid.Row="1"
@@ -92,7 +92,7 @@
 
             <Border Background="{StaticResource BackgroundBrush}" Padding="16,12" BorderBrush="{StaticResource BorderBrushBase}" BorderThickness="0,0,0,1">
                 <DockPanel>
-                    <TextBlock Text="{Binding CurrentPageTitle}" DockPanel.Dock="Left" VerticalAlignment="Center" FontSize="20" FontWeight="SemiBold" Margin="10"/>
+                    <TextBlock Text="{Binding CurrentPageTitle}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="10" Style="{StaticResource PageTitleTextBlock}"/>
                     <Border Width="60" Height="60" DockPanel.Dock="Right"  CornerRadius="16" ClipToBounds="True" Margin="0,0,8,0">
                         <Image Source="{Binding CurrentUserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}" Stretch="Uniform"/>
                     </Border>

--- a/ToolManagementAppV2/Resources/Styles.xaml
+++ b/ToolManagementAppV2/Resources/Styles.xaml
@@ -55,6 +55,26 @@
         <Setter Property="FontSize" Value="16"/>
         <Setter Property="TextWrapping" Value="Wrap"/>
     </Style>
+    <Style x:Key="PageTitleTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="20"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+    </Style>
+    <Style x:Key="CaptionTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="Foreground" Value="{StaticResource ForegroundMutedBrush}"/>
+    </Style>
+    <Style x:Key="LabelTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="Foreground" Value="{StaticResource ForegroundMutedBrush}"/>
+    </Style>
+    <Style x:Key="ListItemTitleTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+    </Style>
+    <Style x:Key="StatisticValueTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="26"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+    </Style>
     <Style TargetType="TextBox">
         <Setter Property="Background" Value="#141C24"/>
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>

--- a/ToolManagementAppV2/Resources/Templates.xaml
+++ b/ToolManagementAppV2/Resources/Templates.xaml
@@ -8,8 +8,8 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                <TextBlock Text="{Binding Title}" FontSize="13" Foreground="{StaticResource ForegroundMutedBrush}"/>
-                <TextBlock Grid.Row="1" Text="{Binding Value}" FontSize="26" FontWeight="SemiBold"/>
+                <TextBlock Text="{Binding Title}" Style="{StaticResource LabelTextBlock}"/>
+                <TextBlock Grid.Row="1" Text="{Binding Value}" Style="{StaticResource StatisticValueTextBlock}"/>
             </Grid>
         </Border>
     </DataTemplate>
@@ -28,8 +28,8 @@
                            Source="{Binding ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=tool}"/>
                 </Border>
                 <StackPanel Grid.Row="1" Margin="0,6,0,0">
-                    <TextBlock Text="{Binding NameDescription}" FontWeight="SemiBold" FontSize="13"/>
-                    <TextBlock Text="{Binding ToolNumber}" Foreground="{StaticResource ForegroundMutedBrush}" FontSize="12"/>
+                    <TextBlock Text="{Binding NameDescription}" Style="{StaticResource ListItemTitleTextBlock}"/>
+                    <TextBlock Text="{Binding ToolNumber}" Style="{StaticResource CaptionTextBlock}"/>
                 </StackPanel>
             </Grid>
         </Border>

--- a/ToolManagementAppV2/Views/Windows/ImageImportMappingWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ImageImportMappingWindow.xaml
@@ -10,7 +10,7 @@
     <DockPanel Margin="10">
         <Border Style="{StaticResource Card}" DockPanel.Dock="Top">
             <StackPanel>
-                <TextBlock Text="Match images by:" FontWeight="SemiBold" Margin="0,0,0,6"/>
+                <TextBlock Text="Match images by:" Style="{StaticResource SectionHeader}"/>
                 <WrapPanel>
                     <CheckBox Content="ToolNumber" IsChecked="{Binding UseToolNumber}" Margin="6,0"/>
                     <CheckBox Content="PartNumber" IsChecked="{Binding UsePartNumber}" Margin="6,0"/>

--- a/ToolManagementAppV2/Views/Windows/LoginWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/LoginWindow.xaml
@@ -65,8 +65,7 @@
                                                Text="{Binding UserName}"
                                                HorizontalAlignment="Center"
                                                Margin="0,6,0,0"
-                                               Foreground="{StaticResource ForegroundMutedBrush}"
-                                               FontSize="12"/>
+                                               Style="{StaticResource CaptionTextBlock}"/>
                                 </Grid>
                             </Button>
                         </DataTemplate>


### PR DESCRIPTION
## Summary
- centralize common text styles for captions, labels, list items, statistics, and page titles
- apply shared styles across main window, login window, templates, and image import mapping window

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a4599e1390832486b91f72e514cf49