### PR TITLE
Fix AvatarSelectionWindow title binding

### DIFF
--- a/InventoryManagementApp/Views/Windows/AvatarSelectionWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/AvatarSelectionWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
-        Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat={0} Inventory Management – Select Avatar}"
+        Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} Inventory Management – Select Avatar'}"
         Height="650" Width="1600"
         Background="{DynamicResource BackgroundBrush}"
         WindowStartupLocation="CenterScreen">


### PR DESCRIPTION
## Summary
- escape `Title` StringFormat in AvatarSelectionWindow and keep the attribute on one line

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a577fda48324a9a25cdaef4fd97c