### PR TITLE
Use SqliteError enum

### DIFF
--- a/InventoryManagementApp/Services/Settings/SettingsService.cs
+++ b/InventoryManagementApp/Services/Settings/SettingsService.cs
@@ -49,7 +49,7 @@ namespace InventoryManagementApp.Services.Settings
                 _logger.LogWarning(ex, "Saving setting {Key} canceled or timed out", key);
                 throw;
             }
-            catch (SqliteException ex) when ((SqliteErrorCode)ex.SqliteErrorCode == SqliteErrorCode.Busy)
+            catch (SqliteException ex) when (ex.SqliteErrorCode == (int)SqliteError.Busy)
             {
                 _logger.LogWarning(ex, "Saving setting {Key} timed out", key);
                 throw;
@@ -76,7 +76,7 @@ namespace InventoryManagementApp.Services.Settings
                 _logger.LogWarning(ex, "Retrieving setting {Key} canceled or timed out", key);
                 throw;
             }
-            catch (SqliteException ex) when ((SqliteErrorCode)ex.SqliteErrorCode == SqliteErrorCode.Busy)
+            catch (SqliteException ex) when (ex.SqliteErrorCode == (int)SqliteError.Busy)
             {
                 _logger.LogWarning(ex, "Retrieving setting {Key} timed out", key);
                 throw;
@@ -106,7 +106,7 @@ namespace InventoryManagementApp.Services.Settings
                 _logger.LogWarning(ex, "Retrieving all settings canceled or timed out");
                 throw;
             }
-            catch (SqliteException ex) when ((SqliteErrorCode)ex.SqliteErrorCode == SqliteErrorCode.Busy)
+            catch (SqliteException ex) when (ex.SqliteErrorCode == (int)SqliteError.Busy)
             {
                 _logger.LogWarning(ex, "Retrieving all settings timed out");
                 throw;
@@ -161,7 +161,7 @@ namespace InventoryManagementApp.Services.Settings
                 _logger.LogWarning(ex, "Updating settings canceled or timed out");
                 throw;
             }
-            catch (SqliteException ex) when ((SqliteErrorCode)ex.SqliteErrorCode == SqliteErrorCode.Busy)
+            catch (SqliteException ex) when (ex.SqliteErrorCode == (int)SqliteError.Busy)
             {
                 tx.Rollback();
                 _logger.LogWarning(ex, "Updating settings timed out");
@@ -192,7 +192,7 @@ namespace InventoryManagementApp.Services.Settings
                 _logger.LogWarning(ex, "Deleting setting {Key} canceled or timed out", key);
                 throw;
             }
-            catch (SqliteException ex) when ((SqliteErrorCode)ex.SqliteErrorCode == SqliteErrorCode.Busy)
+            catch (SqliteException ex) when (ex.SqliteErrorCode == (int)SqliteError.Busy)
             {
                 _logger.LogWarning(ex, "Deleting setting {Key} timed out", key);
                 throw;

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -46,7 +46,7 @@ namespace InventoryManagementApp.Services.Users
                 _logger.LogWarning(ex, "Logging action {Action} canceled or timed out", action);
                 return new Result(false, "Operation canceled");
             }
-            catch (SqliteException ex) when ((SqliteErrorCode)ex.SqliteErrorCode == SqliteErrorCode.Busy)
+            catch (SqliteException ex) when (ex.SqliteErrorCode == (int)SqliteError.Busy)
             {
                 _logger.LogWarning(ex, "Logging action {Action} timed out", action);
                 return new Result(false, ex.Message);
@@ -76,7 +76,7 @@ namespace InventoryManagementApp.Services.Users
                 _logger.LogWarning(ex, "Retrieving recent activity logs canceled or timed out");
                 return new Result<List<ActivityLog>>(null, false, "Operation canceled");
             }
-            catch (SqliteException ex) when ((SqliteErrorCode)ex.SqliteErrorCode == SqliteErrorCode.Busy)
+            catch (SqliteException ex) when (ex.SqliteErrorCode == (int)SqliteError.Busy)
             {
                 _logger.LogWarning(ex, "Retrieving recent activity logs timed out");
                 return new Result<List<ActivityLog>>(null, false, ex.Message);
@@ -105,7 +105,7 @@ namespace InventoryManagementApp.Services.Users
                 _logger.LogWarning(ex, "Purging logs prior to {Threshold} canceled or timed out", threshold);
                 return new Result(false, "Operation canceled");
             }
-            catch (SqliteException ex) when ((SqliteErrorCode)ex.SqliteErrorCode == SqliteErrorCode.Busy)
+            catch (SqliteException ex) when (ex.SqliteErrorCode == (int)SqliteError.Busy)
             {
                 _logger.LogWarning(ex, "Purging logs prior to {Threshold} timed out", threshold);
                 return new Result(false, ex.Message);

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -228,7 +228,7 @@ namespace InventoryManagementApp.Services.Users
             {
                 user.UserID = Convert.ToInt32(await cmd.ExecuteScalarAsync());
             }
-            catch (SqliteException ex) when ((SqliteErrorCode)ex.SqliteErrorCode == SqliteErrorCode.Constraint &&
+            catch (SqliteException ex) when (ex.SqliteErrorCode == (int)SqliteError.Constraint &&
                                              ex.Message.Contains("Users.UserName", StringComparison.OrdinalIgnoreCase))
             {
                 throw new InvalidOperationException("A user with the same username already exists.", ex);


### PR DESCRIPTION
## Summary
- replace deprecated SqliteErrorCode comparisons with SqliteError enum checks
- ensure Microsoft.Data.Sqlite 9.0.8 is referenced

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9925e2f908324ad39342cec477942