### PR TITLE
Add Serilog debug sink and startup logging test

### DIFF
--- a/InventoryManagementApp.Tests/AppLoggingTests.cs
+++ b/InventoryManagementApp.Tests/AppLoggingTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using InventoryManagementApp;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Xunit;
+
+public class AppLoggingTests
+{
+    [Fact]
+    public async Task BuildHost_LogsToDebugAndFile()
+    {
+        using var debugWriter = new StringWriter();
+        var listener = new TextWriterTraceListener(debugWriter);
+        Debug.Listeners.Add(listener);
+        try
+        {
+            var method = typeof(App).GetMethod("BuildHost", BindingFlags.Static | BindingFlags.NonPublic);
+            var host = (IHost)method!.Invoke(null, null)!;
+            await host.StartAsync();
+
+            var logger = host.Services.GetRequiredService<ILogger<App>>();
+            var message = $"Test log {Guid.NewGuid()}";
+            logger.LogInformation(message);
+
+            await host.StopAsync();
+            host.Dispose();
+            Log.CloseAndFlush();
+            Debug.Flush();
+
+            Assert.Contains(message, debugWriter.ToString());
+
+            var logsDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Logs");
+            var logFile = Directory.GetFiles(logsDir, "app-*.log").OrderBy(f => f).Last();
+            var fileContent = File.ReadAllText(logFile);
+            Assert.Contains(message, fileContent);
+        }
+        finally
+        {
+            Debug.Listeners.Remove(listener);
+        }
+    }
+}
+

--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -61,6 +61,7 @@ namespace InventoryManagementApp
                     .MinimumLevel.Debug()
                     .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
                     .Enrich.FromLogContext()
+                    .WriteTo.Debug()
                     .WriteTo.Async(w => w.File(
                         path: logFile,
                         rollingInterval: RollingInterval.Day,

--- a/InventoryManagementApp/InventoryManagementApp.csproj
+++ b/InventoryManagementApp/InventoryManagementApp.csproj
@@ -114,6 +114,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />


### PR DESCRIPTION
## Summary
- log to Debug output alongside rolling files via Serilog
- add Serilog.Sinks.Debug package
- test startup logging captures both Debug and file outputs

## Testing
- ⚠️ `dotnet test` *(dotnet: command not found)*
- ⚠️ `apt-get update` *(403  Forbidden for package repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68a98ba416b4832496d905ecddfff864