### PR TITLE
Handle invalid timestamps in ActivityLogService

### DIFF
--- a/InventoryManagementApp.Tests/Services/ActivityLogServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/ActivityLogServiceTests.cs
@@ -77,5 +77,29 @@ namespace InventoryManagementApp.Tests.Services
                 if (File.Exists(dbPath)) File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public async Task GetRecentLogs_InvalidTimestamp_DoesNotThrow()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                using var db = new DatabaseService(dbPath);
+                using (var conn = db.CreateConnection())
+                using (var cmd = new SQLiteCommand("INSERT INTO ActivityLogs(UserID, UserName, Action, Timestamp) VALUES (1, 'user', 'action', 'not-a-date')", conn))
+                    cmd.ExecuteNonQuery();
+
+                var service = new ActivityLogService(db);
+                var result = await service.GetRecentLogsAsync();
+
+                Assert.True(result.Success);
+                Assert.NotNull(result.Value);
+                Assert.Equal(DateTime.MinValue, result.Value[0].Timestamp);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -119,12 +119,21 @@ namespace InventoryManagementApp.Services.Users
 
         ActivityLog MapLog(IDataRecord r)
         {
+            DateTime timestamp;
+            var rawTimestamp = r["Timestamp"]?.ToString();
+            if (!DateTime.TryParse(rawTimestamp, CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out timestamp))
+            {
+                _logger.LogWarning("Invalid timestamp '{Timestamp}' for log {LogID}", rawTimestamp, r["LogID"]);
+                timestamp = DateTime.MinValue;
+            }
+
             var log = new ActivityLog
             {
                 LogID = Convert.ToInt32(r["LogID"]),
                 UserName = r["UserName"].ToString(),
                 Action = r["Action"].ToString(),
-                Timestamp = DateTime.Parse(r["Timestamp"].ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal)
+                Timestamp = timestamp
             };
 
             log.UserID = r["UserID"] == DBNull.Value


### PR DESCRIPTION
## Summary
- Guard activity log timestamp parsing using `DateTime.TryParse`, logging invalid entries and defaulting to `DateTime.MinValue`
- Add unit test ensuring `GetRecentLogsAsync` handles bad timestamps without throwing

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a822a1090c83248b71bb62c4781288