### PR TITLE
Use plural item label in import/export cancellation messages

### DIFF
--- a/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
@@ -82,10 +82,9 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (OperationCanceledException)
             {
-                var singular = LabelProvider.Instance.ItemLabelSingular;
                 var plural = LabelProvider.Instance.ItemLabelPlural;
-                ImportExportLogs.Add($"{singular} import was cancelled.");
-                await _dialogService.ShowInfoAsync($"{singular} import was cancelled.", $"Import {plural}");
+                ImportExportLogs.Add($"{plural} import was cancelled.");
+                await _dialogService.ShowInfoAsync($"{plural} import was cancelled.", $"Import {plural}");
             }
             catch (Exception ex)
             {
@@ -108,8 +107,8 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (OperationCanceledException)
             {
-                var singular = LabelProvider.Instance.ItemLabelSingular;
-                ImportExportLogs.Add($"{singular} export was cancelled.");
+                var plural = LabelProvider.Instance.ItemLabelPlural;
+                ImportExportLogs.Add($"{plural} export was cancelled.");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- Ensure import/export cancellation logs and dialogs use plural item label
- Confirm other import/export messages rely on plural item terminology

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c34093d08324abc47ad27ab44559