### PR TITLE
Use frame data context for ImportExportPage bindings

### DIFF
--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
@@ -27,8 +27,8 @@
                     <Button Style="{StaticResource CompactPrimaryButton}"
                             Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}"
                             ContentStringFormat="Import {0} Images"
-                            Command="{Binding DataContext.OpenImageImportMappingWindowCommand, RelativeSource={RelativeSource AncestorType=Window}}"
-                            Visibility="{Binding DataContext.IsCurrentUserAdmin, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource BoolToVis}}"/>
+                            Command="{Binding DataContext.OpenImageImportMappingWindowCommand, RelativeSource={RelativeSource AncestorType=Frame}}"
+                            Visibility="{Binding DataContext.IsCurrentUserAdmin, RelativeSource={RelativeSource AncestorType=Frame}, Converter={StaticResource BoolToVis}}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}"
                             Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}"
                             ContentStringFormat="Export {0} CSV"


### PR DESCRIPTION
## Summary
- Allow ImportExportPage to access MainViewModel through the Frame by using `AncestorType=Frame` in bindings

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a81b430b6c8324a9e166a6dcff7b69