### PR TITLE
Ensure ItemNumber mapping when importing items

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -86,6 +86,27 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public async System.Threading.Tasks.Task ImportItemsCommand_MissingItemNumberMapping_ShowsErrorAndDoesNotCallService()
+        {
+            var tmp = Path.GetTempFileName();
+            File.WriteAllText(tmp, "ItemNumber\\n");
+            var fileDlg = new StubFileDialogService { FileToReturn = tmp };
+            var itemService = new CapturingItemService();
+            var dialog = new StubDialogService { MapToReturn = new Dictionary<string, string>() };
+            var vm = new ImportExportViewModel(itemService, new StubCustomerService(), fileDlg, new StubDatabaseBackupService(), dialog);
+
+            await vm.ImportItemsCommand.ExecuteAsync(null);
+
+            Assert.True(dialog.ShowImportMappingCalled);
+            Assert.False(itemService.ImportCalled);
+            Assert.Single(vm.ImportExportLogs);
+            Assert.Contains("number", vm.ImportExportLogs[0], StringComparison.OrdinalIgnoreCase);
+            var lastMsg = dialog.InfoMessages[dialog.InfoMessages.Count - 1].message;
+            Assert.Contains("number", lastMsg, StringComparison.OrdinalIgnoreCase);
+            File.Delete(tmp);
+        }
+
+        [Fact]
         public async System.Threading.Tasks.Task ImportItemsCommand_CanBeCancelled()
         {
             var tmp = Path.GetTempFileName();

--- a/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
@@ -94,6 +94,15 @@ namespace InventoryManagementApp.ViewModels
                 if (map == null)
                     return;
                 var plural = LabelProvider.Instance.ItemLabelPlural;
+                if (!map.TryGetValue(nameof(ItemImportDto.ItemNumber), out var itemNumberHeader) || string.IsNullOrWhiteSpace(itemNumberHeader))
+                {
+                    var singular = LabelProvider.Instance.ItemLabelSingular;
+                    var errorMessage = $"Mapping for {singular} number is required.";
+                    ImportExportLogs.Add(errorMessage);
+                    _logger.LogWarning("Import aborted: missing {ItemLabelSingular} number mapping", singular);
+                    await _dialogService.ShowInfoAsync(errorMessage, $"Import {plural}");
+                    return;
+                }
                 await _dialogService.ShowInfoAsync($"Importing {plural}...", $"Import {plural}");
                 var skippedRows = await _itemService.ImportItemsFromCsvAsync(path, map, cancellationToken);
                 var successMessage = $"Successfully imported {plural} from {path}.";


### PR DESCRIPTION
## Summary
- validate import mapping includes ItemNumber before importing items
- show error and log when ItemNumber mapping missing
- add unit test for missing ItemNumber mapping

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a82a08ca308324ab5da102fc9882ae