### PR TITLE
Handle DateTime.MinValue rendering with new converter

### DIFF
--- a/InventoryManagementApp.Tests/Tests/DateTimeMinToEmptyStringConverterTests.cs
+++ b/InventoryManagementApp.Tests/Tests/DateTimeMinToEmptyStringConverterTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using InventoryManagementApp.Utilities.Converters;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class DateTimeMinToEmptyStringConverterTests
+    {
+        [Fact]
+        public void Convert_MinValue_ReturnsNull()
+        {
+            var converter = new DateTimeMinToEmptyStringConverter();
+            var result = converter.Convert(DateTime.MinValue, typeof(DateTime), null, CultureInfo.InvariantCulture);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Convert_ValidDate_ReturnsSameDate()
+        {
+            var converter = new DateTimeMinToEmptyStringConverter();
+            var date = new DateTime(2024, 5, 1, 12, 0, 0);
+            var result = converter.Convert(date, typeof(DateTime), null, CultureInfo.InvariantCulture);
+            Assert.Equal(date, result);
+        }
+
+        [Fact]
+        public void Convert_InvalidInput_ReturnsBindingDoNothing()
+        {
+            var converter = new DateTimeMinToEmptyStringConverter();
+            var result = converter.Convert("not a date", typeof(DateTime), null, CultureInfo.InvariantCulture);
+            Assert.Equal(Binding.DoNothing, result);
+        }
+
+        [Fact]
+        public void ConvertBack_EmptyString_ReturnsMinValue()
+        {
+            var converter = new DateTimeMinToEmptyStringConverter();
+            var result = converter.ConvertBack(string.Empty, typeof(DateTime), null, CultureInfo.InvariantCulture);
+            Assert.Equal(DateTime.MinValue, result);
+        }
+
+        [Fact]
+        public void ConvertBack_ValidDateString_ReturnsDate()
+        {
+            var converter = new DateTimeMinToEmptyStringConverter();
+            var date = new DateTime(2023, 12, 25);
+            var result = converter.ConvertBack(date.ToString(CultureInfo.InvariantCulture), typeof(DateTime), null, CultureInfo.InvariantCulture);
+            Assert.Equal(date, result);
+        }
+
+        [Fact]
+        public void ConvertBack_InvalidInput_ReturnsBindingDoNothing()
+        {
+            var converter = new DateTimeMinToEmptyStringConverter();
+            var result = converter.ConvertBack(42, typeof(DateTime), null, CultureInfo.InvariantCulture);
+            Assert.Equal(Binding.DoNothing, result);
+        }
+    }
+}

--- a/InventoryManagementApp/Resources/Converters.xaml
+++ b/InventoryManagementApp/Resources/Converters.xaml
@@ -3,4 +3,5 @@
                     xmlns:conv="clr-namespace:InventoryManagementApp.Utilities.Converters;assembly=InventoryManagementApp">
     <conv:NullToDefaultImageConverter x:Key="NullToDefaultImageConverter"/>
     <conv:BooleanToAdminConverter x:Key="BooleanToAdminConverter"/>
+    <conv:DateTimeMinToEmptyStringConverter x:Key="DateTimeMinToEmptyStringConverter"/>
 </ResourceDictionary>

--- a/InventoryManagementApp/Resources/Templates.xaml
+++ b/InventoryManagementApp/Resources/Templates.xaml
@@ -42,7 +42,7 @@
                 <TextBlock.Text>
                     <MultiBinding StringFormat="{}{0} - {1:yyyy-MM-dd HH:mm}">
                         <Binding Path="UserName"/>
-                        <Binding Path="Timestamp"/>
+                        <Binding Path="Timestamp" Converter="{StaticResource DateTimeMinToEmptyStringConverter}"/>
                     </MultiBinding>
                 </TextBlock.Text>
             </TextBlock>
@@ -54,8 +54,8 @@
     <DataGridTextColumn x:Key="RentalItemNumberColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} #'}" Binding="{Binding ItemNumber}" Width="120" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalItemNameColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}" Binding="{Binding NameDescription}" Width="*" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalCustomerColumn" Header="Customer" Binding="{Binding CustomerName}" Width="220" x:Shared="False"/>
-    <DataGridTextColumn x:Key="RentalOutColumn" Header="Out" Binding="{Binding DateOut, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180" x:Shared="False"/>
-    <DataGridTextColumn x:Key="RentalDueColumn" Header="Due" Binding="{Binding DueDate, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180" x:Shared="False"/>
-    <DataGridTextColumn x:Key="RentalReturnedColumn" Header="Returned" Binding="{Binding DateReturned, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180" x:Shared="False"/>
+    <DataGridTextColumn x:Key="RentalOutColumn" Header="Out" Binding="{Binding DateOut, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat=\{0:yyyy-MM-dd HH:mm\}, TargetNullValue=''}" Width="180" x:Shared="False"/>
+    <DataGridTextColumn x:Key="RentalDueColumn" Header="Due" Binding="{Binding DueDate, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat=\{0:yyyy-MM-dd HH:mm\}, TargetNullValue=''}" Width="180" x:Shared="False"/>
+    <DataGridTextColumn x:Key="RentalReturnedColumn" Header="Returned" Binding="{Binding DateReturned, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat=\{0:yyyy-MM-dd HH:mm\}, TargetNullValue=''}" Width="180" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalStatusColumn" Header="Status" Binding="{Binding Status}" Width="140" x:Shared="False"/>
 </ResourceDictionary>

--- a/InventoryManagementApp/Utilities/Converters/DateTimeMinToEmptyStringConverter.cs
+++ b/InventoryManagementApp/Utilities/Converters/DateTimeMinToEmptyStringConverter.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace InventoryManagementApp.Utilities.Converters
+{
+    public class DateTimeMinToEmptyStringConverter : IValueConverter
+    {
+        private readonly ILogger<DateTimeMinToEmptyStringConverter> _logger;
+
+        public DateTimeMinToEmptyStringConverter() : this(null) { }
+
+        public DateTimeMinToEmptyStringConverter(ILogger<DateTimeMinToEmptyStringConverter>? logger = null)
+            => _logger = logger ?? NullLogger<DateTimeMinToEmptyStringConverter>.Instance;
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            try
+            {
+                if (value is DateTime dt)
+                    return dt == DateTime.MinValue ? null : dt;
+
+                if (value is DateTime? ndt)
+                    return ndt.HasValue && ndt.Value == DateTime.MinValue ? null : ndt;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Convert failed");
+            }
+
+            return Binding.DoNothing;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            try
+            {
+                if (value is DateTime dt)
+                    return dt;
+
+                if (value is string s)
+                {
+                    if (string.IsNullOrWhiteSpace(s))
+                        return DateTime.MinValue;
+                    if (DateTime.TryParse(s, culture, DateTimeStyles.None, out var parsed))
+                        return parsed;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "ConvertBack failed");
+            }
+
+            return Binding.DoNothing;
+        }
+    }
+}

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml
@@ -19,7 +19,7 @@
             <DataGrid ItemsSource="{Binding Logs}" IsReadOnly="True" AutoGenerateColumns="False" Style="{StaticResource VirtualizedDataGridStyle}">
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="Timestamp"
-                                         Binding="{Binding Timestamp, StringFormat={}{0:yyyy-MM-dd HH:mm}, TargetNullValue=''}"
+                                         Binding="{Binding Timestamp, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat={}{0:yyyy-MM-dd HH:mm}, TargetNullValue=''}"
                                          Width="180"/>
                     <DataGridTextColumn Header="User"
                                          Binding="{Binding UserName}"

--- a/InventoryManagementApp/Views/Pages/ScannerStatusPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ScannerStatusPage.xaml
@@ -31,7 +31,7 @@
                         <DataGridTextColumn Header="IP" Binding="{Binding Ip}" Width="180"/>
                         <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="160"/>
                         <DataGridTextColumn Header="Last Seen"
-                                            Binding="{Binding LastSeen, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}"
+                                            Binding="{Binding LastSeen, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat='{}{0:yyyy-MM-dd HH:mm}', TargetNullValue=''}"
                                             Width="220"/>
                     </DataGrid.Columns>
                 </DataGrid>

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml
@@ -50,7 +50,7 @@
                     <DataGridTextColumn Header="Phone" Binding="{Binding Phone}" Width="140"/>
                     <DataGridTextColumn Header="Mobile" Binding="{Binding Mobile}" Width="140"/>
                     <DataGridCheckBoxColumn Header="Active" Binding="{Binding IsActive}" Width="100"/>
-                    <DataGridTextColumn Header="Created" Binding="{Binding CreatedAt, StringFormat={}{0:yyyy-MM-dd}, TargetNullValue='N/A'}" Width="140"/>
+                    <DataGridTextColumn Header="Created" Binding="{Binding CreatedAt, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat={}{0:yyyy-MM-dd}, TargetNullValue=''}" Width="140"/>
                 </DataGrid.Columns>
                 <DataGrid.ContextMenu>
                     <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">


### PR DESCRIPTION
## Summary
- add `DateTimeMinToEmptyStringConverter` for blanking `DateTime.MinValue`
- apply converter across pages and shared DataGrid templates
- cover converter with unit tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a83664a3e883248e1abbf063c04daa