### PR TITLE
Remove redundant column self-rename and add migration tests

### DIFF
--- a/InventoryManagementApp.Tests/DatabaseServiceMigrationTests.cs
+++ b/InventoryManagementApp.Tests/DatabaseServiceMigrationTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Data.SQLite;
+using InventoryManagementApp.Services.Core;
+using System.Text.RegularExpressions;
+using Xunit;
+
+public class DatabaseServiceMigrationTests
+{
+    [Fact]
+    public void Migrations_DoNotAttemptSelfRenames()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../"));
+        var path = Path.Combine(repoRoot, "InventoryManagementApp", "Services", "Core", "DatabaseService.cs");
+        var code = File.ReadAllText(path);
+        var pattern = @"RenameColumnIfExists\s*\(\s*[^,]+,\s*[^,]+,\s*""([^""]+)""\s*,\s*""\1""\s*\)";
+        Assert.False(Regex.IsMatch(code, pattern));
+    }
+
+    [Fact]
+    public void RenameColumnIfExists_DoesNothingWhenNamesMatch()
+    {
+        using var conn = new SQLiteConnection("Data Source=:memory:");
+        conn.Open();
+        using var create = new SQLiteCommand("CREATE TABLE Items (IsPowered INTEGER);", conn);
+        create.ExecuteNonQuery();
+
+        var service = (DatabaseService)FormatterServices.GetUninitializedObject(typeof(DatabaseService));
+        var method = typeof(DatabaseService).GetMethod("RenameColumnIfExists", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        method.Invoke(service, new object[] { conn, "Items", "IsPowered", "IsPowered" });
+
+        using var pragma = new SQLiteCommand("PRAGMA table_info(Items);", conn);
+        using var reader = pragma.ExecuteReader();
+        var count = 0;
+        while (reader.Read())
+        {
+            if (reader["name"]?.ToString() == "IsPowered")
+                count++;
+        }
+
+        Assert.Equal(1, count);
+    }
+}
+

--- a/InventoryManagementApp/Services/Core/DatabaseService.cs
+++ b/InventoryManagementApp/Services/Core/DatabaseService.cs
@@ -41,10 +41,6 @@ namespace InventoryManagementApp.Services.Core
             _logger = logger ?? NullLogger<DatabaseService>.Instance;
             ConfigureDatabase();
             InitializeDatabase();
-            using (var conn = CreateConnection())
-            {
-                RenameColumnIfExists(conn, "Items", "IsPowered", "IsPowered");
-            }
             EnsureColumn("Items", "ItemNumber", "TEXT");
             EnsureColumn("Items", "NameDescription", "TEXT");
             EnsureColumn("Items", "ImagePath", "TEXT");


### PR DESCRIPTION
## Summary
- drop unnecessary Items.IsPowered self-rename from DatabaseService
- add tests ensuring migrations avoid self-renames and RenameColumnIfExists ignores identical names

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c78eee1883249cf508325b262bd6