### PR TITLE
Rename tool variables to item in rental view models

### DIFF
--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -226,14 +226,14 @@ namespace InventoryManagementApp.ViewModels
                 return;
             }
 
-            var tool = new ItemModel
+            var item = new ItemModel
             {
                 ItemID = SelectedRental.ItemID,
                 ItemNumber = SelectedRental.ItemNumber,
                 NameDescription = SelectedRental.ItemNumber
             };
 
-            _dialogService.ShowRentalHistory(tool, history);
+            _dialogService.ShowRentalHistory(item, history);
         }
 
         void PrintRental()

--- a/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
+++ b/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
@@ -43,10 +43,10 @@ namespace InventoryManagementApp.ViewModels.Rental
         public IRelayCommand ExportCsvCommand { get; }
         public IRelayCommand CloseCommand { get; }
 
-        public RentalHistoryViewModel(ItemModel? tool, IEnumerable<RentalModel>? history, IDialogService dialogService, ILogger<RentalHistoryViewModel>? logger = null)
+        public RentalHistoryViewModel(ItemModel? item, IEnumerable<RentalModel>? history, IDialogService dialogService, ILogger<RentalHistoryViewModel>? logger = null)
         {
-            ItemDisplayName = tool != null
-                ? $"{tool.ItemNumber} - {tool.NameDescription}"
+            ItemDisplayName = item != null
+                ? $"{item.ItemNumber} - {item.NameDescription}"
                 : "Rental History";
 
             _allHistory = (history ?? Enumerable.Empty<RentalModel>()).ToList();


### PR DESCRIPTION
## Summary
- rename `tool` parameter to `item` in `RentalHistoryViewModel`
- rename local `tool` variable to `item` in `ManageRentalsViewModel`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden, unable to install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c4aece3c8324a2ebf77250f8a67e