### PR TITLE
Add memory budget monitoring to item view model

### DIFF
--- a/InventoryManagementApp.Tests/MemoryBudgetTests.cs
+++ b/InventoryManagementApp.Tests/MemoryBudgetTests.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading.Tasks;
+using InventoryManagementApp.Utilities;
+using Xunit;
+
+public class MemoryBudgetTests
+{
+    [Fact]
+    public async Task ThresholdExceeded_IsRaised_WhenMemoryAboveThreshold()
+    {
+        using var budget = new MemoryBudget(TimeSpan.FromMilliseconds(50), 0);
+        var tcs = new TaskCompletionSource();
+        budget.ThresholdExceeded += (s, e) => tcs.TrySetResult();
+        await Task.WhenAny(tcs.Task, Task.Delay(1000));
+        Assert.True(tcs.Task.IsCompleted);
+    }
+}

--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -24,6 +24,7 @@ using InventoryManagementApp.Views.Pages;
 using InventoryManagementApp.Views.Windows;
 using InventoryManagementApp.Services.Devices;
 using InventoryManagementApp.Data;
+using InventoryManagementApp.Utilities;
 using Microsoft.Data.Sqlite;
 
 namespace InventoryManagementApp
@@ -109,6 +110,7 @@ namespace InventoryManagementApp
                 services.AddSingleton<ISettingsService, SettingsService>();
                 services.AddSingleton<IDialogService, DialogService>();
                 services.AddSingleton<IScannerService, ScannerService>();
+                services.AddSingleton<MemoryBudget>();
                 services.AddSingleton<IMainViewModel, MainViewModel>();
                 services.AddSingleton<ILoginViewModel, LoginViewModel>();
                 services.AddTransient<ItemEditWindow>();

--- a/InventoryManagementApp/Utilities/MemoryBudget.cs
+++ b/InventoryManagementApp/Utilities/MemoryBudget.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+
+namespace InventoryManagementApp.Utilities
+{
+    public sealed class MemoryBudget : IDisposable
+    {
+        private readonly Timer _timer;
+        private readonly long _thresholdBytes;
+
+        public event EventHandler? ThresholdExceeded;
+
+        public MemoryBudget()
+            : this(TimeSpan.FromSeconds(5), 600L * 1024 * 1024)
+        {
+        }
+
+        public MemoryBudget(TimeSpan interval, long thresholdBytes)
+        {
+            _thresholdBytes = thresholdBytes;
+            _timer = new Timer(CheckMemory, null, interval, interval);
+        }
+
+        private void CheckMemory(object? state)
+        {
+            var total = GC.GetTotalMemory(false);
+            if (total > _thresholdBytes)
+            {
+                ThresholdExceeded?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        public void Dispose()
+        {
+            _timer.Dispose();
+        }
+    }
+}

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using InventoryManagementApp.Data;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Utilities;
+using InventoryManagementApp.Utilities.Extensions;
+
+namespace InventoryManagementApp.ViewModels
+{
+    public class ItemsViewModel : ObservableObject, IDisposable
+    {
+        private readonly IItemService _itemService;
+        private readonly MemoryBudget _memoryBudget;
+        private readonly ObservableCollection<ItemModel> _items = new();
+        public ReadOnlyObservableCollection<ItemModel> Items { get; }
+        private int _currentPage = 1;
+        private const int PageSize = 200;
+
+        public ItemsViewModel(IItemService itemService, MemoryBudget memoryBudget)
+        {
+            _itemService = itemService;
+            _memoryBudget = memoryBudget;
+            Items = new(_items);
+            _memoryBudget.ThresholdExceeded += OnThresholdExceeded;
+        }
+
+        public async Task LoadPageAsync(int page, CancellationToken cancellationToken = default)
+        {
+            _currentPage = page;
+            var list = new List<ItemModel>();
+            await foreach (var item in _itemService.GetItemsAsync(new ItemPage(page, PageSize), cancellationToken))
+                list.Add(item);
+            _items.AddRange(list);
+            TrimToWindow();
+        }
+
+        private void OnThresholdExceeded(object? sender, EventArgs e) => TrimToWindow();
+
+        private void TrimToWindow()
+        {
+            var max = PageSize * 3;
+            if (_items.Count <= max) return;
+            var start = Math.Max(0, (_currentPage - 2) * PageSize);
+            var trimmed = _items.Skip(start).Take(max).ToList();
+            _items.ReplaceRange(trimmed);
+        }
+
+        public void Dispose()
+        {
+            _memoryBudget.ThresholdExceeded -= OnThresholdExceeded;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Monitor GC usage with MemoryBudget service
- Trim ItemsViewModel to three pages when memory budget exceeded
- Register MemoryBudget in application services

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c78b0a6483248fb4f893e9852d40