### PR TITLE
Fix token splits in ManageItemsPage XAML

### DIFF
--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -13,7 +13,10 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
+                <TextBlock
+                    Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}"
+                    Style="{StaticResource SubheadingTextBlock}"
+                    Margin="0,0,0,8"/>
 
                 <DataGrid Grid.Row="1"
                           ItemsSource="{Binding SearchResults}"
@@ -31,17 +34,34 @@
                     </DataGrid.Columns>
                     <DataGrid.ContextMenu>
                         <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                            <MenuItem Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Rent {0}}" Command="{Binding OpenRentalsCommand}"/>
+                            <MenuItem
+                                Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Rent {0}}"
+                                Command="{Binding OpenRentalsCommand}"/>
                             <MenuItem Header="Delete" Command="{Binding DeleteItemCommand}"/>
                         </ContextMenu>
                     </DataGrid.ContextMenu>
                 </DataGrid>
 
                 <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditItemCommand}"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="View Details" Command="{Binding ViewDetailsCommand}" Margin="8,0,0,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Rental History" Command="{Binding OpenRentalHistoryCommand}" Margin="8,0,0,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="New" Command="{Binding NewItemCommand}" Margin="8,0,0,0"/>
+                    <Button
+                        Style="{StaticResource PrimaryButton}"
+                        Content="Edit"
+                        Command="{Binding EditItemCommand}"/>
+                    <Button
+                        Style="{StaticResource PrimaryButton}"
+                        Content="View Details"
+                        Command="{Binding ViewDetailsCommand}"
+                        Margin="8,0,0,0"/>
+                    <Button
+                        Style="{StaticResource PrimaryButton}"
+                        Content="Rental History"
+                        Command="{Binding OpenRentalHistoryCommand}"
+                        Margin="8,0,0,0"/>
+                    <Button
+                        Style="{StaticResource PrimaryButton}"
+                        Content="New"
+                        Command="{Binding NewItemCommand}"
+                        Margin="8,0,0,0"/>
                 </StackPanel>
             </Grid>
         </Border>


### PR DESCRIPTION
## Summary
- format ManageItemsPage to keep XAML attribute values continuous

## Testing
- `dotnet build InventoryManagementApp.sln` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d55b61948324b93c0310598ef44f