### PR TITLE
Rename tool card template and update rental bindings

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/ItemCardTemplateBindingTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/ItemCardTemplateBindingTests.cs
@@ -8,10 +8,10 @@ using Xunit;
 
 namespace ToolManagementAppV2.Tests.Tests
 {
-    public class ToolCardTemplateBindingTests
+    public class ItemCardTemplateBindingTests
     {
         [Fact]
-        public void ToolCardTemplate_UsesNullToDefaultImageConverter()
+        public void ItemCardTemplate_UsesNullToDefaultImageConverter()
         {
             Exception? threadEx = null;
             var thread = new Thread(() =>
@@ -22,7 +22,7 @@ namespace ToolManagementAppV2.Tests.Tests
                     {
                         Source = new Uri("pack://application:,,,/Resources/Templates.xaml", UriKind.Absolute)
                     };
-                    var template = Assert.IsType<DataTemplate>(dict["ToolCardTemplate"]);
+                    var template = Assert.IsType<DataTemplate>(dict["ItemCardTemplate"]);
                     var grid = Assert.IsType<Grid>(template.LoadContent());
                     var border = Assert.IsType<Border>(grid.Children[0]);
                     var image = Assert.IsType<Image>(border.Child);

--- a/ToolManagementAppV2/Resources/Templates.xaml
+++ b/ToolManagementAppV2/Resources/Templates.xaml
@@ -17,7 +17,7 @@
     <ItemsPanelTemplate x:Key="WrapPanelItems">
         <WrapPanel Orientation="Horizontal" ItemWidth="260" ItemHeight="100"/>
     </ItemsPanelTemplate>
-    <DataTemplate x:Key="ToolCardTemplate">
+    <DataTemplate x:Key="ItemCardTemplate">
         <Border Style="{StaticResource Card}" Width="220" Padding="0">
             <Grid>
                 <Grid.RowDefinitions>
@@ -53,7 +53,7 @@
     <!-- Shared rental DataGrid columns -->
     <DataGridTextColumn x:Key="RentalIdColumn" Header="Rental #" Binding="{Binding RentalId}" Width="120" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalItemNumberColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat={}{0} #}" Binding="{Binding ItemNumber}" Width="120" x:Shared="False"/>
-    <DataGridTextColumn x:Key="RentalToolNameColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}" Binding="{Binding ToolName}" Width="*" x:Shared="False"/>
+    <DataGridTextColumn x:Key="RentalItemNameColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}" Binding="{Binding NameDescription}" Width="*" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalCustomerColumn" Header="Customer" Binding="{Binding CustomerName}" Width="220" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalOutColumn" Header="Out" Binding="{Binding DateOut, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalDueColumn" Header="Due" Binding="{Binding DueDate, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180" x:Shared="False"/>

--- a/ToolManagementAppV2/Views/Pages/ItemSearchPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/ItemSearchPage.xaml
@@ -32,7 +32,7 @@
                  ScrollViewer.VerticalScrollBarVisibility="Disabled"
                  VirtualizingPanel.IsVirtualizing="True"
                  VirtualizingPanel.VirtualizationMode="Recycling"
-                 ItemTemplate="{StaticResource ToolCardTemplate}"
+                 ItemTemplate="{StaticResource ItemCardTemplate}"
                  av:ItemsSource="{av:SampleData ItemCount=5}">
             <ListBox.ItemsPanel>
                 <ItemsPanelTemplate>

--- a/ToolManagementAppV2/Views/Pages/ManageRentalsPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/ManageRentalsPage.xaml
@@ -23,7 +23,7 @@
                 <DataGrid.Columns>
                     <StaticResource ResourceKey="RentalIdColumn"/>
                     <StaticResource ResourceKey="RentalItemNumberColumn"/>
-                    <StaticResource ResourceKey="RentalToolNameColumn"/>
+                    <StaticResource ResourceKey="RentalItemNameColumn"/>
                     <StaticResource ResourceKey="RentalCustomerColumn"/>
                     <StaticResource ResourceKey="RentalOutColumn"/>
                     <StaticResource ResourceKey="RentalDueColumn"/>

--- a/ToolManagementAppV2/Views/Windows/RentalHistoryWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/RentalHistoryWindow.xaml
@@ -26,7 +26,7 @@
                 <DataGrid.Columns>
                     <StaticResource ResourceKey="RentalIdColumn"/>
                     <StaticResource ResourceKey="RentalItemNumberColumn"/>
-                    <StaticResource ResourceKey="RentalToolNameColumn"/>
+                    <StaticResource ResourceKey="RentalItemNameColumn"/>
                     <StaticResource ResourceKey="RentalCustomerColumn"/>
                     <StaticResource ResourceKey="RentalOutColumn"/>
                     <StaticResource ResourceKey="RentalDueColumn"/>


### PR DESCRIPTION
## Summary
- rename ToolCardTemplate to ItemCardTemplate
- rename RentalToolNameColumn to RentalItemNameColumn and bind to item name
- adjust pages, windows, and tests to new template and column names

## Testing
- ⚠️ `dotnet test` *(dotnet: command not found)*
- ⚠️ `apt-get update` *(403 Forbidden while accessing repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68a5924605788324a87c9b897ca086d6