### PR TITLE
Implement incremental item loading for Manage Items page

### DIFF
--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -111,6 +111,7 @@ namespace InventoryManagementApp
                 services.AddSingleton<IDialogService, DialogService>();
                 services.AddSingleton<IScannerService, ScannerService>();
                 services.AddSingleton<MemoryBudget>();
+                services.AddTransient<ItemsViewModel>();
                 services.AddSingleton<IMainViewModel, MainViewModel>();
                 services.AddSingleton<ILoginViewModel, LoginViewModel>();
                 services.AddTransient<ItemEditWindow>();

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -9,51 +8,115 @@ using InventoryManagementApp.Data;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Utilities;
-using InventoryManagementApp.Utilities.Extensions;
 
 namespace InventoryManagementApp.ViewModels
 {
-    public class ItemsViewModel : ObservableObject, IDisposable
+    public partial class ItemsViewModel : ObservableObject, IDisposable
     {
         private readonly IItemService _itemService;
         private readonly MemoryBudget _memoryBudget;
-        private readonly ObservableCollection<ItemModel> _items = new();
-        public ReadOnlyObservableCollection<ItemModel> Items { get; }
-        private int _currentPage = 1;
+        private CancellationTokenSource _filterCts = new();
+
         private const int PageSize = 200;
+        public IncrementalLoadingCollection<ItemModel> Items { get; }
+
+        [ObservableProperty]
+        private ItemModel? selectedItem;
+
+        [ObservableProperty]
+        private string filter = string.Empty;
 
         public ItemsViewModel(IItemService itemService, MemoryBudget memoryBudget)
         {
             _itemService = itemService;
             _memoryBudget = memoryBudget;
-            Items = new(_items);
+            Items = new IncrementalLoadingCollection<ItemModel>(LoadPageAsync, PageSize);
             _memoryBudget.ThresholdExceeded += OnThresholdExceeded;
         }
 
-        public async Task LoadPageAsync(int page, CancellationToken cancellationToken = default)
+        private async Task<IList<ItemModel>> LoadPageAsync(int page, CancellationToken ct)
         {
-            _currentPage = page;
-            var list = new List<ItemModel>();
-            await foreach (var item in _itemService.GetItemsAsync(new ItemPage(page, PageSize), cancellationToken))
-                list.Add(item);
-            _items.AddRange(list);
-            TrimToWindow();
+            var result = new List<ItemModel>();
+            var pageInfo = new ItemPage(page, PageSize);
+            var source = string.IsNullOrWhiteSpace(Filter)
+                ? _itemService.GetItemsAsync(pageInfo, ct)
+                : _itemService.SearchItemsAsync(Filter, pageInfo, ct);
+            await foreach (var item in source.ConfigureAwait(false))
+                result.Add(item);
+            return result;
         }
 
-        private void OnThresholdExceeded(object? sender, EventArgs e) => TrimToWindow();
+        public Task LoadMoreAsync(CancellationToken ct = default) => Items.LoadMoreAsync(ct);
 
-        private void TrimToWindow()
+        partial void OnFilterChanged(string value)
         {
-            var max = PageSize * 3;
-            if (_items.Count <= max) return;
-            var start = Math.Max(0, (_currentPage - 2) * PageSize);
-            var trimmed = _items.Skip(start).Take(max).ToList();
-            _items.ReplaceRange(trimmed);
+            _filterCts.Cancel();
+            _filterCts.Dispose();
+            _filterCts = new CancellationTokenSource();
+            _ = ApplyFilterAsync(_filterCts.Token);
         }
+
+        private async Task ApplyFilterAsync(CancellationToken token)
+        {
+            try
+            {
+                await Task.Delay(300, token).ConfigureAwait(false);
+            }
+            catch (TaskCanceledException)
+            {
+                return;
+            }
+            Items.Reset();
+            await Items.LoadMoreAsync(token).ConfigureAwait(false);
+        }
+
+        private void OnThresholdExceeded(object? sender, EventArgs e) => Items.TrimToWindow(PageSize * 3);
 
         public void Dispose()
         {
             _memoryBudget.ThresholdExceeded -= OnThresholdExceeded;
+            _filterCts.Cancel();
+            _filterCts.Dispose();
+        }
+    }
+
+    public class IncrementalLoadingCollection<T> : ObservableCollection<T>
+    {
+        private readonly Func<int, CancellationToken, Task<IList<T>>> _loader;
+        private readonly int _pageSize;
+        private int _page;
+        public bool HasMoreItems { get; private set; } = true;
+
+        public IncrementalLoadingCollection(Func<int, CancellationToken, Task<IList<T>>> loader, int pageSize)
+        {
+            _loader = loader;
+            _pageSize = pageSize;
+        }
+
+        public async Task LoadMoreAsync(CancellationToken ct = default)
+        {
+            if (!HasMoreItems) return;
+            var next = _page + 1;
+            var items = await _loader(next, ct).ConfigureAwait(false);
+            foreach (var item in items)
+                Add(item);
+            _page = next;
+            if (items.Count < _pageSize)
+                HasMoreItems = false;
+        }
+
+        public void Reset()
+        {
+            Clear();
+            _page = 0;
+            HasMoreItems = true;
+        }
+
+        public void TrimToWindow(int max)
+        {
+            if (Count <= max) return;
+            while (Count > max)
+                RemoveAt(0);
         }
     }
 }

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -258,11 +258,12 @@ namespace InventoryManagementApp.ViewModels
             OpenManageItemsCommand = new AsyncRelayCommand(async () =>
             {
                 var plural = LabelProvider.Instance.ItemLabelPlural;
-                var page = new ManageItemsPage { DataContext = ItemManagement, Title = $"Manage {plural}" };
+                var page = new ManageItemsPage { Title = $"Manage {plural}" };
                 CurrentPage = page;
                 try
                 {
-                    await ItemManagement.LoadItemsAsync(new ItemPage(1, 50));
+                    var vm = (ItemsViewModel)page.DataContext;
+                    await vm.LoadMoreAsync();
                 }
                 catch (Exception ex)
                 {

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -19,7 +19,7 @@
                     Margin="0,0,0,8"/>
 
                 <DataGrid Grid.Row="1"
-                          ItemsSource="{Binding SearchResults}"
+                          ItemsSource="{Binding Items}"
                           SelectedItem="{Binding SelectedItem}"
                           IsReadOnly="True"
                           AutoGenerateColumns="False"

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
@@ -1,5 +1,8 @@
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using InventoryManagementApp.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace InventoryManagementApp.Views.Pages
 {
@@ -8,6 +11,7 @@ namespace InventoryManagementApp.Views.Pages
         public ManageItemsPage()
         {
             InitializeComponent();
+            DataContext = ((App)Application.Current).Host.Services.GetRequiredService<ItemsViewModel>();
         }
 
         private void DataGridRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
## Summary
- Add new `ItemsViewModel` with 200-item incremental loading and 300 ms debounced filtering
- Register and inject `ItemsViewModel` for `ManageItemsPage` and remove old `ItemManagementViewModel` dependency
- Update `MainViewModel` to initialize the page using the new incremental loader

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f64778d88324bd726754ee930833