### PR TITLE
Fix link button style TextBlock closure

### DIFF
--- a/ToolManagementAppV2/Resources/Styles.xaml
+++ b/ToolManagementAppV2/Resources/Styles.xaml
@@ -267,11 +267,11 @@
                 <DataTemplate>
                     <TextBlock Text="{Binding}"
                                TextDecorations="Underline"
-                               Foreground="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=Foreground}"/>
-                </TextBlock>
-            </DataTemplate>
-        </Setter.Value>
-    </Setter>
+                               Foreground="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=Foreground}">
+                    </TextBlock>
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
     <Style TargetType="Border" x:Key="Card">
         <Setter Property="Background" Value="{StaticResource SurfaceBrush}"/>


### PR DESCRIPTION
## Summary
- fix improper TextBlock closing in link button style DataTemplate

## Testing
- `dotnet test` *(fails: command not found)*
- `dotnet build ToolManagementAppV2/ToolManagementAppV2.csproj` *(fails: command not found)*
- `dotnet run --project ToolManagementAppV2` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d71fdf5c8324bc4f78d1b0351531