### PR TITLE
Align default item labels

### DIFF
--- a/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/SettingsServiceTests.cs
@@ -447,8 +447,8 @@ namespace ToolManagementAppV2.Tests.Services
             {
                 var dbService = new DatabaseService(dbPath);
                 var service = new SettingsService(dbService);
-                Assert.Equal("ItemModel", service.GetItemLabelSingularAsync().GetAwaiter().GetResult());
-                Assert.Equal("Tools", service.GetItemLabelPluralAsync().GetAwaiter().GetResult());
+                Assert.Equal("Item", service.GetItemLabelSingularAsync().GetAwaiter().GetResult());
+                Assert.Equal("Items", service.GetItemLabelPluralAsync().GetAwaiter().GetResult());
                 service.SaveItemLabelSingularAsync("Widget").GetAwaiter().GetResult();
                 service.SaveItemLabelPluralAsync("Widgets").GetAwaiter().GetResult();
                 Assert.Equal("Widget", service.GetItemLabelSingularAsync().GetAwaiter().GetResult());

--- a/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/SettingsViewModelTests.cs
@@ -193,7 +193,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void ItemLabels_UpdateServiceAndProvider()
         {
             var settings = new StubSettingsService();
-            LabelProvider.Instance.UpdateLabels("ItemModel", "Tools");
+            LabelProvider.Instance.UpdateLabels("Item", "Items");
             var vm = new SettingsViewModel(new StubFileDialogService(), settings, new StubDialogService());
             vm.ItemLabelSingular = "Widget";
             vm.ItemLabelPlural = "Widgets";
@@ -201,7 +201,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
             Assert.Equal("Widgets", settings.ItemLabelPlural);
             Assert.Equal("Widget", LabelProvider.Instance.ItemLabelSingular);
             Assert.Equal("Widgets", LabelProvider.Instance.ItemLabelPlural);
-            LabelProvider.Instance.UpdateLabels("ItemModel", "Tools");
+            LabelProvider.Instance.UpdateLabels("Item", "Items");
         }
 
         [Fact]
@@ -242,8 +242,8 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public IEnumerable<string> ScannerIps { get; set; } = Array.Empty<string>();
         public int PasswordIterations { get; set; } = 100_000;
         public int AutoLogoutMinutes { get; set; }
-        public string ItemLabelSingular { get; set; } = "ItemModel";
-        public string ItemLabelPlural { get; set; } = "Tools";
+        public string ItemLabelSingular { get; set; } = "Item";
+        public string ItemLabelPlural { get; set; } = "Items";
 
         public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
         {

--- a/ToolManagementAppV2/Services/Settings/SettingsService.cs
+++ b/ToolManagementAppV2/Services/Settings/SettingsService.cs
@@ -293,7 +293,7 @@ namespace ToolManagementAppV2.Services.Settings
         public async Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default)
         {
             var value = await GetSettingAsync(ItemLabelSingularKey, cancellationToken).ConfigureAwait(false);
-            return string.IsNullOrWhiteSpace(value) ? "ItemModel" : value;
+            return string.IsNullOrWhiteSpace(value) ? "Item" : value;
         }
 
         public async Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default)
@@ -305,7 +305,7 @@ namespace ToolManagementAppV2.Services.Settings
         public async Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default)
         {
             var value = await GetSettingAsync(ItemLabelPluralKey, cancellationToken).ConfigureAwait(false);
-            return string.IsNullOrWhiteSpace(value) ? "Tools" : value;
+            return string.IsNullOrWhiteSpace(value) ? "Items" : value;
         }
 
         public async Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- Align SettingsService fallback labels with LabelProvider by defaulting to "Item"/"Items"
- Adjust unit tests to expect new default labels

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a559ae5c83248e31a0e642bcbd11