### PR TITLE
Support cancellable dashboard loading and tests

### DIFF
--- a/InventoryManagementApp.Tests/DashboardViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DashboardViewModelTests.cs
@@ -121,6 +121,52 @@ public class DashboardViewModelTests
             => Task.FromResult(new Result<List<ActivityLog>>(new List<ActivityLog>(), true));
     }
 
+    private sealed class SlowItemRepository : IItemRepository
+    {
+        public bool Canceled { get; private set; }
+
+        public IAsyncEnumerable<ItemModel> GetPageAsync(ItemFilter filter, ItemPage page, CancellationToken ct)
+            => AsyncEnumerable.Empty<ItemModel>();
+
+        public async Task<int> CountAsync(ItemFilter filter, CancellationToken ct)
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5), ct);
+                return 0;
+            }
+            catch (OperationCanceledException)
+            {
+                Canceled = true;
+                throw;
+            }
+        }
+
+        public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct)
+            => Task.CompletedTask;
+    }
+
+    private sealed class CancellableActivityLogService : ActivityLogService
+    {
+        public bool Canceled { get; private set; }
+
+        public CancellableActivityLogService(DatabaseService db) : base(db) { }
+
+        public override async Task<Result<List<ActivityLog>>> GetRecentLogsAsync(int count = 50, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+                return new Result<List<ActivityLog>>(new List<ActivityLog>(), true);
+            }
+            catch (OperationCanceledException)
+            {
+                Canceled = true;
+                throw;
+            }
+        }
+    }
+
     [Fact]
     public async Task LoadStatsAsync_UsesRepositoryCount()
     {
@@ -153,6 +199,38 @@ public class DashboardViewModelTests
         Assert.Equal(1, userService.CountCalls);
         Assert.Equal(0, userService.GetCalls);
         Assert.Contains(vm.StatCards, s => s.Title == "Total Items" && s.Value == "42");
+    }
+
+    [Fact]
+    public async Task LoadAsync_Cancelled_DoesNotPopulateCollections()
+    {
+        using var db = new DatabaseService(":memory:");
+        var repo = new SlowItemRepository();
+        var itemService = new ItemService(db, repo);
+        var rentalService = new StubRentalService();
+        var customerService = new StubCustomerService();
+        var userService = new StubUserService();
+        var activityLogService = new CancellableActivityLogService(db);
+
+        var vm = new DashboardViewModel(
+            itemService,
+            rentalService,
+            customerService,
+            userService,
+            activityLogService,
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }));
+
+        using var cts = new CancellationTokenSource();
+        var task = vm.LoadAsync(cts.Token);
+        cts.Cancel();
+        await task;
+
+        Assert.True(repo.Canceled);
+        Assert.True(activityLogService.Canceled);
+        Assert.Empty(vm.StatCards);
+        Assert.Empty(vm.RecentActivity);
     }
 }
 

--- a/InventoryManagementApp/ViewModels/DashboardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DashboardViewModel.cs
@@ -71,10 +71,12 @@ namespace InventoryManagementApp.ViewModels
                 try { _openImportExportCommand.Execute(null); }
                 catch (Exception ex) { _logger.LogError(ex, "Failed to open import/export page"); }
             });
-
-            _ = LoadStatsAsync(CancellationToken.None);
-            _ = LoadRecentActivityAsync(CancellationToken.None);
         }
+
+        public Task LoadAsync(CancellationToken cancellationToken)
+            => Task.WhenAll(
+                LoadStatsAsync(cancellationToken),
+                LoadRecentActivityAsync(cancellationToken));
 
         internal async Task LoadStatsAsync(CancellationToken cancellationToken)
         {

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -47,6 +47,7 @@ namespace InventoryManagementApp.ViewModels
         readonly Func<Task<bool>> _showLoginWindow;
         readonly IDispatcherTimer _autoLogoutTimer;
         int _autoLogoutMinutes;
+        CancellationTokenSource? _pageLoadCts;
 
         EventHandler<User?>? _userContextChangedHandler;
         PropertyChangedEventHandler? _itemManagementPropertyChangedHandler;
@@ -66,6 +67,7 @@ namespace InventoryManagementApp.ViewModels
             get => _currentPage;
             set
             {
+                CancelCurrentPageLoad();
                 if (SetProperty(ref _currentPage, value))
                     CurrentPageTitle = value?.Title ?? value?.GetType().Name ?? "Dashboard";
             }
@@ -116,6 +118,13 @@ namespace InventoryManagementApp.ViewModels
         }
 
         public ItemModel? SelectedItem => ItemManagement.SelectedItem;
+
+        void CancelCurrentPageLoad()
+        {
+            _pageLoadCts?.Cancel();
+            _pageLoadCts?.Dispose();
+            _pageLoadCts = null;
+        }
 
         public void ResetAutoLogoutTimer()
         {
@@ -238,7 +247,8 @@ namespace InventoryManagementApp.ViewModels
                     var vm = new DashboardViewModel(_itemService, _rentalService, _customerService, _userService, _activityLogService, OpenManageItemsCommand, OpenRentalsCommand, OpenImportExportCommand);
                     var page = new DashboardPage { DataContext = vm, Title = "Dashboard" };
                     CurrentPage = page;
-                    await Task.CompletedTask;
+                    _pageLoadCts = new CancellationTokenSource();
+                    await vm.LoadAsync(_pageLoadCts.Token);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary
- Allow dashboard data to load via `LoadAsync(CancellationToken)`
- Cancel in-flight dashboard queries when navigating away
- Test that dashboard load respects cancellation tokens

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a94005fdd083249605d7736b4dffbd