### PR TITLE
Handle invalid activity log timestamps

### DIFF
--- a/InventoryManagementApp.Tests/Services/ActivityLogServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/ActivityLogServiceTests.cs
@@ -94,7 +94,7 @@ namespace InventoryManagementApp.Tests.Services
 
                 Assert.True(result.Success);
                 Assert.NotNull(result.Value);
-                Assert.Equal(DateTime.MinValue, result.Value[0].Timestamp);
+                Assert.NotEqual(DateTime.MinValue, result.Value[0].Timestamp);
             }
             finally
             {

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -125,7 +125,7 @@ namespace InventoryManagementApp.Services.Users
                     DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out timestamp))
             {
                 _logger.LogWarning("Invalid timestamp '{Timestamp}' for log {LogID}", rawTimestamp, r["LogID"]);
-                timestamp = DateTime.MinValue;
+                timestamp = DateTime.UtcNow;
             }
 
             // Ensure timestamps are converted to the local timezone before exposing them to the UI.

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml
@@ -19,7 +19,7 @@
             <DataGrid ItemsSource="{Binding Logs}" IsReadOnly="True" AutoGenerateColumns="False" Style="{StaticResource VirtualizedDataGridStyle}">
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="Timestamp"
-                                         Binding="{Binding Timestamp, StringFormat={}{0:yyyy-MM-dd HH:mm}}"
+                                         Binding="{Binding Timestamp, StringFormat={}{0:yyyy-MM-dd HH:mm}, TargetNullValue=''}"
                                          Width="180"/>
                     <DataGridTextColumn Header="User"
                                          Binding="{Binding UserName}"


### PR DESCRIPTION
## Summary
- Prevent invalid activity log entries from using `DateTime.MinValue` by defaulting to `DateTime.UtcNow`
- Add null-aware binding for timestamps in Activity Logs page
- Adjust unit test for invalid timestamp mapping

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8339368d88324a47962ad8527c111