### PR TITLE
Add null-safety checks across view models and services

### DIFF
--- a/InventoryManagementApp/Services/DialogService.cs
+++ b/InventoryManagementApp/Services/DialogService.cs
@@ -22,6 +22,7 @@ namespace InventoryManagementApp.Services
 
         public DialogService(IServiceProvider serviceProvider, ILogger<DialogService>? logger = null)
         {
+            ArgumentNullException.ThrowIfNull(serviceProvider);
             _serviceProvider = serviceProvider;
             _logger = logger ?? NullLogger<DialogService>.Instance;
         }
@@ -59,11 +60,12 @@ namespace InventoryManagementApp.Services
 
         public ItemModel? ShowEditItemDialog(ItemModel item)
         {
+            ArgumentNullException.ThrowIfNull(item);
             ItemEditWindow? win = null;
             win = ActivatorUtilities.CreateInstance<ItemEditWindow>(_serviceProvider,
                 item,
-                (Action)(() => win!.DialogResult = true),
-                (Action)(() => win!.DialogResult = false));
+                (Action)(() => { if (win != null) win.DialogResult = true; }),
+                (Action)(() => { if (win != null) win.DialogResult = false; }));
             try { win.Owner = System.Windows.Application.Current?.MainWindow; }
             catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for ItemEditWindow"); }
             try { return win.ShowDialog() == true ? item : null; }
@@ -72,6 +74,7 @@ namespace InventoryManagementApp.Services
 
         public Task<ItemModel?> ShowEditItemDialogAsync(ItemModel item)
         {
+            ArgumentNullException.ThrowIfNull(item);
             var dispatcher = System.Windows.Application.Current?.Dispatcher;
             if (dispatcher != null)
                 return dispatcher.InvokeAsync(() => ShowEditItemDialog(item)).Task;
@@ -82,8 +85,8 @@ namespace InventoryManagementApp.Services
 
         public void ShowItemDetails(ItemModel item)
         {
-            ItemDetailsWindow win = null!;
-            win = new ItemDetailsWindow(item);
+            ArgumentNullException.ThrowIfNull(item);
+            var win = new ItemDetailsWindow(item);
             try { win.Owner = System.Windows.Application.Current?.MainWindow; }
             catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for ItemDetailsWindow"); }
             try { win.ShowDialog(); }
@@ -92,11 +95,12 @@ namespace InventoryManagementApp.Services
 
         public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers)
         {
+            ArgumentNullException.ThrowIfNull(item);
+            ArgumentNullException.ThrowIfNull(customers);
             var vm = new RentItemPopupViewModel(item, customers);
             var win = new RentItemPopupWindow { DataContext = vm };
 
-            EventHandler handler = null!;
-            handler = (_, _) => win.Close();
+            EventHandler handler = (_, _) => win.Close();
             vm.RequestClose += handler;
 
             try
@@ -119,10 +123,10 @@ namespace InventoryManagementApp.Services
         public CustomerModel? ShowAddCustomerDialog()
         {
             var customer = new CustomerModel();
-            CustomerEditWindow win = null!;
+            CustomerEditWindow? win = null;
             win = new CustomerEditWindow(customer,
-                onSave: () => win.DialogResult = true,
-                onCancel: () => win.DialogResult = false);
+                onSave: () => { if (win != null) win.DialogResult = true; },
+                onCancel: () => { if (win != null) win.DialogResult = false; });
             try { win.Owner = System.Windows.Application.Current?.MainWindow; }
             catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for CustomerEditWindow"); }
             try { return win.ShowDialog() == true ? customer : null; }
@@ -140,6 +144,8 @@ namespace InventoryManagementApp.Services
 
         public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history)
         {
+            ArgumentNullException.ThrowIfNull(item);
+            ArgumentNullException.ThrowIfNull(history);
             var vm = new RentalHistoryViewModel(item, history, this);
             var win = new RentalHistoryWindow(vm) { Title = $"Rental History - {item.ItemNumber}" };
             try { win.Owner = System.Windows.Application.Current?.MainWindow; }
@@ -153,6 +159,8 @@ namespace InventoryManagementApp.Services
             IEnumerable<string> propertyNames,
             IEnumerable<string>? requiredPropertyNames = null)
         {
+            ArgumentNullException.ThrowIfNull(headers);
+            ArgumentNullException.ThrowIfNull(propertyNames);
             var win = CreateImportMappingWindow(headers, propertyNames, requiredPropertyNames);
             try { win.Owner = System.Windows.Application.Current?.MainWindow; }
             catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for ImportMappingWindow"); }
@@ -162,7 +170,7 @@ namespace InventoryManagementApp.Services
                 {
                     return win.VM.Mappings
                         .Where(m => !string.IsNullOrEmpty(m.SelectedColumn))
-                        .ToDictionary(m => m.PropertyName, m => m.SelectedColumn!);
+                        .ToDictionary(m => m.PropertyName, m => m.SelectedColumn ?? string.Empty);
                 }
             }
             catch (Exception ex) { _logger.LogError(ex, "Failed to show ImportMappingWindow"); }
@@ -186,6 +194,9 @@ namespace InventoryManagementApp.Services
 
         public void ShowPrintPreview(FlowDocument document, string title, string description)
         {
+            ArgumentNullException.ThrowIfNull(document);
+            ArgumentNullException.ThrowIfNull(title);
+            ArgumentNullException.ThrowIfNull(description);
             var win = new PrintPreviewWindow();
             try { win.Owner = System.Windows.Application.Current?.MainWindow; }
             catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for PrintPreviewWindow"); }

--- a/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
@@ -13,8 +13,8 @@ namespace InventoryManagementApp.ViewModels
 {
     public class CustomerManagementViewModel : ObservableObject
     {
-        private readonly ICustomerService _customerService;
-        private readonly IDialogService _dialogService;
+        private readonly ICustomerService? _customerService;
+        private readonly IDialogService? _dialogService;
 
         public ObservableCollection<CustomerModel> Customers { get; } = new();
 
@@ -84,14 +84,15 @@ namespace InventoryManagementApp.ViewModels
 
         public async Task LoadCustomersAsync()
         {
+            if (_customerService == null) return;
             var all = await _customerService.GetAllCustomersAsync();
             Customers.ReplaceRange(all);
         }
 
         async Task AddCustomerAsync()
         {
-            var customer = _dialogService.ShowAddCustomerDialog();
-            if (customer == null) return;
+            var customer = _dialogService?.ShowAddCustomerDialog();
+            if (customer == null || _customerService == null || _dialogService == null) return;
 
             try
             {
@@ -107,7 +108,7 @@ namespace InventoryManagementApp.ViewModels
 
         async Task UpdateCustomerAsync()
         {
-            if (SelectedCustomer == null) return;
+            if (SelectedCustomer == null || _customerService == null || _dialogService == null) return;
             var updated = new CustomerModel
             {
                 CustomerID = SelectedCustomer.CustomerID,
@@ -132,6 +133,7 @@ namespace InventoryManagementApp.ViewModels
 
         async Task SearchCustomersAsync()
         {
+            if (_customerService == null) return;
             var all = await _customerService.GetAllCustomersAsync();
             if (!string.IsNullOrWhiteSpace(CustomerSearchTerm))
             {
@@ -159,7 +161,7 @@ namespace InventoryManagementApp.ViewModels
 
         async Task DeleteCustomerAsync()
         {
-            if (SelectedCustomer == null)
+            if (SelectedCustomer == null || _customerService == null || _dialogService == null)
                 return;
 
             try

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -50,8 +50,8 @@ namespace InventoryManagementApp.ViewModels
             set => SetProperty(ref _searchTerm, value);
         }
 
-        private ItemModel _selectedItem;
-        public ItemModel SelectedItem
+        private ItemModel? _selectedItem;
+        public ItemModel? SelectedItem
         {
             get => _selectedItem;
             set
@@ -79,8 +79,8 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _selectedCategory, value))
                 {
-                    _searchCts.Cancel();
-                    _searchCts.Dispose();
+                    _searchCts?.Cancel();
+                    _searchCts?.Dispose();
                     _searchCts = new CancellationTokenSource();
                     SearchCommand.Execute(null);
                 }
@@ -96,7 +96,7 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand OpenRentalHistoryCommand { get; }
 
         readonly IDispatcherTimer _searchDebounceTimer;
-        CancellationTokenSource _searchCts = new();
+        CancellationTokenSource? _searchCts = new();
 
         bool _suppressItemsChanged;
         bool _disposed;
@@ -112,7 +112,7 @@ namespace InventoryManagementApp.ViewModels
                 if (SetProperty(ref _searchText, value))
                 {
                     SearchTerm = value;
-                    _searchCts.Cancel();
+                    _searchCts?.Cancel();
                     _searchDebounceTimer.Stop();
                     _searchDebounceTimer.Start();
                 }
@@ -150,7 +150,7 @@ namespace InventoryManagementApp.ViewModels
         void OnSearchDebounceTimerTick(object? s, EventArgs e)
         {
             _searchDebounceTimer.Stop();
-            _searchCts.Dispose();
+            _searchCts?.Dispose();
             _searchCts = new CancellationTokenSource();
             SearchCommand.Execute(null);
         }
@@ -180,7 +180,7 @@ namespace InventoryManagementApp.ViewModels
         /// </summary>
         async Task FilterItemsAsync()
         {
-            var cancellationToken = _searchCts.Token;
+            var cancellationToken = _searchCts?.Token ?? CancellationToken.None;
             var term = string.IsNullOrWhiteSpace(SearchTerm) ? string.Empty : SearchTerm.Trim();
             var page = new ItemPage(1, PageSize);
             var list = new List<ItemModel>();
@@ -239,27 +239,28 @@ namespace InventoryManagementApp.ViewModels
 
         async Task EditItemAsync(CancellationToken cancellationToken)
         {
-            if (SelectedItem == null) return;
+            var selected = SelectedItem;
+            if (selected == null) return;
 
             var clone = new ItemModel
             {
-                ItemID = SelectedItem.ItemID,
-                ItemNumber = SelectedItem.ItemNumber,
-                PartNumber = SelectedItem.PartNumber,
-                Name = SelectedItem.Name,
-                Brand = SelectedItem.Brand,
-                Location = SelectedItem.Location,
-                QuantityOnHand = SelectedItem.QuantityOnHand,
-                RentedQuantity = SelectedItem.RentedQuantity,
-                Supplier = SelectedItem.Supplier,
-                PurchasedDate = SelectedItem.PurchasedDate,
-                Notes = SelectedItem.Notes,
-                Keywords = SelectedItem.Keywords,
-                IsPowered = SelectedItem.IsPowered,
-                IsCheckedOut = SelectedItem.IsCheckedOut,
-                CheckedOutBy = SelectedItem.CheckedOutBy,
-                CheckedOutTime = SelectedItem.CheckedOutTime,
-                ImagePath = SelectedItem.ImagePath
+                ItemID = selected.ItemID,
+                ItemNumber = selected.ItemNumber,
+                PartNumber = selected.PartNumber,
+                Name = selected.Name,
+                Brand = selected.Brand,
+                Location = selected.Location,
+                QuantityOnHand = selected.QuantityOnHand,
+                RentedQuantity = selected.RentedQuantity,
+                Supplier = selected.Supplier,
+                PurchasedDate = selected.PurchasedDate,
+                Notes = selected.Notes,
+                Keywords = selected.Keywords,
+                IsPowered = selected.IsPowered,
+                IsCheckedOut = selected.IsCheckedOut,
+                CheckedOutBy = selected.CheckedOutBy,
+                CheckedOutTime = selected.CheckedOutTime,
+                ImagePath = selected.ImagePath
             };
 
             var updated = await _dialogService.ShowEditItemDialogAsync(clone);
@@ -284,21 +285,23 @@ namespace InventoryManagementApp.ViewModels
 
         void ViewDetails()
         {
-            if (SelectedItem == null) return;
-            _dialogService.ShowItemDetails(SelectedItem);
+            var item = SelectedItem;
+            if (item == null) return;
+            _dialogService.ShowItemDetails(item);
         }
 
         async Task OpenRentalHistoryAsync()
         {
-            if (SelectedItem == null) return;
+            var item = SelectedItem;
+            if (item == null) return;
             try
             {
-                var history = await _rentalService.GetRentalHistoryForItemAsync(SelectedItem.ItemID);
-                _dialogService.ShowRentalHistory(SelectedItem, history);
+                var history = await _rentalService.GetRentalHistoryForItemAsync(item.ItemID);
+                _dialogService.ShowRentalHistory(item, history);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to open rental history for {ItemLabelSingular} {ItemID}", LabelProvider.Instance.ItemLabelSingular, SelectedItem.ItemID);
+                _logger.LogError(ex, "Failed to open rental history for {ItemLabelSingular} {ItemID}", LabelProvider.Instance.ItemLabelSingular, item.ItemID);
             }
         }
 
@@ -339,16 +342,17 @@ namespace InventoryManagementApp.ViewModels
 
         async Task OpenRentalsAsync(CancellationToken cancellationToken)
         {
-            if (SelectedItem == null) return;
+            var item = SelectedItem;
+            if (item == null) return;
 
             try
             {
                 var customers = await _customerService.GetAllCustomersAsync(cancellationToken);
-                var result = _dialogService.ShowRentItemDialog(SelectedItem, customers);
+                var result = _dialogService.ShowRentItemDialog(item, customers);
                 if (result != null)
                 {
                     var (customer, dueDate) = result.Value;
-                    await _rentalService.RentItemAsync(SelectedItem.ItemID,
+                    await _rentalService.RentItemAsync(item.ItemID,
                         customer.CustomerID,
                         DateTime.Today,
                         dueDate);
@@ -365,7 +369,7 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to rent {ItemLabelSingular} {ItemID}", LabelProvider.Instance.ItemLabelSingular, SelectedItem?.ItemID);
+                _logger.LogError(ex, "Failed to rent {ItemLabelSingular} {ItemID}", LabelProvider.Instance.ItemLabelSingular, item.ItemID);
                 await _dialogService.ShowInfoAsync($"Failed to rent {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {ex.Message}", "Error");
             }
         }
@@ -412,7 +416,7 @@ namespace InventoryManagementApp.ViewModels
             _searchDebounceTimer.Tick -= OnSearchDebounceTimerTick;
             _searchDebounceTimer.Stop();
 
-            var cts = Interlocked.Exchange(ref _searchCts, null!);
+            var cts = Interlocked.Exchange(ref _searchCts, null);
             try
             {
                 cts?.Cancel();

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -72,6 +72,9 @@ namespace InventoryManagementApp.ViewModels
                                        ILogger<UserManagementViewModel>? logger = null,
                                        IServiceProvider? serviceProvider = null)
         {
+            ArgumentNullException.ThrowIfNull(userService);
+            ArgumentNullException.ThrowIfNull(fileDialogService);
+            ArgumentNullException.ThrowIfNull(dialogService);
             _userService = userService;
             _fileDialogService = fileDialogService;
             _dialogService = dialogService;
@@ -87,7 +90,7 @@ namespace InventoryManagementApp.ViewModels
             SearchUsersCommand = new RelayCommand(SearchUsers);
             ClearUserSearchCommand = new RelayCommand(ClearUserSearch);
 
-            EditUserCommand = new RelayCommand(() => EditUser(SelectedUser!), () => SelectedUser != null);
+            EditUserCommand = new RelayCommand(() => EditUser(SelectedUser), () => SelectedUser != null);
             EditUserFromRowCommand = new RelayCommand<UserModel>(EditUser);
             ResetPasswordFromRowCommand = new AsyncRelayCommand<UserModel>(ResetPasswordFor);
             DeleteUserFromRowCommand = new AsyncRelayCommand<UserModel>(DeleteUserAsync);
@@ -349,7 +352,7 @@ namespace InventoryManagementApp.ViewModels
                         var idxAll = _allUsers.IndexOf(user);
                         if (idxAll >= 0) _allUsers[idxAll] = clone;
                         if (ReferenceEquals(SelectedUser, user)) SelectedUser = clone;
-                        win.DialogResult = true;
+                        win?.DialogResult = true;
                     }
                     catch (UnauthorizedAccessException)
                     {
@@ -361,14 +364,14 @@ namespace InventoryManagementApp.ViewModels
                         _dialogService.ShowInfo($"Failed to update user: {ex.Message}", "Error");
                     }
                 },
-                onCancel: () => win.Close(),
+                onCancel: () => win?.Close(),
                 onRemoveAvatar: () => clone.UserPhotoPath = null);
 
             try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for UsersEditWindow"); }
             try { win.ShowDialog(); } catch (Exception ex) { _logger.LogError(ex, "Failed to show UsersEditWindow"); }
         }
 
-        async Task ResetPasswordFor(UserModel user)
+        async Task ResetPasswordFor(UserModel? user)
         {
             if (user == null) return;
             var newPassword = SecurityHelper.GeneratePassword();
@@ -392,7 +395,7 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        async Task DeleteUserAsync(UserModel user)
+        async Task DeleteUserAsync(UserModel? user)
         {
             if (user == null) return;
             try


### PR DESCRIPTION
## Summary
- validate service provider and parameters in DialogService and replace null-forgiving with guarded access
- mark ItemManagementViewModel.SelectedItem nullable and guard search cancellation token source
- allow null services in CustomerManagementViewModel and guard operations when dependencies are absent
- enforce required dependencies in UserManagementViewModel and eliminate unsafe event handler usage

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a9933a4c488324855b43cee7725545