### PR TITLE
Fix ItemSearchPage xmlns and binding formatting

### DIFF
--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
@@ -3,7 +3,10 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
-      xmlns:av="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="av" x:Class="InventoryManagementApp.Views.Pages.ItemSearchPage"
+      xmlns:av="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="av"
+      x:Class="InventoryManagementApp.Views.Pages.ItemSearchPage"
       Background="{StaticResource BackgroundBrush}">
     <Grid Margin="8">
         <Grid.RowDefinitions>
@@ -22,7 +25,11 @@
                           ItemsSource="{Binding Categories}"
                           SelectedItem="{Binding SelectedCategory, Mode=TwoWay}"
                           Margin="8,0,0,0"/>
-                <Button Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Search {0}}" Command="{Binding SearchCommand}" Margin="8,0,0,0"/>
+                <Button Grid.Column="2"
+                        Style="{StaticResource PrimaryButton}"
+                        Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Search {0}}"
+                        Command="{Binding SearchCommand}"
+                        Margin="8,0,0,0"/>
             </Grid>
         </Border>
         <ListBox x:Name="ItemsList" Grid.Row="1"


### PR DESCRIPTION
## Summary
- tidy `ItemSearchPage.xaml` namespace declarations
- reformat button binding for clarity

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d563c4d883248957fab778cac4ce