### PR TITLE
Handle nullable scanner last-seen timestamps

### DIFF
--- a/InventoryManagementApp.Tests/Services/ScannerServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/ScannerServiceTests.cs
@@ -31,8 +31,9 @@ namespace InventoryManagementApp.Tests.Services
                 var list = devices.ToList();
                 Assert.Single(list);
                 Assert.Equal("127.0.0.1", list[0].Ip);
-                Assert.InRange(list[0].LastSeen, before, after);
-                Assert.Equal(DateTimeKind.Local, list[0].LastSeen.Kind);
+                Assert.NotNull(list[0].LastSeen);
+                Assert.InRange(list[0].LastSeen!.Value, before, after);
+                Assert.Equal(DateTimeKind.Local, list[0].LastSeen!.Value.Kind);
             }
             finally
             {

--- a/InventoryManagementApp.Tests/ViewModels/ScannerStatusViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ScannerStatusViewModelTests.cs
@@ -38,7 +38,8 @@ namespace InventoryManagementApp.Tests.ViewModels
             await vm.RefreshCommand.ExecuteAsync(null);
             Assert.Single(vm.Devices);
             Assert.Equal(1, svc.CallCount);
-            Assert.Equal(DateTimeKind.Local, vm.Devices[0].LastSeen.Kind);
+            Assert.NotNull(vm.Devices[0].LastSeen);
+            Assert.Equal(DateTimeKind.Local, vm.Devices[0].LastSeen!.Value.Kind);
         }
 
         [Fact]
@@ -50,6 +51,28 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.True(vm.IsTimerRunning);
             vm.AutoRefresh = false;
             Assert.False(vm.IsTimerRunning);
+        }
+
+        class NullLastSeenScannerService : IScannerService
+        {
+            public Task<IEnumerable<ScannerDevice>> GetScannerDevicesAsync(CancellationToken cancellationToken)
+            {
+                IEnumerable<ScannerDevice> result = new[]
+                {
+                    new ScannerDevice { Name = "A", Ip = "1.1.1.1", Status = "Online", LastSeen = null }
+                };
+                return Task.FromResult(result);
+            }
+        }
+
+        [Fact]
+        public async Task RefreshCommand_AllowsNullLastSeen()
+        {
+            var svc = new NullLastSeenScannerService();
+            var vm = new ScannerStatusViewModel(svc, new StubDialogService());
+            await vm.RefreshCommand.ExecuteAsync(null);
+            Assert.Single(vm.Devices);
+            Assert.Null(vm.Devices[0].LastSeen);
         }
 
         [Fact]

--- a/InventoryManagementApp/Models/ScannerDevice.cs
+++ b/InventoryManagementApp/Models/ScannerDevice.cs
@@ -8,7 +8,7 @@ namespace InventoryManagementApp.Models
         string _name = string.Empty;
         string _ip = string.Empty;
         string _status = string.Empty;
-        DateTime _lastSeen;
+        DateTime? _lastSeen;
 
         public string Name
         {
@@ -28,7 +28,7 @@ namespace InventoryManagementApp.Models
             set => SetProperty(ref _status, value);
         }
 
-        public DateTime LastSeen
+        public DateTime? LastSeen
         {
             get => _lastSeen;
             set => SetProperty(ref _lastSeen, value);

--- a/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
@@ -62,10 +62,10 @@ namespace InventoryManagementApp.ViewModels
                 Devices.Clear();
                 foreach (var d in devices)
                 {
-                    if (d.LastSeen.Kind != DateTimeKind.Local)
+                    if (d.LastSeen.HasValue && d.LastSeen.Value.Kind != DateTimeKind.Local)
                     {
-                        _logger.LogWarning("Device {Ip} reported LastSeen kind {Kind}; converting to local time", d.Ip, d.LastSeen.Kind);
-                        d.LastSeen = d.LastSeen.ToLocalTime();
+                        _logger.LogWarning("Device {Ip} reported LastSeen kind {Kind}; converting to local time", d.Ip, d.LastSeen.Value.Kind);
+                        d.LastSeen = d.LastSeen.Value.ToLocalTime();
                     }
                     Devices.Add(d);
                 }

--- a/InventoryManagementApp/Views/Pages/ScannerStatusPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ScannerStatusPage.xaml
@@ -31,7 +31,7 @@
                         <DataGridTextColumn Header="IP" Binding="{Binding Ip}" Width="180"/>
                         <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="160"/>
                         <DataGridTextColumn Header="Last Seen"
-                                            Binding="{Binding LastSeen, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}"
+                                            Binding="{Binding LastSeen, StringFormat='{}{0:yyyy-MM-dd HH:mm}', TargetNullValue=''}"
                                             Width="220"/>
                     </DataGrid.Columns>
                 </DataGrid>

--- a/InventoryManagementApp/Views/Windows/ScannerStatusWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ScannerStatusWindow.xaml
@@ -34,7 +34,7 @@
                         <DataGridTextColumn Header="IP" Binding="{Binding Ip}" Width="180"/>
                         <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="160"/>
                         <DataGridTextColumn Header="Last Seen"
-                                            Binding="{Binding LastSeen, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}"
+                                            Binding="{Binding LastSeen, StringFormat='{}{0:yyyy-MM-dd HH:mm}', TargetNullValue=''}"
                                             Width="220"/>
                     </DataGrid.Columns>
                 </DataGrid>


### PR DESCRIPTION
## Summary
- allow `ScannerDevice.LastSeen` to be nullable
- convert LastSeen to local time only when present
- show blank Last Seen in scanner status views when timestamp is missing
- extend tests for null LastSeen

## Testing
- ⚠️ `dotnet test` *(dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8365cdb0083248e6e64c2aefa1400