### PR TITLE
Add XAML virtualization test for ManageItemsPage

### DIFF
--- a/InventoryManagementApp.Tests/InventoryManagementApp.Tests.csproj
+++ b/InventoryManagementApp.Tests/InventoryManagementApp.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.5.1" />

--- a/InventoryManagementApp.Tests/ManageItemsPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ManageItemsPageXamlTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Markup;
+using System.Windows.Media;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ManageItemsPageXamlTests
+    {
+        [Fact]
+        public void DataGrid_UsesVirtualization()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary
+                    {
+                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                    });
+
+                    var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml"));
+                    var xaml = File.ReadAllText(path);
+                    xaml = Regex.Replace(xaml, "x:Class=\"[^\"]*\"\s*", string.Empty);
+
+                    var page = (Page)XamlReader.Parse(xaml);
+                    var dataGrid = FindVisualChild<DataGrid>(page) ?? throw new InvalidOperationException("DataGrid not found");
+
+                    Assert.True(VirtualizingStackPanel.GetIsVirtualizing(dataGrid));
+                    Assert.Equal(VirtualizationMode.Recycling, VirtualizingStackPanel.GetVirtualizationMode(dataGrid));
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadEx != null) throw threadEx;
+        }
+
+        private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                if (child is T t)
+                    return t;
+                var result = FindVisualChild<T>(child);
+                if (result != null)
+                    return result;
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enable WPF support in test project
- verify ManageItemsPage DataGrid enables recycling virtualization

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a941fd1f708324aec9cc499a6d2717