### PR TITLE
Enable column virtualization on ManageItemsPage

### DIFF
--- a/InventoryManagementApp.Tests/ManageItemsPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ManageItemsPageXamlTests.cs
@@ -13,7 +13,7 @@ namespace InventoryManagementApp.Tests
     public class ManageItemsPageXamlTests
     {
         [Fact]
-        public void DataGrid_UsesVirtualization()
+        public void DataGrid_UsesRowAndColumnVirtualization()
         {
             Exception? threadEx = null;
             var thread = new Thread(() =>
@@ -35,6 +35,8 @@ namespace InventoryManagementApp.Tests
 
                     Assert.True(VirtualizingStackPanel.GetIsVirtualizing(dataGrid));
                     Assert.Equal(VirtualizationMode.Recycling, VirtualizingStackPanel.GetVirtualizationMode(dataGrid));
+                    Assert.True(dataGrid.EnableRowVirtualization);
+                    Assert.True(dataGrid.EnableColumnVirtualization);
                 }
                 catch (Exception ex)
                 {

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -23,6 +23,7 @@
                           SelectedItem="{Binding SelectedItem}"
                           IsReadOnly="True"
                           AutoGenerateColumns="False"
+                          EnableColumnVirtualization="True"
                           Background="{StaticResource SurfaceBrush}"
                           BorderBrush="{StaticResource BorderBrushAlt}"
                           Style="{StaticResource VirtualizedDataGridStyle}">


### PR DESCRIPTION
## Summary
- enable DataGrid column virtualization in ManageItemsPage
- test that DataGrid row and column virtualization are enabled

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a9455e83c88324bb160e155f70fbac