### PR TITLE
Apply WAL pragmas and indexes per SQLite connection

### DIFF
--- a/InventoryManagementApp.Tests/SqliteConnectionFactoryTests.cs
+++ b/InventoryManagementApp.Tests/SqliteConnectionFactoryTests.cs
@@ -1,15 +1,41 @@
+using System.Collections.Generic;
 using InventoryManagementApp.Data;
 using Xunit;
 
 public class SqliteConnectionFactoryTests
 {
     [Fact]
-    public void Create_ExecutesPragmasOnlyOnce()
+    public void Create_ExecutesPragmasEachTime()
     {
         SqliteConnectionFactory.Reset();
         var factory = new SqliteConnectionFactory("Data Source=:memory:");
         using var first = factory.Create();
         using var second = factory.Create();
-        Assert.Equal(1, SqliteConnectionFactory.PragmasExecutionCount);
+        Assert.Equal(2, SqliteConnectionFactory.PragmasExecutionCount);
+    }
+
+    [Fact]
+    public void Create_CreatesIndexesWhenItemsTableExists()
+    {
+        SqliteConnectionFactory.Reset();
+        var factory = new SqliteConnectionFactory("Data Source=:memory:");
+        using (var conn = factory.Create())
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "CREATE TABLE Items (ItemNumber TEXT, NameDescription TEXT, AvailableQuantity INTEGER, UpdatedAt TEXT);";
+            cmd.ExecuteNonQuery();
+        }
+
+        using var verify = factory.Create();
+        using var check = verify.CreateCommand();
+        check.CommandText = "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='Items' ORDER BY name;";
+        using var reader = check.ExecuteReader();
+        var indexes = new List<string>();
+        while (reader.Read())
+            indexes.Add(reader.GetString(0));
+        Assert.Contains("IX_Items_ItemNumber", indexes);
+        Assert.Contains("IX_Items_NameDescription", indexes);
+        Assert.Contains("IX_Items_AvailableQuantity", indexes);
+        Assert.Contains("IX_Items_UpdatedAt", indexes);
     }
 }

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,7 +22,7 @@ public sealed class ItemRepository : IItemRepository
             sql += " WHERE ItemNumber LIKE @Search COLLATE NOCASE OR NameDescription LIKE @Search COLLATE NOCASE";
         sql += " ORDER BY ItemID LIMIT @Take OFFSET @Skip";
         var param = new { Search = $"%{filter.Search}%", Take = page.Size, Skip = (page.Number - 1) * page.Size };
-        await using var conn = _factory.Create();
+        await using var conn = (DbConnection)_factory.Create();
         await using var reader = await conn.ExecuteReaderAsync(
             new CommandDefinition(sql, param, cancellationToken: ct)).ConfigureAwait(false);
 
@@ -79,13 +80,13 @@ public sealed class ItemRepository : IItemRepository
             sql += " WHERE ItemNumber LIKE @Search COLLATE NOCASE OR NameDescription LIKE @Search COLLATE NOCASE";
             param = new { Search = $"%{filter.Search}%" };
         }
-        using var conn = _factory.Create();
+        await using var conn = (DbConnection)_factory.Create();
         return await conn.ExecuteScalarAsync<int>(new CommandDefinition(sql, param, cancellationToken: ct));
     }
 
     public async Task SaveChangesAsync(IEnumerable<Item> changes, CancellationToken ct)
     {
-        using var conn = _factory.Create();
+        await using var conn = (DbConnection)_factory.Create();
         using var tx = conn.BeginTransaction();
         const string sql = "UPDATE Items SET NameDescription=@Name, Location=@Location, AvailableQuantity=@QuantityOnHand, Price=@Price WHERE ItemID=@ItemID";
         foreach (var item in changes)

--- a/InventoryManagementApp/Data/SqliteConnectionFactory.cs
+++ b/InventoryManagementApp/Data/SqliteConnectionFactory.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Microsoft.Data.Sqlite;
 
 namespace InventoryManagementApp.Data;
@@ -5,30 +6,51 @@ namespace InventoryManagementApp.Data;
 public sealed class SqliteConnectionFactory
 {
     private readonly string _connectionString;
-    private static bool _pragmasExecuted;
+    private static readonly object _lock = new();
     internal static int PragmasExecutionCount { get; private set; }
 
     public SqliteConnectionFactory(string connectionString)
-        => _connectionString = connectionString;
+    {
+        var builder = new SqliteConnectionStringBuilder(connectionString)
+        {
+            Pooling = true
+        };
+        _connectionString = builder.ToString();
+    }
 
     internal static void Reset()
     {
-        _pragmasExecuted = false;
         PragmasExecutionCount = 0;
     }
 
-    public SqliteConnection Create()
+    public IDbConnection Create()
     {
         var connection = new SqliteConnection(_connectionString);
         connection.Open();
-        if (!_pragmasExecuted)
+
+        lock (_lock)
         {
             using var cmd = connection.CreateCommand();
             cmd.CommandText = "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;";
             cmd.ExecuteNonQuery();
-            _pragmasExecuted = true;
+
+            cmd.CommandText = "SELECT 1 FROM sqlite_master WHERE type='table' AND name='Items';";
+            var exists = cmd.ExecuteScalar() != null;
+
+            if (exists)
+            {
+                cmd.CommandText = """
+                    CREATE INDEX IF NOT EXISTS IX_Items_ItemNumber ON Items(ItemNumber);
+                    CREATE INDEX IF NOT EXISTS IX_Items_NameDescription ON Items(NameDescription);
+                    CREATE INDEX IF NOT EXISTS IX_Items_AvailableQuantity ON Items(AvailableQuantity);
+                    CREATE INDEX IF NOT EXISTS IX_Items_UpdatedAt ON Items(UpdatedAt);
+                    """;
+                cmd.ExecuteNonQuery();
+            }
+
             PragmasExecutionCount++;
         }
+
         return connection;
     }
 }


### PR DESCRIPTION
## Summary
- ensure every SQLite connection enables WAL and NORMAL sync under a lock
- create indexes for common query columns when the Items table exists
- expose pooled IDbConnection and update repository + tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a97c059da48324bb339a8efdd2b7d7