### PR TITLE
Handle null search in ItemRepository CountAsync and add count tests

### DIFF
--- a/InventoryManagementApp.Tests/ItemRepositoryCountTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryCountTests.cs
@@ -1,0 +1,64 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using InventoryManagementApp.Data;
+using InventoryManagementApp.Models.Domain;
+using Xunit;
+
+public class ItemRepositoryCountTests
+{
+    private static SqliteConnectionFactory CreateFactory()
+        => new("Data Source=:memory:");
+
+    private static async Task SeedAsync(SqliteConnectionFactory factory)
+    {
+        using var conn = factory.Create();
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = @"CREATE TABLE Items (
+            ItemID INTEGER PRIMARY KEY AUTOINCREMENT,
+            ItemNumber TEXT,
+            NameDescription TEXT,
+            Location TEXT,
+            Brand TEXT,
+            PartNumber TEXT,
+            Supplier TEXT,
+            PurchasedDate TEXT,
+            Notes TEXT,
+            Keywords TEXT,
+            AvailableQuantity INTEGER,
+            RentedQuantity INTEGER,
+            ImagePath TEXT,
+            IsCheckedOut INTEGER,
+            CheckedOutBy TEXT,
+            CheckedOutTime TEXT,
+            IsPowered INTEGER
+        );";
+        cmd.ExecuteNonQuery();
+        await conn.ExecuteAsync(
+            "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsCheckedOut, IsPowered) VALUES (@ItemNumber,@Name,0,0,0,0)",
+            new { ItemNumber = "A1", Name = "Hand Saw" });
+        await conn.ExecuteAsync(
+            "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsCheckedOut, IsPowered) VALUES (@ItemNumber,@Name,0,0,0,0)",
+            new { ItemNumber = "B2", Name = "Hammer" });
+    }
+
+    [Fact]
+    public async Task CountAsync_NoSearch_ReturnsTotalCount()
+    {
+        var factory = CreateFactory();
+        await SeedAsync(factory);
+        var repo = new ItemRepository(factory);
+        var count = await repo.CountAsync(new ItemFilter(null), CancellationToken.None);
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public async Task CountAsync_WithSearch_FiltersResults()
+    {
+        var factory = CreateFactory();
+        await SeedAsync(factory);
+        var repo = new ItemRepository(factory);
+        var count = await repo.CountAsync(new ItemFilter("saw"), CancellationToken.None);
+        Assert.Equal(1, count);
+    }
+}

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -71,9 +71,12 @@ public sealed class ItemRepository : IItemRepository
     public async Task<int> CountAsync(ItemFilter filter, CancellationToken ct)
     {
         var sql = "SELECT COUNT(*) FROM Items";
-        object param = new { Search = $"%{filter.Search}%" };
+        object? param = null;
         if (!string.IsNullOrWhiteSpace(filter.Search))
+        {
             sql += " WHERE ItemNumber LIKE @Search COLLATE NOCASE OR NameDescription LIKE @Search COLLATE NOCASE";
+            param = new { Search = $"%{filter.Search}%" };
+        }
         using var conn = _factory.Create();
         return await conn.ExecuteScalarAsync<int>(new CommandDefinition(sql, param, cancellationToken: ct));
     }


### PR DESCRIPTION
## Summary
- Handle ItemRepository.CountAsync when Search is null or whitespace by omitting WHERE clause and parameters
- Add unit tests verifying CountAsync with and without search terms

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a94e5d5b3083249f4b1f29a6da6a2e