### PR TITLE
Rename IsPowerTool to IsPowered

### DIFF
--- a/ToolManagementAppV2.Tests/Services/DatabaseColumnDefaultsTests.cs
+++ b/ToolManagementAppV2.Tests/Services/DatabaseColumnDefaultsTests.cs
@@ -28,7 +28,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var service = new DatabaseService(dbPath);
 
                 using var conn2 = service.CreateConnection();
-                using (var cmdCheck = new SQLiteCommand("SELECT IsPowerTool, IsCheckedOut FROM Items", conn2))
+                using (var cmdCheck = new SQLiteCommand("SELECT IsPowered, IsCheckedOut FROM Items", conn2))
                 using (var reader = cmdCheck.ExecuteReader())
                 {
                     Assert.True(reader.Read());
@@ -36,7 +36,7 @@ namespace ToolManagementAppV2.Tests.Services
                     Assert.Equal(0, reader.GetInt32(1));
                 }
 
-                using var cmdNulls = new SQLiteCommand("SELECT COUNT(*) FROM Items WHERE IsPowerTool IS NULL OR IsCheckedOut IS NULL", conn2);
+                using var cmdNulls = new SQLiteCommand("SELECT COUNT(*) FROM Items WHERE IsPowered IS NULL OR IsCheckedOut IS NULL", conn2);
                 var nullCount = Convert.ToInt32(cmdNulls.ExecuteScalar());
                 Assert.Equal(0, nullCount);
             }

--- a/ToolManagementAppV2.Tests/Services/ItemServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ItemServiceTests.cs
@@ -568,14 +568,14 @@ namespace ToolManagementAppV2.Tests.Services
                             Notes TEXT,
                             AvailableQuantity INTEGER,
                             RentedQuantity INTEGER,
-                            IsPowerTool INTEGER,
+                            IsPowered INTEGER,
                             IsCheckedOut INTEGER,
                             CheckedOutBy TEXT,
                             CheckedOutTime DATETIME,
                             ImagePath TEXT,
                             Keywords TEXT
                         );
-                        INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsPowerTool, IsCheckedOut)
+                        INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsPowered, IsCheckedOut)
                         VALUES ('T1', 'Test', NULL, NULL, NULL, NULL);
                     ";
                     cmd.ExecuteNonQuery();
@@ -589,7 +589,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var tool = tools[0];
                 Assert.Equal(0, tool.QuantityOnHand);
                 Assert.Equal(0, tool.RentedQuantity);
-                Assert.False(tool.IsPowerTool);
+                Assert.False(tool.IsPowered);
                 Assert.False(tool.IsCheckedOut);
             }
             finally
@@ -621,14 +621,14 @@ namespace ToolManagementAppV2.Tests.Services
                             Notes TEXT,
                             AvailableQuantity INTEGER,
                             RentedQuantity INTEGER,
-                            IsPowerTool INTEGER,
+                            IsPowered INTEGER,
                             IsCheckedOut INTEGER,
                             CheckedOutBy TEXT,
                             CheckedOutTime DATETIME,
                             ImagePath TEXT,
                             Keywords TEXT
                         );
-                        INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsPowerTool, IsCheckedOut)
+                        INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsPowered, IsCheckedOut)
                         VALUES ('T1', 'Test', NULL, NULL, NULL, NULL);
                     ";
                     cmd.ExecuteNonQuery();
@@ -641,7 +641,7 @@ namespace ToolManagementAppV2.Tests.Services
                 Assert.Single(tools);
                 var tool = tools[0];
                 Assert.Equal("T1", tool.ItemNumber);
-                Assert.False(tool.IsPowerTool);
+                Assert.False(tool.IsPowered);
                 Assert.Equal(0, tool.QuantityOnHand);
             }
             finally

--- a/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/CsvImportTests.cs
@@ -180,13 +180,13 @@ public class CsvImportTests
         {
             using var db = new DatabaseService(dbPath);
             var service = new ItemService(db);
-            service.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 5, IsPowerTool = true });
+            service.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 5, IsPowered = true });
 
             await service.ExportItemsToCsvAsync(csvPath);
 
             var lines = await File.ReadAllLinesAsync(csvPath);
             Assert.True(lines.Length > 1);
-            Assert.Equal("ItemNumber,NameDescription,Location,Brand,PartNumber,Supplier,PurchasedDate,Notes,AvailableQuantity,IsPowerTool", lines[0]);
+            Assert.Equal("ItemNumber,NameDescription,Location,Brand,PartNumber,Supplier,PurchasedDate,Notes,AvailableQuantity,IsPowered", lines[0]);
             Assert.Contains("T1", lines[1]);
         }
         finally

--- a/ToolManagementAppV2.Tests/ViewModels/ItemManagementViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ItemManagementViewModelTests.cs
@@ -88,7 +88,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 var dialog = new StubDialogService();
                 var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
                 toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
-                toolService.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Cordless Drill", IsPowerTool = true });
+                toolService.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Cordless Drill", IsPowered = true });
                 vm.SearchTerm = string.Empty;
                 await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
                 Assert.Equal(2, vm.SearchResults.Count);
@@ -278,7 +278,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 vm.NewItem.QuantityOnHand = 5;
                 vm.NewItem.Supplier = "ABC";
                 vm.NewItem.Notes = "Note";
-                vm.NewItem.IsPowerTool = true;
+                vm.NewItem.IsPowered = true;
                 await vm.NewItemCommand.ExecuteAsync(null);
                 var tools = toolService.GetAllItems();
                 Assert.Single(tools);
@@ -291,7 +291,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
                 Assert.Equal(5, item.QuantityOnHand);
                 Assert.Equal("ABC", item.Supplier);
                 Assert.Equal("Note", item.Notes);
-                Assert.True(item.IsPowerTool);
+                Assert.True(item.IsPowered);
             }
             finally
             {

--- a/ToolManagementAppV2/Models/Domain/ItemModel.cs
+++ b/ToolManagementAppV2/Models/Domain/ItemModel.cs
@@ -100,11 +100,11 @@ namespace ToolManagementAppV2.Models.Domain
             set => SetProperty(ref _keywords, value);
         }
 
-        private bool _isPowerTool;
-        public bool IsPowerTool
+        private bool _isPowered;
+        public bool IsPowered
         {
-            get => _isPowerTool;
-            set => SetProperty(ref _isPowerTool, value);
+            get => _isPowered;
+            set => SetProperty(ref _isPowered, value);
         }
 
         private bool _isCheckedOut;

--- a/ToolManagementAppV2/Services/Core/CsvHelperUtil.cs
+++ b/ToolManagementAppV2/Services/Core/CsvHelperUtil.cs
@@ -67,7 +67,7 @@ namespace ToolManagementAppV2.Utilities.IO
                     PurchasedDate = TryParseDate(GetMapped(cols, headers, map, "PurchasedDate")),
                     Notes = GetMapped(cols, headers, map, "Notes"),
                     QuantityOnHand = TryParseInt(GetMapped(cols, headers, map, "AvailableQuantity")),
-                    IsPowerTool = TryParseBool(GetMapped(cols, headers, map, "IsPowerTool"))
+                    IsPowered = TryParseBool(GetMapped(cols, headers, map, "IsPowered"))
                 });
             }
 
@@ -88,7 +88,7 @@ namespace ToolManagementAppV2.Utilities.IO
         {
             var lines = new List<string>
             {
-                "ItemNumber,NameDescription,Location,Brand,PartNumber,Supplier,PurchasedDate,Notes,AvailableQuantity,IsPowerTool"
+                "ItemNumber,NameDescription,Location,Brand,PartNumber,Supplier,PurchasedDate,Notes,AvailableQuantity,IsPowered"
             };
             lines.AddRange(items.Select(t =>
                 string.Join(",",
@@ -101,7 +101,7 @@ namespace ToolManagementAppV2.Utilities.IO
                     Quote(t.PurchasedDate?.ToString("yyyy-MM-dd")),
                     Quote(t.Notes),
                     Quote(t.QuantityOnHand.ToString()),
-                    Quote(t.IsPowerTool ? "1" : "0"))));
+                    Quote(t.IsPowered ? "1" : "0"))));
             File.WriteAllLines(filePath, lines);
         }
 
@@ -109,7 +109,7 @@ namespace ToolManagementAppV2.Utilities.IO
         {
             var lines = new List<string>
             {
-                "ItemNumber,NameDescription,Location,Brand,PartNumber,Supplier,PurchasedDate,Notes,AvailableQuantity,IsPowerTool"
+                "ItemNumber,NameDescription,Location,Brand,PartNumber,Supplier,PurchasedDate,Notes,AvailableQuantity,IsPowered"
             };
             lines.AddRange(items.Select(t =>
                 string.Join(",",
@@ -122,7 +122,7 @@ namespace ToolManagementAppV2.Utilities.IO
                     Quote(t.PurchasedDate?.ToString("yyyy-MM-dd")),
                     Quote(t.Notes),
                     Quote(t.QuantityOnHand.ToString()),
-                    Quote(t.IsPowerTool ? "1" : "0"))));
+                    Quote(t.IsPowered ? "1" : "0"))));
             await File.WriteAllLinesAsync(filePath, lines).ConfigureAwait(false);
         }
 

--- a/ToolManagementAppV2/Services/Core/DatabaseService.cs
+++ b/ToolManagementAppV2/Services/Core/DatabaseService.cs
@@ -41,13 +41,17 @@ namespace ToolManagementAppV2.Services.Core
             _logger = logger ?? NullLogger<DatabaseService>.Instance;
             ConfigureDatabase();
             InitializeDatabase();
+            using (var conn = CreateConnection())
+            {
+                RenameColumnIfExists(conn, "Items", "IsPowerTool", "IsPowered");
+            }
             EnsureColumn("Items", "ItemNumber", "TEXT");
             EnsureColumn("Items", "NameDescription", "TEXT");
             EnsureColumn("Items", "ImagePath", "TEXT");
             EnsureColumn("Items", "CheckedOutBy", "TEXT");
             EnsureColumn("Items", "CheckedOutTime", "DATETIME");
             EnsureColumn("Items", "Keywords", "TEXT");
-            EnsureColumn("Items", "IsPowerTool", "INTEGER", "0");
+            EnsureColumn("Items", "IsPowered", "INTEGER", "0");
             EnsureColumn("Items", "IsCheckedOut", "INTEGER", "0");
             // Ensure indexes that depend on newly added columns
             using (var conn = CreateConnection())
@@ -131,7 +135,7 @@ namespace ToolManagementAppV2.Services.Core
                     Notes TEXT,
                     AvailableQuantity INTEGER NOT NULL DEFAULT 0,
                     RentedQuantity INTEGER NOT NULL DEFAULT 0,
-                    IsPowerTool INTEGER NOT NULL DEFAULT 0,
+                    IsPowered INTEGER NOT NULL DEFAULT 0,
                     IsCheckedOut INTEGER NOT NULL DEFAULT 0,
                     CheckedOutBy TEXT,
                     CheckedOutTime DATETIME
@@ -254,6 +258,25 @@ namespace ToolManagementAppV2.Services.Core
                     _logger.LogError(ex, "Failed to ensure index on {Table}.{Columns}", table, string.Join(",", columns));
                     throw;
                 }
+            }
+        }
+
+        void RenameColumnIfExists(SQLiteConnection conn, string table, string oldName, string newName)
+        {
+            using var info = new SQLiteCommand($"PRAGMA table_info({table})", conn);
+            using var rdr = info.ExecuteReader();
+            var oldExists = false;
+            var newExists = false;
+            while (rdr.Read())
+            {
+                var name = rdr["name"].ToString();
+                if (string.Equals(name, oldName, StringComparison.OrdinalIgnoreCase)) oldExists = true;
+                if (string.Equals(name, newName, StringComparison.OrdinalIgnoreCase)) newExists = true;
+            }
+            if (oldExists && !newExists)
+            {
+                using var rename = new SQLiteCommand($"ALTER TABLE {table} RENAME COLUMN {oldName} TO {newName}", conn);
+                rename.ExecuteNonQuery();
             }
         }
 

--- a/ToolManagementAppV2/Services/Items/ItemService.cs
+++ b/ToolManagementAppV2/Services/Items/ItemService.cs
@@ -25,8 +25,8 @@ namespace ToolManagementAppV2.Services.Items
         const string AllItemsSql = "SELECT * FROM Items";
         const string UpsertItemCsv = @"
             INSERT INTO Items
-              (ItemNumber, NameDescription, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity, RentedQuantity, ImagePath, IsCheckedOut, IsPowerTool)
-            VALUES (@ItemNumber,@Desc,@Loc,@Brand,@PN,@Sup,@PD,@Notes,@Keywords,@Avail,@Rent,@Img,0,@Power);
+              (ItemNumber, NameDescription, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity, RentedQuantity, ImagePath, IsCheckedOut, IsPowered)
+            VALUES (@ItemNumber,@Desc,@Loc,@Brand,@PN,@Sup,@PD,@Notes,@Keywords,@Avail,@Rent,@Img,0,@Powered);
             SELECT last_insert_rowid();";
         const int MaxQuantityOnHand = 10000;
         const int MaxSearchTerms = 10;
@@ -158,7 +158,7 @@ namespace ToolManagementAppV2.Services.Items
                 new SQLiteParameter("@Avail", item.QuantityOnHand),
                 new SQLiteParameter("@Rent", item.RentedQuantity),
                 new SQLiteParameter("@Img", (object)item.ImagePath ?? DBNull.Value),
-                new SQLiteParameter("@Power", item.IsPowerTool ? 1 : 0)
+                new SQLiteParameter("@Powered", item.IsPowered ? 1 : 0)
             };
             using var cmd = new SQLiteCommand(UpsertItemCsv, conn, tran);
             cmd.Parameters.AddRange(p);
@@ -310,7 +310,7 @@ namespace ToolManagementAppV2.Services.Items
                 : DateTime.Parse(r["CheckedOutTime"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
             ImagePath = r["ImagePath"]?.ToString(),
             Keywords = r["Keywords"]?.ToString(),
-            IsPowerTool = (r["IsPowerTool"] is DBNull ? 0 : Convert.ToInt32(r["IsPowerTool"])) == 1
+            IsPowered = (r["IsPowered"] is DBNull ? 0 : Convert.ToInt32(r["IsPowered"])) == 1
         };
 
         private async Task AddItemInternalAsync(ItemModel item, CancellationToken cancellationToken)
@@ -343,7 +343,7 @@ namespace ToolManagementAppV2.Services.Items
                   Keywords = @Keywords,
                   AvailableQuantity = @Avail,
                   RentedQuantity = @Rent,
-                  IsPowerTool = @Power,
+                  IsPowered = @Powered,
                   IsCheckedOut = @Out,
                   CheckedOutBy = @By,
                   CheckedOutTime = @Time,
@@ -363,7 +363,7 @@ namespace ToolManagementAppV2.Services.Items
                 new SQLiteParameter("@Keywords", (object)item.Keywords ?? DBNull.Value),
                 new SQLiteParameter("@Avail", item.QuantityOnHand),
                 new SQLiteParameter("@Rent", item.RentedQuantity),
-                new SQLiteParameter("@Power", item.IsPowerTool ? 1 : 0),
+                new SQLiteParameter("@Powered", item.IsPowered ? 1 : 0),
                 new SQLiteParameter("@Out", item.IsCheckedOut ? 1 : 0),
                 new SQLiteParameter("@By", (object)item.CheckedOutBy ?? DBNull.Value),
                 new SQLiteParameter("@Time", (object)item.CheckedOutTime ?? DBNull.Value),

--- a/ToolManagementAppV2/ViewModels/ItemManagementViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ItemManagementViewModel.cs
@@ -250,7 +250,7 @@ namespace ToolManagementAppV2.ViewModels
                 PurchasedDate = SelectedItem.PurchasedDate,
                 Notes = SelectedItem.Notes,
                 Keywords = SelectedItem.Keywords,
-                IsPowerTool = SelectedItem.IsPowerTool,
+                IsPowered = SelectedItem.IsPowered,
                 IsCheckedOut = SelectedItem.IsCheckedOut,
                 CheckedOutBy = SelectedItem.CheckedOutBy,
                 CheckedOutTime = SelectedItem.CheckedOutTime,

--- a/ToolManagementAppV2/Views/Windows/ItemEditWindow.xaml
+++ b/ToolManagementAppV2/Views/Windows/ItemEditWindow.xaml
@@ -47,7 +47,7 @@
             <TextBlock Grid.Row="5" Grid.Column="0" Text="Supplier" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding ItemModel.Supplier, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <CheckBox Grid.Row="6" Grid.ColumnSpan="2" Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Power {0}}" IsChecked="{Binding ItemModel.IsPowerTool}" Margin="0,0,0,8"/>
+            <CheckBox Grid.Row="6" Grid.ColumnSpan="2" Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Power {0}}" IsChecked="{Binding ItemModel.IsPowered}" Margin="0,0,0,8"/>
 
             <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,0,0,8">
                 <Image Width="100" Height="100" Stretch="Uniform"


### PR DESCRIPTION
## Summary
- rename `IsPowerTool` property and database column to `IsPowered`
- update CSV headers, services, and UI bindings to the new name
- migrate existing databases to the new column and adjust tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a59ce448508324a6a14d91509c94c9