### PR TITLE
Add configurable application name

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -58,6 +58,36 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public async Task InitializeAsync_UsesDefaultTitle_WhenSettingMissing()
+        {
+            if (System.Windows.Application.Current == null)
+                new System.Windows.Application();
+
+            var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");
+            try
+            {
+                using var dbService = new DatabaseService(dbPath);
+                var userContext = new ApplicationUserContext();
+                var auth = new AuthorizationService(userContext);
+                var userService = new UserService(dbService, userContext, auth);
+                await userService.AddUserAsync(new User { UserName = "admin", PasswordHash = "Strong1!", IsAdmin = true });
+                var settingsService = new SettingsService(dbService);
+
+                var vm = new LoginViewModel(userService, settingsService, new StubDialogService(), userContext)
+                {
+                    PromptForPasswordAsync = (u, ct) => Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("Strong1!", false))
+                };
+                await vm.InitializeAsync();
+
+                Assert.Equal("Tool Inventory Management – Login", vm.WindowTitle);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public async Task LoadUsersAsync_CreatesAdminUser_WhenNoUsers()
         {
             if (System.Windows.Application.Current == null)

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -29,6 +29,24 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public void Constructor_PopulatesApplicationName_WhenSettingExists()
+        {
+            var settings = new StubSettingsService { GetSettingValue = "MyApp" };
+            var vm = new SettingsViewModel(new StubFileDialogService(), settings, new StubDialogService());
+            Assert.Equal("MyApp", vm.ApplicationName);
+        }
+
+        [Fact]
+        public void ApplicationName_Setter_SavesValue()
+        {
+            var settings = new StubSettingsService();
+            var vm = new SettingsViewModel(new StubFileDialogService(), settings, new StubDialogService());
+            vm.ApplicationName = "NewName";
+            Assert.Equal("ApplicationName", settings.SavedKey);
+            Assert.Equal("NewName", settings.SavedValue);
+        }
+
+        [Fact]
         public void TestDbConnection_CreatesDatabaseFile()
         {
             var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".db");

--- a/ToolManagementAppV2.Tests/Views/AvatarSelectionWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/AvatarSelectionWindowTests.cs
@@ -45,6 +45,37 @@ namespace ToolManagementAppV2.Tests.Views
         }
 
         [Fact]
+        public void Loaded_UsesDefaultTitle_WhenSettingMissing()
+        {
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var settings = new StubSettingsService { AppName = string.Empty };
+                    var logger = new TestLogger<AvatarSelectionWindow>();
+                    var window = new AvatarSelectionWindow(settings, logger) { Title = "Original" };
+
+                    window.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+
+                    Assert.Equal("Tool Inventory Management – Select Avatar", window.Title);
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+                throw threadException;
+        }
+
+        [Fact]
         public void Loaded_LogsError_WhenSettingFails()
         {
             Exception? threadException = null;

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -30,6 +30,10 @@ namespace ToolManagementAppV2.ViewModels
             if (!string.IsNullOrWhiteSpace(logoPath))
                 CompanyLogoPath = logoPath;
 
+            var appName = _settingsService.GetSettingAsync("ApplicationName").GetAwaiter().GetResult();
+            if (!string.IsNullOrWhiteSpace(appName))
+                _applicationName = appName;
+
             ThemeOptions = new ObservableCollection<string> { "Light", "Dark" };
             _theme = ThemeOptions[0];
             _passwordIterations = _settingsService.GetPasswordIterationsAsync().GetAwaiter().GetResult();
@@ -54,7 +58,25 @@ namespace ToolManagementAppV2.ViewModels
         public string ApplicationName
         {
             get => _applicationName;
-            set => SetProperty(ref _applicationName, value);
+            set
+            {
+                if (SetProperty(ref _applicationName, value))
+                {
+                    try
+                    {
+                        _settingsService.SaveSettingAsync("ApplicationName", value).GetAwaiter().GetResult();
+                    }
+                    catch (UnauthorizedAccessException ex)
+                    {
+                        _logger.LogWarning(ex, "Unauthorized to change settings.");
+                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to save application name.");
+                    }
+                }
+            }
         }
 
         private string _companyLogoPath;

--- a/ToolManagementAppV2/Views/Pages/SettingsPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/SettingsPage.xaml
@@ -55,10 +55,17 @@
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
 
-                        <TextBlock Text="Company Logo" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                        <TextBlock Text="Application Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                        <TextBox Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding ApplicationName}" Margin="8,0,0,8"/>
 
-                        <StackPanel Grid.Column="1" Orientation="Horizontal">
+                        <TextBlock Grid.Row="1" Text="Company Logo" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+
+                        <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal">
                             <Border Width="64" Height="64" CornerRadius="6" Background="{StaticResource SurfaceAltBrush}" Margin="8,0,8,0">
                                 <Image Width="64" Height="64"
                                        Source="{Binding CompanyLogoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=logo}"
@@ -67,8 +74,8 @@
                             <TextBlock Text="{Binding CompanyLogoPath}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
                         </StackPanel>
 
-                        <Button Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Change Logo" Command="{Binding BrowseCompanyLogoCommand}" Margin="8,0,8,0"/>
-                        <Button Grid.Column="3" Style="{StaticResource PrimaryButton}" Content="Save Logo" Command="{Binding SaveCompanyLogoCommand}" />
+                        <Button Grid.Row="1" Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Change Logo" Command="{Binding BrowseCompanyLogoCommand}" Margin="8,0,8,0"/>
+                        <Button Grid.Row="1" Grid.Column="3" Style="{StaticResource PrimaryButton}" Content="Save Logo" Command="{Binding SaveCompanyLogoCommand}" />
                     </Grid>
                 </StackPanel>
             </Border>

--- a/ToolManagementAppV2/Views/Windows/AvatarSelectionWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/Windows/AvatarSelectionWindow.xaml.cs
@@ -49,8 +49,9 @@ namespace ToolManagementAppV2.Views.Windows
                 }
 
                 var appName = await _settingsService.GetSettingAsync("ApplicationName");
-                if (!string.IsNullOrWhiteSpace(appName))
-                    Title = $"{appName} – Select Avatar";
+                Title = !string.IsNullOrWhiteSpace(appName)
+                    ? $"{appName} – Select Avatar"
+                    : "Tool Inventory Management – Select Avatar";
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- load and persist `ApplicationName` setting in `SettingsViewModel`
- expose application name field in Settings UI
- fall back to default application name when setting missing
- add unit tests for application name behavior and defaults

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a54a50a200832494da41efc14a9a57