### PR TITLE
Reduce left navigation scroll speed

### DIFF
--- a/InventoryManagementApp.Tests/Views/MainWindowTests.cs
+++ b/InventoryManagementApp.Tests/Views/MainWindowTests.cs
@@ -415,7 +415,7 @@ namespace InventoryManagementApp.Tests.Views
                         scrollViewer.RaiseEvent(args);
 
                         Assert.True(args.Handled);
-                        Assert.True(scrollViewer.VerticalOffset > initialOffset);
+                        Assert.Equal(initialOffset + 30, scrollViewer.VerticalOffset);
                     }
                     finally
                     {

--- a/InventoryManagementApp/MainWindow.xaml.cs
+++ b/InventoryManagementApp/MainWindow.xaml.cs
@@ -11,6 +11,8 @@ namespace InventoryManagementApp
 {
     public partial class MainWindow : Window, IMainWindow
     {
+        const double ScrollFactor = 0.25;
+
         readonly IDatabaseService? _ownedDb;
 
         /// <summary>
@@ -46,7 +48,8 @@ namespace InventoryManagementApp
         {
             if (sender is ScrollViewer scrollViewer)
             {
-                var target = scrollViewer.VerticalOffset - e.Delta;
+                var target = scrollViewer.VerticalOffset - e.Delta * ScrollFactor;
+                target = Math.Max(0, Math.Min(target, scrollViewer.ScrollableHeight));
                 scrollViewer.ScrollToVerticalOffset(target);
                 e.Handled = true;
             }


### PR DESCRIPTION
## Summary
- slow down left navigation wheel scrolling with a 0.25 scroll factor and clamped offset
- verify reduced scroll amount with updated MainWindow scroll test

## Testing
- `dotnet test` *(fails: command not found; attempted to install but apt repositories are unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c794fd1c832483ca1bce7ee32c0d