### PR TITLE
Expose image import command in ImportExportViewModel

### DIFF
--- a/InventoryManagementApp.Tests/Views/ImportExportPageTests.cs
+++ b/InventoryManagementApp.Tests/Views/ImportExportPageTests.cs
@@ -37,8 +37,10 @@ namespace InventoryManagementApp.Tests.Views
                         var grid = (Grid)page.Content;
                         var panel = (WrapPanel)((Border)grid.Children[0]).Child;
                         var importBtn = (Button)panel.Children[0];
+                        var importImagesBtn = (Button)panel.Children[1];
 
                         Assert.Equal(vm.ImportItemsCommand, importBtn.Command);
+                        Assert.Equal(vm.OpenImageImportMappingWindowCommand, importImagesBtn.Command);
                         var asyncCmd = (CommunityToolkit.Mvvm.Input.IAsyncRelayCommand)importBtn.Command;
                         var task = asyncCmd.ExecuteAsync(null);
                         task.GetAwaiter().GetResult();

--- a/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.ImportExport;
+using InventoryManagementApp.Models.Domain;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using InventoryManagementApp.Utilities.IO;
@@ -24,12 +25,16 @@ namespace InventoryManagementApp.ViewModels
         private readonly IDatabaseBackupService _databaseService;
         private readonly IDialogService _dialogService;
         private readonly ILogger<ImportExportViewModel> _logger;
+        private readonly IUserContext _userContext;
 
         public IAsyncRelayCommand ImportItemsCommand { get; }
         public IRelayCommand CancelImportItemsCommand { get; }
         public IAsyncRelayCommand ExportItemsCommand { get; }
         public IAsyncRelayCommand ImportCustomersCommand { get; }
         public IAsyncRelayCommand ExportCustomersCommand { get; }
+        public IAsyncRelayCommand OpenImageImportMappingWindowCommand { get; }
+
+        public bool IsCurrentUserAdmin => _userContext.IsAdmin;
 
         /// <summary>
         /// Command that triggers an asynchronous database backup.
@@ -47,6 +52,8 @@ namespace InventoryManagementApp.ViewModels
                                      IFileDialogService fileDialogService,
                                      IDatabaseBackupService databaseService,
                                      IDialogService dialogService,
+                                     IAsyncRelayCommand? openImageImportMappingWindowCommand = null,
+                                     IUserContext? userContext = null,
                                      ILogger<ImportExportViewModel>? logger = null)
         {
             _itemService = itemService;
@@ -55,12 +62,24 @@ namespace InventoryManagementApp.ViewModels
             _databaseService = databaseService;
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<ImportExportViewModel>.Instance;
+            OpenImageImportMappingWindowCommand = openImageImportMappingWindowCommand ?? new AsyncRelayCommand(ct => Task.CompletedTask);
+            _userContext = userContext ?? new DummyUserContext();
+            _userContext.UserChanged += (_, _) => OnPropertyChanged(nameof(IsCurrentUserAdmin));
             ImportItemsCommand = new AsyncRelayCommand(ct => ImportItemsAsync(ct));
             CancelImportItemsCommand = new RelayCommand(() => ImportItemsCommand.Cancel());
             ExportItemsCommand = new AsyncRelayCommand(ct => ExportItemsAsync(ct));
             ImportCustomersCommand = new AsyncRelayCommand(ct => ImportCustomersAsync(ct));
             ExportCustomersCommand = new AsyncRelayCommand(ct => ExportCustomersAsync(ct));
             BackupDatabaseCommand = new AsyncRelayCommand(ct => BackupDatabaseAsync(ct));
+        }
+
+        private sealed class DummyUserContext : IUserContext
+        {
+            public User? CurrentUser { get; set; }
+            public event EventHandler<User?>? UserChanged;
+            public bool IsAdmin => false;
+            public string UserName => string.Empty;
+            public string Role => string.Empty;
         }
 
         async Task ImportItemsAsync(CancellationToken cancellationToken)

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -201,6 +201,8 @@ namespace InventoryManagementApp.ViewModels
             _userContextChangedHandler = (_, _) => RefreshCurrentUser();
             _userContext.UserChanged += _userContextChangedHandler;
 
+            OpenImageImportMappingWindowCommand = new AsyncRelayCommand(ct => OpenImageImportMappingWindowAsync(ct));
+
             ItemManagement = new ItemManagementViewModel(itemService, customerService, rentalService, _dialogService);
             _itemManagementPropertyChangedHandler = (s, e) =>
             {
@@ -213,7 +215,7 @@ namespace InventoryManagementApp.ViewModels
             UserManagement = new UserManagementViewModel(userService, fileDialogService, _dialogService, _userContext);
             CustomerManagement = new CustomerManagementViewModel(customerService, _dialogService);
             ManageRentals = new ManageRentalsViewModel(rentalService, _dialogService);
-            ImportExport = new ImportExportViewModel(itemService, customerService, fileDialogService, databaseService, _dialogService);
+            ImportExport = new ImportExportViewModel(itemService, customerService, fileDialogService, databaseService, _dialogService, OpenImageImportMappingWindowCommand, _userContext);
             Reports = new ReportsViewModel(new ReportService(itemService, rentalService, activityLogService, customerService, userService));
             ActivityLogs = new ActivityLogsViewModel(activityLogService);
             Settings = new SettingsViewModel(_fileDialogService, _settingsService, _dialogService);
@@ -311,8 +313,6 @@ namespace InventoryManagementApp.ViewModels
             });
 
             OpenImportMappingWindowCommand = new AsyncRelayCommand(ct => OpenImportMappingWindowAsync(ct));
-
-            OpenImageImportMappingWindowCommand = new AsyncRelayCommand(ct => OpenImageImportMappingWindowAsync(ct));
 
             GlobalSearchCommand = new AsyncRelayCommand(ct => GlobalSearchAsync(ct));
 

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
@@ -27,8 +27,8 @@
                     <Button Style="{StaticResource CompactPrimaryButton}"
                             Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}"
                             ContentStringFormat="Import {0} Images"
-                            Command="{Binding DataContext.OpenImageImportMappingWindowCommand, RelativeSource={RelativeSource AncestorType=Frame}}"
-                            Visibility="{Binding DataContext.IsCurrentUserAdmin, RelativeSource={RelativeSource AncestorType=Frame}, Converter={StaticResource BoolToVis}}"/>
+                            Command="{Binding OpenImageImportMappingWindowCommand}"
+                            Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
                     <Button Style="{StaticResource CompactPrimaryButton}"
                             Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}"
                             ContentStringFormat="Export {0} CSV"


### PR DESCRIPTION
## Summary
- expose image import mapping command and admin flag on `ImportExportViewModel`
- simplify XAML bindings to use view model properties directly
- verify image import command binding in import/export page tests

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a81c39defc8324a8a5363562b3f52a