### PR TITLE
Enable editing of item details with batch save

### DIFF
--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -22,8 +22,9 @@ namespace InventoryManagementApp.Tests
         public void CommandsExistAndExecute()
         {
             var service = new DummyItemService();
+            var repository = new DummyItemRepository();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget);
+            using var vm = new ItemsViewModel(service, repository, memoryBudget);
 
             Assert.NotNull(vm.EditItemCommand);
             Assert.True(vm.EditItemCommand.CanExecute(null));
@@ -52,8 +53,9 @@ namespace InventoryManagementApp.Tests
                 ["third"] = new() { new ItemModel { ItemID = 3 } }
             };
             var service = new RecordingItemService(data);
+            var repository = new DummyItemRepository();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget);
+            using var vm = new ItemsViewModel(service, repository, memoryBudget);
 
             vm.Filter = "first";
             await Task.Delay(100);
@@ -77,8 +79,9 @@ namespace InventoryManagementApp.Tests
                 ["new"] = new() { new ItemModel { ItemID = 2 } }
             };
             var service = new RecordingItemService(data, defaults);
+            var repository = new DummyItemRepository();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget);
+            using var vm = new ItemsViewModel(service, repository, memoryBudget);
 
             await vm.LoadMoreAsync();
             Assert.Single(vm.Items);
@@ -98,8 +101,9 @@ namespace InventoryManagementApp.Tests
         public async Task ConcurrentLoadMoreCallsDoNotDuplicateOrSkipPages()
         {
             var service = new PagingItemService();
+            var repository = new DummyItemRepository();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget);
+            using var vm = new ItemsViewModel(service, repository, memoryBudget);
 
             var tasks = new[]
             {
@@ -119,8 +123,9 @@ namespace InventoryManagementApp.Tests
         public void DisposeCanBeCalledMultipleTimesAndCancelsToken()
         {
             var service = new DummyItemService();
+            var repository = new DummyItemRepository();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            var vm = new ItemsViewModel(service, memoryBudget);
+            var vm = new ItemsViewModel(service, repository, memoryBudget);
             vm.Items.Add(new ItemModel { ItemID = 1 });
             var ctsField = typeof(ItemsViewModel).GetField("_filterCts", BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.NotNull(ctsField);
@@ -130,6 +135,38 @@ namespace InventoryManagementApp.Tests
             vm.Dispose();
             Assert.True(token.IsCancellationRequested);
             Assert.Empty(vm.Items);
+        }
+
+        [Fact]
+        public async Task EditsAreQueued()
+        {
+            var item = new ItemModel { ItemID = 1, QuantityOnHand = 1, Location = "A", Price = 1m };
+            var service = new StaticItemService(item);
+            var repository = new RecordingItemRepository();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var vm = new ItemsViewModel(service, repository, memoryBudget);
+            await vm.LoadMoreAsync();
+            var loaded = vm.Items[0];
+            loaded.QuantityOnHand = 5;
+            loaded.Price = 2m;
+            Assert.Equal(1, vm.PendingEdits.Count);
+            Assert.Empty(repository.Saved);
+        }
+
+        [Fact]
+        public async Task SaveChangesPersistsQueuedEdits()
+        {
+            var item = new ItemModel { ItemID = 1, QuantityOnHand = 1, Location = "A", Price = 1m };
+            var service = new StaticItemService(item);
+            var repository = new RecordingItemRepository();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var vm = new ItemsViewModel(service, repository, memoryBudget);
+            await vm.LoadMoreAsync();
+            var loaded = vm.Items[0];
+            loaded.Location = "B";
+            await vm.SaveChangesCommand.ExecuteAsync(null);
+            Assert.Single(repository.Saved);
+            Assert.Empty(vm.PendingEdits);
         }
 
         private sealed class PagingItemService : IItemService
@@ -239,6 +276,52 @@ namespace InventoryManagementApp.Tests
                     await Task.Delay(10, ct);
                     yield return item;
                 }
+            }
+        }
+
+        private sealed class StaticItemService : IItemService
+        {
+            private readonly ItemModel _item;
+            public StaticItemService(ItemModel item) => _item = item;
+            public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(null);
+            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, CancellationToken cancellationToken = default) => Enumerate(cancellationToken);
+            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, CancellationToken cancellationToken = default) => Enumerate(cancellationToken);
+            public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+            public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => Task.FromResult(false);
+            public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
+            public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, SqliteConnection? conn = null, SqliteTransaction? tx = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+            private async IAsyncEnumerable<ItemModel> Enumerate([EnumeratorCancellation] CancellationToken ct)
+            {
+                await Task.Yield();
+                yield return _item;
+            }
+        }
+
+        private sealed class DummyItemRepository : IItemRepository
+        {
+            public IAsyncEnumerable<ItemModel> GetPageAsync(ItemFilter filter, ItemPage page, CancellationToken ct) => AsyncEnumerable.Empty<ItemModel>();
+            public Task<int> CountAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+            public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct) => Task.CompletedTask;
+        }
+
+        private sealed class RecordingItemRepository : IItemRepository
+        {
+            public List<ItemModel> Saved { get; } = new();
+            public IAsyncEnumerable<ItemModel> GetPageAsync(ItemFilter filter, ItemPage page, CancellationToken ct) => AsyncEnumerable.Empty<ItemModel>();
+            public Task<int> CountAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+            public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct)
+            {
+                Saved.AddRange(changes);
+                return Task.CompletedTask;
             }
         }
     }

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -16,7 +16,7 @@ public sealed class ItemRepository : IItemRepository
 
     public async IAsyncEnumerable<Item> GetPageAsync(ItemFilter filter, ItemPage page, [EnumeratorCancellation] CancellationToken ct)
     {
-        var sql = "SELECT ItemID, ItemNumber, NameDescription AS Name, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity AS QuantityOnHand, RentedQuantity, ImagePath, IsCheckedOut, CheckedOutBy, CheckedOutTime, IsPowered FROM Items";
+        var sql = "SELECT ItemID, ItemNumber, NameDescription AS Name, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity AS QuantityOnHand, RentedQuantity, Price, ImagePath, IsCheckedOut, CheckedOutBy, CheckedOutTime, IsPowered FROM Items";
         if (!string.IsNullOrWhiteSpace(filter.Search))
             sql += " WHERE ItemNumber LIKE @Search COLLATE NOCASE OR NameDescription LIKE @Search COLLATE NOCASE";
         sql += " ORDER BY ItemID LIMIT @Take OFFSET @Skip";
@@ -37,6 +37,7 @@ public sealed class ItemRepository : IItemRepository
         var ordinalKeywords = reader.GetOrdinal("Keywords");
         var ordinalQuantityOnHand = reader.GetOrdinal("QuantityOnHand");
         var ordinalRentedQuantity = reader.GetOrdinal("RentedQuantity");
+        var ordinalPrice = reader.GetOrdinal("Price");
         var ordinalImagePath = reader.GetOrdinal("ImagePath");
         var ordinalIsCheckedOut = reader.GetOrdinal("IsCheckedOut");
         var ordinalCheckedOutBy = reader.GetOrdinal("CheckedOutBy");
@@ -59,6 +60,7 @@ public sealed class ItemRepository : IItemRepository
                 Keywords = reader.IsDBNull(ordinalKeywords) ? string.Empty : reader.GetString(ordinalKeywords),
                 QuantityOnHand = reader.IsDBNull(ordinalQuantityOnHand) ? 0 : reader.GetInt32(ordinalQuantityOnHand),
                 RentedQuantity = reader.IsDBNull(ordinalRentedQuantity) ? 0 : reader.GetInt32(ordinalRentedQuantity),
+                Price = reader.IsDBNull(ordinalPrice) ? 0m : reader.GetDecimal(ordinalPrice),
                 ImagePath = reader.IsDBNull(ordinalImagePath) ? string.Empty : reader.GetString(ordinalImagePath),
                 IsCheckedOut = !reader.IsDBNull(ordinalIsCheckedOut) && reader.GetInt32(ordinalIsCheckedOut) == 1,
                 CheckedOutBy = reader.IsDBNull(ordinalCheckedOutBy) ? string.Empty : reader.GetString(ordinalCheckedOutBy),
@@ -85,7 +87,7 @@ public sealed class ItemRepository : IItemRepository
     {
         using var conn = _factory.Create();
         using var tx = conn.BeginTransaction();
-        const string sql = "UPDATE Items SET NameDescription=@Name, Location=@Location, AvailableQuantity=@QuantityOnHand WHERE ItemID=@ItemID";
+        const string sql = "UPDATE Items SET NameDescription=@Name, Location=@Location, AvailableQuantity=@QuantityOnHand, Price=@Price WHERE ItemID=@ItemID";
         foreach (var item in changes)
         {
             ct.ThrowIfCancellationRequested();
@@ -94,6 +96,7 @@ public sealed class ItemRepository : IItemRepository
                 item.Name,
                 item.Location,
                 QuantityOnHand = item.QuantityOnHand,
+                item.Price,
                 item.ItemID
             }, tx);
         }

--- a/InventoryManagementApp/Models/Domain/ItemModel.cs
+++ b/InventoryManagementApp/Models/Domain/ItemModel.cs
@@ -46,6 +46,13 @@ namespace InventoryManagementApp.Models.Domain
             set => SetProperty(ref _location, value);
         }
 
+        private decimal _price;
+        public decimal Price
+        {
+            get => _price;
+            set => SetProperty(ref _price, value);
+        }
+
         private int _quantityOnHand;
         public int QuantityOnHand
         {

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -15,9 +16,11 @@ namespace InventoryManagementApp.ViewModels
     public partial class ItemsViewModel : ObservableObject, IDisposable
     {
         private readonly IItemService _itemService;
+        private readonly IItemRepository _itemRepository;
         private readonly MemoryBudget _memoryBudget;
         private CancellationTokenSource _filterCts = new();
         private bool _disposed;
+        private readonly List<ItemModel> _pendingEdits = new();
 
         private const int PageSize = 200;
         public IncrementalLoadingCollection<ItemModel> Items { get; }
@@ -26,6 +29,9 @@ namespace InventoryManagementApp.ViewModels
         public IRelayCommand ViewDetailsCommand { get; }
         public IRelayCommand OpenRentalHistoryCommand { get; }
         public IRelayCommand NewItemCommand { get; }
+        public IAsyncRelayCommand SaveChangesCommand { get; }
+
+        public IReadOnlyCollection<ItemModel> PendingEdits => _pendingEdits;
 
         [ObservableProperty]
         private ItemModel? selectedItem;
@@ -33,9 +39,10 @@ namespace InventoryManagementApp.ViewModels
         [ObservableProperty]
         private string filter = string.Empty;
 
-        public ItemsViewModel(IItemService itemService, MemoryBudget memoryBudget)
+        public ItemsViewModel(IItemService itemService, IItemRepository itemRepository, MemoryBudget memoryBudget)
         {
             _itemService = itemService;
+            _itemRepository = itemRepository;
             _memoryBudget = memoryBudget;
             Items = new IncrementalLoadingCollection<ItemModel>(LoadPageAsync, PageSize);
             _memoryBudget.ThresholdExceeded += OnThresholdExceeded;
@@ -44,6 +51,7 @@ namespace InventoryManagementApp.ViewModels
             ViewDetailsCommand = new RelayCommand(() => { /* View details placeholder */ });
             OpenRentalHistoryCommand = new RelayCommand(() => { /* Open rental history placeholder */ });
             NewItemCommand = new RelayCommand(() => { /* New item placeholder */ });
+            SaveChangesCommand = new AsyncRelayCommand(ct => SaveChangesAsync(ct));
         }
 
         private async Task<IList<ItemModel>> LoadPageAsync(int page, CancellationToken ct)
@@ -54,7 +62,10 @@ namespace InventoryManagementApp.ViewModels
                 ? _itemService.GetItemsAsync(pageInfo, ct)
                 : _itemService.SearchItemsAsync(Filter, pageInfo, ct);
             await foreach (var item in source.ConfigureAwait(false))
+            {
+                item.PropertyChanged += Item_PropertyChanged;
                 result.Add(item);
+            }
             return result;
         }
 
@@ -84,11 +95,30 @@ namespace InventoryManagementApp.ViewModels
 
         private void OnThresholdExceeded(object? sender, EventArgs e) => Items.TrimToWindow(PageSize * 3);
 
+        private void Item_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (sender is not ItemModel item) return;
+            if (e.PropertyName == nameof(ItemModel.QuantityOnHand) || e.PropertyName == nameof(ItemModel.Location) || e.PropertyName == nameof(ItemModel.Price))
+            {
+                if (!_pendingEdits.Contains(item))
+                    _pendingEdits.Add(item);
+            }
+        }
+
+        private async Task SaveChangesAsync(CancellationToken ct)
+        {
+            if (_pendingEdits.Count == 0) return;
+            await _itemRepository.SaveChangesAsync(_pendingEdits, ct).ConfigureAwait(false);
+            _pendingEdits.Clear();
+        }
+
         public void Dispose()
         {
             if (_disposed) return;
             _disposed = true;
             _memoryBudget.ThresholdExceeded -= OnThresholdExceeded;
+            foreach (var item in Items)
+                item.PropertyChanged -= Item_PropertyChanged;
             Items.Reset();
             _filterCts.Cancel();
             _filterCts.Dispose();

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -21,7 +21,7 @@
                 <DataGrid Grid.Row="1"
                           ItemsSource="{Binding Items}"
                           SelectedItem="{Binding SelectedItem}"
-                          IsReadOnly="True"
+                          IsReadOnly="False"
                           AutoGenerateColumns="False"
                           EnableColumnVirtualization="True"
                           Background="{StaticResource SurfaceBrush}"
@@ -34,10 +34,12 @@
                         </Style>
                     </DataGrid.RowStyle>
                     <DataGrid.Columns>
-                        <DataGridTextColumn Header="Number" Binding="{Binding ItemNumber}" Width="140"/>
-                        <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="280"/>
-                        <DataGridTextColumn Header="Brand" Binding="{Binding Brand}" Width="160"/>
-                        <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="180"/>
+                        <DataGridTextColumn Header="Number" Binding="{Binding ItemNumber, Mode=OneWay}" Width="140"/>
+                        <DataGridTextColumn Header="Name" Binding="{Binding Name, Mode=OneWay}" Width="280"/>
+                        <DataGridTextColumn Header="Brand" Binding="{Binding Brand, Mode=OneWay}" Width="160"/>
+                        <DataGridTextColumn Header="Qty" Binding="{Binding QuantityOnHand, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100"/>
+                        <DataGridTextColumn Header="Location" Binding="{Binding Location, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="180"/>
+                        <DataGridTextColumn Header="Price" Binding="{Binding Price, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="120"/>
                     </DataGrid.Columns>
                     <DataGrid.ContextMenu>
                         <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"


### PR DESCRIPTION
## Summary
- Allow editing Quantity, Location, and Price in ManageItemsPage grid
- Track pending item edits in ItemsViewModel and batch-save via SaveChangesCommand
- Add ItemModel Price property and repository support with tests for edit queue and save

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a952df66e483249d8bd84732312a16