### PR TITLE
Use local time for scanner LastSeen

### DIFF
--- a/InventoryManagementApp.Tests/Services/ScannerServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/ScannerServiceTests.cs
@@ -24,14 +24,15 @@ namespace InventoryManagementApp.Tests.Services
 
                 var service = new ScannerService(settings);
 
-                var before = DateTime.UtcNow;
+                var before = DateTime.UtcNow.ToLocalTime();
                 var devices = await service.GetScannerDevicesAsync(CancellationToken.None);
-                var after = DateTime.UtcNow;
+                var after = DateTime.UtcNow.ToLocalTime();
 
                 var list = devices.ToList();
                 Assert.Single(list);
                 Assert.Equal("127.0.0.1", list[0].Ip);
                 Assert.InRange(list[0].LastSeen, before, after);
+                Assert.Equal(DateTimeKind.Local, list[0].LastSeen.Kind);
             }
             finally
             {

--- a/InventoryManagementApp.Tests/ViewModels/ScannerStatusViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ScannerStatusViewModelTests.cs
@@ -22,7 +22,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             CallCount++;
             IEnumerable<ScannerDevice> result = new[]
             {
-                new ScannerDevice { Name = "A", Ip = "1.1.1.1", Status = "Online", LastSeen = DateTime.Now }
+                new ScannerDevice { Name = "A", Ip = "1.1.1.1", Status = "Online", LastSeen = DateTime.UtcNow }
             };
             return Task.FromResult(result);
         }
@@ -38,6 +38,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             await vm.RefreshCommand.ExecuteAsync(null);
             Assert.Single(vm.Devices);
             Assert.Equal(1, svc.CallCount);
+            Assert.Equal(DateTimeKind.Local, vm.Devices[0].LastSeen.Kind);
         }
 
         [Fact]

--- a/InventoryManagementApp/Services/Devices/ScannerService.cs
+++ b/InventoryManagementApp/Services/Devices/ScannerService.cs
@@ -39,7 +39,7 @@ namespace InventoryManagementApp.Services.Devices
                     {
                         Name = $"Scanner {ip}",
                         Ip = ip,
-                        LastSeen = DateTime.UtcNow
+                        LastSeen = DateTime.UtcNow.ToLocalTime()
                     };
                     try
                     {

--- a/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
@@ -61,7 +61,14 @@ namespace InventoryManagementApp.ViewModels
                 var devices = await _service.GetScannerDevicesAsync(cancellationToken);
                 Devices.Clear();
                 foreach (var d in devices)
+                {
+                    if (d.LastSeen.Kind != DateTimeKind.Local)
+                    {
+                        _logger.LogWarning("Device {Ip} reported LastSeen kind {Kind}; converting to local time", d.Ip, d.LastSeen.Kind);
+                        d.LastSeen = d.LastSeen.ToLocalTime();
+                    }
                     Devices.Add(d);
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- Record scanner last seen timestamps in local time
- Normalize device timestamps to local time in the status view model
- Test coverage for local timestamps

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8314ebc848324926177087f354825