### PR TITLE
Optimize dashboard stat loading with service counts

### DIFF
--- a/InventoryManagementApp.Tests/DashboardViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DashboardViewModelTests.cs
@@ -36,8 +36,20 @@ public class DashboardViewModelTests
 
     private sealed class StubRentalService : IRentalService
     {
+        public int CountCalls { get; private set; }
+        public int GetCalls { get; private set; }
+
+        public Task<int> CountActiveRentalsAsync()
+        {
+            CountCalls++;
+            return Task.FromResult(3);
+        }
+
         public Task<List<Rental>> GetActiveRentalsAsync()
-            => Task.FromResult(new List<Rental>());
+        {
+            GetCalls++;
+            return Task.FromResult(new List<Rental>());
+        }
 
         public Task DeleteRentalAsync(int rentalID) => throw new NotImplementedException();
         public Task ExtendRentalAsync(int rentalID, DateTime newDueDate) => throw new NotImplementedException();
@@ -51,8 +63,20 @@ public class DashboardViewModelTests
 
     private sealed class StubCustomerService : ICustomerService
     {
+        public int CountCalls { get; private set; }
+        public int GetCalls { get; private set; }
+
+        public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default)
+        {
+            CountCalls++;
+            return Task.FromResult(4);
+        }
+
         public Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default)
-            => Task.FromResult(new List<Customer>());
+        {
+            GetCalls++;
+            return Task.FromResult(new List<Customer>());
+        }
 
         public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
@@ -65,8 +89,20 @@ public class DashboardViewModelTests
 
     private sealed class StubUserService : IUserService
     {
+        public int CountCalls { get; private set; }
+        public int GetCalls { get; private set; }
+
+        public Task<int> CountUsersAsync()
+        {
+            CountCalls++;
+            return Task.FromResult(5);
+        }
+
         public Task<List<User>> GetAllUsersAsync()
-            => Task.FromResult(new List<User>());
+        {
+            GetCalls++;
+            return Task.FromResult(new List<User>());
+        }
 
         public Task<User?> GetUserByIDAsync(int userID) => throw new NotImplementedException();
         public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => throw new NotImplementedException();
@@ -110,6 +146,12 @@ public class DashboardViewModelTests
         await vm.LoadStatsAsync(CancellationToken.None);
 
         Assert.Equal(before + 1, repo.CountCalls);
+        Assert.Equal(1, rentalService.CountCalls);
+        Assert.Equal(0, rentalService.GetCalls);
+        Assert.Equal(1, customerService.CountCalls);
+        Assert.Equal(0, customerService.GetCalls);
+        Assert.Equal(1, userService.CountCalls);
+        Assert.Equal(0, userService.GetCalls);
         Assert.Contains(vm.StatCards, s => s.Title == "Total Items" && s.Value == "42");
     }
 }

--- a/InventoryManagementApp/Interfaces/ICustomerService.cs
+++ b/InventoryManagementApp/Interfaces/ICustomerService.cs
@@ -14,6 +14,7 @@ namespace InventoryManagementApp.Interfaces
         Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default);
         Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default);
         Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default);
+        Task<int> CountCustomersAsync(CancellationToken cancellationToken = default);
         Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default);
         Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default);
         Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default);

--- a/InventoryManagementApp/Interfaces/IRentalService.cs
+++ b/InventoryManagementApp/Interfaces/IRentalService.cs
@@ -30,6 +30,7 @@ namespace InventoryManagementApp.Interfaces
         Task ExtendRentalAsync(int rentalID, DateTime newDueDate);
         Task DeleteRentalAsync(int rentalID);
         Task<List<Rental>> GetActiveRentalsAsync();
+        Task<int> CountActiveRentalsAsync();
         Task<List<Rental>> GetOverdueRentalsAsync();
         Task<List<Rental>> GetAllRentalsAsync();
         Task<List<Rental>> GetRentalHistoryForItemAsync(int itemID);

--- a/InventoryManagementApp/Interfaces/IUserService.cs
+++ b/InventoryManagementApp/Interfaces/IUserService.cs
@@ -8,6 +8,7 @@ namespace InventoryManagementApp.Interfaces
     public interface IUserService
     {
         Task<List<User>> GetAllUsersAsync();
+        Task<int> CountUsersAsync();
         Task<User?> GetUserByIDAsync(int userID);
         Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password);
         Task<User?> GetCurrentUserAsync();

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -54,6 +54,9 @@ namespace InventoryManagementApp.Services.Customers
         public Task<List<CustomerModel>> GetAllCustomersAsync(CancellationToken cancellationToken = default) =>
             GetAllCustomersInternalAsync(cancellationToken);
 
+        public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default) =>
+            CountCustomersInternalAsync(cancellationToken);
+
         public Task<List<CustomerModel>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) =>
             SearchCustomersInternalAsync(searchTerm, cancellationToken);
 
@@ -153,6 +156,22 @@ namespace InventoryManagementApp.Services.Customers
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to get all customers");
+                throw;
+            }
+        }
+
+        async Task<int> CountCustomersInternalAsync(CancellationToken cancellationToken)
+        {
+            const string sql = "SELECT COUNT(*) FROM Customers";
+            using var conn = _dbService.CreateConnection();
+            try
+            {
+                var result = await SqliteHelper.ExecuteScalarAsync(conn, sql, null, cancellationToken);
+                return Convert.ToInt32(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to count customers");
                 throw;
             }
         }

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -245,6 +245,13 @@ namespace InventoryManagementApp.Services.Rentals
             }
         }
 
+        public async Task<int> CountActiveRentalsAsync()
+        {
+            using var conn = _dbService.CreateConnection();
+            const string sql = "SELECT COUNT(*) FROM Rentals WHERE Status='Rented'";
+            return Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql).ConfigureAwait(false));
+        }
+
         public async Task<List<Rental>> GetActiveRentalsAsync()
         {
             using var conn = _dbService.CreateConnection();

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -102,6 +102,14 @@ namespace InventoryManagementApp.Services.Users
             return await SqliteHelper.ExecuteReaderAsync(conn, sql, null, MapUser);
         }
 
+        public async Task<int> CountUsersAsync()
+        {
+            using var conn = _dbService.CreateConnection();
+            const string sql = "SELECT COUNT(*) FROM Users";
+            var result = await SqliteHelper.ExecuteScalarAsync(conn, sql);
+            return Convert.ToInt32(result);
+        }
+
         public async Task<User?> GetUserByIDAsync(int userID)
         {
             using var conn = _dbService.CreateConnection();

--- a/InventoryManagementApp/ViewModels/DashboardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DashboardViewModel.cs
@@ -81,14 +81,21 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 StatCards.Clear();
-                var count = await _itemService.CountItemsAsync(new ItemFilter(null), cancellationToken);
-                StatCards.Add(new StatCard { Title = $"Total {LabelProvider.Instance.ItemLabelPlural}", Value = count.ToString() });
-                var activeRentals = await _rentalService.GetActiveRentalsAsync();
-                var customers = await _customerService.GetAllCustomersAsync(cancellationToken);
-                var users = await _userService.GetAllUsersAsync();
-                StatCards.Add(new StatCard { Title = "Active Rentals", Value = activeRentals.Count.ToString() });
-                StatCards.Add(new StatCard { Title = "Total Customers", Value = customers.Count.ToString() });
-                StatCards.Add(new StatCard { Title = "Total Users", Value = users.Count.ToString() });
+                var itemCountTask = _itemService.CountItemsAsync(new ItemFilter(null), cancellationToken);
+                var rentalCountTask = _rentalService.CountActiveRentalsAsync();
+                var customerCountTask = _customerService.CountCustomersAsync(cancellationToken);
+                var userCountTask = _userService.CountUsersAsync();
+
+                await Task.WhenAll(itemCountTask, rentalCountTask, customerCountTask, userCountTask).ConfigureAwait(false);
+
+                StatCards.Add(new StatCard
+                {
+                    Title = $"Total {LabelProvider.Instance.ItemLabelPlural}",
+                    Value = itemCountTask.Result.ToString()
+                });
+                StatCards.Add(new StatCard { Title = "Active Rentals", Value = rentalCountTask.Result.ToString() });
+                StatCards.Add(new StatCard { Title = "Total Customers", Value = customerCountTask.Result.ToString() });
+                StatCards.Add(new StatCard { Title = "Total Users", Value = userCountTask.Result.ToString() });
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
## Summary
- Replace list enumeration in `DashboardViewModel.LoadStatsAsync` with concurrent count queries for items, rentals, customers, and users
- Add count methods to rental, customer, and user services and their interfaces
- Cover new behavior with unit tests verifying count usage

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a92e6358a88324bf2dd53e02a5f502