### PR TITLE
Reorder SqliteHelper map parameter

### DIFF
--- a/InventoryManagementApp/Services/Core/SqliteHelper.cs
+++ b/InventoryManagementApp/Services/Core/SqliteHelper.cs
@@ -48,7 +48,7 @@ namespace InventoryManagementApp.Services.Core
             return cmd.ExecuteScalar();
         }
 
-        public static List<T> ExecuteReader<T>(string connStr, string sql, SqliteParameter[]? parameters = null, Func<IDataRecord, T> map)
+        public static List<T> ExecuteReader<T>(string connStr, string sql, Func<IDataRecord, T> map, SqliteParameter[]? parameters = null)
         {
             var list = new List<T>();
             using var conn = new SqliteConnection(connStr);
@@ -61,7 +61,7 @@ namespace InventoryManagementApp.Services.Core
             return list;
         }
 
-        public static List<T> ExecuteReader<T>(SqliteConnection conn, string sql, SqliteParameter[]? parameters = null, Func<IDataRecord, T> map)
+        public static List<T> ExecuteReader<T>(SqliteConnection conn, string sql, Func<IDataRecord, T> map, SqliteParameter[]? parameters = null)
         {
             var list = new List<T>();
             using var cmd = new SqliteCommand(sql, conn);
@@ -138,7 +138,7 @@ namespace InventoryManagementApp.Services.Core
             return await cmd.ExecuteScalarAsync(cancellationToken);
         }
 
-        public static async Task<List<T>> ExecuteReaderAsync<T>(string connStr, string sql, SqliteParameter[]? parameters = null, Func<IDataRecord, T> map, CancellationToken cancellationToken = default)
+        public static async Task<List<T>> ExecuteReaderAsync<T>(string connStr, string sql, Func<IDataRecord, T> map, SqliteParameter[]? parameters = null, CancellationToken cancellationToken = default)
         {
             var list = new List<T>();
             using var conn = new SqliteConnection(connStr);
@@ -151,7 +151,7 @@ namespace InventoryManagementApp.Services.Core
             return list;
         }
 
-        public static async Task<List<T>> ExecuteReaderAsync<T>(SqliteConnection conn, string sql, SqliteParameter[]? parameters = null, Func<IDataRecord, T> map, CancellationToken cancellationToken = default)
+        public static async Task<List<T>> ExecuteReaderAsync<T>(SqliteConnection conn, string sql, Func<IDataRecord, T> map, SqliteParameter[]? parameters = null, CancellationToken cancellationToken = default)
         {
             var list = new List<T>();
             using var cmd = new SqliteCommand(sql, conn);

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -135,7 +135,7 @@ namespace InventoryManagementApp.Services.Customers
             using var conn = _dbService.CreateConnection();
             try
             {
-                var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapCustomer, cancellationToken);
+                var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapCustomer, p, cancellationToken);
                 return list.FirstOrDefault();
             }
             catch (Exception ex)
@@ -151,7 +151,7 @@ namespace InventoryManagementApp.Services.Customers
             using var conn = _dbService.CreateConnection();
             try
             {
-                return await SqliteHelper.ExecuteReaderAsync(conn, sql, null, MapCustomer, cancellationToken);
+                return await SqliteHelper.ExecuteReaderAsync(conn, sql, MapCustomer, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -185,7 +185,7 @@ namespace InventoryManagementApp.Services.Customers
             using var conn = _dbService.CreateConnection();
             try
             {
-                return await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapCustomer, cancellationToken);
+                return await SqliteHelper.ExecuteReaderAsync(conn, sql, MapCustomer, p, cancellationToken);
             }
             catch (Exception ex)
             {

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -103,7 +103,8 @@ namespace InventoryManagementApp.Services.Items
             using var conn = _dbService.CreateConnection();
             return SqliteHelper.ExecuteReaderAsync(conn,
                 "SELECT * FROM Items WHERE CheckedOutBy=@User AND IsCheckedOut=1",
-                new[] { new SqliteParameter("@User", userName) }, MapItem, cancellationToken);
+                MapItem,
+                new[] { new SqliteParameter("@User", userName) }, cancellationToken);
         }
 
         public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default)
@@ -414,7 +415,8 @@ namespace InventoryManagementApp.Services.Items
         {
             using var conn = _dbService.CreateConnection();
             var list = await SqliteHelper.ExecuteReaderAsync(conn, "SELECT * FROM Items WHERE ItemID=@ItemID",
-                new[] { new SqliteParameter("@ItemID", itemID) }, MapItem, cancellationToken);
+                MapItem,
+                new[] { new SqliteParameter("@ItemID", itemID) }, cancellationToken);
             return list.FirstOrDefault();
         }
 
@@ -432,8 +434,8 @@ namespace InventoryManagementApp.Services.Items
             using var conn = _dbService.CreateConnection();
             var record = (await SqliteHelper.ExecuteReaderAsync(conn,
                 "SELECT IsCheckedOut, AvailableQuantity FROM Items WHERE ItemID=@ID",
-                new[] { new SqliteParameter("@ID", itemID) },
-                r => new { Out = Convert.ToInt32(r["IsCheckedOut"]) == 1, Qty = Convert.ToInt32(r["AvailableQuantity"]) }, cancellationToken)).FirstOrDefault();
+                r => new { Out = Convert.ToInt32(r["IsCheckedOut"]) == 1, Qty = Convert.ToInt32(r["AvailableQuantity"]) },
+                new[] { new SqliteParameter("@ID", itemID) }, cancellationToken)).FirstOrDefault();
 
             if (record == null)
                 throw new InvalidOperationException($"ItemModel {itemID} not found.");
@@ -483,8 +485,9 @@ namespace InventoryManagementApp.Services.Items
             using var conn = _dbService.CreateConnection();
             var existingNumbers = new HashSet<string>(
                 await SqliteHelper.ExecuteReaderAsync(conn,
-                    "SELECT ItemNumber FROM Items", null,
-                    r => r.GetString(0), cancellationToken));
+                    "SELECT ItemNumber FROM Items",
+                    r => r.GetString(0),
+                    null, cancellationToken));
 
             using var tran = conn.BeginTransaction();
             var row = 1; // header already read

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -256,7 +256,7 @@ namespace InventoryManagementApp.Services.Rentals
         {
             using var conn = _dbService.CreateConnection();
             var sql = BaseSelect + " WHERE r.Status='Rented'";
-            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, null, MapRental);
+            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental);
             return list.Where(r => r != null).Select(r => r!).ToList();
         }
 
@@ -265,14 +265,14 @@ namespace InventoryManagementApp.Services.Rentals
             const string sql = BaseSelect + @" WHERE r.Status = 'Rented' AND r.DueDate < @Today";
             var p = new[] { new SqliteParameter("@Today", DateTime.Today) };
             using var conn = _dbService.CreateConnection();
-            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapRental);
+            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);
             return list.Where(r => r != null).Select(r => r!).ToList();
         }
 
         public async Task<List<Rental>> GetAllRentalsAsync()
         {
             using var conn = _dbService.CreateConnection();
-            var list = await SqliteHelper.ExecuteReaderAsync(conn, BaseSelect, null, MapRental);
+            var list = await SqliteHelper.ExecuteReaderAsync(conn, BaseSelect, MapRental);
             return list.Where(r => r != null).Select(r => r!).ToList();
         }
 
@@ -281,7 +281,7 @@ namespace InventoryManagementApp.Services.Rentals
             const string sql = BaseSelect + @" WHERE r.ItemID = @ItemID ORDER BY r.RentalDate DESC";
             var p = new[] { new SqliteParameter("@ItemID", itemID) };
             using var conn = _dbService.CreateConnection();
-            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapRental);
+            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);
             return list.Where(r => r != null).Select(r => r!).ToList();
         }
 
@@ -290,7 +290,7 @@ namespace InventoryManagementApp.Services.Rentals
             const string sql = BaseSelect + @" WHERE r.CustomerID = @CustomerID ORDER BY r.RentalDate DESC";
             var p = new[] { new SqliteParameter("@CustomerID", customerID) };
             using var conn = _dbService.CreateConnection();
-            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapRental);
+            var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);
             return list.Where(r => r != null).Select(r => r!).ToList();
         }
     }

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -68,7 +68,7 @@ namespace InventoryManagementApp.Services.Users
                      LIMIT @Count";
                 var p = new[] { new SqliteParameter("@Count", count) };
                 using var conn = _dbService.CreateConnection();
-                var logs = await SqliteHelper.ExecuteReaderAsync(conn, sql, p, MapLog, cancellationToken).ConfigureAwait(false);
+                var logs = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapLog, p, cancellationToken).ConfigureAwait(false);
                 return new Result<List<ActivityLog>>(logs, true);
             }
             catch (OperationCanceledException ex)

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -99,7 +99,7 @@ namespace InventoryManagementApp.Services.Users
         {
             using var conn = _dbService.CreateConnection();
             const string sql = "SELECT UserID, UserName, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, PasswordExpired FROM Users";
-            return await SqliteHelper.ExecuteReaderAsync(conn, sql, null, MapUser);
+            return await SqliteHelper.ExecuteReaderAsync(conn, sql, MapUser);
         }
 
         public async Task<int> CountUsersAsync()
@@ -114,7 +114,8 @@ namespace InventoryManagementApp.Services.Users
         {
             using var conn = _dbService.CreateConnection();
             var list = await SqliteHelper.ExecuteReaderAsync(conn, "SELECT * FROM Users WHERE UserID=@ID",
-                new[] { new SqliteParameter("@ID", userID) }, MapUser);
+                MapUser,
+                new[] { new SqliteParameter("@ID", userID) });
             return list.FirstOrDefault();
         }
 
@@ -127,7 +128,8 @@ namespace InventoryManagementApp.Services.Users
 
             var users = await SqliteHelper.ExecuteReaderAsync(conn,
                 "SELECT * FROM Users WHERE UserName=@UserName",
-                new[] { new SqliteParameter("@UserName", userName) }, MapUser);
+                MapUser,
+                new[] { new SqliteParameter("@UserName", userName) });
 
             var u = users.FirstOrDefault();
             if (u == null) return (AuthenticationResult.IncorrectPassword, null);


### PR DESCRIPTION
## Summary
- place the required mapping delegate before optional SqliteParameter arrays in SqliteHelper and async counterparts
- update services to call ExecuteReader with new parameter order

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9965410b8832489a2753abb3f3823