### PR TITLE
Rename tool services and views to item

### DIFF
--- a/ToolManagementAppV2.Tests/AsyncServiceExtensions.cs
+++ b/ToolManagementAppV2.Tests/AsyncServiceExtensions.cs
@@ -12,18 +12,18 @@ namespace ToolManagementAppV2.Tests;
 public static class AsyncServiceExtensions
 {
     // ItemService wrappers
-    public static void AddTool(this IItemService svc, ItemModel tool, CancellationToken token = default)
-        => svc.AddToolAsync(tool, token).GetAwaiter().GetResult();
-    public static void UpdateTool(this IItemService svc, ItemModel tool, CancellationToken token = default)
-        => svc.UpdateToolAsync(tool, token).GetAwaiter().GetResult();
-    public static void DeleteTool(this IItemService svc, int id, CancellationToken token = default)
-        => svc.DeleteToolAsync(id, token).GetAwaiter().GetResult();
-    public static ItemModel? GetToolByID(this IItemService svc, int id, CancellationToken token = default)
-        => svc.GetToolByIDAsync(id, token).GetAwaiter().GetResult();
-    public static List<ItemModel> GetAllTools(this IItemService svc, CancellationToken token = default)
-        => svc.GetAllToolsAsync(token).GetAwaiter().GetResult();
-    public static List<ItemModel> SearchTools(this IItemService svc, string? text, CancellationToken token = default)
-        => svc.SearchToolsAsync(text, token).GetAwaiter().GetResult();
+    public static void AddItem(this IItemService svc, ItemModel item, CancellationToken token = default)
+        => svc.AddItemAsync(item, token).GetAwaiter().GetResult();
+    public static void UpdateItem(this IItemService svc, ItemModel item, CancellationToken token = default)
+        => svc.UpdateItemAsync(item, token).GetAwaiter().GetResult();
+    public static void DeleteItem(this IItemService svc, int id, CancellationToken token = default)
+        => svc.DeleteItemAsync(id, token).GetAwaiter().GetResult();
+    public static ItemModel? GetItemByID(this IItemService svc, int id, CancellationToken token = default)
+        => svc.GetItemByIDAsync(id, token).GetAwaiter().GetResult();
+    public static List<ItemModel> GetAllItems(this IItemService svc, CancellationToken token = default)
+        => svc.GetAllItemsAsync(token).GetAwaiter().GetResult();
+    public static List<ItemModel> SearchItems(this IItemService svc, string? text, CancellationToken token = default)
+        => svc.SearchItemsAsync(text, token).GetAwaiter().GetResult();
     public static string GenerateNextItemNumber(this IItemService svc, CancellationToken token = default)
         => svc.GenerateNextItemNumberAsync(token).GetAwaiter().GetResult();
 

--- a/ToolManagementAppV2.Tests/Extensions/ItemServiceExtensions.cs
+++ b/ToolManagementAppV2.Tests/Extensions/ItemServiceExtensions.cs
@@ -10,45 +10,45 @@ namespace ToolManagementAppV2.Tests.Extensions
 {
     public static class ItemServiceExtensions
     {
-        public static void AddTool(this IItemService service, ItemModel tool) =>
-            service.AddToolAsync(tool).GetAwaiter().GetResult();
+        public static void AddItem(this IItemService service, ItemModel item) =>
+            service.AddItemAsync(item).GetAwaiter().GetResult();
 
-        public static void UpdateTool(this IItemService service, ItemModel tool) =>
-            service.UpdateToolAsync(tool).GetAwaiter().GetResult();
+        public static void UpdateItem(this IItemService service, ItemModel item) =>
+            service.UpdateItemAsync(item).GetAwaiter().GetResult();
 
-        public static void DeleteTool(this IItemService service, int toolID) =>
-            service.DeleteToolAsync(toolID).GetAwaiter().GetResult();
+        public static void DeleteItem(this IItemService service, int itemID) =>
+            service.DeleteItemAsync(itemID).GetAwaiter().GetResult();
 
-        public static ItemModel? GetToolByID(this IItemService service, int toolID) =>
-            service.GetToolByIDAsync(toolID).GetAwaiter().GetResult();
+        public static ItemModel? GetItemByID(this IItemService service, int itemID) =>
+            service.GetItemByIDAsync(itemID).GetAwaiter().GetResult();
 
-        public static List<ItemModel> GetAllTools(this IItemService service) =>
-            service.GetAllToolsAsync().GetAwaiter().GetResult();
+        public static List<ItemModel> GetAllItems(this IItemService service) =>
+            service.GetAllItemsAsync().GetAwaiter().GetResult();
 
-        public static List<ItemModel> SearchTools(this IItemService service, string? searchText) =>
-            service.SearchToolsAsync(searchText).GetAwaiter().GetResult();
+        public static List<ItemModel> SearchItems(this IItemService service, string? searchText) =>
+            service.SearchItemsAsync(searchText).GetAwaiter().GetResult();
         public static string GenerateNextItemNumber(this IItemService service) =>
             service.GenerateNextItemNumberAsync().GetAwaiter().GetResult();
 
-        public static bool ToggleToolCheckOutStatus(this IItemService service, int toolID, string currentUser) =>
-            service.ToggleToolCheckOutStatusAsync(toolID, currentUser).GetAwaiter().GetResult();
+        public static bool ToggleItemCheckOutStatus(this IItemService service, int itemID, string currentUser) =>
+            service.ToggleItemCheckOutStatusAsync(itemID, currentUser).GetAwaiter().GetResult();
 
-        public static List<ItemModel> GetToolsCheckedOutBy(this IItemService service, string userName) =>
-            service.GetToolsCheckedOutByAsync(userName).GetAwaiter().GetResult();
+        public static List<ItemModel> GetItemsCheckedOutBy(this IItemService service, string userName) =>
+            service.GetItemsCheckedOutByAsync(userName).GetAwaiter().GetResult();
 
-        public static void UpdateToolImage(this IItemService service, int toolID, string imagePath) =>
-            service.UpdateToolImageAsync(toolID, imagePath).GetAwaiter().GetResult();
+        public static void UpdateItemImage(this IItemService service, int itemID, string imagePath) =>
+            service.UpdateItemImageAsync(itemID, imagePath).GetAwaiter().GetResult();
 
-        public static List<int> ImportToolsFromCsv(this IItemService service, string filePath, IDictionary<string, string> map) =>
-            service.ImportToolsFromCsvAsync(filePath, map, CancellationToken.None).GetAwaiter().GetResult();
+        public static List<int> ImportItemsFromCsv(this IItemService service, string filePath, IDictionary<string, string> map) =>
+            service.ImportItemsFromCsvAsync(filePath, map, CancellationToken.None).GetAwaiter().GetResult();
 
-        public static void ExportToolsToCsv(this IItemService service, string filePath) =>
-            service.ExportToolsToCsvAsync(filePath, CancellationToken.None).GetAwaiter().GetResult();
+        public static void ExportItemsToCsv(this IItemService service, string filePath) =>
+            service.ExportItemsToCsvAsync(filePath, CancellationToken.None).GetAwaiter().GetResult();
 
-        public static ImageImportResult ImportToolImages(this IItemService service, string folderPath, Func<ItemModel, IEnumerable<string>> selector) =>
-            service.ImportToolImagesAsync(folderPath, selector, null, CancellationToken.None).GetAwaiter().GetResult();
+        public static ImageImportResult ImportItemImages(this IItemService service, string folderPath, Func<ItemModel, IEnumerable<string>> selector) =>
+            service.ImportItemImagesAsync(folderPath, selector, null, CancellationToken.None).GetAwaiter().GetResult();
 
-        public static void UpdateToolQuantities(this IItemService service, int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) =>
-            service.UpdateToolQuantitiesAsync(toolID, qtyChange, isRental, conn, tx, CancellationToken.None).GetAwaiter().GetResult();
+        public static void UpdateItemQuantities(this IItemService service, int itemID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null) =>
+            service.UpdateItemQuantitiesAsync(itemID, qtyChange, isRental, conn, tx, CancellationToken.None).GetAwaiter().GetResult();
     }
 }

--- a/ToolManagementAppV2.Tests/Services/InterfaceReferenceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/InterfaceReferenceTests.cs
@@ -1,7 +1,7 @@
 using System.IO;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Users;

--- a/ToolManagementAppV2.Tests/Services/ItemServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ItemServiceTests.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Collections.Generic;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.ImportExport;
 using Xunit;
@@ -36,7 +36,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 IItemService service = new ItemService(dbService);
 
-                service.AddTool(new ItemModel
+                service.AddItem(new ItemModel
                 {
                     ItemNumber = "T1",
                     NameDescription = "Test ItemModel",
@@ -47,7 +47,7 @@ namespace ToolManagementAppV2.Tests.Services
                     RentedQuantity = 0
                 });
 
-                var results = service.SearchTools(null);
+                var results = service.SearchItems(null);
                 Assert.Single(results);
             }
             finally
@@ -66,10 +66,10 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 IItemService service = new ItemService(dbService);
 
-                service.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
-                service.AddTool(new ItemModel { ItemNumber = "T2", NameDescription = "Saw" });
+                service.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
+                service.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Saw" });
 
-                var results = service.SearchTools("Ham");
+                var results = service.SearchItems("Ham");
                 Assert.Single(results);
                 Assert.Equal("T1", results[0].ItemNumber);
             }
@@ -89,10 +89,10 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 IItemService service = new ItemService(dbService);
 
-                service.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
-                service.AddTool(new ItemModel { ItemNumber = "T2", NameDescription = "Hammer", Brand = "BrandB" });
+                service.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
+                service.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Hammer", Brand = "BrandB" });
 
-                var results = service.SearchTools("Hammer BrandA");
+                var results = service.SearchItems("Hammer BrandA");
                 Assert.Single(results);
                 Assert.Equal("BrandA", results[0].Brand);
             }
@@ -114,10 +114,10 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 var service = new ItemService(dbService, logger: loggerFactory.CreateLogger<ItemService>());
 
-                service.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
+                service.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
 
                 var search = string.Join(' ', Enumerable.Repeat("Hammer", 10)) + " extra";
-                var results = service.SearchTools(search);
+                var results = service.SearchItems(search);
 
                 Assert.Single(results);
                 Assert.Contains(logs, l => l.Level == LogLevel.Information && l.Message.Contains("truncating"));
@@ -130,7 +130,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void AddTool_SetsGeneratedItemID()
+        public void AddItem_SetsGeneratedItemID()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -147,7 +147,7 @@ namespace ToolManagementAppV2.Tests.Services
                     PartNumber = "PN"
                 };
 
-                service.AddTool(tool);
+                service.AddItem(tool);
 
                 Assert.True(tool.ItemID > 0);
             }
@@ -159,7 +159,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public async Task AddToolAsync_SetsGeneratedItemID()
+        public async Task AddItemAsync_SetsGeneratedItemID()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -176,7 +176,7 @@ namespace ToolManagementAppV2.Tests.Services
                     PartNumber = "PN"
                 };
 
-                await service.AddToolAsync(tool);
+                await service.AddItemAsync(tool);
 
                 Assert.True(tool.ItemID > 0);
             }
@@ -188,7 +188,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void AddTool_WithImagePath_PersistsPath()
+        public void AddItem_WithImagePath_PersistsPath()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -206,8 +206,8 @@ namespace ToolManagementAppV2.Tests.Services
                     ImagePath = "Images/test.jpg"
                 };
 
-                service.AddTool(tool);
-                var stored = service.GetAllTools().Single();
+                service.AddItem(tool);
+                var stored = service.GetAllItems().Single();
 
                 Assert.Equal("Images/test.jpg", stored.ImagePath);
             }
@@ -219,7 +219,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void AddTool_DuplicateItemNumber_Throws()
+        public void AddItem_DuplicateItemNumber_Throws()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -227,10 +227,10 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 IItemService service = new ItemService(dbService);
 
-                service.AddTool(new ItemModel { ItemNumber = "T1" });
+                service.AddItem(new ItemModel { ItemNumber = "T1" });
 
                 var dup = new ItemModel { ItemNumber = "T1" };
-                var ex = Assert.Throws<InvalidOperationException>(() => service.AddTool(dup));
+                var ex = Assert.Throws<InvalidOperationException>(() => service.AddItem(dup));
                 Assert.Contains("T1", ex.Message);
             }
             finally
@@ -241,7 +241,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void AddTool_BlankItemNumber_GeneratesNumber()
+        public void AddItem_BlankItemNumber_GeneratesNumber()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -250,10 +250,10 @@ namespace ToolManagementAppV2.Tests.Services
                 IItemService service = new ItemService(dbService);
 
                 var tool = new ItemModel { ItemNumber = "" };
-                service.AddTool(tool);
+                service.AddItem(tool);
 
                 Assert.Equal("T1", tool.ItemNumber);
-                Assert.Single(service.GetAllTools());
+                Assert.Single(service.GetAllItems());
             }
             finally
             {
@@ -263,16 +263,16 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public async Task SearchToolsAsync_Cancellation_Throws()
+        public async Task SearchItemsAsync_Cancellation_Throws()
         {
             var dbPath = Path.GetTempFileName();
             try
             {
                 var dbService = new DatabaseService(dbPath);
                 IItemService service = new ItemService(dbService);
-                service.AddTool(new ItemModel { ItemNumber = "T1" });
+                service.AddItem(new ItemModel { ItemNumber = "T1" });
                 using var cts = new CancellationTokenSource();
-                var searchTask = service.SearchToolsAsync("T1", cts.Token);
+                var searchTask = service.SearchItemsAsync("T1", cts.Token);
                 cts.Cancel();
                 await Assert.ThrowsAsync<OperationCanceledException>(async () => await searchTask);
             }
@@ -284,18 +284,18 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void UpdateTool_DuplicateItemNumber_Throws()
+        public void UpdateItem_DuplicateItemNumber_Throws()
         {
             var dbPath = Path.GetTempFileName();
             try
             {
                 var dbService = new DatabaseService(dbPath);
                 var service = new ItemService(dbService);
-                service.AddTool(new ItemModel { ItemNumber = "T1" });
-                service.AddTool(new ItemModel { ItemNumber = "T2" });
-                var t2 = service.GetAllTools().First(t => t.ItemNumber == "T2");
+                service.AddItem(new ItemModel { ItemNumber = "T1" });
+                service.AddItem(new ItemModel { ItemNumber = "T2" });
+                var t2 = service.GetAllItems().First(t => t.ItemNumber == "T2");
                 t2.ItemNumber = "T1";
-                var ex = Assert.Throws<InvalidOperationException>(() => service.UpdateTool(t2));
+                var ex = Assert.Throws<InvalidOperationException>(() => service.UpdateItem(t2));
                 Assert.Contains("T1", ex.Message);
             }
             finally
@@ -306,18 +306,18 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateToolAsync_DuplicateItemNumber_Throws()
+        public async Task UpdateItemAsync_DuplicateItemNumber_Throws()
         {
             var dbPath = Path.GetTempFileName();
             try
             {
                 var dbService = new DatabaseService(dbPath);
                 var service = new ItemService(dbService);
-                service.AddTool(new ItemModel { ItemNumber = "T1" });
-                service.AddTool(new ItemModel { ItemNumber = "T2" });
-                var t2 = service.GetAllTools().First(t => t.ItemNumber == "T2");
+                service.AddItem(new ItemModel { ItemNumber = "T1" });
+                service.AddItem(new ItemModel { ItemNumber = "T2" });
+                var t2 = service.GetAllItems().First(t => t.ItemNumber == "T2");
                 t2.ItemNumber = "T1";
-                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => service.UpdateToolAsync(t2));
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => service.UpdateItemAsync(t2));
                 Assert.Contains("T1", ex.Message);
             }
             finally
@@ -328,7 +328,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateToolAsync_SameItemNumber_DoesNotThrow()
+        public async Task UpdateItemAsync_SameItemNumber_DoesNotThrow()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -336,10 +336,10 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 var service = new ItemService(dbService);
                 var tool = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
-                await service.AddToolAsync(tool);
+                await service.AddItemAsync(tool);
 
                 tool.NameDescription = "Updated";
-                var ex = await Record.ExceptionAsync(() => service.UpdateToolAsync(tool));
+                var ex = await Record.ExceptionAsync(() => service.UpdateItemAsync(tool));
                 Assert.Null(ex);
             }
             finally
@@ -350,7 +350,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void UpdateTool_DatabaseError_LogsAndThrows()
+        public void UpdateItem_DatabaseError_LogsAndThrows()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -360,11 +360,11 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 var service = new ItemService(dbService, logger: loggerFactory.CreateLogger<ItemService>());
 
-                service.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
-                var tool = service.GetAllTools().First();
+                service.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
+                var tool = service.GetAllItems().First();
                 tool.ItemNumber = null;
 
-                var ex = Assert.Throws<InvalidOperationException>(() => service.UpdateTool(tool));
+                var ex = Assert.Throws<InvalidOperationException>(() => service.UpdateItem(tool));
                 Assert.Contains("Failed to update tool", ex.Message);
                 Assert.IsType<SQLiteException>(ex.InnerException);
                 Assert.Contains(logs, l => l.Level == LogLevel.Error && l.Message.Contains("Failed to update tool"));
@@ -386,17 +386,17 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 var db = new DatabaseService(dbPath);
                 IItemService svc = new ItemService(db);
-                svc.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "A" });
-                svc.AddTool(new ItemModel { ItemNumber = "T2", NameDescription = "B" });
-                svc.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "C" });
+                svc.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "A" });
+                svc.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "B" });
+                svc.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "C" });
 
                 File.WriteAllText(Path.Combine(imgDir, "T1.jpg"), string.Empty);
                 File.WriteAllText(Path.Combine(imgDir, "T2.jpg"), string.Empty);
                 File.WriteAllText(Path.Combine(imgDir, "X.jpg"), string.Empty);
 
-                var result = svc.ImportToolImages(imgDir, t => new[] { t.ItemNumber });
+                var result = svc.ImportItemImages(imgDir, t => new[] { t.ItemNumber });
 
-                var all = svc.GetAllTools();
+                var all = svc.GetAllItems();
                 var t2 = all.First(t => t.ItemNumber == "T2");
                 Assert.NotNull(t2.ImagePath);
                 Assert.Single(result.ConflictingFiles);
@@ -420,19 +420,19 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 var db = new DatabaseService(dbPath);
                 IItemService svc = new ItemService(db);
-                svc.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "A" });
+                svc.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "A" });
                 File.WriteAllText(Path.Combine(imgDir, "T1.jpg"), string.Empty);
 
                 var destDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images");
                 if (Directory.Exists(destDir)) Directory.Delete(destDir, true);
 
-                var result = svc.ImportToolImages(imgDir, t => new[] { t.ItemNumber });
+                var result = svc.ImportItemImages(imgDir, t => new[] { t.ItemNumber });
 
                 Assert.Equal(1, result.ImportedCount);
                 var expected = Path.Combine(destDir, "T1.jpg");
                 Assert.True(File.Exists(expected));
 
-                var tool = svc.GetAllTools().First();
+                var tool = svc.GetAllItems().First();
                 Assert.Equal($"Images/{Path.GetFileName(expected)}", tool.ImagePath);
             }
             finally
@@ -464,9 +464,9 @@ namespace ToolManagementAppV2.Tests.Services
                 using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
                 var db = new DatabaseService(dbPath);
                 var svc = new ItemService(db, logger: loggerFactory.CreateLogger<ItemService>());
-                svc.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "A" });
+                svc.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "A" });
 
-                var result = svc.ImportToolImages(imgDir, t => new[] { t.ItemNumber });
+                var result = svc.ImportItemImages(imgDir, t => new[] { t.ItemNumber });
 
                 Assert.Equal(0, result.ImportedCount);
                 Assert.Contains(logs, l => l.Level == LogLevel.Error && l.Message.Contains("Failed to create image directory"));
@@ -480,15 +480,15 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public async Task GetAllToolsAsync_ReturnsTools()
+        public async Task GetAllItemsAsync_ReturnsTools()
         {
             var dbPath = Path.GetTempFileName();
             try
             {
                 var dbService = new DatabaseService(dbPath);
                 IItemService service = new ItemService(dbService);
-                service.AddTool(new ItemModel { ItemNumber = "T1" });
-                var tools = await service.GetAllToolsAsync();
+                service.AddItem(new ItemModel { ItemNumber = "T1" });
+                var tools = await service.GetAllItemsAsync();
                 Assert.Single(tools);
             }
             finally
@@ -505,13 +505,13 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 var db = new DatabaseService(dbPath);
                 var svc = new ItemService(db);
-                svc.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "A" });
-                var first = svc.GetAllTools();
+                svc.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "A" });
+                var first = svc.GetAllItems();
                 using (var conn = db.CreateConnection())
                 {
                     SqliteHelper.ExecuteNonQuery(conn, "INSERT INTO Tools (ItemNumber) VALUES ('T2')", null);
                 }
-                var second = svc.GetAllTools();
+                var second = svc.GetAllItems();
                 Assert.Single(second);
             }
             finally
@@ -535,8 +535,8 @@ namespace ToolManagementAppV2.Tests.Services
                     {"ItemNumber", "ItemNumber"}
                 };
 
-                Assert.Throws<SQLiteException>(() => service.ImportToolsFromCsv(csvPath, map));
-                Assert.Empty(service.GetAllTools());
+                Assert.Throws<SQLiteException>(() => service.ImportItemsFromCsv(csvPath, map));
+                Assert.Empty(service.GetAllItems());
             }
             finally
             {
@@ -583,7 +583,7 @@ namespace ToolManagementAppV2.Tests.Services
 
                 var dbService = new DatabaseService(dbPath);
                 var svc = new ItemService(dbService);
-                var tools = svc.GetAllTools();
+                var tools = svc.GetAllItems();
 
                 Assert.Single(tools);
                 var tool = tools[0];
@@ -636,7 +636,7 @@ namespace ToolManagementAppV2.Tests.Services
 
                 var dbService = new DatabaseService(dbPath);
                 var svc = new ItemService(dbService);
-                var tools = svc.SearchTools("T1");
+                var tools = svc.SearchItems("T1");
 
                 Assert.Single(tools);
                 var tool = tools[0];
@@ -651,7 +651,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void UpdateToolQuantities_NoRows_LogsWarningAndThrows()
+        public void UpdateItemQuantities_NoRows_LogsWarningAndThrows()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -661,7 +661,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 IItemService service = new ItemService(dbService, logger: loggerFactory.CreateLogger<ItemService>());
 
-                service.AddTool(new ItemModel
+                service.AddItem(new ItemModel
                 {
                     ItemNumber = "T1",
                     NameDescription = "Hammer",
@@ -669,8 +669,8 @@ namespace ToolManagementAppV2.Tests.Services
                     RentedQuantity = 0
                 });
 
-                var addedTool = service.GetAllTools().First();
-                Assert.Throws<InvalidOperationException>(() => service.UpdateToolQuantities(addedTool.ItemID, 1, true));
+                var addedTool = service.GetAllItems().First();
+                Assert.Throws<InvalidOperationException>(() => service.UpdateItemQuantities(addedTool.ItemID, 1, true));
                 Assert.Contains(logs, l => l.Level == LogLevel.Warning && l.Message.Contains("Quantity update affected 0 rows"));
             }
             finally
@@ -693,7 +693,7 @@ namespace ToolManagementAppV2.Tests.Services
                 }
 
                 var svc = new ItemService(dbService);
-                var ex = Assert.Throws<InvalidOperationException>(() => svc.DeleteTool(1));
+                var ex = Assert.Throws<InvalidOperationException>(() => svc.DeleteItem(1));
                 Assert.Contains("Failed to delete tool 1", ex.Message);
             }
             finally
@@ -703,7 +703,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public async Task DeleteToolAsync_WhenSqlFails_Throws()
+        public async Task DeleteItemAsync_WhenSqlFails_Throws()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -716,7 +716,7 @@ namespace ToolManagementAppV2.Tests.Services
                 }
 
                 var svc = new ItemService(dbService);
-                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => svc.DeleteToolAsync(1));
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => svc.DeleteItemAsync(1));
                 Assert.Contains("Failed to delete tool 1", ex.Message);
             }
             finally
@@ -726,7 +726,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void AddTool_ConcurrentAdds_Succeeds()
+        public void AddItem_ConcurrentAdds_Succeeds()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -735,7 +735,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var svc = new ItemService(dbService);
 
                 var tasks = Enumerable.Range(0, 10).Select(i => Task.Run(() =>
-                    svc.AddTool(new ItemModel
+                    svc.AddItem(new ItemModel
                     {
                         ItemNumber = $"T{i}",
                         NameDescription = $"ItemModel{i}"
@@ -745,7 +745,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var ex = Record.Exception(() => Task.WaitAll(tasks));
                 Assert.Null(ex);
 
-                var all = svc.GetAllTools();
+                var all = svc.GetAllItems();
                 Assert.Equal(10, all.Count);
             }
             finally
@@ -762,7 +762,7 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 var dbService = new DatabaseService(dbPath);
                 var svc = new ItemService(dbService);
-                svc.AddTool(new ItemModel
+                svc.AddItem(new ItemModel
                 {
                     ItemNumber = "T1",
                     NameDescription = "Test",
@@ -770,15 +770,15 @@ namespace ToolManagementAppV2.Tests.Services
                     RentedQuantity = 0
                 });
 
-                var tool = svc.GetAllTools().Single();
+                var tool = svc.GetAllItems().Single();
 
                 var before = DateTime.UtcNow;
-                var result = svc.ToggleToolCheckOutStatus(tool.ItemID, "user");
+                var result = svc.ToggleItemCheckOutStatus(tool.ItemID, "user");
                 var after = DateTime.UtcNow;
 
                 Assert.True(result);
 
-                var updated = svc.GetToolByID(tool.ItemID);
+                var updated = svc.GetItemByID(tool.ItemID);
                 Assert.True(updated.IsCheckedOut);
                 Assert.NotNull(updated.CheckedOutTime);
                 Assert.InRange(updated.CheckedOutTime!.Value, before, after);
@@ -790,17 +790,17 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public async Task DeleteToolAsync_RemovesTool()
+        public async Task DeleteItemAsync_RemovesTool()
         {
             var dbPath = Path.GetTempFileName();
             try
             {
                 var dbService = new DatabaseService(dbPath);
                 var svc = new ItemService(dbService);
-                await svc.AddToolAsync(new ItemModel { ItemNumber = "T1", QuantityOnHand = 1 });
-                var tool = (await svc.GetAllToolsAsync()).Single();
-                await svc.DeleteToolAsync(tool.ItemID);
-                var remaining = await svc.GetAllToolsAsync();
+                await svc.AddItemAsync(new ItemModel { ItemNumber = "T1", QuantityOnHand = 1 });
+                var tool = (await svc.GetAllItemsAsync()).Single();
+                await svc.DeleteItemAsync(tool.ItemID);
+                var remaining = await svc.GetAllItemsAsync();
                 Assert.Empty(remaining);
             }
             finally
@@ -810,17 +810,17 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public async Task ToggleToolCheckOutStatusAsync_UpdatesQuantity()
+        public async Task ToggleItemCheckOutStatusAsync_UpdatesQuantity()
         {
             var dbPath = Path.GetTempFileName();
             try
             {
                 var dbService = new DatabaseService(dbPath);
                 var svc = new ItemService(dbService);
-                await svc.AddToolAsync(new ItemModel { ItemNumber = "T2", QuantityOnHand = 1 });
-                var tool = (await svc.GetAllToolsAsync()).Single();
-                var success = await svc.ToggleToolCheckOutStatusAsync(tool.ItemID, "u");
-                var updated = await svc.GetToolByIDAsync(tool.ItemID);
+                await svc.AddItemAsync(new ItemModel { ItemNumber = "T2", QuantityOnHand = 1 });
+                var tool = (await svc.GetAllItemsAsync()).Single();
+                var success = await svc.ToggleItemCheckOutStatusAsync(tool.ItemID, "u");
+                var updated = await svc.GetItemByIDAsync(tool.ItemID);
                 Assert.True(success);
                 Assert.True(updated.IsCheckedOut);
                 Assert.Equal(0, updated.QuantityOnHand);
@@ -832,7 +832,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public async Task SearchToolsAsync_Cancelled_Throws()
+        public async Task SearchItemsAsync_Cancelled_Throws()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -841,7 +841,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var svc = new ItemService(dbService);
                 using var cts = new CancellationTokenSource();
                 cts.Cancel();
-                await Assert.ThrowsAsync<OperationCanceledException>(() => svc.SearchToolsAsync("test", cts.Token));
+                await Assert.ThrowsAsync<OperationCanceledException>(() => svc.SearchItemsAsync("test", cts.Token));
             }
             finally
             {
@@ -866,9 +866,9 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 var svc = new FailingCopyItemService(dbService, loggerFactory.CreateLogger<ItemService>());
 
-                svc.AddTool(new ItemModel { ItemNumber = "T1" });
+                svc.AddItem(new ItemModel { ItemNumber = "T1" });
 
-                var result = svc.ImportToolImages(tempDir, t => new[] { t.ItemNumber });
+                var result = svc.ImportItemImages(tempDir, t => new[] { t.ItemNumber });
 
                 Assert.Equal(0, result.ImportedCount);
                 Assert.Contains(imgPath, result.ConflictingFiles);
@@ -898,9 +898,9 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 var svc = new ItemService(dbService);
 
-                svc.AddTool(new ItemModel { ItemNumber = "T1" });
+                svc.AddItem(new ItemModel { ItemNumber = "T1" });
 
-                var result = svc.ImportToolImages(tempDir, t => new[] { t.ItemNumber });
+                var result = svc.ImportItemImages(tempDir, t => new[] { t.ItemNumber });
 
                 Assert.Equal(1, result.ImportedCount);
                 Assert.Empty(result.ConflictingFiles);
@@ -910,7 +910,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var destFile = Path.Combine(destDir, Path.GetFileName(imgPath));
                 Assert.True(File.Exists(destFile));
 
-                var tool = svc.GetAllTools().Single();
+                var tool = svc.GetAllItems().Single();
                 Assert.Equal($"Images/{Path.GetFileName(imgPath)}", tool.ImagePath);
             }
             finally
@@ -923,7 +923,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public async Task ImportToolImagesAsync_RespectsCancellation()
+        public async Task ImportItemImagesAsync_RespectsCancellation()
         {
             var dbPath = Path.GetTempFileName();
             var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -936,8 +936,8 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 var dbService = new DatabaseService(dbPath);
                 var svc = new ItemService(dbService);
-                svc.AddTool(new ItemModel { ItemNumber = "T1" });
-                svc.AddTool(new ItemModel { ItemNumber = "T2" });
+                svc.AddItem(new ItemModel { ItemNumber = "T1" });
+                svc.AddItem(new ItemModel { ItemNumber = "T2" });
 
                 var cts = new CancellationTokenSource();
                 var progress = new Progress<ImageImportProgress>(p =>
@@ -947,7 +947,7 @@ namespace ToolManagementAppV2.Tests.Services
                 });
 
                 await Assert.ThrowsAsync<OperationCanceledException>(() =>
-                    svc.ImportToolImagesAsync(tempDir, t => new[] { t.ItemNumber }, progress, cts.Token));
+                    svc.ImportItemImagesAsync(tempDir, t => new[] { t.ItemNumber }, progress, cts.Token));
             }
             finally
             {
@@ -959,7 +959,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public async Task AddToolAsync_LogsActivity()
+        public async Task AddItemAsync_LogsActivity()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -969,7 +969,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var auth = new AllowAllAuthorizationService();
                 var logService = new ActivityLogService(dbService);
                 var svc = new ItemService(dbService, auth, null, logService, ctx);
-                await svc.AddToolAsync(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, RentedQuantity = 0 });
+                await svc.AddItemAsync(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, RentedQuantity = 0 });
                 var logs = await logService.GetRecentLogsAsync();
                 Assert.Contains(logs.Value, l => l.Action.Contains("Added tool"));
             }

--- a/ToolManagementAppV2.Tests/Services/RentalServiceConcurrentTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceConcurrentTests.cs
@@ -7,7 +7,7 @@ using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.Services
@@ -25,8 +25,8 @@ namespace ToolManagementAppV2.Tests.Services
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db, toolService);
 
-                toolService.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
-                var tool = toolService.GetAllTools().First();
+                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
+                var tool = toolService.GetAllItems().First();
 
                 customerService.AddCustomer(new Customer { Company = "Acme" });
                 var cust = customerService.GetAllCustomers().First();
@@ -53,7 +53,7 @@ namespace ToolManagementAppV2.Tests.Services
 
                 Task.WaitAll(t1, t2);
 
-                var updated = toolService.GetToolByID(tool.ItemID);
+                var updated = toolService.GetItemByID(tool.ItemID);
                 Assert.Equal(0, updated.QuantityOnHand);
                 Assert.Equal(1, updated.RentedQuantity);
                 Assert.Single(rentalService.GetAllRentals());

--- a/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/RentalServiceTests.cs
@@ -9,7 +9,7 @@ using ToolManagementAppV2.Models.ImportExport;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Interfaces;
 using System.Threading;
 using System.Threading.Tasks;
@@ -41,8 +41,8 @@ namespace ToolManagementAppV2.Tests.Services
                 IRentalService rentalService = new RentalService(db, toolService);
 
                 var tool = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 5 };
-                toolService.AddTool(tool);
-                var addedTool = toolService.GetAllTools().First();
+                toolService.AddItem(tool);
+                var addedTool = toolService.GetAllItems().First();
 
                 var cust = new Customer { Company = "Acme" };
                 customerService.AddCustomer(cust);
@@ -74,8 +74,8 @@ namespace ToolManagementAppV2.Tests.Services
                 IRentalService rentalService = new RentalService(db, toolService);
 
                 var tool = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 0 };
-                toolService.AddTool(tool);
-                var addedTool = toolService.GetAllTools().First();
+                toolService.AddItem(tool);
+                var addedTool = toolService.GetAllItems().First();
 
                 customerService.AddCustomer(new Customer { Company = "Acme" });
                 var cust = customerService.GetAllCustomers().First();
@@ -103,8 +103,8 @@ namespace ToolManagementAppV2.Tests.Services
                 IRentalService rentalService = new RentalService(db, toolService);
 
                 var tool = new ItemModel { ItemNumber = "T2", NameDescription = "Wrench", QuantityOnHand = 0 };
-                toolService.AddTool(tool);
-                var addedTool = toolService.GetAllTools().First();
+                toolService.AddItem(tool);
+                var addedTool = toolService.GetAllItems().First();
 
                 customerService.AddCustomer(new Customer { Company = "Beta" });
                 var cust = customerService.GetAllCustomers().First();
@@ -190,8 +190,8 @@ namespace ToolManagementAppV2.Tests.Services
                 var rentalService = new RentalService(db, toolService);
 
                 var tool = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 };
-                toolService.AddTool(tool);
-                var addedTool = toolService.GetAllTools().First();
+                toolService.AddItem(tool);
+                var addedTool = toolService.GetAllItems().First();
 
                 customerService.AddCustomer(new Customer { Company = "Acme" });
                 var cust = customerService.GetAllCustomers().First();
@@ -223,8 +223,8 @@ namespace ToolManagementAppV2.Tests.Services
                 var rentalService = new RentalService(db, toolService);
 
                 var tool = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 };
-                toolService.AddTool(tool);
-                var addedTool = toolService.GetAllTools().First();
+                toolService.AddItem(tool);
+                var addedTool = toolService.GetAllItems().First();
 
                 customerService.AddCustomer(new Customer { Company = "Acme" });
                 var cust = customerService.GetAllCustomers().First();
@@ -274,8 +274,8 @@ namespace ToolManagementAppV2.Tests.Services
                 var rentalService = new RentalService(db, toolService);
 
                 var tool = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, Location = "A1", ImagePath = "path" };
-                toolService.AddTool(tool);
-                var addedTool = toolService.GetAllTools().First();
+                toolService.AddItem(tool);
+                var addedTool = toolService.GetAllItems().First();
 
                 var customer = new Customer { Company = "Acme", Contact = "Bob", Email = "b@c.com", Phone = "111", Mobile = "222", Address = "Addr" };
                 customerService.AddCustomer(customer);
@@ -311,22 +311,22 @@ namespace ToolManagementAppV2.Tests.Services
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db, toolService);
 
-                toolService.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
-                var tool = toolService.GetAllTools().First();
+                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
+                var tool = toolService.GetAllItems().First();
 
                 customerService.AddCustomer(new Customer { Company = "Acme" });
                 var cust = customerService.GetAllCustomers().First();
 
                 rentalService.RentTool(tool.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
-                var rented = toolService.GetToolByID(tool.ItemID);
+                var rented = toolService.GetItemByID(tool.ItemID);
                 Assert.Equal(0, rented.QuantityOnHand);
                 Assert.Equal(1, rented.RentedQuantity);
 
                 var rental = rentalService.GetAllRentals().First();
                 rentalService.ReturnTool(rental.RentalID, DateTime.Today);
 
-                var returned = toolService.GetToolByID(tool.ItemID);
+                var returned = toolService.GetItemByID(tool.ItemID);
                 Assert.Equal(1, returned.QuantityOnHand);
                 Assert.Equal(0, returned.RentedQuantity);
             }
@@ -348,8 +348,8 @@ namespace ToolManagementAppV2.Tests.Services
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db, toolService);
 
-                toolService.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
-                var tool = toolService.GetAllTools().First();
+                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
+                var tool = toolService.GetAllItems().First();
 
                 customerService.AddCustomer(new Customer { Company = "Acme" });
                 var cust = customerService.GetAllCustomers().First();
@@ -367,7 +367,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var after = rentalService2.GetAllRentals().First();
                 Assert.Equal(originalDue, after.DueDate);
 
-                var toolAfter = toolService.GetToolByID(tool.ItemID);
+                var toolAfter = toolService.GetItemByID(tool.ItemID);
                 Assert.Equal(0, toolAfter.QuantityOnHand);
                 Assert.Equal(1, toolAfter.RentedQuantity);
             }
@@ -392,9 +392,9 @@ namespace ToolManagementAppV2.Tests.Services
                 var customerService = new CustomerService(db, auth);
                 var rentalService = new RentalService(db, auth, toolService, null, logService, ctx);
 
-                await toolService.AddToolAsync(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, RentedQuantity = 0 });
+                await toolService.AddItemAsync(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, RentedQuantity = 0 });
                 await customerService.AddCustomerAsync(new Customer { Company = "Acme" });
-                var tool = (await toolService.GetAllToolsAsync()).First();
+                var tool = (await toolService.GetAllItemsAsync()).First();
                 var cust = (await customerService.GetAllCustomersAsync()).First();
 
                 await rentalService.RentToolAsync(tool.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
@@ -411,19 +411,19 @@ namespace ToolManagementAppV2.Tests.Services
 
         class FailingItemService : IItemService
         {
-            public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
-            public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-            public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-            public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-            public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
-            public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default)
+            public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task AddItemAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateItemAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default)
                 => throw new InvalidOperationException("fail");
             public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
         }

--- a/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
@@ -11,7 +11,7 @@ using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Models.ImportExport;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Customers;
@@ -53,21 +53,21 @@ public class ReportServiceAsyncTests
         public DelayItemService(int delay, int count)
         { _delay = delay; _tools = new List<ItemModel>(new ItemModel[count]); }
 
-        public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) =>
+        public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) =>
             Task.Delay(_delay, cancellationToken).ContinueWith(_ => _tools, cancellationToken);
 
-        public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
-        public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task AddItemAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 

--- a/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
@@ -6,7 +6,7 @@ using System.Windows.Documents;
 using Xunit;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Customers;
@@ -40,7 +40,7 @@ namespace ToolManagementAppV2.Tests.Services
                     QuantityOnHand = 1,
                     RentedQuantity = 0
                 };
-                toolService.AddTool(tool);
+                toolService.AddItem(tool);
 
                 var customer = new Customer
                 {
@@ -104,7 +104,7 @@ namespace ToolManagementAppV2.Tests.Services
                     QuantityOnHand = 1,
                     RentedQuantity = 0
                 };
-                toolService.AddTool(tool);
+                toolService.AddItem(tool);
 
                 var customer = new Customer
                 {

--- a/ToolManagementAppV2.Tests/Services/ToolCheckOutTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ToolCheckOutTests.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Linq;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Interfaces;
 using Xunit;
 
@@ -18,10 +18,10 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var service = new ItemService(new DatabaseService(db));
-                service.AddTool(new ItemModel { ItemNumber = "T1", QuantityOnHand = 0 });
-                var tool = service.GetAllTools().First();
-                var result = service.ToggleToolCheckOutStatus(tool.ItemID, "u");
-                var updated = service.GetToolByID(tool.ItemID);
+                service.AddItem(new ItemModel { ItemNumber = "T1", QuantityOnHand = 0 });
+                var tool = service.GetAllItems().First();
+                var result = service.ToggleItemCheckOutStatus(tool.ItemID, "u");
+                var updated = service.GetItemByID(tool.ItemID);
                 Assert.False(result);
                 Assert.False(updated.IsCheckedOut);
                 Assert.Equal(0, updated.QuantityOnHand);
@@ -39,15 +39,15 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 IItemService svc = new ItemService(new DatabaseService(db));
-                svc.AddTool(new ItemModel { ItemNumber = "T2", QuantityOnHand = 1 });
-                var tool = svc.GetAllTools().First();
-                var first = svc.ToggleToolCheckOutStatus(tool.ItemID, "u");
-                var outTool = svc.GetToolByID(tool.ItemID);
+                svc.AddItem(new ItemModel { ItemNumber = "T2", QuantityOnHand = 1 });
+                var tool = svc.GetAllItems().First();
+                var first = svc.ToggleItemCheckOutStatus(tool.ItemID, "u");
+                var outTool = svc.GetItemByID(tool.ItemID);
                 Assert.True(first);
                 Assert.True(outTool.IsCheckedOut);
                 Assert.Equal(0, outTool.QuantityOnHand);
-                var second = svc.ToggleToolCheckOutStatus(tool.ItemID, "u");
-                var back = svc.GetToolByID(tool.ItemID);
+                var second = svc.ToggleItemCheckOutStatus(tool.ItemID, "u");
+                var back = svc.GetItemByID(tool.ItemID);
                 Assert.True(second);
                 Assert.False(back.IsCheckedOut);
                 Assert.Equal(1, back.QuantityOnHand);
@@ -65,7 +65,7 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var service = new ItemService(new DatabaseService(db));
-                Assert.Throws<InvalidOperationException>(() => service.ToggleToolCheckOutStatus(42, "u"));
+                Assert.Throws<InvalidOperationException>(() => service.ToggleItemCheckOutStatus(42, "u"));
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/TestHelpers.cs
+++ b/ToolManagementAppV2.Tests/TestHelpers.cs
@@ -11,7 +11,7 @@ using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Settings;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.ViewModels;
 
@@ -65,9 +65,9 @@ namespace ToolManagementAppV2.Tests
         {
             public void ShowInfo(string message, string title) { }
             public bool ShowConfirmation(string message, string title) => false;
-            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-            public void ShowToolDetails(ItemModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+            public void ShowItemDetails(ItemModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/Tests/AppUnhandledExceptionTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/AppUnhandledExceptionTests.cs
@@ -105,9 +105,9 @@ namespace ToolManagementAppV2.Tests.Tests
             public int InfoCount { get; private set; }
             public void ShowInfo(string message, string title) => InfoCount++;
             public bool ShowConfirmation(string message, string title) => false;
-            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-            public void ShowToolDetails(ItemModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+            public void ShowItemDetails(ItemModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System;
 using ToolManagementAppV2.Utilities.IO;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Models.Domain;
 using Xunit;
 using System.Threading;
@@ -97,7 +97,7 @@ public class CsvImportTests
     }
 
     [Fact]
-    public async System.Threading.Tasks.Task ImportToolsFromCsvAsync_SkipsInvalidRows()
+    public async System.Threading.Tasks.Task ImportItemsFromCsvAsync_SkipsInvalidRows()
     {
         var dbPath = Path.GetTempFileName();
         var csvPath = Path.GetTempFileName();
@@ -116,11 +116,11 @@ public class CsvImportTests
                 {"NameDescription", "NameDescription"}
             };
 
-            var invalid = await service.ImportToolsFromCsvAsync(csvPath, map, CancellationToken.None);
+            var invalid = await service.ImportItemsFromCsvAsync(csvPath, map, CancellationToken.None);
 
             Assert.Single(invalid);
             Assert.Contains(2, invalid);
-            Assert.Single(service.GetAllTools());
+            Assert.Single(service.GetAllItems());
         }
         finally
         {
@@ -130,7 +130,7 @@ public class CsvImportTests
     }
 
     [Fact]
-    public async System.Threading.Tasks.Task ImportToolsFromCsvAsync_PerformanceWithDuplicates()
+    public async System.Threading.Tasks.Task ImportItemsFromCsvAsync_PerformanceWithDuplicates()
     {
         var dbPath = Path.GetTempFileName();
         var csvPath = Path.GetTempFileName();
@@ -140,7 +140,7 @@ public class CsvImportTests
             var service = new ItemService(db);
 
             for (int i = 0; i < 100; i++)
-                service.AddTool(new ItemModel { ItemNumber = $"E{i}", NameDescription = $"Existing {i}" });
+                service.AddItem(new ItemModel { ItemNumber = $"E{i}", NameDescription = $"Existing {i}" });
 
             var sb = new System.Text.StringBuilder();
             sb.AppendLine("ItemNumber,NameDescription");
@@ -157,12 +157,12 @@ public class CsvImportTests
             };
 
             var sw = System.Diagnostics.Stopwatch.StartNew();
-            var invalid = await service.ImportToolsFromCsvAsync(csvPath, map, CancellationToken.None);
+            var invalid = await service.ImportItemsFromCsvAsync(csvPath, map, CancellationToken.None);
             sw.Stop();
 
             Assert.True(sw.ElapsedMilliseconds < 5000, $"Import took {sw.ElapsedMilliseconds}ms");
             Assert.Empty(invalid);
-            Assert.Equal(1000, service.GetAllTools().Count);
+            Assert.Equal(1000, service.GetAllItems().Count);
         }
         finally
         {
@@ -172,7 +172,7 @@ public class CsvImportTests
     }
 
     [Fact]
-    public async System.Threading.Tasks.Task ExportToolsToCsvAsync_WritesExpectedFile()
+    public async System.Threading.Tasks.Task ExportItemsToCsvAsync_WritesExpectedFile()
     {
         var dbPath = Path.GetTempFileName();
         var csvPath = Path.GetTempFileName();
@@ -180,9 +180,9 @@ public class CsvImportTests
         {
             using var db = new DatabaseService(dbPath);
             var service = new ItemService(db);
-            service.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 5, IsPowerTool = true });
+            service.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 5, IsPowerTool = true });
 
-            await service.ExportToolsToCsvAsync(csvPath);
+            await service.ExportItemsToCsvAsync(csvPath);
 
             var lines = await File.ReadAllLinesAsync(csvPath);
             Assert.True(lines.Length > 1);

--- a/ToolManagementAppV2.Tests/Tests/CustomersPageBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CustomersPageBindingTests.cs
@@ -76,9 +76,9 @@ namespace ToolManagementAppV2.Tests.Tests
     {
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/Tests/DependencyInjectionTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/DependencyInjectionTests.cs
@@ -2,7 +2,7 @@ using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Services;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.Services.Core;

--- a/ToolManagementAppV2.Tests/Tests/ManageItemsPageMenuTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ManageItemsPageMenuTests.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Windows.Controls;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.ViewModels;
@@ -39,7 +39,7 @@ namespace ToolManagementAppV2.Tests.Tests
                 var items = menu.Items.OfType<MenuItem>().ToArray();
 
                 Assert.Equal(vm.OpenRentalsCommand, items[0].Command);
-                Assert.Equal(vm.DeleteToolCommand, items[1].Command);
+                Assert.Equal(vm.DeleteItemCommand, items[1].Command);
             }
             finally
             {
@@ -68,9 +68,9 @@ namespace ToolManagementAppV2.Tests.Tests
                 var stack = (StackPanel)innerGrid.Children[2];
 
                 Assert.Equal(3, stack.Children.Count);
-                Assert.Equal(vm.EditToolCommand, ((Button)stack.Children[0]).Command);
+                Assert.Equal(vm.EditItemCommand, ((Button)stack.Children[0]).Command);
                 Assert.Equal(vm.ViewDetailsCommand, ((Button)stack.Children[1]).Command);
-                Assert.Equal(vm.NewToolCommand, ((Button)stack.Children[2]).Command);
+                Assert.Equal(vm.NewItemCommand, ((Button)stack.Children[2]).Command);
             }
             finally
             {
@@ -82,9 +82,9 @@ namespace ToolManagementAppV2.Tests.Tests
         {
             public void ShowInfo(string message, string title) { }
             public bool ShowConfirmation(string message, string title) => true;
-            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-            public void ShowToolDetails(ItemModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+            public void ShowItemDetails(ItemModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/Tests/ManageRentalsPageDeleteTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ManageRentalsPageDeleteTests.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Windows.Controls;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.ViewModels;
@@ -30,7 +30,7 @@ namespace ToolManagementAppV2.Tests.Tests
                 var rentalService = new RentalService(db);
 
                 var tool = new ItemModel { ItemNumber = "T1" };
-                toolService.AddTool(tool);
+                toolService.AddItem(tool);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
@@ -64,9 +64,9 @@ namespace ToolManagementAppV2.Tests.Tests
     {
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/Tests/ManageRentalsPageMenuTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ManageRentalsPageMenuTests.cs
@@ -97,9 +97,9 @@ namespace ToolManagementAppV2.Tests.Tests
     {
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -6,7 +6,7 @@ using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.ViewModels;
@@ -54,7 +54,7 @@ namespace ToolManagementAppV2.Tests.Tests
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
-                toolService.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
+                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
 
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
                 await vm.OpenSearchItemsCommand.ExecuteAsync(null);
@@ -83,9 +83,9 @@ class StubDialogService : IDialogService
 {
     public void ShowInfo(string message, string title) { }
     public bool ShowConfirmation(string message, string title) => false;
-    public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-    public void ShowToolDetails(ToolModel tool) { }
-    public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+    public ToolModel? ShowEditItemDialog(ToolModel tool) => null;
+    public void ShowItemDetails(ToolModel tool) { }
+    public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
     public CustomerModel? ShowAddCustomerDialog() => null;
     public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
     public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/Utilities/AsyncHelpersTests.cs
+++ b/ToolManagementAppV2.Tests/Utilities/AsyncHelpersTests.cs
@@ -26,10 +26,10 @@ namespace ToolManagementAppV2.Tests.Utilities
             }
             public bool ShowConfirmation(string message, string title) => true;
             public Task<bool> ShowConfirmationAsync(string message, string title) => Task.FromResult(true);
-            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-            public Task<ItemModel?> ShowEditToolDialogAsync(ItemModel tool) => Task.FromResult<ItemModel?>(null);
-            public void ShowToolDetails(ItemModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+            public Task<ItemModel?> ShowEditItemDialogAsync(ItemModel tool) => Task.FromResult<ItemModel?>(null);
+            public void ShowItemDetails(ItemModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/ViewModels/CustomerManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/CustomerManagementViewModelTests.cs
@@ -293,9 +293,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => AddCustomerResult;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/ViewModels/DashboardViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/DashboardViewModelTests.cs
@@ -3,7 +3,7 @@ using System.IO;
 using CommunityToolkit.Mvvm.Input;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
@@ -46,7 +46,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 Assert.NotEmpty(vm.StatCards);
                 Assert.NotEmpty(vm.RecentActivity);
 
-                vm.NewToolCommand.Execute(null);
+                vm.NewItemCommand.Execute(null);
                 vm.OpenRentalsCommand.Execute(null);
                 vm.OpenImportExportCommand.Execute(null);
 

--- a/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -150,9 +150,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public bool ShowImportMappingCalled { get; private set; }
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }
@@ -170,24 +170,24 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public bool ImportCalled { get; private set; }
         public IDictionary<string,string>? MapUsed { get; private set; }
-        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
+        public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
             ImportCalled = true;
             MapUsed = map;
             return Task.FromResult(new List<int>());
         }
-        public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
-        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task AddItemAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 
@@ -230,42 +230,42 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
     class StubItemService : IItemService
     {
-        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
+        public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
             => Task.FromResult(new List<int>());
-        public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
-        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task AddItemAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 
     class CancelableItemService : IItemService
     {
-        public async Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
+        public async Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
             await Task.Delay(Timeout.Infinite, cancellationToken);
             return new List<int>();
         }
-        public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
-        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task AddItemAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 

--- a/ToolManagementAppV2.Tests/ViewModels/ItemManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ItemManagementViewModelTests.cs
@@ -8,7 +8,7 @@ using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Models;
 using ToolManagementAppV2.Models.ImportExport;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Interfaces;
@@ -35,8 +35,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
                 var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
-                toolService.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
-                toolService.AddTool(new ItemModel { ItemNumber = "T2", NameDescription = "Saw" });
+                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
+                toolService.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Saw" });
                 vm.SearchTerm = "Ham";
                 await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
                 Assert.Single(vm.SearchResults);
@@ -61,8 +61,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
                 var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
-                toolService.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
-                toolService.AddTool(new ItemModel { ItemNumber = "T2", NameDescription = "Hammer", Brand = "BrandB" });
+                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
+                toolService.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Hammer", Brand = "BrandB" });
                 vm.SearchTerm = "Hammer BrandA";
                 await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
                 Assert.Single(vm.SearchResults);
@@ -87,8 +87,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
                 var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
-                toolService.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
-                toolService.AddTool(new ItemModel { ItemNumber = "T2", NameDescription = "Cordless Drill", IsPowerTool = true });
+                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
+                toolService.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Cordless Drill", IsPowerTool = true });
                 vm.SearchTerm = string.Empty;
                 await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
                 Assert.Equal(2, vm.SearchResults.Count);
@@ -114,7 +114,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
                 var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
-                toolService.AddTool(new ItemModel { ItemNumber = "T1", Brand = "BrandA" });
+                toolService.AddItem(new ItemModel { ItemNumber = "T1", Brand = "BrandA" });
                 await vm.LoadToolsAsync();
 
                 Assert.Contains("BrandA", vm.Categories);
@@ -140,7 +140,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IItemService toolService = new ItemService(db);
                 var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
 
-                toolService.AddTool(new ItemModel { ItemNumber = "T1" });
+                toolService.AddItem(new ItemModel { ItemNumber = "T1" });
                 await vm.LoadToolsAsync();
                 await vm.LoadToolsAsync();
 
@@ -166,10 +166,10 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 IItemService toolService = new ItemService(db);
                 var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
 
-                toolService.AddTool(new ItemModel { ItemNumber = "T1", Brand = "BrandA" });
+                toolService.AddItem(new ItemModel { ItemNumber = "T1", Brand = "BrandA" });
                 await vm.LoadToolsAsync();
 
-                toolService.AddTool(new ItemModel { ItemNumber = "T2", Brand = "BrandB" });
+                toolService.AddItem(new ItemModel { ItemNumber = "T2", Brand = "BrandB" });
                 await vm.LoadToolsAsync();
 
                 Assert.Equal(2, vm.Tools.Count);
@@ -184,7 +184,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task AddTool_ShowsDialog_OnError()
+        public async Task AddItem_ShowsDialog_OnError()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -196,9 +196,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var dialog = new StubDialogService();
                 var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
                 vm.NewTool.ItemNumber = string.Empty;
-                await vm.NewToolCommand.ExecuteAsync(null);
+                await vm.NewItemCommand.ExecuteAsync(null);
                 Assert.True(dialog.InfoShown);
-                Assert.Empty(toolService.GetAllTools());
+                Assert.Empty(toolService.GetAllItems());
                 Assert.Equal(string.Empty, vm.NewTool.ItemNumber);
             }
             finally
@@ -212,17 +212,17 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             public bool InfoShown;
             public bool ConfirmationResult;
-            public Func<ItemModel, ItemModel?>? EditToolHandler;
+            public Func<ItemModel, ItemModel?>? EditItemHandler;
             public Action<ItemModel>? ViewDetailsHandler;
 
             public void ShowInfo(string message, string title) => InfoShown = true;
             public bool ShowConfirmation(string message, string title) => ConfirmationResult;
-            public ItemModel? ShowEditToolDialog(ItemModel tool) => EditToolHandler?.Invoke(tool);
-            public void ShowToolDetails(ItemModel tool) => ViewDetailsHandler?.Invoke(tool);
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditItemDialog(ItemModel item) => EditItemHandler?.Invoke(item);
+            public void ShowItemDetails(ItemModel item) => ViewDetailsHandler?.Invoke(item);
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
-            public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
+            public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
             public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
             public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
@@ -232,7 +232,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         [Theory]
         [InlineData(-1)]
         [InlineData(10001)]
-        public async Task AddToolCommand_ShowsDialog_OnInvalidQuantity(int quantity)
+        public async Task AddItemCommand_ShowsDialog_OnInvalidQuantity(int quantity)
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -246,9 +246,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 vm.NewTool.ItemNumber = "TN1";
                 vm.NewTool.NameDescription = "Hammer";
                 vm.NewTool.QuantityOnHand = quantity;
-                await vm.NewToolCommand.ExecuteAsync(null);
+                await vm.NewItemCommand.ExecuteAsync(null);
                 Assert.True(dialog.InfoShown);
-                Assert.Empty(toolService.GetAllTools());
+                Assert.Empty(toolService.GetAllItems());
                 Assert.Equal(quantity, vm.NewTool.QuantityOnHand);
             }
             finally
@@ -259,7 +259,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task NewToolCommand_PersistsNewToolValues()
+        public async Task NewItemCommand_PersistsNewToolValues()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -279,19 +279,19 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 vm.NewTool.Supplier = "ABC";
                 vm.NewTool.Notes = "Note";
                 vm.NewTool.IsPowerTool = true;
-                await vm.NewToolCommand.ExecuteAsync(null);
-                var tools = toolService.GetAllTools();
+                await vm.NewItemCommand.ExecuteAsync(null);
+                var tools = toolService.GetAllItems();
                 Assert.Single(tools);
-                var tool = tools.First();
-                Assert.Equal("TN1", tool.ItemNumber);
-                Assert.Equal("Hammer", tool.NameDescription);
-                Assert.Equal("PN1", tool.PartNumber);
-                Assert.Equal("BrandA", tool.Brand);
-                Assert.Equal("Shelf", tool.Location);
-                Assert.Equal(5, tool.QuantityOnHand);
-                Assert.Equal("ABC", tool.Supplier);
-                Assert.Equal("Note", tool.Notes);
-                Assert.True(tool.IsPowerTool);
+                var item = tools.First();
+                Assert.Equal("TN1", item.ItemNumber);
+                Assert.Equal("Hammer", item.NameDescription);
+                Assert.Equal("PN1", item.PartNumber);
+                Assert.Equal("BrandA", item.Brand);
+                Assert.Equal("Shelf", item.Location);
+                Assert.Equal(5, item.QuantityOnHand);
+                Assert.Equal("ABC", item.Supplier);
+                Assert.Equal("Note", item.Notes);
+                Assert.True(item.IsPowerTool);
             }
             finally
             {
@@ -301,7 +301,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task EditToolCommand_UpdatesExistingTool_WhenDialogReturnsTool()
+        public async Task EditItemCommand_UpdatesExistingTool_WhenDialogReturnsTool()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -312,17 +312,17 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
                 var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
-                var tool = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", ImagePath = "img1.png" };
-                toolService.AddTool(tool);
+                var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", ImagePath = "img1.png" };
+                toolService.AddItem(item);
                 await vm.LoadToolsAsync();
                 vm.SelectedItem = vm.Tools.First();
-                dialog.EditToolHandler = t =>
+                dialog.EditItemHandler = t =>
                 {
                     t.NameDescription = "Updated Hammer";
                     return t;
                 };
-                await vm.EditToolCommand.ExecuteAsync(null);
-                var updated = toolService.GetAllTools().First();
+                await vm.EditItemCommand.ExecuteAsync(null);
+                var updated = toolService.GetAllItems().First();
                 Assert.Equal("Updated Hammer", updated.NameDescription);
                 Assert.Equal("Updated Hammer", vm.Tools.First().NameDescription);
                 Assert.Equal("img1.png", updated.ImagePath);
@@ -336,7 +336,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task EditToolCommand_DoesNothing_WhenDialogReturnsNull()
+        public async Task EditItemCommand_DoesNothing_WhenDialogReturnsNull()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -347,13 +347,13 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
                 var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
-                var tool = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
-                toolService.AddTool(tool);
+                var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
+                toolService.AddItem(item);
                 await vm.LoadToolsAsync();
                 vm.SelectedItem = vm.Tools.First();
-                dialog.EditToolHandler = _ => null;
-                await vm.EditToolCommand.ExecuteAsync(null);
-                var unchanged = toolService.GetAllTools().First();
+                dialog.EditItemHandler = _ => null;
+                await vm.EditItemCommand.ExecuteAsync(null);
+                var unchanged = toolService.GetAllItems().First();
                 Assert.Equal("Hammer", unchanged.NameDescription);
             }
             finally
@@ -364,7 +364,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task DeleteToolCommand_RemovesTool()
+        public async Task DeleteItemCommand_RemovesTool()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -375,12 +375,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService { ConfirmationResult = true };
                 var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
-                var tool = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
-                toolService.AddTool(tool);
+                var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
+                toolService.AddItem(item);
                 await vm.LoadToolsAsync();
                 vm.SelectedItem = vm.Tools.First();
-                await vm.DeleteToolCommand.ExecuteAsync(null);
-                Assert.Empty(toolService.GetAllTools());
+                await vm.DeleteItemCommand.ExecuteAsync(null);
+                Assert.Empty(toolService.GetAllItems());
                 Assert.Empty(vm.Tools);
             }
             finally
@@ -391,7 +391,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task DeleteToolCommand_Cancelled_DoesNotRemoveTool()
+        public async Task DeleteItemCommand_Cancelled_DoesNotRemoveTool()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -402,12 +402,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService { ConfirmationResult = false };
                 var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
-                var tool = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
-                toolService.AddTool(tool);
+                var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
+                toolService.AddItem(item);
                 await vm.LoadToolsAsync();
                 vm.SelectedItem = vm.Tools.First();
-                await vm.DeleteToolCommand.ExecuteAsync(null);
-                Assert.Single(toolService.GetAllTools());
+                await vm.DeleteItemCommand.ExecuteAsync(null);
+                Assert.Single(toolService.GetAllItems());
                 Assert.Single(vm.Tools);
             }
             finally
@@ -418,22 +418,22 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task DeleteToolCommand_OnError_ShowsDialogAndLogs()
+        public async Task DeleteItemCommand_OnError_ShowsDialogAndLogs()
         {
             var toolService = new FailingItemService();
             var dialog = new StubDialogService { ConfirmationResult = true };
             var logger = new CapturingLogger<ItemManagementViewModel>();
             var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), dialog, logger);
-            var tool = new ItemModel { ItemID = 1, ItemNumber = "T1", NameDescription = "Hammer" };
-            vm.Tools.Add(tool);
-            vm.SelectedItem = tool;
+            var item = new ItemModel { ItemID = 1, ItemNumber = "T1", NameDescription = "Hammer" };
+            vm.Tools.Add(item);
+            vm.SelectedItem = item;
 
-            await vm.DeleteToolCommand.ExecuteAsync(null);
+            await vm.DeleteItemCommand.ExecuteAsync(null);
 
             Assert.True(dialog.InfoShown);
-            Assert.Equal("Failed to delete tool 1", logger.LastError);
+            Assert.Equal("Failed to delete item 1", logger.LastError);
             Assert.Single(vm.Tools);
-            Assert.Equal(tool, vm.SelectedItem);
+            Assert.Equal(item, vm.SelectedItem);
         }
 
         [Fact]
@@ -451,7 +451,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 Assert.False(vm.OpenRentalsCommand.CanExecute(null));
 
-                toolService.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
+                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
                 await vm.LoadToolsAsync();
                 vm.SelectedItem = vm.Tools.First();
 
@@ -476,8 +476,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
                 var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
-                var tool = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
-                toolService.AddTool(tool);
+                var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
+                toolService.AddItem(item);
                 await vm.LoadToolsAsync();
                 vm.SelectedItem = vm.Tools.First();
                 bool called = false;
@@ -509,7 +509,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 Assert.False(vm.ViewDetailsCommand.CanExecute(null));
 
-                toolService.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
+                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
                 await vm.LoadToolsAsync();
                 vm.SelectedItem = vm.Tools.First();
 
@@ -534,8 +534,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
             vm.SearchTerm = "Ham";
             await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
-            Assert.Equal(1, toolService.SearchToolsAsyncCalls);
-            Assert.Equal(0, toolService.GetAllToolsAsyncCalls);
+            Assert.Equal(1, toolService.SearchItemsAsyncCalls);
+            Assert.Equal(0, toolService.GetAllItemsAsyncCalls);
         }
 
         [Fact]
@@ -549,11 +549,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
 
             await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
-            Assert.Equal(1, toolService.GetAllToolsAsyncCalls);
-            Assert.Equal(0, toolService.SearchToolsAsyncCalls);
+            Assert.Equal(1, toolService.GetAllItemsAsyncCalls);
+            Assert.Equal(0, toolService.SearchItemsAsyncCalls);
 
             await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
-            Assert.Equal(1, toolService.GetAllToolsAsyncCalls);
+            Assert.Equal(1, toolService.GetAllItemsAsyncCalls);
         }
 
         [Fact]
@@ -571,11 +571,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
             vm.SearchText = "Ha";
             vm.SearchText = "Ham";
 
-            Assert.Equal(0, toolService.SearchToolsAsyncCalls);
+            Assert.Equal(0, toolService.SearchItemsAsyncCalls);
 
             timer.RaiseTick();
 
-            Assert.Equal(1, toolService.SearchToolsAsyncCalls);
+            Assert.Equal(1, toolService.SearchItemsAsyncCalls);
         }
 
         [Fact]
@@ -615,20 +615,20 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
         class CountingItemService : IItemService
         {
-            public int GetAllToolsAsyncCalls { get; private set; }
-            public int SearchToolsAsyncCalls { get; private set; }
+            public int GetAllItemsAsyncCalls { get; private set; }
+            public int SearchItemsAsyncCalls { get; private set; }
             readonly List<ItemModel> _tools;
             public CountingItemService(IEnumerable<ItemModel> tools) => _tools = tools.ToList();
 
-            public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default)
+            public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default)
             {
-                GetAllToolsAsyncCalls++;
+                GetAllItemsAsyncCalls++;
                 return Task.FromResult(_tools.ToList());
             }
 
-            public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default)
+            public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default)
             {
-                SearchToolsAsyncCalls++;
+                SearchItemsAsyncCalls++;
                 if (cancellationToken.IsCancellationRequested)
                     return Task.FromCanceled<List<ItemModel>>(cancellationToken);
                 if (string.IsNullOrWhiteSpace(searchText))
@@ -643,35 +643,35 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 return Task.FromResult(results);
             }
 
-            public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
-            public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
         }
 
         class FailingItemService : IItemService
         {
-            public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new Exception("failure");
-            public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-            public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-            public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-            public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
-            public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
-            public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new Exception("failure");
+            public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
+            public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
         }
 

--- a/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/LoginViewModelTests.cs
@@ -583,9 +583,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => true;
-       public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+       public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
@@ -672,9 +672,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
             LastMessage = message;
         }
         public bool ShowConfirmation(string message, string title) => true;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelAutoLogoutTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelAutoLogoutTests.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
@@ -78,9 +78,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             public void ShowInfo(string message, string title) { }
             public bool ShowConfirmation(string message, string title) => false;
-            public ToolManagementAppV2.Models.Domain.ItemModel? ShowEditToolDialog(ToolManagementAppV2.Models.Domain.ItemModel tool) => null;
-            public void ShowToolDetails(ToolManagementAppV2.Models.Domain.ItemModel tool) { }
-            public (ToolManagementAppV2.Models.Domain.CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolManagementAppV2.Models.Domain.ItemModel tool, System.Collections.Generic.IEnumerable<ToolManagementAppV2.Models.Domain.CustomerModel> customers) => null;
+            public ToolManagementAppV2.Models.Domain.ItemModel? ShowEditItemDialog(ToolManagementAppV2.Models.Domain.ItemModel tool) => null;
+            public void ShowItemDetails(ToolManagementAppV2.Models.Domain.ItemModel tool) { }
+            public (ToolManagementAppV2.Models.Domain.CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ToolManagementAppV2.Models.Domain.ItemModel tool, System.Collections.Generic.IEnumerable<ToolManagementAppV2.Models.Domain.CustomerModel> customers) => null;
             public ToolManagementAppV2.Models.Domain.CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ToolManagementAppV2.Models.Domain.ItemModel tool, System.Collections.Generic.IEnumerable<ToolManagementAppV2.Models.Domain.RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -3,7 +3,7 @@ using System.Windows;
 using System.Collections.Generic;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.ViewModels;
@@ -82,9 +82,9 @@ class StubDialogService : IDialogService
 {
     public void ShowInfo(string message, string title) { }
     public bool ShowConfirmation(string message, string title) => false;
-    public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-    public void ShowToolDetails(ItemModel tool) { }
-    public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+    public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+    public void ShowItemDetails(ItemModel tool) { }
+    public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
     public CustomerModel? ShowAddCustomerDialog() => null;
     public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
     public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelDisposalTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelDisposalTests.cs
@@ -10,7 +10,7 @@ using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Settings;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
@@ -94,9 +94,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
         {
             public void ShowInfo(string message, string title) { }
             public bool ShowConfirmation(string message, string title) => false;
-            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-            public void ShowToolDetails(ToolModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
+            public ToolModel? ShowEditItemDialog(ToolModel tool) => null;
+            public void ShowItemDetails(ToolModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ToolModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ToolModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelImportMappingTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelImportMappingTests.cs
@@ -9,7 +9,7 @@ using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Settings;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
@@ -58,9 +58,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
             public Dictionary<string,string>? MapToReturn { get; set; }
             public void ShowInfo(string message, string title) { }
             public bool ShowConfirmation(string message, string title) => false;
-            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-            public void ShowToolDetails(ItemModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+            public void ShowItemDetails(ItemModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.ViewModels;
@@ -286,8 +286,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                toolService.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
-                toolService.AddTool(new ItemModel { ItemNumber = "T2", NameDescription = "Saw" });
+                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
+                toolService.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Saw" });
 
                 var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
                 vm.GlobalSearchText = "Ham";
@@ -414,9 +414,9 @@ class StubDialogService : IDialogService
 
     public void ShowInfo(string message, string title) => InfoShown = true;
     public bool ShowConfirmation(string message, string title) => false;
-    public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-    public void ShowToolDetails(ToolModel tool) { }
-    public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+    public ToolModel? ShowEditItemDialog(ToolModel tool) => null;
+    public void ShowItemDetails(ToolModel tool) { }
+    public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
     public CustomerModel? ShowAddCustomerDialog() => null;
 
     public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => ImportMap;

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.ViewModels;
@@ -272,9 +272,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public bool InfoShown { get; private set; }
         public void ShowInfo(string message, string title) => InfoShown = true;
         public bool ShowConfirmation(string message, string title) => false;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelTests.cs
@@ -7,7 +7,7 @@ using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Settings;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
@@ -128,9 +128,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public bool ThrowOnShowPrintLabelDialog { get; set; }
         public void ShowInfo(string message, string title) => InfoShown = true;
         public bool ShowConfirmation(string message, string title) => false;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelTitleTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelTitleTests.cs
@@ -6,7 +6,7 @@ using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Settings;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Utilities.Helpers;

--- a/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ManageRentalsViewModelTests.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.ViewModels;
@@ -29,8 +29,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 var tool1 = new ItemModel { ItemNumber = "T1" };
                 var tool2 = new ItemModel { ItemNumber = "T2" };
-                toolService.AddTool(tool1);
-                toolService.AddTool(tool2);
+                toolService.AddItem(tool1);
+                toolService.AddItem(tool2);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
@@ -74,8 +74,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 var tool1 = new ItemModel { ItemNumber = "Alpha" };
                 var tool2 = new ItemModel { ItemNumber = "Beta" };
-                toolService.AddTool(tool1);
-                toolService.AddTool(tool2);
+                toolService.AddItem(tool1);
+                toolService.AddItem(tool2);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
@@ -111,7 +111,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var rentalService = new RentalService(db);
 
                 var tool = new ItemModel { ItemNumber = "T1" };
-                toolService.AddTool(tool);
+                toolService.AddItem(tool);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
@@ -168,7 +168,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var rentalService = new RentalService(db);
 
                 var tool = new ItemModel { ItemNumber = "T1" };
-                toolService.AddTool(tool);
+                toolService.AddItem(tool);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
@@ -204,7 +204,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var rentalService = new RentalService(db);
 
                 var tool = new ItemModel { ItemNumber = "T1" };
-                toolService.AddTool(tool);
+                toolService.AddItem(tool);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
@@ -238,7 +238,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var rentalService = new RentalService(db);
 
                 var tool = new ItemModel { ItemNumber = "T1" };
-                toolService.AddTool(tool);
+                toolService.AddItem(tool);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
@@ -417,9 +417,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
             return Task.CompletedTask;
         }
         public bool ShowConfirmation(string message, string title) => false;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
@@ -434,9 +434,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public string? LastInfoMessage { get; private set; }
         public void ShowInfo(string message, string title) => LastInfoMessage = message;
         public bool ShowConfirmation(string message, string title) => false;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -11,7 +11,7 @@ using ToolManagementAppV2.Models.ImportExport;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Rentals;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
@@ -210,9 +210,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public bool ShowImportMappingCalled { get; private set; }
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }
@@ -230,45 +230,45 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public bool ImportCalled { get; private set; }
         public bool ExportCalled { get; private set; }
-        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
+        public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
             ImportCalled = true;
             return Task.FromResult(new List<int>());
         }
-        public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default)
+        public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default)
         {
             ExportCalled = true;
             return Task.CompletedTask;
         }
-        public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, System.Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
-        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task AddItemAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task UpdateItemAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, System.Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 
     class FailItemService : IItemService
     {
-        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromException<List<int>>(new System.Exception("fail"));
-        public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.FromException(new System.Exception("fail"));
-        public Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, System.Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
-        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromException<List<int>>(new System.Exception("fail"));
+        public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.FromException(new System.Exception("fail"));
+        public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task AddItemAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task UpdateItemAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, System.Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 

--- a/ToolManagementAppV2.Tests/ViewModels/PasswordPromptViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/PasswordPromptViewModelTests.cs
@@ -84,9 +84,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
         public void ShowInfo(string message, string title) => InfoShown = true;
         public bool ShowConfirmation(string message, string title) => ConfirmationResult;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/ViewModels/PrintLabelViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/PrintLabelViewModelTests.cs
@@ -51,9 +51,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public bool InfoShown { get; private set; }
         public void ShowInfo(string message, string title) => InfoShown = true;
         public bool ShowConfirmation(string message, string title) => false;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/ViewModels/RentItemPopupViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/RentItemPopupViewModelTests.cs
@@ -6,14 +6,14 @@ using Xunit;
 
 namespace ToolManagementAppV2.Tests.ViewModels
 {
-    public class RentToolPopupViewModelTests
+    public class RentItemPopupViewModelTests
     {
         [Fact]
         public void CheckOutCommand_SetsResultsAndRaisesClose()
         {
-            var tool = new ItemModel();
+            var item = new ItemModel();
             var customer = new CustomerModel { CustomerID = 1, Company = "ACME" };
-            var vm = new RentToolPopupViewModel(tool, new[] { customer })
+            var vm = new RentItemPopupViewModel(item, new[] { customer })
             {
                 SelectedCustomer = customer,
                 SelectedDueDate = DateTime.Today.AddDays(3)

--- a/ToolManagementAppV2.Tests/ViewModels/RentalHistoryViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/RentalHistoryViewModelTests.cs
@@ -89,11 +89,11 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
             public bool ShowConfirmation(string message, string title) => true;
 
-            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
+            public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
 
-            public void ShowToolDetails(ItemModel tool) { }
+            public void ShowItemDetails(ItemModel tool) { }
 
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
 
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }

--- a/ToolManagementAppV2.Tests/ViewModels/ReportsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ReportsViewModelTests.cs
@@ -6,7 +6,7 @@ using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.ViewModels;
 using Xunit;
@@ -31,7 +31,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var reportService = new ReportService(toolService, rentalService, activityService, customerService, userService);
 
                 var tool = new ItemModel { ItemNumber = "T1", QuantityOnHand = 1 };
-                toolService.AddTool(tool);
+                toolService.AddItem(tool);
 
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);

--- a/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ScannerStatusViewModelTests.cs
@@ -105,9 +105,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public bool InfoShown;
         public void ShowInfo(string message, string title) => InfoShown = true;
         public bool ShowConfirmation(string message, string title) => false;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -308,9 +308,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
         
         public bool ShowConfirmation(string message, string title) => true;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
@@ -324,9 +324,9 @@ namespace ToolManagementAppV2.Tests.ViewModels
     {
         public void ShowInfo(string message, string title) => throw new InvalidOperationException("dialog failure");
         public bool ShowConfirmation(string message, string title) => false;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -482,7 +482,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public void RentToolPopupWindow_RequestCloseHandler_DoesNotLeak()
+        public void RentItemPopupWindow_RequestCloseHandler_DoesNotLeak()
         {
             WeakReference? winRef = null;
             bool? aliveBeforeUnsubscribe = null;
@@ -492,8 +492,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             {
                 try
                 {
-                    var vm = new RentToolPopupViewModel(new ItemModel(), new List<CustomerModel>());
-                    var win = new RentToolPopupWindow { DataContext = vm };
+                    var vm = new RentItemPopupViewModel(new ItemModel(), new List<CustomerModel>());
+                    var win = new RentItemPopupWindow { DataContext = vm };
                     var captured = win;
                     EventHandler handler = (_, _) => captured.Close();
                     vm.RequestClose += handler;
@@ -555,9 +555,9 @@ class StubDialogService : IDialogService
         LastInfoTitle = title;
     }
     public bool ShowConfirmation(string message, string title) => false;
-    public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-    public void ShowToolDetails(ItemModel tool) { }
-    public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+    public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+    public void ShowItemDetails(ItemModel tool) { }
+    public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
     public CustomerModel? ShowAddCustomerDialog() => null;
     public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
     public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
@@ -80,9 +80,9 @@ namespace ToolManagementAppV2.Tests.Views
         public bool ShowImportMappingCalled { get; private set; }
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }
@@ -99,23 +99,23 @@ namespace ToolManagementAppV2.Tests.Views
     class StubItemService : IItemService
     {
         public bool ImportCalled { get; private set; }
-        public Task<System.Collections.Generic.List<int>> ImportToolsFromCsvAsync(string filePath, System.Collections.Generic.IDictionary<string, string> map, CancellationToken cancellationToken)
+        public Task<System.Collections.Generic.List<int>> ImportItemsFromCsvAsync(string filePath, System.Collections.Generic.IDictionary<string, string> map, CancellationToken cancellationToken)
         {
             ImportCalled = true;
             return Task.FromResult(new System.Collections.Generic.List<int>());
         }
-        public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task<System.Collections.Generic.List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ItemModel>());
-        public Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<System.Collections.Generic.List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ItemModel>());
-        public Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<System.Collections.Generic.List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ItemModel>());
-        public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, System.Collections.Generic.IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
-        public Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<System.Collections.Generic.List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ItemModel>());
+        public Task AddItemAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemAsync(ItemModel tool, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<System.Collections.Generic.List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ItemModel>());
+        public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<System.Collections.Generic.List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ItemModel>());
+        public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, System.Collections.Generic.IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 

--- a/ToolManagementAppV2.Tests/Views/ItemSearchTypingTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ItemSearchTypingTests.cs
@@ -4,7 +4,7 @@ using System.Threading;
 using ToolManagementAppV2.Interfaces;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services.Core;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.ViewModels;
@@ -30,8 +30,8 @@ namespace ToolManagementAppV2.Tests.Views
                     var rentalService = new RentalService(db);
                     var dialog = new StubDialogService();
                     var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
-                    toolService.AddTool(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
-                    toolService.AddTool(new ItemModel { ItemNumber = "T2", NameDescription = "Hand Saw" });
+                    toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
+                    toolService.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Hand Saw" });
                     vm.LoadToolsAsync().Wait();
                     var page = new ItemSearchPage { DataContext = vm };
                     var window = new System.Windows.Window { Content = page, Width = 800, Height = 600 };
@@ -53,9 +53,9 @@ namespace ToolManagementAppV2.Tests.Views
         {
             public void ShowInfo(string message, string title) { }
             public bool ShowConfirmation(string message, string title) => false;
-            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-            public void ShowToolDetails(ItemModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+            public void ShowItemDetails(ItemModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
         }
     }

--- a/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
@@ -16,7 +16,7 @@ using CommunityToolkit.Mvvm.Input;
 using System.Threading.Tasks;
 using System.Windows;
 using ToolManagementAppV2.Models.Domain;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
@@ -422,9 +422,9 @@ namespace ToolManagementAppV2.Tests.Views
         {
             public void ShowInfo(string message, string title) { }
             public bool ShowConfirmation(string message, string title) => false;
-            public ToolModel? ShowEditToolDialog(ToolModel tool) => null;
-            public void ShowToolDetails(ToolModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
+            public ToolModel? ShowEditItemDialog(ToolModel tool) => null;
+            public void ShowItemDetails(ToolModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ToolModel tool, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ToolModel tool, IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/Views/PasswordPromptWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/PasswordPromptWindowTests.cs
@@ -86,9 +86,9 @@ namespace ToolManagementAppV2.Tests.Views
 
             public void ShowInfo(string message, string title) { }
             public bool ShowConfirmation(string message, string title) => ConfirmationResult;
-            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-            public void ShowToolDetails(ItemModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+            public void ShowItemDetails(ItemModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, System.Collections.Generic.IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/Views/RentalsFilterWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/RentalsFilterWindowTests.cs
@@ -84,9 +84,9 @@ namespace ToolManagementAppV2.Tests.Views
                 return Task.CompletedTask;
             }
             public bool ShowConfirmation(string message, string title) => false;
-            public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-            public void ShowToolDetails(ItemModel tool) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+            public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+            public void ShowItemDetails(ItemModel tool) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/UsersPageTests.cs
@@ -227,9 +227,9 @@ namespace ToolManagementAppV2.Tests.Views
     {
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ItemModel? ShowEditToolDialog(ItemModel tool) => null;
-        public void ShowToolDetails(ItemModel tool) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
+        public ItemModel? ShowEditItemDialog(ItemModel tool) => null;
+        public void ShowItemDetails(ItemModel tool) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel tool, IEnumerable<CustomerModel> customers) => null;
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ToolManagementAppV2.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel tool, System.Collections.Generic.IEnumerable<RentalModel> history) { }

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -15,7 +15,7 @@ using ToolManagementAppV2.Services;
 using ToolManagementAppV2.Services.Core;
 using ToolManagementAppV2.Services.Customers;
 using ToolManagementAppV2.Services.Rentals;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Settings;
 using ToolManagementAppV2.ViewModels;

--- a/ToolManagementAppV2/Interfaces/IDialogService.cs
+++ b/ToolManagementAppV2/Interfaces/IDialogService.cs
@@ -17,16 +17,16 @@ namespace ToolManagementAppV2.Interfaces
         Task<bool> ShowConfirmationAsync(string message, string title) =>
             System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowConfirmation(message, title)).Task
             ?? Task.FromResult(false);
-        ItemModel? ShowEditToolDialog(ItemModel tool);
-        Task<ItemModel?> ShowEditToolDialogAsync(ItemModel tool) =>
-            System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowEditToolDialog(tool)).Task
+        ItemModel? ShowEditItemDialog(ItemModel item);
+        Task<ItemModel?> ShowEditItemDialogAsync(ItemModel item) =>
+            System.Windows.Application.Current?.Dispatcher?.InvokeAsync(() => ShowEditItemDialog(item)).Task
             ?? Task.FromResult<ItemModel?>(null);
-        void ShowToolDetails(ItemModel tool);
-        (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers);
+        void ShowItemDetails(ItemModel item);
+        (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers);
         CustomerModel? ShowAddCustomerDialog();
 
         void ShowRentalsFilter(ManageRentalsViewModel viewModel);
-        void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history);
+        void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history);
         Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties);
         Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping();
         void ShowPrintPreview(FlowDocument document, string title, string description);

--- a/ToolManagementAppV2/Interfaces/IItemService.cs
+++ b/ToolManagementAppV2/Interfaces/IItemService.cs
@@ -10,20 +10,20 @@ namespace ToolManagementAppV2.Interfaces
 {
     public interface IItemService
     {
-        Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default);
-        Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default);
-        Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default);
-        Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default);
-        Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default);
-        Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default);
-        Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default);
-        Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default);
-        Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default);
-        Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken);
-        Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default);
-        Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default);
+        Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default);
+        Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default);
+        Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default);
+        Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default);
+        Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default);
+        Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default);
+        Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default);
+        Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default);
+        Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default);
+        Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken);
+        Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default);
+        Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default);
         Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default);
-        Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental,
+        Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental,
             SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default);
     }
 }

--- a/ToolManagementAppV2/Services/Core/CsvHelperUtil.cs
+++ b/ToolManagementAppV2/Services/Core/CsvHelperUtil.cs
@@ -84,7 +84,7 @@ namespace ToolManagementAppV2.Utilities.IO
             }, cancellationToken).ConfigureAwait(false);
         }
 
-        public static void ExportToolsToCsv(string filePath, List<ItemModel> tools)
+        public static void ExportItemsToCsv(string filePath, List<ItemModel> tools)
         {
             var lines = new List<string>
             {
@@ -105,7 +105,7 @@ namespace ToolManagementAppV2.Utilities.IO
             File.WriteAllLines(filePath, lines);
         }
 
-        public static async Task ExportToolsToCsvAsync(string filePath, List<ItemModel> tools)
+        public static async Task ExportItemsToCsvAsync(string filePath, List<ItemModel> tools)
         {
             var lines = new List<string>
             {

--- a/ToolManagementAppV2/Services/DialogService.cs
+++ b/ToolManagementAppV2/Services/DialogService.cs
@@ -57,43 +57,43 @@ namespace ToolManagementAppV2.Services
             return Task.FromResult(false);
         }
 
-        public ItemModel? ShowEditToolDialog(ItemModel tool)
+        public ItemModel? ShowEditItemDialog(ItemModel item)
         {
             ItemEditWindow? win = null;
             win = ActivatorUtilities.CreateInstance<ItemEditWindow>(_serviceProvider,
-                tool,
+                item,
                 (Action)(() => win!.DialogResult = true),
                 (Action)(() => win!.DialogResult = false));
             try { win.Owner = System.Windows.Application.Current?.MainWindow; }
             catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for ItemEditWindow"); }
-            try { return win.ShowDialog() == true ? tool : null; }
+            try { return win.ShowDialog() == true ? item : null; }
             catch (Exception ex) { _logger.LogError(ex, "Failed to show ItemEditWindow"); return null; }
         }
 
-        public Task<ItemModel?> ShowEditToolDialogAsync(ItemModel tool)
+        public Task<ItemModel?> ShowEditItemDialogAsync(ItemModel item)
         {
             var dispatcher = System.Windows.Application.Current?.Dispatcher;
             if (dispatcher != null)
-                return dispatcher.InvokeAsync(() => ShowEditToolDialog(tool)).Task;
+                return dispatcher.InvokeAsync(() => ShowEditItemDialog(item)).Task;
 
-            _logger.LogWarning("No dispatcher available for ShowEditToolDialogAsync; returning null.");
+            _logger.LogWarning("No dispatcher available for ShowEditItemDialogAsync; returning null.");
             return Task.FromResult<ItemModel?>(null);
         }
 
-        public void ShowToolDetails(ItemModel tool)
+        public void ShowItemDetails(ItemModel item)
         {
-            ToolDetailsWindow win = null!;
-            win = new ToolDetailsWindow(tool);
+            ItemDetailsWindow win = null!;
+            win = new ItemDetailsWindow(item);
             try { win.Owner = System.Windows.Application.Current?.MainWindow; }
-            catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for ToolDetailsWindow"); }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for ItemDetailsWindow"); }
             try { win.ShowDialog(); }
-            catch (Exception ex) { _logger.LogError(ex, "Failed to show ToolDetailsWindow"); }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to show ItemDetailsWindow"); }
         }
 
-        public (CustomerModel customer, DateTime dueDate)? ShowRentToolDialog(ItemModel tool, IEnumerable<CustomerModel> customers)
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers)
         {
-            var vm = new RentToolPopupViewModel(tool, customers);
-            var win = new RentToolPopupWindow { DataContext = vm };
+            var vm = new RentItemPopupViewModel(item, customers);
+            var win = new RentItemPopupWindow { DataContext = vm };
 
             EventHandler handler = null!;
             handler = (_, _) => win.Close();
@@ -138,10 +138,10 @@ namespace ToolManagementAppV2.Services
             catch (Exception ex) { _logger.LogError(ex, "Failed to show RentalsFilterWindow"); }
         }
 
-        public void ShowRentalHistory(ItemModel tool, IEnumerable<RentalModel> history)
+        public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history)
         {
-            var vm = new RentalHistoryViewModel(tool, history, this);
-            var win = new RentalHistoryWindow(vm) { Title = $"Rental History - {tool.ItemNumber}" };
+            var vm = new RentalHistoryViewModel(item, history, this);
+            var win = new RentalHistoryWindow(vm) { Title = $"Rental History - {item.ItemNumber}" };
             try { win.Owner = System.Windows.Application.Current?.MainWindow; }
             catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for RentalHistoryWindow"); }
             try { win.ShowDialog(); }

--- a/ToolManagementAppV2/Services/Items/ItemService.cs
+++ b/ToolManagementAppV2/Services/Items/ItemService.cs
@@ -17,13 +17,13 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ToolManagementAppV2.Services.Users;
 
-namespace ToolManagementAppV2.Services.Tools
+namespace ToolManagementAppV2.Services.Items
 {
     public class ItemService : IItemService
     {
         readonly DatabaseService _dbService;
-        const string AllToolsSql = "SELECT * FROM Tools";
-        const string UpsertToolCsv = @"
+        const string AllItemsSql = "SELECT * FROM Tools";
+        const string UpsertItemCsv = @"
             INSERT INTO Tools
               (ItemNumber, NameDescription, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity, RentedQuantity, ImagePath, IsCheckedOut, IsPowerTool)
             VALUES (@ItemNumber,@Desc,@Loc,@Brand,@PN,@Sup,@PD,@Notes,@Keywords,@Avail,@Rent,@Img,0,@Power);
@@ -51,85 +51,85 @@ namespace ToolManagementAppV2.Services.Tools
                 throw new ArgumentOutOfRangeException(nameof(ItemModel.QuantityOnHand), $"QuantityOnHand must be between 0 and {MaxQuantityOnHand}.");
         }
 
-        public async Task AddToolAsync(ItemModel tool, CancellationToken cancellationToken = default)
+        public async Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
-            await AddToolInternalAsync(tool, cancellationToken).ConfigureAwait(false);
+            await AddItemInternalAsync(item, cancellationToken).ConfigureAwait(false);
             if (_activityLog != null)
             {
                 var user = _context?.CurrentUser;
-                await _activityLog.LogActionAsync(user?.UserID ?? 0, user?.UserName ?? string.Empty, $"Added tool {tool.ItemNumber}", cancellationToken).ConfigureAwait(false);
+                await _activityLog.LogActionAsync(user?.UserID ?? 0, user?.UserName ?? string.Empty, $"Added item {item.ItemNumber}", cancellationToken).ConfigureAwait(false);
             }
         }
 
-        public async Task UpdateToolAsync(ItemModel tool, CancellationToken cancellationToken = default)
+        public async Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
-            await UpdateToolInternalAsync(tool, cancellationToken).ConfigureAwait(false);
+            await UpdateItemInternalAsync(item, cancellationToken).ConfigureAwait(false);
             if (_activityLog != null)
             {
                 var user = _context?.CurrentUser;
-                await _activityLog.LogActionAsync(user?.UserID ?? 0, user?.UserName ?? string.Empty, $"Updated tool {tool.ItemNumber}", cancellationToken).ConfigureAwait(false);
+                await _activityLog.LogActionAsync(user?.UserID ?? 0, user?.UserName ?? string.Empty, $"Updated item {item.ItemNumber}", cancellationToken).ConfigureAwait(false);
             }
         }
 
-        public async Task DeleteToolAsync(int toolID, CancellationToken cancellationToken = default)
+        public async Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
-            await DeleteToolInternalAsync(toolID, cancellationToken).ConfigureAwait(false);
+            await DeleteItemInternalAsync(itemID, cancellationToken).ConfigureAwait(false);
             if (_activityLog != null)
             {
                 var user = _context?.CurrentUser;
-                await _activityLog.LogActionAsync(user?.UserID ?? 0, user?.UserName ?? string.Empty, $"Deleted tool {toolID}", cancellationToken).ConfigureAwait(false);
+                await _activityLog.LogActionAsync(user?.UserID ?? 0, user?.UserName ?? string.Empty, $"Deleted item {itemID}", cancellationToken).ConfigureAwait(false);
             }
         }
 
-        public async Task<bool> ToggleToolCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default)
+        public async Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
-            var result = await ToggleToolCheckOutStatusInternalAsync(toolID, currentUser, cancellationToken).ConfigureAwait(false);
+            var result = await ToggleItemCheckOutStatusInternalAsync(itemID, currentUser, cancellationToken).ConfigureAwait(false);
             if (result && _activityLog != null)
             {
                 int userId = _context?.CurrentUser?.UserID ?? 0;
-                await _activityLog.LogActionAsync(userId, currentUser, $"Toggled tool {toolID} check-out status", cancellationToken).ConfigureAwait(false);
+                await _activityLog.LogActionAsync(userId, currentUser, $"Toggled item {itemID} check-out status", cancellationToken).ConfigureAwait(false);
             }
             return result;
         }
 
-        public Task<List<ItemModel>> GetToolsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default)
+        public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default)
         {
             using var conn = _dbService.CreateConnection();
             return SqliteHelper.ExecuteReaderAsync(conn,
                 "SELECT * FROM Tools WHERE CheckedOutBy=@User AND IsCheckedOut=1",
-                new[] { new SQLiteParameter("@User", userName) }, MapTool, cancellationToken);
+                new[] { new SQLiteParameter("@User", userName) }, MapItem, cancellationToken);
         }
 
-        public Task UpdateToolImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default)
+        public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
             const string sql = "UPDATE Tools SET ImagePath=@Img WHERE ItemID=@ID";
             var p = new[]
             {
                 new SQLiteParameter("@Img", imagePath),
-                new SQLiteParameter("@ID", toolID)
+                new SQLiteParameter("@ID", itemID)
             };
             using var conn = _dbService.CreateConnection();
             return SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);
         }
 
-        public Task<List<int>> ImportToolsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
+        public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
             _auth.EnsureAdmin();
-            return ImportToolsFromCsvInternalAsync(filePath, map, cancellationToken);
+            return ImportItemsFromCsvInternalAsync(filePath, map, cancellationToken);
         }
 
-        public Task ExportToolsToCsvAsync(string filePath, CancellationToken cancellationToken = default)
-            => ExportToolsToCsvInternalAsync(filePath, cancellationToken);
+        public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default)
+            => ExportItemsToCsvInternalAsync(filePath, cancellationToken);
 
-        public Task<ImageImportResult> ImportToolImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default)
+        public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
-            return ImportToolImagesInternalAsync(folderPath, keySelector, progress, cancellationToken);
+            return ImportItemImagesInternalAsync(folderPath, keySelector, progress, cancellationToken);
         }
 
         public async Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default)
@@ -141,45 +141,45 @@ namespace ToolManagementAppV2.Services.Tools
             return $"T{max + 1}";
         }
 
-        async Task InsertToolAsync(SQLiteConnection conn, SQLiteTransaction? tran, ItemModel tool, CancellationToken cancellationToken)
+        async Task InsertItemAsync(SQLiteConnection conn, SQLiteTransaction? tran, ItemModel item, CancellationToken cancellationToken)
         {
-            ValidateQuantity(tool.QuantityOnHand);
+            ValidateQuantity(item.QuantityOnHand);
             var p = new[]
             {
-                new SQLiteParameter("@ItemNumber", tool.ItemNumber),
-                new SQLiteParameter("@Desc", (object)tool.NameDescription ?? DBNull.Value),
-                new SQLiteParameter("@Loc", tool.Location),
-                new SQLiteParameter("@Brand", tool.Brand),
-                new SQLiteParameter("@PN", tool.PartNumber),
-                new SQLiteParameter("@Sup", (object)tool.Supplier ?? DBNull.Value),
-                new SQLiteParameter("@PD", (object)tool.PurchasedDate ?? DBNull.Value),
-                new SQLiteParameter("@Notes", (object)tool.Notes ?? DBNull.Value),
-                new SQLiteParameter("@Keywords", (object)tool.Keywords ?? DBNull.Value),
-                new SQLiteParameter("@Avail", tool.QuantityOnHand),
-                new SQLiteParameter("@Rent", tool.RentedQuantity),
-                new SQLiteParameter("@Img", (object)tool.ImagePath ?? DBNull.Value),
-                new SQLiteParameter("@Power", tool.IsPowerTool ? 1 : 0)
+                new SQLiteParameter("@ItemNumber", item.ItemNumber),
+                new SQLiteParameter("@Desc", (object)item.NameDescription ?? DBNull.Value),
+                new SQLiteParameter("@Loc", item.Location),
+                new SQLiteParameter("@Brand", item.Brand),
+                new SQLiteParameter("@PN", item.PartNumber),
+                new SQLiteParameter("@Sup", (object)item.Supplier ?? DBNull.Value),
+                new SQLiteParameter("@PD", (object)item.PurchasedDate ?? DBNull.Value),
+                new SQLiteParameter("@Notes", (object)item.Notes ?? DBNull.Value),
+                new SQLiteParameter("@Keywords", (object)item.Keywords ?? DBNull.Value),
+                new SQLiteParameter("@Avail", item.QuantityOnHand),
+                new SQLiteParameter("@Rent", item.RentedQuantity),
+                new SQLiteParameter("@Img", (object)item.ImagePath ?? DBNull.Value),
+                new SQLiteParameter("@Power", item.IsPowerTool ? 1 : 0)
             };
-            using var cmd = new SQLiteCommand(UpsertToolCsv, conn, tran);
+            using var cmd = new SQLiteCommand(UpsertItemCsv, conn, tran);
             cmd.Parameters.AddRange(p);
             var result = await cmd.ExecuteScalarAsync(cancellationToken);
             if (result != null)
-                tool.ItemID = Convert.ToInt32(result);
+                item.ItemID = Convert.ToInt32(result);
         }
     
-        private async Task<ImageImportResult> ImportToolImagesInternalAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress, CancellationToken cancellationToken)
+        private async Task<ImageImportResult> ImportItemImagesInternalAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress, CancellationToken cancellationToken)
         {
             var result = new ImageImportResult();
             if (string.IsNullOrWhiteSpace(folderPath) || keySelector == null)
                 return result;
 
             cancellationToken.ThrowIfCancellationRequested();
-            var tools = await GetAllToolsAsync(cancellationToken);
+            var tools = await GetAllItemsAsync(cancellationToken);
             var groups = new Dictionary<string, List<ItemModel>>(StringComparer.OrdinalIgnoreCase);
-            foreach (var tool in tools)
+            foreach (var item in tools)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var keys = keySelector(tool);
+                var keys = keySelector(item);
                 if (keys == null) continue;
                 foreach (var key in keys)
                 {
@@ -188,7 +188,7 @@ namespace ToolManagementAppV2.Services.Tools
                         continue;
                     if (!groups.TryGetValue(k, out var list))
                         groups[k] = list = new List<ItemModel>();
-                    list.Add(tool);
+                    list.Add(item);
                 }
             }
 
@@ -229,8 +229,8 @@ namespace ToolManagementAppV2.Services.Tools
                     result.ConflictingFiles.Add(file);
                     continue;
                 }
-                var tool = list[0];
-                if (!string.IsNullOrEmpty(tool.ImagePath))
+                var item = list[0];
+                if (!string.IsNullOrEmpty(item.ImagePath))
                 {
                     result.ConflictingFiles.Add(file);
                     continue;
@@ -250,7 +250,7 @@ namespace ToolManagementAppV2.Services.Tools
                     }
                 }
                 var relative = $"Images/{Path.GetFileName(dest)}";
-                await UpdateToolImageAsync(tool.ItemID, relative, cancellationToken);
+                await UpdateItemImageAsync(item.ItemID, relative, cancellationToken);
                 result.ImportedCount++;
                 processed++;
                 progress?.Report(new ImageImportProgress { Processed = processed, Total = total });
@@ -266,7 +266,7 @@ namespace ToolManagementAppV2.Services.Tools
             await source.CopyToAsync(destination, cancellationToken);
         }
 
-        private async Task<bool> ToolExistsAsync(string toolNumber, int? exceptId = null, CancellationToken cancellationToken = default)
+        private async Task<bool> ItemExistsAsync(string toolNumber, int? exceptId = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(toolNumber))
                 return false;
@@ -288,7 +288,7 @@ namespace ToolManagementAppV2.Services.Tools
             return count > 0;
         }
     
-        ItemModel MapTool(IDataRecord r) => new()
+        ItemModel MapItem(IDataRecord r) => new()
         {
             ItemID = r["ItemID"] is DBNull ? 0 : Convert.ToInt32(r["ItemID"]),
             ItemNumber = r["ItemNumber"].ToString(),
@@ -313,23 +313,23 @@ namespace ToolManagementAppV2.Services.Tools
             IsPowerTool = (r["IsPowerTool"] is DBNull ? 0 : Convert.ToInt32(r["IsPowerTool"])) == 1
         };
 
-        private async Task AddToolInternalAsync(ItemModel tool, CancellationToken cancellationToken)
+        private async Task AddItemInternalAsync(ItemModel item, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrWhiteSpace(tool?.ItemNumber))
-                tool.ItemNumber = await GenerateNextItemNumberAsync(cancellationToken);
-            if (await ToolExistsAsync(tool.ItemNumber, null, cancellationToken))
-                throw new InvalidOperationException($"ItemModel {tool.ItemNumber} already exists.");
-            ValidateQuantity(tool.QuantityOnHand);
+            if (string.IsNullOrWhiteSpace(item?.ItemNumber))
+                item.ItemNumber = await GenerateNextItemNumberAsync(cancellationToken);
+            if (await ItemExistsAsync(item.ItemNumber, null, cancellationToken))
+                throw new InvalidOperationException($"ItemModel {item.ItemNumber} already exists.");
+            ValidateQuantity(item.QuantityOnHand);
             using var conn = _dbService.CreateConnection();
-            await InsertToolAsync(conn, null, tool, cancellationToken);
+            await InsertItemAsync(conn, null, item, cancellationToken);
         }
 
-        private async Task UpdateToolInternalAsync(ItemModel tool, CancellationToken cancellationToken)
+        private async Task UpdateItemInternalAsync(ItemModel item, CancellationToken cancellationToken)
         {
-            if (await ToolExistsAsync(tool.ItemNumber, tool.ItemID, cancellationToken))
-                throw new InvalidOperationException($"ItemModel {tool.ItemNumber} already exists.");
+            if (await ItemExistsAsync(item.ItemNumber, item.ItemID, cancellationToken))
+                throw new InvalidOperationException($"ItemModel {item.ItemNumber} already exists.");
             using var conn = _dbService.CreateConnection();
-            ValidateQuantity(tool.QuantityOnHand);
+            ValidateQuantity(item.QuantityOnHand);
             const string sql = @"
                 UPDATE Tools SET
                   ItemNumber = @ItemNumber,
@@ -351,23 +351,23 @@ namespace ToolManagementAppV2.Services.Tools
                 WHERE ItemID = @ID";
             var p = new[]
             {
-                new SQLiteParameter("@ID", tool.ItemID),
-                new SQLiteParameter("@ItemNumber", tool.ItemNumber),
-                new SQLiteParameter("@Desc", (object)tool.NameDescription ?? DBNull.Value),
-                new SQLiteParameter("@Loc", tool.Location),
-                new SQLiteParameter("@Brand", tool.Brand),
-                new SQLiteParameter("@PN", tool.PartNumber),
-                new SQLiteParameter("@Sup", (object)tool.Supplier ?? DBNull.Value),
-                new SQLiteParameter("@PD", (object)tool.PurchasedDate ?? DBNull.Value),
-                new SQLiteParameter("@Notes", (object)tool.Notes ?? DBNull.Value),
-                new SQLiteParameter("@Keywords", (object)tool.Keywords ?? DBNull.Value),
-                new SQLiteParameter("@Avail", tool.QuantityOnHand),
-                new SQLiteParameter("@Rent", tool.RentedQuantity),
-                new SQLiteParameter("@Power", tool.IsPowerTool ? 1 : 0),
-                new SQLiteParameter("@Out", tool.IsCheckedOut ? 1 : 0),
-                new SQLiteParameter("@By", (object)tool.CheckedOutBy ?? DBNull.Value),
-                new SQLiteParameter("@Time", (object)tool.CheckedOutTime ?? DBNull.Value),
-                new SQLiteParameter("@Img", (object)tool.ImagePath ?? DBNull.Value)
+                new SQLiteParameter("@ID", item.ItemID),
+                new SQLiteParameter("@ItemNumber", item.ItemNumber),
+                new SQLiteParameter("@Desc", (object)item.NameDescription ?? DBNull.Value),
+                new SQLiteParameter("@Loc", item.Location),
+                new SQLiteParameter("@Brand", item.Brand),
+                new SQLiteParameter("@PN", item.PartNumber),
+                new SQLiteParameter("@Sup", (object)item.Supplier ?? DBNull.Value),
+                new SQLiteParameter("@PD", (object)item.PurchasedDate ?? DBNull.Value),
+                new SQLiteParameter("@Notes", (object)item.Notes ?? DBNull.Value),
+                new SQLiteParameter("@Keywords", (object)item.Keywords ?? DBNull.Value),
+                new SQLiteParameter("@Avail", item.QuantityOnHand),
+                new SQLiteParameter("@Rent", item.RentedQuantity),
+                new SQLiteParameter("@Power", item.IsPowerTool ? 1 : 0),
+                new SQLiteParameter("@Out", item.IsCheckedOut ? 1 : 0),
+                new SQLiteParameter("@By", (object)item.CheckedOutBy ?? DBNull.Value),
+                new SQLiteParameter("@Time", (object)item.CheckedOutTime ?? DBNull.Value),
+                new SQLiteParameter("@Img", (object)item.ImagePath ?? DBNull.Value)
             };
             try
             {
@@ -375,47 +375,47 @@ namespace ToolManagementAppV2.Services.Tools
             }
             catch (SQLiteException ex)
             {
-                _logger.LogError(ex, "Failed to update tool {ItemID}", tool.ItemID);
-                throw new InvalidOperationException($"Failed to update tool {tool.ItemID}.", ex);
+                _logger.LogError(ex, "Failed to update item {ItemID}", item.ItemID);
+                throw new InvalidOperationException($"Failed to update item {item.ItemID}.", ex);
             }
         }
 
-        private async Task DeleteToolInternalAsync(int toolID, CancellationToken cancellationToken)
+        private async Task DeleteItemInternalAsync(int itemID, CancellationToken cancellationToken)
         {
             using var conn = _dbService.CreateConnection();
             try
             {
                 await SqliteHelper.ExecuteNonQueryAsync(conn, "DELETE FROM Tools WHERE ItemID=@ID",
-                    new[] { new SQLiteParameter("@ID", toolID) }, cancellationToken);
+                    new[] { new SQLiteParameter("@ID", itemID) }, cancellationToken);
             }
             catch (SQLiteException ex)
             {
-                _logger.LogError(ex, "Failed to delete tool {ItemID}", toolID);
-                throw new InvalidOperationException($"Failed to delete tool {toolID}.", ex);
+                _logger.LogError(ex, "Failed to delete item {ItemID}", itemID);
+                throw new InvalidOperationException($"Failed to delete item {itemID}.", ex);
             }
         }
 
-        public async Task<ItemModel?> GetToolByIDAsync(int toolID, CancellationToken cancellationToken = default)
+        public async Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default)
         {
             using var conn = _dbService.CreateConnection();
             var list = await SqliteHelper.ExecuteReaderAsync(conn, "SELECT * FROM Tools WHERE ItemID=@ItemID",
-                new[] { new SQLiteParameter("@ItemID", toolID) }, MapTool, cancellationToken);
+                new[] { new SQLiteParameter("@ItemID", itemID) }, MapItem, cancellationToken);
             return list.FirstOrDefault();
         }
 
-        public async Task<List<ItemModel>> GetAllToolsAsync(CancellationToken cancellationToken = default)
+        public async Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default)
         {
             using var conn = _dbService.CreateConnection();
-            return await SqliteHelper.ExecuteReaderAsync(conn, AllToolsSql, null, MapTool, cancellationToken);
+            return await SqliteHelper.ExecuteReaderAsync(conn, AllItemsSql, null, MapItem, cancellationToken);
         }
 
-        public async Task<List<ItemModel>> SearchToolsAsync(string? searchText, CancellationToken cancellationToken = default)
+        public async Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (string.IsNullOrWhiteSpace(searchText))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                return await GetAllToolsAsync(cancellationToken);
+                return await GetAllItemsAsync(cancellationToken);
             }
 
             using var conn = _dbService.CreateConnection();
@@ -452,19 +452,19 @@ namespace ToolManagementAppV2.Services.Tools
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            return await SqliteHelper.ExecuteReaderAsync(conn, sb.ToString(), parameters.ToArray(), MapTool, cancellationToken);
+            return await SqliteHelper.ExecuteReaderAsync(conn, sb.ToString(), parameters.ToArray(), MapItem, cancellationToken);
         }
 
-        private async Task<bool> ToggleToolCheckOutStatusInternalAsync(int toolID, string currentUser, CancellationToken cancellationToken)
+        private async Task<bool> ToggleItemCheckOutStatusInternalAsync(int itemID, string currentUser, CancellationToken cancellationToken)
         {
             using var conn = _dbService.CreateConnection();
             var record = (await SqliteHelper.ExecuteReaderAsync(conn,
                 "SELECT IsCheckedOut, AvailableQuantity FROM Tools WHERE ItemID=@ID",
-                new[] { new SQLiteParameter("@ID", toolID) },
+                new[] { new SQLiteParameter("@ID", itemID) },
                 r => new { Out = Convert.ToInt32(r["IsCheckedOut"]) == 1, Qty = Convert.ToInt32(r["AvailableQuantity"]) }, cancellationToken)).FirstOrDefault();
 
             if (record == null)
-                throw new InvalidOperationException($"ItemModel {toolID} not found.");
+                throw new InvalidOperationException($"ItemModel {itemID} not found.");
 
             if (!record.Out && record.Qty <= 0)
                 return false;
@@ -486,7 +486,7 @@ namespace ToolManagementAppV2.Services.Tools
                 new SQLiteParameter("@By", by),
                 new SQLiteParameter("@Time", time),
                 new SQLiteParameter("@Q", qtyChange),
-                new SQLiteParameter("@ID", toolID)
+                new SQLiteParameter("@ID", itemID)
             }, cancellationToken);
 
             if (rows == 0)
@@ -495,7 +495,7 @@ namespace ToolManagementAppV2.Services.Tools
             return true;
         }
 
-        private async Task<List<int>> ImportToolsFromCsvInternalAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
+        private async Task<List<int>> ImportItemsFromCsvInternalAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
             var (tools, invalidRows) = await CsvHelperUtil.LoadToolsFromCsvAsync(filePath, map, cancellationToken);
             using var conn = _dbService.CreateConnection();
@@ -507,14 +507,14 @@ namespace ToolManagementAppV2.Services.Tools
             using var tran = conn.BeginTransaction();
             try
             {
-                foreach (var tool in tools)
+                foreach (var item in tools)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    if (string.IsNullOrWhiteSpace(tool.ItemNumber) ||
-                        existingNumbers.Contains(tool.ItemNumber))
+                    if (string.IsNullOrWhiteSpace(item.ItemNumber) ||
+                        existingNumbers.Contains(item.ItemNumber))
                         continue;
-                    await InsertToolAsync(conn, tran, tool, cancellationToken);
-                    existingNumbers.Add(tool.ItemNumber);
+                    await InsertItemAsync(conn, tran, item, cancellationToken);
+                    existingNumbers.Add(item.ItemNumber);
                 }
                 tran.Commit();
                 return invalidRows;
@@ -527,13 +527,13 @@ namespace ToolManagementAppV2.Services.Tools
             }
         }
 
-        private async Task ExportToolsToCsvInternalAsync(string filePath, CancellationToken cancellationToken)
+        private async Task ExportItemsToCsvInternalAsync(string filePath, CancellationToken cancellationToken)
         {
-            var tools = await GetAllToolsAsync(cancellationToken);
-            await CsvHelperUtil.ExportToolsToCsvAsync(filePath, tools);
+            var tools = await GetAllItemsAsync(cancellationToken);
+            await CsvHelperUtil.ExportItemsToCsvAsync(filePath, tools);
         }
 
-        public async Task UpdateToolQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default)
+        public async Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default)
         {
             if (qtyChange <= 0) throw new ArgumentException("Quantity change must be positive.", nameof(qtyChange));
             var sql = isRental
@@ -541,7 +541,7 @@ namespace ToolManagementAppV2.Services.Tools
                 : @"UPDATE Tools SET AvailableQuantity = AvailableQuantity + @Q, RentedQuantity = RentedQuantity - @Q WHERE ItemID = @ID AND RentedQuantity >= @Q";
             var p = new[]
             {
-                new SQLiteParameter("@ID", toolID),
+                new SQLiteParameter("@ID", itemID),
                 new SQLiteParameter("@Q", qtyChange)
             };
 
@@ -552,7 +552,7 @@ namespace ToolManagementAppV2.Services.Tools
                     : await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);
                 if (rows == 0)
                 {
-                    _logger.LogWarning("Quantity update affected 0 rows for ItemID {ItemID}", toolID);
+                    _logger.LogWarning("Quantity update affected 0 rows for ItemID {ItemID}", itemID);
                     throw new InvalidOperationException("Quantity update failed.");
                 }
             }
@@ -562,7 +562,7 @@ namespace ToolManagementAppV2.Services.Tools
                 int rows = await SqliteHelper.ExecuteNonQueryAsync(c, sql, p, cancellationToken);
                 if (rows == 0)
                 {
-                    _logger.LogWarning("Quantity update affected 0 rows for ItemID {ItemID}", toolID);
+                    _logger.LogWarning("Quantity update affected 0 rows for ItemID {ItemID}", itemID);
                     throw new InvalidOperationException("Quantity update failed.");
                 }
             }

--- a/ToolManagementAppV2/Services/Items/ReportService.cs
+++ b/ToolManagementAppV2/Services/Items/ReportService.cs
@@ -11,24 +11,24 @@ using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Interfaces;
 
-namespace ToolManagementAppV2.Services.Tools
+namespace ToolManagementAppV2.Services.Items
 {
     public class ReportService
     {
-        readonly IItemService _toolService;
+        readonly IItemService _itemService;
         readonly IRentalService _rentalService;
         readonly ActivityLogService _activityLogService;
         readonly ICustomerService _customerService;
         readonly IUserService _userService;
 
         public ReportService(
-            IItemService toolService,
+            IItemService itemService,
             IRentalService rentalService,
             ActivityLogService activityLogService,
             ICustomerService customerService,
             IUserService userService)
         {
-            _toolService = toolService;
+            _itemService = itemService;
             _rentalService = rentalService;
             _activityLogService = activityLogService;
             _customerService = customerService;
@@ -37,8 +37,8 @@ namespace ToolManagementAppV2.Services.Tools
 
         public async Task<FlowDocument> GenerateInventoryReport()
         {
-            var tools = await _toolService.GetAllToolsAsync().ConfigureAwait(false);
-            var lines = tools.Select(t =>
+            var items = await _itemService.GetAllItemsAsync().ConfigureAwait(false);
+            var lines = items.Select(t =>
                 $"ItemModel ID: {t.ItemID} | ItemNumber: {t.ItemNumber} | Qty: {t.QuantityOnHand} | Location: {t.Location} | Supplier: {t.Supplier}");
             return BuildReport("ItemModel Inventory Report", lines);
         }
@@ -84,20 +84,20 @@ namespace ToolManagementAppV2.Services.Tools
 
         public async Task<FlowDocument> GenerateSummaryReport()
         {
-            var totalToolsTask = _toolService.GetAllToolsAsync();
+            var totalItemsTask = _itemService.GetAllItemsAsync();
             var totalRentalsTask = _rentalService.GetAllRentalsAsync();
             var totalActiveRentalsTask = _rentalService.GetActiveRentalsAsync();
             var totalCustomersTask = _customerService.GetAllCustomersAsync();
             var totalUsersTask = _userService.GetAllUsersAsync();
 
             await Task.WhenAll(
-                totalToolsTask,
+                totalItemsTask,
                 totalRentalsTask,
                 totalActiveRentalsTask,
                 totalCustomersTask,
                 totalUsersTask).ConfigureAwait(false);
 
-            var totalTools = await totalToolsTask.ConfigureAwait(false);
+            var totalItems = await totalItemsTask.ConfigureAwait(false);
             var totalRentals = await totalRentalsTask.ConfigureAwait(false);
             var totalActiveRentals = await totalActiveRentalsTask.ConfigureAwait(false);
             var totalCustomers = await totalCustomersTask.ConfigureAwait(false);
@@ -105,7 +105,7 @@ namespace ToolManagementAppV2.Services.Tools
 
             var lines = new[]
             {
-                $"Total Tools: {totalTools.Count}",
+                $"Total Items: {totalItems.Count}",
                 $"Total Rentals (History): {totalRentals.Count}",
                 $"Active Rentals: {totalActiveRentals.Count}",
                 $"Total Customers: {totalCustomers.Count}",

--- a/ToolManagementAppV2/Services/Rentals/RentalService.cs
+++ b/ToolManagementAppV2/Services/Rentals/RentalService.cs
@@ -17,17 +17,17 @@ namespace ToolManagementAppV2.Services.Rentals
     public class RentalService : IRentalService
     {
         private readonly DatabaseService _dbService;
-        private readonly IItemService? _toolService;
+        private readonly IItemService? _itemService;
         private readonly ILogger<RentalService> _logger;
         private readonly IAuthorizationService _auth;
         private readonly ActivityLogService? _activityLog;
         private readonly IUserContext? _context;
 
-        public RentalService(DatabaseService dbService, IAuthorizationService? authorizationService = null, IItemService? toolService = null, ILogger<RentalService>? logger = null, ActivityLogService? activityLogService = null, IUserContext? userContext = null)
+        public RentalService(DatabaseService dbService, IAuthorizationService? authorizationService = null, IItemService? itemService = null, ILogger<RentalService>? logger = null, ActivityLogService? activityLogService = null, IUserContext? userContext = null)
         {
             _dbService = dbService ?? throw new ArgumentNullException(nameof(dbService));
             _auth = authorizationService ?? new NoOpAuthorizationService();
-            _toolService = toolService; // may be null if inventory sync not desired
+            _itemService = itemService; // may be null if inventory sync not desired
             _logger = logger ?? NullLogger<RentalService>.Instance;
             _activityLog = activityLogService;
             _context = userContext;
@@ -113,8 +113,8 @@ namespace ToolManagementAppV2.Services.Rentals
                         new SQLiteParameter("@DueDate", dueDate)
                     });
 
-                if (_toolService != null)
-                    await _toolService.UpdateToolQuantitiesAsync(toolID, 1, true, conn, tx);
+                if (_itemService != null)
+                    await _itemService.UpdateItemQuantitiesAsync(toolID, 1, true, conn, tx);
             });
             if (_activityLog != null)
             {
@@ -143,8 +143,8 @@ namespace ToolManagementAppV2.Services.Rentals
                         new SQLiteParameter("@RentalID", rentalID)
                     });
 
-                if (_toolService != null)
-                    await _toolService.UpdateToolQuantitiesAsync(toolID, 1, false, conn, tx);
+                if (_itemService != null)
+                    await _itemService.UpdateItemQuantitiesAsync(toolID, 1, false, conn, tx);
             });
             if (_activityLog != null)
             {
@@ -177,12 +177,12 @@ namespace ToolManagementAppV2.Services.Rentals
                 if (await updateCmd.ExecuteNonQueryAsync() == 0)
                     throw new InvalidOperationException("Unable to extend rental. Rental not found or already returned.");
 
-                if (_toolService != null)
+                if (_itemService != null)
                 {
                     if (oldDueDate <= DateTime.Today && newDueDate > DateTime.Today)
-                        await _toolService.UpdateToolQuantitiesAsync(toolID, 1, true, conn, tx);
+                        await _itemService.UpdateItemQuantitiesAsync(toolID, 1, true, conn, tx);
                     else if (oldDueDate > DateTime.Today && newDueDate <= DateTime.Today)
-                        await _toolService.UpdateToolQuantitiesAsync(toolID, 1, false, conn, tx);
+                        await _itemService.UpdateItemQuantitiesAsync(toolID, 1, false, conn, tx);
                 }
             });
             if (_activityLog != null)

--- a/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/DashboardViewModel.cs
@@ -16,7 +16,7 @@ namespace ToolManagementAppV2.ViewModels
 {
     public class DashboardViewModel : ObservableObject
     {
-        readonly IItemService _toolService;
+        readonly IItemService _itemService;
         readonly IRentalService _rentalService;
         readonly ICustomerService _customerService;
         readonly IUserService _userService;
@@ -29,11 +29,11 @@ namespace ToolManagementAppV2.ViewModels
         public ObservableCollection<StatCard> StatCards { get; } = new();
         public ObservableCollection<ActivityLog> RecentActivity { get; } = new();
 
-        public IRelayCommand NewToolCommand { get; }
+        public IRelayCommand NewItemCommand { get; }
         public IRelayCommand OpenRentalsCommand { get; }
         public IRelayCommand OpenImportExportCommand { get; }
 
-        public DashboardViewModel(IItemService toolService,
+        public DashboardViewModel(IItemService itemService,
                                   IRentalService rentalService,
                                   ICustomerService customerService,
                                   IUserService userService,
@@ -43,7 +43,7 @@ namespace ToolManagementAppV2.ViewModels
                                   IRelayCommand openImportExportCommand,
                                   ILogger<DashboardViewModel>? logger = null)
         {
-            _toolService = toolService ?? throw new ArgumentNullException(nameof(toolService));
+            _itemService = itemService ?? throw new ArgumentNullException(nameof(itemService));
             _rentalService = rentalService ?? throw new ArgumentNullException(nameof(rentalService));
             _customerService = customerService ?? throw new ArgumentNullException(nameof(customerService));
             _userService = userService ?? throw new ArgumentNullException(nameof(userService));
@@ -53,7 +53,7 @@ namespace ToolManagementAppV2.ViewModels
             _openImportExportCommand = openImportExportCommand ?? throw new ArgumentNullException(nameof(openImportExportCommand));
             _logger = logger ?? NullLogger<DashboardViewModel>.Instance;
 
-            NewToolCommand = new RelayCommand(() =>
+            NewItemCommand = new RelayCommand(() =>
             {
                 try { _openManageItemsCommand.Execute(null); }
                 catch (Exception ex) { _logger.LogError(ex, "Failed to open manage {ItemLabelPlural} page", LabelProvider.Instance.ItemLabelPlural.ToLower()); }
@@ -80,7 +80,7 @@ namespace ToolManagementAppV2.ViewModels
             try
             {
                 StatCards.Clear();
-                var tools = await _toolService.GetAllToolsAsync(cancellationToken);
+                var tools = await _itemService.GetAllItemsAsync(cancellationToken);
                 StatCards.Add(new StatCard { Title = $"Total {LabelProvider.Instance.ItemLabelPlural}", Value = tools.Count.ToString() });
                 var activeRentals = await _rentalService.GetActiveRentalsAsync();
                 var customers = await _customerService.GetAllCustomersAsync(cancellationToken);

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -18,7 +18,7 @@ namespace ToolManagementAppV2.ViewModels
 {
     public class ImportExportViewModel : ObservableObject
     {
-        private readonly IItemService _toolService;
+        private readonly IItemService _itemService;
         private readonly ICustomerService _customerService;
         private readonly IFileDialogService _fileDialogService;
         private readonly IDatabaseBackupService _databaseService;
@@ -42,14 +42,14 @@ namespace ToolManagementAppV2.ViewModels
 
         public ObservableCollection<string> ImportExportLogs { get; } = new();
 
-        public ImportExportViewModel(IItemService toolService,
+        public ImportExportViewModel(IItemService itemService,
                                      ICustomerService customerService,
                                      IFileDialogService fileDialogService,
                                      IDatabaseBackupService databaseService,
                                      IDialogService dialogService,
                                      ILogger<ImportExportViewModel>? logger = null)
         {
-            _toolService = toolService;
+            _itemService = itemService;
             _customerService = customerService;
             _fileDialogService = fileDialogService;
             _databaseService = databaseService;
@@ -76,7 +76,7 @@ namespace ToolManagementAppV2.ViewModels
                     return;
                 var plural = LabelProvider.Instance.ItemLabelPlural;
                 await _dialogService.ShowInfoAsync($"Importing {plural}...", $"Import {plural}");
-                await _toolService.ImportToolsFromCsvAsync(path, map, cancellationToken);
+                await _itemService.ImportItemsFromCsvAsync(path, map, cancellationToken);
                 ImportExportLogs.Add($"Successfully imported {plural} from {path}.");
                 await _dialogService.ShowInfoAsync($"Successfully imported {plural} from {path}.", $"Import {plural}");
             }
@@ -103,7 +103,7 @@ namespace ToolManagementAppV2.ViewModels
             try
             {
                 var plural = LabelProvider.Instance.ItemLabelPlural;
-                await _toolService.ExportToolsToCsvAsync(path, cancellationToken);
+                await _itemService.ExportItemsToCsvAsync(path, cancellationToken);
                 ImportExportLogs.Add($"Successfully exported {plural} to {path}.");
             }
             catch (OperationCanceledException)

--- a/ToolManagementAppV2/ViewModels/ItemDetailsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ItemDetailsViewModel.cs
@@ -1,19 +1,19 @@
-// ViewModels/ToolDetailsViewModel.cs
+// ViewModels/ItemDetailsViewModel.cs
 using System;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
 namespace ToolManagementAppV2.ViewModels
 {
-    public class ToolDetailsViewModel : ObservableObject
+    public class ItemDetailsViewModel : ObservableObject
     {
         public ItemModel ItemModel { get; }
 
         public IRelayCommand CloseCommand { get; }
 
-        public ToolDetailsViewModel(ItemModel tool, Action onClose)
+        public ItemDetailsViewModel(ItemModel item, Action onClose)
         {
-            ItemModel = tool;
+            ItemModel = item;
             CloseCommand = new RelayCommand(onClose);
         }
     }

--- a/ToolManagementAppV2/ViewModels/ItemManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ItemManagementViewModel.cs
@@ -57,7 +57,7 @@ namespace ToolManagementAppV2.ViewModels
                 if (SetProperty(ref _selectedItem, value))
                 {
                     ((AsyncRelayCommand)OpenRentalsCommand).NotifyCanExecuteChanged();
-                    ((AsyncRelayCommand)EditToolCommand).NotifyCanExecuteChanged();
+                    ((AsyncRelayCommand)EditItemCommand).NotifyCanExecuteChanged();
                     ((RelayCommand)ViewDetailsCommand).NotifyCanExecuteChanged();
                     ((AsyncRelayCommand)OpenRentalHistoryCommand).NotifyCanExecuteChanged();
                 }
@@ -86,9 +86,9 @@ namespace ToolManagementAppV2.ViewModels
         }
 
         public IAsyncRelayCommand<CancellationToken> SearchCommand { get; }
-        public IAsyncRelayCommand NewToolCommand { get; }
-        public IAsyncRelayCommand EditToolCommand { get; }
-        public IAsyncRelayCommand DeleteToolCommand { get; }
+        public IAsyncRelayCommand NewItemCommand { get; }
+        public IAsyncRelayCommand EditItemCommand { get; }
+        public IAsyncRelayCommand DeleteItemCommand { get; }
         public IAsyncRelayCommand OpenRentalsCommand { get; }
         public IRelayCommand ViewDetailsCommand { get; }
         public IAsyncRelayCommand OpenRentalHistoryCommand { get; }
@@ -131,9 +131,9 @@ namespace ToolManagementAppV2.ViewModels
             SearchCommand = new AsyncRelayCommand<CancellationToken>(FilterToolsAsync);
             _searchDebounceTimer = searchDebounceTimer ?? new DispatcherTimerWrapper { Interval = TimeSpan.FromMilliseconds(300) };
             _searchDebounceTimer.Tick += OnSearchDebounceTimerTick;
-            NewToolCommand = new AsyncRelayCommand(ct => AddToolAsync(ct));
-            EditToolCommand = new AsyncRelayCommand(ct => EditToolAsync(ct), () => SelectedItem != null);
-            DeleteToolCommand = new AsyncRelayCommand(ct => DeleteToolAsync(ct));
+            NewItemCommand = new AsyncRelayCommand(ct => AddItemAsync(ct));
+            EditItemCommand = new AsyncRelayCommand(ct => EditItemAsync(ct), () => SelectedItem != null);
+            DeleteItemCommand = new AsyncRelayCommand(ct => DeleteItemAsync(ct));
             OpenRentalsCommand = new AsyncRelayCommand(ct => OpenRentalsAsync(ct), () => SelectedItem != null);
             ViewDetailsCommand = new RelayCommand(ViewDetails, () => SelectedItem != null);
             OpenRentalHistoryCommand = new AsyncRelayCommand(OpenRentalHistoryAsync, () => SelectedItem != null);
@@ -157,7 +157,7 @@ namespace ToolManagementAppV2.ViewModels
             _suppressToolsChanged = true;
             try
             {
-                var all = await _itemService.GetAllToolsAsync();
+                var all = await _itemService.GetAllItemsAsync();
                 Tools.ReplaceRange(all);
                 SearchResults.ReplaceRange(all);
                 LoadCategories(Tools);
@@ -180,13 +180,13 @@ namespace ToolManagementAppV2.ViewModels
 
             if (!string.IsNullOrEmpty(term))
             {
-                source = await _itemService.SearchToolsAsync(term, cancellationToken);
+                source = await _itemService.SearchItemsAsync(term, cancellationToken);
             }
             else
             {
                 if (Tools.Count == 0)
                 {
-                    var all = await _itemService.GetAllToolsAsync();
+                    var all = await _itemService.GetAllItemsAsync();
                     Tools.ReplaceRange(all);
                 }
                 source = Tools;
@@ -201,13 +201,13 @@ namespace ToolManagementAppV2.ViewModels
             LoadCategories(source, suppressSearch: true);
         }
 
-        async Task AddToolAsync(CancellationToken cancellationToken)
+        async Task AddItemAsync(CancellationToken cancellationToken)
         {
             try
             {
                 if (string.IsNullOrWhiteSpace(NewTool.ItemNumber))
                     NewTool.ItemNumber = await _itemService.GenerateNextItemNumberAsync(cancellationToken);
-                await _itemService.AddToolAsync(NewTool, cancellationToken);
+                await _itemService.AddItemAsync(NewTool, cancellationToken);
                 await LoadToolsAsync();
                 await FilterToolsAsync(cancellationToken);
                 NewTool = new ItemModel();
@@ -232,7 +232,7 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        async Task EditToolAsync(CancellationToken cancellationToken)
+        async Task EditItemAsync(CancellationToken cancellationToken)
         {
             if (SelectedItem == null) return;
 
@@ -257,12 +257,12 @@ namespace ToolManagementAppV2.ViewModels
                 ImagePath = SelectedItem.ImagePath
             };
 
-            var updated = await _dialogService.ShowEditToolDialogAsync(clone);
+            var updated = await _dialogService.ShowEditItemDialogAsync(clone);
             if (updated == null) return;
 
             try
             {
-                await _itemService.UpdateToolAsync(updated, cancellationToken);
+                await _itemService.UpdateItemAsync(updated, cancellationToken);
                 await LoadToolsAsync();
                 await FilterToolsAsync(cancellationToken);
                 SelectedItem = Tools.FirstOrDefault(t => t.ItemID == updated.ItemID);
@@ -280,7 +280,7 @@ namespace ToolManagementAppV2.ViewModels
         void ViewDetails()
         {
             if (SelectedItem == null) return;
-            _dialogService.ShowToolDetails(SelectedItem);
+            _dialogService.ShowItemDetails(SelectedItem);
         }
 
         async Task OpenRentalHistoryAsync()
@@ -297,7 +297,7 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        async Task DeleteToolAsync(CancellationToken cancellationToken)
+        async Task DeleteItemAsync(CancellationToken cancellationToken)
         {
             if (SelectedItem == null) return;
             var confirm = await _dialogService.ShowConfirmationAsync(
@@ -308,7 +308,7 @@ namespace ToolManagementAppV2.ViewModels
 
             try
             {
-                await _itemService.DeleteToolAsync(SelectedItem.ItemID, cancellationToken);
+                await _itemService.DeleteItemAsync(SelectedItem.ItemID, cancellationToken);
                 await LoadToolsAsync();
                 await FilterToolsAsync(cancellationToken);
                 SelectedItem = null;
@@ -335,7 +335,7 @@ namespace ToolManagementAppV2.ViewModels
             try
             {
                 var customers = await _customerService.GetAllCustomersAsync(cancellationToken);
-                var result = _dialogService.ShowRentToolDialog(SelectedItem, customers);
+                var result = _dialogService.ShowRentItemDialog(SelectedItem, customers);
                 if (result != null)
                 {
                     var (customer, dueDate) = result.Value;

--- a/ToolManagementAppV2/ViewModels/MainViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/MainViewModel.cs
@@ -14,7 +14,7 @@ using Forms = System.Windows.Forms;
 using ToolManagementAppV2.Models.Domain;
 using ToolManagementAppV2.Services;
 using ToolManagementAppV2.Services.Rentals;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Views.Pages;
 using ToolManagementAppV2.Views.Windows;
@@ -32,7 +32,7 @@ namespace ToolManagementAppV2.ViewModels
 {
     public class MainViewModel : ObservableObject, IMainViewModel, IDisposable
     {
-        readonly IItemService _toolService;
+        readonly IItemService _itemService;
         readonly IUserService _userService;
         readonly IUserContext _userContext;
         readonly ICustomerService _customerService;
@@ -163,7 +163,7 @@ namespace ToolManagementAppV2.ViewModels
         public IRelayCommand OpenPrintLabelWindowCommand { get; }
         public IRelayCommand OpenScannerStatusPageCommand { get; }
 
-        public MainViewModel(IItemService toolService,
+        public MainViewModel(IItemService itemService,
                              IUserService userService,
                              IUserContext userContext,
                              ICustomerService customerService,
@@ -178,7 +178,7 @@ namespace ToolManagementAppV2.ViewModels
                              IDispatcherTimer? autoLogoutTimer = null,
                              IScannerService? scannerService = null)
         {
-            _toolService = toolService;
+            _itemService = itemService;
             _userService = userService;
             _userContext = userContext;
             _customerService = customerService;
@@ -201,7 +201,7 @@ namespace ToolManagementAppV2.ViewModels
             _userContextChangedHandler = (_, _) => RefreshCurrentUser();
             _userContext.UserChanged += _userContextChangedHandler;
 
-            ItemManagement = new ItemManagementViewModel(toolService, customerService, rentalService, _dialogService);
+            ItemManagement = new ItemManagementViewModel(itemService, customerService, rentalService, _dialogService);
             _itemManagementPropertyChangedHandler = (s, e) =>
             {
                 if (e.PropertyName == nameof(ItemManagementViewModel.SelectedItem))
@@ -213,8 +213,8 @@ namespace ToolManagementAppV2.ViewModels
             UserManagement = new UserManagementViewModel(userService, fileDialogService, _dialogService);
             CustomerManagement = new CustomerManagementViewModel(customerService, _dialogService);
             ManageRentals = new ManageRentalsViewModel(rentalService, _dialogService);
-            ImportExport = new ImportExportViewModel(toolService, customerService, fileDialogService, databaseService, _dialogService);
-            Reports = new ReportsViewModel(new ReportService(toolService, rentalService, activityLogService, customerService, userService));
+            ImportExport = new ImportExportViewModel(itemService, customerService, fileDialogService, databaseService, _dialogService);
+            Reports = new ReportsViewModel(new ReportService(itemService, rentalService, activityLogService, customerService, userService));
             ActivityLogs = new ActivityLogsViewModel(activityLogService);
             Settings = new SettingsViewModel(_fileDialogService, _settingsService, _dialogService);
             var logoPath = _settingsService.GetSettingAsync("CompanyLogoPath").GetAwaiter().GetResult();
@@ -230,7 +230,7 @@ namespace ToolManagementAppV2.ViewModels
 
             OpenDashboardCommand = new RelayCommand(() =>
             {
-                var vm = new DashboardViewModel(_toolService, _rentalService, _customerService, _userService, _activityLogService, OpenManageItemsCommand, OpenRentalsCommand, OpenImportExportCommand);
+                var vm = new DashboardViewModel(_itemService, _rentalService, _customerService, _userService, _activityLogService, OpenManageItemsCommand, OpenRentalsCommand, OpenImportExportCommand);
                 var page = new DashboardPage { DataContext = vm, Title = "Dashboard" };
                 CurrentPage = page;
             });
@@ -445,7 +445,7 @@ namespace ToolManagementAppV2.ViewModels
                         mappingString);
                     var plural = LabelProvider.Instance.ItemLabelPlural;
                     await _dialogService.ShowInfoAsync($"Importing {plural}...", $"Import {plural}");
-                    var invalid = await _toolService.ImportToolsFromCsvAsync(path, map, cancellationToken);
+                    var invalid = await _itemService.ImportItemsFromCsvAsync(path, map, cancellationToken);
                     var msg = invalid.Count == 0
                         ? $"Successfully imported {plural}."
                         : $"Imported with {invalid.Count} invalid rows.";
@@ -470,7 +470,7 @@ namespace ToolManagementAppV2.ViewModels
             {
                 var progress = new Progress<ImageImportProgress>(p =>
                     _logger.LogInformation("Imported {Processed}/{Total} images", p.Processed, p.Total));
-                var result = await _toolService.ImportToolImagesAsync(dlg.SelectedPath, selector, progress, cancellationToken);
+                var result = await _itemService.ImportItemImagesAsync(dlg.SelectedPath, selector, progress, cancellationToken);
                 _dialogService.ShowInfo(
                     $"Imported {result.ImportedCount} images. Unmatched: {result.UnmatchedFiles.Count}, Conflicts: {result.ConflictingFiles.Count}",
                     "Import Images");

--- a/ToolManagementAppV2/ViewModels/RentItemPopupViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/RentItemPopupViewModel.cs
@@ -6,7 +6,7 @@ using ToolManagementAppV2.Models.Domain;
 
 namespace ToolManagementAppV2.ViewModels.Rental
 {
-    public class RentToolPopupViewModel : ObservableObject
+    public class RentItemPopupViewModel : ObservableObject
     {
         public ObservableCollection<CustomerModel> Customers { get; }
         public CustomerModel? SelectedCustomer { get; set; }
@@ -19,7 +19,7 @@ namespace ToolManagementAppV2.ViewModels.Rental
         public IRelayCommand CheckOutCommand { get; }
         public IRelayCommand CancelCommand { get; }
 
-        public RentToolPopupViewModel(ItemModel tool, IEnumerable<CustomerModel> customers)
+        public RentItemPopupViewModel(ItemModel item, IEnumerable<CustomerModel> customers)
         {
             Customers = new ObservableCollection<CustomerModel>(customers);
             CheckOutCommand = new RelayCommand(Confirm);

--- a/ToolManagementAppV2/ViewModels/ReportsViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ReportsViewModel.cs
@@ -5,7 +5,7 @@ using System.Data;
 using System.Linq;
 using System.Windows.Documents;
 using System.Threading.Tasks;
-using ToolManagementAppV2.Services.Tools;
+using ToolManagementAppV2.Services.Items;
 
 namespace ToolManagementAppV2.ViewModels
 {

--- a/ToolManagementAppV2/Views/Pages/DashboardPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/DashboardPage.xaml
@@ -37,7 +37,7 @@
                 <StackPanel>
                     <TextBlock Text="Quick Actions" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
                     <WrapPanel>
-                        <Button Style="{StaticResource PrimaryButton}" Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=New {0}}" Command="{Binding NewToolCommand}" Margin="0,0,8,8"/>
+                        <Button Style="{StaticResource PrimaryButton}" Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=New {0}}" Command="{Binding NewItemCommand}" Margin="0,0,8,8"/>
                         <Button Style="{StaticResource PrimaryButton}" Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Rent {0}}" Command="{Binding OpenRentalsCommand}" Margin="0,0,8,8"/>
                     </WrapPanel>
                 </StackPanel>

--- a/ToolManagementAppV2/Views/Pages/ManageItemsPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/ManageItemsPage.xaml
@@ -32,16 +32,16 @@
                     <DataGrid.ContextMenu>
                         <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
                             <MenuItem Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Rent {0}}" Command="{Binding OpenRentalsCommand}"/>
-                            <MenuItem Header="Delete" Command="{Binding DeleteToolCommand}"/>
+                            <MenuItem Header="Delete" Command="{Binding DeleteItemCommand}"/>
                         </ContextMenu>
                     </DataGrid.ContextMenu>
                 </DataGrid>
 
                 <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditToolCommand}"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditItemCommand}"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="View Details" Command="{Binding ViewDetailsCommand}" Margin="8,0,0,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Rental History" Command="{Binding OpenRentalHistoryCommand}" Margin="8,0,0,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="New" Command="{Binding NewToolCommand}" Margin="8,0,0,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="New" Command="{Binding NewItemCommand}" Margin="8,0,0,0"/>
                 </StackPanel>
             </Grid>
         </Border>

--- a/ToolManagementAppV2/Views/Windows/ItemDetailsWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ItemDetailsWindow.xaml
@@ -1,5 +1,5 @@
-<!-- Views/ToolDetailsWindow.xaml -->
-<Window x:Class="ToolManagementAppV2.Views.Windows.ToolDetailsWindow"
+<!-- Views/ItemDetailsWindow.xaml -->
+<Window x:Class="ToolManagementAppV2.Views.Windows.ItemDetailsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers"

--- a/ToolManagementAppV2/Views/Windows/ItemDetailsWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/Windows/ItemDetailsWindow.xaml.cs
@@ -1,16 +1,16 @@
-// Views/ToolDetailsWindow.xaml.cs
+// Views/ItemDetailsWindow.xaml.cs
 using System.Windows;
 using ToolManagementAppV2.ViewModels;
 using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views.Windows
 {
-    public partial class ToolDetailsWindow : Window
+    public partial class ItemDetailsWindow : Window
     {
-        public ToolDetailsWindow(ItemModel tool)
+        public ItemDetailsWindow(ItemModel item)
         {
             InitializeComponent();
-            DataContext = new ToolDetailsViewModel(tool, () => Close());
+            DataContext = new ItemDetailsViewModel(item, () => Close());
             this.DisposeDataContextOnUnload();
         }
     }

--- a/ToolManagementAppV2/Views/Windows/RentItemPopupWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/RentItemPopupWindow.xaml
@@ -1,5 +1,5 @@
-<!-- Views/RentToolPopupWindow.xaml -->
-<Window x:Class="ToolManagementAppV2.Views.Windows.RentToolPopupWindow"
+<!-- Views/RentItemPopupWindow.xaml -->
+<Window x:Class="ToolManagementAppV2.Views.Windows.RentItemPopupWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:helpers="clr-namespace:ToolManagementAppV2.Utilities.Helpers"

--- a/ToolManagementAppV2/Views/Windows/RentItemPopupWindow.xaml.cs
+++ b/ToolManagementAppV2/Views/Windows/RentItemPopupWindow.xaml.cs
@@ -3,9 +3,9 @@ using ToolManagementAppV2.Utilities.Extensions;
 
 namespace ToolManagementAppV2.Views.Windows
 {
-    public partial class RentToolPopupWindow : Window
+    public partial class RentItemPopupWindow : Window
     {
-        public RentToolPopupWindow()
+        public RentItemPopupWindow()
         {
             InitializeComponent();
             this.DisposeDataContextOnUnload();


### PR DESCRIPTION
## Summary
- migrate tool services to item services and update method signatures
- rename windows and view models from *Tool* to *Item* for consistent terminology
- adjust commands and dialog interface to use item naming across UI

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a588588f5083249fbbb3363da7a584