### PR TITLE
Update tests to use item terminology and labels

### DIFF
--- a/ToolManagementAppV2.Tests/Services/ItemServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ItemServiceTests.cs
@@ -365,9 +365,9 @@ namespace ToolManagementAppV2.Tests.Services
                 item.ItemNumber = null;
 
                 var ex = Assert.Throws<InvalidOperationException>(() => service.UpdateItem(item));
-                Assert.Contains("Failed to update tool", ex.Message);
+                Assert.Contains("Failed to update item", ex.Message);
                 Assert.IsType<SQLiteException>(ex.InnerException);
-                Assert.Contains(logs, l => l.Level == LogLevel.Error && l.Message.Contains("Failed to update tool"));
+                Assert.Contains(logs, l => l.Level == LogLevel.Error && l.Message.Contains("Failed to update item"));
             }
             finally
             {
@@ -480,7 +480,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public async Task GetAllItemsAsync_ReturnsTools()
+        public async Task GetAllItemsAsync_ReturnsItems()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -488,8 +488,8 @@ namespace ToolManagementAppV2.Tests.Services
                 var dbService = new DatabaseService(dbPath);
                 IItemService service = new ItemService(dbService);
                 service.AddItem(new ItemModel { ItemNumber = "T1" });
-                var tools = await service.GetAllItemsAsync();
-                Assert.Single(tools);
+                var items = await service.GetAllItemsAsync();
+                Assert.Single(items);
             }
             finally
             {
@@ -498,7 +498,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void GetAllTools_CachesResultsBetweenCalls()
+        public void GetAllItems_CachesResultsBetweenCalls()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -521,7 +521,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void ImportToolsFromCsv_PartialFailure_RollsBack()
+        public void ImportItemsFromCsv_PartialFailure_RollsBack()
         {
             var dbPath = Path.GetTempFileName();
             var csvPath = Path.GetTempFileName();
@@ -546,7 +546,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void GetAllTools_AllowsNullNumericColumns()
+        public void GetAllItems_AllowsNullNumericColumns()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -583,10 +583,10 @@ namespace ToolManagementAppV2.Tests.Services
 
                 var dbService = new DatabaseService(dbPath);
                 var svc = new ItemService(dbService);
-                var tools = svc.GetAllItems();
+                var items = svc.GetAllItems();
 
-                Assert.Single(tools);
-                var item = tools[0];
+                Assert.Single(items);
+                var item = items[0];
                 Assert.Equal(0, item.QuantityOnHand);
                 Assert.Equal(0, item.RentedQuantity);
                 Assert.False(item.IsPowered);
@@ -636,10 +636,10 @@ namespace ToolManagementAppV2.Tests.Services
 
                 var dbService = new DatabaseService(dbPath);
                 var svc = new ItemService(dbService);
-                var tools = svc.SearchItems("T1");
+                var items = svc.SearchItems("T1");
 
-                Assert.Single(tools);
-                var item = tools[0];
+                Assert.Single(items);
+                var item = items[0];
                 Assert.Equal("T1", item.ItemNumber);
                 Assert.False(item.IsPowered);
                 Assert.Equal(0, item.QuantityOnHand);
@@ -669,8 +669,8 @@ namespace ToolManagementAppV2.Tests.Services
                     RentedQuantity = 0
                 });
 
-                var addedTool = service.GetAllItems().First();
-                Assert.Throws<InvalidOperationException>(() => service.UpdateItemQuantities(addedTool.ItemID, 1, true));
+                var addedItem = service.GetAllItems().First();
+                Assert.Throws<InvalidOperationException>(() => service.UpdateItemQuantities(addedItem.ItemID, 1, true));
                 Assert.Contains(logs, l => l.Level == LogLevel.Warning && l.Message.Contains("Quantity update affected 0 rows"));
             }
             finally
@@ -680,7 +680,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void DeleteTool_WhenSqlFails_Throws()
+        public void DeleteItem_WhenSqlFails_Throws()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -694,7 +694,7 @@ namespace ToolManagementAppV2.Tests.Services
 
                 var svc = new ItemService(dbService);
                 var ex = Assert.Throws<InvalidOperationException>(() => svc.DeleteItem(1));
-                Assert.Contains("Failed to delete tool 1", ex.Message);
+                Assert.Contains("Failed to delete item 1", ex.Message);
             }
             finally
             {
@@ -717,7 +717,7 @@ namespace ToolManagementAppV2.Tests.Services
 
                 var svc = new ItemService(dbService);
                 var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => svc.DeleteItemAsync(1));
-                Assert.Contains("Failed to delete tool 1", ex.Message);
+                Assert.Contains("Failed to delete item 1", ex.Message);
             }
             finally
             {
@@ -755,7 +755,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public void ToggleToolCheckOutStatus_SetsUtcTime()
+        public void ToggleItemCheckOutStatus_SetsUtcTime()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -790,7 +790,7 @@ namespace ToolManagementAppV2.Tests.Services
         }
 
         [Fact]
-        public async Task DeleteItemAsync_RemovesTool()
+        public async Task DeleteItemAsync_RemovesItem()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -971,7 +971,7 @@ namespace ToolManagementAppV2.Tests.Services
                 var svc = new ItemService(dbService, auth, null, logService, ctx);
                 await svc.AddItemAsync(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, RentedQuantity = 0 });
                 var logs = await logService.GetRecentLogsAsync();
-                Assert.Contains(logs.Value, l => l.Action.Contains("Added tool"));
+                Assert.Contains(logs.Value, l => l.Action.Contains("Added item"));
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceSyncTests.cs
@@ -15,6 +15,7 @@ using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Utilities.Helpers;
 using Xunit;
 
 namespace ToolManagementAppV2.Tests.Services;
@@ -25,20 +26,20 @@ public class ReportServiceAsyncTests
     public void GenerateSummaryReport_UsesConcurrentAsyncCalls()
     {
         const int delay = 200;
-        var toolService = new DelayItemService(delay, 3);
+        var itemService = new DelayItemService(delay, 3);
         var rentalService = new DelayRentalService(delay, 5, 2);
         var customerService = new DelayCustomerService(delay, 4);
         var userService = new DelayUserService(delay, 1);
         using var db = new DatabaseService(Path.GetTempFileName());
         var activity = new ActivityLogService(db);
-        var svc = new ReportService(toolService, rentalService, activity, customerService, userService);
+        var svc = new ReportService(itemService, rentalService, activity, customerService, userService);
 
         var sw = Stopwatch.StartNew();
         var doc = svc.GenerateSummaryReport().GetAwaiter().GetResult();
         sw.Stop();
 
         var text = new TextRange(doc.ContentStart, doc.ContentEnd).Text;
-        Assert.Contains("Total Tools: 3", text);
+        Assert.Contains($"Total {LabelProvider.Instance.ItemLabelPlural}: 3", text);
         Assert.Contains("Total Rentals (History): 5", text);
         Assert.Contains("Active Rentals: 2", text);
         Assert.Contains("Total Customers: 4", text);
@@ -49,25 +50,25 @@ public class ReportServiceAsyncTests
 
     class DelayItemService : IItemService
     {
-        readonly int _delay; readonly List<ItemModel> _tools;
+        readonly int _delay; readonly List<ItemModel> _items;
         public DelayItemService(int delay, int count)
-        { _delay = delay; _tools = new List<ItemModel>(new ItemModel[count]); }
+        { _delay = delay; _items = new List<ItemModel>(new ItemModel[count]); }
 
         public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) =>
-            Task.Delay(_delay, cancellationToken).ContinueWith(_ => _tools, cancellationToken);
+            Task.Delay(_delay, cancellationToken).ContinueWith(_ => _items, cancellationToken);
 
         public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
         public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 

--- a/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
+++ b/ToolManagementAppV2.Tests/Services/ReportServiceTests.cs
@@ -10,6 +10,7 @@ using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.Services.Customers;
+using ToolManagementAppV2.Utilities.Helpers;
 
 namespace ToolManagementAppV2.Tests.Services
 {
@@ -22,15 +23,15 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
-                var rentalService = new RentalService(db, toolService);
+                var rentalService = new RentalService(db, itemService);
                 var activityLogService = new ActivityLogService(db);
-                var reportService = new ReportService(toolService, rentalService, activityLogService, customerService, userService);
+                var reportService = new ReportService(itemService, rentalService, activityLogService, customerService, userService);
 
-                var tool = new ItemModel
+                var item = new ItemModel
                 {
                     ItemNumber = "T1",
                     NameDescription = "Hammer",
@@ -40,7 +41,7 @@ namespace ToolManagementAppV2.Tests.Services
                     QuantityOnHand = 1,
                     RentedQuantity = 0
                 };
-                toolService.AddItem(tool);
+                itemService.AddItem(item);
 
                 var customer = new Customer
                 {
@@ -60,13 +61,13 @@ namespace ToolManagementAppV2.Tests.Services
                 };
                 userService.AddUser(user);
 
-                rentalService.RentItem(tool.ItemID, customer.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(item.ItemID, customer.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
                 var task = Task.Run(() => reportService.GenerateSummaryReport().Result);
                 Assert.True(task.Wait(TimeSpan.FromSeconds(5)), "GenerateSummaryReport deadlocked.");
                 var doc = task.Result;
                 var text = new TextRange(doc.ContentStart, doc.ContentEnd).Text;
-                Assert.Contains("Total Tools: 1", text);
+                Assert.Contains($"Total {LabelProvider.Instance.ItemLabelPlural}: 1", text);
                 Assert.Contains("Total Rentals (History): 1", text);
                 Assert.Contains("Active Rentals: 1", text);
                 Assert.Contains("Total Customers: 1", text);
@@ -86,15 +87,15 @@ namespace ToolManagementAppV2.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
-                var rentalService = new RentalService(db, toolService);
+                var rentalService = new RentalService(db, itemService);
                 var activityLogService = new ActivityLogService(db);
-                var reportService = new ReportService(toolService, rentalService, activityLogService, customerService, userService);
+                var reportService = new ReportService(itemService, rentalService, activityLogService, customerService, userService);
 
-                var tool = new ItemModel
+                var item = new ItemModel
                 {
                     ItemNumber = "T1",
                     NameDescription = "Hammer",
@@ -104,7 +105,7 @@ namespace ToolManagementAppV2.Tests.Services
                     QuantityOnHand = 1,
                     RentedQuantity = 0
                 };
-                toolService.AddItem(tool);
+                itemService.AddItem(item);
 
                 var customer = new Customer
                 {
@@ -124,11 +125,11 @@ namespace ToolManagementAppV2.Tests.Services
                 };
                 userService.AddUser(user);
 
-                rentalService.RentItem(tool.ItemID, customer.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(item.ItemID, customer.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
                 var doc = await reportService.GenerateSummaryReport();
                 var text = new TextRange(doc.ContentStart, doc.ContentEnd).Text;
-                Assert.Contains("Total Tools: 1", text);
+                Assert.Contains($"Total {LabelProvider.Instance.ItemLabelPlural}: 1", text);
                 Assert.Contains("Total Rentals (History): 1", text);
                 Assert.Contains("Active Rentals: 1", text);
                 Assert.Contains("Total Customers: 1", text);

--- a/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
+++ b/ToolManagementAppV2.Tests/Tests/NavigationCommandsTests.cs
@@ -61,8 +61,8 @@ namespace ToolManagementAppV2.Tests.Tests
 
                 var page = Assert.IsType<ItemSearchPage>(vm.CurrentPage);
                 Assert.Same(vm.ItemManagement, page.DataContext);
-                Assert.Same(vm.ItemManagement.Tools, page.ItemsList.ItemsSource);
-                Assert.NotEmpty(vm.ItemManagement.Tools);
+                Assert.Same(vm.ItemManagement.Items, page.ItemsList.ItemsSource);
+                Assert.NotEmpty(vm.ItemManagement.Items);
             }
             finally
             {

--- a/ToolManagementAppV2.Tests/ViewModels/ReportsViewModelTests.cs
+++ b/ToolManagementAppV2.Tests/ViewModels/ReportsViewModelTests.cs
@@ -9,6 +9,7 @@ using ToolManagementAppV2.Services.Rentals;
 using ToolManagementAppV2.Services.Items;
 using ToolManagementAppV2.Services.Users;
 using ToolManagementAppV2.ViewModels;
+using ToolManagementAppV2.Utilities.Helpers;
 using Xunit;
 using System.Threading.Tasks;
 
@@ -51,7 +52,7 @@ namespace ToolManagementAppV2.Tests.ViewModels
 
                 await vm.RunReportCommand.ExecuteAsync(null);
                 Assert.NotNull(vm.ReportResults);
-                Assert.Contains("Total Tools: 1",
+                Assert.Contains($"Total {LabelProvider.Instance.ItemLabelPlural}: 1",
                     vm.ReportResults.Rows.Cast<DataRow>().Select(r => r[0]?.ToString()));
 
                 vm.SelectedReport = null;


### PR DESCRIPTION
## Summary
- rename tool-related test names and variables to item naming
- replace hard-coded "Total Tools" strings with LabelProvider-based item labels
- adjust navigation tests to expect Items collection

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a68accabb08324ab34fb485adf255c