### PR TITLE
Rename tool import/export commands to item commands

### DIFF
--- a/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -14,7 +14,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
     public class ImportExportViewModelTests
     {
         [Fact]
-        public async System.Threading.Tasks.Task ImportToolsCommand_UsesMappingFromDialog()
+        public async System.Threading.Tasks.Task ImportItemsCommand_UsesMappingFromDialog()
         {
             var tmp = Path.GetTempFileName();
             File.WriteAllText(tmp, "ItemNumber\n");
@@ -23,7 +23,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var dialog = new StubDialogService { MapToReturn = new Dictionary<string,string>{{"ItemNumber","ItemNumber"}} };
             var vm = new ImportExportViewModel(toolSvc, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
 
-            await vm.ImportToolsCommand.ExecuteAsync(null);
+            await vm.ImportItemsCommand.ExecuteAsync(null);
 
             Assert.True(dialog.ShowImportMappingCalled);
             Assert.True(toolSvc.ImportCalled);
@@ -69,7 +69,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async System.Threading.Tasks.Task ImportToolsCommand_CancelledMapping_DoesNotCallService()
+        public async System.Threading.Tasks.Task ImportItemsCommand_CancelledMapping_DoesNotCallService()
         {
             var tmp = Path.GetTempFileName();
             File.WriteAllText(tmp, "ItemNumber\n");
@@ -78,7 +78,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var dialog = new StubDialogService { MapToReturn = null };
             var vm = new ImportExportViewModel(toolSvc, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
 
-            await vm.ImportToolsCommand.ExecuteAsync(null);
+            await vm.ImportItemsCommand.ExecuteAsync(null);
 
             Assert.True(dialog.ShowImportMappingCalled);
             Assert.False(toolSvc.ImportCalled);
@@ -86,7 +86,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async System.Threading.Tasks.Task ImportToolsCommand_CanBeCancelled()
+        public async System.Threading.Tasks.Task ImportItemsCommand_CanBeCancelled()
         {
             var tmp = Path.GetTempFileName();
             File.WriteAllText(tmp, "ItemNumber\n");
@@ -95,8 +95,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
             var dialog = new StubDialogService { MapToReturn = new Dictionary<string,string>{{"ItemNumber","ItemNumber"}} };
             var vm = new ImportExportViewModel(toolSvc, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
 
-            var execute = vm.ImportToolsCommand.ExecuteAsync(null);
-            vm.ImportToolsCommand.Cancel();
+            var execute = vm.ImportItemsCommand.ExecuteAsync(null);
+            vm.ImportItemsCommand.Cancel();
             await execute;
 
             Assert.Single(vm.ImportExportLogs);

--- a/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/NewPageViewModelTests.cs
@@ -41,7 +41,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task ImportExportViewModel_ImportToolsCommand_LogsSuccess()
+        public async Task ImportExportViewModel_ImportItemsCommand_LogsSuccess()
         {
             var toolService = new StubItemService();
             var customerService = new StubCustomerService();
@@ -51,7 +51,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             fileDlg.FileToReturn = tmp;
             var dialog = new StubDialogService();
             var vm = new ImportExportViewModel(toolService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
-            await vm.ImportToolsCommand.ExecuteAsync(null);
+            await vm.ImportItemsCommand.ExecuteAsync(null);
             Assert.True(toolService.ImportCalled);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Successfully imported tools", vm.ImportExportLogs[0]);
@@ -59,12 +59,12 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task ImportExportViewModel_ExportToolsCommand_LogsSuccess()
+        public async Task ImportExportViewModel_ExportItemsCommand_LogsSuccess()
         {
             var toolService = new StubItemService();
             var customerService = new StubCustomerService();
             var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
-            await vm.ExportToolsCommand.ExecuteAsync(null);
+            await vm.ExportItemsCommand.ExecuteAsync(null);
             Assert.True(toolService.ExportCalled);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Successfully exported tools", vm.ImportExportLogs[0]);
@@ -121,7 +121,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         }
 
         [Fact]
-        public async Task ImportExportViewModel_ImportToolsCommand_LogsFailure()
+        public async Task ImportExportViewModel_ImportItemsCommand_LogsFailure()
         {
             var toolService = new FailItemService();
             var customerService = new StubCustomerService();
@@ -131,19 +131,19 @@ namespace ToolManagementAppV2.Tests.ViewModels
             fileDlg.FileToReturn = tmp;
             var dialog = new StubDialogService();
             var vm = new ImportExportViewModel(toolService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
-            await vm.ImportToolsCommand.ExecuteAsync(null);
+            await vm.ImportItemsCommand.ExecuteAsync(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Failed to import tools", vm.ImportExportLogs[0]);
             File.Delete(tmp);
         }
 
         [Fact]
-        public async Task ImportExportViewModel_ExportToolsCommand_LogsFailure()
+        public async Task ImportExportViewModel_ExportItemsCommand_LogsFailure()
         {
             var toolService = new FailItemService();
             var customerService = new StubCustomerService();
             var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
-            await vm.ExportToolsCommand.ExecuteAsync(null);
+            await vm.ExportItemsCommand.ExecuteAsync(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Failed to export tools", vm.ImportExportLogs[0]);
         }

--- a/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
+++ b/ToolManagementAppV2.Tests/Views/ImportExportPageTests.cs
@@ -38,7 +38,7 @@ namespace ToolManagementAppV2.Tests.Views
                         var panel = (WrapPanel)((Border)grid.Children[0]).Child;
                         var importBtn = (Button)panel.Children[0];
 
-                        Assert.Equal(vm.ImportToolsCommand, importBtn.Command);
+                        Assert.Equal(vm.ImportItemsCommand, importBtn.Command);
                         var asyncCmd = (CommunityToolkit.Mvvm.Input.IAsyncRelayCommand)importBtn.Command;
                         var task = asyncCmd.ExecuteAsync(null);
                         task.GetAwaiter().GetResult();

--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -25,9 +25,9 @@ namespace ToolManagementAppV2.ViewModels
         private readonly IDialogService _dialogService;
         private readonly ILogger<ImportExportViewModel> _logger;
 
-        public IAsyncRelayCommand ImportToolsCommand { get; }
-        public IRelayCommand CancelImportToolsCommand { get; }
-        public IAsyncRelayCommand ExportToolsCommand { get; }
+        public IAsyncRelayCommand ImportItemsCommand { get; }
+        public IRelayCommand CancelImportItemsCommand { get; }
+        public IAsyncRelayCommand ExportItemsCommand { get; }
         public IAsyncRelayCommand ImportCustomersCommand { get; }
         public IAsyncRelayCommand ExportCustomersCommand { get; }
 
@@ -55,9 +55,9 @@ namespace ToolManagementAppV2.ViewModels
             _databaseService = databaseService;
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<ImportExportViewModel>.Instance;
-            ImportToolsCommand = new AsyncRelayCommand(ct => ImportToolsAsync(ct));
-            CancelImportToolsCommand = new RelayCommand(() => ImportToolsCommand.Cancel());
-            ExportToolsCommand = new AsyncRelayCommand(ct => ExportToolsAsync(ct));
+            ImportItemsCommand = new AsyncRelayCommand(ct => ImportToolsAsync(ct));
+            CancelImportItemsCommand = new RelayCommand(() => ImportItemsCommand.Cancel());
+            ExportItemsCommand = new AsyncRelayCommand(ct => ExportToolsAsync(ct));
             ImportCustomersCommand = new AsyncRelayCommand(ct => ImportCustomersAsync(ct));
             ExportCustomersCommand = new AsyncRelayCommand(ct => ExportCustomersAsync(ct));
             BackupDatabaseCommand = new AsyncRelayCommand(ct => BackupDatabaseAsync(ct));

--- a/ToolManagementAppV2/Views/Pages/ImportExportPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/ImportExportPage.xaml
@@ -20,12 +20,12 @@
             <StackPanel Grid.Column="0" Margin="0,0,8,0">
                 <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}" Style="{StaticResource SectionHeader}" />
                 <WrapPanel>
-                    <Button Style="{StaticResource CompactPrimaryButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Import {0} CSV}" Command="{Binding ImportToolsCommand}"/>
+                    <Button Style="{StaticResource CompactPrimaryButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Import {0} CSV}" Command="{Binding ImportItemsCommand}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Import {0} Images}" Command="{Binding DataContext.OpenImageImportMappingWindowCommand, RelativeSource={RelativeSource AncestorType=Window}}"
                             Visibility="{Binding DataContext.IsCurrentUserAdmin, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource BoolToVis}}"/>
-                    <Button Style="{StaticResource CompactPrimaryButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Export {0} CSV}" Command="{Binding ExportToolsCommand}"/>
+                    <Button Style="{StaticResource CompactPrimaryButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Export {0} CSV}" Command="{Binding ExportItemsCommand}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}" Content="Backup Database" Command="{Binding BackupDatabaseCommand}"/>
-                    <Button Style="{StaticResource CompactPrimaryButton}" Content="Cancel Import" Command="{Binding CancelImportToolsCommand}" IsEnabled="{Binding ImportToolsCommand.IsRunning}"/>
+                    <Button Style="{StaticResource CompactPrimaryButton}" Content="Cancel Import" Command="{Binding CancelImportItemsCommand}" IsEnabled="{Binding ImportItemsCommand.IsRunning}"/>
 
                 </WrapPanel>
             </StackPanel>


### PR DESCRIPTION
## Summary
- rename import/export command properties from *Tools* to *Items*
- update Import/Export page bindings to use new command names
- adjust tests for updated command names

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a212237c8324994627f9405ca472