### PR TITLE
Guard incremental page loads with semaphore

### DIFF
--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -93,6 +93,65 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain(vm.Items, i => i.ItemID == 1);
         }
 
+        [Fact]
+        public async Task ConcurrentLoadMoreCallsDoNotDuplicateOrSkipPages()
+        {
+            var service = new PagingItemService();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var vm = new ItemsViewModel(service, memoryBudget);
+
+            var tasks = new[]
+            {
+                vm.LoadMoreAsync(),
+                vm.LoadMoreAsync(),
+                vm.LoadMoreAsync()
+            };
+            await Task.WhenAll(tasks);
+
+            const int pageSize = 200;
+            Assert.Equal(pageSize * 3, vm.Items.Count);
+            Assert.Equal(new[] { 1, 2, 3 }, service.Pages);
+            Assert.Equal(vm.Items.Count, vm.Items.Select(i => i.ItemID).Distinct().Count());
+        }
+
+        private sealed class PagingItemService : IItemService
+        {
+            private const int PageSize = 200;
+            public List<int> Pages { get; } = new();
+
+            public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(null);
+
+            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, CancellationToken cancellationToken = default)
+            {
+                Pages.Add(page.Number);
+                return EnumeratePageAsync(page.Number, cancellationToken);
+            }
+
+            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+            public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => Task.FromResult(false);
+            public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
+            public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, SqliteConnection? conn = null, SqliteTransaction? tx = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+            private async IAsyncEnumerable<ItemModel> EnumeratePageAsync(int page, [EnumeratorCancellation] CancellationToken ct)
+            {
+                for (int i = 0; i < PageSize; i++)
+                {
+                    await Task.Yield();
+                    ct.ThrowIfCancellationRequested();
+                    yield return new ItemModel { ItemID = (page - 1) * PageSize + i + 1 };
+                }
+            }
+        }
+
         private sealed class DummyItemService : IItemService
         {
             public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -96,6 +96,7 @@ namespace InventoryManagementApp.ViewModels
         private readonly Func<int, CancellationToken, Task<IList<T>>> _loader;
         private readonly int _pageSize;
         private int _page;
+        private readonly SemaphoreSlim _gate = new(1, 1);
         public bool HasMoreItems { get; private set; } = true;
 
         public IncrementalLoadingCollection(Func<int, CancellationToken, Task<IList<T>>> loader, int pageSize)
@@ -106,14 +107,22 @@ namespace InventoryManagementApp.ViewModels
 
         public async Task LoadMoreAsync(CancellationToken ct = default)
         {
-            if (!HasMoreItems) return;
-            var next = _page + 1;
-            var items = await _loader(next, ct).ConfigureAwait(false);
-            foreach (var item in items)
-                Add(item);
-            _page = next;
-            if (items.Count < _pageSize)
-                HasMoreItems = false;
+            await _gate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                if (!HasMoreItems) return;
+                var next = _page + 1;
+                var items = await _loader(next, ct).ConfigureAwait(false);
+                foreach (var item in items)
+                    Add(item);
+                _page = next;
+                if (items.Count < _pageSize)
+                    HasMoreItems = false;
+            }
+            finally
+            {
+                _gate.Release();
+            }
         }
 
         public void Reset()


### PR DESCRIPTION
## Summary
- ensure IncrementalLoadingCollection serializes page loading using SemaphoreSlim
- add concurrency test to verify sequential paging under parallel load requests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a94ee8aec0832489736e4b99ff39f3