### PR TITLE
Ensure item dates are converted to local time

### DIFF
--- a/InventoryManagementApp.Tests/Services/ItemServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/ItemServiceTests.cs
@@ -187,6 +187,29 @@ namespace InventoryManagementApp.Tests.Services
         }
 
         [Fact]
+        public void GetItemByID_ValidDates_AreLocal()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var dbService = new DatabaseService(dbPath);
+                var service = new ItemService(dbService);
+
+                service.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Test", PurchasedDate = DateTime.UtcNow });
+                var item = service.GetAllItems().First();
+
+                var fetched = service.GetItemByID(item.ItemID);
+                Assert.NotNull(fetched.PurchasedDate);
+                Assert.Equal(DateTimeKind.Local, fetched.PurchasedDate!.Value.Kind);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
         public async Task AddItemAsync_SetsGeneratedItemID()
         {
             var dbPath = Path.GetTempFileName();
@@ -785,7 +808,7 @@ namespace InventoryManagementApp.Tests.Services
         }
 
         [Fact]
-        public void ToggleItemCheckOutStatus_SetsUtcTime()
+        public void ToggleItemCheckOutStatus_SetsLocalTime()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -811,7 +834,8 @@ namespace InventoryManagementApp.Tests.Services
                 var updated = svc.GetItemByID(item.ItemID);
                 Assert.True(updated.IsCheckedOut);
                 Assert.NotNull(updated.CheckedOutTime);
-                Assert.InRange(updated.CheckedOutTime!.Value, before, after);
+                Assert.Equal(DateTimeKind.Local, updated.CheckedOutTime!.Value.Kind);
+                Assert.InRange(updated.CheckedOutTime!.Value, before.ToLocalTime(), after.ToLocalTime());
             }
             finally
             {

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -318,7 +318,7 @@ namespace InventoryManagementApp.Services.Items
             var text = value?.ToString();
             if (DateTime.TryParse(text, CultureInfo.InvariantCulture,
                     DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dt))
-                return dt;
+                return DateTime.SpecifyKind(dt, DateTimeKind.Utc).ToLocalTime();
             _logger.LogError("Failed to parse {Field}: {Value}", field, text);
             return null;
         }


### PR DESCRIPTION
## Summary
- convert parsed item dates from UTC to local time
- test that PurchasedDate and CheckedOutTime are stored as local

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a82e9e82108324848a910b04de48d6