### PR TITLE
Rename import/export methods to item terminology

### DIFF
--- a/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
+++ b/ToolManagementAppV2/ViewModels/ImportExportViewModel.cs
@@ -55,15 +55,15 @@ namespace ToolManagementAppV2.ViewModels
             _databaseService = databaseService;
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<ImportExportViewModel>.Instance;
-            ImportItemsCommand = new AsyncRelayCommand(ct => ImportToolsAsync(ct));
+            ImportItemsCommand = new AsyncRelayCommand(ct => ImportItemsAsync(ct));
             CancelImportItemsCommand = new RelayCommand(() => ImportItemsCommand.Cancel());
-            ExportItemsCommand = new AsyncRelayCommand(ct => ExportToolsAsync(ct));
+            ExportItemsCommand = new AsyncRelayCommand(ct => ExportItemsAsync(ct));
             ImportCustomersCommand = new AsyncRelayCommand(ct => ImportCustomersAsync(ct));
             ExportCustomersCommand = new AsyncRelayCommand(ct => ExportCustomersAsync(ct));
             BackupDatabaseCommand = new AsyncRelayCommand(ct => BackupDatabaseAsync(ct));
         }
 
-        async Task ImportToolsAsync(CancellationToken cancellationToken)
+        async Task ImportItemsAsync(CancellationToken cancellationToken)
         {
             var path = _fileDialogService.OpenFile("CSV Files|*.csv", AppContext.BaseDirectory);
             if (string.IsNullOrEmpty(path)) return;
@@ -96,7 +96,7 @@ namespace ToolManagementAppV2.ViewModels
             }
         }
 
-        async Task ExportToolsAsync(CancellationToken cancellationToken)
+        async Task ExportItemsAsync(CancellationToken cancellationToken)
         {
             var path = _fileDialogService.SaveFile("CSV Files|*.csv");
             if (string.IsNullOrEmpty(path)) return;

--- a/ToolManagementAppV2/Views/Pages/ImportExportPage.xaml
+++ b/ToolManagementAppV2/Views/Pages/ImportExportPage.xaml
@@ -16,7 +16,7 @@
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 
-            <!-- Tools -->
+            <!-- Items -->
             <StackPanel Grid.Column="0" Margin="0,0,8,0">
                 <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}" Style="{StaticResource SectionHeader}" />
                 <WrapPanel>


### PR DESCRIPTION
## Summary
- rename ImportToolsAsync/ExportToolsAsync to ImportItemsAsync/ExportItemsAsync
- update ImportExportPage comment from Tools to Items

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68a662d6db388324a307aa8e2d8d2532