### PR TITLE
Convert activity log timestamps to local time

### DIFF
--- a/InventoryManagementApp.Tests/Services/ActivityLogServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/ActivityLogServiceTests.cs
@@ -101,5 +101,31 @@ namespace InventoryManagementApp.Tests.Services
                 if (File.Exists(dbPath)) File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public async Task GetRecentLogs_ConvertsTimestampToLocalTime()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                using var db = new DatabaseService(dbPath);
+                using (var conn = db.CreateConnection())
+                using (var cmd = new SQLiteCommand("INSERT INTO ActivityLogs(UserID, UserName, Action, Timestamp) VALUES (1, 'user', 'action', '2024-01-01 00:00:00')", conn))
+                    cmd.ExecuteNonQuery();
+
+                var service = new ActivityLogService(db);
+                var result = await service.GetRecentLogsAsync();
+
+                Assert.True(result.Success);
+                var log = Assert.Single(result.Value);
+                Assert.Equal(DateTimeKind.Local, log.Timestamp.Kind);
+                var expected = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc).ToLocalTime();
+                Assert.Equal(expected, log.Timestamp);
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
     }
 }

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -128,6 +128,14 @@ namespace InventoryManagementApp.Services.Users
                 timestamp = DateTime.MinValue;
             }
 
+            // Ensure timestamps are converted to the local timezone before exposing them to the UI.
+            // Attempting to convert DateTime.MinValue can throw if the local offset is negative,
+            // so only convert when the timestamp is valid.
+            if (timestamp != DateTime.MinValue)
+            {
+                timestamp = DateTime.SpecifyKind(timestamp, DateTimeKind.Utc).ToLocalTime();
+            }
+
             var log = new ActivityLog
             {
                 LogID = Convert.ToInt32(r["LogID"]),


### PR DESCRIPTION
## Summary
- convert activity log timestamps from UTC to local time when reading from the database
- add regression test verifying timestamp is converted to local time

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a82af8633c8324b02a01ac5fc7c9c5