### PR TITLE
Rename dashboard tools variable to items

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/DashboardViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/DashboardViewModelTests.cs
@@ -23,22 +23,22 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
                 await activityLogService.LogActionAsync(1, "user", "action");
 
-                bool newTool = false, rentals = false, import = false;
+                bool newItem = false, rentals = false, import = false;
 
                 var vm = new DashboardViewModel(
-                    toolService,
+                    itemService,
                     rentalService,
                     customerService,
                     userService,
                     activityLogService,
-                    new RelayCommand(() => newTool = true),
+                    new RelayCommand(() => newItem = true),
                     new RelayCommand(() => rentals = true),
                     new RelayCommand(() => import = true));
 
@@ -50,7 +50,7 @@ namespace InventoryManagementApp.Tests.ViewModels
                 vm.OpenRentalsCommand.Execute(null);
                 vm.OpenImportExportCommand.Execute(null);
 
-                Assert.True(newTool);
+                Assert.True(newItem);
                 Assert.True(rentals);
                 Assert.True(import);
             }
@@ -62,7 +62,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Theory]
-        [InlineData("toolService")]
+        [InlineData("itemService")]
         [InlineData("rentalService")]
         [InlineData("customerService")]
         [InlineData("userService")]
@@ -76,7 +76,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
@@ -86,7 +86,7 @@ namespace InventoryManagementApp.Tests.ViewModels
                 IRelayCommand importCmd = new RelayCommand(() => { });
 
                 var ex = Assert.Throws<ArgumentNullException>(() => new DashboardViewModel(
-                    nullParam == "toolService" ? null : toolService,
+                    nullParam == "itemService" ? null : itemService,
                     nullParam == "rentalService" ? null : rentalService,
                     nullParam == "customerService" ? null : customerService,
                     nullParam == "userService" ? null : userService,
@@ -111,12 +111,12 @@ namespace InventoryManagementApp.Tests.ViewModels
             try
             {
                 var db = new DatabaseService(dbPath);
-                IItemService toolService = new ItemService(db);
+                IItemService itemService = new ItemService(db);
                 IUserService userService = new UserService(db, new ApplicationUserContext());
                 ICustomerService customerService = new CustomerService(db);
                 IRentalService rentalService = new RentalService(db);
                 var activityLogService = new ActivityLogService(db);
-                var vm = new DashboardViewModel(toolService, rentalService, customerService, userService, activityLogService,
+                var vm = new DashboardViewModel(itemService, rentalService, customerService, userService, activityLogService,
                     new RelayCommand(() => { }), new RelayCommand(() => { }), new RelayCommand(() => { }));
                 vm.StatCards.Clear();
                 var cts = new CancellationTokenSource();

--- a/InventoryManagementApp/ViewModels/DashboardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DashboardViewModel.cs
@@ -80,8 +80,8 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 StatCards.Clear();
-                var tools = await _itemService.GetAllItemsAsync(cancellationToken);
-                StatCards.Add(new StatCard { Title = $"Total {LabelProvider.Instance.ItemLabelPlural}", Value = tools.Count.ToString() });
+                var items = await _itemService.GetAllItemsAsync(cancellationToken);
+                StatCards.Add(new StatCard { Title = $"Total {LabelProvider.Instance.ItemLabelPlural}", Value = items.Count.ToString() });
                 var activeRentals = await _rentalService.GetActiveRentalsAsync();
                 var customers = await _customerService.GetAllCustomersAsync(cancellationToken);
                 var users = await _userService.GetAllUsersAsync();


### PR DESCRIPTION
## Summary
- rename `tools` variable to `items` in dashboard statistics
- update `DashboardViewModelTests` for new variable names

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6bad57abc83249556d18dcdea1ec3