### PR TITLE
Add dual-threshold memory budget with view-model cache policies

### DIFF
--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -26,7 +26,7 @@ namespace InventoryManagementApp.Tests
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
             var settings = new DummySettingsService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
 
             Assert.NotNull(vm.EditItemCommand);
@@ -47,6 +47,45 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void SteadyExceeded_TrimsToThreePages()
+        {
+            var service = new DummyItemService();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
+            var settings = new DummySettingsService();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
+            var pageField = typeof(ItemsViewModel).GetField("pageSize", BindingFlags.NonPublic | BindingFlags.Instance);
+            pageField!.SetValue(vm, 2);
+            vm.Items.PageSize = 2;
+            for (int i = 0; i < 10; i++)
+                vm.Items.Add(new ItemModel { ItemID = i });
+            var method = typeof(ItemsViewModel).GetMethod("OnSteadyExceeded", BindingFlags.NonPublic | BindingFlags.Instance);
+            method!.Invoke(vm, new object?[] { null, EventArgs.Empty });
+            Assert.Equal(6, vm.Items.Count);
+            Assert.Equal(4, vm.Items[0].ItemID);
+        }
+
+        [Fact]
+        public void PeakExceeded_ClearsItems()
+        {
+            var service = new DummyItemService();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
+            var settings = new DummySettingsService();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
+            var pageField = typeof(ItemsViewModel).GetField("pageSize", BindingFlags.NonPublic | BindingFlags.Instance);
+            pageField!.SetValue(vm, 2);
+            vm.Items.PageSize = 2;
+            vm.Items.Add(new ItemModel { ItemID = 1 });
+            vm.Items.Add(new ItemModel { ItemID = 2 });
+            var method = typeof(ItemsViewModel).GetMethod("OnPeakExceeded", BindingFlags.NonPublic | BindingFlags.Instance);
+            method!.Invoke(vm, new object?[] { null, EventArgs.Empty });
+            Assert.Empty(vm.Items);
+        }
+
+        [Fact]
         public async Task RapidFilterChangesOnlyLoadsLastRequest()
         {
             var data = new Dictionary<string, List<ItemModel>>
@@ -59,7 +98,7 @@ namespace InventoryManagementApp.Tests
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
             var settings = new DummySettingsService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
 
             vm.Filter = "first";
@@ -87,7 +126,7 @@ namespace InventoryManagementApp.Tests
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
             var settings = new DummySettingsService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
 
             await vm.LoadMoreAsync();
@@ -111,7 +150,7 @@ namespace InventoryManagementApp.Tests
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
             var settings = new DummySettingsService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
 
             var tasks = new[]
@@ -135,7 +174,7 @@ namespace InventoryManagementApp.Tests
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
             var settings = new DummySettingsService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
             var loadTask = vm.LoadMoreAsync();
             Assert.True(vm.Items.IsLoading);
@@ -149,7 +188,7 @@ namespace InventoryManagementApp.Tests
             var service = new DummyItemService();
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
             var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
             vm.Items.Add(new ItemModel { ItemID = 1 });
@@ -170,7 +209,7 @@ namespace InventoryManagementApp.Tests
             var service = new StaticItemService(item);
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
             using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
             await vm.LoadMoreAsync();
@@ -188,7 +227,7 @@ namespace InventoryManagementApp.Tests
             var service = new StaticItemService(item, repository);
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
             using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
             await vm.LoadMoreAsync();
@@ -206,7 +245,7 @@ namespace InventoryManagementApp.Tests
             var dialog = new RecordingDialogService { EditItemDialogResult = new ItemModel { ItemID = 1 } };
             var itemService = new RecordingItemService2();
             var rental = new DummyRentalService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
             using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings);
             vm.SelectedItem = item;
@@ -222,7 +261,7 @@ namespace InventoryManagementApp.Tests
             var dialog = new RecordingDialogService { EditItemDialogResult = new ItemModel { ItemID = 1 } };
             var itemService = new RecordingItemService2 { UpdateException = new OperationCanceledException() };
             var rental = new DummyRentalService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
             using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings);
             vm.SelectedItem = item;
@@ -237,7 +276,7 @@ namespace InventoryManagementApp.Tests
             var dialog = new RecordingDialogService();
             var itemService = new DummyItemService();
             var rental = new DummyRentalService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
             using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings);
             vm.SelectedItem = new ItemModel();
@@ -251,7 +290,7 @@ namespace InventoryManagementApp.Tests
             var dialog = new RecordingDialogService { DetailsException = new InvalidOperationException() };
             var itemService = new DummyItemService();
             var rental = new DummyRentalService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
             using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings);
             vm.SelectedItem = new ItemModel();
@@ -266,7 +305,7 @@ namespace InventoryManagementApp.Tests
             var dialog = new RecordingDialogService();
             var rentalService = new RecordingRentalService();
             var itemService = new DummyItemService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
             using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rentalService, settings);
             vm.SelectedItem = item;
@@ -282,7 +321,7 @@ namespace InventoryManagementApp.Tests
             var dialog = new RecordingDialogService();
             var rentalService = new RecordingRentalService { HistoryException = new OperationCanceledException() };
             var itemService = new DummyItemService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
             using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rentalService, settings);
             vm.SelectedItem = item;
@@ -297,7 +336,7 @@ namespace InventoryManagementApp.Tests
             var dialog = new RecordingDialogService { EditItemDialogResult = new ItemModel { ItemID = 2 } };
             var itemService = new RecordingItemService2();
             var rental = new DummyRentalService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
             using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings);
             await vm.NewItemCommand.ExecuteAsync(null);
@@ -311,7 +350,7 @@ namespace InventoryManagementApp.Tests
             var dialog = new RecordingDialogService { EditItemDialogResult = new ItemModel { ItemID = 2 } };
             var itemService = new RecordingItemService2 { AddException = new OperationCanceledException() };
             var rental = new DummyRentalService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
             using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings);
             await vm.NewItemCommand.ExecuteAsync(null);

--- a/InventoryManagementApp.Tests/MemoryBudgetTests.cs
+++ b/InventoryManagementApp.Tests/MemoryBudgetTests.cs
@@ -6,11 +6,21 @@ using Xunit;
 public class MemoryBudgetTests
 {
     [Fact]
-    public async Task ThresholdExceeded_IsRaised_WhenMemoryAboveThreshold()
+    public async Task SteadyExceeded_IsRaised_WhenMemoryAboveSteadyThreshold()
     {
-        using var budget = new MemoryBudget(TimeSpan.FromMilliseconds(50), 0);
+        using var budget = new MemoryBudget(TimeSpan.FromMilliseconds(50), 0, long.MaxValue);
         var tcs = new TaskCompletionSource();
-        budget.ThresholdExceeded += (s, e) => tcs.TrySetResult();
+        budget.SteadyExceeded += (s, e) => tcs.TrySetResult();
+        await Task.WhenAny(tcs.Task, Task.Delay(1000));
+        Assert.True(tcs.Task.IsCompleted);
+    }
+
+    [Fact]
+    public async Task PeakExceeded_IsRaised_WhenMemoryAbovePeakThreshold()
+    {
+        using var budget = new MemoryBudget(TimeSpan.FromMilliseconds(50), 0, 0);
+        var tcs = new TaskCompletionSource();
+        budget.PeakExceeded += (s, e) => tcs.TrySetResult();
         await Task.WhenAny(tcs.Task, Task.Delay(1000));
         Assert.True(tcs.Task.IsCompleted);
     }

--- a/InventoryManagementApp/Utilities/MemoryBudget.cs
+++ b/InventoryManagementApp/Utilities/MemoryBudget.cs
@@ -7,27 +7,34 @@ namespace InventoryManagementApp.Utilities
     public sealed class MemoryBudget : IDisposable
     {
         private readonly Timer _timer;
-        private readonly long _thresholdBytes;
+        private readonly long _steadyThresholdBytes;
+        private readonly long _peakThresholdBytes;
 
-        public event EventHandler? ThresholdExceeded;
+        public event EventHandler? SteadyExceeded;
+        public event EventHandler? PeakExceeded;
 
         public MemoryBudget()
-            : this(TimeSpan.FromSeconds(5), 600L * 1024 * 1024)
+            : this(TimeSpan.FromSeconds(5), 400L * 1024 * 1024, 800L * 1024 * 1024)
         {
         }
 
-        public MemoryBudget(TimeSpan interval, long thresholdBytes)
+        public MemoryBudget(TimeSpan interval, long steadyThresholdBytes, long peakThresholdBytes)
         {
-            _thresholdBytes = thresholdBytes;
+            _steadyThresholdBytes = steadyThresholdBytes;
+            _peakThresholdBytes = peakThresholdBytes;
             _timer = new Timer(CheckMemory, null, interval, interval);
         }
 
         private void CheckMemory(object? state)
         {
             var total = GC.GetTotalMemory(false);
-            if (total > _thresholdBytes)
+            if (total > _peakThresholdBytes)
             {
-                ThresholdExceeded?.Invoke(this, EventArgs.Empty);
+                PeakExceeded?.Invoke(this, EventArgs.Empty);
+            }
+            else if (total > _steadyThresholdBytes)
+            {
+                SteadyExceeded?.Invoke(this, EventArgs.Empty);
             }
         }
 

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -89,7 +89,8 @@ namespace InventoryManagementApp.ViewModels
                         selectedSortOption = opt;
                 }
             }
-            _memoryBudget.ThresholdExceeded += OnThresholdExceeded;
+            _memoryBudget.SteadyExceeded += OnSteadyExceeded;
+            _memoryBudget.PeakExceeded += OnPeakExceeded;
 
             EditItemCommand = new AsyncRelayCommand(ct => EditItemAsync(ct));
             ViewDetailsCommand = new RelayCommand(ViewDetails);
@@ -138,7 +139,9 @@ namespace InventoryManagementApp.ViewModels
             await _settingsService.SaveSettingAsync("LastFilter", Filter, token).ConfigureAwait(false);
         }
 
-        private void OnThresholdExceeded(object? sender, EventArgs e) => Items.TrimToWindow(PageSize * 3);
+        private void OnSteadyExceeded(object? sender, EventArgs e) => Items.TrimToWindow(PageSize * 3);
+
+        private void OnPeakExceeded(object? sender, EventArgs e) => Items.Reset();
 
         partial void OnSelectedSortOptionChanged(SortOption value) => _ = ApplySortAsync(value);
 
@@ -327,7 +330,8 @@ namespace InventoryManagementApp.ViewModels
         {
             if (_disposed) return;
             _disposed = true;
-            _memoryBudget.ThresholdExceeded -= OnThresholdExceeded;
+            _memoryBudget.SteadyExceeded -= OnSteadyExceeded;
+            _memoryBudget.PeakExceeded -= OnPeakExceeded;
             foreach (var item in Items)
                 item.PropertyChanged -= Item_PropertyChanged;
             Items.Reset();


### PR DESCRIPTION
## Summary
- Support steady and peak thresholds in MemoryBudget with separate events
- Handle new MemoryBudget events in ItemsViewModel to trim or clear cached pages
- Extend unit tests for new memory budget behavior and view-model reactions

## Testing
- `dotnet test` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed/403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a98aae27bc8324b65e31bf62955773