### PR TITLE
Quote XAML StringFormat bindings

### DIFF
--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -30,12 +30,12 @@
                     <StackPanel Orientation="Vertical" Margin="12,0,12,8">
                         <TextBlock Text="Operations" Style="{StaticResource CaptionTextBlock}" Margin="6,8,6,2"/>
                         <Button Style="{StaticResource NavButton}" Content="Dashboard" Command="{Binding OpenDashboardCommand}"/>
-                        <Button Style="{StaticResource NavButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Search {0}}" Command="{Binding OpenSearchItemsCommand}"/>
+                        <Button Style="{StaticResource NavButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Search {0}'}" Command="{Binding OpenSearchItemsCommand}"/>
 
                         <Separator/>
 
                         <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}" Style="{StaticResource CaptionTextBlock}" Margin="6,8,6,2"/>
-                        <Button Style="{StaticResource NavButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Manage {0}}" Command="{Binding OpenManageItemsCommand}" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
+                        <Button Style="{StaticResource NavButton}" Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Manage {0}'}" Command="{Binding OpenManageItemsCommand}" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
                         <Button Style="{StaticResource NavButton}" Content="Customers" Command="{Binding OpenCustomersCommand}"/>
                         <Button Style="{StaticResource NavButton}" Content="Users" Command="{Binding OpenUsersCommand}" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
 

--- a/InventoryManagementApp/Resources/Templates.xaml
+++ b/InventoryManagementApp/Resources/Templates.xaml
@@ -51,7 +51,7 @@
 
     <!-- Shared rental DataGrid columns -->
     <DataGridTextColumn x:Key="RentalIdColumn" Header="Rental #" Binding="{Binding RentalId}" Width="120" x:Shared="False"/>
-    <DataGridTextColumn x:Key="RentalItemNumberColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat={}{0} #}" Binding="{Binding ItemNumber}" Width="120" x:Shared="False"/>
+    <DataGridTextColumn x:Key="RentalItemNumberColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} #'}" Binding="{Binding ItemNumber}" Width="120" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalItemNameColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}" Binding="{Binding NameDescription}" Width="*" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalCustomerColumn" Header="Customer" Binding="{Binding CustomerName}" Width="220" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalOutColumn" Header="Out" Binding="{Binding DateOut, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180" x:Shared="False"/>

--- a/InventoryManagementApp/Views/Controls/SearchBar.xaml
+++ b/InventoryManagementApp/Views/Controls/SearchBar.xaml
@@ -12,7 +12,7 @@
             </TextBox.InputBindings>
         </TextBox>
         <Button Style="{StaticResource PrimaryButton}"
-                Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Search {0}}"
+                Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Search {0}'}"
                 Command="{Binding SearchCommand, ElementName=Root}"
                 Margin="8,0,0,0"/>
     </StackPanel>

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml
@@ -37,8 +37,8 @@
                 <StackPanel>
                     <TextBlock Text="Quick Actions" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
                     <WrapPanel>
-                        <Button Style="{StaticResource PrimaryButton}" Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=New {0}}" Command="{Binding NewItemCommand}" Margin="0,0,8,8"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Rent {0}}" Command="{Binding OpenRentalsCommand}" Margin="0,0,8,8"/>
+                        <Button Style="{StaticResource PrimaryButton}" Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='New {0}'}" Command="{Binding NewItemCommand}" Margin="0,0,8,8"/>
+                        <Button Style="{StaticResource PrimaryButton}" Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Rent {0}'}" Command="{Binding OpenRentalsCommand}" Margin="0,0,8,8"/>
                     </WrapPanel>
                 </StackPanel>
             </Border>

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
@@ -21,14 +21,14 @@
                 <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}" Style="{StaticResource SectionHeader}" />
                 <WrapPanel>
                     <Button Style="{StaticResource CompactPrimaryButton}"
-                            Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Import {0} CSV}"
+                            Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Import {0} CSV'}"
                             Command="{Binding ImportItemsCommand}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}"
-                            Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Import {0} Images}"
+                            Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Import {0} Images'}"
                             Command="{Binding DataContext.OpenImageImportMappingWindowCommand, RelativeSource={RelativeSource AncestorType=Window}}"
                             Visibility="{Binding DataContext.IsCurrentUserAdmin, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource BoolToVis}}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}"
-                            Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Export {0} CSV}"
+                            Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Export {0} CSV'}"
                             Command="{Binding ExportItemsCommand}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}"
                             Content="Backup Database"

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
@@ -27,7 +27,7 @@
                           Margin="8,0,0,0"/>
                 <Button Grid.Column="2"
                         Style="{StaticResource PrimaryButton}"
-                        Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Search {0}}"
+                        Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Search {0}'}"
                         Command="{Binding SearchCommand}"
                         Margin="8,0,0,0"/>
             </Grid>

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -35,7 +35,7 @@
                     <DataGrid.ContextMenu>
                         <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
                             <MenuItem
-                                Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat=Rent {0}}"
+                                Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Rent {0}'}"
                                 Command="{Binding OpenRentalsCommand}"/>
                             <MenuItem Header="Delete" Command="{Binding DeleteItemCommand}"/>
                         </ContextMenu>


### PR DESCRIPTION
## Summary
- Wrap XAML Binding `StringFormat` values in single quotes across navigation, search, dashboard, import/export, and templates for correct parsing.

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c612d90c83248c6d4bfb5533eb72