### PR TITLE
Support deleting multiple items

### DIFF
--- a/InventoryManagementApp.Tests/Tests/ManageItemsPageMenuTests.cs
+++ b/InventoryManagementApp.Tests/Tests/ManageItemsPageMenuTests.cs
@@ -39,7 +39,7 @@ namespace InventoryManagementApp.Tests.Tests
                 var items = menu.Items.OfType<MenuItem>().ToArray();
 
                 Assert.Equal(vm.OpenRentalsCommand, items[0].Command);
-                Assert.Equal(vm.DeleteItemCommand, items[1].Command);
+                Assert.Equal(vm.DeleteItemsCommand, items[1].Command);
             }
             finally
             {

--- a/InventoryManagementApp.Tests/ViewModels/ItemManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ItemManagementViewModelTests.cs
@@ -364,7 +364,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
-        public async Task DeleteItemCommand_RemovesItem()
+        public async Task DeleteItemsCommand_RemovesItem()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -378,8 +378,8 @@ namespace InventoryManagementApp.Tests.ViewModels
                 var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
                 itemService.AddItem(item);
                 await vm.LoadItemsAsync();
-                vm.SelectedItem = vm.Items.First();
-                await vm.DeleteItemCommand.ExecuteAsync(null);
+                var list = new[] { vm.Items.First() };
+                await vm.DeleteItemsCommand.ExecuteAsync(list);
                 Assert.Empty(itemService.GetAllItems());
                 Assert.Empty(vm.Items);
             }
@@ -391,7 +391,7 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
-        public async Task DeleteItemCommand_Cancelled_DoesNotRemoveItem()
+        public async Task DeleteItemsCommand_Cancelled_DoesNotRemoveItem()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -405,8 +405,8 @@ namespace InventoryManagementApp.Tests.ViewModels
                 var item = new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" };
                 itemService.AddItem(item);
                 await vm.LoadItemsAsync();
-                vm.SelectedItem = vm.Items.First();
-                await vm.DeleteItemCommand.ExecuteAsync(null);
+                var list = new[] { vm.Items.First() };
+                await vm.DeleteItemsCommand.ExecuteAsync(list);
                 Assert.Single(itemService.GetAllItems());
                 Assert.Single(vm.Items);
             }
@@ -418,7 +418,34 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
-        public async Task DeleteItemCommand_OnError_ShowsDialogAndLogs()
+        public async Task DeleteItemsCommand_RemovesAllSelectedItems()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                var db = new DatabaseService(dbPath);
+                IItemService itemService = new ItemService(db);
+                var customerService = new CustomerService(db);
+                var rentalService = new RentalService(db);
+                var dialog = new StubDialogService { ConfirmationResult = true };
+                var vm = new ItemManagementViewModel(itemService, customerService, rentalService, dialog);
+                itemService.AddItem(new ItemModel { ItemNumber = "T1", NameDescription = "Hammer" });
+                itemService.AddItem(new ItemModel { ItemNumber = "T2", NameDescription = "Saw" });
+                await vm.LoadItemsAsync();
+                var list = vm.Items.ToList();
+                await vm.DeleteItemsCommand.ExecuteAsync(list);
+                Assert.Empty(itemService.GetAllItems());
+                Assert.Empty(vm.Items);
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteItemsCommand_OnError_ShowsDialogAndLogs()
         {
             var itemService = new FailingItemService();
             var dialog = new StubDialogService { ConfirmationResult = true };
@@ -427,8 +454,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             var item = new ItemModel { ItemID = 1, ItemNumber = "T1", NameDescription = "Hammer" };
             vm.Items.Add(item);
             vm.SelectedItem = item;
-
-            await vm.DeleteItemCommand.ExecuteAsync(null);
+            await vm.DeleteItemsCommand.ExecuteAsync(new[] { item });
 
             Assert.True(dialog.InfoShown);
             Assert.Equal("Failed to delete item 1", logger.LastError);

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -88,7 +89,7 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand<CancellationToken> SearchCommand { get; }
         public IAsyncRelayCommand NewItemCommand { get; }
         public IAsyncRelayCommand EditItemCommand { get; }
-        public IAsyncRelayCommand DeleteItemCommand { get; }
+        public IAsyncRelayCommand<IList> DeleteItemsCommand { get; }
         public IAsyncRelayCommand OpenRentalsCommand { get; }
         public IRelayCommand ViewDetailsCommand { get; }
         public IAsyncRelayCommand OpenRentalHistoryCommand { get; }
@@ -133,7 +134,7 @@ namespace InventoryManagementApp.ViewModels
             _searchDebounceTimer.Tick += OnSearchDebounceTimerTick;
             NewItemCommand = new AsyncRelayCommand(ct => AddItemAsync(ct));
             EditItemCommand = new AsyncRelayCommand(ct => EditItemAsync(ct), () => SelectedItem != null);
-            DeleteItemCommand = new AsyncRelayCommand(ct => DeleteItemAsync(ct));
+            DeleteItemsCommand = new AsyncRelayCommand<IList>(DeleteItemsAsync);
             OpenRentalsCommand = new AsyncRelayCommand(ct => OpenRentalsAsync(ct), () => SelectedItem != null);
             ViewDetailsCommand = new RelayCommand(ViewDetails, () => SelectedItem != null);
             OpenRentalHistoryCommand = new AsyncRelayCommand(OpenRentalHistoryAsync, () => SelectedItem != null);
@@ -297,18 +298,22 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        async Task DeleteItemAsync(CancellationToken cancellationToken)
+        async Task DeleteItemsAsync(IList items, CancellationToken cancellationToken)
         {
-            if (SelectedItem == null) return;
-            var confirm = await _dialogService.ShowConfirmationAsync(
-                $"Delete {LabelProvider.Instance.ItemLabelSingular.ToLower()} '{SelectedItem.NameDescription}'?",
-                "Confirm Delete");
+            if (items == null || items.Count == 0) return;
+            string message = items.Count == 1
+                ? $"Delete {LabelProvider.Instance.ItemLabelSingular.ToLower()} '{((ItemModel)items[0]).NameDescription}'?"
+                : $"Delete {items.Count} {LabelProvider.Instance.ItemLabelPlural.ToLower()}?";
+            var confirm = await _dialogService.ShowConfirmationAsync(message, "Confirm Delete");
             if (!confirm)
                 return;
 
             try
             {
-                await _itemService.DeleteItemAsync(SelectedItem.ItemID, cancellationToken);
+                foreach (ItemModel item in items)
+                {
+                    await _itemService.DeleteItemAsync(item.ItemID, cancellationToken);
+                }
                 await LoadItemsAsync();
                 await FilterItemsAsync(cancellationToken);
                 SelectedItem = null;
@@ -323,8 +328,8 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to delete {ItemLabelSingular} {ItemID}", LabelProvider.Instance.ItemLabelSingular, SelectedItem.ItemID);
-                await _dialogService.ShowInfoAsync($"Failed to delete {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {ex.Message}", "Error");
+                _logger.LogError(ex, "Failed to delete {ItemLabelPlural}", LabelProvider.Instance.ItemLabelPlural);
+                await _dialogService.ShowInfoAsync($"Failed to delete {LabelProvider.Instance.ItemLabelPlural.ToLower()}: {ex.Message}", "Error");
             }
         }
 

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -45,7 +45,9 @@
                                 Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}"
                                 HeaderStringFormat="Rent {0}"
                                 Command="{Binding OpenRentalsCommand}"/>
-                            <MenuItem Header="Delete" Command="{Binding DeleteItemCommand}"/>
+                            <MenuItem Header="Delete"
+                                      Command="{Binding DeleteItemsCommand}"
+                                      CommandParameter="{Binding SelectedItems, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
                         </ContextMenu>
                     </DataGrid.ContextMenu>
                 </DataGrid>

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
@@ -14,7 +14,11 @@ namespace InventoryManagementApp.Views.Pages
         {
             if (sender is DataGridRow row)
             {
-                row.IsSelected = true;
+                if (!row.IsSelected)
+                {
+                    row.IsSelected = true;
+                }
+                e.Handled = true;
             }
         }
     }


### PR DESCRIPTION
## Summary
- allow deleting multiple items from Manage Items page
- preserve multi-selection when opening context menu
- add DeleteItemsCommand and multi-item delete tests

## Testing
- `dotnet test` *(command not found)*
- `apt-get update` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a834e2e2588324a474ddb3b417a46a