### PR TITLE
Add required property support to import mapping

### DIFF
--- a/InventoryManagementApp.Tests/Services/DialogServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/DialogServiceTests.cs
@@ -26,7 +26,10 @@ namespace InventoryManagementApp.Tests.Services
                 _window = window;
             }
 
-            protected override ImportMappingWindow CreateImportMappingWindow(IEnumerable<string> headers, IEnumerable<string> propertyNames)
+            protected override ImportMappingWindow CreateImportMappingWindow(
+                IEnumerable<string> headers,
+                IEnumerable<string> propertyNames,
+                IEnumerable<string>? requiredPropertyNames)
                 => _window;
         }
 

--- a/InventoryManagementApp.Tests/TestHelpers.cs
+++ b/InventoryManagementApp.Tests/TestHelpers.cs
@@ -71,7 +71,7 @@ namespace InventoryManagementApp.Tests
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
             public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/Tests/AppUnhandledExceptionTests.cs
+++ b/InventoryManagementApp.Tests/Tests/AppUnhandledExceptionTests.cs
@@ -111,7 +111,7 @@ namespace InventoryManagementApp.Tests.Tests
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
-            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
             public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/Tests/CustomersPageBindingTests.cs
+++ b/InventoryManagementApp.Tests/Tests/CustomersPageBindingTests.cs
@@ -82,7 +82,7 @@ namespace InventoryManagementApp.Tests.Tests
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
         public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/Tests/ManageItemsPageMenuTests.cs
+++ b/InventoryManagementApp.Tests/Tests/ManageItemsPageMenuTests.cs
@@ -117,7 +117,7 @@ namespace InventoryManagementApp.Tests.Tests
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
             public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/Tests/ManageRentalsPageDeleteTests.cs
+++ b/InventoryManagementApp.Tests/Tests/ManageRentalsPageDeleteTests.cs
@@ -70,7 +70,7 @@ namespace InventoryManagementApp.Tests.Tests
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
-        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
         public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/Tests/ManageRentalsPageMenuTests.cs
+++ b/InventoryManagementApp.Tests/Tests/ManageRentalsPageMenuTests.cs
@@ -103,7 +103,7 @@ namespace InventoryManagementApp.Tests.Tests
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
         public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/Tests/NavigationCommandsTests.cs
+++ b/InventoryManagementApp.Tests/Tests/NavigationCommandsTests.cs
@@ -89,7 +89,7 @@ class StubDialogService : IDialogService
     public CustomerModel? ShowAddCustomerDialog() => null;
     public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
     public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-    public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+    public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
     public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
     public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
     public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/Utilities/AsyncHelpersTests.cs
+++ b/InventoryManagementApp.Tests/Utilities/AsyncHelpersTests.cs
@@ -33,7 +33,7 @@ namespace InventoryManagementApp.Tests.Utilities
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
             public Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/ViewModels/CustomerManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/CustomerManagementViewModelTests.cs
@@ -299,7 +299,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         public CustomerModel? ShowAddCustomerDialog() => AddCustomerResult;
         public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
         public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/ViewModels/ImportExportViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportViewModelTests.cs
@@ -196,7 +196,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
-        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties)
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null)
         {
             ShowImportMappingCalled = true;
             return MapToReturn;

--- a/InventoryManagementApp.Tests/ViewModels/ImportMappingViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportMappingViewModelTests.cs
@@ -40,5 +40,24 @@ namespace InventoryManagementApp.Tests.ViewModels
 
             Assert.True(called);
         }
+
+        [Fact]
+        public void OkCommand_InvokesOnOk_WhenOnlyRequiredFieldsMapped()
+        {
+            var headers = new[] { "ItemNumber", "NameDescription", "Extra" };
+            var properties = new[] { "ItemNumber", "NameDescription", "Extra" };
+            var required = new[] { "ItemNumber", "NameDescription" };
+
+            var called = false;
+            var vm = new ImportMappingViewModel(headers, properties, () => called = true, () => { }, required);
+
+            vm.Mappings.First(m => m.PropertyName == "ItemNumber").SelectedColumn = "ItemNumber";
+            vm.Mappings.First(m => m.PropertyName == "NameDescription").SelectedColumn = "NameDescription";
+            // leave Extra unmapped
+
+            vm.OkCommand.Execute(null);
+
+            Assert.True(called);
+        }
     }
 }

--- a/InventoryManagementApp.Tests/ViewModels/ItemManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ItemManagementViewModelTests.cs
@@ -223,7 +223,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
             public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/ViewModels/LoginViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/LoginViewModelTests.cs
@@ -589,7 +589,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
         public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
@@ -678,7 +678,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
-        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
         public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/ViewModels/MainViewModelAutoLogoutTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/MainViewModelAutoLogoutTests.cs
@@ -84,7 +84,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             public InventoryManagementApp.Models.Domain.CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(InventoryManagementApp.Models.Domain.ItemModel item, System.Collections.Generic.IEnumerable<InventoryManagementApp.Models.Domain.RentalModel> history) { }
-            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
             public Func<InventoryManagementApp.Models.Domain.ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/ViewModels/MainViewModelCurrentUserTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/MainViewModelCurrentUserTests.cs
@@ -88,7 +88,7 @@ class StubDialogService : IDialogService
     public CustomerModel? ShowAddCustomerDialog() => null;
     public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
     public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-    public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+    public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
     public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
     public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
     public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/ViewModels/MainViewModelDisposalTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/MainViewModelDisposalTests.cs
@@ -100,7 +100,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
             public Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/ViewModels/MainViewModelImportMappingTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/MainViewModelImportMappingTests.cs
@@ -64,7 +64,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
-            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => MapToReturn;
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => MapToReturn;
             public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/ViewModels/MainViewModelNavigationTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/MainViewModelNavigationTests.cs
@@ -419,7 +419,7 @@ class StubDialogService : IDialogService
     public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
     public CustomerModel? ShowAddCustomerDialog() => null;
 
-    public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => ImportMap;
+    public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => ImportMap;
     public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
     public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
     public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;

--- a/InventoryManagementApp.Tests/ViewModels/MainViewModelSwitchUserTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/MainViewModelSwitchUserTests.cs
@@ -278,7 +278,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
         public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/ViewModels/MainViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/MainViewModelTests.cs
@@ -134,7 +134,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
         public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog()

--- a/InventoryManagementApp.Tests/ViewModels/ManageRentalsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ManageRentalsViewModelTests.cs
@@ -423,7 +423,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
         public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
@@ -440,7 +440,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
-        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
         public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) => throw new InvalidOperationException("boom");
         public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/ViewModels/NewPageViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/NewPageViewModelTests.cs
@@ -217,7 +217,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
-        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties)
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null)
         {
             ShowImportMappingCalled = true;
             return MapToReturn;

--- a/InventoryManagementApp.Tests/ViewModels/PasswordPromptViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/PasswordPromptViewModelTests.cs
@@ -90,7 +90,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
         public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/ViewModels/PrintLabelViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/PrintLabelViewModelTests.cs
@@ -57,7 +57,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
         public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/ViewModels/RentalHistoryViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/RentalHistoryViewModelTests.cs
@@ -116,7 +116,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
             public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/ViewModels/ScannerStatusViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ScannerStatusViewModelTests.cs
@@ -111,7 +111,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
-        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
         public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/SettingsViewModelTests.cs
@@ -314,7 +314,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
         public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }
@@ -330,7 +330,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
-        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
         public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -580,7 +580,7 @@ class StubDialogService : IDialogService
     public CustomerModel? ShowAddCustomerDialog() => null;
     public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
     public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-    public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+    public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
     public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
     public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
     public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/Views/ImportExportPageTests.cs
+++ b/InventoryManagementApp.Tests/Views/ImportExportPageTests.cs
@@ -88,7 +88,7 @@ namespace InventoryManagementApp.Tests.Views
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties)
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null)
         {
             ShowImportMappingCalled = true;
             return MapToReturn;

--- a/InventoryManagementApp.Tests/Views/MainWindowTests.cs
+++ b/InventoryManagementApp.Tests/Views/MainWindowTests.cs
@@ -472,7 +472,7 @@ namespace InventoryManagementApp.Tests.Views
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
-            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
             public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/Views/PasswordPromptWindowTests.cs
+++ b/InventoryManagementApp.Tests/Views/PasswordPromptWindowTests.cs
@@ -92,7 +92,7 @@ namespace InventoryManagementApp.Tests.Views
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+            public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
             public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/Views/RentalsFilterWindowTests.cs
+++ b/InventoryManagementApp.Tests/Views/RentalsFilterWindowTests.cs
@@ -90,7 +90,7 @@ namespace InventoryManagementApp.Tests.Views
             public CustomerModel? ShowAddCustomerDialog() => null;
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
-            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties) => null;
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
             public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp.Tests/Views/UsersPageTests.cs
+++ b/InventoryManagementApp.Tests/Views/UsersPageTests.cs
@@ -233,7 +233,7 @@ namespace InventoryManagementApp.Tests.Views
         public CustomerModel? ShowAddCustomerDialog() => null;
         public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
         public void ShowRentalHistory(ItemModel item, System.Collections.Generic.IEnumerable<RentalModel> history) { }
-        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties) => null;
+        public System.Collections.Generic.Dictionary<string, string>? ShowImportMapping(System.Collections.Generic.IEnumerable<string> headers, System.Collections.Generic.IEnumerable<string> properties, System.Collections.Generic.IEnumerable<string>? requiredPropertyNames = null) => null;
         public System.Func<ItemModel, System.Collections.Generic.IEnumerable<string>>? ShowImageImportMapping() => null;
         public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
         public void ShowPrintLabelDialog() { }

--- a/InventoryManagementApp/Interfaces/IDialogService.cs
+++ b/InventoryManagementApp/Interfaces/IDialogService.cs
@@ -27,7 +27,10 @@ namespace InventoryManagementApp.Interfaces
 
         void ShowRentalsFilter(ManageRentalsViewModel viewModel);
         void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history);
-        Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties);
+        Dictionary<string, string>? ShowImportMapping(
+            IEnumerable<string> headers,
+            IEnumerable<string> properties,
+            IEnumerable<string>? requiredPropertyNames = null);
         Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping();
         void ShowPrintPreview(FlowDocument document, string title, string description);
         void ShowPrintLabelDialog();

--- a/InventoryManagementApp/Services/DialogService.cs
+++ b/InventoryManagementApp/Services/DialogService.cs
@@ -148,9 +148,12 @@ namespace InventoryManagementApp.Services
             catch (Exception ex) { _logger.LogError(ex, "Failed to show RentalHistoryWindow"); }
         }
 
-        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> propertyNames)
+        public Dictionary<string, string>? ShowImportMapping(
+            IEnumerable<string> headers,
+            IEnumerable<string> propertyNames,
+            IEnumerable<string>? requiredPropertyNames = null)
         {
-            var win = CreateImportMappingWindow(headers, propertyNames);
+            var win = CreateImportMappingWindow(headers, propertyNames, requiredPropertyNames);
             try { win.Owner = System.Windows.Application.Current?.MainWindow; }
             catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for ImportMappingWindow"); }
             try
@@ -166,8 +169,11 @@ namespace InventoryManagementApp.Services
             return null;
         }
 
-        protected virtual ImportMappingWindow CreateImportMappingWindow(IEnumerable<string> headers, IEnumerable<string> propertyNames)
-            => new ImportMappingWindow(headers, propertyNames);
+        protected virtual ImportMappingWindow CreateImportMappingWindow(
+            IEnumerable<string> headers,
+            IEnumerable<string> propertyNames,
+            IEnumerable<string>? requiredPropertyNames)
+            => new ImportMappingWindow(headers, propertyNames, requiredPropertyNames);
 
         public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping()
         {

--- a/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
@@ -90,7 +90,10 @@ namespace InventoryManagementApp.ViewModels
             {
                 var headers = await CsvHelperUtil.ReadHeadersAsync(path);
                 var properties = typeof(ItemImportDto).GetProperties().Select(p => p.Name);
-                var map = _dialogService.ShowImportMapping(headers, properties);
+                var map = _dialogService.ShowImportMapping(
+                    headers,
+                    properties,
+                    new[] { nameof(ItemImportDto.ItemNumber), nameof(ItemImportDto.NameDescription) });
                 if (map == null)
                     return;
                 var plural = LabelProvider.Instance.ItemLabelPlural;

--- a/InventoryManagementApp/ViewModels/ImportMappingViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportMappingViewModel.cs
@@ -53,7 +53,7 @@ namespace InventoryManagementApp.ViewModels
             );
 
             _requiredProperties = new HashSet<string>(
-                requiredPropertyNames ?? Mappings.Select(m => m.PropertyName));
+                requiredPropertyNames ?? Enumerable.Empty<string>());
 
             OkCommand = new RelayCommand(() =>
             {


### PR DESCRIPTION
## Summary
- Allow specifying required properties for import mapping dialogs
- Pass ItemNumber and NameDescription as required fields for item import
- Ensure import mapping view model treats missing required list as optional
- Update dialog stubs and add unit test for required mapping behavior

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a82bdc3ba083248689ef55c4d5c86a