### PR TITLE
Select row on DataGrid right-click for proper context menu

### DIFF
--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -26,6 +26,12 @@
                           Background="{StaticResource SurfaceBrush}"
                           BorderBrush="{StaticResource BorderBrushAlt}"
                           Style="{StaticResource VirtualizedDataGridStyle}">
+                    <DataGrid.RowStyle>
+                        <Style TargetType="DataGridRow">
+                            <EventSetter Event="PreviewMouseRightButtonDown"
+                                         Handler="DataGridRow_PreviewMouseRightButtonDown"/>
+                        </Style>
+                    </DataGrid.RowStyle>
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Number" Binding="{Binding ItemNumber}" Width="140"/>
                         <DataGridTextColumn Header="Name" Binding="{Binding NameDescription}" Width="280"/>

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace InventoryManagementApp.Views.Pages
 {
@@ -7,6 +8,14 @@ namespace InventoryManagementApp.Views.Pages
         public ManageItemsPage()
         {
             InitializeComponent();
+        }
+
+        private void DataGridRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is DataGridRow row)
+            {
+                row.IsSelected = true;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure right-clicking a DataGrid row selects it so the context menu targets the correct item

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8320c578883249fdfb3861661bad7