### PR TITLE
Add count queries for dashboard statistics

### DIFF
--- a/InventoryManagementApp/Interfaces/ICustomerService.cs
+++ b/InventoryManagementApp/Interfaces/ICustomerService.cs
@@ -14,6 +14,7 @@ namespace InventoryManagementApp.Interfaces
         Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default);
         Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default);
         Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default);
+        Task<int> GetCustomerCountAsync(CancellationToken cancellationToken = default);
         Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default);
         Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default);
         Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default);

--- a/InventoryManagementApp/Interfaces/IItemService.cs
+++ b/InventoryManagementApp/Interfaces/IItemService.cs
@@ -15,6 +15,7 @@ namespace InventoryManagementApp.Interfaces
         Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default);
         Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default);
         Task<List<ItemModel>> GetAllItemsAsync(CancellationToken cancellationToken = default);
+        Task<int> GetItemCountAsync(CancellationToken cancellationToken = default);
         Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default);
         Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default);
         Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default);

--- a/InventoryManagementApp/Interfaces/IRentalService.cs
+++ b/InventoryManagementApp/Interfaces/IRentalService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Models;
 using InventoryManagementApp.Models.Domain;
@@ -34,5 +35,6 @@ namespace InventoryManagementApp.Interfaces
         Task<List<Rental>> GetAllRentalsAsync();
         Task<List<Rental>> GetRentalHistoryForItemAsync(int itemID);
         Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID);
+        Task<int> GetActiveRentalCountAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/InventoryManagementApp/Interfaces/IUserService.cs
+++ b/InventoryManagementApp/Interfaces/IUserService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Models;
 using InventoryManagementApp.Models.Domain;
@@ -15,6 +16,7 @@ namespace InventoryManagementApp.Interfaces
         Task UpdateUserAsync(User user);
         Task<bool> TryDeleteUserAsync(int userID);
         Task<bool> ChangeUserPasswordAsync(int userID, string newPassword);
+        Task<int> GetUserCountAsync(CancellationToken cancellationToken = default);
     }
 }
 

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -54,6 +54,9 @@ namespace InventoryManagementApp.Services.Customers
         public Task<List<CustomerModel>> GetAllCustomersAsync(CancellationToken cancellationToken = default) =>
             GetAllCustomersInternalAsync(cancellationToken);
 
+        public Task<int> GetCustomerCountAsync(CancellationToken cancellationToken = default) =>
+            GetCustomerCountInternalAsync(cancellationToken);
+
         public Task<List<CustomerModel>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) =>
             SearchCustomersInternalAsync(searchTerm, cancellationToken);
 
@@ -153,6 +156,22 @@ namespace InventoryManagementApp.Services.Customers
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to get all customers");
+                throw;
+            }
+        }
+
+        async Task<int> GetCustomerCountInternalAsync(CancellationToken cancellationToken)
+        {
+            const string sql = "SELECT COUNT(*) FROM Customers";
+            using var conn = _dbService.CreateConnection();
+            try
+            {
+                var result = await SqliteHelper.ExecuteScalarAsync(conn, sql, null, cancellationToken);
+                return Convert.ToInt32(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to count customers");
                 throw;
             }
         }

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -422,6 +422,9 @@ namespace InventoryManagementApp.Services.Items
             return items;
         }
 
+        public Task<int> GetItemCountAsync(CancellationToken cancellationToken = default)
+            => _repository.CountAsync(new ItemFilter(null), cancellationToken);
+
         public async Task<List<ItemModel>> SearchItemsAsync(string? searchText, CancellationToken cancellationToken = default)
         {
             var items = new List<ItemModel>();

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.SQLite;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
@@ -251,6 +252,14 @@ namespace InventoryManagementApp.Services.Rentals
             var sql = BaseSelect + " WHERE r.Status='Rented'";
             var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, null, MapRental);
             return list.Where(r => r != null).Select(r => r!).ToList();
+        }
+
+        public async Task<int> GetActiveRentalCountAsync(CancellationToken cancellationToken = default)
+        {
+            using var conn = _dbService.CreateConnection();
+            const string sql = "SELECT COUNT(*) FROM Rentals WHERE Status='Rented'";
+            var result = await SqliteHelper.ExecuteScalarAsync(conn, sql, null, cancellationToken);
+            return Convert.ToInt32(result);
         }
 
         public async Task<List<Rental>> GetOverdueRentalsAsync()

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data.SQLite;
 using System.Data;
+using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Models;
 using InventoryManagementApp.Models.Domain;
@@ -100,6 +101,14 @@ namespace InventoryManagementApp.Services.Users
             using var conn = _dbService.CreateConnection();
             const string sql = "SELECT UserID, UserName, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, PasswordExpired FROM Users";
             return await SqliteHelper.ExecuteReaderAsync(conn, sql, null, MapUser);
+        }
+
+        public async Task<int> GetUserCountAsync(CancellationToken cancellationToken = default)
+        {
+            using var conn = _dbService.CreateConnection();
+            const string sql = "SELECT COUNT(*) FROM Users";
+            var result = await SqliteHelper.ExecuteScalarAsync(conn, sql, null, cancellationToken);
+            return Convert.ToInt32(result);
         }
 
         public async Task<User?> GetUserByIDAsync(int userID)

--- a/InventoryManagementApp/ViewModels/DashboardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DashboardViewModel.cs
@@ -80,14 +80,21 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 StatCards.Clear();
-                var items = await _itemService.GetAllItemsAsync(cancellationToken);
-                StatCards.Add(new StatCard { Title = $"Total {LabelProvider.Instance.ItemLabelPlural}", Value = items.Count.ToString() });
-                var activeRentals = await _rentalService.GetActiveRentalsAsync();
-                var customers = await _customerService.GetAllCustomersAsync(cancellationToken);
-                var users = await _userService.GetAllUsersAsync();
-                StatCards.Add(new StatCard { Title = "Active Rentals", Value = activeRentals.Count.ToString() });
-                StatCards.Add(new StatCard { Title = "Total Customers", Value = customers.Count.ToString() });
-                StatCards.Add(new StatCard { Title = "Total Users", Value = users.Count.ToString() });
+
+                var itemCountTask = _itemService.GetItemCountAsync(cancellationToken);
+                var rentalCountTask = _rentalService.GetActiveRentalCountAsync(cancellationToken);
+                var customerCountTask = _customerService.GetCustomerCountAsync(cancellationToken);
+                var userCountTask = _userService.GetUserCountAsync(cancellationToken);
+
+                var itemCount = await itemCountTask;
+                var activeRentalCount = await rentalCountTask;
+                var customerCount = await customerCountTask;
+                var userCount = await userCountTask;
+
+                StatCards.Add(new StatCard { Title = $"Total {LabelProvider.Instance.ItemLabelPlural}", Value = itemCount.ToString() });
+                StatCards.Add(new StatCard { Title = "Active Rentals", Value = activeRentalCount.ToString() });
+                StatCards.Add(new StatCard { Title = "Total Customers", Value = customerCount.ToString() });
+                StatCards.Add(new StatCard { Title = "Total Users", Value = userCount.ToString() });
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
## Summary
- add async count methods to item, customer, rental, and user services
- update DashboardViewModel to use count APIs for stat cards

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a857b28340832485e7152886c91cd8