### PR TITLE
Align item model naming with database columns

### DIFF
--- a/InventoryManagementApp.Tests/ItemRepositoryPaginationTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryPaginationTests.cs
@@ -54,8 +54,8 @@ public class ItemRepositoryPaginationTests
         await foreach (var item in repo.GetPageAsync(new ItemFilter(null), page, CancellationToken.None))
             result.Add(item);
         Assert.Collection(result,
-            i => Assert.Equal("Item 3", i.NameDescription),
-            i => Assert.Equal("Item 4", i.NameDescription));
+            i => Assert.Equal("Item 3", i.Name),
+            i => Assert.Equal("Item 4", i.Name));
     }
 
     [Fact]
@@ -68,6 +68,6 @@ public class ItemRepositoryPaginationTests
         var enumerable = repo.GetPageAsync(new ItemFilter(null), page, CancellationToken.None);
         await using var enumerator = enumerable.GetAsyncEnumerator();
         Assert.True(await enumerator.MoveNextAsync());
-        Assert.Equal("Item 1", enumerator.Current.NameDescription);
+        Assert.Equal("Item 1", enumerator.Current.Name);
     }
 }

--- a/InventoryManagementApp.Tests/ItemRepositorySearchTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositorySearchTests.cs
@@ -54,7 +54,7 @@ public class ItemRepositorySearchTests
     }
 
     [Fact]
-    public async Task GetPageAsync_SearchNameDescription_IgnoresCase()
+    public async Task GetPageAsync_SearchName_IgnoresCase()
     {
         var factory = CreateFactory();
         await SeedAsync(factory);
@@ -63,6 +63,6 @@ public class ItemRepositorySearchTests
         await foreach (var item in repo.GetPageAsync(new ItemFilter("saw"), new ItemPage(1, 10), CancellationToken.None))
             result.Add(item);
         Assert.Single(result);
-        Assert.Equal("Hand Saw", result[0].NameDescription);
+        Assert.Equal("Hand Saw", result[0].Name);
     }
 }

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -16,7 +16,7 @@ public sealed class ItemRepository : IItemRepository
 
     public async IAsyncEnumerable<Item> GetPageAsync(ItemFilter filter, ItemPage page, [EnumeratorCancellation] CancellationToken ct)
     {
-        var sql = "SELECT * FROM Items";
+        var sql = "SELECT ItemID, ItemNumber, NameDescription AS Name, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity AS QuantityOnHand, RentedQuantity, ImagePath, IsCheckedOut, CheckedOutBy, CheckedOutTime, IsPowered FROM Items";
         if (!string.IsNullOrWhiteSpace(filter.Search))
             sql += " WHERE ItemNumber LIKE @Search COLLATE NOCASE OR NameDescription LIKE @Search COLLATE NOCASE";
         sql += " ORDER BY ItemID LIMIT @Take OFFSET @Skip";
@@ -27,7 +27,7 @@ public sealed class ItemRepository : IItemRepository
 
         var ordinalItemID = reader.GetOrdinal("ItemID");
         var ordinalItemNumber = reader.GetOrdinal("ItemNumber");
-        var ordinalNameDescription = reader.GetOrdinal("NameDescription");
+        var ordinalName = reader.GetOrdinal("Name");
         var ordinalLocation = reader.GetOrdinal("Location");
         var ordinalBrand = reader.GetOrdinal("Brand");
         var ordinalPartNumber = reader.GetOrdinal("PartNumber");
@@ -35,7 +35,7 @@ public sealed class ItemRepository : IItemRepository
         var ordinalPurchasedDate = reader.GetOrdinal("PurchasedDate");
         var ordinalNotes = reader.GetOrdinal("Notes");
         var ordinalKeywords = reader.GetOrdinal("Keywords");
-        var ordinalAvailableQuantity = reader.GetOrdinal("AvailableQuantity");
+        var ordinalQuantityOnHand = reader.GetOrdinal("QuantityOnHand");
         var ordinalRentedQuantity = reader.GetOrdinal("RentedQuantity");
         var ordinalImagePath = reader.GetOrdinal("ImagePath");
         var ordinalIsCheckedOut = reader.GetOrdinal("IsCheckedOut");
@@ -49,7 +49,7 @@ public sealed class ItemRepository : IItemRepository
             {
                 ItemID = !reader.IsDBNull(ordinalItemID) ? reader.GetInt32(ordinalItemID) : 0,
                 ItemNumber = reader.IsDBNull(ordinalItemNumber) ? string.Empty : reader.GetString(ordinalItemNumber),
-                NameDescription = reader.IsDBNull(ordinalNameDescription) ? string.Empty : reader.GetString(ordinalNameDescription),
+                Name = reader.IsDBNull(ordinalName) ? string.Empty : reader.GetString(ordinalName),
                 Location = reader.IsDBNull(ordinalLocation) ? string.Empty : reader.GetString(ordinalLocation),
                 Brand = reader.IsDBNull(ordinalBrand) ? string.Empty : reader.GetString(ordinalBrand),
                 PartNumber = reader.IsDBNull(ordinalPartNumber) ? string.Empty : reader.GetString(ordinalPartNumber),
@@ -57,7 +57,7 @@ public sealed class ItemRepository : IItemRepository
                 PurchasedDate = reader.IsDBNull(ordinalPurchasedDate) ? null : reader.GetDateTime(ordinalPurchasedDate),
                 Notes = reader.IsDBNull(ordinalNotes) ? string.Empty : reader.GetString(ordinalNotes),
                 Keywords = reader.IsDBNull(ordinalKeywords) ? string.Empty : reader.GetString(ordinalKeywords),
-                QuantityOnHand = reader.IsDBNull(ordinalAvailableQuantity) ? 0 : reader.GetInt32(ordinalAvailableQuantity),
+                QuantityOnHand = reader.IsDBNull(ordinalQuantityOnHand) ? 0 : reader.GetInt32(ordinalQuantityOnHand),
                 RentedQuantity = reader.IsDBNull(ordinalRentedQuantity) ? 0 : reader.GetInt32(ordinalRentedQuantity),
                 ImagePath = reader.IsDBNull(ordinalImagePath) ? string.Empty : reader.GetString(ordinalImagePath),
                 IsCheckedOut = !reader.IsDBNull(ordinalIsCheckedOut) && reader.GetInt32(ordinalIsCheckedOut) == 1,
@@ -82,13 +82,13 @@ public sealed class ItemRepository : IItemRepository
     {
         using var conn = _factory.Create();
         using var tx = conn.BeginTransaction();
-        const string sql = "UPDATE Items SET NameDescription=@NameDescription, Location=@Location, AvailableQuantity=@QuantityOnHand WHERE ItemID=@ItemID";
+        const string sql = "UPDATE Items SET NameDescription=@Name, Location=@Location, AvailableQuantity=@QuantityOnHand WHERE ItemID=@ItemID";
         foreach (var item in changes)
         {
             ct.ThrowIfCancellationRequested();
             await conn.ExecuteAsync(sql, new
             {
-                item.NameDescription,
+                item.Name,
                 item.Location,
                 QuantityOnHand = item.QuantityOnHand,
                 item.ItemID

--- a/InventoryManagementApp/Models/DTOs/ItemImportDto.cs
+++ b/InventoryManagementApp/Models/DTOs/ItemImportDto.cs
@@ -3,7 +3,7 @@
     public class ItemImportDto
     {
         public string ItemNumber { get; set; }
-        public string NameDescription { get; set; }
+        public string Name { get; set; }
         public string Location { get; set; }
         public string Brand { get; set; }
         public string PartNumber { get; set; }

--- a/InventoryManagementApp/Models/Domain/ItemModel.cs
+++ b/InventoryManagementApp/Models/Domain/ItemModel.cs
@@ -25,11 +25,11 @@ namespace InventoryManagementApp.Models.Domain
             set => SetProperty(ref _partNumber, value);
         }
 
-        private string _nameDescription = string.Empty;
-        public string NameDescription
+        private string _name = string.Empty;
+        public string Name
         {
-            get => _nameDescription;
-            set => SetProperty(ref _nameDescription, value);
+            get => _name;
+            set => SetProperty(ref _name, value);
         }
 
         private string _brand = string.Empty;

--- a/InventoryManagementApp/Resources/Templates.xaml
+++ b/InventoryManagementApp/Resources/Templates.xaml
@@ -28,7 +28,7 @@
                     <Image Stretch="UniformToFill" Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
                 </Border>
                 <StackPanel Grid.Row="1" Margin="0,6,0,0">
-                    <TextBlock Text="{Binding NameDescription}" Style="{StaticResource ListItemTitleTextBlock}"/>
+                    <TextBlock Text="{Binding Name}" Style="{StaticResource ListItemTitleTextBlock}"/>
                     <TextBlock Text="{Binding ItemNumber}" Style="{StaticResource CaptionTextBlock}"/>
                 </StackPanel>
             </Grid>
@@ -52,7 +52,7 @@
     <!-- Shared rental DataGrid columns -->
     <DataGridTextColumn x:Key="RentalIdColumn" Header="Rental #" Binding="{Binding RentalId}" Width="120" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalItemNumberColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} #'}" Binding="{Binding ItemNumber}" Width="120" x:Shared="False"/>
-    <DataGridTextColumn x:Key="RentalItemNameColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}" Binding="{Binding NameDescription}" Width="*" x:Shared="False"/>
+    <DataGridTextColumn x:Key="RentalItemNameColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}" Binding="{Binding Name}" Width="*" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalCustomerColumn" Header="Customer" Binding="{Binding CustomerName}" Width="220" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalOutColumn" Header="Out" Binding="{Binding DateOut, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat=\{0:yyyy-MM-dd HH:mm\}, TargetNullValue=''}" Width="180" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalDueColumn" Header="Due" Binding="{Binding DueDate, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat=\{0:yyyy-MM-dd HH:mm\}, TargetNullValue=''}" Width="180" x:Shared="False"/>

--- a/InventoryManagementApp/Services/Core/CsvHelperUtil.cs
+++ b/InventoryManagementApp/Services/Core/CsvHelperUtil.cs
@@ -59,7 +59,7 @@ namespace InventoryManagementApp.Utilities.IO
                 list.Add(new ItemModel
                 {
                     ItemNumber = itemNumber,
-                    NameDescription = GetMapped(cols, headers, map, "NameDescription"),
+                    Name = GetMapped(cols, headers, map, "NameDescription"),
                     Location = GetMapped(cols, headers, map, "Location"),
                     Brand = GetMapped(cols, headers, map, "Brand"),
                     PartNumber = GetMapped(cols, headers, map, "PartNumber"),
@@ -93,7 +93,7 @@ namespace InventoryManagementApp.Utilities.IO
             lines.AddRange(items.Select(t =>
                 string.Join(",",
                     Quote(t.ItemNumber),
-                    Quote(t.NameDescription),
+                    Quote(t.Name),
                     Quote(t.Location),
                     Quote(t.Brand),
                     Quote(t.PartNumber),
@@ -114,7 +114,7 @@ namespace InventoryManagementApp.Utilities.IO
             lines.AddRange(items.Select(t =>
                 string.Join(",",
                     Quote(t.ItemNumber),
-                    Quote(t.NameDescription),
+                    Quote(t.Name),
                     Quote(t.Location),
                     Quote(t.Brand),
                     Quote(t.PartNumber),

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -149,7 +149,7 @@ namespace InventoryManagementApp.Services.Items
             var p = new[]
             {
                 new SqliteParameter("@ItemNumber", item.ItemNumber),
-                new SqliteParameter("@Desc", (object)item.NameDescription ?? DBNull.Value),
+                new SqliteParameter("@Desc", (object)item.Name ?? DBNull.Value),
                 new SqliteParameter("@Loc", item.Location),
                 new SqliteParameter("@Brand", item.Brand),
                 new SqliteParameter("@PN", item.PartNumber),
@@ -297,7 +297,7 @@ namespace InventoryManagementApp.Services.Items
             ItemID = r["ItemID"] is DBNull ? 0 : Convert.ToInt32(r["ItemID"]),
             ItemNumber = r["ItemNumber"].ToString(),
             PartNumber = r["PartNumber"].ToString(),
-            NameDescription = r["NameDescription"].ToString(),
+            Name = r["NameDescription"].ToString(),
             Brand = r["Brand"].ToString(),
             Location = r["Location"].ToString(),
             QuantityOnHand = r["AvailableQuantity"] is DBNull ? 0 : Convert.ToInt32(r["AvailableQuantity"]),
@@ -367,7 +367,7 @@ namespace InventoryManagementApp.Services.Items
             {
                 new SqliteParameter("@ID", item.ItemID),
                 new SqliteParameter("@ItemNumber", item.ItemNumber),
-                new SqliteParameter("@Desc", (object)item.NameDescription ?? DBNull.Value),
+                new SqliteParameter("@Desc", (object)item.Name ?? DBNull.Value),
                 new SqliteParameter("@Loc", item.Location),
                 new SqliteParameter("@Brand", item.Brand),
                 new SqliteParameter("@PN", item.PartNumber),
@@ -504,7 +504,7 @@ namespace InventoryManagementApp.Services.Items
                     var item = new ItemModel
                     {
                         ItemNumber = itemNumber,
-                        NameDescription = GetMapped(cols, headers, map, "NameDescription"),
+                        Name = GetMapped(cols, headers, map, "NameDescription"),
                         Location = GetMapped(cols, headers, map, "Location"),
                         Brand = GetMapped(cols, headers, map, "Brand"),
                         PartNumber = GetMapped(cols, headers, map, "PartNumber"),

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -55,7 +55,7 @@ namespace InventoryManagementApp.Services.Rentals
 
         const string BaseSelect = @"SELECT r.*,
                                     t.ItemNumber,
-                                    t.NameDescription,
+                                    t.NameDescription AS Name,
                                     t.Location AS ItemLocation,
                                     t.ImagePath,
                                     c.Company,

--- a/InventoryManagementApp/ViewModels/ImageImportMappingViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImageImportMappingViewModel.cs
@@ -14,8 +14,8 @@ namespace InventoryManagementApp.ViewModels
         bool _usePartNumber;
         public bool UsePartNumber { get => _usePartNumber; set => SetProperty(ref _usePartNumber, value); }
 
-        bool _useNameDescription;
-        public bool UseNameDescription { get => _useNameDescription; set => SetProperty(ref _useNameDescription, value); }
+        bool _useName;
+        public bool UseName { get => _useName; set => SetProperty(ref _useName, value); }
 
         public IRelayCommand OkCommand { get; }
         public IRelayCommand CancelCommand { get; }
@@ -35,8 +35,8 @@ namespace InventoryManagementApp.ViewModels
                     keys.Add(t.ItemNumber.Trim().ToUpperInvariant());
                 if (UsePartNumber && !string.IsNullOrWhiteSpace(t.PartNumber))
                     keys.Add(t.PartNumber.Trim().ToUpperInvariant());
-                if (UseNameDescription && !string.IsNullOrWhiteSpace(t.NameDescription))
-                    keys.Add(t.NameDescription.Trim().ToUpperInvariant());
+                if (UseName && !string.IsNullOrWhiteSpace(t.Name))
+                    keys.Add(t.Name.Trim().ToUpperInvariant());
                 return keys;
             };
         }

--- a/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
@@ -104,7 +104,7 @@ namespace InventoryManagementApp.ViewModels
                 var map = _dialogService.ShowImportMapping(
                     headers,
                     properties,
-                    new[] { nameof(ItemImportDto.ItemNumber), nameof(ItemImportDto.NameDescription) });
+                    new[] { nameof(ItemImportDto.ItemNumber), nameof(ItemImportDto.Name) });
                 if (map == null)
                     return;
                 var plural = LabelProvider.Instance.ItemLabelPlural;

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -246,7 +246,7 @@ namespace InventoryManagementApp.ViewModels
                 ItemID = SelectedItem.ItemID,
                 ItemNumber = SelectedItem.ItemNumber,
                 PartNumber = SelectedItem.PartNumber,
-                NameDescription = SelectedItem.NameDescription,
+                Name = SelectedItem.Name,
                 Brand = SelectedItem.Brand,
                 Location = SelectedItem.Location,
                 QuantityOnHand = SelectedItem.QuantityOnHand,
@@ -306,7 +306,7 @@ namespace InventoryManagementApp.ViewModels
         {
             if (items == null || items.Count == 0) return;
             string message = items.Count == 1
-                ? $"Delete {LabelProvider.Instance.ItemLabelSingular.ToLower()} '{((ItemModel)items[0]).NameDescription}'?"
+                ? $"Delete {LabelProvider.Instance.ItemLabelSingular.ToLower()} '{((ItemModel)items[0]).Name}'?"
                 : $"Delete {items.Count} {LabelProvider.Instance.ItemLabelPlural.ToLower()}?";
             var confirm = await _dialogService.ShowConfirmationAsync(message, "Confirm Delete");
             if (!confirm)

--- a/InventoryManagementApp/ViewModels/ItemViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemViewModel.cs
@@ -16,6 +16,6 @@ namespace InventoryManagementApp.ViewModels
             _item = item;
         }
 
-        public string DisplayName => $"{_item.ItemNumber} - {_item.NameDescription}";
+        public string DisplayName => $"{_item.ItemNumber} - {_item.Name}";
     }
 }

--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -230,7 +230,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 ItemID = SelectedRental.ItemID,
                 ItemNumber = SelectedRental.ItemNumber,
-                NameDescription = SelectedRental.ItemNumber
+                Name = SelectedRental.ItemNumber
             };
 
             _dialogService.ShowRentalHistory(item, history);

--- a/InventoryManagementApp/ViewModels/PrintLabelViewModel.cs
+++ b/InventoryManagementApp/ViewModels/PrintLabelViewModel.cs
@@ -83,7 +83,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 var sp = new StackPanel { Orientation = System.Windows.Controls.Orientation.Vertical };
                 sp.Children.Add(new TextBlock { Text = t.ItemNumber });
-                sp.Children.Add(new TextBlock { Text = t.NameDescription });
+                sp.Children.Add(new TextBlock { Text = t.Name });
                 sp.Children.Add(new TextBlock { Text = t.Location });
                 if (IncludeQr)
                     sp.Children.Add(new TextBlock { Text = "[QR]" });

--- a/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
+++ b/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
@@ -46,7 +46,7 @@ namespace InventoryManagementApp.ViewModels.Rental
         public RentalHistoryViewModel(ItemModel? item, IEnumerable<RentalModel>? history, IDialogService dialogService, ILogger<RentalHistoryViewModel>? logger = null)
         {
             ItemDisplayName = item != null
-                ? $"{item.ItemNumber} - {item.NameDescription}"
+                ? $"{item.ItemNumber} - {item.Name}"
                 : "Rental History";
 
             _allHistory = (history ?? Enumerable.Empty<RentalModel>()).ToList();

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -34,7 +34,7 @@
                     </DataGrid.RowStyle>
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Number" Binding="{Binding ItemNumber}" Width="140"/>
-                        <DataGridTextColumn Header="Name" Binding="{Binding NameDescription}" Width="280"/>
+                        <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="280"/>
                         <DataGridTextColumn Header="Brand" Binding="{Binding Brand}" Width="160"/>
                         <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="180"/>
                     </DataGrid.Columns>

--- a/InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml
@@ -15,7 +15,7 @@
                 <WrapPanel>
                     <CheckBox Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0}Number'}" IsChecked="{Binding UseItemNumber}" Margin="6,0"/>
                     <CheckBox Content="PartNumber" IsChecked="{Binding UsePartNumber}" Margin="6,0"/>
-                    <CheckBox Content="NameDescription" IsChecked="{Binding UseNameDescription}" Margin="6,0"/>
+                    <CheckBox Content="Name" IsChecked="{Binding UseName}" Margin="6,0"/>
                 </WrapPanel>
             </StackPanel>
         </Border>

--- a/InventoryManagementApp/Views/Windows/ItemDetailsWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ItemDetailsWindow.xaml
@@ -34,7 +34,7 @@
             <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding ItemModel.ItemNumber}" Margin="8,4"/>
 
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding ItemModel.NameDescription}" Margin="8,4"/>
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding ItemModel.Name}" Margin="8,4"/>
 
             <TextBlock Grid.Row="3" Grid.Column="0" Text="Brand" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
             <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding ItemModel.Brand}" Margin="8,4"/>

--- a/InventoryManagementApp/Views/Windows/ItemEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ItemEditWindow.xaml
@@ -33,7 +33,7 @@
             <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ItemModel.ItemNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding ItemModel.NameDescription, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding ItemModel.Name, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Brand" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
             <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding ItemModel.Brand, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>

--- a/InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml
@@ -39,7 +39,7 @@
                       ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} #'}" Binding="{Binding ItemNumber}" Width="120"/>
-                    <DataGridTextColumn Header="Name" Binding="{Binding NameDescription}" Width="*"/>
+                    <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
                     <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="180"/>
                 </DataGrid.Columns>
             </DataGrid>


### PR DESCRIPTION
## Summary
- rename ItemModel.NameDescription to Name and map AvailableQuantity as QuantityOnHand
- alias SQL queries to match updated model properties
- update related views, view models, and tests for new property names

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a942e158fc8324b6ddff8e07b1d83d