### PR TITLE
Handle optional import mappings and ignore null selections

### DIFF
--- a/InventoryManagementApp.Tests/Services/DialogServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/DialogServiceTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using InventoryManagementApp.Services;
+using InventoryManagementApp.Views.Windows;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Services
+{
+    public class DialogServiceTests
+    {
+        private class StubImportMappingWindow : ImportMappingWindow
+        {
+            public StubImportMappingWindow(IEnumerable<string> headers, IEnumerable<string> properties)
+                : base(headers, properties)
+            {
+                Loaded += (_, __) => { DialogResult = true; Close(); };
+            }
+        }
+
+        private class TestDialogService : DialogService
+        {
+            private readonly ImportMappingWindow _window;
+            public TestDialogService(ImportMappingWindow window)
+                : base(new ServiceCollection().BuildServiceProvider())
+            {
+                _window = window;
+            }
+
+            protected override ImportMappingWindow CreateImportMappingWindow(IEnumerable<string> headers, IEnumerable<string> propertyNames)
+                => _window;
+        }
+
+        [Fact]
+        public void ShowImportMapping_ExcludesNullMappings()
+        {
+            var headers = new[] { "H1", "H2" };
+            var properties = new[] { "Prop1", "Prop2" };
+            var window = new StubImportMappingWindow(headers, properties);
+            window.VM.Mappings[0].SelectedColumn = "H1";
+            // second mapping remains null
+
+            var service = new TestDialogService(window);
+
+            var result = service.ShowImportMapping(headers, properties);
+
+            Assert.Single(result);
+            Assert.Equal("Prop1", result["H1"]);
+        }
+    }
+}

--- a/InventoryManagementApp.Tests/ViewModels/ImportMappingViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportMappingViewModelTests.cs
@@ -22,5 +22,23 @@ namespace InventoryManagementApp.Tests.ViewModels
                 Assert.Null(mapping.SelectedColumn);
             }
         }
+
+        [Fact]
+        public void OkCommand_InvokesOnOk_WhenRequiredFieldsMapped()
+        {
+            var headers = new[] { "ItemNumber", "NameDescription" };
+            var properties = new[] { "ItemNumber", "NameDescription" };
+            var required = new[] { "ItemNumber" };
+
+            var called = false;
+            var vm = new ImportMappingViewModel(headers, properties, () => called = true, () => { }, required);
+
+            vm.Mappings.First(m => m.PropertyName == "ItemNumber").SelectedColumn = "ItemNumber";
+            // leave NameDescription unmapped
+
+            vm.OkCommand.Execute(null);
+
+            Assert.True(called);
+        }
     }
 }

--- a/InventoryManagementApp/Services/DialogService.cs
+++ b/InventoryManagementApp/Services/DialogService.cs
@@ -150,19 +150,24 @@ namespace InventoryManagementApp.Services
 
         public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> propertyNames)
         {
-            var win = new ImportMappingWindow(headers, propertyNames);
+            var win = CreateImportMappingWindow(headers, propertyNames);
             try { win.Owner = System.Windows.Application.Current?.MainWindow; }
             catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for ImportMappingWindow"); }
             try
             {
                 if (win.ShowDialog() == true)
                 {
-                    return win.VM.Mappings.ToDictionary(m => m.SelectedColumn!, m => m.PropertyName);
+                    return win.VM.Mappings
+                        .Where(m => !string.IsNullOrEmpty(m.SelectedColumn))
+                        .ToDictionary(m => m.SelectedColumn!, m => m.PropertyName);
                 }
             }
             catch (Exception ex) { _logger.LogError(ex, "Failed to show ImportMappingWindow"); }
             return null;
         }
+
+        protected virtual ImportMappingWindow CreateImportMappingWindow(IEnumerable<string> headers, IEnumerable<string> propertyNames)
+            => new ImportMappingWindow(headers, propertyNames);
 
         public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping()
         {

--- a/InventoryManagementApp/ViewModels/ImportMappingViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportMappingViewModel.cs
@@ -35,11 +35,14 @@ namespace InventoryManagementApp.ViewModels
         public IRelayCommand OkCommand { get; }
         public IRelayCommand CancelCommand { get; }
 
+        private readonly HashSet<string> _requiredProperties;
+
         public ImportMappingViewModel(
             IEnumerable<string> headers,
             IEnumerable<string> properties,
             Action onOk,
-            Action onCancel)
+            Action onCancel,
+            IEnumerable<string>? requiredPropertyNames = null)
         {
             var headerList = (headers ?? Enumerable.Empty<string>()).ToList();
             ColumnHeaders = headerList;
@@ -49,9 +52,13 @@ namespace InventoryManagementApp.ViewModels
                     .Select(prop => new FieldMapping(prop, ColumnHeaders))
             );
 
+            _requiredProperties = new HashSet<string>(
+                requiredPropertyNames ?? Mappings.Select(m => m.PropertyName));
+
             OkCommand = new RelayCommand(() =>
             {
-                if (Mappings.Any(m => string.IsNullOrEmpty(m.SelectedColumn)))
+                if (_requiredProperties.Any(req =>
+                        string.IsNullOrEmpty(Mappings.FirstOrDefault(m => m.PropertyName == req)?.SelectedColumn)))
                     return;
                 onOk();
             });

--- a/InventoryManagementApp/Views/Windows/ImportMappingWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/ImportMappingWindow.xaml.cs
@@ -10,14 +10,15 @@ namespace InventoryManagementApp.Views.Windows
 {
     public partial class ImportMappingWindow : Window
     {
-        public ImportMappingWindow(IEnumerable<string> headers, IEnumerable<string> propertyNames)
+        public ImportMappingWindow(IEnumerable<string> headers, IEnumerable<string> propertyNames, IEnumerable<string>? requiredPropertyNames = null)
         {
             InitializeComponent();
             DataContext = new ImportMappingViewModel(
                 headers,
                 propertyNames,
                 () => { DialogResult = true; Close(); },
-                () => { DialogResult = false; Close(); });
+                () => { DialogResult = false; Close(); },
+                requiredPropertyNames);
             this.DisposeDataContextOnUnload();
         }
 


### PR DESCRIPTION
## Summary
- Allow specifying required properties when mapping imports
- Skip unmapped columns when building import dictionaries
- Add tests for required mappings and filtered dialog results

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7de2387c88324b109ac5246e64535