### PR TITLE
Refactor CSV import utilities for item terminology

### DIFF
--- a/ToolManagementAppV2.Tests/Tests/CsvHelperUtilTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CsvHelperUtilTests.cs
@@ -9,7 +9,7 @@ namespace ToolManagementAppV2.Tests
         [Fact]
         public void GetMapped_IgnoresHeaderCase()
         {
-            var headers = new[] { "toolnumber", "location" };
+            var headers = new[] { "itemnumber", "location" };
             var row = new[] { "123", "Loc" };
             var map = new Dictionary<string, string> { ["ItemNumber"] = "ItemNumber", ["Location"] = "LOCATION" };
 
@@ -28,9 +28,9 @@ namespace ToolManagementAppV2.Tests
         [Fact]
         public void GetMapped_IgnoresHeaderCase_Reversed()
         {
-            var headers = new[] { "TOOLNUMBER", "LOCATION" };
+            var headers = new[] { "ITEMNUMBER", "LOCATION" };
             var row = new[] { "321", "Loc" };
-            var map = new Dictionary<string, string> { ["ItemNumber"] = "toolnumber", ["Location"] = "location" };
+            var map = new Dictionary<string, string> { ["ItemNumber"] = "itemnumber", ["Location"] = "location" };
 
             var number = typeof(CsvHelperUtil)
                 .GetMethod("GetMapped", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!

--- a/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
@@ -11,7 +11,7 @@ using System.Threading;
 public class CsvImportTests
 {
     [Fact]
-    public void LoadToolsFromCsv_SkipsRowsMissingItemNumber()
+    public void LoadItemsFromCsv_SkipsRowsMissingItemNumber()
     {
         var csv = string.Join('\n',
             "ItemNumber,NameDescription,AvailableQuantity",
@@ -27,14 +27,14 @@ public class CsvImportTests
             { "AvailableQuantity", "AvailableQuantity" }
         };
 
-        var tools = CsvHelperUtil.LoadToolsFromCsv(path, map, out var invalid);
+        var items = CsvHelperUtil.LoadItemsFromCsv(path, map, out var invalid);
 
-        Assert.Single(tools);
+        Assert.Single(items);
         Assert.Contains(2, invalid);
     }
 
     [Fact]
-    public void LoadToolsFromCsv_HandlesQuotedHeaders()
+    public void LoadItemsFromCsv_HandlesQuotedHeaders()
     {
         var csv = string.Join('\n',
             "\"ItemNumber\",\"NameDescription\",\"AvailableQuantity\"",
@@ -49,15 +49,15 @@ public class CsvImportTests
             { "AvailableQuantity", "AvailableQuantity" }
         };
 
-        var tools = CsvHelperUtil.LoadToolsFromCsv(path, map, out var invalid);
+        var items = CsvHelperUtil.LoadItemsFromCsv(path, map, out var invalid);
 
-        Assert.Single(tools);
+        Assert.Single(items);
         Assert.Empty(invalid);
-        Assert.Equal("T1", tools[0].ItemNumber);
+        Assert.Equal("T1", items[0].ItemNumber);
     }
 
     [Fact]
-    public void LoadToolsFromCsv_MissingRequiredMapping_Throws()
+    public void LoadItemsFromCsv_MissingRequiredMapping_Throws()
     {
         var csv = string.Join('\n',
             "ItemNumber,NameDescription",
@@ -70,11 +70,11 @@ public class CsvImportTests
             { "NameDescription", "NameDescription" }
         };
 
-        Assert.Throws<ArgumentException>(() => CsvHelperUtil.LoadToolsFromCsv(path, map, out _));
+        Assert.Throws<ArgumentException>(() => CsvHelperUtil.LoadItemsFromCsv(path, map, out _));
     }
 
     [Fact]
-    public async Task LoadToolsFromCsvAsync_RespectsCancellation()
+    public async Task LoadItemsFromCsvAsync_RespectsCancellation()
     {
         var csv = string.Join('\n',
             "ItemNumber,NameDescription",
@@ -91,7 +91,7 @@ public class CsvImportTests
         var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(() => CsvHelperUtil.LoadToolsFromCsvAsync(path, map, cts.Token));
+        await Assert.ThrowsAsync<OperationCanceledException>(() => CsvHelperUtil.LoadItemsFromCsvAsync(path, map, cts.Token));
 
         if (File.Exists(path)) File.Delete(path);
     }

--- a/ToolManagementAppV2/Models/DTOs/ItemImportDto.cs
+++ b/ToolManagementAppV2/Models/DTOs/ItemImportDto.cs
@@ -1,6 +1,6 @@
 ﻿namespace ToolManagementAppV2.Models.ImportExport
 {
-    public class ToolImportDto
+    public class ItemImportDto
     {
         public string ItemNumber { get; set; }
         public string NameDescription { get; set; }

--- a/ToolManagementAppV2/Services/Core/CsvHelperUtil.cs
+++ b/ToolManagementAppV2/Services/Core/CsvHelperUtil.cs
@@ -32,7 +32,7 @@ namespace ToolManagementAppV2.Utilities.IO
         }
 
 
-        public static List<ItemModel> LoadToolsFromCsv(string filePath, IDictionary<string, string> map, out List<int> invalidRows)
+        public static List<ItemModel> LoadItemsFromCsv(string filePath, IDictionary<string, string> map, out List<int> invalidRows)
         {
             ValidateRequired(map, "ItemNumber");
             var list = new List<ItemModel>();
@@ -49,8 +49,8 @@ namespace ToolManagementAppV2.Utilities.IO
             {
                 row++;
                 var cols = parser.ReadFields();
-                var toolNumber = GetMapped(cols, headers, map, "ItemNumber");
-                if (string.IsNullOrWhiteSpace(toolNumber))
+                var itemNumber = GetMapped(cols, headers, map, "ItemNumber");
+                if (string.IsNullOrWhiteSpace(itemNumber))
                 {
                     invalidRows.Add(row);
                     continue;
@@ -58,7 +58,7 @@ namespace ToolManagementAppV2.Utilities.IO
 
                 list.Add(new ItemModel
                 {
-                    ItemNumber = toolNumber,
+                    ItemNumber = itemNumber,
                     NameDescription = GetMapped(cols, headers, map, "NameDescription"),
                     Location = GetMapped(cols, headers, map, "Location"),
                     Brand = GetMapped(cols, headers, map, "Brand"),
@@ -74,23 +74,23 @@ namespace ToolManagementAppV2.Utilities.IO
             return list;
         }
 
-        public static async Task<(List<ItemModel> Tools, List<int> InvalidRows)> LoadToolsFromCsvAsync(
+        public static async Task<(List<ItemModel> Items, List<int> InvalidRows)> LoadItemsFromCsvAsync(
             string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default)
         {
             return await Task.Run(() =>
             {
-                var tools = LoadToolsFromCsv(filePath, map, out var invalid);
-                return (tools, invalid);
+                var items = LoadItemsFromCsv(filePath, map, out var invalid);
+                return (items, invalid);
             }, cancellationToken).ConfigureAwait(false);
         }
 
-        public static void ExportItemsToCsv(string filePath, List<ItemModel> tools)
+        public static void ExportItemsToCsv(string filePath, List<ItemModel> items)
         {
             var lines = new List<string>
             {
                 "ItemNumber,NameDescription,Location,Brand,PartNumber,Supplier,PurchasedDate,Notes,AvailableQuantity,IsPowerTool"
             };
-            lines.AddRange(tools.Select(t =>
+            lines.AddRange(items.Select(t =>
                 string.Join(",",
                     Quote(t.ItemNumber),
                     Quote(t.NameDescription),
@@ -105,13 +105,13 @@ namespace ToolManagementAppV2.Utilities.IO
             File.WriteAllLines(filePath, lines);
         }
 
-        public static async Task ExportItemsToCsvAsync(string filePath, List<ItemModel> tools)
+        public static async Task ExportItemsToCsvAsync(string filePath, List<ItemModel> items)
         {
             var lines = new List<string>
             {
                 "ItemNumber,NameDescription,Location,Brand,PartNumber,Supplier,PurchasedDate,Notes,AvailableQuantity,IsPowerTool"
             };
-            lines.AddRange(tools.Select(t =>
+            lines.AddRange(items.Select(t =>
                 string.Join(",",
                     Quote(t.ItemNumber),
                     Quote(t.NameDescription),

--- a/ToolManagementAppV2/Services/Items/ItemService.cs
+++ b/ToolManagementAppV2/Services/Items/ItemService.cs
@@ -174,9 +174,9 @@ namespace ToolManagementAppV2.Services.Items
                 return result;
 
             cancellationToken.ThrowIfCancellationRequested();
-            var tools = await GetAllItemsAsync(cancellationToken);
+            var items = await GetAllItemsAsync(cancellationToken);
             var groups = new Dictionary<string, List<ItemModel>>(StringComparer.OrdinalIgnoreCase);
-            foreach (var item in tools)
+            foreach (var item in items)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var keys = keySelector(item);
@@ -497,7 +497,7 @@ namespace ToolManagementAppV2.Services.Items
 
         private async Task<List<int>> ImportItemsFromCsvInternalAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
-            var (tools, invalidRows) = await CsvHelperUtil.LoadToolsFromCsvAsync(filePath, map, cancellationToken);
+            var (items, invalidRows) = await CsvHelperUtil.LoadItemsFromCsvAsync(filePath, map, cancellationToken);
             using var conn = _dbService.CreateConnection();
             var existingNumbers = new HashSet<string>(
                 await SqliteHelper.ExecuteReaderAsync(conn,
@@ -507,7 +507,7 @@ namespace ToolManagementAppV2.Services.Items
             using var tran = conn.BeginTransaction();
             try
             {
-                foreach (var item in tools)
+                foreach (var item in items)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     if (string.IsNullOrWhiteSpace(item.ItemNumber) ||
@@ -521,7 +521,7 @@ namespace ToolManagementAppV2.Services.Items
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to import tools from CSV");
+                _logger.LogError(ex, "Failed to import items from CSV");
                 tran.Rollback();
                 throw;
             }
@@ -529,8 +529,8 @@ namespace ToolManagementAppV2.Services.Items
 
         private async Task ExportItemsToCsvInternalAsync(string filePath, CancellationToken cancellationToken)
         {
-            var tools = await GetAllItemsAsync(cancellationToken);
-            await CsvHelperUtil.ExportItemsToCsvAsync(filePath, tools);
+            var items = await GetAllItemsAsync(cancellationToken);
+            await CsvHelperUtil.ExportItemsToCsvAsync(filePath, items);
         }
 
         public async Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default)

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -70,7 +70,7 @@ namespace ToolManagementAppV2.ViewModels
             try
             {
                 var headers = await CsvHelperUtil.ReadHeadersAsync(path);
-                var properties = typeof(ToolImportDto).GetProperties().Select(p => p.Name);
+                var properties = typeof(ItemImportDto).GetProperties().Select(p => p.Name);
                 var map = _dialogService.ShowImportMapping(headers, properties);
                 if (map == null)
                     return;


### PR DESCRIPTION
## Summary
- Rename ToolImportDto to ItemImportDto and update consumers
- Replace LoadToolsFromCsv methods with LoadItemsFromCsv variants
- Align tests and CSV mappings with item naming

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package dotnet-sdk-8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a5995b5c508324bd908a573199a350