### PR TITLE
refactor: clean up ImportExport XAML formatting

### DIFF
--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
@@ -20,12 +20,23 @@
             <StackPanel Grid.Column="0" Margin="0,0,8,0">
                 <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}" Style="{StaticResource SectionHeader}" />
                 <WrapPanel>
-                    <Button Style="{StaticResource CompactPrimaryButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Import {0} CSV}" Command="{Binding ImportItemsCommand}"/>
-                    <Button Style="{StaticResource CompactPrimaryButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Import {0} Images}" Command="{Binding DataContext.OpenImageImportMappingWindowCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                    <Button Style="{StaticResource CompactPrimaryButton}"
+                            Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Import {0} CSV}"
+                            Command="{Binding ImportItemsCommand}"/>
+                    <Button Style="{StaticResource CompactPrimaryButton}"
+                            Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Import {0} Images}"
+                            Command="{Binding DataContext.OpenImageImportMappingWindowCommand, RelativeSource={RelativeSource AncestorType=Window}}"
                             Visibility="{Binding DataContext.IsCurrentUserAdmin, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource BoolToVis}}"/>
-                    <Button Style="{StaticResource CompactPrimaryButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Export {0} CSV}" Command="{Binding ExportItemsCommand}"/>
-                    <Button Style="{StaticResource CompactPrimaryButton}" Content="Backup Database" Command="{Binding BackupDatabaseCommand}"/>
-                    <Button Style="{StaticResource CompactPrimaryButton}" Content="Cancel Import" Command="{Binding CancelImportItemsCommand}" IsEnabled="{Binding ImportItemsCommand.IsRunning}"/>
+                    <Button Style="{StaticResource CompactPrimaryButton}"
+                            Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Export {0} CSV}"
+                            Command="{Binding ExportItemsCommand}"/>
+                    <Button Style="{StaticResource CompactPrimaryButton}"
+                            Content="Backup Database"
+                            Command="{Binding BackupDatabaseCommand}"/>
+                    <Button Style="{StaticResource CompactPrimaryButton}"
+                            Content="Cancel Import"
+                            Command="{Binding CancelImportItemsCommand}"
+                            IsEnabled="{Binding ImportItemsCommand.IsRunning}"/>
 
                 </WrapPanel>
             </StackPanel>
@@ -34,8 +45,12 @@
             <StackPanel Grid.Column="1" Margin="8,0,0,0">
                 <TextBlock Text="Customers" Style="{StaticResource SectionHeader}" />
                 <WrapPanel>
-                    <Button Style="{StaticResource CompactPrimaryButton}" Content="Import Customers CSV" Command="{Binding ImportCustomersCommand}"/>
-                    <Button Style="{StaticResource CompactPrimaryButton}" Content="Export Customers CSV" Command="{Binding ExportCustomersCommand}"/>
+                    <Button Style="{StaticResource CompactPrimaryButton}"
+                            Content="Import Customers CSV"
+                            Command="{Binding ImportCustomersCommand}"/>
+                    <Button Style="{StaticResource CompactPrimaryButton}"
+                            Content="Export Customers CSV"
+                            Command="{Binding ExportCustomersCommand}"/>
                 </WrapPanel>
             </StackPanel>
         </Grid>


### PR DESCRIPTION
## Summary
- refactor ImportExportPage XAML so resource references and command bindings remain intact on single lines

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d55d9b84832480635f1847f95e0e