### PR TITLE
Add context menu styles

### DIFF
--- a/InventoryManagementApp/Resources/Styles.xaml
+++ b/InventoryManagementApp/Resources/Styles.xaml
@@ -343,6 +343,28 @@
         <Setter Property="Padding" Value="10,6"/>
         <Setter Property="Height" Value="36"/>
     </Style>
+    <Style TargetType="ContextMenu">
+        <Setter Property="Background" Value="{StaticResource SurfaceAltBrush}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
+    </Style>
+    <Style TargetType="MenuItem">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
+        <Setter Property="Padding" Value="8,4"/>
+        <Style.Triggers>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter Property="Background" Value="#2D3C4E"/>
+                <Setter Property="Foreground" Value="White"/>
+            </Trigger>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter Property="Background" Value="#1E90FF"/>
+                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="FontWeight" Value="SemiBold"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
     <SolidColorBrush x:Key="BtnBg" Color="#2A2E37"/>
     <SolidColorBrush x:Key="BtnBgHover" Color="#353A45"/>
     <SolidColorBrush x:Key="BtnBorder" Color="#444A57"/>

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -33,7 +33,8 @@
                         <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="180"/>
                     </DataGrid.Columns>
                     <DataGrid.ContextMenu>
-                        <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                        <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
+                                    DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
                             <MenuItem
                                 Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}"
                                 HeaderStringFormat="Rent {0}"

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
@@ -31,7 +31,8 @@
                     <StaticResource ResourceKey="RentalStatusColumn"/>
                 </DataGrid.Columns>
                 <DataGrid.ContextMenu>
-                    <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                    <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
+                                DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
                         <MenuItem Header="Check In" Command="{Binding CheckInCommand}"/>
                         <MenuItem Header="Extend" Command="{Binding ExtendCommand}"/>
                         <MenuItem Header="History" Command="{Binding OpenHistoryCommand}"/>

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml
@@ -53,7 +53,7 @@
                     <DataGridTextColumn Header="Created" Binding="{Binding CreatedAt, StringFormat=\{0:yyyy-MM-dd\}}" Width="140"/>
                 </DataGrid.Columns>
                 <DataGrid.ContextMenu>
-                    <ContextMenu>
+                    <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
                         <MenuItem Header="Edit"
                                   Command="{Binding PlacementTarget.DataContext.EditUserFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                                   CommandParameter="{Binding PlacementTarget.SelectedItem,


### PR DESCRIPTION
## Summary
- add global ContextMenu and MenuItem styles with themed colors and hover/selection behavior
- apply default ContextMenu style to item, rental, and user pages

## Testing
- `dotnet test` *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a801dcbe1c8324a612e3cca72dd0ac