### PR TITLE
Fix unbuffered item query causing reader closure

### DIFF
--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -23,7 +23,7 @@ public sealed class ItemRepository : IItemRepository
         var param = new { Search = $"%{filter.Search}%", Take = page.Size, Skip = (page.Number - 1) * page.Size };
         using var conn = _factory.Create();
         var rows = await conn.QueryAsync<Item>(
-            new CommandDefinition(sql, param, flags: CommandFlags.None, cancellationToken: ct));
+            new CommandDefinition(sql, param, flags: CommandFlags.Buffered, cancellationToken: ct));
         foreach (var row in rows)
         {
             ct.ThrowIfCancellationRequested();


### PR DESCRIPTION
## Summary
- Buffer item queries to avoid 'reader is closed' errors during async enumeration

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a85a2f269c8324adb2df7832f5d398