### PR TITLE
Fix mapping orientation in dialog service

### DIFF
--- a/InventoryManagementApp.Tests/Services/DialogServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/DialogServiceTests.cs
@@ -47,7 +47,7 @@ namespace InventoryManagementApp.Tests.Services
             var result = service.ShowImportMapping(headers, properties);
 
             Assert.Single(result);
-            Assert.Equal("Prop1", result["H1"]);
+            Assert.Equal("H1", result["Prop1"]);
         }
     }
 }

--- a/InventoryManagementApp/Services/DialogService.cs
+++ b/InventoryManagementApp/Services/DialogService.cs
@@ -162,7 +162,7 @@ namespace InventoryManagementApp.Services
                 {
                     return win.VM.Mappings
                         .Where(m => !string.IsNullOrEmpty(m.SelectedColumn))
-                        .ToDictionary(m => m.SelectedColumn!, m => m.PropertyName);
+                        .ToDictionary(m => m.PropertyName, m => m.SelectedColumn!);
                 }
             }
             catch (Exception ex) { _logger.LogError(ex, "Failed to show ImportMappingWindow"); }


### PR DESCRIPTION
## Summary
- fix ShowImportMapping to map property names to selected columns
- update DialogService unit test for new mapping order

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden when attempting to install .NET runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68a82e1d302883248661a91d968299ca