### PR TITLE
Execute SQLite PRAGMAs only once

### DIFF
--- a/InventoryManagementApp.Tests/SqliteConnectionFactoryTests.cs
+++ b/InventoryManagementApp.Tests/SqliteConnectionFactoryTests.cs
@@ -1,0 +1,15 @@
+using InventoryManagementApp.Data;
+using Xunit;
+
+public class SqliteConnectionFactoryTests
+{
+    [Fact]
+    public void Create_ExecutesPragmasOnlyOnce()
+    {
+        SqliteConnectionFactory.Reset();
+        var factory = new SqliteConnectionFactory("Data Source=:memory:");
+        using var first = factory.Create();
+        using var second = factory.Create();
+        Assert.Equal(1, SqliteConnectionFactory.PragmasExecutionCount);
+    }
+}

--- a/InventoryManagementApp/Data/SqliteConnectionFactory.cs
+++ b/InventoryManagementApp/Data/SqliteConnectionFactory.cs
@@ -5,17 +5,30 @@ namespace InventoryManagementApp.Data;
 public sealed class SqliteConnectionFactory
 {
     private readonly string _connectionString;
+    private static bool _pragmasExecuted;
+    internal static int PragmasExecutionCount { get; private set; }
 
     public SqliteConnectionFactory(string connectionString)
         => _connectionString = connectionString;
+
+    internal static void Reset()
+    {
+        _pragmasExecuted = false;
+        PragmasExecutionCount = 0;
+    }
 
     public SqliteConnection Create()
     {
         var connection = new SqliteConnection(_connectionString);
         connection.Open();
-        using var cmd = connection.CreateCommand();
-        cmd.CommandText = "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;";
-        cmd.ExecuteNonQuery();
+        if (!_pragmasExecuted)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;";
+            cmd.ExecuteNonQuery();
+            _pragmasExecuted = true;
+            PragmasExecutionCount++;
+        }
         return connection;
     }
 }


### PR DESCRIPTION
## Summary
- run SQLite performance PRAGMAs only on first connection
- add unit test for one-time PRAGMA execution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9469dde108324b5fb4161a741346b