### PR TITLE
Handle nullable user creation dates

### DIFF
--- a/InventoryManagementApp.Tests/Services/UserActiveTests.cs
+++ b/InventoryManagementApp.Tests/Services/UserActiveTests.cs
@@ -23,8 +23,9 @@ namespace InventoryManagementApp.Tests.Services
                 userService.AddUser(user);
                 var added = userService.GetAllUsers().First();
                 Assert.True(added.IsActive);
-                Assert.Equal(DateTimeKind.Local, added.CreatedAt.Kind);
-                Assert.True((DateTime.Now - added.CreatedAt).TotalMinutes < 5);
+                Assert.NotNull(added.CreatedAt);
+                Assert.Equal(DateTimeKind.Local, added.CreatedAt!.Value.Kind);
+                Assert.True((DateTime.Now - added.CreatedAt!.Value).TotalMinutes < 5);
             }
             finally
             {

--- a/InventoryManagementApp.Tests/Services/Users/UserServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/Users/UserServiceTests.cs
@@ -37,7 +37,8 @@ public class UserServiceTests
             var stored = userService.GetUserByID(first.UserID);
             Assert.NotNull(stored);
             Assert.True(stored!.IsAdmin);
-            Assert.Equal(DateTimeKind.Local, stored.CreatedAt.Kind);
+            Assert.NotNull(stored.CreatedAt);
+            Assert.Equal(DateTimeKind.Local, stored.CreatedAt!.Value.Kind);
         }
         finally
         {

--- a/InventoryManagementApp.Tests/Views/UsersPageTests.cs
+++ b/InventoryManagementApp.Tests/Views/UsersPageTests.cs
@@ -214,6 +214,54 @@ namespace InventoryManagementApp.Tests.Views
                     File.Delete(dbPath);
             }
         }
+
+        [Fact]
+        public void CreatedAt_Null_ShowsNA()
+        {
+            var dbPath = Path.GetTempFileName();
+            Exception? threadException = null;
+
+            try
+            {
+                var thread = new Thread(() =>
+                {
+                    try
+                    {
+                        var db = new DatabaseService(dbPath);
+                        IUserService userService = new UserService(db, new ApplicationUserContext());
+                        var vm = new UserManagementViewModel(userService, new StubFileDialogService(), new StubDialogService());
+                        userService.AddUser(new User { UserName = "user1", PasswordHash = "Strong1!" });
+                        vm.LoadUsers();
+                        vm.Users.First().CreatedAt = null;
+
+                        var page = new UsersPage(vm);
+                        var grid = (Grid)page.Content;
+                        var dataGrid = (DataGrid)((Border)grid.Children[1]).Child;
+                        dataGrid.UpdateLayout();
+                        var text = ((TextBlock)dataGrid.Columns[7].GetCellContent(dataGrid.Items[0])).Text;
+                        Assert.Equal("N/A", text);
+                    }
+                    catch (Exception ex)
+                    {
+                        threadException = ex;
+                    }
+                });
+
+                thread.SetApartmentState(ApartmentState.STA);
+                thread.Start();
+                thread.Join();
+
+                if (threadException != null)
+                {
+                    throw threadException;
+                }
+            }
+            finally
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+        }
     }
 
     class StubFileDialogService : IFileDialogService

--- a/InventoryManagementApp/Models/Domain/User.cs
+++ b/InventoryManagementApp/Models/Domain/User.cs
@@ -41,8 +41,8 @@ namespace InventoryManagementApp.Models.Domain
         private bool _isActive = true;
         public bool IsActive { get => _isActive; set => SetProperty(ref _isActive, value); }
 
-        private DateTime _createdAt;
-        public DateTime CreatedAt { get => _createdAt; set => SetProperty(ref _createdAt, value); }
+        private DateTime? _createdAt;
+        public DateTime? CreatedAt { get => _createdAt; set => SetProperty(ref _createdAt, value); }
 
         private bool _passwordExpired;
         public bool PasswordExpired { get => _passwordExpired; set => SetProperty(ref _passwordExpired, value); }

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -71,9 +71,9 @@ namespace InventoryManagementApp.Services.Users
                 return false;
             }
 
-            var createdAt = ParseToUtcNullable(HasColumn("CreatedAt") ? rdr["CreatedAt"] : DBNull.Value) ?? DateTime.MinValue;
-            if (createdAt.Kind != DateTimeKind.Local)
-                createdAt = createdAt.ToLocalTime();
+            DateTime? createdAt = ParseToUtcNullable(HasColumn("CreatedAt") ? rdr["CreatedAt"] : DBNull.Value);
+            if (createdAt.HasValue && createdAt.Value.Kind != DateTimeKind.Local)
+                createdAt = createdAt.Value.ToLocalTime();
 
             return new User
             {
@@ -198,7 +198,7 @@ namespace InventoryManagementApp.Services.Users
             string hashed = result.hash;
             string salt = result.salt;
 
-            if (user.CreatedAt == default)
+            if (user.CreatedAt == null)
                 user.CreatedAt = DateTime.UtcNow;
             cmd.Parameters.AddRange(new[]
             {

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml
@@ -50,7 +50,7 @@
                     <DataGridTextColumn Header="Phone" Binding="{Binding Phone}" Width="140"/>
                     <DataGridTextColumn Header="Mobile" Binding="{Binding Mobile}" Width="140"/>
                     <DataGridCheckBoxColumn Header="Active" Binding="{Binding IsActive}" Width="100"/>
-                    <DataGridTextColumn Header="Created" Binding="{Binding CreatedAt, StringFormat=\{0:yyyy-MM-dd\}}" Width="140"/>
+                    <DataGridTextColumn Header="Created" Binding="{Binding CreatedAt, StringFormat={}{0:yyyy-MM-dd}, TargetNullValue='N/A'}" Width="140"/>
                 </DataGrid.Columns>
                 <DataGrid.ContextMenu>
                     <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">


### PR DESCRIPTION
## Summary
- allow user creation dates to be nullable and remove DateTime.MinValue fallback
- show "N/A" for missing creation dates on Users page
- add tests for nullable creation dates

## Testing
- `dotnet test` *(command not found: dotnet)*
- `apt-get install -y dotnet-sdk-8.0` *(Unable to locate package dotnet-sdk-8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a834d981ac8324bd408453077ba735