### PR TITLE
Allow customizable item labels

### DIFF
--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -438,5 +438,27 @@ namespace ToolManagementAppV2.Tests.Services
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void ItemLabels_SaveAndRetrieve()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var service = new SettingsService(dbService);
+                Assert.Equal("Tool", service.GetItemLabelSingularAsync().GetAwaiter().GetResult());
+                Assert.Equal("Tools", service.GetItemLabelPluralAsync().GetAwaiter().GetResult());
+                service.SaveItemLabelSingularAsync("Widget").GetAwaiter().GetResult();
+                service.SaveItemLabelPluralAsync("Widgets").GetAwaiter().GetResult();
+                Assert.Equal("Widget", service.GetItemLabelSingularAsync().GetAwaiter().GetResult());
+                Assert.Equal("Widgets", service.GetItemLabelPluralAsync().GetAwaiter().GetResult());
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -79,7 +79,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 };
                 await vm.InitializeAsync();
 
-                Assert.Equal("Tool Inventory Management – Login", vm.WindowTitle);
+                Assert.Equal($"{LabelProvider.Instance.ItemLabelSingular} Inventory Management – Login", vm.WindowTitle);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -190,6 +190,21 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
+        public void ItemLabels_UpdateServiceAndProvider()
+        {
+            var settings = new StubSettingsService();
+            LabelProvider.Instance.UpdateLabels("Tool", "Tools");
+            var vm = new SettingsViewModel(new StubFileDialogService(), settings, new StubDialogService());
+            vm.ItemLabelSingular = "Widget";
+            vm.ItemLabelPlural = "Widgets";
+            Assert.Equal("Widget", settings.ItemLabelSingular);
+            Assert.Equal("Widgets", settings.ItemLabelPlural);
+            Assert.Equal("Widget", LabelProvider.Instance.ItemLabelSingular);
+            Assert.Equal("Widgets", LabelProvider.Instance.ItemLabelPlural);
+            LabelProvider.Instance.UpdateLabels("Tool", "Tools");
+        }
+
+        [Fact]
         public void PasswordIterations_AboveLimit_PersistsClampedValue()
         {
             var path = System.IO.Path.GetTempFileName();
@@ -227,6 +242,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public IEnumerable<string> ScannerIps { get; set; } = Array.Empty<string>();
         public int PasswordIterations { get; set; } = 100_000;
         public int AutoLogoutMinutes { get; set; }
+        public string ItemLabelSingular { get; set; } = "Tool";
+        public string ItemLabelPlural { get; set; } = "Tools";
 
         public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
         {
@@ -261,6 +278,21 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default)
         {
             AutoLogoutMinutes = minutes;
+            return Task.CompletedTask;
+        }
+
+        public Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(ItemLabelSingular);
+        public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default)
+        {
+            ItemLabelSingular = label;
+            return Task.CompletedTask;
+        }
+        public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(ItemLabelPlural);
+        public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default)
+        {
+            ItemLabelPlural = label;
             return Task.CompletedTask;
         }
     }

--- a/ToolManagementAppV2.Tests/Views/AvatarSelectionWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/AvatarSelectionWindowTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Views.Pages;
 using ToolManagementAppV2.Views.Windows;
+using ToolManagementAppV2.Utilities.Helpers;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.Views
@@ -59,7 +60,7 @@ namespace ToolManagementAppV2.Tests.Views
 
                     window.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
 
-                    Assert.Equal("Tool Inventory Management – Select Avatar", window.Title);
+                    Assert.Equal($"{LabelProvider.Instance.ItemLabelSingular} Inventory Management – Select Avatar", window.Title);
                 }
                 catch (Exception ex)
                 {
@@ -112,6 +113,8 @@ namespace ToolManagementAppV2.Tests.Views
         class StubSettingsService : ISettingsService
         {
             public string? AppName { get; set; }
+            public string ItemLabelSingular { get; set; } = "Tool";
+            public string ItemLabelPlural { get; set; } = "Tools";
 
             public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default)
                 => Task.FromResult(AppName);
@@ -136,6 +139,20 @@ namespace ToolManagementAppV2.Tests.Views
                 => Task.FromResult(0);
             public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
+            public Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult(ItemLabelSingular);
+            public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default)
+            {
+                ItemLabelSingular = label;
+                return Task.CompletedTask;
+            }
+            public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult(ItemLabelPlural);
+            public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default)
+            {
+                ItemLabelPlural = label;
+                return Task.CompletedTask;
+            }
         }
 
         class FailingSettingsService : ISettingsService
@@ -162,6 +179,14 @@ namespace ToolManagementAppV2.Tests.Views
             public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default)
                 => Task.FromResult(0);
             public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult("Tool");
+            public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult("Tools");
+            public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
         }
     }

--- a/ToolManagementAppV2.Tests/Views/ToolSearchPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ToolSearchPageTests.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Linq;
 using System.Threading;
 using ToolManagementAppV2.Views.Pages;
 using ToolManagementAppV2.Views.Windows;
+using ToolManagementAppV2.Utilities.Helpers;
+using ToolManagementAppV2.Tests;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.Views
@@ -35,6 +38,37 @@ namespace ToolManagementAppV2.Tests.Views
             {
                 throw threadException;
             }
+        }
+
+        [Fact]
+        public void SearchButton_UsesItemLabel()
+        {
+            Exception? threadException = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    LabelProvider.Instance.UpdateLabels("Widget", "Widgets");
+                    if (System.Windows.Application.Current == null)
+                        new System.Windows.Application();
+                    var page = new ToolSearchPage();
+                    var button = TestHelpers.FindVisualChildren<System.Windows.Controls.Button>(page)
+                        .First(b => (string)b.Content! == "Search Widgets");
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+                finally
+                {
+                    LabelProvider.Instance.UpdateLabels("Tool", "Tools");
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadException != null)
+                throw threadException;
         }
     }
 }

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -122,8 +122,10 @@ namespace ToolManagementAppV2
 
             var loggerFactory = Host.Services.GetRequiredService<ILoggerFactory>();
             PathHelper.Configure(loggerFactory.CreateLogger("PathHelper"));
-            SecurityHelper.SettingsService = Host.Services.GetRequiredService<ISettingsService>();
+            var settingsService = Host.Services.GetRequiredService<ISettingsService>();
+            SecurityHelper.SettingsService = settingsService;
             await SecurityHelper.GetIterationsAsync().ConfigureAwait(false);
+            await LabelProvider.Instance.InitializeAsync(settingsService).ConfigureAwait(false);
 
             var main = (Window)Host.Services.GetRequiredService<IMainWindow>();
             Current.MainWindow = main;

--- a/ToolManagementAppV2/Interfaces/ISettingsService.cs
+++ b/ToolManagementAppV2/Interfaces/ISettingsService.cs
@@ -21,5 +21,11 @@ namespace ToolManagementAppV2.Interfaces
         // Auto logout configuration
         Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default);
         Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default);
+
+        // Item label configuration
+        Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default);
+        Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default);
+        Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default);
+        Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default);
     }
 }

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -3,7 +3,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:ToolManagementAppV2.Controls"
-        Title="Tool Management" Width="1280" Height="800" WindowStartupLocation="CenterScreen"
+        xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers"
+        Title="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat={0} Management}" Width="1280" Height="800" WindowStartupLocation="CenterScreen"
         Background="{StaticResource BackgroundBrush}">
     <DockPanel LastChildFill="True">
         <Border DockPanel.Dock="Left" Width="260" Background="{StaticResource SurfaceBrush}" BorderBrush="{StaticResource BorderBrushBase}" BorderThickness="0,0,1,0">
@@ -17,7 +18,7 @@
                 <StackPanel Orientation="Vertical" Margin="16,16,16,8">
                     <StackPanel Orientation="Horizontal">
                         <Image Source="{Binding CompanyLogoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=logo}" Width="36" Height="36" Margin="0,0,8,0"/>
-                        <TextBlock Text="Tool Management" Style="{StaticResource HeadingTextBlock}"/>
+                        <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat={0} Management}" Style="{StaticResource HeadingTextBlock}"/>
                     </StackPanel>
                         <TextBlock Text="{Binding CurrentPageTitle}" Style="{StaticResource CaptionTextBlock}" Margin="0,4,0,0"/>
                 </StackPanel>
@@ -29,12 +30,12 @@
                     <StackPanel Orientation="Vertical" Margin="12,0,12,8">
                         <TextBlock Text="Operations" Style="{StaticResource CaptionTextBlock}" Margin="6,8,6,2"/>
                         <Button Style="{StaticResource NavButton}" Content="Dashboard" Command="{Binding OpenDashboardCommand}"/>
-                        <Button Style="{StaticResource NavButton}" Content="Search Tools" Command="{Binding OpenSearchToolsCommand}"/>
+                        <Button Style="{StaticResource NavButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Search {0}}" Command="{Binding OpenSearchToolsCommand}"/>
 
                         <Separator/>
 
                         <TextBlock Text="Workshop" Style="{StaticResource CaptionTextBlock}" Margin="6,8,6,2"/>
-                        <Button Style="{StaticResource NavButton}" Content="Manage Tools" Command="{Binding OpenManageToolsCommand}" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
+                        <Button Style="{StaticResource NavButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Manage {0}}" Command="{Binding OpenManageToolsCommand}" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
                         <Button Style="{StaticResource NavButton}" Content="Customers" Command="{Binding OpenCustomersCommand}"/>
                         <Button Style="{StaticResource NavButton}" Content="Users" Command="{Binding OpenUsersCommand}" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
 

--- a/ToolManagementAppV2/Resources/Templates.xaml
+++ b/ToolManagementAppV2/Resources/Templates.xaml
@@ -1,6 +1,7 @@
 <!-- Resources/Templates.xaml -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers">
     <DataTemplate x:Key="StatCardTemplate">
         <Border Style="{StaticResource Card}">
             <Grid>
@@ -51,8 +52,8 @@
 
     <!-- Shared rental DataGrid columns -->
     <DataGridTextColumn x:Key="RentalIdColumn" Header="Rental #" Binding="{Binding RentalId}" Width="120" x:Shared="False"/>
-    <DataGridTextColumn x:Key="RentalToolNumberColumn" Header="Tool #" Binding="{Binding ToolNumber}" Width="120" x:Shared="False"/>
-    <DataGridTextColumn x:Key="RentalToolNameColumn" Header="Tool" Binding="{Binding ToolName}" Width="*" x:Shared="False"/>
+    <DataGridTextColumn x:Key="RentalToolNumberColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat={}{0} #}" Binding="{Binding ToolNumber}" Width="120" x:Shared="False"/>
+    <DataGridTextColumn x:Key="RentalToolNameColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}" Binding="{Binding ToolName}" Width="*" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalCustomerColumn" Header="Customer" Binding="{Binding CustomerName}" Width="220" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalOutColumn" Header="Out" Binding="{Binding DateOut, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalDueColumn" Header="Due" Binding="{Binding DueDate, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180" x:Shared="False"/>

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -207,6 +207,8 @@ namespace ToolManagementAppV2.Services.Settings
         const string ScannerIpKey = "ScannerIpAddresses";
         const string PasswordIterationsKey = "PasswordIterations";
         const string AutoLogoutMinutesKey = "AutoLogoutMinutes";
+        const string ItemLabelSingularKey = "ItemLabelSingular";
+        const string ItemLabelPluralKey = "ItemLabelPlural";
 
         public async Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default)
         {
@@ -286,6 +288,30 @@ namespace ToolManagementAppV2.Services.Settings
             if (minutes < 0)
                 throw new ArgumentOutOfRangeException(nameof(minutes));
             await SaveSettingAsync(AutoLogoutMinutesKey, minutes.ToString(), cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default)
+        {
+            var value = await GetSettingAsync(ItemLabelSingularKey, cancellationToken).ConfigureAwait(false);
+            return string.IsNullOrWhiteSpace(value) ? "Tool" : value;
+        }
+
+        public async Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default)
+        {
+            _auth.EnsureAdmin();
+            await SaveSettingAsync(ItemLabelSingularKey, label, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default)
+        {
+            var value = await GetSettingAsync(ItemLabelPluralKey, cancellationToken).ConfigureAwait(false);
+            return string.IsNullOrWhiteSpace(value) ? "Tools" : value;
+        }
+
+        public async Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default)
+        {
+            _auth.EnsureAdmin();
+            await SaveSettingAsync(ItemLabelPluralKey, label, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/ToolManagementAppV2/Utilities/Helpers/LabelProvider.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/LabelProvider.cs
@@ -1,0 +1,43 @@
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using ToolManagementAppV2.Interfaces;
+
+namespace ToolManagementAppV2.Utilities.Helpers
+{
+    public class LabelProvider : ObservableObject
+    {
+        public static LabelProvider Instance { get; } = new LabelProvider();
+
+        LabelProvider() { }
+
+        private string _itemLabelSingular = "Tool";
+        public string ItemLabelSingular
+        {
+            get => _itemLabelSingular;
+            private set => SetProperty(ref _itemLabelSingular, value);
+        }
+
+        private string _itemLabelPlural = "Tools";
+        public string ItemLabelPlural
+        {
+            get => _itemLabelPlural;
+            private set => SetProperty(ref _itemLabelPlural, value);
+        }
+
+        public async Task InitializeAsync(ISettingsService settingsService)
+        {
+            var singular = await settingsService.GetItemLabelSingularAsync().ConfigureAwait(false);
+            var plural = await settingsService.GetItemLabelPluralAsync().ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(singular))
+                ItemLabelSingular = singular;
+            if (!string.IsNullOrWhiteSpace(plural))
+                ItemLabelPlural = plural;
+        }
+
+        public void UpdateLabels(string singular, string plural)
+        {
+            ItemLabelSingular = singular;
+            ItemLabelPlural = plural;
+        }
+    }
+}

--- a/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
@@ -10,6 +10,7 @@ using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Users;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using ToolManagementAppV2.Utilities.Helpers;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -55,7 +56,7 @@ namespace ToolManagementAppV2.ViewModels
             NewToolCommand = new RelayCommand(() =>
             {
                 try { _openManageToolsCommand.Execute(null); }
-                catch (Exception ex) { _logger.LogError(ex, "Failed to open manage tools page"); }
+                catch (Exception ex) { _logger.LogError(ex, "Failed to open manage {ItemLabelPlural} page", LabelProvider.Instance.ItemLabelPlural.ToLower()); }
             });
 
             OpenRentalsCommand = new RelayCommand(() =>
@@ -80,7 +81,7 @@ namespace ToolManagementAppV2.ViewModels
             {
                 StatCards.Clear();
                 var tools = await _toolService.GetAllToolsAsync(cancellationToken);
-                StatCards.Add(new StatCard { Title = "Total Tools", Value = tools.Count.ToString() });
+                StatCards.Add(new StatCard { Title = $"Total {LabelProvider.Instance.ItemLabelPlural}", Value = tools.Count.ToString() });
                 var activeRentals = await _rentalService.GetActiveRentalsAsync();
                 var customers = await _customerService.GetAllCustomersAsync(cancellationToken);
                 var users = await _userService.GetAllUsersAsync();

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -12,6 +12,7 @@ using ToolManagementAppV2.Models.ImportExport;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ToolManagementAppV2.Utilities.IO;
+using ToolManagementAppV2.Utilities.Helpers;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -73,21 +74,25 @@ namespace ToolManagementAppV2.ViewModels
                 var map = _dialogService.ShowImportMapping(headers, properties);
                 if (map == null)
                     return;
-                await _dialogService.ShowInfoAsync("Importing tools...", "Import Tools");
+                var plural = LabelProvider.Instance.ItemLabelPlural;
+                await _dialogService.ShowInfoAsync($"Importing {plural}...", $"Import {plural}");
                 await _toolService.ImportToolsFromCsvAsync(path, map, cancellationToken);
-                ImportExportLogs.Add($"Successfully imported tools from {path}.");
-                await _dialogService.ShowInfoAsync($"Successfully imported tools from {path}.", "Import Tools");
+                ImportExportLogs.Add($"Successfully imported {plural} from {path}.");
+                await _dialogService.ShowInfoAsync($"Successfully imported {plural} from {path}.", $"Import {plural}");
             }
             catch (OperationCanceledException)
             {
-                ImportExportLogs.Add("Tool import was cancelled.");
-                await _dialogService.ShowInfoAsync("Tool import was cancelled.", "Import Tools");
+                var singular = LabelProvider.Instance.ItemLabelSingular;
+                var plural = LabelProvider.Instance.ItemLabelPlural;
+                ImportExportLogs.Add($"{singular} import was cancelled.");
+                await _dialogService.ShowInfoAsync($"{singular} import was cancelled.", $"Import {plural}");
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to import tools from {Path}", path);
-                ImportExportLogs.Add($"Failed to import tools from {path}: {ex.Message}");
-                await _dialogService.ShowInfoAsync($"Failed to import tools from {path}: {ex.Message}", "Import Tools");
+                var plural = LabelProvider.Instance.ItemLabelPlural;
+                _logger.LogError(ex, "Failed to import {ItemLabelPlural} from {Path}", plural, path);
+                ImportExportLogs.Add($"Failed to import {plural} from {path}: {ex.Message}");
+                await _dialogService.ShowInfoAsync($"Failed to import {plural} from {path}: {ex.Message}", $"Import {plural}");
             }
         }
 
@@ -97,17 +102,20 @@ namespace ToolManagementAppV2.ViewModels
             if (string.IsNullOrEmpty(path)) return;
             try
             {
+                var plural = LabelProvider.Instance.ItemLabelPlural;
                 await _toolService.ExportToolsToCsvAsync(path, cancellationToken);
-                ImportExportLogs.Add($"Successfully exported tools to {path}.");
+                ImportExportLogs.Add($"Successfully exported {plural} to {path}.");
             }
             catch (OperationCanceledException)
             {
-                ImportExportLogs.Add("Tool export was cancelled.");
+                var singular = LabelProvider.Instance.ItemLabelSingular;
+                ImportExportLogs.Add($"{singular} export was cancelled.");
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to export tools to {Path}", path);
-                ImportExportLogs.Add($"Failed to export tools to {path}: {ex.Message}");
+                var plural = LabelProvider.Instance.ItemLabelPlural;
+                _logger.LogError(ex, "Failed to export {ItemLabelPlural} to {Path}", plural, path);
+                ImportExportLogs.Add($"Failed to export {plural} to {path}: {ex.Message}");
             }
         }
 

--- a/ToolManagementAppV2/ViewModels/LoginViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/LoginViewModel.cs
@@ -170,7 +170,7 @@ namespace ToolManagementAppV2.ViewModels
             var appName = await _settingsService.GetSettingAsync("ApplicationName", cancellationToken);
             return !string.IsNullOrWhiteSpace(appName)
                 ? $"{appName} – Login"
-                : "Tool Inventory Management – Login";
+                : $"{LabelProvider.Instance.ItemLabelSingular} Inventory Management – Login";
         }
 
         async Task LoadUsersAsync()

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -25,6 +25,7 @@ using ToolManagementAppV2.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using ToolManagementAppV2.Models.ImportExport;
 using ToolManagementAppV2.Utilities;
+using ToolManagementAppV2.Utilities.Helpers;
 using Application = System.Windows.Application;
 
 namespace ToolManagementAppV2.ViewModels
@@ -219,7 +220,8 @@ namespace ToolManagementAppV2.ViewModels
             OpenSearchToolsCommand = new AsyncRelayCommand(async () =>
             {
                 await ToolManagement.LoadToolsAsync();
-                var page = new ToolSearchPage { DataContext = ToolManagement, Title = "Search Tools" };
+                var plural = LabelProvider.Instance.ItemLabelPlural;
+                var page = new ToolSearchPage { DataContext = ToolManagement, Title = $"Search {plural}" };
                 // If your ToolManagement VM supports a query setter, apply GlobalSearchText there.
                 CurrentPage = page;
             });
@@ -227,7 +229,8 @@ namespace ToolManagementAppV2.ViewModels
             OpenManageToolsCommand = new AsyncRelayCommand(async () =>
             {
                 await ToolManagement.LoadToolsAsync();
-                var page = new ManageToolsPage { DataContext = ToolManagement, Title = "Manage Tools" };
+                var plural = LabelProvider.Instance.ItemLabelPlural;
+                var page = new ManageToolsPage { DataContext = ToolManagement, Title = $"Manage {plural}" };
                 CurrentPage = page;
             });
 
@@ -420,18 +423,20 @@ namespace ToolManagementAppV2.ViewModels
                     _logger.LogInformation("Import mapping selected. Headers: {Headers}. Map: {Map}",
                         string.Join(", ", headers),
                         mappingString);
-                    await _dialogService.ShowInfoAsync("Importing tools...", "Import Tools");
+                    var plural = LabelProvider.Instance.ItemLabelPlural;
+                    await _dialogService.ShowInfoAsync($"Importing {plural}...", $"Import {plural}");
                     var invalid = await _toolService.ImportToolsFromCsvAsync(path, map, cancellationToken);
                     var msg = invalid.Count == 0
-                        ? "Successfully imported tools."
+                        ? $"Successfully imported {plural}."
                         : $"Imported with {invalid.Count} invalid rows.";
-                    await _dialogService.ShowInfoAsync(msg, "Import Tools");
+                    await _dialogService.ShowInfoAsync(msg, $"Import {plural}");
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to import tools from CSV");
-                await _dialogService.ShowInfoAsync($"Failed to import tools: {ex.Message}", "Import Tools");
+                var plural = LabelProvider.Instance.ItemLabelPlural;
+                _logger.LogError(ex, "Failed to import {ItemLabelPlural} from CSV", plural);
+                await _dialogService.ShowInfoAsync($"Failed to import {plural}: {ex.Message}", $"Import {plural}");
             }
         }
 

--- a/ToolManagementAppV2/ViewModels/PrintLabelViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/PrintLabelViewModel.cs
@@ -5,6 +5,7 @@ using System.Windows.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Utilities.Helpers;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -44,7 +45,7 @@ namespace ToolManagementAppV2.ViewModels
             {
                 var dlg = new System.Windows.Controls.PrintDialog();
                 if (dlg.ShowDialog() == true)
-                    dlg.PrintDocument(((IDocumentPaginatorSource)doc).DocumentPaginator, "Tool Labels");
+                    dlg.PrintDocument(((IDocumentPaginatorSource)doc).DocumentPaginator, $"{LabelProvider.Instance.ItemLabelSingular} Labels");
             });
             Templates = new ObservableCollection<string> { "Standard", "Compact" };
             _selectedTemplate = Templates.First();
@@ -57,7 +58,7 @@ namespace ToolManagementAppV2.ViewModels
         private void Preview()
         {
             var doc = BuildDocument();
-            _dialogService.ShowPrintPreview(doc, "Tool Labels", string.Empty);
+            _dialogService.ShowPrintPreview(doc, $"{LabelProvider.Instance.ItemLabelSingular} Labels", string.Empty);
         }
 
         private void Print()

--- a/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/SettingsViewModel.cs
@@ -9,6 +9,7 @@ using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Services.Core;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using ToolManagementAppV2.Utilities.Helpers;
 
 namespace ToolManagementAppV2.ViewModels
 {
@@ -38,6 +39,8 @@ namespace ToolManagementAppV2.ViewModels
             _theme = ThemeOptions[0];
             _passwordIterations = _settingsService.GetPasswordIterationsAsync().GetAwaiter().GetResult();
             _autoLogoutMinutes = _settingsService.GetAutoLogoutMinutesAsync().GetAwaiter().GetResult();
+            _itemLabelSingular = LabelProvider.Instance.ItemLabelSingular;
+            _itemLabelPlural = LabelProvider.Instance.ItemLabelPlural;
             TestDbCommand = new RelayCommand(() =>
             {
                 var success = TestDbConnection(out var message);
@@ -84,6 +87,58 @@ namespace ToolManagementAppV2.ViewModels
         {
             get => _companyLogoPath;
             set => SetProperty(ref _companyLogoPath, value);
+        }
+
+        private string _itemLabelSingular;
+        public string ItemLabelSingular
+        {
+            get => _itemLabelSingular;
+            set
+            {
+                if (SetProperty(ref _itemLabelSingular, value))
+                {
+                    try
+                    {
+                        _settingsService.SaveItemLabelSingularAsync(value).GetAwaiter().GetResult();
+                        LabelProvider.Instance.UpdateLabels(value, ItemLabelPlural);
+                    }
+                    catch (UnauthorizedAccessException ex)
+                    {
+                        _logger.LogWarning(ex, "Unauthorized to change settings.");
+                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to save item label singular.");
+                    }
+                }
+            }
+        }
+
+        private string _itemLabelPlural;
+        public string ItemLabelPlural
+        {
+            get => _itemLabelPlural;
+            set
+            {
+                if (SetProperty(ref _itemLabelPlural, value))
+                {
+                    try
+                    {
+                        _settingsService.SaveItemLabelPluralAsync(value).GetAwaiter().GetResult();
+                        LabelProvider.Instance.UpdateLabels(ItemLabelSingular, value);
+                    }
+                    catch (UnauthorizedAccessException ex)
+                    {
+                        _logger.LogWarning(ex, "Unauthorized to change settings.");
+                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to save item label plural.");
+                    }
+                }
+            }
         }
 
         private int _defaultRentalDuration;

--- a/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolManagementViewModel.cs
@@ -11,6 +11,7 @@ using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Utilities;
 using ToolManagementAppV2.Utilities.Extensions;
 using ToolManagementAppV2.Services;
+using ToolManagementAppV2.Utilities.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -217,16 +218,16 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (UnauthorizedAccessException)
             {
-                await _dialogService.ShowInfoAsync("You are not authorized to add tools.", "Unauthorized");
+                await _dialogService.ShowInfoAsync($"You are not authorized to add {LabelProvider.Instance.ItemLabelPlural.ToLower()}.", "Unauthorized");
             }
             catch (InvalidOperationException ex)
             {
-                _logger.LogError(ex, "Failed to add tool due to invalid operation");
+                _logger.LogError(ex, "Failed to add {ItemLabelSingular} due to invalid operation", LabelProvider.Instance.ItemLabelSingular);
                 await _dialogService.ShowInfoAsync(ex.Message, "Error");
             }
             catch (ArgumentException ex)
             {
-                _logger.LogError(ex, "Failed to add tool due to invalid argument");
+                _logger.LogError(ex, "Failed to add {ItemLabelSingular} due to invalid argument", LabelProvider.Instance.ItemLabelSingular);
                 await _dialogService.ShowInfoAsync(ex.Message, "Error");
             }
         }
@@ -272,7 +273,7 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (UnauthorizedAccessException)
             {
-                await _dialogService.ShowInfoAsync("You are not authorized to update tools.", "Unauthorized");
+                await _dialogService.ShowInfoAsync($"You are not authorized to update {LabelProvider.Instance.ItemLabelPlural.ToLower()}.", "Unauthorized");
             }
         }
 
@@ -292,7 +293,7 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to open rental history for tool {ToolID}", SelectedTool.ToolID);
+                _logger.LogError(ex, "Failed to open rental history for {ItemLabelSingular} {ToolID}", LabelProvider.Instance.ItemLabelSingular, SelectedTool.ToolID);
             }
         }
 
@@ -300,7 +301,7 @@ namespace ToolManagementAppV2.ViewModels
         {
             if (SelectedTool == null) return;
             var confirm = await _dialogService.ShowConfirmationAsync(
-                $"Delete tool '{SelectedTool.NameDescription}'?",
+                $"Delete {LabelProvider.Instance.ItemLabelSingular.ToLower()} '{SelectedTool.NameDescription}'?",
                 "Confirm Delete");
             if (!confirm)
                 return;
@@ -318,12 +319,12 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (UnauthorizedAccessException)
             {
-                await _dialogService.ShowInfoAsync("You are not authorized to delete tools.", "Unauthorized");
+                await _dialogService.ShowInfoAsync($"You are not authorized to delete {LabelProvider.Instance.ItemLabelPlural.ToLower()}.", "Unauthorized");
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to delete tool {ToolID}", SelectedTool.ToolID);
-                await _dialogService.ShowInfoAsync($"Failed to delete tool: {ex.Message}", "Error");
+                _logger.LogError(ex, "Failed to delete {ItemLabelSingular} {ToolID}", LabelProvider.Instance.ItemLabelSingular, SelectedTool.ToolID);
+                await _dialogService.ShowInfoAsync($"Failed to delete {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {ex.Message}", "Error");
             }
         }
 
@@ -351,12 +352,12 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (UnauthorizedAccessException)
             {
-                await _dialogService.ShowInfoAsync("You are not authorized to rent tools.", "Unauthorized");
+                await _dialogService.ShowInfoAsync($"You are not authorized to rent {LabelProvider.Instance.ItemLabelPlural.ToLower()}.", "Unauthorized");
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to rent tool {ToolID}", SelectedTool?.ToolID);
-                await _dialogService.ShowInfoAsync($"Failed to rent tool: {ex.Message}", "Error");
+                _logger.LogError(ex, "Failed to rent {ItemLabelSingular} {ToolID}", LabelProvider.Instance.ItemLabelSingular, SelectedTool?.ToolID);
+                await _dialogService.ShowInfoAsync($"Failed to rent {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {ex.Message}", "Error");
             }
         }
 

--- a/ToolManagementAppV2/Views/Controls/SearchBar.xaml
+++ b/ToolManagementAppV2/Views/Controls/SearchBar.xaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="ToolManagementAppV2.Controls.SearchBar"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers"
              x:Name="Root">
     <StackPanel Orientation="Horizontal">
         <TextBox x:Name="SearchTextBox"
@@ -11,7 +12,7 @@
             </TextBox.InputBindings>
         </TextBox>
         <Button Style="{StaticResource PrimaryButton}"
-                Content="Search Tools"
+                Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Search {0}}"
                 Command="{Binding SearchCommand, ElementName=Root}"
                 Margin="8,0,0,0"/>
     </StackPanel>

--- a/ToolManagementAppV2/Views/Pages/DashboardPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/DashboardPage.xaml
@@ -2,6 +2,7 @@
 <Page x:Class="ToolManagementAppV2.Views.Pages.DashboardPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers"
       Background="{StaticResource BackgroundBrush}">
     <Grid Margin="8">
         <Grid.RowDefinitions>
@@ -36,8 +37,8 @@
                 <StackPanel>
                     <TextBlock Text="Quick Actions" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
                     <WrapPanel>
-                        <Button Style="{StaticResource PrimaryButton}" Content="New Tool" Command="{Binding NewToolCommand}" Margin="0,0,8,8"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Rent Tool" Command="{Binding OpenRentalsCommand}" Margin="0,0,8,8"/>
+                        <Button Style="{StaticResource PrimaryButton}" Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=New {0}}" Command="{Binding NewToolCommand}" Margin="0,0,8,8"/>
+                        <Button Style="{StaticResource PrimaryButton}" Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Rent {0}}" Command="{Binding OpenRentalsCommand}" Margin="0,0,8,8"/>
                     </WrapPanel>
                 </StackPanel>
             </Border>

--- a/ToolManagementAppV2/Views/Pages/ImportExportPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/ImportExportPage.xaml
@@ -2,6 +2,7 @@
 <Page x:Class="ToolManagementAppV2.Views.Pages.ImportExportPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers"
       Background="{StaticResource BackgroundBrush}">
     <Grid Margin="8">
         <Grid.RowDefinitions>
@@ -17,12 +18,12 @@
 
             <!-- Tools -->
             <StackPanel Grid.Column="0" Margin="0,0,8,0">
-                <TextBlock Text="Tools" Style="{StaticResource SectionHeader}" />
+                <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}" Style="{StaticResource SectionHeader}" />
                 <WrapPanel>
-                    <Button Style="{StaticResource CompactPrimaryButton}" Content="Import Tools CSV" Command="{Binding ImportToolsCommand}"/>
-                    <Button Style="{StaticResource CompactPrimaryButton}" Content="Import Tool Images" Command="{Binding DataContext.OpenImageImportMappingWindowCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                    <Button Style="{StaticResource CompactPrimaryButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Import {0} CSV}" Command="{Binding ImportToolsCommand}"/>
+                    <Button Style="{StaticResource CompactPrimaryButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Import {0} Images}" Command="{Binding DataContext.OpenImageImportMappingWindowCommand, RelativeSource={RelativeSource AncestorType=Window}}"
                             Visibility="{Binding DataContext.IsCurrentUserAdmin, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource BoolToVis}}"/>
-                    <Button Style="{StaticResource CompactPrimaryButton}" Content="Export Tools CSV" Command="{Binding ExportToolsCommand}"/>
+                    <Button Style="{StaticResource CompactPrimaryButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Export {0} CSV}" Command="{Binding ExportToolsCommand}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}" Content="Backup Database" Command="{Binding BackupDatabaseCommand}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}" Content="Cancel Import" Command="{Binding CancelImportToolsCommand}" IsEnabled="{Binding ImportToolsCommand.IsRunning}"/>
 

--- a/ToolManagementAppV2/Views/Pages/ManageToolsPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/ManageToolsPage.xaml
@@ -2,6 +2,7 @@
 <Page x:Class="ToolManagementAppV2.Views.Pages.ManageToolsPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers"
       Background="{StaticResource BackgroundBrush}">
     <Grid Margin="8">
         <Border Style="{StaticResource Card}">
@@ -12,7 +13,7 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <TextBlock Text="Tools" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
+                <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
 
                 <DataGrid Grid.Row="1"
                           ItemsSource="{Binding Tools}"
@@ -30,7 +31,7 @@
                     </DataGrid.Columns>
                     <DataGrid.ContextMenu>
                         <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                            <MenuItem Header="Rent" Command="{Binding OpenRentalsCommand}"/>
+                            <MenuItem Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Rent {0}}" Command="{Binding OpenRentalsCommand}"/>
                             <MenuItem Header="Delete" Command="{Binding DeleteToolCommand}"/>
                         </ContextMenu>
                     </DataGrid.ContextMenu>

--- a/ToolManagementAppV2/Views/Pages/SettingsPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/SettingsPage.xaml
@@ -34,6 +34,8 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
                         <TextBlock Text="Theme" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                         <ComboBox Grid.Column="1" SelectedItem="{Binding Theme}" ItemsSource="{Binding ThemeOptions}" Margin="8,0,0,0"/>
@@ -41,6 +43,10 @@
                         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding PasswordIterations}" Margin="8,0,0,0" PreviewTextInput="PasswordIterationsBox_PreviewTextInput"/>
                         <TextBlock Grid.Row="2" Text="Auto-logout (minutes)" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                         <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding AutoLogoutMinutes}" Margin="8,0,0,0" PreviewTextInput="AutoLogoutMinutesBox_PreviewTextInput"/>
+                        <TextBlock Grid.Row="3" Text="Singular Item Label" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding ItemLabelSingular}" Margin="8,0,0,0"/>
+                        <TextBlock Grid.Row="4" Text="Plural Item Label" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                        <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding ItemLabelPlural}" Margin="8,0,0,0"/>
                     </Grid>
                 </StackPanel>
             </Border>

--- a/ToolManagementAppV2/Views/Pages/ToolSearchPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/ToolSearchPage.xaml
@@ -2,6 +2,7 @@
 <Page
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers"
       xmlns:av="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="av" x:Class="ToolManagementAppV2.Views.Pages.ToolSearchPage"
       Background="{StaticResource BackgroundBrush}">
     <Grid Margin="8">
@@ -21,7 +22,7 @@
                           ItemsSource="{Binding Categories}"
                           SelectedItem="{Binding SelectedCategory, Mode=TwoWay}"
                           Margin="8,0,0,0"/>
-                <Button Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Search Tools" Command="{Binding SearchCommand}" Margin="8,0,0,0"/>
+                <Button Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Search {0}}" Command="{Binding SearchCommand}" Margin="8,0,0,0"/>
             </Grid>
         </Border>
         <ListBox x:Name="ToolsList" Grid.Row="1"

--- a/ToolManagementAppV2/Views/Windows/AvatarSelectionWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/AvatarSelectionWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="ToolManagementAppV2.Views.Windows.AvatarSelectionWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Tool Inventory Management – Select Avatar"
+        xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers"
+        Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat={0} Inventory Management – Select Avatar}"
         Height="650" Width="1600"
         Background="{DynamicResource BackgroundBrush}"
         WindowStartupLocation="CenterScreen">

--- a/ToolManagementAppV2/Views/Windows/AvatarSelectionWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/Windows/AvatarSelectionWindow.xaml.cs
@@ -8,6 +8,7 @@ using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Utilities.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using ToolManagementAppV2.Utilities.Helpers;
 
 
 namespace ToolManagementAppV2.Views.Windows
@@ -51,7 +52,7 @@ namespace ToolManagementAppV2.Views.Windows
                 var appName = await _settingsService.GetSettingAsync("ApplicationName");
                 Title = !string.IsNullOrWhiteSpace(appName)
                     ? $"{appName} – Select Avatar"
-                    : "Tool Inventory Management – Select Avatar";
+                    : $"{LabelProvider.Instance.ItemLabelSingular} Inventory Management – Select Avatar";
             }
             catch (Exception ex)
             {

--- a/ToolManagementAppV2/Views/Windows/ImageImportMappingWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ImageImportMappingWindow.xaml
@@ -3,7 +3,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:ToolManagementAppV2.Controls"
-        Title="Import Tool Pictures"
+        xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers"
+        Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Import {0} Pictures}"
         Width="600" Height="220"
         WindowStartupLocation="CenterScreen"
         Background="{StaticResource BackgroundBrush}">
@@ -12,7 +13,7 @@
             <StackPanel>
                 <TextBlock Text="Match images by:" Style="{StaticResource SectionHeader}"/>
                 <WrapPanel>
-                    <CheckBox Content="ToolNumber" IsChecked="{Binding UseToolNumber}" Margin="6,0"/>
+                    <CheckBox Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat={0}Number}" IsChecked="{Binding UseToolNumber}" Margin="6,0"/>
                     <CheckBox Content="PartNumber" IsChecked="{Binding UsePartNumber}" Margin="6,0"/>
                     <CheckBox Content="NameDescription" IsChecked="{Binding UseNameDescription}" Margin="6,0"/>
                 </WrapPanel>

--- a/ToolManagementAppV2/Views/Windows/PrintLabelWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/PrintLabelWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:domain="clr-namespace:ToolManagementAppV2.Models.Domain"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers"
         mc:Ignorable="d"
         Title="Print Labels"
         Width="720" Height="420"
@@ -37,7 +38,7 @@
                       Style="{StaticResource VirtualizedDataGridStyle}"
                       ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
                 <DataGrid.Columns>
-                    <DataGridTextColumn Header="Tool #" Binding="{Binding ToolNumber}" Width="120"/>
+                    <DataGridTextColumn Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat={}{0} #}" Binding="{Binding ToolNumber}" Width="120"/>
                     <DataGridTextColumn Header="Name" Binding="{Binding NameDescription}" Width="*"/>
                     <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="180"/>
                 </DataGrid.Columns>

--- a/ToolManagementAppV2/Views/Windows/RentToolPopupWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/RentToolPopupWindow.xaml
@@ -2,13 +2,14 @@
 <Window x:Class="ToolManagementAppV2.Views.Windows.RentToolPopupWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Rent Tool"
+        xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers"
+        Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Rent {0}}"
         Width="800" Height="420"
         WindowStartupLocation="CenterScreen"
         Background="{StaticResource BackgroundBrush}">
     <DockPanel Margin="10">
         <Border DockPanel.Dock="Top" Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" Padding="10" CornerRadius="8">
-            <TextBlock Text="Rent Tool" Style="{StaticResource HeadingTextBlock}"/>
+            <TextBlock Text="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Rent {0}}" Style="{StaticResource HeadingTextBlock}"/>
         </Border>
 
         <Border Style="{StaticResource Card}" Margin="0,8,0,8">

--- a/ToolManagementAppV2/Views/Windows/ToolDetailsWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ToolDetailsWindow.xaml
@@ -2,7 +2,8 @@
 <Window x:Class="ToolManagementAppV2.Views.Windows.ToolDetailsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Tool Details" Width="520" Height="420" WindowStartupLocation="CenterOwner"
+        xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers"
+        Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat={0} Details}" Width="520" Height="420" WindowStartupLocation="CenterOwner"
         Background="{StaticResource BackgroundBrush}">
     <Grid Margin="12">
         <Grid.RowDefinitions>
@@ -29,7 +30,7 @@
             <Image Grid.Row="0" Grid.ColumnSpan="2" Width="120" Height="120" Margin="0,0,0,8" HorizontalAlignment="Center"
                    Source="{Binding Tool.ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=tool}"/>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Tool Number" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat={}{0} Number}" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
             <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Tool.ToolNumber}" Margin="8,4"/>
 
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>

--- a/ToolManagementAppV2/Views/Windows/ToolEditWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ToolEditWindow.xaml
@@ -3,7 +3,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:ToolManagementAppV2.Views.Controls"
-        Title="Tool" Width="520" Height="420" WindowStartupLocation="CenterOwner"
+        xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers"
+        Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}" Width="520" Height="420" WindowStartupLocation="CenterOwner"
         Background="{StaticResource BackgroundBrush}">
     <Grid Margin="12">
         <Grid.RowDefinitions>
@@ -28,7 +29,7 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="0" Grid.Column="0" Text="Tool Number" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat={}{0} Number}" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Tool.ToolNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
@@ -46,7 +47,7 @@
             <TextBlock Grid.Row="5" Grid.Column="0" Text="Supplier" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Tool.Supplier, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <CheckBox Grid.Row="6" Grid.ColumnSpan="2" Content="Power Tool" IsChecked="{Binding Tool.IsPowerTool}" Margin="0,0,0,8"/>
+            <CheckBox Grid.Row="6" Grid.ColumnSpan="2" Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Power {0}}" IsChecked="{Binding Tool.IsPowerTool}" Margin="0,0,0,8"/>
 
             <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,0,0,8">
                 <Image Width="100" Height="100" Stretch="Uniform"


### PR DESCRIPTION
## Summary
- Add singular and plural item label settings with persistence
- Centralize runtime label access through a new `LabelProvider`
- Replace hard-coded tool text in UI and view models with dynamic labels

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a55a4baad48324869b139339350841