### PR TITLE
Replace window null-conditionals with explicit checks

### DIFF
--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -165,7 +165,8 @@ namespace InventoryManagementApp.ViewModels
             var window = System.Windows.Application.Current.Windows
                 .OfType<Window>()
                 .FirstOrDefault(w => w.DataContext == this);
-            window?.Close();
+            if (window != null)
+                window.Close();
         }
 
         async Task CheckInAsync()

--- a/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
+++ b/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
@@ -133,7 +133,8 @@ namespace InventoryManagementApp.ViewModels.Rental
             var window = System.Windows.Application.Current.Windows
                 .OfType<Window>()
                 .FirstOrDefault(w => w.DataContext == this);
-            window?.Close();
+            if (window != null)
+                window.Close();
         }
     }
 }

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -352,7 +352,8 @@ namespace InventoryManagementApp.ViewModels
                         var idxAll = _allUsers.IndexOf(user);
                         if (idxAll >= 0) _allUsers[idxAll] = clone;
                         if (ReferenceEquals(SelectedUser, user)) SelectedUser = clone;
-                        win?.DialogResult = true;
+                        if (win != null)
+                            win.DialogResult = true;
                     }
                     catch (UnauthorizedAccessException)
                     {
@@ -364,7 +365,11 @@ namespace InventoryManagementApp.ViewModels
                         _dialogService.ShowInfo($"Failed to update user: {ex.Message}", "Error");
                     }
                 },
-                onCancel: () => win?.Close(),
+                onCancel: () =>
+                {
+                    if (win != null)
+                        win.Close();
+                },
                 onRemoveAvatar: () => clone.UserPhotoPath = null);
 
             try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for UsersEditWindow"); }


### PR DESCRIPTION
## Summary
- replace nullable window invocations with explicit null checks in user, rental, and history view models

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a999730a0c8324ad3c28a6bd85e25c