### PR TITLE
Ensure template bindings are single-line

### DIFF
--- a/InventoryManagementApp/Resources/Templates.xaml
+++ b/InventoryManagementApp/Resources/Templates.xaml
@@ -25,8 +25,7 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <Border Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" CornerRadius="8">
-                    <Image Stretch="UniformToFill"
-                           Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
+                    <Image Stretch="UniformToFill" Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
                 </Border>
                 <StackPanel Grid.Row="1" Margin="0,6,0,0">
                     <TextBlock Text="{Binding NameDescription}" Style="{StaticResource ListItemTitleTextBlock}"/>


### PR DESCRIPTION
## Summary
- fix broken `NullToDefaultImageConverter` binding formatting in `Templates.xaml`

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d56f46088324b07559936558dbc6