### PR TITLE
Handle item page load errors before navigation

### DIFF
--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -239,19 +239,35 @@ namespace InventoryManagementApp.ViewModels
 
             OpenSearchItemsCommand = new AsyncRelayCommand(async () =>
             {
-                await ItemManagement.LoadItemsAsync();
                 var plural = LabelProvider.Instance.ItemLabelPlural;
                 var page = new ItemSearchPage { DataContext = ItemManagement, Title = $"Search {plural}" };
                 // If your ItemManagement VM supports a query setter, apply GlobalSearchText there.
                 CurrentPage = page;
+                try
+                {
+                    await ItemManagement.LoadItemsAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to open search items page");
+                    _dialogService.ShowInfo($"Failed to open search {plural} page: {ex.Message}", $"Search {plural}");
+                }
             });
 
             OpenManageItemsCommand = new AsyncRelayCommand(async () =>
             {
-                await ItemManagement.LoadItemsAsync();
                 var plural = LabelProvider.Instance.ItemLabelPlural;
                 var page = new ManageItemsPage { DataContext = ItemManagement, Title = $"Manage {plural}" };
                 CurrentPage = page;
+                try
+                {
+                    await ItemManagement.LoadItemsAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to open manage items page");
+                    _dialogService.ShowInfo($"Failed to open manage {plural} page: {ex.Message}", $"Manage {plural}");
+                }
             });
 
             OpenRentalsCommand = new AsyncRelayCommand(async () =>


### PR DESCRIPTION
## Summary
- Ensure item search and management pages are assigned before loading data
- Add logging and dialog notifications when loading items fails

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8575268ac83248822cc45b910f41a