### PR TITLE
Log skipped rows when importing items

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -105,6 +105,24 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public async System.Threading.Tasks.Task ImportItemsCommand_LogsSkippedRowsAndNotifiesUser()
+        {
+            var tmp = Path.GetTempFileName();
+            File.WriteAllText(tmp, "ItemNumber\n");
+            var fileDlg = new StubFileDialogService { FileToReturn = tmp };
+            var itemService = new CapturingItemService { InvalidRowsToReturn = new List<int> { 2, 5 } };
+            var dialog = new StubDialogService { MapToReturn = new Dictionary<string, string> { { "ItemNumber", "ItemNumber" } } };
+            var vm = new ImportExportViewModel(itemService, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
+
+            await vm.ImportItemsCommand.ExecuteAsync(null);
+
+            Assert.Contains(vm.ImportExportLogs, l => l.Contains("Skipped rows: 2, 5"));
+            var lastMsg = dialog.InfoMessages[dialog.InfoMessages.Count - 1].message;
+            Assert.Contains("Skipped rows: 2, 5", lastMsg);
+            File.Delete(tmp);
+        }
+
+        [Fact]
         public async System.Threading.Tasks.Task ExportCustomersCommand_LogsSuccess()
         {
             var customerSvc = new CapturingCustomerService();
@@ -148,7 +166,8 @@ namespace InventoryManagementApp.Tests.ViewModels
     {
         public Dictionary<string, string>? MapToReturn { get; set; }
         public bool ShowImportMappingCalled { get; private set; }
-        public void ShowInfo(string message, string title) { }
+        public List<(string message, string title)> InfoMessages { get; } = new();
+        public void ShowInfo(string message, string title) => InfoMessages.Add((message, title));
         public bool ShowConfirmation(string message, string title) => false;
         public ItemModel? ShowEditItemDialog(ItemModel item) => null;
         public void ShowItemDetails(ItemModel item) { }
@@ -170,11 +189,12 @@ namespace InventoryManagementApp.Tests.ViewModels
     {
         public bool ImportCalled { get; private set; }
         public IDictionary<string,string>? MapUsed { get; private set; }
+        public List<int> InvalidRowsToReturn { get; set; } = new();
         public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
             ImportCalled = true;
             MapUsed = map;
-            return Task.FromResult(new List<int>());
+            return Task.FromResult(InvalidRowsToReturn);
         }
         public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());

--- a/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
@@ -95,9 +95,16 @@ namespace InventoryManagementApp.ViewModels
                     return;
                 var plural = LabelProvider.Instance.ItemLabelPlural;
                 await _dialogService.ShowInfoAsync($"Importing {plural}...", $"Import {plural}");
-                await _itemService.ImportItemsFromCsvAsync(path, map, cancellationToken);
-                ImportExportLogs.Add($"Successfully imported {plural} from {path}.");
-                await _dialogService.ShowInfoAsync($"Successfully imported {plural} from {path}.", $"Import {plural}");
+                var skippedRows = await _itemService.ImportItemsFromCsvAsync(path, map, cancellationToken);
+                var successMessage = $"Successfully imported {plural} from {path}.";
+                ImportExportLogs.Add(successMessage);
+                if (skippedRows.Any())
+                {
+                    var skippedMessage = $"Skipped rows: {string.Join(", ", skippedRows)}";
+                    ImportExportLogs.Add(skippedMessage);
+                    successMessage += $" {skippedMessage}";
+                }
+                await _dialogService.ShowInfoAsync(successMessage, $"Import {plural}");
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
## Summary
- capture skipped rows from item CSV import
- log and display skipped row numbers to the user
- test logging and notification of skipped rows

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a82653493c83248a355183c6b5f1bf