### PR TITLE
Fix delete menu binding for item management

### DIFF
--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -46,8 +46,10 @@
                                 HeaderStringFormat="Rent {0}"
                                 Command="{Binding OpenRentalsCommand}"/>
                             <MenuItem Header="Delete"
-                                      Command="{Binding DeleteItemsCommand}"
-                                      CommandParameter="{Binding SelectedItems, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
+                                      Command="{Binding PlacementTarget.DataContext.DeleteItemsCommand,
+                                                        RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                      CommandParameter="{Binding PlacementTarget.SelectedItems,
+                                                        RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                         </ContextMenu>
                     </DataGrid.ContextMenu>
                 </DataGrid>


### PR DESCRIPTION
## Summary
- fix Delete context menu binding to use PlacementTarget SelectedItems and DeleteItemsCommand

## Testing
- ⚠️ `dotnet test` *(dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8385376888324ad8523ab59ddd802