### PR TITLE
Refactor navigation commands to async and add tests

### DIFF
--- a/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using InventoryManagementApp.Data;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.Services.Core;
+using InventoryManagementApp.Services.Users;
+using InventoryManagementApp.ViewModels;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class MainViewModelNavigationTests
+    {
+        [Fact]
+        public async Task OpenSearchItemsCommand_PropagatesException()
+        {
+            await RunOnStaThread(async () =>
+            {
+                using var db = new DatabaseService(":memory:");
+                using var vm = CreateMainViewModel(db, new FailingItemService(), new DummyDialogService());
+                await Assert.ThrowsAsync<InvalidOperationException>(() => vm.OpenSearchItemsCommand.ExecuteAsync(null));
+            });
+        }
+
+        [Fact]
+        public async Task OpenPrintLabelWindowCommand_PropagatesException()
+        {
+            await RunOnStaThread(async () =>
+            {
+                using var db = new DatabaseService(":memory:");
+                using var vm = CreateMainViewModel(db, new DummyItemService(), new ThrowingDialogService());
+                await Assert.ThrowsAsync<InvalidOperationException>(() => vm.OpenPrintLabelWindowCommand.ExecuteAsync(null));
+            });
+        }
+
+        static MainViewModel CreateMainViewModel(DatabaseService db, IItemService itemService, IDialogService dialogService)
+        {
+            var activityLog = new ActivityLogService(db);
+            return new MainViewModel(
+                itemService,
+                new DummyUserService(),
+                new DummyUserContext(),
+                new DummyCustomerService(),
+                new DummyRentalService(),
+                new DummyFileDialogService(),
+                activityLog,
+                new DummySettingsService(),
+                db,
+                dialogService,
+                NullLogger<MainViewModel>.Instance,
+                () => Task.FromResult(true),
+                new DummyDispatcherTimer(),
+                new DummyScannerService());
+        }
+
+        static Task RunOnStaThread(Func<Task> action)
+        {
+            var tcs = new TaskCompletionSource<object?>();
+            var thread = new Thread(async () =>
+            {
+                try
+                {
+                    await action();
+                    tcs.SetResult(null);
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            return tcs.Task;
+        }
+
+        private sealed class DummyItemService : IItemService
+        {
+            public virtual Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public virtual Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public virtual Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public virtual Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(null);
+            public virtual IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public virtual IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public virtual Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+            public virtual Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => Task.FromResult(false);
+            public virtual Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public virtual Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public virtual Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
+            public virtual Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public virtual Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public virtual Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public virtual Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, System.Data.SQLite.SQLiteConnection? conn = null, System.Data.SQLite.SQLiteTransaction? tx = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+
+        private sealed class FailingItemService : DummyItemService
+        {
+            public override IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, CancellationToken cancellationToken = default) => AsyncEnumerable.Throw<ItemModel>(new InvalidOperationException("fail"));
+        }
+
+        private sealed class DummyUserService : IUserService
+        {
+            public Task<List<User>> GetAllUsersAsync() => Task.FromResult(new List<User>());
+            public Task<int> CountUsersAsync() => Task.FromResult(0);
+            public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult<User?>(null);
+            public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult((AuthenticationResult.Failure, (User?)null));
+            public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
+            public Task AddUserAsync(User user) => Task.CompletedTask;
+            public Task UpdateUserAsync(User user) => Task.CompletedTask;
+            public Task<bool> TryDeleteUserAsync(int userID) => Task.FromResult(false);
+            public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => Task.FromResult(false);
+        }
+
+        private sealed class DummyCustomerService : ICustomerService
+        {
+            public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult(new Customer());
+            public Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
+            public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
+            public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default) => Task.FromResult(new CustomerImportResult());
+            public Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+
+        private sealed class DummyRentalService : IRentalService
+        {
+            public Task RentItemAsync(int itemID, int customerID, DateTime rentalDate, DateTime dueDate) => Task.CompletedTask;
+            public Task ReturnItemAsync(int rentalID, DateTime returnDate) => Task.CompletedTask;
+            public Task ExtendRentalAsync(int rentalID, DateTime newDueDate) => Task.CompletedTask;
+            public Task DeleteRentalAsync(int rentalID) => Task.CompletedTask;
+            public Task<List<Rental>> GetActiveRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<int> CountActiveRentalsAsync() => Task.FromResult(0);
+            public Task<List<Rental>> GetOverdueRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetAllRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetRentalHistoryForItemAsync(int itemID) => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID) => Task.FromResult(new List<Rental>());
+        }
+
+        private sealed class DummyFileDialogService : IFileDialogService
+        {
+            public string? OpenFile(string filter, string? initialDirectory = null) => null;
+            public string? SaveFile(string filter) => null;
+        }
+
+        private sealed class DummySettingsService : ISettingsService
+        {
+            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+
+        private sealed class DummyDialogService : IDialogService
+        {
+            public virtual void ShowInfo(string message, string title) { }
+            public virtual bool ShowConfirmation(string message, string title) => false;
+            public virtual ItemModel? ShowEditItemDialog(ItemModel item) => null;
+            public virtual void ShowItemDetails(ItemModel item) { }
+            public virtual (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
+            public virtual CustomerModel? ShowAddCustomerDialog() => null;
+            public virtual void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public virtual void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
+            public virtual Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
+            public virtual Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public virtual void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+            public virtual void ShowPrintLabelDialog() { }
+        }
+
+        private sealed class ThrowingDialogService : DummyDialogService
+        {
+            public override void ShowPrintLabelDialog() => throw new InvalidOperationException("fail");
+        }
+
+        private sealed class DummyUserContext : IUserContext
+        {
+            User? _currentUser;
+            public User? CurrentUser
+            {
+                get => _currentUser;
+                set
+                {
+                    _currentUser = value;
+                    UserChanged?.Invoke(this, value);
+                }
+            }
+            public event EventHandler<User?>? UserChanged;
+            public bool IsAdmin => false;
+            public string UserName => string.Empty;
+            public string Role => string.Empty;
+        }
+
+        private sealed class DummyDispatcherTimer : IDispatcherTimer
+        {
+            public event EventHandler? Tick;
+            public TimeSpan Interval { get; set; }
+            public bool IsEnabled { get; private set; }
+            public void Start() => IsEnabled = true;
+            public void Stop() => IsEnabled = false;
+        }
+
+        private sealed class DummyScannerService : IScannerService
+        {
+            public Task<IEnumerable<ScannerDevice>> GetScannerDevicesAsync(CancellationToken cancellationToken) => Task.FromResult<IEnumerable<ScannerDevice>>(Array.Empty<ScannerDevice>());
+        }
+    }
+}

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -144,25 +144,25 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        public IRelayCommand OpenDashboardCommand { get; }
+        public IAsyncRelayCommand OpenDashboardCommand { get; }
         public IAsyncRelayCommand OpenSearchItemsCommand { get; }
         public IAsyncRelayCommand OpenManageItemsCommand { get; }
         public IAsyncRelayCommand OpenRentalsCommand { get; }
         public IAsyncRelayCommand OpenCustomersCommand { get; }
         public IAsyncRelayCommand OpenUsersCommand { get; }
-        public IRelayCommand OpenSettingsCommand { get; }
-        public IRelayCommand OpenImportExportCommand { get; }
+        public IAsyncRelayCommand OpenSettingsCommand { get; }
+        public IAsyncRelayCommand OpenImportExportCommand { get; }
         public IAsyncRelayCommand OpenActivityLogsCommand { get; }
-        public IRelayCommand OpenReportsCommand { get; }
+        public IAsyncRelayCommand OpenReportsCommand { get; }
         public IAsyncRelayCommand OpenImportMappingWindowCommand { get; }
         public IAsyncRelayCommand OpenImageImportMappingWindowCommand { get; }
         public IRelayCommand ExitCommand { get; }
         public IAsyncRelayCommand GlobalSearchCommand { get; }
         public IAsyncRelayCommand SwitchUserCommand { get; }
 
-        public IRelayCommand OpenPrintPreviewWindowCommand { get; }
-        public IRelayCommand OpenPrintLabelWindowCommand { get; }
-        public IRelayCommand OpenScannerStatusPageCommand { get; }
+        public IAsyncRelayCommand OpenPrintPreviewWindowCommand { get; }
+        public IAsyncRelayCommand OpenPrintLabelWindowCommand { get; }
+        public IAsyncRelayCommand OpenScannerStatusPageCommand { get; }
 
         public MainViewModel(IItemService itemService,
                              IUserService userService,
@@ -231,18 +231,27 @@ namespace InventoryManagementApp.ViewModels
             Settings.PropertyChanged += Settings_PropertyChanged;
             UpdateAutoLogoutTimer();
 
-            OpenDashboardCommand = new RelayCommand(() =>
+            OpenDashboardCommand = new AsyncRelayCommand(async () =>
             {
-                var vm = new DashboardViewModel(_itemService, _rentalService, _customerService, _userService, _activityLogService, OpenManageItemsCommand, OpenRentalsCommand, OpenImportExportCommand);
-                var page = new DashboardPage { DataContext = vm, Title = "Dashboard" };
-                CurrentPage = page;
+                try
+                {
+                    var vm = new DashboardViewModel(_itemService, _rentalService, _customerService, _userService, _activityLogService, OpenManageItemsCommand, OpenRentalsCommand, OpenImportExportCommand);
+                    var page = new DashboardPage { DataContext = vm, Title = "Dashboard" };
+                    CurrentPage = page;
+                    await Task.CompletedTask;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to open dashboard page");
+                    _dialogService.ShowInfo($"Failed to open dashboard page: {ex.Message}", "Dashboard");
+                    throw;
+                }
             });
 
             OpenSearchItemsCommand = new AsyncRelayCommand(async () =>
             {
                 var plural = LabelProvider.Instance.ItemLabelPlural;
                 var page = new ItemSearchPage { DataContext = ItemManagement, Title = $"Search {plural}" };
-                // If your ItemManagement VM supports a query setter, apply GlobalSearchText there.
                 CurrentPage = page;
                 try
                 {
@@ -252,6 +261,7 @@ namespace InventoryManagementApp.ViewModels
                 {
                     _logger.LogError(ex, "Failed to open search items page");
                     _dialogService.ShowInfo($"Failed to open search {plural} page: {ex.Message}", $"Search {plural}");
+                    throw;
                 }
             });
 
@@ -269,21 +279,40 @@ namespace InventoryManagementApp.ViewModels
                 {
                     _logger.LogError(ex, "Failed to open manage items page");
                     _dialogService.ShowInfo($"Failed to open manage {plural} page: {ex.Message}", $"Manage {plural}");
+                    throw;
                 }
             });
 
             OpenRentalsCommand = new AsyncRelayCommand(async () =>
             {
-                await ManageRentals.LoadRentalsAsync();
-                var page = new ManageRentalsPage { DataContext = ManageRentals, Title = "Manage Rentals" };
-                CurrentPage = page;
+                try
+                {
+                    await ManageRentals.LoadRentalsAsync();
+                    var page = new ManageRentalsPage { DataContext = ManageRentals, Title = "Manage Rentals" };
+                    CurrentPage = page;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to open rentals page");
+                    _dialogService.ShowInfo($"Failed to open rentals page: {ex.Message}", "Manage Rentals");
+                    throw;
+                }
             });
 
             OpenCustomersCommand = new AsyncRelayCommand(async () =>
             {
-                await CustomerManagement.LoadCustomersAsync();
-                var page = new CustomersPage { DataContext = CustomerManagement, Title = "Customers" };
-                CurrentPage = page;
+                try
+                {
+                    await CustomerManagement.LoadCustomersAsync();
+                    var page = new CustomersPage { DataContext = CustomerManagement, Title = "Customers" };
+                    CurrentPage = page;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to open customers page");
+                    _dialogService.ShowInfo($"Failed to open customers page: {ex.Message}", "Customers");
+                    throw;
+                }
             });
 
             OpenUsersCommand = new AsyncRelayCommand(async () =>
@@ -298,36 +327,76 @@ namespace InventoryManagementApp.ViewModels
                 {
                     _logger.LogError(ex, "Failed to open users page");
                     _dialogService.ShowInfo($"Failed to open users page: {ex.Message}", "Users");
+                    throw;
                 }
             });
 
-            OpenSettingsCommand = new RelayCommand(() =>
+            OpenSettingsCommand = new AsyncRelayCommand(async () =>
             {
-                var page = new SettingsPage
+                try
+                {
+                    var page = new SettingsPage
                     {
                         DataContext = Settings,
                         Title = "Settings"
                     };
-                CurrentPage = page;
+                    CurrentPage = page;
+                    await Task.CompletedTask;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to open settings page");
+                    _dialogService.ShowInfo($"Failed to open settings page: {ex.Message}", "Settings");
+                    throw;
+                }
             });
 
-            OpenImportExportCommand = new RelayCommand(() =>
+            OpenImportExportCommand = new AsyncRelayCommand(async () =>
             {
-                var page = new ImportExportPage { DataContext = ImportExport, Title = "Import / Export" };
-                CurrentPage = page;
+                try
+                {
+                    var page = new ImportExportPage { DataContext = ImportExport, Title = "Import / Export" };
+                    CurrentPage = page;
+                    await Task.CompletedTask;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to open import/export page");
+                    _dialogService.ShowInfo($"Failed to open import/export page: {ex.Message}", "Import / Export");
+                    throw;
+                }
             });
 
             OpenActivityLogsCommand = new AsyncRelayCommand(async () =>
             {
-                await ActivityLogs.LoadLogsAsync();
-                var page = new ActivityLogsPage { DataContext = ActivityLogs, Title = "Activity Logs" };
-                CurrentPage = page;
+                try
+                {
+                    await ActivityLogs.LoadLogsAsync();
+                    var page = new ActivityLogsPage { DataContext = ActivityLogs, Title = "Activity Logs" };
+                    CurrentPage = page;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to open activity logs page");
+                    _dialogService.ShowInfo($"Failed to open activity logs page: {ex.Message}", "Activity Logs");
+                    throw;
+                }
             });
 
-            OpenReportsCommand = new RelayCommand(() =>
+            OpenReportsCommand = new AsyncRelayCommand(async () =>
             {
-                var page = new ReportsPage { DataContext = Reports, Title = "Reports" };
-                CurrentPage = page;
+                try
+                {
+                    var page = new ReportsPage { DataContext = Reports, Title = "Reports" };
+                    CurrentPage = page;
+                    await Task.CompletedTask;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to open reports page");
+                    _dialogService.ShowInfo($"Failed to open reports page: {ex.Message}", "Reports");
+                    throw;
+                }
             });
 
             OpenImportMappingWindowCommand = new AsyncRelayCommand(ct => OpenImportMappingWindowAsync(ct));
@@ -343,7 +412,7 @@ namespace InventoryManagementApp.ViewModels
                 {
                     if (await _showLoginWindow())
                     {
-                        OpenDashboardCommand.Execute(null);
+                        await OpenDashboardCommand.ExecuteAsync(null);
                     }
                     else
                     {
@@ -357,6 +426,7 @@ namespace InventoryManagementApp.ViewModels
                     _userContext.CurrentUser = previousUser;
                     _logger.LogError(ex, "Switch user failed.");
                     _dialogService.ShowInfo("Failed to switch user.", "Switch User");
+                    throw;
                 }
             });
 
@@ -381,33 +451,54 @@ namespace InventoryManagementApp.ViewModels
                 }
             });
 
-            OpenPrintPreviewWindowCommand = new RelayCommand(() =>
+            OpenPrintPreviewWindowCommand = new AsyncRelayCommand(async () =>
             {
-                var doc = new FlowDocument(new Paragraph(new Run("Preview document")));
-                _dialogService.ShowPrintPreview(doc, "Print Preview", string.Empty);
+                try
+                {
+                    var doc = new FlowDocument(new Paragraph(new Run("Preview document")));
+                    _dialogService.ShowPrintPreview(doc, "Print Preview", string.Empty);
+                    await Task.CompletedTask;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to open print preview window");
+                    throw;
+                }
             });
 
-            OpenPrintLabelWindowCommand = new RelayCommand(() =>
+            OpenPrintLabelWindowCommand = new AsyncRelayCommand(async () =>
             {
                 try
                 {
                     _dialogService.ShowPrintLabelDialog();
+                    await Task.CompletedTask;
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to open print label dialog");
                     _dialogService.ShowInfo($"Failed to open print label dialog: {ex.Message}", "Error");
+                    throw;
                 }
             });
 
-            OpenScannerStatusPageCommand = new RelayCommand(() =>
+            OpenScannerStatusPageCommand = new AsyncRelayCommand(async () =>
             {
-                var vm = new ScannerStatusViewModel(_scannerService, _dialogService);
-                var page = new ScannerStatusPage { DataContext = vm, Title = "Scanner Status" };
-                CurrentPage = page;
+                try
+                {
+                    var vm = new ScannerStatusViewModel(_scannerService, _dialogService);
+                    var page = new ScannerStatusPage { DataContext = vm, Title = "Scanner Status" };
+                    CurrentPage = page;
+                    await Task.CompletedTask;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to open scanner status page");
+                    _dialogService.ShowInfo($"Failed to open scanner status page: {ex.Message}", "Scanner Status");
+                    throw;
+                }
             });
 
-            OpenDashboardCommand.Execute(null);
+            _ = OpenDashboardCommand.ExecuteAsync(null);
         }
 
         void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
## Summary
- replace RelayCommand with AsyncRelayCommand for navigation and await page initialization
- log and rethrow failures during navigation
- add unit tests ensuring navigation commands propagate exceptions

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a92f50853c8324bbfb5313637ada5e