### PR TITLE
Add AvatarTileButton style for avatar selection

### DIFF
--- a/ToolManagementAppV2/Resources/Styles.xaml
+++ b/ToolManagementAppV2/Resources/Styles.xaml
@@ -376,4 +376,10 @@
             </Setter.Value>
         </Setter>
     </Style>
+    <Style x:Key="AvatarTileButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="0"/>
+    </Style>
 </ResourceDictionary>

--- a/ToolManagementAppV2/Views/Windows/AvatarSelectionWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/AvatarSelectionWindow.xaml
@@ -26,8 +26,7 @@
                 <DataTemplate>
                     <Button Command="{Binding DataContext.SelectAvatarCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
                             CommandParameter="{Binding}"
-                            Background="Transparent"
-                            BorderThickness="0"
+                            Style="{StaticResource AvatarTileButton}"
                             Margin="5">
                         <Border Background="{DynamicResource CardBackgroundBrush}" CornerRadius="5" Padding="10">
                             <Image Source="{Binding}" Width="100" Height="100"/>


### PR DESCRIPTION
## Summary
- add AvatarTileButton style with transparent background, no border, and zero padding
- use AvatarTileButton style for avatar selection buttons in AvatarSelectionWindow

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a467d185008324abd3165e798e701f