### PR TITLE
Use neutral default database path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ The application can be rebranded via its **Settings** to suit different inventor
 
 These options enable using the app for tracking AV gear, sports equipment, or any other lendable items.
 
+## Configuration
+The application reads configuration from `appsettings.json`. By default, the SQLite database is stored in `inventory.db` within the application's base directory. This path can be changed by updating the `Database:Path` setting.
+
 ## Prerequisites
 - **.NET 8 SDK**
 

--- a/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -173,7 +173,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void OpenSettingsCommand_NavigatesToSettingsPage()
         {
             var dbPath = Path.GetTempFileName();
-            var tempDb = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db");
+            var tempDb = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "inventory.db");
             try
             {
                 var db = new DatabaseService(dbPath);
@@ -207,7 +207,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
         public void OpenSettingsCommand_ReusesSettingsViewModelInstance()
         {
             var dbPath = Path.GetTempFileName();
-            var tempDb = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tool_inventory.db");
+            var tempDb = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "inventory.db");
             try
             {
                 var db = new DatabaseService(dbPath);

--- a/ToolManagementAppV2/App.xaml.cs
+++ b/ToolManagementAppV2/App.xaml.cs
@@ -77,7 +77,7 @@ namespace ToolManagementAppV2
                     var config = sp.GetRequiredService<IConfiguration>();
                     var logger = sp.GetRequiredService<ILogger<DatabaseService>>();
                     var dbPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
-                        config["Database:Path"] ?? "tool_inventory.db");
+                        config["Database:Path"] ?? "inventory.db");
                     return new DatabaseService(dbPath, logger);
                 });
                 services.AddSingleton<IDatabaseService>(sp => sp.GetRequiredService<DatabaseService>());

--- a/ToolManagementAppV2/appsettings.json
+++ b/ToolManagementAppV2/appsettings.json
@@ -1,6 +1,6 @@
 {
   "Database": {
-    "Path": "tool_inventory.db"
+    "Path": "inventory.db"
   },
   "Logging": {
     "Directory": "Logs"


### PR DESCRIPTION
## Summary
- rename default SQLite database file to `inventory.db`
- update test references and documentation to match new database file name

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a58294c4832498025e23e125451b