### PR TITLE
Fix settings page bindings formatting

### DIFF
--- a/InventoryManagementApp/Views/Pages/SettingsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/SettingsPage.xaml
@@ -15,9 +15,16 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <TextBlock Text="Connection String" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Column="1" Text="{Binding ConnectionString}" Margin="8,0,8,0"/>
-                        <Button Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Test" Command="{Binding TestDbCommand}"/>
+                        <TextBlock Text="Connection String"
+                                   Style="{StaticResource LabelTextBlock}"
+                                   VerticalAlignment="Center"/>
+                        <TextBox Grid.Column="1"
+                                 Text="{Binding ConnectionString}"
+                                 Margin="8,0,8,0"/>
+                        <Button Grid.Column="2"
+                                Style="{StaticResource PrimaryButton}"
+                                Content="Test"
+                                Command="{Binding TestDbCommand}"/>
                     </Grid>
                 </StackPanel>
             </Border>
@@ -45,8 +52,14 @@
                         <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding AutoLogoutMinutes}" Margin="8,0,0,0" PreviewTextInput="AutoLogoutMinutesBox_PreviewTextInput"/>
                         <TextBlock Grid.Row="3" Text="Singular Item Label" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                         <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding ItemLabelSingular}" Margin="8,0,0,0"/>
-                        <TextBlock Grid.Row="4" Text="Plural Item Label" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding ItemLabelPlural}" Margin="8,0,0,0"/>
+                        <TextBlock Grid.Row="4"
+                                   Text="Plural Item Label"
+                                   Style="{StaticResource LabelTextBlock}"
+                                   VerticalAlignment="Center"/>
+                        <TextBox Grid.Row="4"
+                                 Grid.Column="1"
+                                 Text="{Binding ItemLabelPlural}"
+                                 Margin="8,0,0,0"/>
                     </Grid>
                 </StackPanel>
             </Border>


### PR DESCRIPTION
## Summary
- tidy up connection string and plural item label bindings on Settings page to keep `TestDbCommand`, `LabelTextBlock`, and `ItemLabelPlural` intact

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d56d495c8324a668008978ea3578