### PR TITLE
Handle invalid rental dates

### DIFF
--- a/InventoryManagementApp.Tests/Services/RentalServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/RentalServiceTests.cs
@@ -410,7 +410,7 @@ namespace InventoryManagementApp.Tests.Services
         }
 
         [Fact]
-        public void GetAllRentals_InvalidDates_NoException()
+        public void GetAllRentals_InvalidDates_Skipped()
         {
             var dbPath = Path.GetTempFileName();
             try
@@ -432,11 +432,12 @@ namespace InventoryManagementApp.Tests.Services
                 cmd.Parameters.AddWithValue("@C", cust.CustomerID);
                 cmd.ExecuteNonQuery();
 
+                // add a valid rental
+                rentalService.RentItem(item.ItemID, cust.CustomerID, DateTime.Today, DateTime.Today.AddDays(1));
+
                 var rentals = rentalService.GetAllRentals();
                 Assert.Single(rentals);
-                Assert.Null(rentals[0].ReturnDate);
-
-                rentalService.ExtendRental(rentals[0].RentalID, DateTime.Today.AddDays(1));
+                Assert.All(rentals, r => Assert.NotEqual(default, r.RentalDate));
             }
             finally
             {

--- a/InventoryManagementApp/Resources/Templates.xaml
+++ b/InventoryManagementApp/Resources/Templates.xaml
@@ -54,8 +54,8 @@
     <DataGridTextColumn x:Key="RentalItemNumberColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} #'}" Binding="{Binding ItemNumber}" Width="120" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalItemNameColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}" Binding="{Binding NameDescription}" Width="*" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalCustomerColumn" Header="Customer" Binding="{Binding CustomerName}" Width="220" x:Shared="False"/>
-    <DataGridTextColumn x:Key="RentalOutColumn" Header="Out" Binding="{Binding DateOut, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180" x:Shared="False"/>
+    <DataGridTextColumn x:Key="RentalOutColumn" Header="Out" Binding="{Binding RentalDate, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalDueColumn" Header="Due" Binding="{Binding DueDate, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180" x:Shared="False"/>
-    <DataGridTextColumn x:Key="RentalReturnedColumn" Header="Returned" Binding="{Binding DateReturned, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="180" x:Shared="False"/>
+    <DataGridTextColumn x:Key="RentalReturnedColumn" Header="Returned" Binding="{Binding ReturnDate, StringFormat=\{0:yyyy-MM-dd HH:mm\}, TargetNullValue=''}" Width="180" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalStatusColumn" Header="Status" Binding="{Binding Status}" Width="140" x:Shared="False"/>
 </ResourceDictionary>

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SQLite;
+using System.Linq;
 using System.Threading.Tasks;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
@@ -69,25 +70,36 @@ namespace InventoryManagementApp.Services.Rentals
 
         // Synchronous rental operations removed; use async equivalents instead.
 
-        Rental MapRental(IDataRecord r) => new()
+        Rental? MapRental(IDataRecord r)
         {
-            RentalID = Convert.ToInt32(r["RentalID"]),
-            ItemID = Convert.ToInt32(r["ItemID"]),
-            CustomerID = Convert.ToInt32(r["CustomerID"]),
-            RentalDate = ParseDateOrDefault(r["RentalDate"], "RentalDate"),
-            DueDate = ParseDateOrDefault(r["DueDate"], "DueDate"),
-            ReturnDate = r["ReturnDate"] is DBNull ? null : ParseNullableDate(r["ReturnDate"], "ReturnDate"),
-            Status = r["Status"].ToString(),
-            ItemNumber = r["ItemNumber"].ToString(),
-            CustomerName = r["Company"].ToString(),
-            CustomerContact = r["Contact"].ToString(),
-            CustomerEmail = r["Email"].ToString(),
-            CustomerPhone = r["Phone"].ToString(),
-            CustomerMobile = r["Mobile"].ToString(),
-            CustomerAddress = r["Address"].ToString(),
-            ImagePath = r["ImagePath"].ToString(),
-            ItemLocation = r["ItemLocation"].ToString()
-        };
+            try
+            {
+                return new Rental
+                {
+                    RentalID = Convert.ToInt32(r["RentalID"]),
+                    ItemID = Convert.ToInt32(r["ItemID"]),
+                    CustomerID = Convert.ToInt32(r["CustomerID"]),
+                    RentalDate = ParseDateOrDefault(r["RentalDate"], "RentalDate"),
+                    DueDate = ParseDateOrDefault(r["DueDate"], "DueDate"),
+                    ReturnDate = r["ReturnDate"] is DBNull ? null : ParseNullableDate(r["ReturnDate"], "ReturnDate"),
+                    Status = r["Status"].ToString(),
+                    ItemNumber = r["ItemNumber"].ToString(),
+                    CustomerName = r["Company"].ToString(),
+                    CustomerContact = r["Contact"].ToString(),
+                    CustomerEmail = r["Email"].ToString(),
+                    CustomerPhone = r["Phone"].ToString(),
+                    CustomerMobile = r["Mobile"].ToString(),
+                    CustomerAddress = r["Address"].ToString(),
+                    ImagePath = r["ImagePath"].ToString(),
+                    ItemLocation = r["ItemLocation"].ToString()
+                };
+            }
+            catch (FormatException ex)
+            {
+                _logger.LogError(ex, "Skipping rental with invalid date");
+                return null;
+            }
+        }
 
         DateTime ParseDateOrDefault(object? value, string field)
         {
@@ -96,7 +108,7 @@ namespace InventoryManagementApp.Services.Rentals
                     DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dt))
                 return DateTime.SpecifyKind(dt, DateTimeKind.Utc).ToLocalTime();
             _logger.LogError("Failed to parse {Field}: {Value}", field, text);
-            return default;
+            throw new FormatException($"Invalid date value for {field}: {text}");
         }
 
         DateTime? ParseNullableDate(object? value, string field)
@@ -237,7 +249,8 @@ namespace InventoryManagementApp.Services.Rentals
         {
             using var conn = _dbService.CreateConnection();
             var sql = BaseSelect + " WHERE r.Status='Rented'";
-            return await SqliteHelper.ExecuteReaderAsync(conn, sql, null, MapRental);
+            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, null, MapRental);
+            return list.Where(r => r != null).Select(r => r!).ToList();
         }
 
         public async Task<List<Rental>> GetOverdueRentalsAsync()
@@ -245,13 +258,15 @@ namespace InventoryManagementApp.Services.Rentals
             const string sql = BaseSelect + @" WHERE r.Status = 'Rented' AND r.DueDate < @Today";
             var p = new[] { new SQLiteParameter("@Today", DateTime.Today) };
             using var conn = _dbService.CreateConnection();
-            return await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapRental);
+            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapRental);
+            return list.Where(r => r != null).Select(r => r!).ToList();
         }
 
         public async Task<List<Rental>> GetAllRentalsAsync()
         {
             using var conn = _dbService.CreateConnection();
-            return await SqliteHelper.ExecuteReaderAsync(conn, BaseSelect, null, MapRental);
+            var list = await SqliteHelper.ExecuteReaderAsync(conn, BaseSelect, null, MapRental);
+            return list.Where(r => r != null).Select(r => r!).ToList();
         }
 
         public async Task<List<Rental>> GetRentalHistoryForItemAsync(int itemID)
@@ -259,7 +274,8 @@ namespace InventoryManagementApp.Services.Rentals
             const string sql = BaseSelect + @" WHERE r.ItemID = @ItemID ORDER BY r.RentalDate DESC";
             var p = new[] { new SQLiteParameter("@ItemID", itemID) };
             using var conn = _dbService.CreateConnection();
-            return await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapRental);
+            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapRental);
+            return list.Where(r => r != null).Select(r => r!).ToList();
         }
 
         public async Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID)
@@ -267,7 +283,8 @@ namespace InventoryManagementApp.Services.Rentals
             const string sql = BaseSelect + @" WHERE r.CustomerID = @CustomerID ORDER BY r.RentalDate DESC";
             var p = new[] { new SQLiteParameter("@CustomerID", customerID) };
             using var conn = _dbService.CreateConnection();
-            return await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapRental);
+            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapRental);
+            return list.Where(r => r != null).Select(r => r!).ToList();
         }
     }
 }


### PR DESCRIPTION
## Summary
- throw on invalid rental dates and skip malformed rows
- ensure rental DataGrid columns bind to valid timestamps
- test skipping invalid rental rows

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a83661649c832498d96b96e2bab175