### PR TITLE
Show loading indicator and free row thumbnails

### DIFF
--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -129,6 +129,21 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task IncrementalCollectionTracksLoadingState()
+        {
+            var service = new RecordingItemService(new Dictionary<string, List<ItemModel>>(), new List<ItemModel> { new ItemModel { ItemID = 1 } });
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
+            var settings = new DummySettingsService();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
+            var loadTask = vm.LoadMoreAsync();
+            Assert.True(vm.Items.IsLoading);
+            await loadTask;
+            Assert.False(vm.Items.IsLoading);
+        }
+
+        [Fact]
         public void DisposeCanBeCalledMultipleTimesAndCancelsToken()
         {
             var service = new DummyItemService();

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -343,6 +343,18 @@ namespace InventoryManagementApp.ViewModels
         private int _page;
         private readonly SemaphoreSlim _gate = new(1, 1);
         public bool HasMoreItems { get; private set; } = true;
+        private bool _isLoading;
+
+        public bool IsLoading
+        {
+            get => _isLoading;
+            private set
+            {
+                if (_isLoading == value) return;
+                _isLoading = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(IsLoading)));
+            }
+        }
 
         public int PageSize
         {
@@ -362,6 +374,7 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 if (!HasMoreItems) return;
+                IsLoading = true;
                 var next = _page + 1;
                 var items = await _loader(next, ct).ConfigureAwait(false);
                 foreach (var item in items)
@@ -372,6 +385,7 @@ namespace InventoryManagementApp.ViewModels
             }
             finally
             {
+                IsLoading = false;
                 _gate.Release();
             }
         }

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -11,6 +11,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
                 <StackPanel Margin="0,0,0,8">
@@ -24,46 +25,71 @@
                     </StackPanel>
                 </StackPanel>
 
-                <DataGrid Grid.Row="1"
-                          ItemsSource="{Binding Items}"
-                          SelectedItem="{Binding SelectedItem}"
-                          IsReadOnly="False"
-                          AutoGenerateColumns="False"
-                          EnableColumnVirtualization="True"
-                          Background="{StaticResource SurfaceBrush}"
-                          BorderBrush="{StaticResource BorderBrushAlt}"
-                          Style="{StaticResource VirtualizedDataGridStyle}">
-                    <DataGrid.RowStyle>
-                        <Style TargetType="DataGridRow">
-                            <EventSetter Event="PreviewMouseRightButtonDown"
-                                         Handler="DataGridRow_PreviewMouseRightButtonDown"/>
-                        </Style>
-                    </DataGrid.RowStyle>
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Number" Binding="{Binding ItemNumber, Mode=OneWay}" Width="140"/>
-                        <DataGridTextColumn Header="Name" Binding="{Binding Name, Mode=OneWay}" Width="280"/>
-                        <DataGridTextColumn Header="Brand" Binding="{Binding Brand, Mode=OneWay}" Width="160"/>
-                        <DataGridTextColumn Header="Qty" Binding="{Binding QuantityOnHand, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100"/>
-                        <DataGridTextColumn Header="Location" Binding="{Binding Location, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="180"/>
-                        <DataGridTextColumn Header="Price" Binding="{Binding Price, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="120"/>
-                    </DataGrid.Columns>
-                    <DataGrid.ContextMenu>
-                        <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
-                                    DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                            <MenuItem
-                                Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}"
-                                HeaderStringFormat="Rent {0}"
-                                Command="{Binding OpenRentalsCommand}"/>
-                            <MenuItem Header="Delete"
-                                      Command="{Binding PlacementTarget.DataContext.DeleteItemsCommand,
-                                                        RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                                      CommandParameter="{Binding PlacementTarget.SelectedItems,
-                                                        RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                        </ContextMenu>
-                    </DataGrid.ContextMenu>
-                </DataGrid>
+                <Grid Grid.Row="1">
+                    <DataGrid ItemsSource="{Binding Items}"
+                              SelectedItem="{Binding SelectedItem}"
+                              IsReadOnly="False"
+                              AutoGenerateColumns="False"
+                              EnableColumnVirtualization="True"
+                              Background="{StaticResource SurfaceBrush}"
+                              BorderBrush="{StaticResource BorderBrushAlt}"
+                              Style="{StaticResource VirtualizedDataGridStyle}">
+                        <DataGrid.RowStyle>
+                            <Style TargetType="DataGridRow">
+                                <EventSetter Event="PreviewMouseRightButtonDown"
+                                             Handler="DataGridRow_PreviewMouseRightButtonDown"/>
+                                <EventSetter Event="DataContextChanged"
+                                             Handler="DataGridRow_ContainerContentChanging"/>
+                            </Style>
+                        </DataGrid.RowStyle>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Number" Binding="{Binding ItemNumber, Mode=OneWay}" Width="140"/>
+                            <DataGridTextColumn Header="Name" Binding="{Binding Name, Mode=OneWay}" Width="280"/>
+                            <DataGridTextColumn Header="Brand" Binding="{Binding Brand, Mode=OneWay}" Width="160"/>
+                            <DataGridTextColumn Header="Qty" Binding="{Binding QuantityOnHand, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100"/>
+                            <DataGridTextColumn Header="Location" Binding="{Binding Location, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="180"/>
+                            <DataGridTextColumn Header="Price" Binding="{Binding Price, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="120"/>
+                        </DataGrid.Columns>
+                        <DataGrid.ContextMenu>
+                            <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
+                                        DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                <MenuItem
+                                    Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}"
+                                    HeaderStringFormat="Rent {0}"
+                                    Command="{Binding OpenRentalsCommand}"/>
+                                <MenuItem Header="Delete"
+                                          Command="{Binding PlacementTarget.DataContext.DeleteItemsCommand,
+                                                            RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                          CommandParameter="{Binding PlacementTarget.SelectedItems,
+                                                            RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                    </DataGrid>
+                    <TextBlock Text="No results"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"
+                               FontSize="16"
+                               FontWeight="SemiBold">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Items.Count}" Value="0">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Grid>
 
-                <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+                <ProgressBar Grid.Row="2"
+                             IsIndeterminate="True"
+                             Height="4"
+                             Margin="0,8,0,0"
+                             Visibility="{Binding Items.IsLoading, Converter={StaticResource BoolToVis}}"/>
+
+                <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
                     <Button
                         Style="{StaticResource PrimaryButton}"
                         Content="Edit"

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
@@ -1,6 +1,8 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using InventoryManagementApp.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Application = System.Windows.Application;
@@ -25,6 +27,32 @@ namespace InventoryManagementApp.Views.Pages
                 }
                 e.Handled = true;
             }
+        }
+
+        private void DataGridRow_ContainerContentChanging(object? sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (sender is not DataGridRow row) return;
+            var img = FindVisualChild<Image>(row);
+            if (img?.Source is BitmapImage bmp)
+            {
+                bmp.StreamSource?.Dispose();
+            }
+            if (img != null)
+                img.Source = null;
+        }
+
+        private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+        {
+            for (var i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                if (child is T result)
+                    return result;
+                var descendant = FindVisualChild<T>(child);
+                if (descendant != null)
+                    return descendant;
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- display progress bar row and 'No results' overlay on ManageItemsPage
- clear recycled row thumbnails via ContainerContentChanging handler
- expose IsLoading on IncrementalLoadingCollection with unit test

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a9853ee0648324a76acebc951988cf