### PR TITLE
chore: refine banned words check

### DIFF
--- a/scripts/check-banned-words.sh
+++ b/scripts/check-banned-words.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# This script checks for the banned word 'tool' outside Items.csv
+# This script checks for the banned words 'tool' or 'tools' outside Items.csv
 # Returns non-zero exit code if such occurrences are found.
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
-# Run ripgrep and capture matches excluding Items.csv
-MATCHES=$(rg -n -i '\btool' --glob '!Items.csv' || true)
+# Run ripgrep and capture matches excluding Items.csv, this script, and known safe terms
+MATCHES=$(rg -n -i '\btools?\b' \
+  --glob '!Items.csv' \
+  --glob '!scripts/check-banned-words.sh' \
+  --glob '!**/ToolBar*' \
+  --glob '!**/Toolkit*' || true)
 if [[ -n "$MATCHES" ]]; then
   echo "$MATCHES"
-  echo "Banned word 'tool' found outside Items.csv" >&2
+  echo "Banned word 'tool' or 'tools' found outside Items.csv" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- restrict banned word search to whole words and ignore safe patterns

## Testing
- `bash scripts/check-banned-words.sh` *(fails: Banned word 'tool' or 'tools' found outside Items.csv)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dde9c1a88324b9c12ac3d8c5a9ea