### PR TITLE
Fix SearchCommand execution overloads

### DIFF
--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -81,7 +81,7 @@ namespace InventoryManagementApp.ViewModels
                     _searchCts.Cancel();
                     _searchCts.Dispose();
                     _searchCts = new CancellationTokenSource();
-                    SearchCommand.Execute();
+                    SearchCommand.Execute(null);
                 }
             }
         }
@@ -150,7 +150,7 @@ namespace InventoryManagementApp.ViewModels
             _searchDebounceTimer.Stop();
             _searchCts.Dispose();
             _searchCts = new CancellationTokenSource();
-            SearchCommand.Execute();
+            SearchCommand.Execute(null);
         }
 
         public async Task LoadItemsAsync()


### PR DESCRIPTION
## Summary
- pass `null` to `SearchCommand.Execute` when changing category or debounce timer fires, preventing ambiguous overload usage

## Testing
- `dotnet build InventoryManagementApp.sln` *(fails: command not found)*
- `dotnet test InventoryManagementApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a857a86e7c832486b27184e1dec5eb