### PR TITLE
Refactor tool entities to items

### DIFF
--- a/ToolManagementAppV2.Tests/AsyncServiceExtensions.cs
+++ b/ToolManagementAppV2.Tests/AsyncServiceExtensions.cs
@@ -11,20 +11,20 @@ namespace ToolManagementAppV2.Tests;
 
 public static class AsyncServiceExtensions
 {
-    // ToolService wrappers
-    public static void AddTool(this IToolService svc, Tool tool, CancellationToken token = default)
+    // ItemService wrappers
+    public static void AddTool(this IItemService svc, ItemModel tool, CancellationToken token = default)
         => svc.AddToolAsync(tool, token).GetAwaiter().GetResult();
-    public static void UpdateTool(this IToolService svc, Tool tool, CancellationToken token = default)
+    public static void UpdateTool(this IItemService svc, ItemModel tool, CancellationToken token = default)
         => svc.UpdateToolAsync(tool, token).GetAwaiter().GetResult();
-    public static void DeleteTool(this IToolService svc, int id, CancellationToken token = default)
+    public static void DeleteTool(this IItemService svc, int id, CancellationToken token = default)
         => svc.DeleteToolAsync(id, token).GetAwaiter().GetResult();
-    public static Tool? GetToolByID(this IToolService svc, int id, CancellationToken token = default)
+    public static ItemModel? GetToolByID(this IItemService svc, int id, CancellationToken token = default)
         => svc.GetToolByIDAsync(id, token).GetAwaiter().GetResult();
-    public static List<Tool> GetAllTools(this IToolService svc, CancellationToken token = default)
+    public static List<ItemModel> GetAllTools(this IItemService svc, CancellationToken token = default)
         => svc.GetAllToolsAsync(token).GetAwaiter().GetResult();
-    public static List<Tool> SearchTools(this IToolService svc, string? text, CancellationToken token = default)
+    public static List<ItemModel> SearchTools(this IItemService svc, string? text, CancellationToken token = default)
         => svc.SearchToolsAsync(text, token).GetAwaiter().GetResult();
-    public static string GenerateNextToolNumber(this IToolService svc, CancellationToken token = default)
+    public static string GenerateNextToolNumber(this IItemService svc, CancellationToken token = default)
         => svc.GenerateNextToolNumberAsync(token).GetAwaiter().GetResult();
 
     // CustomerService wrappers

--- a/ToolManagementAppV2.Tests/Extensions/ToolServiceExtensions.cs
+++ b/ToolManagementAppV2.Tests/Extensions/ToolServiceExtensions.cs
@@ -4,51 +4,51 @@ using System.Data.SQLite;
 using System.Threading;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.ImportExport;
-using ToolModel = ToolManagementAppV2.Models.Domain.Tool;
+using ItemModel = ToolManagementAppV2.Models.Domain.ItemModel;
 
 namespace ToolManagementAppV2.Tests.Extensions
 {
-    public static class ToolServiceExtensions
+    public static class ItemServiceExtensions
     {
-        public static void AddTool(this IToolService service, ToolModel tool) =>
+        public static void AddTool(this IItemService service, ItemModel tool) =>
             service.AddToolAsync(tool).GetAwaiter().GetResult();
 
-        public static void UpdateTool(this IToolService service, ToolModel tool) =>
+        public static void UpdateTool(this IItemService service, ItemModel tool) =>
             service.UpdateToolAsync(tool).GetAwaiter().GetResult();
 
-        public static void DeleteTool(this IToolService service, int toolID) =>
+        public static void DeleteTool(this IItemService service, int toolID) =>
             service.DeleteToolAsync(toolID).GetAwaiter().GetResult();
 
-        public static ToolModel? GetToolByID(this IToolService service, int toolID) =>
+        public static ItemModel? GetToolByID(this IItemService service, int toolID) =>
             service.GetToolByIDAsync(toolID).GetAwaiter().GetResult();
 
-        public static List<ToolModel> GetAllTools(this IToolService service) =>
+        public static List<ItemModel> GetAllTools(this IItemService service) =>
             service.GetAllToolsAsync().GetAwaiter().GetResult();
 
-        public static List<ToolModel> SearchTools(this IToolService service, string? searchText) =>
+        public static List<ItemModel> SearchTools(this IItemService service, string? searchText) =>
             service.SearchToolsAsync(searchText).GetAwaiter().GetResult();
-        public static string GenerateNextToolNumber(this IToolService service) =>
+        public static string GenerateNextToolNumber(this IItemService service) =>
             service.GenerateNextToolNumberAsync().GetAwaiter().GetResult();
 
-        public static bool ToggleToolCheckOutStatus(this IToolService service, int toolID, string currentUser) =>
+        public static bool ToggleToolCheckOutStatus(this IItemService service, int toolID, string currentUser) =>
             service.ToggleToolCheckOutStatusAsync(toolID, currentUser).GetAwaiter().GetResult();
 
-        public static List<ToolModel> GetToolsCheckedOutBy(this IToolService service, string userName) =>
+        public static List<ItemModel> GetToolsCheckedOutBy(this IItemService service, string userName) =>
             service.GetToolsCheckedOutByAsync(userName).GetAwaiter().GetResult();
 
-        public static void UpdateToolImage(this IToolService service, int toolID, string imagePath) =>
+        public static void UpdateToolImage(this IItemService service, int toolID, string imagePath) =>
             service.UpdateToolImageAsync(toolID, imagePath).GetAwaiter().GetResult();
 
-        public static List<int> ImportToolsFromCsv(this IToolService service, string filePath, IDictionary<string, string> map) =>
+        public static List<int> ImportToolsFromCsv(this IItemService service, string filePath, IDictionary<string, string> map) =>
             service.ImportToolsFromCsvAsync(filePath, map, CancellationToken.None).GetAwaiter().GetResult();
 
-        public static void ExportToolsToCsv(this IToolService service, string filePath) =>
+        public static void ExportToolsToCsv(this IItemService service, string filePath) =>
             service.ExportToolsToCsvAsync(filePath, CancellationToken.None).GetAwaiter().GetResult();
 
-        public static ImageImportResult ImportToolImages(this IToolService service, string folderPath, Func<ToolModel, IEnumerable<string>> selector) =>
+        public static ImageImportResult ImportToolImages(this IItemService service, string folderPath, Func<ItemModel, IEnumerable<string>> selector) =>
             service.ImportToolImagesAsync(folderPath, selector, null, CancellationToken.None).GetAwaiter().GetResult();
 
-        public static void UpdateToolQuantities(this IToolService service, int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) =>
+        public static void UpdateToolQuantities(this IItemService service, int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) =>
             service.UpdateToolQuantitiesAsync(toolID, qtyChange, isRental, conn, tx, CancellationToken.None).GetAwaiter().GetResult();
     }
 }

--- a/ToolManagementAppV2.Tests/Services/InterfaceReferenceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/InterfaceReferenceTests.cs
@@ -19,7 +19,7 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolSvc = new ToolService(db);
+                IItemService toolSvc = new ItemService(db);
                 ICustomerService custSvc = new CustomerService(db);
                 IRentalService rentalSvc = new RentalService(db, toolSvc);
                 IUserService userSvc = new UserService(db, new ApplicationUserContext());

--- a/ToolManagementAppV2.Tests/Services/RentalServiceConcurrentTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceConcurrentTests.cs
@@ -21,11 +21,11 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db, toolService);
 
-                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
+                toolService.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
                 var tool = toolService.GetAllTools().First();
 
                 customerService.AddCustomer(new Customer { Company = "Acme" });

--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -36,11 +36,11 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db, toolService);
 
-                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 5 };
+                var tool = new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 5 };
                 toolService.AddTool(tool);
                 var addedTool = toolService.GetAllTools().First();
 
@@ -69,11 +69,11 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db, toolService);
 
-                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 0 };
+                var tool = new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 0 };
                 toolService.AddTool(tool);
                 var addedTool = toolService.GetAllTools().First();
 
@@ -98,11 +98,11 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db, toolService);
 
-                var tool = new Tool { ToolNumber = "T2", NameDescription = "Wrench", QuantityOnHand = 0 };
+                var tool = new ItemModel { ToolNumber = "T2", NameDescription = "Wrench", QuantityOnHand = 0 };
                 toolService.AddTool(tool);
                 var addedTool = toolService.GetAllTools().First();
 
@@ -127,7 +127,7 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 IRentalService rentalService = new RentalService(db, toolService);
 
                 Assert.Throws<InvalidOperationException>(() => rentalService.ReturnTool(1, DateTime.Today));
@@ -146,7 +146,7 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 IRentalService rentalService = new RentalService(db, toolService);
 
                 Assert.Throws<InvalidOperationException>(() => rentalService.ReturnTool(1, DateTime.Today));
@@ -165,7 +165,7 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var rentalService = new RentalService(db, toolService);
 
                 Assert.Throws<InvalidOperationException>(() =>
@@ -185,11 +185,11 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db, toolService);
 
-                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 };
+                var tool = new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 };
                 toolService.AddTool(tool);
                 var addedTool = toolService.GetAllTools().First();
 
@@ -218,11 +218,11 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db, toolService);
 
-                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 };
+                var tool = new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 };
                 toolService.AddTool(tool);
                 var addedTool = toolService.GetAllTools().First();
 
@@ -250,7 +250,7 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var rentalService = new RentalService(db, toolService);
 
                 Assert.Throws<InvalidOperationException>(() => rentalService.DeleteRental(1));
@@ -269,11 +269,11 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db, toolService);
 
-                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, Location = "A1", ToolImagePath = "path" };
+                var tool = new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, Location = "A1", ToolImagePath = "path" };
                 toolService.AddTool(tool);
                 var addedTool = toolService.GetAllTools().First();
 
@@ -307,11 +307,11 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db, toolService);
 
-                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
+                toolService.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
                 var tool = toolService.GetAllTools().First();
 
                 customerService.AddCustomer(new Customer { Company = "Acme" });
@@ -344,11 +344,11 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db, toolService);
 
-                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
+                toolService.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
                 var tool = toolService.GetAllTools().First();
 
                 customerService.AddCustomer(new Customer { Company = "Acme" });
@@ -358,8 +358,8 @@ namespace ToolManagementAppV2.Tests.Services
                 var rental = rentalService.GetAllRentals().First();
                 var originalDue = rental.DueDate;
 
-                var failingToolService = new FailingToolService();
-                var rentalService2 = new RentalService(db, failingToolService);
+                var failingItemService = new FailingItemService();
+                var rentalService2 = new RentalService(db, failingItemService);
 
                 Assert.Throws<InvalidOperationException>(() =>
                     rentalService2.ExtendRental(rental.RentalID, DateTime.Today.AddDays(1)));
@@ -388,11 +388,11 @@ namespace ToolManagementAppV2.Tests.Services
                 var ctx = new StubUserContext { CurrentUser = new User { UserID = 1, UserName = "tester", IsAdmin = true } };
                 var auth = new AllowAllAuthorizationService();
                 var logService = new ActivityLogService(db);
-                var toolService = new ToolService(db, auth, null, logService, ctx);
+                var toolService = new ItemService(db, auth, null, logService, ctx);
                 var customerService = new CustomerService(db, auth);
                 var rentalService = new RentalService(db, auth, toolService, null, logService, ctx);
 
-                await toolService.AddToolAsync(new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, RentedQuantity = 0 });
+                await toolService.AddToolAsync(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, RentedQuantity = 0 });
                 await customerService.AddCustomerAsync(new Customer { Company = "Acme" });
                 var tool = (await toolService.GetAllToolsAsync()).First();
                 var cust = (await customerService.GetAllCustomersAsync()).First();
@@ -409,20 +409,20 @@ namespace ToolManagementAppV2.Tests.Services
             }
         }
 
-        class FailingToolService : IToolService
+        class FailingItemService : IItemService
         {
             public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
             public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-            public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+            public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
             public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+            public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
             public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
             public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default)
                 => throw new InvalidOperationException("fail");
             public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");

--- a/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
@@ -25,7 +25,7 @@ public class ReportServiceAsyncTests
     public void GenerateSummaryReport_UsesConcurrentAsyncCalls()
     {
         const int delay = 200;
-        var toolService = new DelayToolService(delay, 3);
+        var toolService = new DelayItemService(delay, 3);
         var rentalService = new DelayRentalService(delay, 5, 2);
         var customerService = new DelayCustomerService(delay, 4);
         var userService = new DelayUserService(delay, 1);
@@ -47,26 +47,26 @@ public class ReportServiceAsyncTests
         Assert.True(sw.ElapsedMilliseconds < delay * 3, $"Expected < {delay * 3}ms but was {sw.ElapsedMilliseconds}ms");
     }
 
-    class DelayToolService : IToolService
+    class DelayItemService : IItemService
     {
-        readonly int _delay; readonly List<Tool> _tools;
-        public DelayToolService(int delay, int count)
-        { _delay = delay; _tools = new List<Tool>(new Tool[count]); }
+        readonly int _delay; readonly List<ItemModel> _tools;
+        public DelayItemService(int delay, int count)
+        { _delay = delay; _tools = new List<ItemModel>(new ItemModel[count]); }
 
-        public Task<List<Tool>> GetAllToolsAsync(CancellationToken cancellationToken = default) =>
+        public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) =>
             Task.Delay(_delay, cancellationToken).ContinueWith(_ => _tools, cancellationToken);
 
-        public Task AddToolAsync(Tool tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task UpdateToolAsync(Tool tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<Tool?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<Tool>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<Tool>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
         public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<Tool, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }

--- a/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
@@ -22,7 +22,7 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
@@ -30,7 +30,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var activityLogService = new ActivityLogService(db);
                 var reportService = new ReportService(toolService, rentalService, activityLogService, customerService, userService);
 
-                var tool = new Tool
+                var tool = new ItemModel
                 {
                     ToolNumber = "T1",
                     NameDescription = "Hammer",
@@ -86,7 +86,7 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
@@ -94,7 +94,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var activityLogService = new ActivityLogService(db);
                 var reportService = new ReportService(toolService, rentalService, activityLogService, customerService, userService);
 
-                var tool = new Tool
+                var tool = new ItemModel
                 {
                     ToolNumber = "T1",
                     NameDescription = "Hammer",

--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -447,7 +447,7 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 var dbService = new DatabaseService(dbPath);
                 var service = new SettingsService(dbService);
-                Assert.Equal("Tool", service.GetItemLabelSingularAsync().GetAwaiter().GetResult());
+                Assert.Equal("ItemModel", service.GetItemLabelSingularAsync().GetAwaiter().GetResult());
                 Assert.Equal("Tools", service.GetItemLabelPluralAsync().GetAwaiter().GetResult());
                 service.SaveItemLabelSingularAsync("Widget").GetAwaiter().GetResult();
                 service.SaveItemLabelPluralAsync("Widgets").GetAwaiter().GetResult();

--- a/ToolManagementAppV2.Tests/Services/ToolCheckOutTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolCheckOutTests.cs
@@ -17,8 +17,8 @@ namespace ToolManagementAppV2.Tests.Services
             var db = Path.GetTempFileName();
             try
             {
-                var service = new ToolService(new DatabaseService(db));
-                service.AddTool(new Tool { ToolNumber = "T1", QuantityOnHand = 0 });
+                var service = new ItemService(new DatabaseService(db));
+                service.AddTool(new ItemModel { ToolNumber = "T1", QuantityOnHand = 0 });
                 var tool = service.GetAllTools().First();
                 var result = service.ToggleToolCheckOutStatus(tool.ToolID, "u");
                 var updated = service.GetToolByID(tool.ToolID);
@@ -38,8 +38,8 @@ namespace ToolManagementAppV2.Tests.Services
             var db = Path.GetTempFileName();
             try
             {
-                IToolService svc = new ToolService(new DatabaseService(db));
-                svc.AddTool(new Tool { ToolNumber = "T2", QuantityOnHand = 1 });
+                IItemService svc = new ItemService(new DatabaseService(db));
+                svc.AddTool(new ItemModel { ToolNumber = "T2", QuantityOnHand = 1 });
                 var tool = svc.GetAllTools().First();
                 var first = svc.ToggleToolCheckOutStatus(tool.ToolID, "u");
                 var outTool = svc.GetToolByID(tool.ToolID);
@@ -64,7 +64,7 @@ namespace ToolManagementAppV2.Tests.Services
             var db = Path.GetTempFileName();
             try
             {
-                var service = new ToolService(new DatabaseService(db));
+                var service = new ItemService(new DatabaseService(db));
                 Assert.Throws<InvalidOperationException>(() => service.ToggleToolCheckOutStatus(42, "u"));
             }
             finally

--- a/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolServiceTests.cs
@@ -17,7 +17,7 @@ using ToolManagementAppV2.Services.Users;
 
 namespace ToolManagementAppV2.Tests.Services
 {
-    public class ToolServiceTests
+    public class ItemServiceTests
     {
         class StubUserContext : IUserContext
         {
@@ -34,12 +34,12 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                IToolService service = new ToolService(dbService);
+                IItemService service = new ItemService(dbService);
 
-                service.AddTool(new Tool
+                service.AddTool(new ItemModel
                 {
                     ToolNumber = "T1",
-                    NameDescription = "Test Tool",
+                    NameDescription = "Test ItemModel",
                     Location = "Loc",
                     Brand = "Brand",
                     PartNumber = "PN",
@@ -64,10 +64,10 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                IToolService service = new ToolService(dbService);
+                IItemService service = new ItemService(dbService);
 
-                service.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
-                service.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw" });
+                service.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" });
+                service.AddTool(new ItemModel { ToolNumber = "T2", NameDescription = "Saw" });
 
                 var results = service.SearchTools("Ham");
                 Assert.Single(results);
@@ -87,10 +87,10 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                IToolService service = new ToolService(dbService);
+                IItemService service = new ItemService(dbService);
 
-                service.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
-                service.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Hammer", Brand = "BrandB" });
+                service.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
+                service.AddTool(new ItemModel { ToolNumber = "T2", NameDescription = "Hammer", Brand = "BrandB" });
 
                 var results = service.SearchTools("Hammer BrandA");
                 Assert.Single(results);
@@ -112,9 +112,9 @@ namespace ToolManagementAppV2.Tests.Services
                 var logs = new List<LogEntry>();
                 using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
                 var dbService = new DatabaseService(dbPath);
-                var service = new ToolService(dbService, logger: loggerFactory.CreateLogger<ToolService>());
+                var service = new ItemService(dbService, logger: loggerFactory.CreateLogger<ItemService>());
 
-                service.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
+                service.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" });
 
                 var search = string.Join(' ', Enumerable.Repeat("Hammer", 10)) + " extra";
                 var results = service.SearchTools(search);
@@ -136,9 +136,9 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                IToolService service = new ToolService(dbService);
+                IItemService service = new ItemService(dbService);
 
-                var tool = new Tool
+                var tool = new ItemModel
                 {
                     ToolNumber = "TID1",
                     NameDescription = "Test",
@@ -165,9 +165,9 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                IToolService service = new ToolService(dbService);
+                IItemService service = new ItemService(dbService);
 
-                var tool = new Tool
+                var tool = new ItemModel
                 {
                     ToolNumber = "ATID1",
                     NameDescription = "Test",
@@ -194,9 +194,9 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                IToolService service = new ToolService(dbService);
+                IItemService service = new ItemService(dbService);
 
-                var tool = new Tool
+                var tool = new ItemModel
                 {
                     ToolNumber = "TIMG",
                     NameDescription = "With Image",
@@ -225,11 +225,11 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                IToolService service = new ToolService(dbService);
+                IItemService service = new ItemService(dbService);
 
-                service.AddTool(new Tool { ToolNumber = "T1" });
+                service.AddTool(new ItemModel { ToolNumber = "T1" });
 
-                var dup = new Tool { ToolNumber = "T1" };
+                var dup = new ItemModel { ToolNumber = "T1" };
                 var ex = Assert.Throws<InvalidOperationException>(() => service.AddTool(dup));
                 Assert.Contains("T1", ex.Message);
             }
@@ -247,9 +247,9 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                IToolService service = new ToolService(dbService);
+                IItemService service = new ItemService(dbService);
 
-                var tool = new Tool { ToolNumber = "" };
+                var tool = new ItemModel { ToolNumber = "" };
                 service.AddTool(tool);
 
                 Assert.Equal("T1", tool.ToolNumber);
@@ -269,8 +269,8 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                IToolService service = new ToolService(dbService);
-                service.AddTool(new Tool { ToolNumber = "T1" });
+                IItemService service = new ItemService(dbService);
+                service.AddTool(new ItemModel { ToolNumber = "T1" });
                 using var cts = new CancellationTokenSource();
                 var searchTask = service.SearchToolsAsync("T1", cts.Token);
                 cts.Cancel();
@@ -290,9 +290,9 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                var service = new ToolService(dbService);
-                service.AddTool(new Tool { ToolNumber = "T1" });
-                service.AddTool(new Tool { ToolNumber = "T2" });
+                var service = new ItemService(dbService);
+                service.AddTool(new ItemModel { ToolNumber = "T1" });
+                service.AddTool(new ItemModel { ToolNumber = "T2" });
                 var t2 = service.GetAllTools().First(t => t.ToolNumber == "T2");
                 t2.ToolNumber = "T1";
                 var ex = Assert.Throws<InvalidOperationException>(() => service.UpdateTool(t2));
@@ -312,9 +312,9 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                var service = new ToolService(dbService);
-                service.AddTool(new Tool { ToolNumber = "T1" });
-                service.AddTool(new Tool { ToolNumber = "T2" });
+                var service = new ItemService(dbService);
+                service.AddTool(new ItemModel { ToolNumber = "T1" });
+                service.AddTool(new ItemModel { ToolNumber = "T2" });
                 var t2 = service.GetAllTools().First(t => t.ToolNumber == "T2");
                 t2.ToolNumber = "T1";
                 var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => service.UpdateToolAsync(t2));
@@ -334,8 +334,8 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                var service = new ToolService(dbService);
-                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer" };
+                var service = new ItemService(dbService);
+                var tool = new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" };
                 await service.AddToolAsync(tool);
 
                 tool.NameDescription = "Updated";
@@ -358,9 +358,9 @@ namespace ToolManagementAppV2.Tests.Services
                 var logs = new List<LogEntry>();
                 using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
                 var dbService = new DatabaseService(dbPath);
-                var service = new ToolService(dbService, logger: loggerFactory.CreateLogger<ToolService>());
+                var service = new ItemService(dbService, logger: loggerFactory.CreateLogger<ItemService>());
 
-                service.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
+                service.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" });
                 var tool = service.GetAllTools().First();
                 tool.ToolNumber = null;
 
@@ -385,10 +385,10 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService svc = new ToolService(db);
-                svc.AddTool(new Tool { ToolNumber = "T1", NameDescription = "A" });
-                svc.AddTool(new Tool { ToolNumber = "T2", NameDescription = "B" });
-                svc.AddTool(new Tool { ToolNumber = "T1", NameDescription = "C" });
+                IItemService svc = new ItemService(db);
+                svc.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "A" });
+                svc.AddTool(new ItemModel { ToolNumber = "T2", NameDescription = "B" });
+                svc.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "C" });
 
                 File.WriteAllText(Path.Combine(imgDir, "T1.jpg"), string.Empty);
                 File.WriteAllText(Path.Combine(imgDir, "T2.jpg"), string.Empty);
@@ -419,8 +419,8 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService svc = new ToolService(db);
-                svc.AddTool(new Tool { ToolNumber = "T1", NameDescription = "A" });
+                IItemService svc = new ItemService(db);
+                svc.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "A" });
                 File.WriteAllText(Path.Combine(imgDir, "T1.jpg"), string.Empty);
 
                 var destDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images");
@@ -463,8 +463,8 @@ namespace ToolManagementAppV2.Tests.Services
                 var logs = new List<LogEntry>();
                 using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
                 var db = new DatabaseService(dbPath);
-                var svc = new ToolService(db, logger: loggerFactory.CreateLogger<ToolService>());
-                svc.AddTool(new Tool { ToolNumber = "T1", NameDescription = "A" });
+                var svc = new ItemService(db, logger: loggerFactory.CreateLogger<ItemService>());
+                svc.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "A" });
 
                 var result = svc.ImportToolImages(imgDir, t => new[] { t.ToolNumber });
 
@@ -486,8 +486,8 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                IToolService service = new ToolService(dbService);
-                service.AddTool(new Tool { ToolNumber = "T1" });
+                IItemService service = new ItemService(dbService);
+                service.AddTool(new ItemModel { ToolNumber = "T1" });
                 var tools = await service.GetAllToolsAsync();
                 Assert.Single(tools);
             }
@@ -504,8 +504,8 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var svc = new ToolService(db);
-                svc.AddTool(new Tool { ToolNumber = "T1", NameDescription = "A" });
+                var svc = new ItemService(db);
+                svc.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "A" });
                 var first = svc.GetAllTools();
                 using (var conn = db.CreateConnection())
                 {
@@ -529,7 +529,7 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 File.WriteAllText(csvPath, "ToolNumber\nT1\nT1");
                 var dbService = new DatabaseService(dbPath);
-                var service = new ToolService(dbService);
+                var service = new ItemService(dbService);
                 var map = new Dictionary<string, string>
                 {
                     {"ToolNumber", "ToolNumber"}
@@ -582,7 +582,7 @@ namespace ToolManagementAppV2.Tests.Services
                 }
 
                 var dbService = new DatabaseService(dbPath);
-                var svc = new ToolService(dbService);
+                var svc = new ItemService(dbService);
                 var tools = svc.GetAllTools();
 
                 Assert.Single(tools);
@@ -635,7 +635,7 @@ namespace ToolManagementAppV2.Tests.Services
                 }
 
                 var dbService = new DatabaseService(dbPath);
-                var svc = new ToolService(dbService);
+                var svc = new ItemService(dbService);
                 var tools = svc.SearchTools("T1");
 
                 Assert.Single(tools);
@@ -659,9 +659,9 @@ namespace ToolManagementAppV2.Tests.Services
                 var logs = new List<LogEntry>();
                 using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
                 var dbService = new DatabaseService(dbPath);
-                IToolService service = new ToolService(dbService, logger: loggerFactory.CreateLogger<ToolService>());
+                IItemService service = new ItemService(dbService, logger: loggerFactory.CreateLogger<ItemService>());
 
-                service.AddTool(new Tool
+                service.AddTool(new ItemModel
                 {
                     ToolNumber = "T1",
                     NameDescription = "Hammer",
@@ -692,7 +692,7 @@ namespace ToolManagementAppV2.Tests.Services
                     cmd.ExecuteNonQuery();
                 }
 
-                var svc = new ToolService(dbService);
+                var svc = new ItemService(dbService);
                 var ex = Assert.Throws<InvalidOperationException>(() => svc.DeleteTool(1));
                 Assert.Contains("Failed to delete tool 1", ex.Message);
             }
@@ -715,7 +715,7 @@ namespace ToolManagementAppV2.Tests.Services
                     cmd.ExecuteNonQuery();
                 }
 
-                var svc = new ToolService(dbService);
+                var svc = new ItemService(dbService);
                 var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => svc.DeleteToolAsync(1));
                 Assert.Contains("Failed to delete tool 1", ex.Message);
             }
@@ -732,13 +732,13 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                var svc = new ToolService(dbService);
+                var svc = new ItemService(dbService);
 
                 var tasks = Enumerable.Range(0, 10).Select(i => Task.Run(() =>
-                    svc.AddTool(new Tool
+                    svc.AddTool(new ItemModel
                     {
                         ToolNumber = $"T{i}",
-                        NameDescription = $"Tool{i}"
+                        NameDescription = $"ItemModel{i}"
                     }))
                 ).ToArray();
 
@@ -761,8 +761,8 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                var svc = new ToolService(dbService);
-                svc.AddTool(new Tool
+                var svc = new ItemService(dbService);
+                svc.AddTool(new ItemModel
                 {
                     ToolNumber = "T1",
                     NameDescription = "Test",
@@ -796,8 +796,8 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                var svc = new ToolService(dbService);
-                await svc.AddToolAsync(new Tool { ToolNumber = "T1", QuantityOnHand = 1 });
+                var svc = new ItemService(dbService);
+                await svc.AddToolAsync(new ItemModel { ToolNumber = "T1", QuantityOnHand = 1 });
                 var tool = (await svc.GetAllToolsAsync()).Single();
                 await svc.DeleteToolAsync(tool.ToolID);
                 var remaining = await svc.GetAllToolsAsync();
@@ -816,8 +816,8 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                var svc = new ToolService(dbService);
-                await svc.AddToolAsync(new Tool { ToolNumber = "T2", QuantityOnHand = 1 });
+                var svc = new ItemService(dbService);
+                await svc.AddToolAsync(new ItemModel { ToolNumber = "T2", QuantityOnHand = 1 });
                 var tool = (await svc.GetAllToolsAsync()).Single();
                 var success = await svc.ToggleToolCheckOutStatusAsync(tool.ToolID, "u");
                 var updated = await svc.GetToolByIDAsync(tool.ToolID);
@@ -838,7 +838,7 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                var svc = new ToolService(dbService);
+                var svc = new ItemService(dbService);
                 using var cts = new CancellationTokenSource();
                 cts.Cancel();
                 await Assert.ThrowsAsync<OperationCanceledException>(() => svc.SearchToolsAsync("test", cts.Token));
@@ -864,9 +864,9 @@ namespace ToolManagementAppV2.Tests.Services
                 var logs = new List<LogEntry>();
                 using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
                 var dbService = new DatabaseService(dbPath);
-                var svc = new FailingCopyToolService(dbService, loggerFactory.CreateLogger<ToolService>());
+                var svc = new FailingCopyItemService(dbService, loggerFactory.CreateLogger<ItemService>());
 
-                svc.AddTool(new Tool { ToolNumber = "T1" });
+                svc.AddTool(new ItemModel { ToolNumber = "T1" });
 
                 var result = svc.ImportToolImages(tempDir, t => new[] { t.ToolNumber });
 
@@ -896,9 +896,9 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                var svc = new ToolService(dbService);
+                var svc = new ItemService(dbService);
 
-                svc.AddTool(new Tool { ToolNumber = "T1" });
+                svc.AddTool(new ItemModel { ToolNumber = "T1" });
 
                 var result = svc.ImportToolImages(tempDir, t => new[] { t.ToolNumber });
 
@@ -935,9 +935,9 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var dbService = new DatabaseService(dbPath);
-                var svc = new ToolService(dbService);
-                svc.AddTool(new Tool { ToolNumber = "T1" });
-                svc.AddTool(new Tool { ToolNumber = "T2" });
+                var svc = new ItemService(dbService);
+                svc.AddTool(new ItemModel { ToolNumber = "T1" });
+                svc.AddTool(new ItemModel { ToolNumber = "T2" });
 
                 var cts = new CancellationTokenSource();
                 var progress = new Progress<ImageImportProgress>(p =>
@@ -968,8 +968,8 @@ namespace ToolManagementAppV2.Tests.Services
                 var ctx = new StubUserContext { CurrentUser = new User { UserID = 1, UserName = "tester", IsAdmin = true } };
                 var auth = new AllowAllAuthorizationService();
                 var logService = new ActivityLogService(dbService);
-                var svc = new ToolService(dbService, auth, null, logService, ctx);
-                await svc.AddToolAsync(new Tool { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, RentedQuantity = 0 });
+                var svc = new ItemService(dbService, auth, null, logService, ctx);
+                await svc.AddToolAsync(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, RentedQuantity = 0 });
                 var logs = await logService.GetRecentLogsAsync();
                 Assert.Contains(logs.Value, l => l.Action.Contains("Added tool"));
             }
@@ -979,9 +979,9 @@ namespace ToolManagementAppV2.Tests.Services
             }
         }
 
-        private class FailingCopyToolService : ToolService
+        private class FailingCopyItemService : ItemService
         {
-            public FailingCopyToolService(DatabaseService dbService, ILogger<ToolService> logger)
+            public FailingCopyItemService(DatabaseService dbService, ILogger<ItemService> logger)
                 : base(dbService, logger) { }
 
             protected override Task CopyFileAsync(string sourceFileName, string destFileName, CancellationToken cancellationToken)

--- a/ToolManagementAppV2.Tests/TestHelpers.cs
+++ b/ToolManagementAppV2.Tests/TestHelpers.cs
@@ -24,7 +24,7 @@ namespace ToolManagementAppV2.Tests
             var dbPath = Path.GetTempFileName();
             var db = new DatabaseService(dbPath);
             var auth = new AllowAllAuthorizationService();
-            var toolService = new ToolService(db, auth);
+            var toolService = new ItemService(db, auth);
             var customerService = new CustomerService(db, auth);
             var userContext = new ApplicationUserContext();
             var userService = new UserService(db, userContext, auth);
@@ -65,14 +65,14 @@ namespace ToolManagementAppV2.Tests
         {
             public void ShowInfo(string message, string title) { }
             public bool ShowConfirmation(string message, string title) => false;
-            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-            public void ShowToolDetails(ToolModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+            public void ShowToolDetails(ItemModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-            public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+            public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
             public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-            public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+            public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }
         }

--- a/ToolManagementAppV2.Tests/Tests/AdminButtonVisibilityTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/AdminButtonVisibilityTests.cs
@@ -26,7 +26,7 @@ namespace ToolManagementAppV2.Tests.Tests
                     var dock = Assert.IsType<DockPanel>(window.Content);
                     var stack = Assert.IsType<StackPanel>(dock.Children[0]);
 
-                    var restricted = new[] { "Tool Management", "Users", "Settings", "Import/Export" };
+                    var restricted = new[] { "ItemModel Management", "Users", "Settings", "Import/Export" };
                     bool anyVisible = stack.Children
                         .OfType<Button>()
                         .Where(b => restricted.Contains(b.Content?.ToString()))

--- a/ToolManagementAppV2.Tests/Tests/AppUnhandledExceptionTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/AppUnhandledExceptionTests.cs
@@ -105,14 +105,14 @@ namespace ToolManagementAppV2.Tests.Tests
             public int InfoCount { get; private set; }
             public void ShowInfo(string message, string title) => InfoCount++;
             public bool ShowConfirmation(string message, string title) => false;
-            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-            public void ShowToolDetails(ToolModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+            public void ShowToolDetails(ItemModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
-            public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+            public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }
             public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
-            public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }
         }

--- a/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
@@ -109,7 +109,7 @@ public class CsvImportTests
                 "T1,Screwdriver");
             File.WriteAllText(csvPath, csv);
             var db = new DatabaseService(dbPath);
-            var service = new ToolService(db);
+            var service = new ItemService(db);
             var map = new Dictionary<string, string>
             {
                 {"ToolNumber", "ToolNumber"},
@@ -137,10 +137,10 @@ public class CsvImportTests
         try
         {
             var db = new DatabaseService(dbPath);
-            var service = new ToolService(db);
+            var service = new ItemService(db);
 
             for (int i = 0; i < 100; i++)
-                service.AddTool(new ToolModel { ToolNumber = $"E{i}", NameDescription = $"Existing {i}" });
+                service.AddTool(new ItemModel { ToolNumber = $"E{i}", NameDescription = $"Existing {i}" });
 
             var sb = new System.Text.StringBuilder();
             sb.AppendLine("ToolNumber,NameDescription");
@@ -179,8 +179,8 @@ public class CsvImportTests
         try
         {
             using var db = new DatabaseService(dbPath);
-            var service = new ToolService(db);
-            service.AddTool(new ToolModel { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 5, IsPowerTool = true });
+            var service = new ItemService(db);
+            service.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 5, IsPowerTool = true });
 
             await service.ExportToolsToCsvAsync(csvPath);
 

--- a/ToolManagementAppV2.Tests/Tests/CustomersPageBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CustomersPageBindingTests.cs
@@ -76,14 +76,14 @@ namespace ToolManagementAppV2.Tests.Tests
     {
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
         public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }

--- a/ToolManagementAppV2.Tests/Tests/DependencyInjectionTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/DependencyInjectionTests.cs
@@ -20,7 +20,7 @@ namespace ToolManagementAppV2.Tests.Tests
             var provider = app.Host.Services;
 
             Assert.NotNull(provider.GetService<IDatabaseService>());
-            Assert.NotNull(provider.GetService<IToolService>());
+            Assert.NotNull(provider.GetService<IItemService>());
             Assert.NotNull(provider.GetService<ICustomerService>());
             Assert.NotNull(provider.GetService<IUserService>());
             Assert.NotNull(provider.GetService<IRentalService>());

--- a/ToolManagementAppV2.Tests/Tests/ManageItemsPageMenuTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ManageItemsPageMenuTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace ToolManagementAppV2.Tests.Tests
 {
-    public class ManageToolsPageMenuTests
+    public class ManageItemsPageMenuTests
     {
         [Fact]
         public void ContextMenu_BindsToSecondaryCommands()
@@ -24,12 +24,12 @@ namespace ToolManagementAppV2.Tests.Tests
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db, toolService);
                 var dialog = new StubDialogService();
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
-                var page = new ManageToolsPage { DataContext = vm };
+                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var page = new ManageItemsPage { DataContext = vm };
 
                 var grid = (Grid)page.Content;
                 var border = (Border)grid.Children[0];
@@ -55,12 +55,12 @@ namespace ToolManagementAppV2.Tests.Tests
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db, toolService);
                 var dialog = new StubDialogService();
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
-                var page = new ManageToolsPage { DataContext = vm };
+                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var page = new ManageItemsPage { DataContext = vm };
 
                 var grid = (Grid)page.Content;
                 var border = (Border)grid.Children[0];
@@ -82,14 +82,14 @@ namespace ToolManagementAppV2.Tests.Tests
         {
             public void ShowInfo(string message, string title) { }
             public bool ShowConfirmation(string message, string title) => true;
-            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-            public void ShowToolDetails(ToolModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+            public void ShowToolDetails(ItemModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-            public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+            public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
             public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-            public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+            public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }
         }

--- a/ToolManagementAppV2.Tests/Tests/ManageRentalsPageDeleteTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ManageRentalsPageDeleteTests.cs
@@ -25,11 +25,11 @@ namespace ToolManagementAppV2.Tests.Tests
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool = new Tool { ToolNumber = "T1" };
+                var tool = new ItemModel { ToolNumber = "T1" };
                 toolService.AddTool(tool);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
@@ -64,14 +64,14 @@ namespace ToolManagementAppV2.Tests.Tests
     {
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }
         public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
-        public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }

--- a/ToolManagementAppV2.Tests/Tests/ManageRentalsPageMenuTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ManageRentalsPageMenuTests.cs
@@ -97,14 +97,14 @@ namespace ToolManagementAppV2.Tests.Tests
     {
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
         public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }

--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -47,22 +47,22 @@ namespace ToolManagementAppV2.Tests.Tests
             try
             {
                 using var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
-                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
+                toolService.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" });
 
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
                 await vm.OpenSearchToolsCommand.ExecuteAsync(null);
 
                 var page = Assert.IsType<ToolSearchPage>(vm.CurrentPage);
-                Assert.Same(vm.ToolManagement, page.DataContext);
-                Assert.Same(vm.ToolManagement.Tools, page.ToolsList.ItemsSource);
-                Assert.NotEmpty(vm.ToolManagement.Tools);
+                Assert.Same(vm.ItemManagement, page.DataContext);
+                Assert.Same(vm.ItemManagement.Tools, page.ToolsList.ItemsSource);
+                Assert.NotEmpty(vm.ItemManagement.Tools);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ToolSearchPageLayoutTests.cs
@@ -31,7 +31,7 @@ namespace ToolManagementAppV2.Tests.Tests
         {
             var page = new ToolSearchPage();
             page.ToolsList.ItemsSource = Enumerable.Range(0, 1000)
-                .Select(i => new Tool { ToolID = i, NameDescription = $"Tool {i}" })
+                .Select(i => new ItemModel { ToolID = i, NameDescription = $"ItemModel {i}" })
                 .ToList();
 
             page.ToolsList.Measure(new Size(800, 300));

--- a/ToolManagementAppV2.Tests/Utilities/AsyncHelpersTests.cs
+++ b/ToolManagementAppV2.Tests/Utilities/AsyncHelpersTests.cs
@@ -26,15 +26,15 @@ namespace ToolManagementAppV2.Tests.Utilities
             }
             public bool ShowConfirmation(string message, string title) => true;
             public Task<bool> ShowConfirmationAsync(string message, string title) => Task.FromResult(true);
-            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-            public Task<ToolModel?> ShowEditToolDialogAsync(ToolModel tool) => Task.FromResult<ToolModel?>(null);
-            public void ShowToolDetails(ToolModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+            public Task<ItemModel?> ShowEditToolDialogAsync(ItemModel tool) => Task.FromResult<ItemModel?>(null);
+            public void ShowToolDetails(ItemModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
-            public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+            public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
             public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-            public Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+            public Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }
         }

--- a/ToolManagementAppV2.Tests/ViewModels/CustomerManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/CustomerManagementViewModelTests.cs
@@ -293,14 +293,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => AddCustomerResult;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
         public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/DashboardViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/DashboardViewModelTests.cs
@@ -23,7 +23,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
@@ -67,7 +67,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [InlineData("customerService")]
         [InlineData("userService")]
         [InlineData("activityLogService")]
-        [InlineData("openManageToolsCommand")]
+        [InlineData("openManageItemsCommand")]
         [InlineData("openRentalsCommand")]
         [InlineData("openImportExportCommand")]
         public void Constructor_ThrowsArgumentNull(string nullParam)
@@ -76,7 +76,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
@@ -91,7 +91,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     nullParam == "customerService" ? null : customerService,
                     nullParam == "userService" ? null : userService,
                     nullParam == "activityLogService" ? null : activityLogService,
-                    nullParam == "openManageToolsCommand" ? null : manageCmd,
+                    nullParam == "openManageItemsCommand" ? null : manageCmd,
                     nullParam == "openRentalsCommand" ? null : rentalsCmd,
                     nullParam == "openImportExportCommand" ? null : importCmd));
 
@@ -111,7 +111,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);

--- a/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -19,7 +19,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var tmp = Path.GetTempFileName();
             File.WriteAllText(tmp, "ToolNumber\n");
             var fileDlg = new StubFileDialogService { FileToReturn = tmp };
-            var toolSvc = new CapturingToolService();
+            var toolSvc = new CapturingItemService();
             var dialog = new StubDialogService { MapToReturn = new Dictionary<string,string>{{"ToolNumber","ToolNumber"}} };
             var vm = new ImportExportViewModel(toolSvc, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
 
@@ -40,7 +40,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var fileDlg = new StubFileDialogService { FileToReturn = tmp };
             var customerSvc = new CapturingCustomerService();
             var dialog = new StubDialogService { MapToReturn = new Dictionary<string,string>{{"Company","Company"}} };
-            var vm = new ImportExportViewModel(new StubToolService(), customerSvc, fileDlg, new StubDatabaseBackupService(), dialog);
+            var vm = new ImportExportViewModel(new StubItemService(), customerSvc, fileDlg, new StubDatabaseBackupService(), dialog);
 
             await vm.ImportCustomersCommand.ExecuteAsync(null);
 
@@ -59,7 +59,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var fileDlg = new StubFileDialogService { FileToReturn = tmp };
             var customerSvc = new CapturingCustomerService();
             var dialog = new StubDialogService { MapToReturn = null };
-            var vm = new ImportExportViewModel(new StubToolService(), customerSvc, fileDlg, new StubDatabaseBackupService(), dialog);
+            var vm = new ImportExportViewModel(new StubItemService(), customerSvc, fileDlg, new StubDatabaseBackupService(), dialog);
 
             await vm.ImportCustomersCommand.ExecuteAsync(null);
 
@@ -74,7 +74,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var tmp = Path.GetTempFileName();
             File.WriteAllText(tmp, "ToolNumber\n");
             var fileDlg = new StubFileDialogService { FileToReturn = tmp };
-            var toolSvc = new CapturingToolService();
+            var toolSvc = new CapturingItemService();
             var dialog = new StubDialogService { MapToReturn = null };
             var vm = new ImportExportViewModel(toolSvc, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
 
@@ -91,7 +91,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var tmp = Path.GetTempFileName();
             File.WriteAllText(tmp, "ToolNumber\n");
             var fileDlg = new StubFileDialogService { FileToReturn = tmp };
-            var toolSvc = new CancelableToolService();
+            var toolSvc = new CancelableItemService();
             var dialog = new StubDialogService { MapToReturn = new Dictionary<string,string>{{"ToolNumber","ToolNumber"}} };
             var vm = new ImportExportViewModel(toolSvc, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
 
@@ -109,7 +109,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var customerSvc = new CapturingCustomerService();
             var fileDlg = new StubFileDialogService { FileToReturn = "path.csv" };
-            var vm = new ImportExportViewModel(new StubToolService(), customerSvc, fileDlg, new StubDatabaseBackupService(), new StubDialogService());
+            var vm = new ImportExportViewModel(new StubItemService(), customerSvc, fileDlg, new StubDatabaseBackupService(), new StubDialogService());
 
             await vm.ExportCustomersCommand.ExecuteAsync(null);
 
@@ -123,7 +123,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             var customerSvc = new FailCustomerService();
             var fileDlg = new StubFileDialogService { FileToReturn = "path.csv" };
-            var vm = new ImportExportViewModel(new StubToolService(), customerSvc, fileDlg, new StubDatabaseBackupService(), new StubDialogService());
+            var vm = new ImportExportViewModel(new StubItemService(), customerSvc, fileDlg, new StubDatabaseBackupService(), new StubDialogService());
 
             await vm.ExportCustomersCommand.ExecuteAsync(null);
 
@@ -150,23 +150,23 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public bool ShowImportMappingCalled { get; private set; }
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }
         public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties)
         {
             ShowImportMappingCalled = true;
             return MapToReturn;
         }
-        public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }
 
-    class CapturingToolService : IToolService
+    class CapturingItemService : IItemService
     {
         public bool ImportCalled { get; private set; }
         public IDictionary<string,string>? MapUsed { get; private set; }
@@ -177,16 +177,16 @@ namespace ToolManagementAppV2.Tests.ViewModels
             return Task.FromResult(new List<int>());
         }
         public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-        public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
         public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
@@ -228,26 +228,26 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
     }
 
-    class StubToolService : IToolService
+    class StubItemService : IItemService
     {
         public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
             => Task.FromResult(new List<int>());
         public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-        public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
         public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 
-    class CancelableToolService : IToolService
+    class CancelableItemService : IItemService
     {
         public async Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
@@ -255,16 +255,16 @@ namespace ToolManagementAppV2.Tests.ViewModels
             return new List<int>();
         }
         public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-        public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
         public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }

--- a/ToolManagementAppV2.Tests/ViewModels/ItemManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ItemManagementViewModelTests.cs
@@ -21,7 +21,7 @@ using System.Reflection;
 
 namespace ToolManagementAppV2.Tests.ViewModels
 {
-    public class ToolManagementViewModelTests
+    public class ItemManagementViewModelTests
     {
         [Fact]
         public async Task SearchCommand_FiltersToolsBySearchTerm()
@@ -30,13 +30,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
-                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
-                toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw" });
+                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                toolService.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" });
+                toolService.AddTool(new ItemModel { ToolNumber = "T2", NameDescription = "Saw" });
                 vm.SearchTerm = "Ham";
                 await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
                 Assert.Single(vm.SearchResults);
@@ -56,13 +56,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
-                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
-                toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Hammer", Brand = "BrandB" });
+                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                toolService.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
+                toolService.AddTool(new ItemModel { ToolNumber = "T2", NameDescription = "Hammer", Brand = "BrandB" });
                 vm.SearchTerm = "Hammer BrandA";
                 await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
                 Assert.Single(vm.SearchResults);
@@ -82,13 +82,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
-                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
-                toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Cordless Drill", IsPowerTool = true });
+                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                toolService.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" });
+                toolService.AddTool(new ItemModel { ToolNumber = "T2", NameDescription = "Cordless Drill", IsPowerTool = true });
                 vm.SearchTerm = string.Empty;
                 await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
                 Assert.Equal(2, vm.SearchResults.Count);
@@ -109,17 +109,17 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
-                toolService.AddTool(new Tool { ToolNumber = "T1", Brand = "BrandA" });
+                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                toolService.AddTool(new ItemModel { ToolNumber = "T1", Brand = "BrandA" });
                 await vm.LoadToolsAsync();
 
                 Assert.Contains("BrandA", vm.Categories);
 
-                vm.Tools.Add(new Tool { ToolNumber = "T2", Brand = "BrandB" });
+                vm.Tools.Add(new ItemModel { ToolNumber = "T2", Brand = "BrandB" });
 
                 Assert.Contains("BrandB", vm.Categories);
             }
@@ -137,14 +137,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
-                var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
+                IItemService toolService = new ItemService(db);
+                var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
 
-                toolService.AddTool(new Tool { ToolNumber = "T1" });
+                toolService.AddTool(new ItemModel { ToolNumber = "T1" });
                 await vm.LoadToolsAsync();
                 await vm.LoadToolsAsync();
 
-                var field = typeof(ObservableCollection<ToolModel>).GetField("CollectionChanged", BindingFlags.Instance | BindingFlags.NonPublic);
+                var field = typeof(ObservableCollection<ItemModel>).GetField("CollectionChanged", BindingFlags.Instance | BindingFlags.NonPublic);
                 var handlers = field?.GetValue(vm.Tools) as MulticastDelegate;
                 var count = handlers?.GetInvocationList().Length ?? 0;
                 Assert.Equal(1, count);
@@ -163,13 +163,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
-                var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
+                IItemService toolService = new ItemService(db);
+                var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
 
-                toolService.AddTool(new Tool { ToolNumber = "T1", Brand = "BrandA" });
+                toolService.AddTool(new ItemModel { ToolNumber = "T1", Brand = "BrandA" });
                 await vm.LoadToolsAsync();
 
-                toolService.AddTool(new Tool { ToolNumber = "T2", Brand = "BrandB" });
+                toolService.AddTool(new ItemModel { ToolNumber = "T2", Brand = "BrandB" });
                 await vm.LoadToolsAsync();
 
                 Assert.Equal(2, vm.Tools.Count);
@@ -190,11 +190,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
                 vm.NewTool.ToolNumber = string.Empty;
                 await vm.NewToolCommand.ExecuteAsync(null);
                 Assert.True(dialog.InfoShown);
@@ -212,19 +212,19 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             public bool InfoShown;
             public bool ConfirmationResult;
-            public Func<ToolModel, ToolModel?>? EditToolHandler;
-            public Action<ToolModel>? ViewDetailsHandler;
+            public Func<ItemModel, ItemModel?>? EditToolHandler;
+            public Action<ItemModel>? ViewDetailsHandler;
 
             public void ShowInfo(string message, string title) => InfoShown = true;
             public bool ShowConfirmation(string message, string title) => ConfirmationResult;
-            public ToolModel? ShowEditToolDialog(ToolModel tool) => EditToolHandler?.Invoke(tool);
-            public void ShowToolDetails(ToolModel tool) => ViewDetailsHandler?.Invoke(tool);
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditToolDialog(ItemModel tool) => EditToolHandler?.Invoke(tool);
+            public void ShowToolDetails(ItemModel tool) => ViewDetailsHandler?.Invoke(tool);
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-            public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+            public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
             public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-            public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+            public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }
         }
@@ -238,11 +238,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
                 vm.NewTool.ToolNumber = "TN1";
                 vm.NewTool.NameDescription = "Hammer";
                 vm.NewTool.QuantityOnHand = quantity;
@@ -265,11 +265,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
                 vm.NewTool.ToolNumber = "TN1";
                 vm.NewTool.NameDescription = "Hammer";
                 vm.NewTool.PartNumber = "PN1";
@@ -307,15 +307,15 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
-                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer", ToolImagePath = "img1.png" };
+                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var tool = new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", ToolImagePath = "img1.png" };
                 toolService.AddTool(tool);
                 await vm.LoadToolsAsync();
-                vm.SelectedTool = vm.Tools.First();
+                vm.SelectedItem = vm.Tools.First();
                 dialog.EditToolHandler = t =>
                 {
                     t.NameDescription = "Updated Hammer";
@@ -342,15 +342,15 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
-                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer" };
+                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var tool = new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" };
                 toolService.AddTool(tool);
                 await vm.LoadToolsAsync();
-                vm.SelectedTool = vm.Tools.First();
+                vm.SelectedItem = vm.Tools.First();
                 dialog.EditToolHandler = _ => null;
                 await vm.EditToolCommand.ExecuteAsync(null);
                 var unchanged = toolService.GetAllTools().First();
@@ -370,15 +370,15 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService { ConfirmationResult = true };
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
-                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer" };
+                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var tool = new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" };
                 toolService.AddTool(tool);
                 await vm.LoadToolsAsync();
-                vm.SelectedTool = vm.Tools.First();
+                vm.SelectedItem = vm.Tools.First();
                 await vm.DeleteToolCommand.ExecuteAsync(null);
                 Assert.Empty(toolService.GetAllTools());
                 Assert.Empty(vm.Tools);
@@ -397,15 +397,15 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService { ConfirmationResult = false };
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
-                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer" };
+                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var tool = new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" };
                 toolService.AddTool(tool);
                 await vm.LoadToolsAsync();
-                vm.SelectedTool = vm.Tools.First();
+                vm.SelectedItem = vm.Tools.First();
                 await vm.DeleteToolCommand.ExecuteAsync(null);
                 Assert.Single(toolService.GetAllTools());
                 Assert.Single(vm.Tools);
@@ -420,40 +420,40 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task DeleteToolCommand_OnError_ShowsDialogAndLogs()
         {
-            var toolService = new FailingToolService();
+            var toolService = new FailingItemService();
             var dialog = new StubDialogService { ConfirmationResult = true };
-            var logger = new CapturingLogger<ToolManagementViewModel>();
-            var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), dialog, logger);
-            var tool = new Tool { ToolID = 1, ToolNumber = "T1", NameDescription = "Hammer" };
+            var logger = new CapturingLogger<ItemManagementViewModel>();
+            var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), dialog, logger);
+            var tool = new ItemModel { ToolID = 1, ToolNumber = "T1", NameDescription = "Hammer" };
             vm.Tools.Add(tool);
-            vm.SelectedTool = tool;
+            vm.SelectedItem = tool;
 
             await vm.DeleteToolCommand.ExecuteAsync(null);
 
             Assert.True(dialog.InfoShown);
             Assert.Equal("Failed to delete tool 1", logger.LastError);
             Assert.Single(vm.Tools);
-            Assert.Equal(tool, vm.SelectedTool);
+            Assert.Equal(tool, vm.SelectedItem);
         }
 
         [Fact]
-        public async Task OpenRentalsCommand_CanExecuteDependsOnSelectedTool()
+        public async Task OpenRentalsCommand_CanExecuteDependsOnSelectedItem()
         {
             var dbPath = Path.GetTempFileName();
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
 
                 Assert.False(vm.OpenRentalsCommand.CanExecute(null));
 
-                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
+                toolService.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" });
                 await vm.LoadToolsAsync();
-                vm.SelectedTool = vm.Tools.First();
+                vm.SelectedItem = vm.Tools.First();
 
                 Assert.True(vm.OpenRentalsCommand.CanExecute(null));
             }
@@ -471,21 +471,21 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
-                var tool = new Tool { ToolNumber = "T1", NameDescription = "Hammer" };
+                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var tool = new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" };
                 toolService.AddTool(tool);
                 await vm.LoadToolsAsync();
-                vm.SelectedTool = vm.Tools.First();
+                vm.SelectedItem = vm.Tools.First();
                 bool called = false;
-                Tool? passed = null;
+                ItemModel? passed = null;
                 dialog.ViewDetailsHandler = t => { called = true; passed = t; };
                 vm.ViewDetailsCommand.Execute(null);
                 Assert.True(called);
-                Assert.Equal(vm.SelectedTool, passed);
+                Assert.Equal(vm.SelectedItem, passed);
             }
             finally
             {
@@ -495,23 +495,23 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task ViewDetailsCommand_CanExecuteDependsOnSelectedTool()
+        public async Task ViewDetailsCommand_CanExecuteDependsOnSelectedItem()
         {
             var dbPath = Path.GetTempFileName();
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
 
                 Assert.False(vm.ViewDetailsCommand.CanExecute(null));
 
-                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
+                toolService.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" });
                 await vm.LoadToolsAsync();
-                vm.SelectedTool = vm.Tools.First();
+                vm.SelectedItem = vm.Tools.First();
 
                 Assert.True(vm.ViewDetailsCommand.CanExecute(null));
             }
@@ -525,13 +525,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task FilterToolsAsync_UsesSearchService_WhenTermProvided()
         {
-            var tools = new List<ToolModel>
+            var tools = new List<ItemModel>
             {
-                new Tool { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" },
-                new Tool { ToolNumber = "T2", NameDescription = "Saw", Brand = "BrandB" }
+                new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" },
+                new ItemModel { ToolNumber = "T2", NameDescription = "Saw", Brand = "BrandB" }
             };
-            var toolService = new CountingToolService(tools);
-            var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
+            var toolService = new CountingItemService(tools);
+            var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
             vm.SearchTerm = "Ham";
             await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
             Assert.Equal(1, toolService.SearchToolsAsyncCalls);
@@ -541,12 +541,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task FilterToolsAsync_ReusesCache_WhenNoSearchTerm()
         {
-            var tools = new List<ToolModel>
+            var tools = new List<ItemModel>
             {
-                new Tool { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" }
+                new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" }
             };
-            var toolService = new CountingToolService(tools);
-            var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
+            var toolService = new CountingItemService(tools);
+            var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
 
             await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
             Assert.Equal(1, toolService.GetAllToolsAsyncCalls);
@@ -559,13 +559,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void SearchText_DebouncesRapidChanges()
         {
-            var tools = new List<ToolModel>
+            var tools = new List<ItemModel>
             {
-                new Tool { ToolNumber = "T1", NameDescription = "Hammer" }
+                new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" }
             };
-            var toolService = new CountingToolService(tools);
+            var toolService = new CountingItemService(tools);
             var timer = new TestDispatcherTimer();
-            var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService(), null, timer);
+            var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService(), null, timer);
 
             vm.SearchText = "H";
             vm.SearchText = "Ha";
@@ -581,13 +581,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void Dispose_StopsSearchDebounceTimer()
         {
-            var tools = new List<ToolModel>
+            var tools = new List<ItemModel>
             {
-                new Tool { ToolNumber = "T1", NameDescription = "Hammer" }
+                new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" }
             };
-            var toolService = new CountingToolService(tools);
+            var toolService = new CountingItemService(tools);
             var timer = new TestDispatcherTimer();
-            var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService(), null, timer);
+            var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService(), null, timer);
 
             vm.SearchText = "Ha";
             Assert.True(timer.IsEnabled);
@@ -601,36 +601,36 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task SearchCommand_CanBeCancelled()
         {
-            var tools = new List<ToolModel>
+            var tools = new List<ItemModel>
             {
-                new Tool { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" }
+                new ItemModel { ToolNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" }
             };
-            var toolService = new CountingToolService(tools);
-            var vm = new ToolManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
+            var toolService = new CountingItemService(tools);
+            var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
             vm.SearchTerm = "Ham";
             var cts = new CancellationTokenSource();
             cts.Cancel();
             await Assert.ThrowsAsync<OperationCanceledException>(() => vm.SearchCommand.ExecuteAsync(cts.Token));
         }
 
-        class CountingToolService : IToolService
+        class CountingItemService : IItemService
         {
             public int GetAllToolsAsyncCalls { get; private set; }
             public int SearchToolsAsyncCalls { get; private set; }
-            readonly List<ToolModel> _tools;
-            public CountingToolService(IEnumerable<ToolModel> tools) => _tools = tools.ToList();
+            readonly List<ItemModel> _tools;
+            public CountingItemService(IEnumerable<ItemModel> tools) => _tools = tools.ToList();
 
-            public Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default)
+            public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default)
             {
                 GetAllToolsAsyncCalls++;
                 return Task.FromResult(_tools.ToList());
             }
 
-            public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default)
+            public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default)
             {
                 SearchToolsAsyncCalls++;
                 if (cancellationToken.IsCancellationRequested)
-                    return Task.FromCanceled<List<ToolModel>>(cancellationToken);
+                    return Task.FromCanceled<List<ItemModel>>(cancellationToken);
                 if (string.IsNullOrWhiteSpace(searchText))
                     return Task.FromResult(_tools.ToList());
                 var term = searchText.Trim();
@@ -643,34 +643,34 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 return Task.FromResult(results);
             }
 
-            public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
             public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
         }
 
-        class FailingToolService : IToolService
+        class FailingItemService : IItemService
         {
-            public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new Exception("failure");
-            public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-            public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+            public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
             public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+            public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
             public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
             public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
             public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
         }

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -583,14 +583,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => true;
-       public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+       public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
         public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }
@@ -672,14 +672,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
             LastMessage = message;
         }
         public bool ShowConfirmation(string message, string title) => true;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }
         public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
-        public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelAutoLogoutTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelAutoLogoutTests.cs
@@ -25,7 +25,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -78,14 +78,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             public void ShowInfo(string message, string title) { }
             public bool ShowConfirmation(string message, string title) => false;
-            public ToolManagementAppV2.Models.Domain.ToolModel? ShowEditToolDialog(ToolManagementAppV2.Models.Domain.ToolModel tool) => null;
-            public void ShowToolDetails(ToolManagementAppV2.Models.Domain.ToolModel tool) { }
-            public (ToolManagementAppV2.Models.Domain.CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolManagementAppV2.Models.Domain.ToolModel tool, System.Collections.Generic.IEnumerable<ToolManagementAppV2.Models.Domain.CustomerModel> customers) => null;
+            public ToolManagementAppV2.Models.Domain.ItemModel? ShowEditToolDialog(ToolManagementAppV2.Models.Domain.ItemModel tool) => null;
+            public void ShowToolDetails(ToolManagementAppV2.Models.Domain.ItemModel tool) { }
+            public (ToolManagementAppV2.Models.Domain.CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolManagementAppV2.Models.Domain.ItemModel tool, System.Collections.Generic.IEnumerable<ToolManagementAppV2.Models.Domain.CustomerModel> customers) => null;
             public ToolManagementAppV2.Models.Domain.CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
-            public void ShowRentalHistory(ToolManagementAppV2.Models.Domain.ToolModel tool, System.Collections.Generic.IEnumerable<ToolManagementAppV2.Models.Domain.RentalModel> history) { }
+            public void ShowRentalHistory(ToolManagementAppV2.Models.Domain.ItemModel tool, System.Collections.Generic.IEnumerable<ToolManagementAppV2.Models.Domain.RentalModel> history) { }
             public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-            public Func<ToolManagementAppV2.Models.Domain.ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+            public Func<ToolManagementAppV2.Models.Domain.ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }
         }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -27,7 +27,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -82,14 +82,14 @@ class StubDialogService : IDialogService
 {
     public void ShowInfo(string message, string title) { }
     public bool ShowConfirmation(string message, string title) => false;
-    public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-    public void ShowToolDetails(ToolModel tool) { }
-    public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+    public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+    public void ShowToolDetails(ItemModel tool) { }
+    public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
     public CustomerModel? ShowAddCustomerDialog() => null;
     public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-    public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+    public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
     public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-    public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+    public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
     public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
     public void ShowPrintLabelDialog() { }
 }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelDisposalTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelDisposalTests.cs
@@ -26,7 +26,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -40,12 +40,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
                     fileDialogService, activityLogService, settingsService, db, dialogService);
 
                 var field = typeof(ObservableObject).GetField("PropertyChanged", BindingFlags.Instance | BindingFlags.NonPublic);
-                var handlersBefore = ((MulticastDelegate?)field?.GetValue(vm.ToolManagement))?.GetInvocationList() ?? Array.Empty<Delegate>();
+                var handlersBefore = ((MulticastDelegate?)field?.GetValue(vm.ItemManagement))?.GetInvocationList() ?? Array.Empty<Delegate>();
                 Assert.Contains(handlersBefore, h => ReferenceEquals(h.Target, vm));
 
                 vm.Dispose();
 
-                var handlersAfter = ((MulticastDelegate?)field?.GetValue(vm.ToolManagement))?.GetInvocationList() ?? Array.Empty<Delegate>();
+                var handlersAfter = ((MulticastDelegate?)field?.GetValue(vm.ItemManagement))?.GetInvocationList() ?? Array.Empty<Delegate>();
                 Assert.DoesNotContain(handlersAfter, h => ReferenceEquals(h.Target, vm));
             }
             finally
@@ -64,7 +64,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var dbPath = Path.GetTempFileName();
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelImportMappingTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelImportMappingTests.cs
@@ -29,7 +29,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 using var factory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -58,14 +58,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
             public Dictionary<string,string>? MapToReturn { get; set; }
             public void ShowInfo(string message, string title) { }
             public bool ShowConfirmation(string message, string title) => false;
-            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-            public void ShowToolDetails(ToolModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+            public void ShowToolDetails(ItemModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
-            public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+            public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }
             public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => MapToReturn;
-            public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }
         }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -30,7 +30,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
@@ -40,7 +40,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
 
-                Assert.NotNull(vm.ToolManagement);
+                Assert.NotNull(vm.ItemManagement);
                 Assert.NotNull(vm.UserManagement);
                 Assert.NotNull(vm.CustomerManagement);
                 Assert.NotNull(vm.ManageRentals);
@@ -62,7 +62,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
@@ -90,7 +90,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
@@ -120,7 +120,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var db = new DatabaseService(dbPath);
                 var activityLogService = new ActivityLogService(db);
                 await activityLogService.LogActionAsync(1, "user", "action");
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
@@ -149,7 +149,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 var db = new DatabaseService(dbPath);
                 var activityLogService = new ActivityLogService(db);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
@@ -177,7 +177,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
@@ -211,7 +211,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
@@ -250,7 +250,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
@@ -278,7 +278,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
@@ -286,8 +286,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
-                toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Saw" });
+                toolService.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" });
+                toolService.AddTool(new ItemModel { ToolNumber = "T2", NameDescription = "Saw" });
 
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
                 vm.GlobalSearchText = "Ham";
@@ -295,10 +295,10 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 await vm.GlobalSearchCommand.ExecuteAsync(CancellationToken.None);
 
                 var page = Assert.IsType<ToolSearchPage>(vm.CurrentPage);
-                Assert.Equal("Ham", vm.ToolManagement.SearchText);
+                Assert.Equal("Ham", vm.ItemManagement.SearchText);
                 Assert.Empty(vm.GlobalSearchText);
-                Assert.Single(vm.ToolManagement.SearchResults);
-                Assert.Equal("Hammer", vm.ToolManagement.SearchResults.First().NameDescription);
+                Assert.Single(vm.ItemManagement.SearchResults);
+                Assert.Equal("Hammer", vm.ItemManagement.SearchResults.First().NameDescription);
             }
             finally
             {
@@ -314,7 +314,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
@@ -339,7 +339,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
@@ -366,7 +366,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -30,7 +30,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -82,7 +82,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -128,7 +128,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -169,7 +169,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -207,7 +207,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -272,14 +272,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public bool InfoShown { get; private set; }
         public void ShowInfo(string message, string title) => InfoShown = true;
         public bool ShowConfirmation(string message, string title) => false;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
         public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
@@ -30,7 +30,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -64,7 +64,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -97,7 +97,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new GetAllUsersFailingUserService();
                 var customerService = new CustomerService(db);
@@ -128,14 +128,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public bool ThrowOnShowPrintLabelDialog { get; set; }
         public void ShowInfo(string message, string title) => InfoShown = true;
         public bool ShowConfirmation(string message, string title) => false;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
         public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog()
         {

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelTitleTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelTitleTests.cs
@@ -25,11 +25,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var dbPath = Path.GetTempFileName();
             var originalSingular = LabelProvider.Instance.ItemLabelSingular;
             var originalPlural = LabelProvider.Instance.ItemLabelPlural;
-            LabelProvider.Instance.UpdateLabels("Tool", "Tools");
+            LabelProvider.Instance.UpdateLabels("ItemModel", "Tools");
             try
             {
                 var db = new DatabaseService(dbPath);
-                IToolService toolService = new ToolService(db);
+                IItemService toolService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);

--- a/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
@@ -23,12 +23,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool1 = new Tool { ToolNumber = "T1" };
-                var tool2 = new Tool { ToolNumber = "T2" };
+                var tool1 = new ItemModel { ToolNumber = "T1" };
+                var tool2 = new ItemModel { ToolNumber = "T2" };
                 toolService.AddTool(tool1);
                 toolService.AddTool(tool2);
                 var customer = new Customer { Company = "C1" };
@@ -68,12 +68,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool1 = new Tool { ToolNumber = "Alpha" };
-                var tool2 = new Tool { ToolNumber = "Beta" };
+                var tool1 = new ItemModel { ToolNumber = "Alpha" };
+                var tool2 = new ItemModel { ToolNumber = "Beta" };
                 toolService.AddTool(tool1);
                 toolService.AddTool(tool2);
                 var customer = new Customer { Company = "C1" };
@@ -106,11 +106,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool = new Tool { ToolNumber = "T1" };
+                var tool = new ItemModel { ToolNumber = "T1" };
                 toolService.AddTool(tool);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
@@ -163,11 +163,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool = new Tool { ToolNumber = "T1" };
+                var tool = new ItemModel { ToolNumber = "T1" };
                 toolService.AddTool(tool);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
@@ -199,11 +199,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool = new Tool { ToolNumber = "T1" };
+                var tool = new ItemModel { ToolNumber = "T1" };
                 toolService.AddTool(tool);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
@@ -233,11 +233,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool = new Tool { ToolNumber = "T1" };
+                var tool = new ItemModel { ToolNumber = "T1" };
                 toolService.AddTool(tool);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
@@ -417,14 +417,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
             return Task.CompletedTask;
         }
         public bool ShowConfirmation(string message, string title) => false;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
         public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }
@@ -434,14 +434,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public string? LastInfoMessage { get; private set; }
         public void ShowInfo(string message, string title) => LastInfoMessage = message;
         public bool ShowConfirmation(string message, string title) => false;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }
         public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
-        public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) => throw new InvalidOperationException("boom");
         public void ShowPrintLabelDialog() { }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -43,7 +43,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task ImportExportViewModel_ImportToolsCommand_LogsSuccess()
         {
-            var toolService = new StubToolService();
+            var toolService = new StubItemService();
             var customerService = new StubCustomerService();
             var fileDlg = new StubFileDialogService();
             var tmp = Path.GetTempFileName();
@@ -61,7 +61,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task ImportExportViewModel_ExportToolsCommand_LogsSuccess()
         {
-            var toolService = new StubToolService();
+            var toolService = new StubItemService();
             var customerService = new StubCustomerService();
             var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
             await vm.ExportToolsCommand.ExecuteAsync(null);
@@ -73,7 +73,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task ImportExportViewModel_ImportCustomersCommand_LogsSuccess()
         {
-            var toolService = new StubToolService();
+            var toolService = new StubItemService();
             var customerService = new StubCustomerService();
             var fileDlg = new StubFileDialogService();
             var tmp = Path.GetTempFileName();
@@ -91,7 +91,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task ImportExportViewModel_ExportCustomersCommand_LogsSuccess()
         {
-            var toolService = new StubToolService();
+            var toolService = new StubItemService();
             var customerService = new StubCustomerService();
             var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
             await vm.ExportCustomersCommand.ExecuteAsync(null);
@@ -103,7 +103,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task ImportExportViewModel_BackupDatabaseCommand_LogsSuccess()
         {
-            var vm = new ImportExportViewModel(new StubToolService(), new StubCustomerService(), new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
+            var vm = new ImportExportViewModel(new StubItemService(), new StubCustomerService(), new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
             await vm.BackupDatabaseCommand.ExecuteAsync(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Successfully backed up database", vm.ImportExportLogs[0]);
@@ -112,7 +112,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task ImportExportViewModel_BackupDatabaseCommand_CancelledOperation_LogsCancellation()
         {
-            var vm = new ImportExportViewModel(new StubToolService(), new StubCustomerService(), new StubFileDialogService(), new CancellableDatabaseBackupService(), new StubDialogService());
+            var vm = new ImportExportViewModel(new StubItemService(), new StubCustomerService(), new StubFileDialogService(), new CancellableDatabaseBackupService(), new StubDialogService());
             var task = vm.BackupDatabaseCommand.ExecuteAsync(null);
             vm.BackupDatabaseCommand.Cancel();
             await task;
@@ -123,7 +123,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task ImportExportViewModel_ImportToolsCommand_LogsFailure()
         {
-            var toolService = new FailToolService();
+            var toolService = new FailItemService();
             var customerService = new StubCustomerService();
             var fileDlg = new StubFileDialogService();
             var tmp = Path.GetTempFileName();
@@ -140,7 +140,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task ImportExportViewModel_ExportToolsCommand_LogsFailure()
         {
-            var toolService = new FailToolService();
+            var toolService = new FailItemService();
             var customerService = new StubCustomerService();
             var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
             await vm.ExportToolsCommand.ExecuteAsync(null);
@@ -151,7 +151,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task ImportExportViewModel_ImportCustomersCommand_LogsFailure()
         {
-            var toolService = new StubToolService();
+            var toolService = new StubItemService();
             var customerService = new FailCustomerService();
             var fileDlg = new StubFileDialogService();
             var tmp = Path.GetTempFileName();
@@ -168,7 +168,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public async Task ImportExportViewModel_ExportCustomersCommand_LogsFailure()
         {
-            var toolService = new StubToolService();
+            var toolService = new StubItemService();
             var customerService = new FailCustomerService();
             var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
             await vm.ExportCustomersCommand.ExecuteAsync(null);
@@ -183,7 +183,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var reportService = new ReportService(new StubToolService(), new StubRentalService(), new ActivityLogService(db), new StubCustomerService(), new StubUserService());
+                var reportService = new ReportService(new StubItemService(), new StubRentalService(), new ActivityLogService(db), new StubCustomerService(), new StubUserService());
                 var vm = new ReportsViewModel(reportService);
                 vm.SelectedReport = vm.ReportTypes.First();
                 vm.RunReportCommand.Execute(null);
@@ -210,23 +210,23 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public bool ShowImportMappingCalled { get; private set; }
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }
         public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties)
         {
             ShowImportMappingCalled = true;
             return MapToReturn;
         }
-        public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }
 
-    class StubToolService : IToolService
+    class StubItemService : IItemService
     {
         public bool ImportCalled { get; private set; }
         public bool ExportCalled { get; private set; }
@@ -240,34 +240,34 @@ namespace ToolManagementAppV2.Tests.ViewModels
             ExportCalled = true;
             return Task.CompletedTask;
         }
-        public Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-        public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
         public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, System.Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 
-    class FailToolService : IToolService
+    class FailItemService : IItemService
     {
         public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromException<List<int>>(new System.Exception("fail"));
         public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.FromException(new System.Exception("fail"));
-        public Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
-        public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
         public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ToolModel>());
+        public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, System.Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, System.Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }

--- a/ToolManagementAppV2.Tests/ViewModels/PasswordPromptViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/PasswordPromptViewModelTests.cs
@@ -84,14 +84,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
         public void ShowInfo(string message, string title) => InfoShown = true;
         public bool ShowConfirmation(string message, string title) => ConfirmationResult;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
         public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/PrintLabelViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/PrintLabelViewModelTests.cs
@@ -38,10 +38,10 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void Items_Accepts_ToolModel()
+        public void Items_Accepts_ItemModel()
         {
             var vm = new PrintLabelViewModel(new StubDialogService(), () => { });
-            vm.Items.Add(new ToolModel { ToolNumber = "T1" });
+            vm.Items.Add(new ItemModel { ToolNumber = "T1" });
             Assert.Single(vm.Items);
         }
     }
@@ -51,14 +51,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public bool InfoShown { get; private set; }
         public void ShowInfo(string message, string title) => InfoShown = true;
         public bool ShowConfirmation(string message, string title) => false;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
         public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/RentToolPopupViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/RentToolPopupViewModelTests.cs
@@ -11,7 +11,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void CheckOutCommand_SetsResultsAndRaisesClose()
         {
-            var tool = new ToolModel();
+            var tool = new ItemModel();
             var customer = new CustomerModel { CustomerID = 1, Company = "ACME" };
             var vm = new RentToolPopupViewModel(tool, new[] { customer })
             {

--- a/ToolManagementAppV2.Tests/ViewModels/RentalHistoryViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/RentalHistoryViewModelTests.cs
@@ -89,17 +89,17 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
             public bool ShowConfirmation(string message, string title) => true;
 
-            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
+            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
 
-            public void ShowToolDetails(ToolModel tool) { }
+            public void ShowToolDetails(ItemModel tool) { }
 
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
 
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-            public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+            public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
             public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-            public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+            public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }
         }

--- a/ToolManagementAppV2.Tests/ViewModels/ReportsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ReportsViewModelTests.cs
@@ -23,14 +23,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ToolService(db);
+                var toolService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var userService = new UserService(db, new ApplicationUserContext());
                 var rentalService = new RentalService(db, toolService);
                 var activityService = new ActivityLogService(db);
                 var reportService = new ReportService(toolService, rentalService, activityService, customerService, userService);
 
-                var tool = new Tool { ToolNumber = "T1", QuantityOnHand = 1 };
+                var tool = new ItemModel { ToolNumber = "T1", QuantityOnHand = 1 };
                 toolService.AddTool(tool);
 
                 var customer = new Customer { Company = "C1" };
@@ -61,7 +61,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 Assert.True(vm.RunReportCommand.CanExecute(null));
 
                 await vm.RunReportCommand.ExecuteAsync(null);
-                Assert.Contains("Tool ID:",
+                Assert.Contains("ItemModel ID:",
                     vm.ReportResults.Rows.Cast<DataRow>().Select(r => r[0]?.ToString()));
             }
             finally

--- a/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
@@ -105,14 +105,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public bool InfoShown;
         public void ShowInfo(string message, string title) => InfoShown = true;
         public bool ShowConfirmation(string message, string title) => false;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }
         public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
-        public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -193,7 +193,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void ItemLabels_UpdateServiceAndProvider()
         {
             var settings = new StubSettingsService();
-            LabelProvider.Instance.UpdateLabels("Tool", "Tools");
+            LabelProvider.Instance.UpdateLabels("ItemModel", "Tools");
             var vm = new SettingsViewModel(new StubFileDialogService(), settings, new StubDialogService());
             vm.ItemLabelSingular = "Widget";
             vm.ItemLabelPlural = "Widgets";
@@ -201,7 +201,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             Assert.Equal("Widgets", settings.ItemLabelPlural);
             Assert.Equal("Widget", LabelProvider.Instance.ItemLabelSingular);
             Assert.Equal("Widgets", LabelProvider.Instance.ItemLabelPlural);
-            LabelProvider.Instance.UpdateLabels("Tool", "Tools");
+            LabelProvider.Instance.UpdateLabels("ItemModel", "Tools");
         }
 
         [Fact]
@@ -242,7 +242,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public IEnumerable<string> ScannerIps { get; set; } = Array.Empty<string>();
         public int PasswordIterations { get; set; } = 100_000;
         public int AutoLogoutMinutes { get; set; }
-        public string ItemLabelSingular { get; set; } = "Tool";
+        public string ItemLabelSingular { get; set; } = "ItemModel";
         public string ItemLabelPlural { get; set; } = "Tools";
 
         public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
@@ -308,14 +308,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
         
         public bool ShowConfirmation(string message, string title) => true;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
         public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }
@@ -324,14 +324,14 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public void ShowInfo(string message, string title) => throw new InvalidOperationException("dialog failure");
         public bool ShowConfirmation(string message, string title) => false;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }
         public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
-        public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }

--- a/ToolManagementAppV2.Tests/ViewModels/ToolEditViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ToolEditViewModelTests.cs
@@ -10,7 +10,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void BrowseImageCommand_SetsToolImagePath()
         {
-            var tool = new Tool();
+            var tool = new ItemModel();
             var fileDialog = new StubFileDialogService { OpenPath = "img.png" };
             var vm = new ToolEditViewModel(tool, () => { }, () => { }, fileDialog);
             vm.BrowseImageCommand.Execute(null);
@@ -20,7 +20,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Fact]
         public void RemoveImageCommand_ClearsToolImagePath()
         {
-            var tool = new Tool { ToolImagePath = "img.png" };
+            var tool = new ItemModel { ToolImagePath = "img.png" };
             var vm = new ToolEditViewModel(tool, () => { }, () => { }, new StubFileDialogService());
             vm.RemoveImageCommand.Execute(null);
             Assert.Equal(string.Empty, tool.ToolImagePath);

--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -492,7 +492,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 try
                 {
-                    var vm = new RentToolPopupViewModel(new ToolModel(), new List<CustomerModel>());
+                    var vm = new RentToolPopupViewModel(new ItemModel(), new List<CustomerModel>());
                     var win = new RentToolPopupWindow { DataContext = vm };
                     var captured = win;
                     EventHandler handler = (_, _) => captured.Close();
@@ -555,14 +555,14 @@ class StubDialogService : IDialogService
         LastInfoTitle = title;
     }
     public bool ShowConfirmation(string message, string title) => false;
-    public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-    public void ShowToolDetails(ToolModel tool) { }
-    public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+    public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+    public void ShowToolDetails(ItemModel tool) { }
+    public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
     public CustomerModel? ShowAddCustomerDialog() => null;
     public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-    public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+    public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
     public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-    public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+    public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
     public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
     public void ShowPrintLabelDialog() { }
 }

--- a/ToolManagementAppV2.Tests/Views/AvatarSelectionWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/AvatarSelectionWindowTests.cs
@@ -113,7 +113,7 @@ namespace ToolManagementAppV2.Tests.Views
         class StubSettingsService : ISettingsService
         {
             public string? AppName { get; set; }
-            public string ItemLabelSingular { get; set; } = "Tool";
+            public string ItemLabelSingular { get; set; } = "ItemModel";
             public string ItemLabelPlural { get; set; } = "Tools";
 
             public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default)
@@ -181,7 +181,7 @@ namespace ToolManagementAppV2.Tests.Views
             public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
             public Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default)
-                => Task.FromResult("Tool");
+                => Task.FromResult("ItemModel");
             public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
             public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default)

--- a/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
@@ -28,7 +28,7 @@ namespace ToolManagementAppV2.Tests.Views
                 {
                     try
                     {
-                        var toolSvc = new StubToolService();
+                        var toolSvc = new StubItemService();
                         var customerSvc = new StubCustomerService();
                         var fileDlg = new StubFileDialogService { FileToReturn = tmp };
                         var dialog = new StubDialogService();
@@ -80,23 +80,23 @@ namespace ToolManagementAppV2.Tests.Views
         public bool ShowImportMappingCalled { get; private set; }
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
         public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties)
         {
             ShowImportMappingCalled = true;
             return MapToReturn;
         }
-        public Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }
 
-    class StubToolService : IToolService
+    class StubItemService : IItemService
     {
         public bool ImportCalled { get; private set; }
         public Task<System.Collections.Generic.List<int>> ImportToolsFromCsvAsync(string filePath, System.Collections.Generic.IDictionary<string, string> map, CancellationToken cancellationToken)
@@ -105,16 +105,16 @@ namespace ToolManagementAppV2.Tests.Views
             return Task.FromResult(new System.Collections.Generic.List<int>());
         }
         public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task<System.Collections.Generic.List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ToolModel>());
-        public Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<System.Collections.Generic.List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ItemModel>());
+        public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<System.Collections.Generic.List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ToolModel>());
+        public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<System.Collections.Generic.List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ItemModel>());
         public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<System.Collections.Generic.List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ToolModel>());
+        public Task<System.Collections.Generic.List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ItemModel>());
         public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, System.Collections.Generic.IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, System.Collections.Generic.IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
         public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }

--- a/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
@@ -140,19 +140,19 @@ namespace ToolManagementAppV2.Tests.Views
                 {
                     var originalSingular = LabelProvider.Instance.ItemLabelSingular;
                     var originalPlural = LabelProvider.Instance.ItemLabelPlural;
-                    LabelProvider.Instance.UpdateLabels("Tool", "Tools");
+                    LabelProvider.Instance.UpdateLabels("Item", "Items");
                     var (window, dbPath) = TestHelpers.CreateMainWindow();
                     try
                     {
                         var vm = Assert.IsType<MainViewModel>(window.DataContext);
 
-                        Assert.Equal("Tools Management", window.Title);
+                        Assert.Equal("Items Management", window.Title);
 
                         vm.Settings.ApplicationName = "My App";
                         Assert.Equal("My App", window.Title);
 
                         vm.Settings.ApplicationName = string.Empty;
-                        Assert.Equal("Tools Management", window.Title);
+                        Assert.Equal("Items Management", window.Title);
                     }
                     finally
                     {
@@ -233,7 +233,7 @@ namespace ToolManagementAppV2.Tests.Views
                     try
                     {
                         var db = new DatabaseService(dbPath);
-                        var toolService = new ToolService(db);
+                        var toolService = new ItemService(db);
                         var userContext = new ApplicationUserContext();
                         var userService = new UserService(db, userContext);
                         var customerService = new CustomerService(db);
@@ -315,7 +315,7 @@ namespace ToolManagementAppV2.Tests.Views
                         Assert.NotNull(button);
 
                         var tool = new ToolModel { ToolID = 1 };
-                        vm.ToolManagement.SelectedTool = tool;
+                        vm.ItemManagement.SelectedItem = tool;
 
                         Assert.Same(tool, button!.CommandParameter);
                         Assert.Same(vm.OpenRentalHistoryWindowCommand, button.Command);

--- a/ToolManagementAppV2.Tests/Views/PasswordPromptWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/PasswordPromptWindowTests.cs
@@ -86,14 +86,14 @@ namespace ToolManagementAppV2.Tests.Views
 
             public void ShowInfo(string message, string title) { }
             public bool ShowConfirmation(string message, string title) => ConfirmationResult;
-            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-            public void ShowToolDetails(ToolModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+            public void ShowToolDetails(ItemModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-            public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+            public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
             public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-            public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+            public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }
         }

--- a/ToolManagementAppV2.Tests/Views/RentalsFilterWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/RentalsFilterWindowTests.cs
@@ -84,14 +84,14 @@ namespace ToolManagementAppV2.Tests.Views
                 return Task.CompletedTask;
             }
             public bool ShowConfirmation(string message, string title) => false;
-            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-            public void ShowToolDetails(ToolModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+            public void ShowToolDetails(ItemModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
-            public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }
+            public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }
             public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
-            public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }
         }

--- a/ToolManagementAppV2.Tests/Views/ToolEditWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ToolEditWindowTests.cs
@@ -20,7 +20,7 @@ namespace ToolManagementAppV2.Tests.Views
             {
                 try
                 {
-                    var tool = new Tool();
+                    var tool = new ItemModel();
                     ToolEditWindow? window = null;
                     bool closed = false;
 
@@ -32,7 +32,7 @@ namespace ToolManagementAppV2.Tests.Views
 
                     Assert.IsType<ToolEditViewModel>(window.DataContext);
                     var vm = (ToolEditViewModel)window.DataContext;
-                    Assert.Equal(tool, vm.Tool);
+                    Assert.Equal(tool, vm.ItemModel);
 
                     vm.SaveCommand.Execute(null);
 
@@ -63,7 +63,7 @@ namespace ToolManagementAppV2.Tests.Views
             {
                 try
                 {
-                    var tool = new Tool();
+                    var tool = new ItemModel();
                     ToolEditWindow? window = null;
                     bool closed = false;
 
@@ -99,7 +99,7 @@ namespace ToolManagementAppV2.Tests.Views
         {
             var thread = new Thread(() =>
             {
-                var tool = new Tool();
+                var tool = new ItemModel();
                 ToolEditWindow? window = null;
                 Action onSave = () => window?.Close();
                 Action onCancel = () => window?.Close();

--- a/ToolManagementAppV2.Tests/Views/ToolSearchPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ToolSearchPageTests.cs
@@ -61,7 +61,7 @@ namespace ToolManagementAppV2.Tests.Views
                 }
                 finally
                 {
-                    LabelProvider.Instance.UpdateLabels("Tool", "Tools");
+                    LabelProvider.Instance.UpdateLabels("ItemModel", "Tools");
                 }
             });
             thread.SetApartmentState(ApartmentState.STA);

--- a/ToolManagementAppV2.Tests/Views/ToolSearchTypingTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ToolSearchTypingTests.cs
@@ -25,13 +25,13 @@ namespace ToolManagementAppV2.Tests.Views
                 try
                 {
                     var db = new DatabaseService(dbPath);
-                    IToolService toolService = new ToolService(db);
+                    IItemService toolService = new ItemService(db);
                     var customerService = new CustomerService(db);
                     var rentalService = new RentalService(db);
                     var dialog = new StubDialogService();
-                    var vm = new ToolManagementViewModel(toolService, customerService, rentalService, dialog);
-                    toolService.AddTool(new Tool { ToolNumber = "T1", NameDescription = "Hammer" });
-                    toolService.AddTool(new Tool { ToolNumber = "T2", NameDescription = "Hand Saw" });
+                    var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                    toolService.AddTool(new ItemModel { ToolNumber = "T1", NameDescription = "Hammer" });
+                    toolService.AddTool(new ItemModel { ToolNumber = "T2", NameDescription = "Hand Saw" });
                     vm.LoadToolsAsync().Wait();
                     var page = new ToolSearchPage { DataContext = vm };
                     var window = new System.Windows.Window { Content = page, Width = 800, Height = 600 };
@@ -53,9 +53,9 @@ namespace ToolManagementAppV2.Tests.Views
         {
             public void ShowInfo(string message, string title) { }
             public bool ShowConfirmation(string message, string title) => false;
-            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-            public void ShowToolDetails(ToolModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+            public void ShowToolDetails(ItemModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
         }
     }

--- a/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
@@ -227,14 +227,14 @@ namespace ToolManagementAppV2.Tests.Views
     {
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-        public void ShowToolDetails(ToolModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+        public void ShowToolDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+        public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
         public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
-        public System.Func<ToolModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
+        public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
     }

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -84,7 +84,7 @@ namespace ToolManagementAppV2
                 services.AddSingleton<IDatabaseBackupService>(sp => sp.GetRequiredService<DatabaseService>());
                 services.AddSingleton<IUserContext, ApplicationUserContext>();
                 services.AddSingleton<IAuthorizationService, AuthorizationService>();
-                services.AddSingleton<IToolService, ToolService>();
+                services.AddSingleton<IItemService, ItemService>();
                 services.AddSingleton<ICustomerService, CustomerService>();
                 services.AddSingleton<IUserService, UserService>();
                 services.AddSingleton<IRentalService, RentalService>();

--- a/ToolManagementAppV2/Interfaces/IDialogService.cs
+++ b/ToolManagementAppV2/Interfaces/IDialogService.cs
@@ -17,18 +17,18 @@ namespace ToolManagementAppV2.Interfaces
         Task<bool> ShowConfirmationAsync(string message, string title) =>
             System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowConfirmation(message, title)).Task
             ?? Task.FromResult(false);
-        ToolModel? ShowEditToolDialog(ToolModel tool);
-        Task<ToolModel?> ShowEditToolDialogAsync(ToolModel tool) =>
+        ItemModel? ShowEditToolDialog(ItemModel tool);
+        Task<ItemModel?> ShowEditToolDialogAsync(ItemModel tool) =>
             System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowEditToolDialog(tool)).Task
-            ?? Task.FromResult<ToolModel?>(null);
-        void ShowToolDetails(ToolModel tool);
-        (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers);
+            ?? Task.FromResult<ItemModel?>(null);
+        void ShowToolDetails(ItemModel tool);
+        (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers);
         CustomerModel? ShowAddCustomerDialog();
 
         void ShowRentalsFilter(ManageRentalsViewModel viewModel);
-        void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history);
+        void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history);
         Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties);
-        Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping();
+        Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping();
         void ShowPrintPreview(FlowDocument document, string title, string description);
         void ShowPrintLabelDialog();
     }

--- a/ToolManagementAppV2/Interfaces/IItemService.cs
+++ b/ToolManagementAppV2/Interfaces/IItemService.cs
@@ -8,20 +8,20 @@ using ToolManagementAppV2.Models.ImportExport;
 
 namespace ToolManagementAppV2.Interfaces
 {
-    public interface IToolService
+    public interface IItemService
     {
-        Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default);
-        Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default);
+        Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default);
+        Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default);
         Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default);
-        Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default);
-        Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default);
-        Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default);
+        Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default);
+        Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default);
+        Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default);
         Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default);
-        Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default);
+        Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default);
         Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default);
         Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken);
         Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default);
-        Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default);
+        Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default);
         Task<string> GenerateNextToolNumberAsync(CancellationToken cancellationToken = default);
         Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental,
             SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default);

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -35,7 +35,7 @@
                         <Separator/>
 
                         <TextBlock Text="Workshop" Style="{StaticResource CaptionTextBlock}" Margin="6,8,6,2"/>
-                        <Button Style="{StaticResource NavButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Manage {0}}" Command="{Binding OpenManageToolsCommand}" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
+                        <Button Style="{StaticResource NavButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Manage {0}}" Command="{Binding OpenManageItemsCommand}" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
                         <Button Style="{StaticResource NavButton}" Content="Customers" Command="{Binding OpenCustomersCommand}"/>
                         <Button Style="{StaticResource NavButton}" Content="Users" Command="{Binding OpenUsersCommand}" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
 

--- a/ToolManagementAppV2/Models/Domain/ItemModel.cs
+++ b/ToolManagementAppV2/Models/Domain/ItemModel.cs
@@ -2,7 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ToolManagementAppV2.Models.Domain
 {
-    public class Tool : ObservableObject
+    public class ItemModel : ObservableObject
     {
         private int _toolID;
         public int ToolID

--- a/ToolManagementAppV2/Models/ModelAliases.cs
+++ b/ToolManagementAppV2/Models/ModelAliases.cs
@@ -1,4 +1,4 @@
-﻿global using ToolModel = ToolManagementAppV2.Models.Domain.Tool;
+﻿global using ItemModel = ToolManagementAppV2.Models.Domain.ItemModel;
 global using UserModel = ToolManagementAppV2.Models.Domain.User;
 global using CustomerModel = ToolManagementAppV2.Models.Domain.Customer;
 global using RentalModel = ToolManagementAppV2.Models.Domain.Rental;

--- a/ToolManagementAppV2/Services/Core/CsvHelperUtil.cs
+++ b/ToolManagementAppV2/Services/Core/CsvHelperUtil.cs
@@ -32,10 +32,10 @@ namespace ToolManagementAppV2.Utilities.IO
         }
 
 
-        public static List<ToolModel> LoadToolsFromCsv(string filePath, IDictionary<string, string> map, out List<int> invalidRows)
+        public static List<ItemModel> LoadToolsFromCsv(string filePath, IDictionary<string, string> map, out List<int> invalidRows)
         {
             ValidateRequired(map, "ToolNumber");
-            var list = new List<ToolModel>();
+            var list = new List<ItemModel>();
             invalidRows = new List<int>();
             using var parser = new TextFieldParser(filePath);
             parser.SetDelimiters(",");
@@ -56,7 +56,7 @@ namespace ToolManagementAppV2.Utilities.IO
                     continue;
                 }
 
-                list.Add(new ToolModel
+                list.Add(new ItemModel
                 {
                     ToolNumber = toolNumber,
                     NameDescription = GetMapped(cols, headers, map, "NameDescription"),
@@ -74,7 +74,7 @@ namespace ToolManagementAppV2.Utilities.IO
             return list;
         }
 
-        public static async Task<(List<ToolModel> Tools, List<int> InvalidRows)> LoadToolsFromCsvAsync(
+        public static async Task<(List<ItemModel> Tools, List<int> InvalidRows)> LoadToolsFromCsvAsync(
             string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default)
         {
             return await Task.Run(() =>
@@ -84,7 +84,7 @@ namespace ToolManagementAppV2.Utilities.IO
             }, cancellationToken).ConfigureAwait(false);
         }
 
-        public static void ExportToolsToCsv(string filePath, List<ToolModel> tools)
+        public static void ExportToolsToCsv(string filePath, List<ItemModel> tools)
         {
             var lines = new List<string>
             {
@@ -105,7 +105,7 @@ namespace ToolManagementAppV2.Utilities.IO
             File.WriteAllLines(filePath, lines);
         }
 
-        public static async Task ExportToolsToCsvAsync(string filePath, List<ToolModel> tools)
+        public static async Task ExportToolsToCsvAsync(string filePath, List<ItemModel> tools)
         {
             var lines = new List<string>
             {

--- a/ToolManagementAppV2/Services/DialogService.cs
+++ b/ToolManagementAppV2/Services/DialogService.cs
@@ -57,7 +57,7 @@ namespace ToolManagementAppV2.Services
             return Task.FromResult(false);
         }
 
-        public ToolModel? ShowEditToolDialog(ToolModel tool)
+        public ItemModel? ShowEditToolDialog(ItemModel tool)
         {
             ToolEditWindow? win = null;
             win = ActivatorUtilities.CreateInstance<ToolEditWindow>(_serviceProvider,
@@ -70,17 +70,17 @@ namespace ToolManagementAppV2.Services
             catch (Exception ex) { _logger.LogError(ex, "Failed to show ToolEditWindow"); return null; }
         }
 
-        public Task<ToolModel?> ShowEditToolDialogAsync(ToolModel tool)
+        public Task<ItemModel?> ShowEditToolDialogAsync(ItemModel tool)
         {
             var dispatcher = System.Windows.Application.Current?.Dispatcher;
             if (dispatcher != null)
                 return dispatcher.InvokeAsync(() => ShowEditToolDialog(tool)).Task;
 
             _logger.LogWarning("No dispatcher available for ShowEditToolDialogAsync; returning null.");
-            return Task.FromResult<ToolModel?>(null);
+            return Task.FromResult<ItemModel?>(null);
         }
 
-        public void ShowToolDetails(ToolModel tool)
+        public void ShowToolDetails(ItemModel tool)
         {
             ToolDetailsWindow win = null!;
             win = new ToolDetailsWindow(tool);
@@ -90,7 +90,7 @@ namespace ToolManagementAppV2.Services
             catch (Exception ex) { _logger.LogError(ex, "Failed to show ToolDetailsWindow"); }
         }
 
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers)
+        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers)
         {
             var vm = new RentToolPopupViewModel(tool, customers);
             var win = new RentToolPopupWindow { DataContext = vm };
@@ -138,7 +138,7 @@ namespace ToolManagementAppV2.Services
             catch (Exception ex) { _logger.LogError(ex, "Failed to show RentalsFilterWindow"); }
         }
 
-        public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history)
+        public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history)
         {
             var vm = new RentalHistoryViewModel(tool, history, this);
             var win = new RentalHistoryWindow(vm) { Title = $"Rental History - {tool.ToolNumber}" };
@@ -164,7 +164,7 @@ namespace ToolManagementAppV2.Services
             return null;
         }
 
-        public Func<ToolModel, IEnumerable<string>>? ShowImageImportMapping()
+        public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping()
         {
             var win = new ImageImportMappingWindow();
             try { win.Owner = System.Windows.Application.Current?.MainWindow; }

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -17,13 +17,13 @@ namespace ToolManagementAppV2.Services.Rentals
     public class RentalService : IRentalService
     {
         private readonly DatabaseService _dbService;
-        private readonly IToolService? _toolService;
+        private readonly IItemService? _toolService;
         private readonly ILogger<RentalService> _logger;
         private readonly IAuthorizationService _auth;
         private readonly ActivityLogService? _activityLog;
         private readonly IUserContext? _context;
 
-        public RentalService(DatabaseService dbService, IAuthorizationService? authorizationService = null, IToolService? toolService = null, ILogger<RentalService>? logger = null, ActivityLogService? activityLogService = null, IUserContext? userContext = null)
+        public RentalService(DatabaseService dbService, IAuthorizationService? authorizationService = null, IItemService? toolService = null, ILogger<RentalService>? logger = null, ActivityLogService? activityLogService = null, IUserContext? userContext = null)
         {
             _dbService = dbService ?? throw new ArgumentNullException(nameof(dbService));
             _auth = authorizationService ?? new NoOpAuthorizationService();

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -293,7 +293,7 @@ namespace ToolManagementAppV2.Services.Settings
         public async Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default)
         {
             var value = await GetSettingAsync(ItemLabelSingularKey, cancellationToken).ConfigureAwait(false);
-            return string.IsNullOrWhiteSpace(value) ? "Tool" : value;
+            return string.IsNullOrWhiteSpace(value) ? "ItemModel" : value;
         }
 
         public async Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default)

--- a/ToolManagementAppV2/Services/Tools/ItemService.cs
+++ b/ToolManagementAppV2/Services/Tools/ItemService.cs
@@ -19,7 +19,7 @@ using ToolManagementAppV2.Services.Users;
 
 namespace ToolManagementAppV2.Services.Tools
 {
-    public class ToolService : IToolService
+    public class ItemService : IItemService
     {
         readonly DatabaseService _dbService;
         const string AllToolsSql = "SELECT * FROM Tools";
@@ -31,16 +31,16 @@ namespace ToolManagementAppV2.Services.Tools
         const int MaxQuantityOnHand = 10000;
         const int MaxSearchTerms = 10;
     
-        readonly ILogger<ToolService> _logger;
+        readonly ILogger<ItemService> _logger;
         readonly IAuthorizationService _auth;
         readonly ActivityLogService? _activityLog;
         readonly IUserContext? _context;
 
-        public ToolService(DatabaseService dbService, IAuthorizationService? authorizationService = null, ILogger<ToolService>? logger = null, ActivityLogService? activityLogService = null, IUserContext? userContext = null)
+        public ItemService(DatabaseService dbService, IAuthorizationService? authorizationService = null, ILogger<ItemService>? logger = null, ActivityLogService? activityLogService = null, IUserContext? userContext = null)
         {
             _dbService = dbService;
             _auth = authorizationService ?? new NoOpAuthorizationService();
-            _logger = logger ?? NullLogger<ToolService>.Instance;
+            _logger = logger ?? NullLogger<ItemService>.Instance;
             _activityLog = activityLogService;
             _context = userContext;
         }
@@ -48,10 +48,10 @@ namespace ToolManagementAppV2.Services.Tools
         static void ValidateQuantity(int quantity)
         {
             if (quantity < 0 || quantity > MaxQuantityOnHand)
-                throw new ArgumentOutOfRangeException(nameof(Tool.QuantityOnHand), $"QuantityOnHand must be between 0 and {MaxQuantityOnHand}.");
+                throw new ArgumentOutOfRangeException(nameof(ItemModel.QuantityOnHand), $"QuantityOnHand must be between 0 and {MaxQuantityOnHand}.");
         }
 
-        public async Task AddToolAsync(ToolModel tool, CancellationToken cancellationToken = default)
+        public async Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
             await AddToolInternalAsync(tool, cancellationToken).ConfigureAwait(false);
@@ -62,7 +62,7 @@ namespace ToolManagementAppV2.Services.Tools
             }
         }
 
-        public async Task UpdateToolAsync(ToolModel tool, CancellationToken cancellationToken = default)
+        public async Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
             await UpdateToolInternalAsync(tool, cancellationToken).ConfigureAwait(false);
@@ -96,7 +96,7 @@ namespace ToolManagementAppV2.Services.Tools
             return result;
         }
 
-        public Task<List<ToolModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default)
+        public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default)
         {
             using var conn = _dbService.CreateConnection();
             return SqliteHelper.ExecuteReaderAsync(conn,
@@ -126,7 +126,7 @@ namespace ToolManagementAppV2.Services.Tools
         public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default)
             => ExportToolsToCsvInternalAsync(filePath, cancellationToken);
 
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default)
+        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
             return ImportToolImagesInternalAsync(folderPath, keySelector, progress, cancellationToken);
@@ -141,7 +141,7 @@ namespace ToolManagementAppV2.Services.Tools
             return $"T{max + 1}";
         }
 
-        async Task InsertToolAsync(SQLiteConnection conn, SQLiteTransaction? tran, ToolModel tool, CancellationToken cancellationToken)
+        async Task InsertToolAsync(SQLiteConnection conn, SQLiteTransaction? tran, ItemModel tool, CancellationToken cancellationToken)
         {
             ValidateQuantity(tool.QuantityOnHand);
             var p = new[]
@@ -167,7 +167,7 @@ namespace ToolManagementAppV2.Services.Tools
                 tool.ToolID = Convert.ToInt32(result);
         }
     
-        private async Task<ImageImportResult> ImportToolImagesInternalAsync(string folderPath, Func<ToolModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress, CancellationToken cancellationToken)
+        private async Task<ImageImportResult> ImportToolImagesInternalAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress, CancellationToken cancellationToken)
         {
             var result = new ImageImportResult();
             if (string.IsNullOrWhiteSpace(folderPath) || keySelector == null)
@@ -175,7 +175,7 @@ namespace ToolManagementAppV2.Services.Tools
 
             cancellationToken.ThrowIfCancellationRequested();
             var tools = await GetAllToolsAsync(cancellationToken);
-            var groups = new Dictionary<string, List<ToolModel>>(StringComparer.OrdinalIgnoreCase);
+            var groups = new Dictionary<string, List<ItemModel>>(StringComparer.OrdinalIgnoreCase);
             foreach (var tool in tools)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -187,7 +187,7 @@ namespace ToolManagementAppV2.Services.Tools
                     if (string.IsNullOrEmpty(k))
                         continue;
                     if (!groups.TryGetValue(k, out var list))
-                        groups[k] = list = new List<ToolModel>();
+                        groups[k] = list = new List<ItemModel>();
                     list.Add(tool);
                 }
             }
@@ -288,7 +288,7 @@ namespace ToolManagementAppV2.Services.Tools
             return count > 0;
         }
     
-        ToolModel MapTool(IDataRecord r) => new()
+        ItemModel MapTool(IDataRecord r) => new()
         {
             ToolID = r["ToolID"] is DBNull ? 0 : Convert.ToInt32(r["ToolID"]),
             ToolNumber = r["ToolNumber"].ToString(),
@@ -313,21 +313,21 @@ namespace ToolManagementAppV2.Services.Tools
             IsPowerTool = (r["IsPowerTool"] is DBNull ? 0 : Convert.ToInt32(r["IsPowerTool"])) == 1
         };
 
-        private async Task AddToolInternalAsync(ToolModel tool, CancellationToken cancellationToken)
+        private async Task AddToolInternalAsync(ItemModel tool, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(tool?.ToolNumber))
                 tool.ToolNumber = await GenerateNextToolNumberAsync(cancellationToken);
             if (await ToolExistsAsync(tool.ToolNumber, null, cancellationToken))
-                throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
+                throw new InvalidOperationException($"ItemModel {tool.ToolNumber} already exists.");
             ValidateQuantity(tool.QuantityOnHand);
             using var conn = _dbService.CreateConnection();
             await InsertToolAsync(conn, null, tool, cancellationToken);
         }
 
-        private async Task UpdateToolInternalAsync(ToolModel tool, CancellationToken cancellationToken)
+        private async Task UpdateToolInternalAsync(ItemModel tool, CancellationToken cancellationToken)
         {
             if (await ToolExistsAsync(tool.ToolNumber, tool.ToolID, cancellationToken))
-                throw new InvalidOperationException($"Tool {tool.ToolNumber} already exists.");
+                throw new InvalidOperationException($"ItemModel {tool.ToolNumber} already exists.");
             using var conn = _dbService.CreateConnection();
             ValidateQuantity(tool.QuantityOnHand);
             const string sql = @"
@@ -395,7 +395,7 @@ namespace ToolManagementAppV2.Services.Tools
             }
         }
 
-        public async Task<ToolModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default)
+        public async Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default)
         {
             using var conn = _dbService.CreateConnection();
             var list = await SqliteHelper.ExecuteReaderAsync(conn, "SELECT * FROM Tools WHERE ToolID=@ToolID",
@@ -403,13 +403,13 @@ namespace ToolManagementAppV2.Services.Tools
             return list.FirstOrDefault();
         }
 
-        public async Task<List<ToolModel>> GetAllToolsAsync(CancellationToken cancellationToken = default)
+        public async Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default)
         {
             using var conn = _dbService.CreateConnection();
             return await SqliteHelper.ExecuteReaderAsync(conn, AllToolsSql, null, MapTool, cancellationToken);
         }
 
-        public async Task<List<ToolModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default)
+        public async Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (string.IsNullOrWhiteSpace(searchText))
@@ -464,7 +464,7 @@ namespace ToolManagementAppV2.Services.Tools
                 r => new { Out = Convert.ToInt32(r["IsCheckedOut"]) == 1, Qty = Convert.ToInt32(r["AvailableQuantity"]) }, cancellationToken)).FirstOrDefault();
 
             if (record == null)
-                throw new InvalidOperationException($"Tool {toolID} not found.");
+                throw new InvalidOperationException($"ItemModel {toolID} not found.");
 
             if (!record.Out && record.Qty <= 0)
                 return false;

--- a/ToolManagementAppV2/Services/Tools/ReportService.cs
+++ b/ToolManagementAppV2/Services/Tools/ReportService.cs
@@ -15,14 +15,14 @@ namespace ToolManagementAppV2.Services.Tools
 {
     public class ReportService
     {
-        readonly IToolService _toolService;
+        readonly IItemService _toolService;
         readonly IRentalService _rentalService;
         readonly ActivityLogService _activityLogService;
         readonly ICustomerService _customerService;
         readonly IUserService _userService;
 
         public ReportService(
-            IToolService toolService,
+            IItemService toolService,
             IRentalService rentalService,
             ActivityLogService activityLogService,
             ICustomerService customerService,
@@ -39,8 +39,8 @@ namespace ToolManagementAppV2.Services.Tools
         {
             var tools = await _toolService.GetAllToolsAsync().ConfigureAwait(false);
             var lines = tools.Select(t =>
-                $"Tool ID: {t.ToolID} | ToolNumber: {t.ToolNumber} | Qty: {t.QuantityOnHand} | Location: {t.Location} | Supplier: {t.Supplier}");
-            return BuildReport("Tool Inventory Report", lines);
+                $"ItemModel ID: {t.ToolID} | ToolNumber: {t.ToolNumber} | Qty: {t.QuantityOnHand} | Location: {t.Location} | Supplier: {t.Supplier}");
+            return BuildReport("ItemModel Inventory Report", lines);
         }
 
         public async Task<FlowDocument> GenerateRentalReport(bool activeOnly = true)
@@ -52,7 +52,7 @@ namespace ToolManagementAppV2.Services.Tools
             var title = activeOnly ? "Active Rental Report" : "Full Rental History Report";
 
             var lines = rentals.Select(r =>
-                $"Rental ID: {r.RentalID} | Tool ID: {r.ToolID} | Customer ID: {r.CustomerID} | Rental Date: {r.RentalDate:yyyy-MM-dd} | Due Date: {r.DueDate:yyyy-MM-dd} | Return Date: {(r.ReturnDate.HasValue ? r.ReturnDate.Value.ToString("yyyy-MM-dd") : "N/A")} | Status: {r.Status}");
+                $"Rental ID: {r.RentalID} | ItemModel ID: {r.ToolID} | Customer ID: {r.CustomerID} | Rental Date: {r.RentalDate:yyyy-MM-dd} | Due Date: {r.DueDate:yyyy-MM-dd} | Return Date: {(r.ReturnDate.HasValue ? r.ReturnDate.Value.ToString("yyyy-MM-dd") : "N/A")} | Status: {r.Status}");
 
             return BuildReport(title, lines);
         }

--- a/ToolManagementAppV2/Utilities/Helpers/LabelProvider.cs
+++ b/ToolManagementAppV2/Utilities/Helpers/LabelProvider.cs
@@ -10,14 +10,14 @@ namespace ToolManagementAppV2.Utilities.Helpers
 
         LabelProvider() { }
 
-        private string _itemLabelSingular = "Tool";
+        private string _itemLabelSingular = "Item";
         public string ItemLabelSingular
         {
             get => _itemLabelSingular;
             private set => SetProperty(ref _itemLabelSingular, value);
         }
 
-        private string _itemLabelPlural = "Tools";
+        private string _itemLabelPlural = "Items";
         public string ItemLabelPlural
         {
             get => _itemLabelPlural;

--- a/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
@@ -16,12 +16,12 @@ namespace ToolManagementAppV2.ViewModels
 {
     public class DashboardViewModel : ObservableObject
     {
-        readonly IToolService _toolService;
+        readonly IItemService _toolService;
         readonly IRentalService _rentalService;
         readonly ICustomerService _customerService;
         readonly IUserService _userService;
         readonly ActivityLogService _activityLogService;
-        readonly IRelayCommand _openManageToolsCommand;
+        readonly IRelayCommand _openManageItemsCommand;
         readonly IRelayCommand _openRentalsCommand;
         readonly IRelayCommand _openImportExportCommand;
         readonly ILogger<DashboardViewModel> _logger;
@@ -33,12 +33,12 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand OpenRentalsCommand { get; }
         public IRelayCommand OpenImportExportCommand { get; }
 
-        public DashboardViewModel(IToolService toolService,
+        public DashboardViewModel(IItemService toolService,
                                   IRentalService rentalService,
                                   ICustomerService customerService,
                                   IUserService userService,
                                   ActivityLogService activityLogService,
-                                  IRelayCommand openManageToolsCommand,
+                                  IRelayCommand openManageItemsCommand,
                                   IRelayCommand openRentalsCommand,
                                   IRelayCommand openImportExportCommand,
                                   ILogger<DashboardViewModel>? logger = null)
@@ -48,14 +48,14 @@ namespace ToolManagementAppV2.ViewModels
             _customerService = customerService ?? throw new ArgumentNullException(nameof(customerService));
             _userService = userService ?? throw new ArgumentNullException(nameof(userService));
             _activityLogService = activityLogService ?? throw new ArgumentNullException(nameof(activityLogService));
-            _openManageToolsCommand = openManageToolsCommand ?? throw new ArgumentNullException(nameof(openManageToolsCommand));
+            _openManageItemsCommand = openManageItemsCommand ?? throw new ArgumentNullException(nameof(openManageItemsCommand));
             _openRentalsCommand = openRentalsCommand ?? throw new ArgumentNullException(nameof(openRentalsCommand));
             _openImportExportCommand = openImportExportCommand ?? throw new ArgumentNullException(nameof(openImportExportCommand));
             _logger = logger ?? NullLogger<DashboardViewModel>.Instance;
 
             NewToolCommand = new RelayCommand(() =>
             {
-                try { _openManageToolsCommand.Execute(null); }
+                try { _openManageItemsCommand.Execute(null); }
                 catch (Exception ex) { _logger.LogError(ex, "Failed to open manage {ItemLabelPlural} page", LabelProvider.Instance.ItemLabelPlural.ToLower()); }
             });
 

--- a/ToolManagementAppV2/ViewModels/ImageImportMappingViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImageImportMappingViewModel.cs
@@ -26,7 +26,7 @@ namespace ToolManagementAppV2.ViewModels
             CancelCommand = new RelayCommand(onCancel);
         }
 
-        public Func<ToolModel, IEnumerable<string>> BuildSelector()
+        public Func<ItemModel, IEnumerable<string>> BuildSelector()
         {
             return t =>
             {

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -18,7 +18,7 @@ namespace ToolManagementAppV2.ViewModels
 {
     public class ImportExportViewModel : ObservableObject
     {
-        private readonly IToolService _toolService;
+        private readonly IItemService _toolService;
         private readonly ICustomerService _customerService;
         private readonly IFileDialogService _fileDialogService;
         private readonly IDatabaseBackupService _databaseService;
@@ -42,7 +42,7 @@ namespace ToolManagementAppV2.ViewModels
 
         public ObservableCollection<string> ImportExportLogs { get; } = new();
 
-        public ImportExportViewModel(IToolService toolService,
+        public ImportExportViewModel(IItemService toolService,
                                      ICustomerService customerService,
                                      IFileDialogService fileDialogService,
                                      IDatabaseBackupService databaseService,

--- a/ToolManagementAppV2/ViewModels/ItemManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ItemManagementViewModel.cs
@@ -17,16 +17,16 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ToolManagementAppV2.ViewModels
 {
-    public class ToolManagementViewModel : ObservableObject, IDisposable
+    public class ItemManagementViewModel : ObservableObject, IDisposable
     {
-        private readonly IToolService _toolService;
+        private readonly IItemService _itemService;
         private readonly ICustomerService _customerService;
         private readonly IRentalService _rentalService;
         private readonly IDialogService _dialogService;
-        private readonly ILogger<ToolManagementViewModel> _logger;
+        private readonly ILogger<ItemManagementViewModel> _logger;
 
-        public ObservableCollection<ToolModel> Tools { get; } = new();
-        public ObservableCollection<ToolModel> SearchResults { get; } = new();
+        public ObservableCollection<ItemModel> Tools { get; } = new();
+        public ObservableCollection<ItemModel> SearchResults { get; } = new();
 
         /// <summary>
         /// List of available tool categories derived from distinct brands
@@ -34,8 +34,8 @@ namespace ToolManagementAppV2.ViewModels
         /// </summary>
         public ObservableCollection<string> Categories { get; } = new();
 
-        private ToolModel _newTool = new();
-        public ToolModel NewTool
+        private ItemModel _newTool = new();
+        public ItemModel NewTool
         {
             get => _newTool;
             set => SetProperty(ref _newTool, value);
@@ -48,13 +48,13 @@ namespace ToolManagementAppV2.ViewModels
             set => SetProperty(ref _searchTerm, value);
         }
 
-        private ToolModel _selectedTool;
-        public ToolModel SelectedTool
+        private ItemModel _selectedItem;
+        public ItemModel SelectedItem
         {
-            get => _selectedTool;
+            get => _selectedItem;
             set
             {
-                if (SetProperty(ref _selectedTool, value))
+                if (SetProperty(ref _selectedItem, value))
                 {
                     ((AsyncRelayCommand)OpenRentalsCommand).NotifyCanExecuteChanged();
                     ((AsyncRelayCommand)EditToolCommand).NotifyCanExecuteChanged();
@@ -116,27 +116,27 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        public ToolManagementViewModel(IToolService toolService,
+        public ItemManagementViewModel(IItemService itemService,
                                        ICustomerService customerService,
                                        IRentalService rentalService,
                                        IDialogService dialogService,
-                                       ILogger<ToolManagementViewModel>? logger = null,
+                                       ILogger<ItemManagementViewModel>? logger = null,
                                        IDispatcherTimer? searchDebounceTimer = null)
         {
-            _toolService = toolService;
+            _itemService = itemService;
             _customerService = customerService;
             _rentalService = rentalService;
             _dialogService = dialogService;
-            _logger = logger ?? NullLogger<ToolManagementViewModel>.Instance;
+            _logger = logger ?? NullLogger<ItemManagementViewModel>.Instance;
             SearchCommand = new AsyncRelayCommand<CancellationToken>(FilterToolsAsync);
             _searchDebounceTimer = searchDebounceTimer ?? new DispatcherTimerWrapper { Interval = TimeSpan.FromMilliseconds(300) };
             _searchDebounceTimer.Tick += OnSearchDebounceTimerTick;
             NewToolCommand = new AsyncRelayCommand(ct => AddToolAsync(ct));
-            EditToolCommand = new AsyncRelayCommand(ct => EditToolAsync(ct), () => SelectedTool != null);
+            EditToolCommand = new AsyncRelayCommand(ct => EditToolAsync(ct), () => SelectedItem != null);
             DeleteToolCommand = new AsyncRelayCommand(ct => DeleteToolAsync(ct));
-            OpenRentalsCommand = new AsyncRelayCommand(ct => OpenRentalsAsync(ct), () => SelectedTool != null);
-            ViewDetailsCommand = new RelayCommand(ViewDetails, () => SelectedTool != null);
-            OpenRentalHistoryCommand = new AsyncRelayCommand(OpenRentalHistoryAsync, () => SelectedTool != null);
+            OpenRentalsCommand = new AsyncRelayCommand(ct => OpenRentalsAsync(ct), () => SelectedItem != null);
+            ViewDetailsCommand = new RelayCommand(ViewDetails, () => SelectedItem != null);
+            OpenRentalHistoryCommand = new AsyncRelayCommand(OpenRentalHistoryAsync, () => SelectedItem != null);
             // Ensure no duplicate event subscriptions when the view model is
             // constructed multiple times or the collection persists across
             // instances.
@@ -157,7 +157,7 @@ namespace ToolManagementAppV2.ViewModels
             _suppressToolsChanged = true;
             try
             {
-                var all = await _toolService.GetAllToolsAsync();
+                var all = await _itemService.GetAllToolsAsync();
                 Tools.ReplaceRange(all);
                 SearchResults.ReplaceRange(all);
                 LoadCategories(Tools);
@@ -176,17 +176,17 @@ namespace ToolManagementAppV2.ViewModels
         async Task FilterToolsAsync(CancellationToken cancellationToken)
         {
             var term = string.IsNullOrWhiteSpace(SearchTerm) ? string.Empty : SearchTerm.Trim();
-            IEnumerable<ToolModel> source;
+            IEnumerable<ItemModel> source;
 
             if (!string.IsNullOrEmpty(term))
             {
-                source = await _toolService.SearchToolsAsync(term, cancellationToken);
+                source = await _itemService.SearchToolsAsync(term, cancellationToken);
             }
             else
             {
                 if (Tools.Count == 0)
                 {
-                    var all = await _toolService.GetAllToolsAsync();
+                    var all = await _itemService.GetAllToolsAsync();
                     Tools.ReplaceRange(all);
                 }
                 source = Tools;
@@ -206,11 +206,11 @@ namespace ToolManagementAppV2.ViewModels
             try
             {
                 if (string.IsNullOrWhiteSpace(NewTool.ToolNumber))
-                    NewTool.ToolNumber = await _toolService.GenerateNextToolNumberAsync(cancellationToken);
-                await _toolService.AddToolAsync(NewTool, cancellationToken);
+                    NewTool.ToolNumber = await _itemService.GenerateNextToolNumberAsync(cancellationToken);
+                await _itemService.AddToolAsync(NewTool, cancellationToken);
                 await LoadToolsAsync();
                 await FilterToolsAsync(cancellationToken);
-                NewTool = new ToolModel();
+                NewTool = new ItemModel();
             }
             catch (OperationCanceledException)
             {
@@ -234,27 +234,27 @@ namespace ToolManagementAppV2.ViewModels
 
         async Task EditToolAsync(CancellationToken cancellationToken)
         {
-            if (SelectedTool == null) return;
+            if (SelectedItem == null) return;
 
-            var clone = new ToolModel
+            var clone = new ItemModel
             {
-                ToolID = SelectedTool.ToolID,
-                ToolNumber = SelectedTool.ToolNumber,
-                PartNumber = SelectedTool.PartNumber,
-                NameDescription = SelectedTool.NameDescription,
-                Brand = SelectedTool.Brand,
-                Location = SelectedTool.Location,
-                QuantityOnHand = SelectedTool.QuantityOnHand,
-                RentedQuantity = SelectedTool.RentedQuantity,
-                Supplier = SelectedTool.Supplier,
-                PurchasedDate = SelectedTool.PurchasedDate,
-                Notes = SelectedTool.Notes,
-                Keywords = SelectedTool.Keywords,
-                IsPowerTool = SelectedTool.IsPowerTool,
-                IsCheckedOut = SelectedTool.IsCheckedOut,
-                CheckedOutBy = SelectedTool.CheckedOutBy,
-                CheckedOutTime = SelectedTool.CheckedOutTime,
-                ToolImagePath = SelectedTool.ToolImagePath
+                ToolID = SelectedItem.ToolID,
+                ToolNumber = SelectedItem.ToolNumber,
+                PartNumber = SelectedItem.PartNumber,
+                NameDescription = SelectedItem.NameDescription,
+                Brand = SelectedItem.Brand,
+                Location = SelectedItem.Location,
+                QuantityOnHand = SelectedItem.QuantityOnHand,
+                RentedQuantity = SelectedItem.RentedQuantity,
+                Supplier = SelectedItem.Supplier,
+                PurchasedDate = SelectedItem.PurchasedDate,
+                Notes = SelectedItem.Notes,
+                Keywords = SelectedItem.Keywords,
+                IsPowerTool = SelectedItem.IsPowerTool,
+                IsCheckedOut = SelectedItem.IsCheckedOut,
+                CheckedOutBy = SelectedItem.CheckedOutBy,
+                CheckedOutTime = SelectedItem.CheckedOutTime,
+                ToolImagePath = SelectedItem.ToolImagePath
             };
 
             var updated = await _dialogService.ShowEditToolDialogAsync(clone);
@@ -262,10 +262,10 @@ namespace ToolManagementAppV2.ViewModels
 
             try
             {
-                await _toolService.UpdateToolAsync(updated, cancellationToken);
+                await _itemService.UpdateToolAsync(updated, cancellationToken);
                 await LoadToolsAsync();
                 await FilterToolsAsync(cancellationToken);
-                SelectedTool = Tools.FirstOrDefault(t => t.ToolID == updated.ToolID);
+                SelectedItem = Tools.FirstOrDefault(t => t.ToolID == updated.ToolID);
             }
             catch (OperationCanceledException)
             {
@@ -279,39 +279,39 @@ namespace ToolManagementAppV2.ViewModels
 
         void ViewDetails()
         {
-            if (SelectedTool == null) return;
-            _dialogService.ShowToolDetails(SelectedTool);
+            if (SelectedItem == null) return;
+            _dialogService.ShowToolDetails(SelectedItem);
         }
 
         async Task OpenRentalHistoryAsync()
         {
-            if (SelectedTool == null) return;
+            if (SelectedItem == null) return;
             try
             {
-                var history = await _rentalService.GetRentalHistoryForToolAsync(SelectedTool.ToolID);
-                _dialogService.ShowRentalHistory(SelectedTool, history);
+                var history = await _rentalService.GetRentalHistoryForToolAsync(SelectedItem.ToolID);
+                _dialogService.ShowRentalHistory(SelectedItem, history);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to open rental history for {ItemLabelSingular} {ToolID}", LabelProvider.Instance.ItemLabelSingular, SelectedTool.ToolID);
+                _logger.LogError(ex, "Failed to open rental history for {ItemLabelSingular} {ToolID}", LabelProvider.Instance.ItemLabelSingular, SelectedItem.ToolID);
             }
         }
 
         async Task DeleteToolAsync(CancellationToken cancellationToken)
         {
-            if (SelectedTool == null) return;
+            if (SelectedItem == null) return;
             var confirm = await _dialogService.ShowConfirmationAsync(
-                $"Delete {LabelProvider.Instance.ItemLabelSingular.ToLower()} '{SelectedTool.NameDescription}'?",
+                $"Delete {LabelProvider.Instance.ItemLabelSingular.ToLower()} '{SelectedItem.NameDescription}'?",
                 "Confirm Delete");
             if (!confirm)
                 return;
 
             try
             {
-                await _toolService.DeleteToolAsync(SelectedTool.ToolID, cancellationToken);
+                await _itemService.DeleteToolAsync(SelectedItem.ToolID, cancellationToken);
                 await LoadToolsAsync();
                 await FilterToolsAsync(cancellationToken);
-                SelectedTool = null;
+                SelectedItem = null;
             }
             catch (OperationCanceledException)
             {
@@ -323,23 +323,23 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to delete {ItemLabelSingular} {ToolID}", LabelProvider.Instance.ItemLabelSingular, SelectedTool.ToolID);
+                _logger.LogError(ex, "Failed to delete {ItemLabelSingular} {ToolID}", LabelProvider.Instance.ItemLabelSingular, SelectedItem.ToolID);
                 await _dialogService.ShowInfoAsync($"Failed to delete {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {ex.Message}", "Error");
             }
         }
 
         async Task OpenRentalsAsync(CancellationToken cancellationToken)
         {
-            if (SelectedTool == null) return;
+            if (SelectedItem == null) return;
 
             try
             {
                 var customers = await _customerService.GetAllCustomersAsync(cancellationToken);
-                var result = _dialogService.ShowRentToolDialog(SelectedTool, customers);
+                var result = _dialogService.ShowRentToolDialog(SelectedItem, customers);
                 if (result != null)
                 {
                     var (customer, dueDate) = result.Value;
-                    await _rentalService.RentToolAsync(SelectedTool.ToolID,
+                    await _rentalService.RentToolAsync(SelectedItem.ToolID,
                         customer.CustomerID,
                         DateTime.Today,
                         dueDate);
@@ -356,12 +356,12 @@ namespace ToolManagementAppV2.ViewModels
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to rent {ItemLabelSingular} {ToolID}", LabelProvider.Instance.ItemLabelSingular, SelectedTool?.ToolID);
+                _logger.LogError(ex, "Failed to rent {ItemLabelSingular} {ToolID}", LabelProvider.Instance.ItemLabelSingular, SelectedItem?.ToolID);
                 await _dialogService.ShowInfoAsync($"Failed to rent {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {ex.Message}", "Error");
             }
         }
 
-        void LoadCategories(IEnumerable<ToolModel> tools, bool suppressSearch = false)
+        void LoadCategories(IEnumerable<ItemModel> tools, bool suppressSearch = false)
         {
             var categories = tools.Select(t => t.Brand)
                                    .Where(b => !string.IsNullOrWhiteSpace(b))

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -32,7 +32,7 @@ namespace ToolManagementAppV2.ViewModels
 {
     public class MainViewModel : ObservableObject, IMainViewModel, IDisposable
     {
-        readonly IToolService _toolService;
+        readonly IItemService _toolService;
         readonly IUserService _userService;
         readonly IUserContext _userContext;
         readonly ICustomerService _customerService;
@@ -48,9 +48,9 @@ namespace ToolManagementAppV2.ViewModels
         int _autoLogoutMinutes;
 
         EventHandler<User?>? _userContextChangedHandler;
-        PropertyChangedEventHandler? _toolManagementPropertyChangedHandler;
+        PropertyChangedEventHandler? _itemManagementPropertyChangedHandler;
 
-        public ToolManagementViewModel ToolManagement { get; }
+        public ItemManagementViewModel ItemManagement { get; }
         public UserManagementViewModel UserManagement { get; }
         public CustomerManagementViewModel CustomerManagement { get; }
         public ManageRentalsViewModel ManageRentals { get; }
@@ -114,7 +114,7 @@ namespace ToolManagementAppV2.ViewModels
             private set => SetProperty(ref _companyLogoPath, value);
         }
 
-        public ToolModel? SelectedTool => ToolManagement.SelectedTool;
+        public ItemModel? SelectedItem => ItemManagement.SelectedItem;
 
         public void ResetAutoLogoutTimer()
         {
@@ -145,7 +145,7 @@ namespace ToolManagementAppV2.ViewModels
 
         public IRelayCommand OpenDashboardCommand { get; }
         public IAsyncRelayCommand OpenSearchToolsCommand { get; }
-        public IAsyncRelayCommand OpenManageToolsCommand { get; }
+        public IAsyncRelayCommand OpenManageItemsCommand { get; }
         public IAsyncRelayCommand OpenRentalsCommand { get; }
         public IAsyncRelayCommand OpenCustomersCommand { get; }
         public IAsyncRelayCommand OpenUsersCommand { get; }
@@ -163,7 +163,7 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand OpenPrintLabelWindowCommand { get; }
         public IRelayCommand OpenScannerStatusPageCommand { get; }
 
-        public MainViewModel(IToolService toolService,
+        public MainViewModel(IItemService toolService,
                              IUserService userService,
                              IUserContext userContext,
                              ICustomerService customerService,
@@ -201,15 +201,15 @@ namespace ToolManagementAppV2.ViewModels
             _userContextChangedHandler = (_, _) => RefreshCurrentUser();
             _userContext.UserChanged += _userContextChangedHandler;
 
-            ToolManagement = new ToolManagementViewModel(toolService, customerService, rentalService, _dialogService);
-            _toolManagementPropertyChangedHandler = (s, e) =>
+            ItemManagement = new ItemManagementViewModel(toolService, customerService, rentalService, _dialogService);
+            _itemManagementPropertyChangedHandler = (s, e) =>
             {
-                if (e.PropertyName == nameof(ToolManagementViewModel.SelectedTool))
+                if (e.PropertyName == nameof(ItemManagementViewModel.SelectedItem))
                 {
-                    OnPropertyChanged(nameof(SelectedTool));
+                    OnPropertyChanged(nameof(SelectedItem));
                 }
             };
-            ToolManagement.PropertyChanged += _toolManagementPropertyChangedHandler;
+            ItemManagement.PropertyChanged += _itemManagementPropertyChangedHandler;
             UserManagement = new UserManagementViewModel(userService, fileDialogService, _dialogService);
             CustomerManagement = new CustomerManagementViewModel(customerService, _dialogService);
             ManageRentals = new ManageRentalsViewModel(rentalService, _dialogService);
@@ -230,25 +230,25 @@ namespace ToolManagementAppV2.ViewModels
 
             OpenDashboardCommand = new RelayCommand(() =>
             {
-                var vm = new DashboardViewModel(_toolService, _rentalService, _customerService, _userService, _activityLogService, OpenManageToolsCommand, OpenRentalsCommand, OpenImportExportCommand);
+                var vm = new DashboardViewModel(_toolService, _rentalService, _customerService, _userService, _activityLogService, OpenManageItemsCommand, OpenRentalsCommand, OpenImportExportCommand);
                 var page = new DashboardPage { DataContext = vm, Title = "Dashboard" };
                 CurrentPage = page;
             });
 
             OpenSearchToolsCommand = new AsyncRelayCommand(async () =>
             {
-                await ToolManagement.LoadToolsAsync();
+                await ItemManagement.LoadToolsAsync();
                 var plural = LabelProvider.Instance.ItemLabelPlural;
-                var page = new ToolSearchPage { DataContext = ToolManagement, Title = $"Search {plural}" };
-                // If your ToolManagement VM supports a query setter, apply GlobalSearchText there.
+                var page = new ToolSearchPage { DataContext = ItemManagement, Title = $"Search {plural}" };
+                // If your ItemManagement VM supports a query setter, apply GlobalSearchText there.
                 CurrentPage = page;
             });
 
-            OpenManageToolsCommand = new AsyncRelayCommand(async () =>
+            OpenManageItemsCommand = new AsyncRelayCommand(async () =>
             {
-                await ToolManagement.LoadToolsAsync();
+                await ItemManagement.LoadToolsAsync();
                 var plural = LabelProvider.Instance.ItemLabelPlural;
-                var page = new ManageToolsPage { DataContext = ToolManagement, Title = $"Manage {plural}" };
+                var page = new ManageItemsPage { DataContext = ItemManagement, Title = $"Manage {plural}" };
                 CurrentPage = page;
             });
 
@@ -432,7 +432,7 @@ namespace ToolManagementAppV2.ViewModels
                     return;
 
                 var headers = (await CsvHelperUtil.ReadHeadersAsync(path)).ToList();
-                var properties = typeof(ToolModel)
+                var properties = typeof(ItemModel)
                                     .GetProperties()
                                     .Select(p => p.Name)
                                     .ToList();
@@ -479,10 +479,10 @@ namespace ToolManagementAppV2.ViewModels
 
         async Task GlobalSearchAsync(CancellationToken cancellationToken)
         {
-            ToolManagement.SearchText = GlobalSearchText;
+            ItemManagement.SearchText = GlobalSearchText;
             await OpenSearchToolsCommand.ExecuteAsync(null);
-            if (ToolManagement.SearchCommand != null)
-                await ToolManagement.SearchCommand.ExecuteAsync(cancellationToken);
+            if (ItemManagement.SearchCommand != null)
+                await ItemManagement.SearchCommand.ExecuteAsync(cancellationToken);
             GlobalSearchText = string.Empty;
         }
 
@@ -495,15 +495,15 @@ namespace ToolManagementAppV2.ViewModels
                 _userContextChangedHandler = null;
             }
 
-            if (_toolManagementPropertyChangedHandler != null)
+            if (_itemManagementPropertyChangedHandler != null)
             {
-                ToolManagement.PropertyChanged -= _toolManagementPropertyChangedHandler;
-                _toolManagementPropertyChangedHandler = null;
+                ItemManagement.PropertyChanged -= _itemManagementPropertyChangedHandler;
+                _itemManagementPropertyChangedHandler = null;
             }
             Settings.PropertyChanged -= Settings_PropertyChanged;
             _autoLogoutTimer.Tick -= OnAutoLogoutTimerTick;
             _autoLogoutTimer.Stop();
-            ToolManagement.Dispose();
+            ItemManagement.Dispose();
         }
 
         private sealed class DummyScannerService : IScannerService

--- a/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ManageRentalsViewModel.cs
@@ -226,7 +226,7 @@ namespace ToolManagementAppV2.ViewModels
                 return;
             }
 
-            var tool = new ToolModel
+            var tool = new ItemModel
             {
                 ToolID = SelectedRental.ToolID,
                 ToolNumber = SelectedRental.ToolNumber,
@@ -274,7 +274,7 @@ namespace ToolManagementAppV2.ViewModels
                 }
 
                 AddRow("Rental #:", SelectedRental.RentalID.ToString());
-                AddRow("Tool #:", SelectedRental.ToolNumber);
+                AddRow("ItemModel #:", SelectedRental.ToolNumber);
                 AddRow("Customer:", SelectedRental.CustomerName);
                 AddRow("Rental Date:", SelectedRental.RentalDate.ToString("yyyy-MM-dd HH:mm"));
                 AddRow("Due Date:", SelectedRental.DueDate.ToString("yyyy-MM-dd HH:mm"));

--- a/ToolManagementAppV2/ViewModels/PrintLabelViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/PrintLabelViewModel.cs
@@ -31,7 +31,7 @@ namespace ToolManagementAppV2.ViewModels
             set => SetProperty(ref _includeQr, value);
         }
 
-        public ObservableCollection<ToolModel> Items { get; }
+        public ObservableCollection<ItemModel> Items { get; }
 
         public IRelayCommand PreviewCommand { get; }
         public IRelayCommand PrintCommand { get; }
@@ -49,7 +49,7 @@ namespace ToolManagementAppV2.ViewModels
             });
             Templates = new ObservableCollection<string> { "Standard", "Compact" };
             _selectedTemplate = Templates.First();
-            Items = new ObservableCollection<ToolModel>();
+            Items = new ObservableCollection<ItemModel>();
             PreviewCommand = new RelayCommand(Preview);
             PrintCommand = new RelayCommand(Print);
             CloseCommand = new RelayCommand(() => _closeAction?.Invoke());

--- a/ToolManagementAppV2/ViewModels/RentToolPopupViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/RentToolPopupViewModel.cs
@@ -19,7 +19,7 @@ namespace ToolManagementAppV2.ViewModels.Rental
         public IRelayCommand CheckOutCommand { get; }
         public IRelayCommand CancelCommand { get; }
 
-        public RentToolPopupViewModel(ToolModel tool, IEnumerable<CustomerModel> customers)
+        public RentToolPopupViewModel(ItemModel tool, IEnumerable<CustomerModel> customers)
         {
             Customers = new ObservableCollection<CustomerModel>(customers);
             CheckOutCommand = new RelayCommand(Confirm);

--- a/ToolManagementAppV2/ViewModels/RentalHistoryViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/RentalHistoryViewModel.cs
@@ -43,7 +43,7 @@ namespace ToolManagementAppV2.ViewModels.Rental
         public IRelayCommand ExportCsvCommand { get; }
         public IRelayCommand CloseCommand { get; }
 
-        public RentalHistoryViewModel(ToolModel? tool, IEnumerable<RentalModel>? history, IDialogService dialogService, ILogger<RentalHistoryViewModel>? logger = null)
+        public RentalHistoryViewModel(ItemModel? tool, IEnumerable<RentalModel>? history, IDialogService dialogService, ILogger<RentalHistoryViewModel>? logger = null)
         {
             ToolDisplayName = tool != null
                 ? $"{tool.ToolNumber} - {tool.NameDescription}"

--- a/ToolManagementAppV2/ViewModels/ToolDetailsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolDetailsViewModel.cs
@@ -7,13 +7,13 @@ namespace ToolManagementAppV2.ViewModels
 {
     public class ToolDetailsViewModel : ObservableObject
     {
-        public ToolModel Tool { get; }
+        public ItemModel ItemModel { get; }
 
         public IRelayCommand CloseCommand { get; }
 
-        public ToolDetailsViewModel(ToolModel tool, Action onClose)
+        public ToolDetailsViewModel(ItemModel tool, Action onClose)
         {
-            Tool = tool;
+            ItemModel = tool;
             CloseCommand = new RelayCommand(onClose);
         }
     }

--- a/ToolManagementAppV2/ViewModels/ToolEditViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolEditViewModel.cs
@@ -13,18 +13,18 @@ namespace ToolManagementAppV2.ViewModels
         /// </summary>
         private readonly IFileDialogService _fileDialog;
 
-        public ToolModel Tool { get; }
+        public ItemModel ItemModel { get; }
 
         public IRelayCommand SaveCommand { get; }
         public IRelayCommand CancelCommand { get; }
 
         /// <summary>
-        /// Opens a file dialog to select an image and updates <see cref="Tool.ToolImagePath"/>.
+        /// Opens a file dialog to select an image and updates <see cref="ItemModel.ToolImagePath"/>.
         /// </summary>
         public IRelayCommand BrowseImageCommand { get; }
 
         /// <summary>
-        /// Clears the current <see cref="Tool.ToolImagePath"/> and removes the preview.
+        /// Clears the current <see cref="ItemModel.ToolImagePath"/> and removes the preview.
         /// </summary>
         public IRelayCommand RemoveImageCommand { get; }
 
@@ -35,9 +35,9 @@ namespace ToolManagementAppV2.ViewModels
         /// <param name="onSave">Action invoked to persist the tool changes.</param>
         /// <param name="onCancel">Action invoked when editing is canceled.</param>
         /// <param name="fileDialog">Service used for browsing image files.</param>
-        public ToolEditViewModel(ToolModel tool, Action onSave, Action onCancel, IFileDialogService fileDialog)
+        public ToolEditViewModel(ItemModel tool, Action onSave, Action onCancel, IFileDialogService fileDialog)
         {
-            Tool = tool;
+            ItemModel = tool;
             _fileDialog = fileDialog;
 
             SaveCommand = new RelayCommand(onSave);
@@ -52,13 +52,13 @@ namespace ToolManagementAppV2.ViewModels
             var path = _fileDialog.OpenFile("Image Files|*.png;*.jpg;*.jpeg;*.bmp|All Files|*.*");
             if (!string.IsNullOrEmpty(path))
             {
-                Tool.ToolImagePath = path;
+                ItemModel.ToolImagePath = path;
             }
         }
 
         void RemoveImage()
         {
-            Tool.ToolImagePath = string.Empty;
+            ItemModel.ToolImagePath = string.Empty;
         }
     }
 }

--- a/ToolManagementAppV2/ViewModels/ToolViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ToolViewModel.cs
@@ -4,14 +4,14 @@ namespace ToolManagementAppV2.ViewModels
 {
     internal class ToolViewModel : ObservableObject
     {
-        private ToolModel _tool;
-        public ToolModel Tool
+        private ItemModel _tool;
+        public ItemModel ItemModel
         {
             get => _tool;
             set => SetProperty(ref _tool, value);
         }
 
-        public ToolViewModel(ToolModel tool)
+        public ToolViewModel(ItemModel tool)
         {
             _tool = tool;
         }

--- a/ToolManagementAppV2/Views/Pages/ManageItemsPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/ManageItemsPage.xaml
@@ -1,5 +1,5 @@
-<!-- Views/ManageToolsPage.xaml -->
-<Page x:Class="ToolManagementAppV2.Views.Pages.ManageToolsPage"
+<!-- Views/ManageItemsPage.xaml -->
+<Page x:Class="ToolManagementAppV2.Views.Pages.ManageItemsPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers"
@@ -17,7 +17,7 @@
 
                 <DataGrid Grid.Row="1"
                           ItemsSource="{Binding Tools}"
-                          SelectedItem="{Binding SelectedTool}"
+                          SelectedItem="{Binding SelectedItem}"
                           IsReadOnly="True"
                           AutoGenerateColumns="False"
                           Background="{StaticResource SurfaceBrush}"

--- a/ToolManagementAppV2/Views/Pages/ManageItemsPage.xaml.cs
+++ b/ToolManagementAppV2/Views/Pages/ManageItemsPage.xaml.cs
@@ -2,9 +2,9 @@ using System.Windows.Controls;
 
 namespace ToolManagementAppV2.Views.Pages
 {
-    public partial class ManageToolsPage : Page
+    public partial class ManageItemsPage : Page
     {
-        public ManageToolsPage()
+        public ManageItemsPage()
         {
             InitializeComponent();
         }

--- a/ToolManagementAppV2/Views/Windows/ToolDetailsWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ToolDetailsWindow.xaml
@@ -28,30 +28,30 @@
             </Grid.ColumnDefinitions>
 
             <Image Grid.Row="0" Grid.ColumnSpan="2" Width="120" Height="120" Margin="0,0,0,8" HorizontalAlignment="Center"
-                   Source="{Binding Tool.ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=tool}"/>
+                   Source="{Binding ItemModel.ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=tool}"/>
 
             <TextBlock Grid.Row="1" Grid.Column="0" Text="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat={}{0} Number}" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Tool.ToolNumber}" Margin="8,4"/>
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding ItemModel.ToolNumber}" Margin="8,4"/>
 
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Tool.NameDescription}" Margin="8,4"/>
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding ItemModel.NameDescription}" Margin="8,4"/>
 
             <TextBlock Grid.Row="3" Grid.Column="0" Text="Brand" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Tool.Brand}" Margin="8,4"/>
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding ItemModel.Brand}" Margin="8,4"/>
 
             <TextBlock Grid.Row="4" Grid.Column="0" Text="Location" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-            <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Tool.Location}" Margin="8,4"/>
+            <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding ItemModel.Location}" Margin="8,4"/>
 
             <TextBlock Grid.Row="5" Grid.Column="0" Text="Part #" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-            <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding Tool.PartNumber}" Margin="8,4"/>
+            <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding ItemModel.PartNumber}" Margin="8,4"/>
 
             <TextBlock Grid.Row="6" Grid.Column="0" Text="Supplier" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-            <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding Tool.Supplier}" Margin="8,4"/>
+            <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding ItemModel.Supplier}" Margin="8,4"/>
 
             <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Vertical" Margin="0,8,0,0">
                 <TextBlock Text="Notes" Style="{StaticResource LabelTextBlock}"/>
                 <ScrollViewer Height="90" VerticalScrollBarVisibility="Auto">
-                    <TextBlock Text="{Binding Tool.Notes}" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding ItemModel.Notes}" TextWrapping="Wrap"/>
                 </ScrollViewer>
             </StackPanel>
         </Grid>

--- a/ToolManagementAppV2/Views/Windows/ToolDetailsWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/Windows/ToolDetailsWindow.xaml.cs
@@ -7,7 +7,7 @@ namespace ToolManagementAppV2.Views.Windows
 {
     public partial class ToolDetailsWindow : Window
     {
-        public ToolDetailsWindow(ToolModel tool)
+        public ToolDetailsWindow(ItemModel tool)
         {
             InitializeComponent();
             DataContext = new ToolDetailsViewModel(tool, () => Close());

--- a/ToolManagementAppV2/Views/Windows/ToolEditWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ToolEditWindow.xaml
@@ -30,28 +30,28 @@
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Row="0" Grid.Column="0" Text="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat={}{0} Number}" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Tool.ToolNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ItemModel.ToolNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Tool.NameDescription, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding ItemModel.NameDescription, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Brand" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Tool.Brand, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding ItemModel.Brand, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
             <TextBlock Grid.Row="3" Grid.Column="0" Text="Location" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Tool.Location, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding ItemModel.Location, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
             <TextBlock Grid.Row="4" Grid.Column="0" Text="Part #" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Tool.PartNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding ItemModel.PartNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
             <TextBlock Grid.Row="5" Grid.Column="0" Text="Supplier" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Tool.Supplier, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding ItemModel.Supplier, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <CheckBox Grid.Row="6" Grid.ColumnSpan="2" Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Power {0}}" IsChecked="{Binding Tool.IsPowerTool}" Margin="0,0,0,8"/>
+            <CheckBox Grid.Row="6" Grid.ColumnSpan="2" Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Power {0}}" IsChecked="{Binding ItemModel.IsPowerTool}" Margin="0,0,0,8"/>
 
             <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,0,0,8">
                 <Image Width="100" Height="100" Stretch="Uniform"
-                       Source="{Binding Tool.ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=tool}"/>
+                       Source="{Binding ItemModel.ToolImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=tool}"/>
                 <StackPanel Orientation="Vertical" Margin="8,0,0,0">
                     <Button Content="Browse" Style="{StaticResource PrimaryButton}" Width="75" Command="{Binding BrowseImageCommand}"/>
                     <Button Content="Remove" Style="{StaticResource PrimaryButton}" Width="75" Margin="0,4,0,0" Command="{Binding RemoveImageCommand}"/>
@@ -60,7 +60,7 @@
 
             <StackPanel Grid.Row="8" Grid.ColumnSpan="2" Orientation="Vertical">
                 <TextBlock Text="Notes" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/>
-                <TextBox Text="{Binding Tool.Notes, UpdateSourceTrigger=PropertyChanged}" Height="90" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+                <TextBox Text="{Binding ItemModel.Notes, UpdateSourceTrigger=PropertyChanged}" Height="90" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
             </StackPanel>
         </Grid>
 

--- a/ToolManagementAppV2/Views/Windows/ToolEditWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/Windows/ToolEditWindow.xaml.cs
@@ -12,7 +12,7 @@ namespace ToolManagementAppV2.Views.Windows
     {
         private readonly IFileDialogService _fileDialogService;
 
-        public ToolEditWindow(ToolModel tool, Action onSave, Action onCancel, IFileDialogService fileDialogService)
+        public ToolEditWindow(ItemModel tool, Action onSave, Action onCancel, IFileDialogService fileDialogService)
         {
             InitializeComponent();
             _fileDialogService = fileDialogService;


### PR DESCRIPTION
## Summary
- rename ToolModel to ItemModel and update service interface to IItemService
- migrate ToolService to ItemService with new DI registration
- replace ToolManagementViewModel and ManageToolsPage with item-based counterparts and update label defaults

## Testing
- `dotnet test` *(fails: bash: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a5737874f483249e40ceac6bce3017