### PR TITLE
Specify cancellation token in GetAllCustomers reader call

### DIFF
--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -151,7 +151,7 @@ namespace InventoryManagementApp.Services.Customers
             using var conn = _dbService.CreateConnection();
             try
             {
-                return await SqliteHelper.ExecuteReaderAsync(conn, sql, MapCustomer, cancellationToken);
+                return await SqliteHelper.ExecuteReaderAsync(conn, sql, MapCustomer, cancellationToken: cancellationToken);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- pass cancellation token to `SqliteHelper.ExecuteReaderAsync` in `CustomerService.GetAllCustomersInternalAsync`

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9992bea388324a57517e546ec4a25