### PR TITLE
Implement dialog actions for item commands

### DIFF
--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -13,22 +13,25 @@ using InventoryManagementApp.Utilities;
 using InventoryManagementApp.ViewModels;
 using Xunit;
 using System.Reflection;
+using System.Windows.Documents;
 
 namespace InventoryManagementApp.Tests
 {
     public class ItemsViewModelTests
     {
         [Fact]
-        public void CommandsExistAndExecute()
+        public async Task CommandsExistAndExecute()
         {
             var service = new DummyItemService();
             var repository = new DummyItemRepository();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(service, repository, memoryBudget);
+            using var vm = new ItemsViewModel(service, repository, memoryBudget, dialog, rental);
 
             Assert.NotNull(vm.EditItemCommand);
             Assert.True(vm.EditItemCommand.CanExecute(null));
-            vm.EditItemCommand.Execute(null);
+            await vm.EditItemCommand.ExecuteAsync(null);
 
             Assert.NotNull(vm.ViewDetailsCommand);
             Assert.True(vm.ViewDetailsCommand.CanExecute(null));
@@ -36,11 +39,11 @@ namespace InventoryManagementApp.Tests
 
             Assert.NotNull(vm.OpenRentalHistoryCommand);
             Assert.True(vm.OpenRentalHistoryCommand.CanExecute(null));
-            vm.OpenRentalHistoryCommand.Execute(null);
+            await vm.OpenRentalHistoryCommand.ExecuteAsync(null);
 
             Assert.NotNull(vm.NewItemCommand);
             Assert.True(vm.NewItemCommand.CanExecute(null));
-            vm.NewItemCommand.Execute(null);
+            await vm.NewItemCommand.ExecuteAsync(null);
         }
 
         [Fact]
@@ -54,8 +57,10 @@ namespace InventoryManagementApp.Tests
             };
             var service = new RecordingItemService(data);
             var repository = new DummyItemRepository();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(service, repository, memoryBudget);
+            using var vm = new ItemsViewModel(service, repository, memoryBudget, dialog, rental);
 
             vm.Filter = "first";
             await Task.Delay(100);
@@ -80,8 +85,10 @@ namespace InventoryManagementApp.Tests
             };
             var service = new RecordingItemService(data, defaults);
             var repository = new DummyItemRepository();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(service, repository, memoryBudget);
+            using var vm = new ItemsViewModel(service, repository, memoryBudget, dialog, rental);
 
             await vm.LoadMoreAsync();
             Assert.Single(vm.Items);
@@ -102,8 +109,10 @@ namespace InventoryManagementApp.Tests
         {
             var service = new PagingItemService();
             var repository = new DummyItemRepository();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(service, repository, memoryBudget);
+            using var vm = new ItemsViewModel(service, repository, memoryBudget, dialog, rental);
 
             var tasks = new[]
             {
@@ -124,8 +133,10 @@ namespace InventoryManagementApp.Tests
         {
             var service = new DummyItemService();
             var repository = new DummyItemRepository();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            var vm = new ItemsViewModel(service, repository, memoryBudget);
+            var vm = new ItemsViewModel(service, repository, memoryBudget, dialog, rental);
             vm.Items.Add(new ItemModel { ItemID = 1 });
             var ctsField = typeof(ItemsViewModel).GetField("_filterCts", BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.NotNull(ctsField);
@@ -143,8 +154,10 @@ namespace InventoryManagementApp.Tests
             var item = new ItemModel { ItemID = 1, QuantityOnHand = 1, Location = "A", Price = 1m };
             var service = new StaticItemService(item);
             var repository = new RecordingItemRepository();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(service, repository, memoryBudget);
+            using var vm = new ItemsViewModel(service, repository, memoryBudget, dialog, rental);
             await vm.LoadMoreAsync();
             var loaded = vm.Items[0];
             loaded.QuantityOnHand = 5;
@@ -159,14 +172,136 @@ namespace InventoryManagementApp.Tests
             var item = new ItemModel { ItemID = 1, QuantityOnHand = 1, Location = "A", Price = 1m };
             var service = new StaticItemService(item);
             var repository = new RecordingItemRepository();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(service, repository, memoryBudget);
+            using var vm = new ItemsViewModel(service, repository, memoryBudget, dialog, rental);
             await vm.LoadMoreAsync();
             var loaded = vm.Items[0];
             loaded.Location = "B";
             await vm.SaveChangesCommand.ExecuteAsync(null);
             Assert.Single(repository.Saved);
             Assert.Empty(vm.PendingEdits);
+        }
+
+        [Fact]
+        public async Task EditItemCommand_InvokesDialogAndService()
+        {
+            var item = new ItemModel { ItemID = 1 };
+            var dialog = new RecordingDialogService { EditItemDialogResult = new ItemModel { ItemID = 1 } };
+            var itemService = new RecordingItemService2();
+            var repository = new DummyItemRepository();
+            var rental = new DummyRentalService();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var vm = new ItemsViewModel(itemService, repository, memoryBudget, dialog, rental);
+            vm.SelectedItem = item;
+            await vm.EditItemCommand.ExecuteAsync(null);
+            Assert.True(dialog.EditItemDialogCalled);
+            Assert.Single(itemService.Updated);
+        }
+
+        [Fact]
+        public async Task EditItemCommand_HandlesCancellation()
+        {
+            var item = new ItemModel { ItemID = 1 };
+            var dialog = new RecordingDialogService { EditItemDialogResult = new ItemModel { ItemID = 1 } };
+            var itemService = new RecordingItemService2 { UpdateException = new OperationCanceledException() };
+            var repository = new DummyItemRepository();
+            var rental = new DummyRentalService();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var vm = new ItemsViewModel(itemService, repository, memoryBudget, dialog, rental);
+            vm.SelectedItem = item;
+            await vm.EditItemCommand.ExecuteAsync(null);
+            Assert.True(dialog.EditItemDialogCalled);
+            Assert.Single(itemService.Updated);
+        }
+
+        [Fact]
+        public void ViewDetailsCommand_InvokesDialog()
+        {
+            var dialog = new RecordingDialogService();
+            var itemService = new DummyItemService();
+            var repository = new DummyItemRepository();
+            var rental = new DummyRentalService();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var vm = new ItemsViewModel(itemService, repository, memoryBudget, dialog, rental);
+            vm.SelectedItem = new ItemModel();
+            vm.ViewDetailsCommand.Execute(null);
+            Assert.True(dialog.ItemDetailsCalled);
+        }
+
+        [Fact]
+        public void ViewDetailsCommand_HandlesException()
+        {
+            var dialog = new RecordingDialogService { DetailsException = new InvalidOperationException() };
+            var itemService = new DummyItemService();
+            var repository = new DummyItemRepository();
+            var rental = new DummyRentalService();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var vm = new ItemsViewModel(itemService, repository, memoryBudget, dialog, rental);
+            vm.SelectedItem = new ItemModel();
+            vm.ViewDetailsCommand.Execute(null);
+            Assert.True(dialog.ItemDetailsCalled);
+        }
+
+        [Fact]
+        public async Task OpenRentalHistoryCommand_InvokesServices()
+        {
+            var item = new ItemModel { ItemID = 1 };
+            var dialog = new RecordingDialogService();
+            var rentalService = new RecordingRentalService();
+            var itemService = new DummyItemService();
+            var repository = new DummyItemRepository();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var vm = new ItemsViewModel(itemService, repository, memoryBudget, dialog, rentalService);
+            vm.SelectedItem = item;
+            await vm.OpenRentalHistoryCommand.ExecuteAsync(null);
+            Assert.True(rentalService.HistoryCalled);
+            Assert.True(dialog.RentalHistoryCalled);
+        }
+
+        [Fact]
+        public async Task OpenRentalHistoryCommand_HandlesCancellation()
+        {
+            var item = new ItemModel { ItemID = 1 };
+            var dialog = new RecordingDialogService();
+            var rentalService = new RecordingRentalService { HistoryException = new OperationCanceledException() };
+            var itemService = new DummyItemService();
+            var repository = new DummyItemRepository();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var vm = new ItemsViewModel(itemService, repository, memoryBudget, dialog, rentalService);
+            vm.SelectedItem = item;
+            await vm.OpenRentalHistoryCommand.ExecuteAsync(null);
+            Assert.True(rentalService.HistoryCalled);
+            Assert.False(dialog.RentalHistoryCalled);
+        }
+
+        [Fact]
+        public async Task NewItemCommand_InvokesDialogAndService()
+        {
+            var dialog = new RecordingDialogService { EditItemDialogResult = new ItemModel { ItemID = 2 } };
+            var itemService = new RecordingItemService2();
+            var repository = new DummyItemRepository();
+            var rental = new DummyRentalService();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var vm = new ItemsViewModel(itemService, repository, memoryBudget, dialog, rental);
+            await vm.NewItemCommand.ExecuteAsync(null);
+            Assert.True(dialog.EditItemDialogCalled);
+            Assert.Single(itemService.Added);
+        }
+
+        [Fact]
+        public async Task NewItemCommand_HandlesCancellation()
+        {
+            var dialog = new RecordingDialogService { EditItemDialogResult = new ItemModel { ItemID = 2 } };
+            var itemService = new RecordingItemService2 { AddException = new OperationCanceledException() };
+            var repository = new DummyItemRepository();
+            var rental = new DummyRentalService();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var vm = new ItemsViewModel(itemService, repository, memoryBudget, dialog, rental);
+            await vm.NewItemCommand.ExecuteAsync(null);
+            Assert.True(dialog.EditItemDialogCalled);
+            Assert.Single(itemService.Added);
         }
 
         private sealed class PagingItemService : IItemService
@@ -323,6 +458,126 @@ namespace InventoryManagementApp.Tests
                 Saved.AddRange(changes);
                 return Task.CompletedTask;
             }
+        }
+
+        private sealed class DummyDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => true;
+            public ItemModel? ShowEditItemDialog(ItemModel item) => null;
+            public void ShowItemDetails(ItemModel item) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
+            public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+        }
+
+        private sealed class DummyRentalService : IRentalService
+        {
+            public Task RentItemAsync(int itemID, int customerID, DateTime rentalDate, DateTime dueDate) => Task.CompletedTask;
+            public Task ReturnItemAsync(int rentalID, DateTime returnDate) => Task.CompletedTask;
+            public Task ExtendRentalAsync(int rentalID, DateTime newDueDate) => Task.CompletedTask;
+            public Task DeleteRentalAsync(int rentalID) => Task.CompletedTask;
+            public Task<List<Rental>> GetActiveRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<int> CountActiveRentalsAsync() => Task.FromResult(0);
+            public Task<List<Rental>> GetOverdueRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetAllRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetRentalHistoryForItemAsync(int itemID) => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID) => Task.FromResult(new List<Rental>());
+        }
+
+        private sealed class RecordingDialogService : IDialogService
+        {
+            public bool EditItemDialogCalled { get; private set; }
+            public bool ItemDetailsCalled { get; private set; }
+            public bool RentalHistoryCalled { get; private set; }
+            public ItemModel? EditItemDialogResult { get; set; }
+            public Exception? EditItemDialogException { get; set; }
+            public Exception? DetailsException { get; set; }
+            public Exception? RentalHistoryException { get; set; }
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => true;
+            public ItemModel? ShowEditItemDialog(ItemModel item)
+            {
+                EditItemDialogCalled = true;
+                if (EditItemDialogException != null) throw EditItemDialogException;
+                return EditItemDialogResult;
+            }
+            public void ShowItemDetails(ItemModel item)
+            {
+                ItemDetailsCalled = true;
+                if (DetailsException != null) throw DetailsException;
+            }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history)
+            {
+                if (RentalHistoryException != null) throw RentalHistoryException;
+                RentalHistoryCalled = true;
+            }
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
+            public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+        }
+
+        private sealed class RecordingRentalService : IRentalService
+        {
+            public bool HistoryCalled { get; private set; }
+            public Exception? HistoryException { get; set; }
+            public Task RentItemAsync(int itemID, int customerID, DateTime rentalDate, DateTime dueDate) => Task.CompletedTask;
+            public Task ReturnItemAsync(int rentalID, DateTime returnDate) => Task.CompletedTask;
+            public Task ExtendRentalAsync(int rentalID, DateTime newDueDate) => Task.CompletedTask;
+            public Task DeleteRentalAsync(int rentalID) => Task.CompletedTask;
+            public Task<List<Rental>> GetActiveRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<int> CountActiveRentalsAsync() => Task.FromResult(0);
+            public Task<List<Rental>> GetOverdueRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetAllRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetRentalHistoryForItemAsync(int itemID)
+            {
+                HistoryCalled = true;
+                if (HistoryException != null) throw HistoryException;
+                return Task.FromResult(new List<Rental>());
+            }
+            public Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID) => Task.FromResult(new List<Rental>());
+        }
+
+        private sealed class RecordingItemService2 : IItemService
+        {
+            public List<ItemModel> Added { get; } = new();
+            public List<ItemModel> Updated { get; } = new();
+            public Exception? AddException { get; set; }
+            public Exception? UpdateException { get; set; }
+            public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default)
+            {
+                Added.Add(item);
+                if (AddException != null) throw AddException;
+                return Task.CompletedTask;
+            }
+            public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default)
+            {
+                Updated.Add(item);
+                if (UpdateException != null) throw UpdateException;
+                return Task.CompletedTask;
+            }
+            public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(null);
+            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+            public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => Task.FromResult(false);
+            public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
+            public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, SqliteConnection? conn = null, SqliteTransaction? tx = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
         }
     }
 }

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -18,6 +18,8 @@ namespace InventoryManagementApp.ViewModels
         private readonly IItemService _itemService;
         private readonly IItemRepository _itemRepository;
         private readonly MemoryBudget _memoryBudget;
+        private readonly IDialogService _dialogService;
+        private readonly IRentalService _rentalService;
         private CancellationTokenSource _filterCts = new();
         private bool _disposed;
         private readonly List<ItemModel> _pendingEdits = new();
@@ -25,10 +27,10 @@ namespace InventoryManagementApp.ViewModels
         private const int PageSize = 200;
         public IncrementalLoadingCollection<ItemModel> Items { get; }
 
-        public IRelayCommand EditItemCommand { get; }
+        public IAsyncRelayCommand EditItemCommand { get; }
         public IRelayCommand ViewDetailsCommand { get; }
-        public IRelayCommand OpenRentalHistoryCommand { get; }
-        public IRelayCommand NewItemCommand { get; }
+        public IAsyncRelayCommand OpenRentalHistoryCommand { get; }
+        public IAsyncRelayCommand NewItemCommand { get; }
         public IAsyncRelayCommand SaveChangesCommand { get; }
 
         public IReadOnlyCollection<ItemModel> PendingEdits => _pendingEdits;
@@ -39,18 +41,20 @@ namespace InventoryManagementApp.ViewModels
         [ObservableProperty]
         private string filter = string.Empty;
 
-        public ItemsViewModel(IItemService itemService, IItemRepository itemRepository, MemoryBudget memoryBudget)
+        public ItemsViewModel(IItemService itemService, IItemRepository itemRepository, MemoryBudget memoryBudget, IDialogService dialogService, IRentalService rentalService)
         {
             _itemService = itemService;
             _itemRepository = itemRepository;
             _memoryBudget = memoryBudget;
+            _dialogService = dialogService;
+            _rentalService = rentalService;
             Items = new IncrementalLoadingCollection<ItemModel>(LoadPageAsync, PageSize);
             _memoryBudget.ThresholdExceeded += OnThresholdExceeded;
 
-            EditItemCommand = new RelayCommand(() => { /* Edit item placeholder */ });
-            ViewDetailsCommand = new RelayCommand(() => { /* View details placeholder */ });
-            OpenRentalHistoryCommand = new RelayCommand(() => { /* Open rental history placeholder */ });
-            NewItemCommand = new RelayCommand(() => { /* New item placeholder */ });
+            EditItemCommand = new AsyncRelayCommand(ct => EditItemAsync(ct));
+            ViewDetailsCommand = new RelayCommand(ViewDetails);
+            OpenRentalHistoryCommand = new AsyncRelayCommand(ct => OpenRentalHistoryAsync(ct));
+            NewItemCommand = new AsyncRelayCommand(ct => NewItemAsync(ct));
             SaveChangesCommand = new AsyncRelayCommand(ct => SaveChangesAsync(ct));
         }
 
@@ -102,6 +106,114 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (!_pendingEdits.Contains(item))
                     _pendingEdits.Add(item);
+            }
+        }
+
+        private async Task EditItemAsync(CancellationToken ct)
+        {
+            if (SelectedItem == null) return;
+            ItemModel? updated;
+            try
+            {
+                var clone = new ItemModel
+                {
+                    ItemID = SelectedItem.ItemID,
+                    ItemNumber = SelectedItem.ItemNumber,
+                    PartNumber = SelectedItem.PartNumber,
+                    Name = SelectedItem.Name,
+                    Brand = SelectedItem.Brand,
+                    Location = SelectedItem.Location,
+                    QuantityOnHand = SelectedItem.QuantityOnHand,
+                    RentedQuantity = SelectedItem.RentedQuantity,
+                    Supplier = SelectedItem.Supplier,
+                    PurchasedDate = SelectedItem.PurchasedDate,
+                    Notes = SelectedItem.Notes,
+                    Keywords = SelectedItem.Keywords,
+                    IsPowered = SelectedItem.IsPowered,
+                    IsCheckedOut = SelectedItem.IsCheckedOut,
+                    CheckedOutBy = SelectedItem.CheckedOutBy,
+                    CheckedOutTime = SelectedItem.CheckedOutTime,
+                    ImagePath = SelectedItem.ImagePath,
+                    Price = SelectedItem.Price
+                };
+                updated = await _dialogService.ShowEditItemDialogAsync(clone).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch
+            {
+                return;
+            }
+            if (updated == null) return;
+            try
+            {
+                await _itemService.UpdateItemAsync(updated, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch
+            {
+            }
+        }
+
+        private void ViewDetails()
+        {
+            if (SelectedItem == null) return;
+            try
+            {
+                _dialogService.ShowItemDetails(SelectedItem);
+            }
+            catch
+            {
+            }
+        }
+
+        private async Task OpenRentalHistoryAsync(CancellationToken ct)
+        {
+            if (SelectedItem == null) return;
+            try
+            {
+                var history = await _rentalService.GetRentalHistoryForItemAsync(SelectedItem.ItemID).ConfigureAwait(false);
+                _dialogService.ShowRentalHistory(SelectedItem, history);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch
+            {
+            }
+        }
+
+        private async Task NewItemAsync(CancellationToken ct)
+        {
+            ItemModel? item;
+            try
+            {
+                item = await _dialogService.ShowEditItemDialogAsync(new ItemModel()).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch
+            {
+                return;
+            }
+            if (item == null) return;
+            try
+            {
+                await _itemService.AddItemAsync(item, ct).ConfigureAwait(false);
+                Items.Reset();
+                await Items.LoadMoreAsync(ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch
+            {
             }
         }
 


### PR DESCRIPTION
## Summary
- wire ItemsViewModel commands to dialog and rental services for editing, viewing details, history, and creating items
- inject IDialogService and IRentalService dependencies
- add unit tests covering command service invocation and cancellation handling

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9774b57f883249d105555eb77c2be