### PR TITLE
Use subheading style for password labels

### DIFF
--- a/ToolManagementAppV2/Views/Windows/ChangePasswordWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ChangePasswordWindow.xaml
@@ -16,9 +16,9 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" Text="New Password" HorizontalAlignment="Center" Foreground="{StaticResource ForegroundBrush}"/>
+        <TextBlock Grid.Row="0" Text="New Password" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
         <PasswordBox Grid.Row="1" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
-        <TextBlock Grid.Row="2" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Foreground="{StaticResource ForegroundBrush}"/>
+        <TextBlock Grid.Row="2" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
         <PasswordBox Grid.Row="3" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
         <TextBlock Grid.Row="4" Text="{Binding ValidationMessage}" Margin="0,10,0,0" Style="{StaticResource ErrorTextBlock}" HorizontalAlignment="Center"/>
         <controls:DialogButtonBar Grid.Row="5"

--- a/ToolManagementAppV2/Views/Windows/SetupWizardWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/SetupWizardWindow.xaml
@@ -16,9 +16,9 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" Text="Admin Password" HorizontalAlignment="Center" Foreground="{StaticResource ForegroundBrush}"/>
+        <TextBlock Grid.Row="0" Text="Admin Password" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
         <PasswordBox Grid.Row="1" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
-        <TextBlock Grid.Row="2" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Foreground="{StaticResource ForegroundBrush}"/>
+        <TextBlock Grid.Row="2" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
         <PasswordBox Grid.Row="3" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
         <TextBlock Grid.Row="4" Text="{Binding ValidationMessage}" Margin="0,10,0,0" Style="{StaticResource ErrorTextBlock}" HorizontalAlignment="Center"/>
         <Button Grid.Row="5" Content="Generate Random" Style="{StaticResource PrimaryButton}" Margin="0,10,0,0" Command="{Binding GenerateCommand}" HorizontalAlignment="Center"/>


### PR DESCRIPTION
## Summary
- apply `SubheadingTextBlock` style to password labels in SetupWizardWindow
- apply `SubheadingTextBlock` style to password labels in ChangePasswordWindow

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a463526d388324964ab57eaefe414e