### PR TITLE
Clarify item label settings

### DIFF
--- a/InventoryManagementApp/Views/Pages/SettingsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/SettingsPage.xaml
@@ -50,16 +50,18 @@
                         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding PasswordIterations}" Margin="8,0,0,0" PreviewTextInput="PasswordIterationsBox_PreviewTextInput"/>
                         <TextBlock Grid.Row="2" Text="Auto-logout (minutes)" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                         <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding AutoLogoutMinutes}" Margin="8,0,0,0" PreviewTextInput="AutoLogoutMinutesBox_PreviewTextInput"/>
-                        <TextBlock Grid.Row="3" Text="Singular Item Label" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding ItemLabelSingular}" Margin="8,0,0,0"/>
+                        <TextBlock Grid.Row="3" Text="Item name (singular)" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding ItemLabelSingular}" Margin="8,0,0,0"
+                                 ToolTip="Used for buttons like 'New Item' and 'Rent Item'"/>
                         <TextBlock Grid.Row="4"
-                                   Text="Plural Item Label"
+                                   Text="Item name (plural)"
                                    Style="{StaticResource LabelTextBlock}"
                                    VerticalAlignment="Center"/>
                         <TextBox Grid.Row="4"
                                  Grid.Column="1"
                                  Text="{Binding ItemLabelPlural}"
-                                 Margin="8,0,0,0"/>
+                                 Margin="8,0,0,0"
+                                 ToolTip="Used for navigation and import/export pages"/>
                     </Grid>
                 </StackPanel>
             </Border>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ InventoryManagementApp is a WPF application following the MVVM pattern for manag
 ## Settings and Rebranding
 The application can be rebranded via its **Settings** to suit different inventory domains:
 - **Application Name**: Sets the title shown throughout the UI.
-- **Singular Item Label** and **Plural Item Label**: Customize terminology for inventory items.
+- **Item name (singular)** and **Item name (plural)**: Customize terminology for inventory items.
 
 These options enable using the app for tracking AV gear, sports equipment, or any other lendable items.
 


### PR DESCRIPTION
## Summary
- Rename settings for singular/plural item names with contextual tooltips
- Document new item name labels in README

## Testing
- ⚠️ `dotnet test` *(command not found: dotnet)*
- ⚠️ `apt-get update` *(403 Forbidden while attempting to install .NET SDK)*
- ⚠️ `./scripts/check-banned-words.sh` *(banned word 'tool' or 'tools' found outside Items.csv)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c43078f483248c38e3c8bef092a9