### PR TITLE
Attach DataGridRow DataContext handlers on load/unload

### DIFF
--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -38,8 +38,10 @@
                             <Style TargetType="DataGridRow">
                                 <EventSetter Event="PreviewMouseRightButtonDown"
                                              Handler="DataGridRow_PreviewMouseRightButtonDown"/>
-                                <EventSetter Event="DataContextChanged"
-                                             Handler="DataGridRow_ContainerContentChanging"/>
+                                <EventSetter Event="Loaded"
+                                             Handler="DataGridRow_Loaded"/>
+                                <EventSetter Event="Unloaded"
+                                             Handler="DataGridRow_Unloaded"/>
                             </Style>
                         </DataGrid.RowStyle>
                         <DataGrid.Columns>

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
@@ -29,9 +29,33 @@ namespace InventoryManagementApp.Views.Pages
             }
         }
 
-        private void DataGridRow_ContainerContentChanging(object? sender, DependencyPropertyChangedEventArgs e)
+        private void DataGridRow_Loaded(object sender, RoutedEventArgs e)
         {
-            if (sender is not DataGridRow row) return;
+            if (sender is DataGridRow row)
+            {
+                row.DataContextChanged += DataGridRow_DataContextChanged;
+            }
+        }
+
+        private void DataGridRow_Unloaded(object sender, RoutedEventArgs e)
+        {
+            if (sender is DataGridRow row)
+            {
+                row.DataContextChanged -= DataGridRow_DataContextChanged;
+                ReleaseRowImage(row);
+            }
+        }
+
+        private void DataGridRow_DataContextChanged(object? sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (sender is DataGridRow row)
+            {
+                ReleaseRowImage(row);
+            }
+        }
+
+        private static void ReleaseRowImage(DataGridRow row)
+        {
             var img = FindVisualChild<Image>(row);
             if (img?.Source is BitmapImage bmp)
             {


### PR DESCRIPTION
## Summary
- Replace DataContextChanged EventSetter with Loaded/Unloaded to manage DataGridRow lifecycle
- Subscribe/unsubscribe DataContextChanged in code-behind and release images on unload

## Testing
- `dotnet test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a98d2427208324a91b8d61fb841041