### PR TITLE
Enable accent-insensitive search with stable sorting

### DIFF
--- a/InventoryManagementApp.Tests/ItemRepositorySearchTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositorySearchTests.cs
@@ -39,6 +39,9 @@ public class ItemRepositorySearchTests
         await conn.ExecuteAsync(
             "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,0,0,@UpdatedAt)",
             new { ItemNumber = "ABC123", Name = "Hand Saw", UpdatedAt = System.DateTime.UtcNow });
+        await conn.ExecuteAsync(
+            "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,0,0,@UpdatedAt)",
+            new { ItemNumber = "CAFÉ1", Name = "Café Table", UpdatedAt = System.DateTime.UtcNow });
     }
 
     [Fact]
@@ -65,5 +68,29 @@ public class ItemRepositorySearchTests
             result.Add(item);
         Assert.Single(result);
         Assert.Equal("Hand Saw", result[0].Name);
+    }
+
+    [Fact]
+    public async Task GetPageAsync_SearchName_AccentInsensitive()
+    {
+        var factory = CreateFactory();
+        await SeedAsync(factory);
+        var repo = new ItemRepository(factory);
+        var result = new List<ItemModel>();
+        await foreach (var item in repo.GetPageAsync(new ItemFilter("cafe"), new ItemPage(1, 10), CancellationToken.None))
+            result.Add(item);
+        Assert.Contains(result, i => i.Name == "Café Table");
+    }
+
+    [Fact]
+    public async Task GetPageAsync_SearchItemNumber_AccentInsensitive()
+    {
+        var factory = CreateFactory();
+        await SeedAsync(factory);
+        var repo = new ItemRepository(factory);
+        var result = new List<ItemModel>();
+        await foreach (var item in repo.GetPageAsync(new ItemFilter("cafe"), new ItemPage(1, 10), CancellationToken.None))
+            result.Add(item);
+        Assert.Contains(result, i => i.ItemNumber == "CAFÉ1");
     }
 }

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -18,8 +18,14 @@ public sealed class ItemRepository : IItemRepository
     public async IAsyncEnumerable<Item> GetPageAsync(ItemFilter filter, ItemPage page, [EnumeratorCancellation] CancellationToken ct)
     {
         var sql = "SELECT ItemID, ItemNumber, NameDescription AS Name, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity AS QuantityOnHand, RentedQuantity, Price, ImagePath, IsCheckedOut, CheckedOutBy, CheckedOutTime, IsPowered, UpdatedAt FROM Items";
+        var parameters = new DynamicParameters();
         if (!string.IsNullOrWhiteSpace(filter.Search))
-            sql += " WHERE ItemNumber LIKE @Search COLLATE NOCASE OR NameDescription LIKE @Search COLLATE NOCASE";
+        {
+            sql += " WHERE ItemNumber LIKE @ItemNumberPrefix COLLATE NOCASE_NOACCENT OR ItemNumber LIKE @ItemNumberSubstring COLLATE NOCASE_NOACCENT OR NameDescription LIKE @NameSubstring COLLATE NOCASE_NOACCENT";
+            parameters.Add("ItemNumberPrefix", $"{filter.Search}%");
+            parameters.Add("ItemNumberSubstring", $"%{filter.Search}%");
+            parameters.Add("NameSubstring", $"%{filter.Search}%");
+        }
         var orderColumn = filter.SortField switch
         {
             SortField.Name => "NameDescription",
@@ -29,11 +35,12 @@ public sealed class ItemRepository : IItemRepository
             _ => "ItemID"
         };
         var orderDirection = filter.SortDirection == SortDirection.Ascending ? "ASC" : "DESC";
-        sql += $" ORDER BY {orderColumn} {orderDirection} LIMIT @Take OFFSET @Skip";
-        var param = new { Search = $"%{filter.Search}%", Take = page.Size, Skip = (page.Number - 1) * page.Size };
+        sql += $" ORDER BY {orderColumn} {orderDirection}, ItemID ASC LIMIT @Take OFFSET @Skip";
+        parameters.Add("Take", page.Size);
+        parameters.Add("Skip", (page.Number - 1) * page.Size);
         await using var conn = (DbConnection)_factory.Create();
-        await using var reader = await conn.ExecuteReaderAsync(
-            new CommandDefinition(sql, param, cancellationToken: ct)).ConfigureAwait(false);
+        var command = new CommandDefinition(sql, parameters, flags: CommandFlags.Pipelined, cancellationToken: ct);
+        await using var reader = await conn.ExecuteReaderAsync(command).ConfigureAwait(false);
 
         var ordinalItemID = reader.GetOrdinal("ItemID");
         var ordinalItemNumber = reader.GetOrdinal("ItemNumber");
@@ -85,14 +92,16 @@ public sealed class ItemRepository : IItemRepository
     public async Task<int> CountAsync(ItemFilter filter, CancellationToken ct)
     {
         var sql = "SELECT COUNT(*) FROM Items";
-        object? param = null;
+        var parameters = new DynamicParameters();
         if (!string.IsNullOrWhiteSpace(filter.Search))
         {
-            sql += " WHERE ItemNumber LIKE @Search COLLATE NOCASE OR NameDescription LIKE @Search COLLATE NOCASE";
-            param = new { Search = $"%{filter.Search}%" };
+            sql += " WHERE ItemNumber LIKE @ItemNumberPrefix COLLATE NOCASE_NOACCENT OR ItemNumber LIKE @ItemNumberSubstring COLLATE NOCASE_NOACCENT OR NameDescription LIKE @NameSubstring COLLATE NOCASE_NOACCENT";
+            parameters.Add("ItemNumberPrefix", $"{filter.Search}%");
+            parameters.Add("ItemNumberSubstring", $"%{filter.Search}%");
+            parameters.Add("NameSubstring", $"%{filter.Search}%");
         }
         await using var conn = (DbConnection)_factory.Create();
-        return await conn.ExecuteScalarAsync<int>(new CommandDefinition(sql, param, cancellationToken: ct));
+        return await conn.ExecuteScalarAsync<int>(new CommandDefinition(sql, parameters, flags: CommandFlags.Pipelined, cancellationToken: ct));
     }
 
     public async Task SaveChangesAsync(IEnumerable<Item> changes, CancellationToken ct)

--- a/InventoryManagementApp/Data/SqliteConnectionFactory.cs
+++ b/InventoryManagementApp/Data/SqliteConnectionFactory.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Globalization;
 using Microsoft.Data.Sqlite;
 
 namespace InventoryManagementApp.Data;
@@ -27,6 +28,10 @@ public sealed class SqliteConnectionFactory
     {
         var connection = new SqliteConnection(_connectionString);
         connection.Open();
+
+        connection.CreateCollation("NOCASE_NOACCENT", static (x, y) =>
+            string.Compare(x, y, CultureInfo.InvariantCulture,
+                CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace));
 
         lock (_lock)
         {


### PR DESCRIPTION
## Summary
- Support accent- and case-insensitive filtering via custom SQLite collation
- Add validated ORDER BY clause with stable ItemID tiebreaker
- Cover accent-insensitive search in repository tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a97fe76cd883248a8cb71fa96abc75