### PR TITLE
Specify page size when loading items

### DIFF
--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -26,6 +26,7 @@ using Microsoft.Extensions.DependencyInjection;
 using InventoryManagementApp.Models.ImportExport;
 using InventoryManagementApp.Utilities;
 using InventoryManagementApp.Utilities.Helpers;
+using InventoryManagementApp.Data;
 using Application = System.Windows.Application;
 
 namespace InventoryManagementApp.ViewModels
@@ -245,7 +246,7 @@ namespace InventoryManagementApp.ViewModels
                 CurrentPage = page;
                 try
                 {
-                    await ItemManagement.LoadItemsAsync();
+                    await ItemManagement.LoadItemsAsync(new ItemPage(1, 50));
                 }
                 catch (Exception ex)
                 {
@@ -261,7 +262,7 @@ namespace InventoryManagementApp.ViewModels
                 CurrentPage = page;
                 try
                 {
-                    await ItemManagement.LoadItemsAsync();
+                    await ItemManagement.LoadItemsAsync(new ItemPage(1, 50));
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary
- Load item pages with default size 50 when opening search or manage items views
- Add data namespace import for ItemPage

## Testing
- `dotnet build InventoryManagementApp.sln` *(command failed: dotnet not found)*
- `dotnet test InventoryManagementApp.sln` *(command failed: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a85a2af1e883249467b40f71343456