### PR TITLE
Add repository count API to item service and dashboard

### DIFF
--- a/InventoryManagementApp.Tests/DashboardViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DashboardViewModelTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
+using InventoryManagementApp.Data;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Models.ImportExport;
+using InventoryManagementApp.Services.Core;
+using InventoryManagementApp.Services.Items;
+using InventoryManagementApp.Services.Users;
+using InventoryManagementApp.ViewModels;
+using Xunit;
+
+public class DashboardViewModelTests
+{
+    private sealed class FakeItemRepository : IItemRepository
+    {
+        public int CountCalls { get; private set; }
+
+        public IAsyncEnumerable<ItemModel> GetPageAsync(ItemFilter filter, ItemPage page, CancellationToken ct)
+            => AsyncEnumerable.Empty<ItemModel>();
+
+        public Task<int> CountAsync(ItemFilter filter, CancellationToken ct)
+        {
+            CountCalls++;
+            return Task.FromResult(42);
+        }
+
+        public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct)
+            => Task.CompletedTask;
+    }
+
+    private sealed class StubRentalService : IRentalService
+    {
+        public Task<List<Rental>> GetActiveRentalsAsync()
+            => Task.FromResult(new List<Rental>());
+
+        public Task DeleteRentalAsync(int rentalID) => throw new NotImplementedException();
+        public Task ExtendRentalAsync(int rentalID, DateTime newDueDate) => throw new NotImplementedException();
+        public Task<List<Rental>> GetAllRentalsAsync() => throw new NotImplementedException();
+        public Task<List<Rental>> GetOverdueRentalsAsync() => throw new NotImplementedException();
+        public Task<List<Rental>> GetRentalHistoryForItemAsync(int itemID) => throw new NotImplementedException();
+        public Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID) => throw new NotImplementedException();
+        public Task RentItemAsync(int itemID, int customerID, DateTime rentalDate, DateTime dueDate) => throw new NotImplementedException();
+        public Task ReturnItemAsync(int rentalID, DateTime returnDate) => throw new NotImplementedException();
+    }
+
+    private sealed class StubCustomerService : ICustomerService
+    {
+        public Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<Customer>());
+
+        public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    }
+
+    private sealed class StubUserService : IUserService
+    {
+        public Task<List<User>> GetAllUsersAsync()
+            => Task.FromResult(new List<User>());
+
+        public Task<User?> GetUserByIDAsync(int userID) => throw new NotImplementedException();
+        public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => throw new NotImplementedException();
+        public Task<User?> GetCurrentUserAsync() => throw new NotImplementedException();
+        public Task AddUserAsync(User user) => throw new NotImplementedException();
+        public Task UpdateUserAsync(User user) => throw new NotImplementedException();
+        public Task<bool> TryDeleteUserAsync(int userID) => throw new NotImplementedException();
+        public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => throw new NotImplementedException();
+    }
+
+    private sealed class StubActivityLogService : ActivityLogService
+    {
+        public StubActivityLogService(DatabaseService db) : base(db) { }
+
+        public override Task<Result<List<ActivityLog>>> GetRecentLogsAsync(int count = 50, CancellationToken cancellationToken = default)
+            => Task.FromResult(new Result<List<ActivityLog>>(new List<ActivityLog>(), true));
+    }
+
+    [Fact]
+    public async Task LoadStatsAsync_UsesRepositoryCount()
+    {
+        using var db = new DatabaseService(":memory:");
+        var repo = new FakeItemRepository();
+        var itemService = new ItemService(db, repo);
+        var rentalService = new StubRentalService();
+        var customerService = new StubCustomerService();
+        var userService = new StubUserService();
+        var activityLogService = new StubActivityLogService(db);
+
+        var vm = new DashboardViewModel(
+            itemService,
+            rentalService,
+            customerService,
+            userService,
+            activityLogService,
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }));
+
+        var before = repo.CountCalls;
+        await vm.LoadStatsAsync(CancellationToken.None);
+
+        Assert.Equal(before + 1, repo.CountCalls);
+        Assert.Contains(vm.StatCards, s => s.Title == "Total Items" && s.Value == "42");
+    }
+}
+

--- a/InventoryManagementApp/Interfaces/IItemService.cs
+++ b/InventoryManagementApp/Interfaces/IItemService.cs
@@ -17,6 +17,7 @@ namespace InventoryManagementApp.Interfaces
         Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default);
         IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, CancellationToken cancellationToken = default);
         IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, CancellationToken cancellationToken = default);
+        Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct);
         Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default);
         Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default);
         Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default);

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -422,6 +422,9 @@ namespace InventoryManagementApp.Services.Items
         public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, CancellationToken cancellationToken = default)
             => _repository.GetPageAsync(new ItemFilter(searchText), page, cancellationToken);
 
+        public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct)
+            => _repository.CountAsync(filter, ct);
+
         private async Task<bool> ToggleItemCheckOutStatusInternalAsync(int itemID, string currentUser, CancellationToken cancellationToken)
         {
             using var conn = _dbService.CreateConnection();

--- a/InventoryManagementApp/ViewModels/DashboardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DashboardViewModel.cs
@@ -81,9 +81,7 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 StatCards.Clear();
-                var count = 0;
-                await foreach (var _ in _itemService.GetItemsAsync(new ItemPage(1, int.MaxValue), cancellationToken))
-                    count++;
+                var count = await _itemService.CountItemsAsync(new ItemFilter(null), cancellationToken);
                 StatCards.Add(new StatCard { Title = $"Total {LabelProvider.Instance.ItemLabelPlural}", Value = count.ToString() });
                 var activeRentals = await _rentalService.GetActiveRentalsAsync();
                 var customers = await _customerService.GetAllCustomersAsync(cancellationToken);


### PR DESCRIPTION
## Summary
- expose CountItemsAsync on item service
- use repository count to populate dashboard stats
- test dashboard leverages repository count

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ff6280208324821d716e847b53f9