### PR TITLE
Add explicit Image alias in ManageItemsPage

### DIFF
--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using InventoryManagementApp.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
+using Image = System.Windows.Controls.Image;
 using Application = System.Windows.Application;
 
 namespace InventoryManagementApp.Views.Pages


### PR DESCRIPTION
## Summary
- use explicit alias for Image control in ManageItemsPage.xaml.cs to ensure correct type resolution

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a98e8060b4832495b1a833bffc2d11