### PR TITLE
Rename variables in rental and database services

### DIFF
--- a/InventoryManagementApp/Services/Core/DatabaseService.cs
+++ b/InventoryManagementApp/Services/Core/DatabaseService.cs
@@ -109,8 +109,8 @@ namespace InventoryManagementApp.Services.Core
             // Migration: rename legacy Tools table to Items
             using (var check = new SQLiteCommand("SELECT name FROM sqlite_master WHERE type='table' AND name='Tools';", conn))
             {
-                var toolsExists = check.ExecuteScalar();
-                if (toolsExists != null)
+                var toolsTableExists = check.ExecuteScalar();
+                if (toolsTableExists != null)
                 {
                     using var itemsCheck = new SQLiteCommand("SELECT name FROM sqlite_master WHERE type='table' AND name='Items';", conn);
                     var itemsExists = itemsCheck.ExecuteScalar();

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -166,7 +166,7 @@ namespace InventoryManagementApp.Services.Rentals
                 if (!await reader.ReadAsync())
                     throw new InvalidOperationException("Unable to extend rental. Rental not found or already returned.");
 
-                int toolID = Convert.ToInt32(reader["ItemID"]);
+                int itemID = Convert.ToInt32(reader["ItemID"]);
                 DateTime oldDueDate = DateTime.Parse(reader["DueDate"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
 
                 var updateCmd = new SQLiteCommand(
@@ -180,9 +180,9 @@ namespace InventoryManagementApp.Services.Rentals
                 if (_itemService != null)
                 {
                     if (oldDueDate <= DateTime.Today && newDueDate > DateTime.Today)
-                        await _itemService.UpdateItemQuantitiesAsync(toolID, 1, true, conn, tx);
+                        await _itemService.UpdateItemQuantitiesAsync(itemID, 1, true, conn, tx);
                     else if (oldDueDate > DateTime.Today && newDueDate <= DateTime.Today)
-                        await _itemService.UpdateItemQuantitiesAsync(toolID, 1, false, conn, tx);
+                        await _itemService.UpdateItemQuantitiesAsync(itemID, 1, false, conn, tx);
                 }
             });
             if (_activityLog != null)


### PR DESCRIPTION
## Summary
- rename local variable toolID to itemID in RentalService
- clarify migration check variable toolsTableExists in DatabaseService

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c4bd7ea8832484668947aee3c8c5