### PR TITLE
Rename tool references to item in tests

### DIFF
--- a/InventoryManagementApp.Tests/Services/InterfaceReferenceTests.cs
+++ b/InventoryManagementApp.Tests/Services/InterfaceReferenceTests.cs
@@ -19,13 +19,13 @@ namespace InventoryManagementApp.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolSvc = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 ICustomerService custSvc = new CustomerService(db);
-                IRentalService rentalSvc = new RentalService(db, toolSvc);
+                IRentalService rentalSvc = new RentalService(db, itemService);
                 IUserService userSvc = new UserService(db, new ApplicationUserContext());
                 ISettingsService settingsSvc = new SettingsService(db);
 
-                Assert.NotNull(toolSvc);
+                Assert.NotNull(itemService);
                 Assert.NotNull(custSvc);
                 Assert.NotNull(rentalSvc);
                 Assert.NotNull(userSvc);

--- a/InventoryManagementApp.Tests/Services/RentalServiceConcurrentTests.cs
+++ b/InventoryManagementApp.Tests/Services/RentalServiceConcurrentTests.cs
@@ -21,12 +21,12 @@ namespace InventoryManagementApp.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
-                var rentalService = new RentalService(db, toolService);
+                var rentalService = new RentalService(db, itemService);
 
-                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
-                var tool = toolService.GetAllItems().First();
+                itemService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
+                var item = itemService.GetAllItems().First();
 
                 customerService.AddCustomer(new Customer { Company = "Acme" });
                 var cust = customerService.GetAllCustomers().First();
@@ -37,7 +37,7 @@ namespace InventoryManagementApp.Tests.Services
                     barrier.SignalAndWait();
                     try
                     {
-                        rentalService.RentItem(tool.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                        rentalService.RentItem(item.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
                     }
                     catch { }
                 });
@@ -46,14 +46,14 @@ namespace InventoryManagementApp.Tests.Services
                     barrier.SignalAndWait();
                     try
                     {
-                        rentalService.RentItem(tool.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                        rentalService.RentItem(item.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
                     }
                     catch { }
                 });
 
                 Task.WaitAll(t1, t2);
 
-                var updated = toolService.GetItemByID(tool.ItemID);
+                var updated = itemService.GetItemByID(item.ItemID);
                 Assert.Equal(0, updated.QuantityOnHand);
                 Assert.Equal(1, updated.RentedQuantity);
                 Assert.Single(rentalService.GetAllRentals());

--- a/InventoryManagementApp.Tests/Services/RentalServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/RentalServiceTests.cs
@@ -36,22 +36,22 @@ namespace InventoryManagementApp.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db, toolService);
+                IRentalService rentalService = new RentalService(db, itemService);
 
-                var tool = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 5 };
-                toolService.AddItem(tool);
-                var addedTool = toolService.GetAllItems().First();
+                var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 5 };
+                itemService.AddItem(item);
+                var addedItem = itemService.GetAllItems().First();
 
                 var cust = new Customer { Company = "Acme" };
                 customerService.AddCustomer(cust);
                 var addedCust = customerService.GetAllCustomers().First();
 
-                rentalService.RentItem(addedTool.ItemID, addedCust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
-                rentalService.RentItem(addedTool.ItemID, addedCust.CustomerID, DateTime.Today.AddDays(2), DateTime.Today.AddDays(3));
+                rentalService.RentItem(addedItem.ItemID, addedCust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(addedItem.ItemID, addedCust.CustomerID, DateTime.Today.AddDays(2), DateTime.Today.AddDays(3));
 
-                var history = rentalService.GetRentalHistoryForItem(addedTool.ItemID);
+                var history = rentalService.GetRentalHistoryForItem(addedItem.ItemID);
                 Assert.Equal(2, history.Count);
                 Assert.True(history[0].RentalDate > history[1].RentalDate);
             }
@@ -69,19 +69,19 @@ namespace InventoryManagementApp.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db, toolService);
+                IRentalService rentalService = new RentalService(db, itemService);
 
-                var tool = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 0 };
-                toolService.AddItem(tool);
-                var addedTool = toolService.GetAllItems().First();
+                var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 0 };
+                itemService.AddItem(item);
+                var addedItem = itemService.GetAllItems().First();
 
                 customerService.AddCustomer(new Customer { Company = "Acme" });
                 var cust = customerService.GetAllCustomers().First();
 
                 Assert.Throws<InvalidOperationException>(() =>
-                    rentalService.RentItem(addedTool.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1)));
+                    rentalService.RentItem(addedItem.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1)));
                 Assert.Empty(rentalService.GetAllRentals());
             }
             finally
@@ -98,19 +98,19 @@ namespace InventoryManagementApp.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 ICustomerService customerService = new CustomerService(db);
-                IRentalService rentalService = new RentalService(db, toolService);
+                IRentalService rentalService = new RentalService(db, itemService);
 
-                var tool = new ItemModel { ItemNumber = "T2", NameDescription = "Wrench", QuantityOnHand = 0 };
-                toolService.AddItem(tool);
-                var addedTool = toolService.GetAllItems().First();
+                var item = new ItemModel { ItemNumber = "T2", NameDescription = "Wrench", QuantityOnHand = 0 };
+                itemService.AddItem(item);
+                var addedItem = itemService.GetAllItems().First();
 
                 customerService.AddCustomer(new Customer { Company = "Beta" });
                 var cust = customerService.GetAllCustomers().First();
 
                 Assert.Throws<InvalidOperationException>(() =>
-                    rentalService.RentItem(addedTool.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1)));
+                    rentalService.RentItem(addedItem.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1)));
                 Assert.Empty(rentalService.GetAllRentals());
             }
             finally
@@ -127,8 +127,8 @@ namespace InventoryManagementApp.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
-                IRentalService rentalService = new RentalService(db, toolService);
+                var itemService = new ItemService(db);
+                IRentalService rentalService = new RentalService(db, itemService);
 
                 Assert.Throws<InvalidOperationException>(() => rentalService.ReturnItem(1, DateTime.Today));
             }
@@ -146,8 +146,8 @@ namespace InventoryManagementApp.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
-                IRentalService rentalService = new RentalService(db, toolService);
+                var itemService = new ItemService(db);
+                IRentalService rentalService = new RentalService(db, itemService);
 
                 Assert.Throws<InvalidOperationException>(() => rentalService.ReturnItem(1, DateTime.Today));
             }
@@ -165,8 +165,8 @@ namespace InventoryManagementApp.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
-                var rentalService = new RentalService(db, toolService);
+                var itemService = new ItemService(db);
+                var rentalService = new RentalService(db, itemService);
 
                 Assert.Throws<InvalidOperationException>(() =>
                     rentalService.ExtendRental(1, DateTime.Today.AddDays(1)));
@@ -185,18 +185,18 @@ namespace InventoryManagementApp.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
-                var rentalService = new RentalService(db, toolService);
+                var rentalService = new RentalService(db, itemService);
 
-                var tool = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 };
-                toolService.AddItem(tool);
-                var addedTool = toolService.GetAllItems().First();
+                var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 };
+                itemService.AddItem(item);
+                var addedItem = itemService.GetAllItems().First();
 
                 customerService.AddCustomer(new Customer { Company = "Acme" });
                 var cust = customerService.GetAllCustomers().First();
 
-                rentalService.RentItem(addedTool.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(addedItem.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
                 var rental = rentalService.GetAllRentals().First();
 
                 rentalService.ReturnItem(rental.RentalID, DateTime.Today);
@@ -218,18 +218,18 @@ namespace InventoryManagementApp.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
-                var rentalService = new RentalService(db, toolService);
+                var rentalService = new RentalService(db, itemService);
 
-                var tool = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 };
-                toolService.AddItem(tool);
-                var addedTool = toolService.GetAllItems().First();
+                var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 };
+                itemService.AddItem(item);
+                var addedItem = itemService.GetAllItems().First();
 
                 customerService.AddCustomer(new Customer { Company = "Acme" });
                 var cust = customerService.GetAllCustomers().First();
 
-                rentalService.RentItem(addedTool.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(addedItem.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
                 var rental = rentalService.GetAllRentals().First();
 
                 rentalService.DeleteRental(rental.RentalID);
@@ -250,8 +250,8 @@ namespace InventoryManagementApp.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
-                var rentalService = new RentalService(db, toolService);
+                var itemService = new ItemService(db);
+                var rentalService = new RentalService(db, itemService);
 
                 Assert.Throws<InvalidOperationException>(() => rentalService.DeleteRental(1));
             }
@@ -263,25 +263,25 @@ namespace InventoryManagementApp.Tests.Services
         }
 
         [Fact]
-        public void GetActiveRentals_ReturnsCustomerAndToolDetails()
+        public void GetActiveRentals_ReturnsCustomerAndItemDetails()
         {
             var dbPath = Path.GetTempFileName();
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
-                var rentalService = new RentalService(db, toolService);
+                var rentalService = new RentalService(db, itemService);
 
-                var tool = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, Location = "A1", ImagePath = "path" };
-                toolService.AddItem(tool);
-                var addedTool = toolService.GetAllItems().First();
+                var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, Location = "A1", ImagePath = "path" };
+                itemService.AddItem(item);
+                var addedItem = itemService.GetAllItems().First();
 
                 var customer = new Customer { Company = "Acme", Contact = "Bob", Email = "b@c.com", Phone = "111", Mobile = "222", Address = "Addr" };
                 customerService.AddCustomer(customer);
                 var addedCust = customerService.GetAllCustomers().First();
 
-                rentalService.RentItem(addedTool.ItemID, addedCust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(addedItem.ItemID, addedCust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
                 var rentals = rentalService.GetActiveRentals();
                 var r = rentals.First();
@@ -307,26 +307,26 @@ namespace InventoryManagementApp.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
-                var rentalService = new RentalService(db, toolService);
+                var rentalService = new RentalService(db, itemService);
 
-                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
-                var tool = toolService.GetAllItems().First();
+                itemService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
+                var item = itemService.GetAllItems().First();
 
                 customerService.AddCustomer(new Customer { Company = "Acme" });
                 var cust = customerService.GetAllCustomers().First();
 
-                rentalService.RentItem(tool.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(item.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
-                var rented = toolService.GetItemByID(tool.ItemID);
+                var rented = itemService.GetItemByID(item.ItemID);
                 Assert.Equal(0, rented.QuantityOnHand);
                 Assert.Equal(1, rented.RentedQuantity);
 
                 var rental = rentalService.GetAllRentals().First();
                 rentalService.ReturnItem(rental.RentalID, DateTime.Today);
 
-                var returned = toolService.GetItemByID(tool.ItemID);
+                var returned = itemService.GetItemByID(item.ItemID);
                 Assert.Equal(1, returned.QuantityOnHand);
                 Assert.Equal(0, returned.RentedQuantity);
             }
@@ -344,17 +344,17 @@ namespace InventoryManagementApp.Tests.Services
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
-                var rentalService = new RentalService(db, toolService);
+                var rentalService = new RentalService(db, itemService);
 
-                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
-                var tool = toolService.GetAllItems().First();
+                itemService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
+                var item = itemService.GetAllItems().First();
 
                 customerService.AddCustomer(new Customer { Company = "Acme" });
                 var cust = customerService.GetAllCustomers().First();
 
-                rentalService.RentItem(tool.ItemID, cust.CustomerID, DateTime.Today.AddDays(-2), DateTime.Today.AddDays(-1));
+                rentalService.RentItem(item.ItemID, cust.CustomerID, DateTime.Today.AddDays(-2), DateTime.Today.AddDays(-1));
                 var rental = rentalService.GetAllRentals().First();
                 var originalDue = rental.DueDate;
 
@@ -367,9 +367,9 @@ namespace InventoryManagementApp.Tests.Services
                 var after = rentalService2.GetAllRentals().First();
                 Assert.Equal(originalDue, after.DueDate);
 
-                var toolAfter = toolService.GetItemByID(tool.ItemID);
-                Assert.Equal(0, toolAfter.QuantityOnHand);
-                Assert.Equal(1, toolAfter.RentedQuantity);
+                var itemAfter = itemService.GetItemByID(item.ItemID);
+                Assert.Equal(0, itemAfter.QuantityOnHand);
+                Assert.Equal(1, itemAfter.RentedQuantity);
             }
             finally
             {
@@ -390,7 +390,7 @@ namespace InventoryManagementApp.Tests.Services
                 var logService = new ActivityLogService(db);
                 var itemService = new ItemService(db, auth, null, logService, ctx);
                 var customerService = new CustomerService(db, auth);
-                var rentalService = new RentalService(db, auth, toolService, null, logService, ctx);
+                var rentalService = new RentalService(db, auth, itemService, null, logService, ctx);
 
                 await itemService.AddItemAsync(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1, RentedQuantity = 0 });
                 await customerService.AddCustomerAsync(new Customer { Company = "Acme" });
@@ -416,14 +416,14 @@ namespace InventoryManagementApp.Tests.Services
             public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
             public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-            public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-            public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
-            public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default)
+            public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default)
                 => throw new InvalidOperationException("fail");
             public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
         }

--- a/InventoryManagementApp.Tests/Tests/ItemSearchPageBindingTests.cs
+++ b/InventoryManagementApp.Tests/Tests/ItemSearchPageBindingTests.cs
@@ -48,7 +48,7 @@ namespace InventoryManagementApp.Tests.Tests
                     Assert.Null(ex);
 
                     var itemsBinding = BindingOperations.GetBinding(page.ItemsList, ItemsControl.ItemsSourceProperty);
-                    Assert.Equal("Tools", itemsBinding?.Path.Path);
+                    Assert.Equal("Items", itemsBinding?.Path.Path);
 
                     var template = page.ItemsList.ItemTemplate;
                     var outer = Assert.IsType<Border>(template.LoadContent());

--- a/InventoryManagementApp.Tests/Tests/ManageItemsPageMenuTests.cs
+++ b/InventoryManagementApp.Tests/Tests/ManageItemsPageMenuTests.cs
@@ -24,11 +24,11 @@ namespace InventoryManagementApp.Tests.Tests
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
-                var rentalService = new RentalService(db, toolService);
+                var rentalService = new RentalService(db, itemService);
                 var dialog = new StubDialogService();
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
                 var page = new ManageItemsPage { DataContext = vm };
 
                 var grid = (Grid)page.Content;
@@ -55,11 +55,11 @@ namespace InventoryManagementApp.Tests.Tests
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
-                var rentalService = new RentalService(db, toolService);
+                var rentalService = new RentalService(db, itemService);
                 var dialog = new StubDialogService();
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
                 var page = new ManageItemsPage { DataContext = vm };
 
                 var grid = (Grid)page.Content;
@@ -87,11 +87,11 @@ namespace InventoryManagementApp.Tests.Tests
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
-                var rentalService = new RentalService(db, toolService);
+                var rentalService = new RentalService(db, itemService);
                 var dialog = new StubDialogService();
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
                 var page = new ManageItemsPage { DataContext = vm };
 
                 var grid = (Grid)page.Content;

--- a/InventoryManagementApp.Tests/Tests/ManageRentalsPageDeleteTests.cs
+++ b/InventoryManagementApp.Tests/Tests/ManageRentalsPageDeleteTests.cs
@@ -25,17 +25,17 @@ namespace InventoryManagementApp.Tests.Tests
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool = new ItemModel { ItemNumber = "T1" };
-                toolService.AddItem(tool);
+                var item = new ItemModel { ItemNumber = "T1" };
+                itemService.AddItem(item);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
 
-                rentalService.RentItem(tool.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(item.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
                 var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
                 await vm.LoadRentalsAsync();

--- a/InventoryManagementApp.Tests/ViewModels/DashboardViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/DashboardViewModelTests.cs
@@ -23,22 +23,22 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
                 await activityLogService.LogActionAsync(1, "user", "action");
 
-                bool newTool = false, rentals = false, import = false;
+                bool newItem = false, rentals = false, import = false;
 
                 var vm = new DashboardViewModel(
-                    toolService,
+                    itemService,
                     rentalService,
                     customerService,
                     userService,
                     activityLogService,
-                    new RelayCommand(() => newTool = true),
+                    new RelayCommand(() => newItem = true),
                     new RelayCommand(() => rentals = true),
                     new RelayCommand(() => import = true));
 
@@ -50,7 +50,7 @@ namespace InventoryManagementApp.Tests.ViewModels
                 vm.OpenRentalsCommand.Execute(null);
                 vm.OpenImportExportCommand.Execute(null);
 
-                Assert.True(newTool);
+                Assert.True(newItem);
                 Assert.True(rentals);
                 Assert.True(import);
             }
@@ -62,7 +62,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Theory]
-        [InlineData("toolService")]
+        [InlineData("itemService")]
         [InlineData("rentalService")]
         [InlineData("customerService")]
         [InlineData("userService")]
@@ -76,7 +76,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
@@ -86,7 +86,7 @@ namespace InventoryManagementApp.Tests.ViewModels
                 IRelayCommand importCmd = new RelayCommand(() => { });
 
                 var ex = Assert.Throws<ArgumentNullException>(() => new DashboardViewModel(
-                    nullParam == "toolService" ? null : toolService,
+                    nullParam == "itemService" ? null : itemService,
                     nullParam == "rentalService" ? null : rentalService,
                     nullParam == "customerService" ? null : customerService,
                     nullParam == "userService" ? null : userService,
@@ -111,12 +111,12 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
-                var vm = new DashboardViewModel(toolService, rentalService, customerService, userService, activityLogService,
+                var vm = new DashboardViewModel(itemService, rentalService, customerService, userService, activityLogService,
                     new RelayCommand(() => { }), new RelayCommand(() => { }), new RelayCommand(() => { }));
                 vm.StatCards.Clear();
                 var cts = new CancellationTokenSource();

--- a/InventoryManagementApp.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -19,16 +19,16 @@ namespace InventoryManagementApp.Tests.ViewModels
             var tmp = Path.GetTempFileName();
             File.WriteAllText(tmp, "ItemNumber\n");
             var fileDlg = new StubFileDialogService { FileToReturn = tmp };
-            var toolSvc = new CapturingItemService();
+            var itemService = new CapturingItemService();
             var dialog = new StubDialogService { MapToReturn = new Dictionary<string,string>{{"ItemNumber","ItemNumber"}} };
-            var vm = new ImportExportViewModel(toolSvc, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
+            var vm = new ImportExportViewModel(itemService, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
 
             await vm.ImportItemsCommand.ExecuteAsync(null);
 
             Assert.True(dialog.ShowImportMappingCalled);
-            Assert.True(toolSvc.ImportCalled);
+            Assert.True(itemService.ImportCalled);
             Assert.Equal(AppContext.BaseDirectory, fileDlg.InitialDirectoryUsed);
-            Assert.Equal("ItemNumber", toolSvc.MapUsed!["ItemNumber"]);
+            Assert.Equal("ItemNumber", itemService.MapUsed!["ItemNumber"]);
             File.Delete(tmp);
         }
 
@@ -74,14 +74,14 @@ namespace InventoryManagementApp.Tests.ViewModels
             var tmp = Path.GetTempFileName();
             File.WriteAllText(tmp, "ItemNumber\n");
             var fileDlg = new StubFileDialogService { FileToReturn = tmp };
-            var toolSvc = new CapturingItemService();
+            var itemService = new CapturingItemService();
             var dialog = new StubDialogService { MapToReturn = null };
-            var vm = new ImportExportViewModel(toolSvc, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
+            var vm = new ImportExportViewModel(itemService, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
 
             await vm.ImportItemsCommand.ExecuteAsync(null);
 
             Assert.True(dialog.ShowImportMappingCalled);
-            Assert.False(toolSvc.ImportCalled);
+            Assert.False(itemService.ImportCalled);
             File.Delete(tmp);
         }
 
@@ -91,9 +91,9 @@ namespace InventoryManagementApp.Tests.ViewModels
             var tmp = Path.GetTempFileName();
             File.WriteAllText(tmp, "ItemNumber\n");
             var fileDlg = new StubFileDialogService { FileToReturn = tmp };
-            var toolSvc = new CancelableItemService();
+            var itemService = new CancelableItemService();
             var dialog = new StubDialogService { MapToReturn = new Dictionary<string,string>{{"ItemNumber","ItemNumber"}} };
-            var vm = new ImportExportViewModel(toolSvc, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
+            var vm = new ImportExportViewModel(itemService, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
 
             var execute = vm.ImportItemsCommand.ExecuteAsync(null);
             vm.ImportItemsCommand.Cancel();
@@ -180,14 +180,14 @@ namespace InventoryManagementApp.Tests.ViewModels
         public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
         public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
-        public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 
@@ -236,14 +236,14 @@ namespace InventoryManagementApp.Tests.ViewModels
         public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
         public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
-        public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 
@@ -258,14 +258,14 @@ namespace InventoryManagementApp.Tests.ViewModels
         public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
         public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
-        public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 

--- a/InventoryManagementApp.Tests/ViewModels/ItemManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ItemManagementViewModelTests.cs
@@ -30,13 +30,13 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
-                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
-                toolService.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Saw" });
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
+                itemService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
+                itemService.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Saw" });
                 vm.SearchTerm = "Ham";
                 await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
                 Assert.Single(vm.SearchResults);
@@ -56,13 +56,13 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
-                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
-                toolService.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Hammer", Brand = "BrandB" });
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
+                itemService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" });
+                itemService.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Hammer", Brand = "BrandB" });
                 vm.SearchTerm = "Hammer BrandA";
                 await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
                 Assert.Single(vm.SearchResults);
@@ -82,13 +82,13 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
-                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
-                toolService.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Cordless Drill", IsPowered = true });
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
+                itemService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
+                itemService.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Cordless Drill", IsPowered = true });
                 vm.SearchTerm = string.Empty;
                 await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
                 Assert.Equal(2, vm.SearchResults.Count);
@@ -109,12 +109,12 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
-                toolService.AddItem(new ItemModel { ItemNumber = "T1", Brand = "BrandA" });
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
+                itemService.AddItem(new ItemModel { ItemNumber = "T1", Brand = "BrandA" });
                 await vm.LoadItemsAsync();
 
                 Assert.Contains("BrandA", vm.Categories);
@@ -137,10 +137,10 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
-                var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
+                IItemService itemService = new ItemService(db);
+                var vm = new ItemManagementViewModel(itemService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
 
-                toolService.AddItem(new ItemModel { ItemNumber = "T1" });
+                itemService.AddItem(new ItemModel { ItemNumber = "T1" });
                 await vm.LoadItemsAsync();
                 await vm.LoadItemsAsync();
 
@@ -163,13 +163,13 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
-                var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
+                IItemService itemService = new ItemService(db);
+                var vm = new ItemManagementViewModel(itemService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
 
-                toolService.AddItem(new ItemModel { ItemNumber = "T1", Brand = "BrandA" });
+                itemService.AddItem(new ItemModel { ItemNumber = "T1", Brand = "BrandA" });
                 await vm.LoadItemsAsync();
 
-                toolService.AddItem(new ItemModel { ItemNumber = "T2", Brand = "BrandB" });
+                itemService.AddItem(new ItemModel { ItemNumber = "T2", Brand = "BrandB" });
                 await vm.LoadItemsAsync();
 
                 Assert.Equal(2, vm.Items.Count);
@@ -190,15 +190,15 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
                 vm.NewItem.ItemNumber = string.Empty;
                 await vm.NewItemCommand.ExecuteAsync(null);
                 Assert.True(dialog.InfoShown);
-                Assert.Empty(toolService.GetAllItems());
+                Assert.Empty(itemService.GetAllItems());
                 Assert.Equal(string.Empty, vm.NewItem.ItemNumber);
             }
             finally
@@ -238,17 +238,17 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
                 vm.NewItem.ItemNumber = "TN1";
                 vm.NewItem.NameDescription = "Hammer";
                 vm.NewItem.QuantityOnHand = quantity;
                 await vm.NewItemCommand.ExecuteAsync(null);
                 Assert.True(dialog.InfoShown);
-                Assert.Empty(toolService.GetAllItems());
+                Assert.Empty(itemService.GetAllItems());
                 Assert.Equal(quantity, vm.NewItem.QuantityOnHand);
             }
             finally
@@ -265,11 +265,11 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
                 vm.NewItem.ItemNumber = "TN1";
                 vm.NewItem.NameDescription = "Hammer";
                 vm.NewItem.PartNumber = "PN1";
@@ -280,9 +280,9 @@ namespace InventoryManagementApp.Tests.ViewModels
                 vm.NewItem.Notes = "Note";
                 vm.NewItem.IsPowered = true;
                 await vm.NewItemCommand.ExecuteAsync(null);
-                var tools = toolService.GetAllItems();
-                Assert.Single(tools);
-                var item = tools.First();
+                var items = itemService.GetAllItems();
+                Assert.Single(items);
+                var item = items.First();
                 Assert.Equal("TN1", item.ItemNumber);
                 Assert.Equal("Hammer", item.NameDescription);
                 Assert.Equal("PN1", item.PartNumber);
@@ -301,19 +301,19 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
-        public async Task EditItemCommand_UpdatesExistingTool_WhenDialogReturnsTool()
+        public async Task EditItemCommand_UpdatesExistingItem_WhenDialogReturnsItem()
         {
             var dbPath = Path.GetTempFileName();
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
                 var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", ImagePath = "img1.png" };
-                toolService.AddItem(item);
+                itemService.AddItem(item);
                 await vm.LoadItemsAsync();
                 vm.SelectedItem = vm.Items.First();
                 dialog.EditItemHandler = t =>
@@ -322,7 +322,7 @@ namespace InventoryManagementApp.Tests.ViewModels
                     return t;
                 };
                 await vm.EditItemCommand.ExecuteAsync(null);
-                var updated = toolService.GetAllItems().First();
+                var updated = itemService.GetAllItems().First();
                 Assert.Equal("Updated Hammer", updated.NameDescription);
                 Assert.Equal("Updated Hammer", vm.Items.First().NameDescription);
                 Assert.Equal("img1.png", updated.ImagePath);
@@ -342,18 +342,18 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
                 var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
-                toolService.AddItem(item);
+                itemService.AddItem(item);
                 await vm.LoadItemsAsync();
                 vm.SelectedItem = vm.Items.First();
                 dialog.EditItemHandler = _ => null;
                 await vm.EditItemCommand.ExecuteAsync(null);
-                var unchanged = toolService.GetAllItems().First();
+                var unchanged = itemService.GetAllItems().First();
                 Assert.Equal("Hammer", unchanged.NameDescription);
             }
             finally
@@ -364,23 +364,23 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
-        public async Task DeleteItemCommand_RemovesTool()
+        public async Task DeleteItemCommand_RemovesItem()
         {
             var dbPath = Path.GetTempFileName();
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService { ConfirmationResult = true };
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
                 var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
-                toolService.AddItem(item);
+                itemService.AddItem(item);
                 await vm.LoadItemsAsync();
                 vm.SelectedItem = vm.Items.First();
                 await vm.DeleteItemCommand.ExecuteAsync(null);
-                Assert.Empty(toolService.GetAllItems());
+                Assert.Empty(itemService.GetAllItems());
                 Assert.Empty(vm.Items);
             }
             finally
@@ -391,23 +391,23 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
-        public async Task DeleteItemCommand_Cancelled_DoesNotRemoveTool()
+        public async Task DeleteItemCommand_Cancelled_DoesNotRemoveItem()
         {
             var dbPath = Path.GetTempFileName();
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService { ConfirmationResult = false };
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
                 var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
-                toolService.AddItem(item);
+                itemService.AddItem(item);
                 await vm.LoadItemsAsync();
                 vm.SelectedItem = vm.Items.First();
                 await vm.DeleteItemCommand.ExecuteAsync(null);
-                Assert.Single(toolService.GetAllItems());
+                Assert.Single(itemService.GetAllItems());
                 Assert.Single(vm.Items);
             }
             finally
@@ -420,10 +420,10 @@ namespace InventoryManagementApp.Tests.ViewModels
         [Fact]
         public async Task DeleteItemCommand_OnError_ShowsDialogAndLogs()
         {
-            var toolService = new FailingItemService();
+            var itemService = new FailingItemService();
             var dialog = new StubDialogService { ConfirmationResult = true };
             var logger = new CapturingLogger<ItemManagementViewModel>();
-            var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), dialog, logger);
+            var vm = new ItemManagementViewModel(itemService, new StubCustomerService(), new StubRentalService(), dialog, logger);
             var item = new ItemModel { ItemID = 1, ItemNumber = "T1", NameDescription = "Hammer" };
             vm.Items.Add(item);
             vm.SelectedItem = item;
@@ -443,15 +443,15 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
 
                 Assert.False(vm.OpenRentalsCommand.CanExecute(null));
 
-                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
+                itemService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
                 await vm.LoadItemsAsync();
                 vm.SelectedItem = vm.Items.First();
 
@@ -471,13 +471,13 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
                 var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
-                toolService.AddItem(item);
+                itemService.AddItem(item);
                 await vm.LoadItemsAsync();
                 vm.SelectedItem = vm.Items.First();
                 bool called = false;
@@ -501,15 +501,15 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
                 var dialog = new StubDialogService();
-                var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
 
                 Assert.False(vm.ViewDetailsCommand.CanExecute(null));
 
-                toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
+                itemService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
                 await vm.LoadItemsAsync();
                 vm.SelectedItem = vm.Items.First();
 
@@ -525,69 +525,69 @@ namespace InventoryManagementApp.Tests.ViewModels
         [Fact]
         public async Task FilterItemsAsync_UsesSearchService_WhenTermProvided()
         {
-            var tools = new List<ItemModel>
+            var items = new List<ItemModel>
             {
                 new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" },
                 new ItemModel { ItemNumber = "T2", NameDescription = "Saw", Brand = "BrandB" }
             };
-            var toolService = new CountingItemService(tools);
-            var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
+            var itemService = new CountingItemService(items);
+            var vm = new ItemManagementViewModel(itemService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
             vm.SearchTerm = "Ham";
             await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
-            Assert.Equal(1, toolService.SearchItemsAsyncCalls);
-            Assert.Equal(0, toolService.GetAllItemsAsyncCalls);
+            Assert.Equal(1, itemService.SearchItemsAsyncCalls);
+            Assert.Equal(0, itemService.GetAllItemsAsyncCalls);
         }
 
         [Fact]
         public async Task FilterItemsAsync_ReusesCache_WhenNoSearchTerm()
         {
-            var tools = new List<ItemModel>
+            var items = new List<ItemModel>
             {
                 new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" }
             };
-            var toolService = new CountingItemService(tools);
-            var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
+            var itemService = new CountingItemService(items);
+            var vm = new ItemManagementViewModel(itemService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
 
             await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
-            Assert.Equal(1, toolService.GetAllItemsAsyncCalls);
-            Assert.Equal(0, toolService.SearchItemsAsyncCalls);
+            Assert.Equal(1, itemService.GetAllItemsAsyncCalls);
+            Assert.Equal(0, itemService.SearchItemsAsyncCalls);
 
             await vm.SearchCommand.ExecuteAsync(CancellationToken.None);
-            Assert.Equal(1, toolService.GetAllItemsAsyncCalls);
+            Assert.Equal(1, itemService.GetAllItemsAsyncCalls);
         }
 
         [Fact]
         public void SearchText_DebouncesRapidChanges()
         {
-            var tools = new List<ItemModel>
+            var items = new List<ItemModel>
             {
                 new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" }
             };
-            var toolService = new CountingItemService(tools);
+            var itemService = new CountingItemService(items);
             var timer = new TestDispatcherTimer();
-            var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService(), null, timer);
+            var vm = new ItemManagementViewModel(itemService, new StubCustomerService(), new StubRentalService(), new StubDialogService(), null, timer);
 
             vm.SearchText = "H";
             vm.SearchText = "Ha";
             vm.SearchText = "Ham";
 
-            Assert.Equal(0, toolService.SearchItemsAsyncCalls);
+            Assert.Equal(0, itemService.SearchItemsAsyncCalls);
 
             timer.RaiseTick();
 
-            Assert.Equal(1, toolService.SearchItemsAsyncCalls);
+            Assert.Equal(1, itemService.SearchItemsAsyncCalls);
         }
 
         [Fact]
         public void Dispose_StopsSearchDebounceTimer()
         {
-            var tools = new List<ItemModel>
+            var items = new List<ItemModel>
             {
                 new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" }
             };
-            var toolService = new CountingItemService(tools);
+            var itemService = new CountingItemService(items);
             var timer = new TestDispatcherTimer();
-            var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService(), null, timer);
+            var vm = new ItemManagementViewModel(itemService, new StubCustomerService(), new StubRentalService(), new StubDialogService(), null, timer);
 
             vm.SearchText = "Ha";
             Assert.True(timer.IsEnabled);
@@ -601,12 +601,12 @@ namespace InventoryManagementApp.Tests.ViewModels
         [Fact]
         public async Task SearchCommand_CanBeCancelled()
         {
-            var tools = new List<ItemModel>
+            var items = new List<ItemModel>
             {
                 new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", Brand = "BrandA" }
             };
-            var toolService = new CountingItemService(tools);
-            var vm = new ItemManagementViewModel(toolService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
+            var itemService = new CountingItemService(items);
+            var vm = new ItemManagementViewModel(itemService, new StubCustomerService(), new StubRentalService(), new StubDialogService());
             vm.SearchTerm = "Ham";
             var cts = new CancellationTokenSource();
             cts.Cancel();
@@ -617,13 +617,13 @@ namespace InventoryManagementApp.Tests.ViewModels
         {
             public int GetAllItemsAsyncCalls { get; private set; }
             public int SearchItemsAsyncCalls { get; private set; }
-            readonly List<ItemModel> _tools;
-            public CountingItemService(IEnumerable<ItemModel> tools) => _tools = tools.ToList();
+            readonly List<ItemModel> _items;
+            public CountingItemService(IEnumerable<ItemModel> items) => _items = items.ToList();
 
             public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default)
             {
                 GetAllItemsAsyncCalls++;
-                return Task.FromResult(_tools.ToList());
+                return Task.FromResult(_items.ToList());
             }
 
             public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default)
@@ -632,9 +632,9 @@ namespace InventoryManagementApp.Tests.ViewModels
                 if (cancellationToken.IsCancellationRequested)
                     return Task.FromCanceled<List<ItemModel>>(cancellationToken);
                 if (string.IsNullOrWhiteSpace(searchText))
-                    return Task.FromResult(_tools.ToList());
+                    return Task.FromResult(_items.ToList());
                 var term = searchText.Trim();
-                var results = _tools.Where(t =>
+                var results = _items.Where(t =>
                     (t.ItemNumber?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
                     (t.NameDescription?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
                     (t.Brand?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
@@ -645,15 +645,15 @@ namespace InventoryManagementApp.Tests.ViewModels
 
             public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
             public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
         }
 
@@ -661,17 +661,17 @@ namespace InventoryManagementApp.Tests.ViewModels
         {
             public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new Exception("failure");
-            public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => throw new Exception("failure");
+            public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
             public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-            public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-            public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
             public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
-            public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
         }
 

--- a/InventoryManagementApp.Tests/ViewModels/MainViewModelAutoLogoutTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/MainViewModelAutoLogoutTests.cs
@@ -25,7 +25,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -38,7 +38,7 @@ namespace InventoryManagementApp.Tests.ViewModels
                 var loginCalled = false;
                 Func<Task<bool>> login = () => { loginCalled = true; return Task.FromResult(true); };
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                var vm = new MainViewModel(itemService, userService, userContext, customerService, rentalService,
                     new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService(), null, login, timer);
 
                 Assert.True(timer.IsEnabled);

--- a/InventoryManagementApp.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -27,7 +27,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -35,7 +35,7 @@ namespace InventoryManagementApp.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
+                var vm = new MainViewModel(itemService, userService, userContext, customerService, rentalService, new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
 
                 bool adminRaised = false;
                 bool photoRaised = false;

--- a/InventoryManagementApp.Tests/ViewModels/MainViewModelDisposalTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/MainViewModelDisposalTests.cs
@@ -20,7 +20,7 @@ namespace InventoryManagementApp.Tests.ViewModels
     public class MainViewModelDisposalTests
     {
         [Fact]
-        public void Dispose_RemovesToolManagementPropertyChangedHandler()
+        public void Dispose_RemovesItemManagementPropertyChangedHandler()
         {
             var dbPath = Path.GetTempFileName();
             try

--- a/InventoryManagementApp.Tests/ViewModels/MainViewModelImportMappingTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/MainViewModelImportMappingTests.cs
@@ -29,7 +29,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             {
                 using var factory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(logs)));
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -38,7 +38,7 @@ namespace InventoryManagementApp.Tests.ViewModels
                 var settingsService = new SettingsService(db);
                 var fileDlg = new StubFileDialogService { FileToReturn = csvPath };
                 var dialog = new StubDialogService { MapToReturn = new Dictionary<string,string>{{"ItemNumber","ItemNumber"}} };
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                var vm = new MainViewModel(itemService, userService, userContext, customerService, rentalService,
                     fileDlg, activityLogService, settingsService, db, dialog,
                     logger: factory.CreateLogger<MainViewModel>());
 

--- a/InventoryManagementApp.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -30,7 +30,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -45,7 +45,7 @@ namespace InventoryManagementApp.Tests.ViewModels
                     return Task.FromResult(true);
                 };
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                var vm = new MainViewModel(itemService, userService, userContext, customerService, rentalService,
                     new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService(), null, stubLogin);
 
                 userContext.CurrentUser = new User { UserName = "old", IsAdmin = false };
@@ -82,7 +82,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -97,7 +97,7 @@ namespace InventoryManagementApp.Tests.ViewModels
                     return Task.FromResult(true);
                 };
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                var vm = new MainViewModel(itemService, userService, userContext, customerService, rentalService,
                     new StubFileDialogService(), activityLogService, settingsService, db, dialog, null, stubLogin);
 
                 await vm.SwitchUserCommand.ExecuteAsync(null);
@@ -128,7 +128,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -140,7 +140,7 @@ namespace InventoryManagementApp.Tests.ViewModels
                 var logger = new StubLogger<MainViewModel>();
 
                 Func<Task<bool>> stubLogin = () => Task.FromResult(false);
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                var vm = new MainViewModel(itemService, userService, userContext, customerService, rentalService,
                     new StubFileDialogService(), activityLogService, settingsService, db, dialog, logger, stubLogin);
 
                 var oldUser = new User { UserName = "old", IsAdmin = false };
@@ -169,7 +169,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -182,7 +182,7 @@ namespace InventoryManagementApp.Tests.ViewModels
 
                 Func<Task<bool>> stubLogin = () => throw new InvalidOperationException("boom");
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                var vm = new MainViewModel(itemService, userService, userContext, customerService, rentalService,
                     new StubFileDialogService(), activityLogService, settingsService, db, dialog, logger, stubLogin);
 
                 await vm.SwitchUserCommand.ExecuteAsync(null);
@@ -207,7 +207,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -236,7 +236,7 @@ namespace InventoryManagementApp.Tests.ViewModels
                     return true;
                 };
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                var vm = new MainViewModel(itemService, userService, userContext, customerService, rentalService,
                     new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService(), null, stubLogin);
 
                 await vm.SwitchUserCommand.ExecuteAsync(null);

--- a/InventoryManagementApp.Tests/ViewModels/MainViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/MainViewModelTests.cs
@@ -30,7 +30,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -39,7 +39,7 @@ namespace InventoryManagementApp.Tests.ViewModels
                 var settingsService = new SettingsService(db);
                 var dialog = new StubDialogService();
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                var vm = new MainViewModel(itemService, userService, userContext, customerService, rentalService,
                     new StubFileDialogService(), activityLogService, settingsService, db, dialog);
 
                 vm.ExitCommand.Execute(null);
@@ -64,7 +64,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 var userService = new UserService(db, userContext);
                 var customerService = new CustomerService(db);
@@ -73,7 +73,7 @@ namespace InventoryManagementApp.Tests.ViewModels
                 var settingsService = new SettingsService(db);
                 var dialog = new StubDialogService { ThrowOnShowPrintLabelDialog = true };
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                var vm = new MainViewModel(itemService, userService, userContext, customerService, rentalService,
                     new StubFileDialogService(), activityLogService, settingsService, db, dialog);
 
                 vm.OpenPrintLabelWindowCommand.Execute(null);
@@ -97,7 +97,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new GetAllUsersFailingUserService();
                 var customerService = new CustomerService(db);
@@ -106,7 +106,7 @@ namespace InventoryManagementApp.Tests.ViewModels
                 var settingsService = new SettingsService(db);
                 var dialog = new StubDialogService();
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                var vm = new MainViewModel(itemService, userService, userContext, customerService, rentalService,
                     new StubFileDialogService(), activityLogService, settingsService, db, dialog);
 
                 var ex = await Record.ExceptionAsync(() => vm.OpenUsersCommand.ExecuteAsync(null));

--- a/InventoryManagementApp.Tests/ViewModels/MainViewModelTitleTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/MainViewModelTitleTests.cs
@@ -25,11 +25,11 @@ namespace InventoryManagementApp.Tests.ViewModels
             var dbPath = Path.GetTempFileName();
             var originalSingular = LabelProvider.Instance.ItemLabelSingular;
             var originalPlural = LabelProvider.Instance.ItemLabelPlural;
-            LabelProvider.Instance.UpdateLabels("ItemModel", "Tools");
+            LabelProvider.Instance.UpdateLabels("ItemModel", "Items");
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 var userContext = new ApplicationUserContext();
                 IUserService userService = new UserService(db, userContext);
                 ICustomerService customerService = new CustomerService(db);
@@ -37,16 +37,16 @@ namespace InventoryManagementApp.Tests.ViewModels
                 var activityLogService = new ActivityLogService(db);
                 var settingsService = new SettingsService(db);
 
-                var vm = new MainViewModel(toolService, userService, userContext, customerService, rentalService,
+                var vm = new MainViewModel(itemService, userService, userContext, customerService, rentalService,
                     new StubFileDialogService(), activityLogService, settingsService, db, new StubDialogService());
 
-                Assert.Equal("Tools Management", vm.WindowTitle);
+                Assert.Equal("Items Management", vm.WindowTitle);
 
                 vm.Settings.ApplicationName = "My App";
                 Assert.Equal("My App", vm.WindowTitle);
 
                 vm.Settings.ApplicationName = string.Empty;
-                Assert.Equal("Tools Management", vm.WindowTitle);
+                Assert.Equal("Items Management", vm.WindowTitle);
             }
             finally
             {

--- a/InventoryManagementApp.Tests/ViewModels/ManageRentalsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ManageRentalsViewModelTests.cs
@@ -23,20 +23,20 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool1 = new ItemModel { ItemNumber = "T1" };
-                var tool2 = new ItemModel { ItemNumber = "T2" };
-                toolService.AddItem(tool1);
-                toolService.AddItem(tool2);
+                var item1 = new ItemModel { ItemNumber = "T1" };
+                var item2 = new ItemModel { ItemNumber = "T2" };
+                itemService.AddItem(item1);
+                itemService.AddItem(item2);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
 
-                rentalService.RentItem(tool1.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
-                rentalService.RentItem(tool2.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(item1.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(item2.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
                 var all = rentalService.GetAllRentals();
                 rentalService.ReturnItem(all[1].RentalID, DateTime.Today);
 
@@ -68,20 +68,20 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool1 = new ItemModel { ItemNumber = "Alpha" };
-                var tool2 = new ItemModel { ItemNumber = "Beta" };
-                toolService.AddItem(tool1);
-                toolService.AddItem(tool2);
+                var item1 = new ItemModel { ItemNumber = "Alpha" };
+                var item2 = new ItemModel { ItemNumber = "Beta" };
+                itemService.AddItem(item1);
+                itemService.AddItem(item2);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
 
-                rentalService.RentItem(tool1.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
-                rentalService.RentItem(tool2.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(item1.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(item2.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
                 var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
                 await vm.LoadRentalsAsync();
@@ -106,18 +106,18 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool = new ItemModel { ItemNumber = "T1" };
-                toolService.AddItem(tool);
+                var item = new ItemModel { ItemNumber = "T1" };
+                itemService.AddItem(item);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
 
-                rentalService.RentItem(tool.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
-                rentalService.RentItem(tool.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(item.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(item.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
                 var dialog = new StubDialogService();
                 var vm = new ManageRentalsViewModel(rentalService, dialog);
@@ -163,17 +163,17 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool = new ItemModel { ItemNumber = "T1" };
-                toolService.AddItem(tool);
+                var item = new ItemModel { ItemNumber = "T1" };
+                itemService.AddItem(item);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
 
-                rentalService.RentItem(tool.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(item.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
                 var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
                 await vm.LoadRentalsAsync();
@@ -199,17 +199,17 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool = new ItemModel { ItemNumber = "T1" };
-                toolService.AddItem(tool);
+                var item = new ItemModel { ItemNumber = "T1" };
+                itemService.AddItem(item);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
 
-                rentalService.RentItem(tool.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(item.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
                 var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
                 await vm.LoadRentalsAsync();
@@ -233,17 +233,17 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var rentalService = new RentalService(db);
 
-                var tool = new ItemModel { ItemNumber = "T1" };
-                toolService.AddItem(tool);
+                var item = new ItemModel { ItemNumber = "T1" };
+                itemService.AddItem(item);
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
 
-                rentalService.RentItem(tool.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(item.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
                 var vm = new ManageRentalsViewModel(rentalService, new StubDialogService());
                 await vm.LoadRentalsAsync();

--- a/InventoryManagementApp.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/NewPageViewModelTests.cs
@@ -14,6 +14,7 @@ using InventoryManagementApp.Services.Rentals;
 using InventoryManagementApp.Services.Items;
 using InventoryManagementApp.Services.Customers;
 using InventoryManagementApp.ViewModels;
+using InventoryManagementApp.Utilities.Helpers;
 using Xunit;
 using System.Threading.Tasks;
 
@@ -43,44 +44,44 @@ namespace InventoryManagementApp.Tests.ViewModels
         [Fact]
         public async Task ImportExportViewModel_ImportItemsCommand_LogsSuccess()
         {
-            var toolService = new StubItemService();
+            var itemService = new StubItemService();
             var customerService = new StubCustomerService();
             var fileDlg = new StubFileDialogService();
             var tmp = Path.GetTempFileName();
             File.WriteAllText(tmp, "ItemNumber\n");
             fileDlg.FileToReturn = tmp;
             var dialog = new StubDialogService();
-            var vm = new ImportExportViewModel(toolService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
+            var vm = new ImportExportViewModel(itemService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
             await vm.ImportItemsCommand.ExecuteAsync(null);
-            Assert.True(toolService.ImportCalled);
+            Assert.True(itemService.ImportCalled);
             Assert.Single(vm.ImportExportLogs);
-            Assert.StartsWith("Successfully imported tools", vm.ImportExportLogs[0]);
+            Assert.StartsWith($"Successfully imported {LabelProvider.Instance.ItemLabelPlural}", vm.ImportExportLogs[0]);
             File.Delete(tmp);
         }
 
         [Fact]
         public async Task ImportExportViewModel_ExportItemsCommand_LogsSuccess()
         {
-            var toolService = new StubItemService();
+            var itemService = new StubItemService();
             var customerService = new StubCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
+            var vm = new ImportExportViewModel(itemService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
             await vm.ExportItemsCommand.ExecuteAsync(null);
-            Assert.True(toolService.ExportCalled);
+            Assert.True(itemService.ExportCalled);
             Assert.Single(vm.ImportExportLogs);
-            Assert.StartsWith("Successfully exported tools", vm.ImportExportLogs[0]);
+            Assert.StartsWith($"Successfully exported {LabelProvider.Instance.ItemLabelPlural}", vm.ImportExportLogs[0]);
         }
 
         [Fact]
         public async Task ImportExportViewModel_ImportCustomersCommand_LogsSuccess()
         {
-            var toolService = new StubItemService();
+            var itemService = new StubItemService();
             var customerService = new StubCustomerService();
             var fileDlg = new StubFileDialogService();
             var tmp = Path.GetTempFileName();
             File.WriteAllText(tmp, "Company\n");
             fileDlg.FileToReturn = tmp;
             var dialog = new StubDialogService();
-            var vm = new ImportExportViewModel(toolService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
+            var vm = new ImportExportViewModel(itemService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
             await vm.ImportCustomersCommand.ExecuteAsync(null);
             Assert.True(customerService.ImportCalled);
             Assert.Single(vm.ImportExportLogs);
@@ -91,9 +92,9 @@ namespace InventoryManagementApp.Tests.ViewModels
         [Fact]
         public async Task ImportExportViewModel_ExportCustomersCommand_LogsSuccess()
         {
-            var toolService = new StubItemService();
+            var itemService = new StubItemService();
             var customerService = new StubCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
+            var vm = new ImportExportViewModel(itemService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
             await vm.ExportCustomersCommand.ExecuteAsync(null);
             Assert.True(customerService.ExportCalled);
             Assert.Single(vm.ImportExportLogs);
@@ -123,42 +124,42 @@ namespace InventoryManagementApp.Tests.ViewModels
         [Fact]
         public async Task ImportExportViewModel_ImportItemsCommand_LogsFailure()
         {
-            var toolService = new FailItemService();
+            var itemService = new FailItemService();
             var customerService = new StubCustomerService();
             var fileDlg = new StubFileDialogService();
             var tmp = Path.GetTempFileName();
             File.WriteAllText(tmp, "ItemNumber\n");
             fileDlg.FileToReturn = tmp;
             var dialog = new StubDialogService();
-            var vm = new ImportExportViewModel(toolService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
+            var vm = new ImportExportViewModel(itemService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
             await vm.ImportItemsCommand.ExecuteAsync(null);
             Assert.Single(vm.ImportExportLogs);
-            Assert.StartsWith("Failed to import tools", vm.ImportExportLogs[0]);
+            Assert.StartsWith($"Failed to import {LabelProvider.Instance.ItemLabelPlural}", vm.ImportExportLogs[0]);
             File.Delete(tmp);
         }
 
         [Fact]
         public async Task ImportExportViewModel_ExportItemsCommand_LogsFailure()
         {
-            var toolService = new FailItemService();
+            var itemService = new FailItemService();
             var customerService = new StubCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
+            var vm = new ImportExportViewModel(itemService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
             await vm.ExportItemsCommand.ExecuteAsync(null);
             Assert.Single(vm.ImportExportLogs);
-            Assert.StartsWith("Failed to export tools", vm.ImportExportLogs[0]);
+            Assert.StartsWith($"Failed to export {LabelProvider.Instance.ItemLabelPlural}", vm.ImportExportLogs[0]);
         }
 
         [Fact]
         public async Task ImportExportViewModel_ImportCustomersCommand_LogsFailure()
         {
-            var toolService = new StubItemService();
+            var itemService = new StubItemService();
             var customerService = new FailCustomerService();
             var fileDlg = new StubFileDialogService();
             var tmp = Path.GetTempFileName();
             File.WriteAllText(tmp, "Company\n");
             fileDlg.FileToReturn = tmp;
             var dialog = new StubDialogService();
-            var vm = new ImportExportViewModel(toolService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
+            var vm = new ImportExportViewModel(itemService, customerService, fileDlg, new StubDatabaseBackupService(), dialog);
             await vm.ImportCustomersCommand.ExecuteAsync(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Failed to import customers", vm.ImportExportLogs[0]);
@@ -168,9 +169,9 @@ namespace InventoryManagementApp.Tests.ViewModels
         [Fact]
         public async Task ImportExportViewModel_ExportCustomersCommand_LogsFailure()
         {
-            var toolService = new StubItemService();
+            var itemService = new StubItemService();
             var customerService = new FailCustomerService();
-            var vm = new ImportExportViewModel(toolService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
+            var vm = new ImportExportViewModel(itemService, customerService, new StubFileDialogService(), new StubDatabaseBackupService(), new StubDialogService());
             await vm.ExportCustomersCommand.ExecuteAsync(null);
             Assert.Single(vm.ImportExportLogs);
             Assert.StartsWith("Failed to export customers", vm.ImportExportLogs[0]);
@@ -243,14 +244,14 @@ namespace InventoryManagementApp.Tests.ViewModels
         public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
         public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, System.Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
-        public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 
@@ -261,26 +262,26 @@ namespace InventoryManagementApp.Tests.ViewModels
         public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
         public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
-        public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
-        public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, System.Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
-        public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, SQLiteConnection? conn = null, SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 
     class StubRentalService : IRentalService
     {
-        public void RentItem(int toolID, int customerID, System.DateTime rentalDate, System.DateTime dueDate) => throw new System.NotImplementedException();
+        public void RentItem(int itemID, int customerID, System.DateTime rentalDate, System.DateTime dueDate) => throw new System.NotImplementedException();
         public void ReturnItem(int rentalID, System.DateTime returnDate) => throw new System.NotImplementedException();
         public void ExtendRental(int rentalID, System.DateTime newDueDate) => throw new System.NotImplementedException();
         public List<Rental> GetActiveRentals() => new();
         public List<Rental> GetOverdueRentals() => new();
         public List<Rental> GetAllRentals() => new();
-        public List<Rental> GetRentalHistoryForItem(int toolID) => new();
+        public List<Rental> GetRentalHistoryForItem(int itemID) => new();
         public List<Rental> GetRentalHistoryForCustomer(int customerID) => new();
     }
 

--- a/InventoryManagementApp.Tests/ViewModels/RentalHistoryViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/RentalHistoryViewModelTests.cs
@@ -12,7 +12,7 @@ namespace InventoryManagementApp.Tests.ViewModels
     public class RentalHistoryViewModelTests
     {
         [Fact]
-        public void Constructor_SetsItemDisplayName_WhenToolProvided()
+        public void Constructor_SetsItemDisplayName_WhenItemProvided()
         {
             var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
             var vm = new RentalHistoryViewModel(item, Enumerable.Empty<Rental>(), new StubDialogService());
@@ -21,7 +21,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
-        public void Constructor_DefaultsItemDisplayName_WhenToolNull()
+        public void Constructor_DefaultsItemDisplayName_WhenItemNull()
         {
             var vm = new RentalHistoryViewModel(null, Enumerable.Empty<Rental>(), new StubDialogService());
 

--- a/InventoryManagementApp.Tests/ViewModels/ReportsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ReportsViewModelTests.cs
@@ -24,21 +24,21 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                var toolService = new ItemService(db);
+                var itemService = new ItemService(db);
                 var customerService = new CustomerService(db);
                 var userService = new UserService(db, new ApplicationUserContext());
-                var rentalService = new RentalService(db, toolService);
+                var rentalService = new RentalService(db, itemService);
                 var activityService = new ActivityLogService(db);
-                var reportService = new ReportService(toolService, rentalService, activityService, customerService, userService);
+                var reportService = new ReportService(itemService, rentalService, activityService, customerService, userService);
 
-                var tool = new ItemModel { ItemNumber = "T1", QuantityOnHand = 1 };
-                toolService.AddItem(tool);
+                var item = new ItemModel { ItemNumber = "T1", QuantityOnHand = 1 };
+                itemService.AddItem(item);
 
                 var customer = new Customer { Company = "C1" };
                 customerService.AddCustomer(customer);
                 var cust = customerService.GetAllCustomers().First();
 
-                rentalService.RentItem(tool.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+                rentalService.RentItem(item.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
 
                 var user = new User { UserName = "user", PasswordHash = "Strong1!" };
                 userService.AddUser(user);

--- a/InventoryManagementApp.Tests/Views/AvatarSelectionWindowTests.cs
+++ b/InventoryManagementApp.Tests/Views/AvatarSelectionWindowTests.cs
@@ -114,7 +114,7 @@ namespace InventoryManagementApp.Tests.Views
         {
             public string? AppName { get; set; }
             public string ItemLabelSingular { get; set; } = "ItemModel";
-            public string ItemLabelPlural { get; set; } = "Tools";
+            public string ItemLabelPlural { get; set; } = "Items";
 
             public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default)
                 => Task.FromResult(AppName);
@@ -185,7 +185,7 @@ namespace InventoryManagementApp.Tests.Views
             public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
             public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default)
-                => Task.FromResult("Tools");
+                => Task.FromResult("Items");
             public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
         }

--- a/InventoryManagementApp.Tests/Views/ImportExportPageTests.cs
+++ b/InventoryManagementApp.Tests/Views/ImportExportPageTests.cs
@@ -28,11 +28,11 @@ namespace InventoryManagementApp.Tests.Views
                 {
                     try
                     {
-                        var toolSvc = new StubItemService();
+                        var itemService = new StubItemService();
                         var customerSvc = new StubCustomerService();
                         var fileDlg = new StubFileDialogService { FileToReturn = tmp };
                         var dialog = new StubDialogService();
-                        var vm = new ImportExportViewModel(toolSvc, customerSvc, fileDlg, new StubDatabaseBackupService(), dialog);
+                        var vm = new ImportExportViewModel(itemService, customerSvc, fileDlg, new StubDatabaseBackupService(), dialog);
                         var page = new ImportExportPage { DataContext = vm };
                         var grid = (Grid)page.Content;
                         var panel = (WrapPanel)((Border)grid.Children[0]).Child;
@@ -42,7 +42,7 @@ namespace InventoryManagementApp.Tests.Views
                         var asyncCmd = (CommunityToolkit.Mvvm.Input.IAsyncRelayCommand)importBtn.Command;
                         var task = asyncCmd.ExecuteAsync(null);
                         task.GetAwaiter().GetResult();
-                        Assert.True(toolSvc.ImportCalled);
+                        Assert.True(itemService.ImportCalled);
                         Assert.Single(vm.ImportExportLogs);
                     }
                     catch (Exception ex)
@@ -108,14 +108,14 @@ namespace InventoryManagementApp.Tests.Views
         public Task<System.Collections.Generic.List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ItemModel>());
         public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task DeleteItemAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<ItemModel?> GetItemByIDAsync(int toolID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<System.Collections.Generic.List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ItemModel>());
-        public Task<bool> ToggleItemCheckOutStatusAsync(int toolID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<System.Collections.Generic.List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new System.Collections.Generic.List<ItemModel>());
-        public Task UpdateItemImageAsync(int toolID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, System.Collections.Generic.IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
-        public Task UpdateItemQuantitiesAsync(int toolID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult("T1");
     }
 

--- a/InventoryManagementApp.Tests/Views/ItemSearchTypingTests.cs
+++ b/InventoryManagementApp.Tests/Views/ItemSearchTypingTests.cs
@@ -25,13 +25,13 @@ namespace InventoryManagementApp.Tests.Views
                 try
                 {
                     var db = new DatabaseService(dbPath);
-                    IItemService toolService = new ItemService(db);
+                    IItemService itemService = new ItemService(db);
                     var customerService = new CustomerService(db);
                     var rentalService = new RentalService(db);
                     var dialog = new StubDialogService();
-                    var vm = new ItemManagementViewModel(toolService, customerService, rentalService, dialog);
-                    toolService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
-                    toolService.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Hand Saw" });
+                    var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
+                    itemService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
+                    itemService.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Hand Saw" });
                     vm.LoadItemsAsync().Wait();
                     var page = new ItemSearchPage { DataContext = vm };
                     var window = new System.Windows.Window { Content = page, Width = 800, Height = 600 };

--- a/InventoryManagementApp.Tests/Views/MainWindowTests.cs
+++ b/InventoryManagementApp.Tests/Views/MainWindowTests.cs
@@ -140,14 +140,14 @@ namespace InventoryManagementApp.Tests.Views
                 {
                     var originalSingular = LabelProvider.Instance.ItemLabelSingular;
                     var originalPlural = LabelProvider.Instance.ItemLabelPlural;
-                    LabelProvider.Instance.UpdateLabels("Item", "Tools");
+                    LabelProvider.Instance.UpdateLabels("Item", "Items");
                     var (window, dbPath) = TestHelpers.CreateMainWindow();
                     try
                     {
                         var textBlock = TestHelpers.FindVisualChildren<TextBlock>(window)
                             .FirstOrDefault(tb => BindingOperations.GetBinding(tb, TextBlock.TextProperty)?.Path?.Path == "ItemLabelPlural");
                         Assert.NotNull(textBlock);
-                        Assert.Equal("Tools", textBlock!.Text);
+                        Assert.Equal("Items", textBlock!.Text);
                     }
                     finally
                     {
@@ -343,7 +343,7 @@ namespace InventoryManagementApp.Tests.Views
         }
 
         [Fact]
-        public void RentalHistoryButton_BoundToSelectedTool()
+        public void RentalHistoryButton_BoundToSelectedItem()
         {
             Exception? threadException = null;
 


### PR DESCRIPTION
## Summary
- rename test methods and variables from tool* to item*
- use `LabelProvider.Instance.ItemLabelPlural` in import/export tests
- update fixtures to item-centric naming

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6bada911c83249cb1825dda605d39