### PR TITLE
Guard against invalid date strings in services

### DIFF
--- a/InventoryManagementApp.Tests/Services/ItemServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/ItemServiceTests.cs
@@ -159,6 +159,34 @@ namespace InventoryManagementApp.Tests.Services
         }
 
         [Fact]
+        public void GetItemByID_InvalidDates_ReturnsNulls()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var service = new ItemService(dbService);
+
+                service.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Test" });
+                var item = service.GetAllItems().First();
+
+                using var conn = dbService.CreateConnection();
+                var cmd = new SQLiteCommand("UPDATE Items SET PurchasedDate='bad', CheckedOutTime='bad', IsCheckedOut=1 WHERE ItemID=@id", conn);
+                cmd.Parameters.AddWithValue("@id", item.ItemID);
+                cmd.ExecuteNonQuery();
+
+                var fetched = service.GetItemByID(item.ItemID);
+                Assert.Null(fetched.PurchasedDate);
+                Assert.Null(fetched.CheckedOutTime);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public async Task AddItemAsync_SetsGeneratedItemID()
         {
             var dbPath = Path.GetTempFileName();

--- a/InventoryManagementApp.Tests/Services/RentalServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/RentalServiceTests.cs
@@ -409,6 +409,42 @@ namespace InventoryManagementApp.Tests.Services
             }
         }
 
+        [Fact]
+        public void GetAllRentals_InvalidDates_NoException()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                var itemService = new ItemService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+
+                itemService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer", QuantityOnHand = 1 });
+                var item = itemService.GetAllItems().First();
+
+                customerService.AddCustomer(new Customer { Company = "Acme" });
+                var cust = customerService.GetAllCustomers().First();
+
+                using var conn = db.CreateConnection();
+                var cmd = new SQLiteCommand("INSERT INTO Rentals (ItemID, CustomerID, RentalDate, DueDate, ReturnDate, Status) VALUES (@I,@C,'bad','bad','bad','Rented')", conn);
+                cmd.Parameters.AddWithValue("@I", item.ItemID);
+                cmd.Parameters.AddWithValue("@C", cust.CustomerID);
+                cmd.ExecuteNonQuery();
+
+                var rentals = rentalService.GetAllRentals();
+                Assert.Single(rentals);
+                Assert.Null(rentals[0].ReturnDate);
+
+                rentalService.ExtendRental(rentals[0].RentalID, DateTime.Today.AddDays(1));
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
         class FailingItemService : IItemService
         {
             public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -301,17 +301,27 @@ namespace InventoryManagementApp.Services.Items
             Supplier = r["Supplier"].ToString(),
             PurchasedDate = r["PurchasedDate"] is DBNull
                 ? (DateTime?)null
-                : DateTime.Parse(r["PurchasedDate"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                : ParseNullableDate(r["PurchasedDate"], "PurchasedDate"),
             Notes = r["Notes"].ToString(),
             IsCheckedOut = (r["IsCheckedOut"] is DBNull ? 0 : Convert.ToInt32(r["IsCheckedOut"])) == 1,
             CheckedOutBy = r["CheckedOutBy"].ToString(),
             CheckedOutTime = r["CheckedOutTime"] is DBNull
                 ? (DateTime?)null
-                : DateTime.Parse(r["CheckedOutTime"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                : ParseNullableDate(r["CheckedOutTime"], "CheckedOutTime"),
             ImagePath = r["ImagePath"]?.ToString(),
             Keywords = r["Keywords"]?.ToString(),
             IsPowered = (r["IsPowered"] is DBNull ? 0 : Convert.ToInt32(r["IsPowered"])) == 1
         };
+
+        DateTime? ParseNullableDate(object? value, string field)
+        {
+            var text = value?.ToString();
+            if (DateTime.TryParse(text, CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dt))
+                return dt;
+            _logger.LogError("Failed to parse {Field}: {Value}", field, text);
+            return null;
+        }
 
         private async Task AddItemInternalAsync(ItemModel item, CancellationToken cancellationToken)
         {

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -74,9 +74,9 @@ namespace InventoryManagementApp.Services.Rentals
             RentalID = Convert.ToInt32(r["RentalID"]),
             ItemID = Convert.ToInt32(r["ItemID"]),
             CustomerID = Convert.ToInt32(r["CustomerID"]),
-            RentalDate = DateTime.Parse(r["RentalDate"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
-            DueDate = DateTime.Parse(r["DueDate"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
-            ReturnDate = r["ReturnDate"] is DBNull ? null : DateTime.Parse(r["ReturnDate"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+            RentalDate = ParseDateOrDefault(r["RentalDate"], "RentalDate"),
+            DueDate = ParseDateOrDefault(r["DueDate"], "DueDate"),
+            ReturnDate = r["ReturnDate"] is DBNull ? null : ParseNullableDate(r["ReturnDate"], "ReturnDate"),
             Status = r["Status"].ToString(),
             ItemNumber = r["ItemNumber"].ToString(),
             CustomerName = r["Company"].ToString(),
@@ -88,6 +88,26 @@ namespace InventoryManagementApp.Services.Rentals
             ImagePath = r["ImagePath"].ToString(),
             ItemLocation = r["ItemLocation"].ToString()
         };
+
+        DateTime ParseDateOrDefault(object? value, string field)
+        {
+            var text = value?.ToString();
+            if (DateTime.TryParse(text, CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dt))
+                return dt;
+            _logger.LogError("Failed to parse {Field}: {Value}", field, text);
+            return default;
+        }
+
+        DateTime? ParseNullableDate(object? value, string field)
+        {
+            var text = value?.ToString();
+            if (DateTime.TryParse(text, CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dt))
+                return dt;
+            _logger.LogError("Failed to parse {Field}: {Value}", field, text);
+            return null;
+        }
 
         public async Task RentItemAsync(int itemID, int customerID, DateTime rentalDate, DateTime dueDate)
         {
@@ -167,7 +187,13 @@ namespace InventoryManagementApp.Services.Rentals
                     throw new InvalidOperationException("Unable to extend rental. Rental not found or already returned.");
 
                 int itemID = Convert.ToInt32(reader["ItemID"]);
-                DateTime oldDueDate = DateTime.Parse(reader["DueDate"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+                var dueText = reader["DueDate"].ToString();
+                DateTime oldDueDate;
+                if (!DateTime.TryParse(dueText, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out oldDueDate))
+                {
+                    _logger.LogError("Failed to parse DueDate: {Value}", dueText);
+                    oldDueDate = default;
+                }
 
                 var updateCmd = new SQLiteCommand(
                     "UPDATE Rentals SET DueDate=@NewDueDate WHERE RentalID=@RentalID AND Status='Rented'",


### PR DESCRIPTION
## Summary
- Replace DateTime.Parse with TryParse in item and rental services
- Log parsing failures and default to null or default dates
- Add unit tests ensuring malformed date strings do not throw

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a81f6b71cc8324855219ddf69183e6