### PR TITLE
Ensure user creation time is local

### DIFF
--- a/InventoryManagementApp.Tests/Services/UserActiveTests.cs
+++ b/InventoryManagementApp.Tests/Services/UserActiveTests.cs
@@ -23,7 +23,8 @@ namespace InventoryManagementApp.Tests.Services
                 userService.AddUser(user);
                 var added = userService.GetAllUsers().First();
                 Assert.True(added.IsActive);
-                Assert.True((DateTime.UtcNow - added.CreatedAt).TotalMinutes < 5);
+                Assert.Equal(DateTimeKind.Local, added.CreatedAt.Kind);
+                Assert.True((DateTime.Now - added.CreatedAt).TotalMinutes < 5);
             }
             finally
             {

--- a/InventoryManagementApp.Tests/Services/Users/UserServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/Users/UserServiceTests.cs
@@ -37,6 +37,7 @@ public class UserServiceTests
             var stored = userService.GetUserByID(first.UserID);
             Assert.NotNull(stored);
             Assert.True(stored!.IsAdmin);
+            Assert.Equal(DateTimeKind.Local, stored.CreatedAt.Kind);
         }
         finally
         {

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -72,6 +72,8 @@ namespace InventoryManagementApp.Services.Users
             }
 
             var createdAt = ParseToUtcNullable(HasColumn("CreatedAt") ? rdr["CreatedAt"] : DBNull.Value) ?? DateTime.MinValue;
+            if (createdAt.Kind != DateTimeKind.Local)
+                createdAt = createdAt.ToLocalTime();
 
             return new User
             {


### PR DESCRIPTION
## Summary
- convert `UserService` mapping to return `CreatedAt` in local time
- update user tests to assert `CreatedAt` uses local `DateTimeKind`

## Testing
- `dotnet test` *(command not found)*
- `apt-get update` *(403: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a82f85ebb483248f87db583bb59680