### PR TITLE
Detect duplicate rows during CSV item import

### DIFF
--- a/InventoryManagementApp.Tests/Services/ItemServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/ItemServiceTests.cs
@@ -549,7 +549,7 @@ namespace InventoryManagementApp.Tests.Services
         }
 
         [Fact]
-        public void ImportItemsFromCsv_PartialFailure_RollsBack()
+        public void ImportItemsFromCsv_DuplicateRowsReported()
         {
             var dbPath = Path.GetTempFileName();
             var csvPath = Path.GetTempFileName();
@@ -563,8 +563,10 @@ namespace InventoryManagementApp.Tests.Services
                     {"ItemNumber", "ItemNumber"}
                 };
 
-                Assert.Throws<SQLiteException>(() => service.ImportItemsFromCsv(csvPath, map));
-                Assert.Empty(service.GetAllItems());
+                var invalid = service.ImportItemsFromCsv(csvPath, map);
+                Assert.Single(invalid);
+                Assert.Contains(3, invalid);
+                Assert.Single(service.GetAllItems());
             }
             finally
             {

--- a/InventoryManagementApp.Tests/Tests/CsvImportTests.cs
+++ b/InventoryManagementApp.Tests/Tests/CsvImportTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System;
+using System.Linq;
 using InventoryManagementApp.Utilities.IO;
 using InventoryManagementApp.Services.Core;
 using InventoryManagementApp.Services.Items;
@@ -161,7 +162,7 @@ public class CsvImportTests
             sw.Stop();
 
             Assert.True(sw.ElapsedMilliseconds < 5000, $"Import took {sw.ElapsedMilliseconds}ms");
-            Assert.Empty(invalid);
+            Assert.Equal(Enumerable.Range(2, 100), invalid);
             Assert.Equal(1000, service.GetAllItems().Count);
         }
         finally

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -514,18 +514,39 @@ namespace InventoryManagementApp.Services.Items
                     "SELECT ItemNumber FROM Items", null,
                     r => r.GetString(0), cancellationToken));
 
+            // Track invalid rows for quick lookup when determining CSV row numbers
+            var invalidSet = new HashSet<int>(invalidRows);
+            var currentRow = 1; // header row already processed by CsvHelperUtil
+
             using var tran = conn.BeginTransaction();
             try
             {
                 foreach (var item in items)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    if (string.IsNullOrWhiteSpace(item.ItemNumber) ||
-                        existingNumbers.Contains(item.ItemNumber))
+
+                    // advance to the next data row, skipping rows already marked invalid
+                    currentRow++;
+                    while (invalidSet.Contains(currentRow))
+                        currentRow++;
+
+                    if (string.IsNullOrWhiteSpace(item.ItemNumber))
+                    {
+                        invalidRows.Add(currentRow);
                         continue;
+                    }
+
+                    if (existingNumbers.Contains(item.ItemNumber))
+                    {
+                        // record duplicate rows so the caller can notify the user
+                        invalidRows.Add(currentRow);
+                        continue;
+                    }
+
                     await InsertItemAsync(conn, tran, item, cancellationToken);
                     existingNumbers.Add(item.ItemNumber);
                 }
+
                 tran.Commit();
                 return invalidRows;
             }


### PR DESCRIPTION
## Summary
- log duplicate item numbers during CSV imports by recording their row numbers
- add tests ensuring duplicate rows are reported to callers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8291f9ae0832484e33e57c650d6bf