### PR TITLE
Improve activity log timestamp parsing

### DIFF
--- a/InventoryManagementApp.Tests/InventoryManagementApp.Tests.csproj
+++ b/InventoryManagementApp.Tests/InventoryManagementApp.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <ProjectReference Include="../InventoryManagementApp/InventoryManagementApp.csproj" />
+  </ItemGroup>
+</Project>

--- a/InventoryManagementApp.Tests/Services/ActivityLogServiceTests.cs
+++ b/InventoryManagementApp.Tests/Services/ActivityLogServiceTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Data.SQLite;
+using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
+using InventoryManagementApp.Services.Core;
+using InventoryManagementApp.Services.Users;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Services
+{
+    public class ActivityLogServiceTests
+    {
+        [Fact]
+        public async Task GetRecentLogsAsync_ParsesDdMmYyyyTimestamp()
+        {
+            var dbPath = Path.GetTempFileName();
+            try
+            {
+                using var db = new DatabaseService(dbPath);
+                var service = new ActivityLogService(db);
+
+                using (var conn = db.CreateConnection())
+                using (var cmd = new SQLiteCommand(@"INSERT INTO ActivityLogs (UserID, UserName, Action, Timestamp)
+                                                     VALUES (1, 'user', 'action', @ts);", conn))
+                {
+                    cmd.Parameters.AddWithValue("@ts", "25/12/2023 13:45");
+                    cmd.ExecuteNonQuery();
+                }
+
+                var originalCulture = CultureInfo.CurrentCulture;
+                CultureInfo.CurrentCulture = new CultureInfo("en-GB");
+                try
+                {
+                    var result = await service.GetRecentLogsAsync(1);
+                    var log = result.Data[0];
+                    var expected = new DateTime(2023, 12, 25, 13, 45, 0, DateTimeKind.Local);
+                    Assert.Equal(expected, log.Timestamp);
+                }
+                finally
+                {
+                    CultureInfo.CurrentCulture = originalCulture;
+                }
+            }
+            finally
+            {
+                File.Delete(dbPath);
+            }
+        }
+    }
+}

--- a/InventoryManagementApp.sln
+++ b/InventoryManagementApp.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 17.12.35707.178
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InventoryManagementApp", "InventoryManagementApp\InventoryManagementApp.csproj", "{D7C90C3C-2641-4E33-87A2-8778E278A369}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InventoryManagementApp.Tests", "InventoryManagementApp.Tests\InventoryManagementApp.Tests.csproj", "{9C176C36-0300-459A-8440-A7ED1B833DDA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,6 +16,10 @@ Global
 		{D7C90C3C-2641-4E33-87A2-8778E278A369}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D7C90C3C-2641-4E33-87A2-8778E278A369}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D7C90C3C-2641-4E33-87A2-8778E278A369}.Release|Any CPU.Build.0 = Release|Any CPU
+                {9C176C36-0300-459A-8440-A7ED1B833DDA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {9C176C36-0300-459A-8440-A7ED1B833DDA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {9C176C36-0300-459A-8440-A7ED1B833DDA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {9C176C36-0300-459A-8440-A7ED1B833DDA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -119,21 +119,23 @@ namespace InventoryManagementApp.Services.Users
 
         ActivityLog MapLog(IDataRecord r)
         {
-            DateTime timestamp;
             var rawTimestamp = r["Timestamp"]?.ToString();
-            if (!DateTime.TryParse(rawTimestamp, CultureInfo.InvariantCulture,
-                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out timestamp))
+            DateTime timestamp;
+
+            if (!DateTime.TryParseExact(rawTimestamp, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out timestamp) &&
+                !DateTime.TryParse(rawTimestamp, CultureInfo.CurrentCulture, DateTimeStyles.None, out timestamp))
             {
                 _logger.LogWarning("Invalid timestamp '{Timestamp}' for log {LogID}", rawTimestamp, r["LogID"]);
-                timestamp = DateTime.UtcNow;
+                timestamp = DateTime.MinValue;
             }
-
-            // Ensure timestamps are converted to the local timezone before exposing them to the UI.
-            // Attempting to convert DateTime.MinValue can throw if the local offset is negative,
-            // so only convert when the timestamp is valid.
-            if (timestamp != DateTime.MinValue)
+            else
             {
-                timestamp = DateTime.SpecifyKind(timestamp, DateTimeKind.Utc).ToLocalTime();
+                if (timestamp.Kind == DateTimeKind.Unspecified)
+                {
+                    timestamp = DateTime.SpecifyKind(timestamp, DateTimeKind.Local);
+                }
+                timestamp = timestamp.ToLocalTime();
             }
 
             var log = new ActivityLog


### PR DESCRIPTION
## Summary
- Handle ISO and culture-specific timestamps when mapping activity logs
- Add unit test verifying dd/MM/yyyy HH:mm parsing

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a83f7bd2048324b870d98c179d62ac