### PR TITLE
Rename ToolDisplayName to ItemDisplayName

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/RentalHistoryViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/RentalHistoryViewModelTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.IO;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Interfaces;
@@ -10,6 +11,23 @@ namespace InventoryManagementApp.Tests.ViewModels
 {
     public class RentalHistoryViewModelTests
     {
+        [Fact]
+        public void Constructor_SetsItemDisplayName_WhenToolProvided()
+        {
+            var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
+            var vm = new RentalHistoryViewModel(item, Enumerable.Empty<Rental>(), new StubDialogService());
+
+            Assert.Equal("T1 - Hammer", vm.ItemDisplayName);
+        }
+
+        [Fact]
+        public void Constructor_DefaultsItemDisplayName_WhenToolNull()
+        {
+            var vm = new RentalHistoryViewModel(null, Enumerable.Empty<Rental>(), new StubDialogService());
+
+            Assert.Equal("Rental History", vm.ItemDisplayName);
+        }
+
         [Fact]
         public void SearchCommand_FiltersHistory()
         {

--- a/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
+++ b/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
@@ -23,7 +23,7 @@ namespace InventoryManagementApp.ViewModels.Rental
         private readonly IDialogService _dialogService;
 
         public ObservableCollection<RentalModel> History { get; }
-        public string ToolDisplayName { get; }
+        public string ItemDisplayName { get; }
 
         private string _searchText = string.Empty;
         public string SearchText
@@ -45,7 +45,7 @@ namespace InventoryManagementApp.ViewModels.Rental
 
         public RentalHistoryViewModel(ItemModel? tool, IEnumerable<RentalModel>? history, IDialogService dialogService, ILogger<RentalHistoryViewModel>? logger = null)
         {
-            ToolDisplayName = tool != null
+            ItemDisplayName = tool != null
                 ? $"{tool.ItemNumber} - {tool.NameDescription}"
                 : "Rental History";
 


### PR DESCRIPTION
## Summary
- rename `ToolDisplayName` to `ItemDisplayName` in `RentalHistoryViewModel`
- verify `ItemDisplayName` behavior with new unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b6ec9bcc8324888021f85cf6de23