### PR TITLE
Ensure ItemsViewModel dispose resets collection and cancels filter

### DIFF
--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -12,6 +12,7 @@ using InventoryManagementApp.Models.ImportExport;
 using InventoryManagementApp.Utilities;
 using InventoryManagementApp.ViewModels;
 using Xunit;
+using System.Reflection;
 
 namespace InventoryManagementApp.Tests
 {
@@ -112,6 +113,23 @@ namespace InventoryManagementApp.Tests
             Assert.Equal(pageSize * 3, vm.Items.Count);
             Assert.Equal(new[] { 1, 2, 3 }, service.Pages);
             Assert.Equal(vm.Items.Count, vm.Items.Select(i => i.ItemID).Distinct().Count());
+        }
+
+        [Fact]
+        public void DisposeCanBeCalledMultipleTimesAndCancelsToken()
+        {
+            var service = new DummyItemService();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            var vm = new ItemsViewModel(service, memoryBudget);
+            vm.Items.Add(new ItemModel { ItemID = 1 });
+            var ctsField = typeof(ItemsViewModel).GetField("_filterCts", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(ctsField);
+            var cts = (CancellationTokenSource)ctsField!.GetValue(vm)!;
+            var token = cts.Token;
+            vm.Dispose();
+            vm.Dispose();
+            Assert.True(token.IsCancellationRequested);
+            Assert.Empty(vm.Items);
         }
 
         private sealed class PagingItemService : IItemService

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -17,6 +17,7 @@ namespace InventoryManagementApp.ViewModels
         private readonly IItemService _itemService;
         private readonly MemoryBudget _memoryBudget;
         private CancellationTokenSource _filterCts = new();
+        private bool _disposed;
 
         private const int PageSize = 200;
         public IncrementalLoadingCollection<ItemModel> Items { get; }
@@ -85,7 +86,10 @@ namespace InventoryManagementApp.ViewModels
 
         public void Dispose()
         {
+            if (_disposed) return;
+            _disposed = true;
             _memoryBudget.ThresholdExceeded -= OnThresholdExceeded;
+            Items.Reset();
             _filterCts.Cancel();
             _filterCts.Dispose();
         }


### PR DESCRIPTION
## Summary
- Reset items and cancel filter token when ItemsViewModel is disposed, guarding against multiple dispose calls
- Add regression test verifying dispose cancels token and is safe to call repeatedly

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a9514e07a883249e9a4c260100a007