### PR TITLE
Fix Dapper CommandDefinition flags usage in ItemRepository

### DIFF
--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -23,7 +23,7 @@ public sealed class ItemRepository : IItemRepository
         var param = new { Search = $"%{filter.Search}%", Take = page.Size, Skip = (page.Number - 1) * page.Size };
         using var conn = _factory.Create();
         var rows = await conn.QueryAsync<Item>(
-            new CommandDefinition(sql, param, buffered: false, cancellationToken: ct));
+            new CommandDefinition(sql, param, flags: CommandFlags.None, cancellationToken: ct));
         foreach (var row in rows)
         {
             ct.ThrowIfCancellationRequested();


### PR DESCRIPTION
## Summary
- update ItemRepository to use CommandFlags.None in CommandDefinition for unbuffered query

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8539a4e8c8324aa5fe77b9411c4ef