### PR TITLE
Use Dapper CommandFlags in ItemRepository

### DIFF
--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -23,7 +23,7 @@ public sealed class ItemRepository : IItemRepository
         var param = new { Search = $"%{filter.Search}%", Take = page.Size, Skip = (page.Number - 1) * page.Size };
         using var conn = _factory.Create();
         var rows = await conn.QueryAsync<Item>(
-            new CommandDefinition(sql, param, buffered: false, cancellationToken: ct));
+            new CommandDefinition(sql, param, flags: CommandFlags.None, cancellationToken: ct));
         foreach (var row in rows)
         {
             ct.ThrowIfCancellationRequested();


### PR DESCRIPTION
## Summary
- use `CommandFlags.None` with Dapper `CommandDefinition` for unbuffered queries

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a8fcdd60888324a54b1348d0b1b7df