### PR TITLE
feat: replace workshop heading with item label binding

### DIFF
--- a/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
+++ b/ToolManagementAppV2.Tests/Views/MainWindowTests.cs
@@ -130,6 +130,50 @@ namespace ToolManagementAppV2.Tests.Views
         }
 
         [Fact]
+        public void WorkshopHeading_BoundToItemLabelPlural()
+        {
+            Exception? threadException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var originalSingular = LabelProvider.Instance.ItemLabelSingular;
+                    var originalPlural = LabelProvider.Instance.ItemLabelPlural;
+                    LabelProvider.Instance.UpdateLabels("Item", "Tools");
+                    var (window, dbPath) = TestHelpers.CreateMainWindow();
+                    try
+                    {
+                        var textBlock = TestHelpers.FindVisualChildren<TextBlock>(window)
+                            .FirstOrDefault(tb => BindingOperations.GetBinding(tb, TextBlock.TextProperty)?.Path?.Path == "ItemLabelPlural");
+                        Assert.NotNull(textBlock);
+                        Assert.Equal("Tools", textBlock!.Text);
+                    }
+                    finally
+                    {
+                        LabelProvider.Instance.UpdateLabels(originalSingular, originalPlural);
+                        window.Close();
+                        if (File.Exists(dbPath))
+                            File.Delete(dbPath);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    threadException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadException != null)
+            {
+                throw threadException;
+            }
+        }
+
+        [Fact]
         public void Title_Updates_WhenApplicationNameChanges()
         {
             Exception? threadException = null;

--- a/ToolManagementAppV2/MainWindow.xaml
+++ b/ToolManagementAppV2/MainWindow.xaml
@@ -34,7 +34,7 @@
 
                         <Separator/>
 
-                        <TextBlock Text="Workshop" Style="{StaticResource CaptionTextBlock}" Margin="6,8,6,2"/>
+                        <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}" Style="{StaticResource CaptionTextBlock}" Margin="6,8,6,2"/>
                         <Button Style="{StaticResource NavButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Manage {0}}" Command="{Binding OpenManageItemsCommand}" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
                         <Button Style="{StaticResource NavButton}" Content="Customers" Command="{Binding OpenCustomersCommand}"/>
                         <Button Style="{StaticResource NavButton}" Content="Users" Command="{Binding OpenUsersCommand}" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>


### PR DESCRIPTION
## Summary
- bind sidebar "Workshop" heading to ItemLabelPlural so label matches user configuration
- add test verifying sidebar heading uses item label binding

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a59af497e483248b2224f1aa3e6024