### PR TITLE
Bind window title to application name setting

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelTitleTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelTitleTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Windows;
+using ToolManagementAppV2.Interfaces;
+using ToolManagementAppV2.Services.Core;
+using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Services.Rentals;
+using ToolManagementAppV2.Services.Settings;
+using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Users;
+using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Utilities.Helpers;
+using Xunit;
+
+namespace ToolManagementAppV2.Tests.ViewModels
+{
+    public class MainViewModelTitleTests
+    {
+        [Fact]
+        public void WindowTitle_Updates_WhenApplicationNameChanges()
+        {
+            if (Application.Current == null)
+                new Application();
+
+            var dbPath = Path.GetTempFileName();
+            var originalSingular = LabelProvider.Instance.ItemLabelSingular;
+            var originalPlural = LabelProvider.Instance.ItemLabelPlural;
+            LabelProvider.Instance.UpdateLabels("Tool", "Tools");
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IToolService toolService = new ToolService(db);
+                var userContext = new ApplicationUserContext();
+                IUserService userService = new UserService(db, userContext);
+                ICustomerService customerService = new CustomerService(db);
+                IRentalService rentalService = new RentalService(db);
+                var activityLogService = new ActivityLogService(db);
+                var settingsService = new SettingsService(db);
+
+                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                    new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
+
+                Assert.Equal("Tools Management", vm.WindowTitle);
+
+                vm.Settings.ApplicationName = "My App";
+                Assert.Equal("My App", vm.WindowTitle);
+
+                vm.Settings.ApplicationName = string.Empty;
+                Assert.Equal("Tools Management", vm.WindowTitle);
+            }
+            finally
+            {
+                LabelProvider.Instance.UpdateLabels(originalSingular, originalPlural);
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
@@ -23,6 +23,7 @@ using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Controls;
+using ToolManagementAppV2.Utilities.Helpers;
 
 namespace ToolManagementAppV2.Tests.Views
 {
@@ -107,6 +108,55 @@ namespace ToolManagementAppV2.Tests.Views
                     }
                     finally
                     {
+                        window.Close();
+                        if (File.Exists(dbPath))
+                            File.Delete(dbPath);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+            {
+                throw threadException;
+            }
+        }
+
+        [Fact]
+        public void Title_Updates_WhenApplicationNameChanges()
+        {
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var originalSingular = LabelProvider.Instance.ItemLabelSingular;
+                    var originalPlural = LabelProvider.Instance.ItemLabelPlural;
+                    LabelProvider.Instance.UpdateLabels("Tool", "Tools");
+                    var (window, dbPath) = TestHelpers.CreateMainWindow();
+                    try
+                    {
+                        var vm = Assert.IsType<MainViewModel>(window.DataContext);
+
+                        Assert.Equal("Tools Management", window.Title);
+
+                        vm.Settings.ApplicationName = "My App";
+                        Assert.Equal("My App", window.Title);
+
+                        vm.Settings.ApplicationName = string.Empty;
+                        Assert.Equal("Tools Management", window.Title);
+                    }
+                    finally
+                    {
+                        LabelProvider.Instance.UpdateLabels(originalSingular, originalPlural);
                         window.Close();
                         if (File.Exists(dbPath))
                             File.Delete(dbPath);

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:ToolManagementAppV2.Controls"
         xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers"
-        Title="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat={0} Management}" Width="1280" Height="800" WindowStartupLocation="CenterScreen"
+        Title="{Binding WindowTitle}" Width="1280" Height="800" WindowStartupLocation="CenterScreen"
         Background="{StaticResource BackgroundBrush}">
     <DockPanel LastChildFill="True">
         <Border DockPanel.Dock="Left" Width="260" Background="{StaticResource SurfaceBrush}" BorderBrush="{StaticResource BorderBrushBase}" BorderThickness="0,0,1,0">
@@ -18,7 +18,7 @@
                 <StackPanel Orientation="Vertical" Margin="16,16,16,8">
                     <StackPanel Orientation="Horizontal">
                         <Image Source="{Binding CompanyLogoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=logo}" Width="36" Height="36" Margin="0,0,8,0"/>
-                        <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat={0} Management}" Style="{StaticResource HeadingTextBlock}"/>
+                        <TextBlock Text="{Binding WindowTitle}" Style="{StaticResource HeadingTextBlock}"/>
                     </StackPanel>
                         <TextBlock Text="{Binding CurrentPageTitle}" Style="{StaticResource CaptionTextBlock}" Margin="0,4,0,0"/>
                 </StackPanel>

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -92,6 +92,21 @@ namespace ToolManagementAppV2.ViewModels
 
         public string? CurrentUserPhotoPath => _userContext.CurrentUser?.UserPhotoPath;
 
+        private string _applicationName = string.Empty;
+        public string ApplicationName
+        {
+            get => _applicationName;
+            private set
+            {
+                if (SetProperty(ref _applicationName, value))
+                    OnPropertyChanged(nameof(WindowTitle));
+            }
+        }
+
+        public string WindowTitle => string.IsNullOrWhiteSpace(ApplicationName)
+            ? $"{LabelProvider.Instance.ItemLabelPlural} Management"
+            : ApplicationName;
+
         private string? _companyLogoPath;
         public string? CompanyLogoPath
         {
@@ -205,6 +220,9 @@ namespace ToolManagementAppV2.ViewModels
             var logoPath = _settingsService.GetSettingAsync("CompanyLogoPath").GetAwaiter().GetResult();
             if (!string.IsNullOrWhiteSpace(logoPath))
                 CompanyLogoPath = logoPath;
+            var appName = _settingsService.GetSettingAsync("ApplicationName").GetAwaiter().GetResult();
+            if (!string.IsNullOrWhiteSpace(appName))
+                ApplicationName = appName;
             _autoLogoutTimer = autoLogoutTimer ?? new DispatcherTimerWrapper();
             _autoLogoutTimer.Tick += OnAutoLogoutTimerTick;
             Settings.PropertyChanged += Settings_PropertyChanged;
@@ -380,6 +398,8 @@ namespace ToolManagementAppV2.ViewModels
                 UpdateAutoLogoutTimer();
             else if (e.PropertyName == nameof(SettingsViewModel.CompanyLogoPath))
                 CompanyLogoPath = Settings.CompanyLogoPath;
+            else if (e.PropertyName == nameof(SettingsViewModel.ApplicationName))
+                ApplicationName = Settings.ApplicationName;
         }
 
         void UpdateAutoLogoutTimer()


### PR DESCRIPTION
## Summary
- expose `WindowTitle` in `MainViewModel` sourced from `ApplicationName` setting with fallback to item label
- bind main window title and sidebar heading to `WindowTitle`
- add tests ensuring window title updates with application name setting changes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5723973a883249750e7e0754cee40