### PR TITLE
Use window-relative binding for image import button

### DIFF
--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
@@ -27,8 +27,8 @@
                     <Button Style="{StaticResource CompactPrimaryButton}"
                             Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}"
                             ContentStringFormat="Import {0} Images"
-                            Command="{Binding DataContext.OpenImageImportMappingWindowCommand, RelativeSource={RelativeSource AncestorType=Frame}}"
-                            Visibility="{Binding DataContext.IsCurrentUserAdmin, RelativeSource={RelativeSource AncestorType=Frame}, Converter={StaticResource BoolToVis}}"/>
+                            Command="{Binding DataContext.OpenImageImportMappingWindowCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                            Visibility="{Binding DataContext.IsCurrentUserAdmin, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource BoolToVis}}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}"
                             Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}"
                             ContentStringFormat="Export {0} CSV"


### PR DESCRIPTION
## Summary
- fix "Import Images" button to bind to window DataContext for command and admin visibility

## Testing
- ⚠️ `dotnet test` *(dotnet SDK not installed; `apt-get update` failed with 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8191e50dc83248fd2c5dc6d1ececb