### PR TITLE
chore: rename workshop heading test

### DIFF
--- a/InventoryManagementApp.Tests/Views/MainWindowTests.cs
+++ b/InventoryManagementApp.Tests/Views/MainWindowTests.cs
@@ -130,7 +130,7 @@ namespace InventoryManagementApp.Tests.Views
         }
 
         [Fact]
-        public void WorkshopHeading_BoundToItemLabelPlural()
+        public void SidebarHeading_BoundToItemLabelPlural()
         {
             Exception? threadException = null;
 


### PR DESCRIPTION
## Summary
- rename WorkshopHeading_BoundToItemLabelPlural test to SidebarHeading_BoundToItemLabelPlural for more generic naming

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ddeea2c08324b8db37ef36780731