### PR TITLE
Apply label TextBlock style to field labels

### DIFF
--- a/ToolManagementAppV2/Views/Pages/SettingsPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/SettingsPage.xaml
@@ -15,7 +15,7 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <TextBlock Text="Connection String" VerticalAlignment="Center"/>
+                        <TextBlock Text="Connection String" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                         <TextBox Grid.Column="1" Text="{Binding ConnectionString}" Margin="8,0,8,0"/>
                         <Button Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Test" Command="{Binding TestDbCommand}"/>
                     </Grid>
@@ -35,11 +35,11 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
-                        <TextBlock Text="Theme" VerticalAlignment="Center"/>
+                        <TextBlock Text="Theme" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                         <ComboBox Grid.Column="1" SelectedItem="{Binding Theme}" ItemsSource="{Binding ThemeOptions}" Margin="8,0,0,0"/>
-                        <TextBlock Grid.Row="1" Text="Password Iterations" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Row="1" Text="Password Iterations" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding PasswordIterations}" Margin="8,0,0,0" PreviewTextInput="PasswordIterationsBox_PreviewTextInput"/>
-                        <TextBlock Grid.Row="2" Text="Auto-logout (minutes)" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Row="2" Text="Auto-logout (minutes)" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                         <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding AutoLogoutMinutes}" Margin="8,0,0,0" PreviewTextInput="AutoLogoutMinutesBox_PreviewTextInput"/>
                     </Grid>
                 </StackPanel>
@@ -56,7 +56,7 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
 
-                        <TextBlock Text="Company Logo" VerticalAlignment="Center"/>
+                        <TextBlock Text="Company Logo" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
 
                         <StackPanel Grid.Column="1" Orientation="Horizontal">
                             <Border Width="64" Height="64" CornerRadius="6" Background="{StaticResource SurfaceAltBrush}" Margin="8,0,8,0">

--- a/ToolManagementAppV2/Views/Windows/CustomerEditWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/CustomerEditWindow.xaml
@@ -25,22 +25,22 @@
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="0" Grid.Column="0" Text="Company" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Company" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Customer.Company, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Contact" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Contact" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Customer.Contact, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Email" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Email" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Customer.Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="Phone" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Phone" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Customer.Phone, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Text="Mobile" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Mobile" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Customer.Mobile, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Address" VerticalAlignment="Center" Margin="0,0,8,0"/>
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Address" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,0"/>
             <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Customer.Address, UpdateSourceTrigger=PropertyChanged}"/>
         </Grid>
 

--- a/ToolManagementAppV2/Views/Windows/PasswordPromptWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/PasswordPromptWindow.xaml
@@ -27,8 +27,8 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <TextBlock Text="Password"
-                           VerticalAlignment="Center"
-                           Foreground="{StaticResource ForegroundMutedBrush}"/>
+                           Style="{StaticResource LabelTextBlock}"
+                           VerticalAlignment="Center"/>
                 <PasswordBox x:Name="PasswordBox"
                              Grid.Column="1"
                              PasswordChar="•"

--- a/ToolManagementAppV2/Views/Windows/PrintLabelWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/PrintLabelWindow.xaml
@@ -24,7 +24,7 @@
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Text="Label Template" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+                <TextBlock Text="Label Template" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                 <ComboBox Grid.Column="1" ItemsSource="{Binding Templates}" SelectedItem="{Binding SelectedTemplate}" Margin="8,0,0,0"/>
                 <CheckBox Grid.Column="2" Content="Include QR" IsChecked="{Binding IncludeQr}" HorizontalAlignment="Left" Margin="8,4,0,0"/>
             </Grid>

--- a/ToolManagementAppV2/Views/Windows/RentToolPopupWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/RentToolPopupWindow.xaml
@@ -22,13 +22,13 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
 
-                <TextBlock Text="Customer" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+                <TextBlock Grid.Row="0" Grid.Column="0" Text="Customer" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                 <ComboBox Grid.Row="0" Grid.Column="1"
                           ItemsSource="{Binding Customers}"
                           DisplayMemberPath="Company"
                           SelectedItem="{Binding SelectedCustomer, Mode=TwoWay}" Margin="8,4"/>
 
-                <TextBlock Text="Due Date" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+                <TextBlock Grid.Row="1" Grid.Column="0" Text="Due Date" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                 <DatePicker Grid.Row="1" Grid.Column="1"
                             SelectedDate="{Binding SelectedDueDate, Mode=TwoWay}" Margin="8,4"/>
             </Grid>

--- a/ToolManagementAppV2/Views/Windows/ToolDetailsWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ToolDetailsWindow.xaml
@@ -29,26 +29,26 @@
             <Image Grid.Row="0" Grid.ColumnSpan="2" Width="120" Height="120" Margin="0,0,0,8" HorizontalAlignment="Center"
                    Source="{Binding Tool.ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=tool}"/>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Tool Number" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Tool Number" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
             <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Tool.ToolNumber}" Margin="8,4"/>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Name" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
             <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Tool.NameDescription}" Margin="8,4"/>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="Brand" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Brand" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
             <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Tool.Brand}" Margin="8,4"/>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Text="Location" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Location" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
             <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Tool.Location}" Margin="8,4"/>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Part #" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Part #" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
             <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding Tool.PartNumber}" Margin="8,4"/>
 
-            <TextBlock Grid.Row="6" Grid.Column="0" Text="Supplier" VerticalAlignment="Center" Foreground="{StaticResource ForegroundMutedBrush}"/>
+            <TextBlock Grid.Row="6" Grid.Column="0" Text="Supplier" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
             <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding Tool.Supplier}" Margin="8,4"/>
 
             <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Vertical" Margin="0,8,0,0">
-                <TextBlock Text="Notes" Foreground="{StaticResource ForegroundMutedBrush}"/>
+                <TextBlock Text="Notes" Style="{StaticResource LabelTextBlock}"/>
                 <ScrollViewer Height="90" VerticalScrollBarVisibility="Auto">
                     <TextBlock Text="{Binding Tool.Notes}" TextWrapping="Wrap"/>
                 </ScrollViewer>

--- a/ToolManagementAppV2/Views/Windows/ToolEditWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ToolEditWindow.xaml
@@ -28,22 +28,22 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="0" Grid.Column="0" Text="Tool Number" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Tool Number" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Tool.ToolNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Tool.NameDescription, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Brand" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Brand" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Tool.Brand, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="Location" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Location" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Tool.Location, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Text="Part #" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Part #" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Tool.PartNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Supplier" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Supplier" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Tool.Supplier, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
             <CheckBox Grid.Row="6" Grid.ColumnSpan="2" Content="Power Tool" IsChecked="{Binding Tool.IsPowerTool}" Margin="0,0,0,8"/>
@@ -58,7 +58,7 @@
             </StackPanel>
 
             <StackPanel Grid.Row="8" Grid.ColumnSpan="2" Orientation="Vertical">
-                <TextBlock Text="Notes" Margin="0,0,0,4"/>
+                <TextBlock Text="Notes" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/>
                 <TextBox Text="{Binding Tool.Notes, UpdateSourceTrigger=PropertyChanged}" Height="90" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
             </StackPanel>
         </Grid>

--- a/ToolManagementAppV2/Views/Windows/UsersEditWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/UsersEditWindow.xaml
@@ -40,19 +40,19 @@
                 <Button Style="{StaticResource PrimaryButton}" Width="130" Content="Remove Avatar" Command="{Binding RemoveAvatarCommand}"/>
             </StackPanel>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Username" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Username" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding EditingUser.UserName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Email" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Email" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding EditingUser.Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="Phone" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Phone" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding EditingUser.Phone, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Text="Mobile" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Mobile" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding EditingUser.Mobile, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Role" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Role" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <ComboBox Grid.Row="5" Grid.Column="1" SelectedValuePath="Tag" SelectedValue="{Binding EditingUser.IsAdmin, Mode=TwoWay}" Margin="0,0,0,8">
                 <ComboBoxItem Content="User" Tag="False"/>
                 <ComboBoxItem Content="Admin" Tag="True"/>


### PR DESCRIPTION
## Summary
- Style all field labels with `LabelTextBlock` and remove explicit foreground colors
- Standardize label styling in editing dialogs and settings page

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a465027ad88324adae7c7929152589