### PR TITLE
Persist item list settings and expose sort options

### DIFF
--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -25,8 +25,9 @@ namespace InventoryManagementApp.Tests
             var service = new DummyItemService();
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
+            var settings = new DummySettingsService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
 
             Assert.NotNull(vm.EditItemCommand);
             Assert.True(vm.EditItemCommand.CanExecute(null));
@@ -57,8 +58,9 @@ namespace InventoryManagementApp.Tests
             var service = new RecordingItemService(data);
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
+            var settings = new DummySettingsService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
 
             vm.Filter = "first";
             await Task.Delay(100);
@@ -84,8 +86,9 @@ namespace InventoryManagementApp.Tests
             var service = new RecordingItemService(data, defaults);
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
+            var settings = new DummySettingsService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
 
             await vm.LoadMoreAsync();
             Assert.Single(vm.Items);
@@ -107,8 +110,9 @@ namespace InventoryManagementApp.Tests
             var service = new PagingItemService();
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
+            var settings = new DummySettingsService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
 
             var tasks = new[]
             {
@@ -118,7 +122,7 @@ namespace InventoryManagementApp.Tests
             };
             await Task.WhenAll(tasks);
 
-            const int pageSize = 200;
+            var pageSize = vm.PageSize;
             Assert.Equal(pageSize * 3, vm.Items.Count);
             Assert.Equal(new[] { 1, 2, 3 }, service.Pages);
             Assert.Equal(vm.Items.Count, vm.Items.Select(i => i.ItemID).Distinct().Count());
@@ -131,7 +135,8 @@ namespace InventoryManagementApp.Tests
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            var vm = new ItemsViewModel(service, memoryBudget, dialog, rental);
+            var settings = new DummySettingsService();
+            var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
             vm.Items.Add(new ItemModel { ItemID = 1 });
             var ctsField = typeof(ItemsViewModel).GetField("_filterCts", BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.NotNull(ctsField);
@@ -151,7 +156,8 @@ namespace InventoryManagementApp.Tests
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental);
+            var settings = new DummySettingsService();
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
             await vm.LoadMoreAsync();
             var loaded = vm.Items[0];
             loaded.QuantityOnHand = 5;
@@ -168,7 +174,8 @@ namespace InventoryManagementApp.Tests
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental);
+            var settings = new DummySettingsService();
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
             await vm.LoadMoreAsync();
             var loaded = vm.Items[0];
             loaded.Location = "B";
@@ -185,7 +192,8 @@ namespace InventoryManagementApp.Tests
             var itemService = new RecordingItemService2();
             var rental = new DummyRentalService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental);
+            var settings = new DummySettingsService();
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings);
             vm.SelectedItem = item;
             await vm.EditItemCommand.ExecuteAsync(null);
             Assert.True(dialog.EditItemDialogCalled);
@@ -200,7 +208,8 @@ namespace InventoryManagementApp.Tests
             var itemService = new RecordingItemService2 { UpdateException = new OperationCanceledException() };
             var rental = new DummyRentalService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental);
+            var settings = new DummySettingsService();
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings);
             vm.SelectedItem = item;
             await vm.EditItemCommand.ExecuteAsync(null);
             Assert.True(dialog.EditItemDialogCalled);
@@ -214,7 +223,8 @@ namespace InventoryManagementApp.Tests
             var itemService = new DummyItemService();
             var rental = new DummyRentalService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental);
+            var settings = new DummySettingsService();
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings);
             vm.SelectedItem = new ItemModel();
             vm.ViewDetailsCommand.Execute(null);
             Assert.True(dialog.ItemDetailsCalled);
@@ -227,7 +237,8 @@ namespace InventoryManagementApp.Tests
             var itemService = new DummyItemService();
             var rental = new DummyRentalService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental);
+            var settings = new DummySettingsService();
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings);
             vm.SelectedItem = new ItemModel();
             vm.ViewDetailsCommand.Execute(null);
             Assert.True(dialog.ItemDetailsCalled);
@@ -241,7 +252,8 @@ namespace InventoryManagementApp.Tests
             var rentalService = new RecordingRentalService();
             var itemService = new DummyItemService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rentalService);
+            var settings = new DummySettingsService();
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rentalService, settings);
             vm.SelectedItem = item;
             await vm.OpenRentalHistoryCommand.ExecuteAsync(null);
             Assert.True(rentalService.HistoryCalled);
@@ -256,7 +268,8 @@ namespace InventoryManagementApp.Tests
             var rentalService = new RecordingRentalService { HistoryException = new OperationCanceledException() };
             var itemService = new DummyItemService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rentalService);
+            var settings = new DummySettingsService();
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rentalService, settings);
             vm.SelectedItem = item;
             await vm.OpenRentalHistoryCommand.ExecuteAsync(null);
             Assert.True(rentalService.HistoryCalled);
@@ -270,7 +283,8 @@ namespace InventoryManagementApp.Tests
             var itemService = new RecordingItemService2();
             var rental = new DummyRentalService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental);
+            var settings = new DummySettingsService();
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings);
             await vm.NewItemCommand.ExecuteAsync(null);
             Assert.True(dialog.EditItemDialogCalled);
             Assert.Single(itemService.Added);
@@ -283,7 +297,8 @@ namespace InventoryManagementApp.Tests
             var itemService = new RecordingItemService2 { AddException = new OperationCanceledException() };
             var rental = new DummyRentalService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental);
+            var settings = new DummySettingsService();
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings);
             await vm.NewItemCommand.ExecuteAsync(null);
             Assert.True(dialog.EditItemDialogCalled);
             Assert.Single(itemService.Added);
@@ -476,6 +491,25 @@ namespace InventoryManagementApp.Tests
             public Task<List<Rental>> GetAllRentalsAsync() => Task.FromResult(new List<Rental>());
             public Task<List<Rental>> GetRentalHistoryForItemAsync(int itemID) => Task.FromResult(new List<Rental>());
             public Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID) => Task.FromResult(new List<Rental>());
+        }
+
+        private sealed class DummySettingsService : ISettingsService
+        {
+            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
         }
 
         private sealed class RecordingDialogService : IDialogService

--- a/InventoryManagementApp/Data/SortOption.cs
+++ b/InventoryManagementApp/Data/SortOption.cs
@@ -1,0 +1,3 @@
+namespace InventoryManagementApp.Data;
+
+public readonly record struct SortOption(SortField Field, SortDirection Direction, string DisplayName);

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -20,11 +20,11 @@ namespace InventoryManagementApp.ViewModels
         private readonly MemoryBudget _memoryBudget;
         private readonly IDialogService _dialogService;
         private readonly IRentalService _rentalService;
+        private readonly ISettingsService _settingsService;
         private CancellationTokenSource _filterCts = new();
         private bool _disposed;
         private readonly List<ItemModel> _pendingEdits = new();
 
-        private const int PageSize = 200;
         public IncrementalLoadingCollection<ItemModel> Items { get; }
 
         public IAsyncRelayCommand EditItemCommand { get; }
@@ -42,18 +42,53 @@ namespace InventoryManagementApp.ViewModels
         private string filter = string.Empty;
 
         [ObservableProperty]
-        private SortField sortField = SortField.Name;
+        private SortOption selectedSortOption;
 
         [ObservableProperty]
-        private SortDirection sortDirection = SortDirection.Ascending;
+        private int pageSize = 200;
 
-        public ItemsViewModel(IItemService itemService, MemoryBudget memoryBudget, IDialogService dialogService, IRentalService rentalService)
+        public ObservableCollection<SortOption> SortOptions { get; }
+
+        public ItemsViewModel(IItemService itemService, MemoryBudget memoryBudget, IDialogService dialogService, IRentalService rentalService, ISettingsService settingsService)
         {
             _itemService = itemService;
             _memoryBudget = memoryBudget;
             _dialogService = dialogService;
             _rentalService = rentalService;
+            _settingsService = settingsService;
             Items = new IncrementalLoadingCollection<ItemModel>(LoadPageAsync, PageSize);
+            SortOptions = new ObservableCollection<SortOption>(new[]
+            {
+                new SortOption(SortField.Name, SortDirection.Ascending, "Name Asc"),
+                new SortOption(SortField.Name, SortDirection.Descending, "Name Desc"),
+                new SortOption(SortField.ItemNumber, SortDirection.Ascending, "Number Asc"),
+                new SortOption(SortField.ItemNumber, SortDirection.Descending, "Number Desc"),
+                new SortOption(SortField.QuantityOnHand, SortDirection.Ascending, "Qty Asc"),
+                new SortOption(SortField.QuantityOnHand, SortDirection.Descending, "Qty Desc"),
+                new SortOption(SortField.UpdatedAt, SortDirection.Ascending, "Updated Asc"),
+                new SortOption(SortField.UpdatedAt, SortDirection.Descending, "Updated Desc")
+            });
+            selectedSortOption = SortOptions[0];
+            var psSetting = _settingsService.GetSettingAsync("PageSize").GetAwaiter().GetResult();
+            if (int.TryParse(psSetting, out var ps) && ps > 0)
+            {
+                pageSize = ps;
+                Items.PageSize = ps;
+            }
+            var filterSetting = _settingsService.GetSettingAsync("LastFilter").GetAwaiter().GetResult();
+            if (!string.IsNullOrEmpty(filterSetting))
+                filter = filterSetting;
+            var sortSetting = _settingsService.GetSettingAsync("LastSort").GetAwaiter().GetResult();
+            if (!string.IsNullOrEmpty(sortSetting))
+            {
+                var parts = sortSetting.Split('|');
+                if (parts.Length == 2 && Enum.TryParse(parts[0], out SortField sf) && Enum.TryParse(parts[1], out SortDirection sd))
+                {
+                    var opt = SortOptions.FirstOrDefault(o => o.Field == sf && o.Direction == sd);
+                    if (opt != default)
+                        selectedSortOption = opt;
+                }
+            }
             _memoryBudget.ThresholdExceeded += OnThresholdExceeded;
 
             EditItemCommand = new AsyncRelayCommand(ct => EditItemAsync(ct));
@@ -68,8 +103,8 @@ namespace InventoryManagementApp.ViewModels
             var result = new List<ItemModel>();
             var pageInfo = new ItemPage(page, PageSize);
             var source = string.IsNullOrWhiteSpace(Filter)
-                ? _itemService.GetItemsAsync(pageInfo, SortField, SortDirection, ct)
-                : _itemService.SearchItemsAsync(Filter, pageInfo, SortField, SortDirection, ct);
+                ? _itemService.GetItemsAsync(pageInfo, SelectedSortOption.Field, SelectedSortOption.Direction, ct)
+                : _itemService.SearchItemsAsync(Filter, pageInfo, SelectedSortOption.Field, SelectedSortOption.Direction, ct);
             await foreach (var item in source.ConfigureAwait(false))
             {
                 item.PropertyChanged += Item_PropertyChanged;
@@ -100,9 +135,30 @@ namespace InventoryManagementApp.ViewModels
             }
             Items.Reset();
             await Items.LoadMoreAsync(token).ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync("LastFilter", Filter, token).ConfigureAwait(false);
         }
 
         private void OnThresholdExceeded(object? sender, EventArgs e) => Items.TrimToWindow(PageSize * 3);
+
+        partial void OnSelectedSortOptionChanged(SortOption value) => _ = ApplySortAsync(value);
+
+        private async Task ApplySortAsync(SortOption value)
+        {
+            Items.Reset();
+            await Items.LoadMoreAsync().ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync("LastSort", $"{value.Field}|{value.Direction}").ConfigureAwait(false);
+        }
+
+        partial void OnPageSizeChanged(int value) => _ = ApplyPageSizeAsync(value);
+
+        private async Task ApplyPageSizeAsync(int value)
+        {
+            Items.PageSize = value;
+            Items.TrimToWindow(value * 3);
+            Items.Reset();
+            await Items.LoadMoreAsync().ConfigureAwait(false);
+            await _settingsService.SaveSettingAsync("PageSize", value.ToString()).ConfigureAwait(false);
+        }
 
         private void Item_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
@@ -283,10 +339,16 @@ namespace InventoryManagementApp.ViewModels
     public class IncrementalLoadingCollection<T> : ObservableCollection<T>
     {
         private readonly Func<int, CancellationToken, Task<IList<T>>> _loader;
-        private readonly int _pageSize;
+        private int _pageSize;
         private int _page;
         private readonly SemaphoreSlim _gate = new(1, 1);
         public bool HasMoreItems { get; private set; } = true;
+
+        public int PageSize
+        {
+            get => _pageSize;
+            set => _pageSize = value;
+        }
 
         public IncrementalLoadingCollection(Func<int, CancellationToken, Task<IList<T>>> loader, int pageSize)
         {

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -13,10 +13,16 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <TextBlock
-                    Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}"
-                    Style="{StaticResource SubheadingTextBlock}"
-                    Margin="0,0,0,8"/>
+                <StackPanel Margin="0,0,0,8">
+                    <TextBlock
+                        Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}"
+                        Style="{StaticResource SubheadingTextBlock}"/>
+                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                        <TextBox Width="200" Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged}"/>
+                        <ComboBox Width="180" ItemsSource="{Binding SortOptions}" SelectedItem="{Binding SelectedSortOption}" DisplayMemberPath="DisplayName" Margin="8,0,0,0"/>
+                        <TextBox Width="60" Text="{Binding PageSize, UpdateSourceTrigger=PropertyChanged}" Margin="8,0,0,0"/>
+                    </StackPanel>
+                </StackPanel>
 
                 <DataGrid Grid.Row="1"
                           ItemsSource="{Binding Items}"


### PR DESCRIPTION
## Summary
- load and persist page size, filter, and sort settings using `ISettingsService`
- provide sort option collection and bind filter, sort, and page size controls in UI
- allow dynamic page size updates that reset loader and trim page window

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a980ba5f8c8324b47c392d5e977a91