### PR TITLE
Guard UpdatedAt index creation

### DIFF
--- a/InventoryManagementApp.Tests/SqliteConnectionFactoryTests.cs
+++ b/InventoryManagementApp.Tests/SqliteConnectionFactoryTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using InventoryManagementApp.Data;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 public class SqliteConnectionFactoryTests
@@ -62,5 +63,47 @@ public class SqliteConnectionFactoryTests
         Assert.Contains("IX_Items_NameDescription", indexes);
         Assert.Contains("IX_Items_AvailableQuantity", indexes);
         Assert.DoesNotContain("IX_Items_UpdatedAt", indexes);
+    }
+
+    [Fact]
+    public void Create_LogsWarningWhenUpdatedAtColumnMissing()
+    {
+        SqliteConnectionFactory.Reset();
+        var logger = new ListLogger<SqliteConnectionFactory>();
+        var factory = new SqliteConnectionFactory("Data Source=:memory:", logger);
+        using (var conn = factory.Create())
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "CREATE TABLE Items (ItemNumber TEXT, NameDescription TEXT, AvailableQuantity INTEGER);";
+            cmd.ExecuteNonQuery();
+        }
+
+        using (factory.Create()) { }
+
+        Assert.Contains(LogLevel.Warning, logger.Levels);
+        Assert.Contains(logger.Messages, m => m.Contains("UpdatedAt"));
+    }
+}
+
+internal sealed class ListLogger<T> : ILogger<T>
+{
+    public List<LogLevel> Levels { get; } = new();
+    public List<string> Messages { get; } = new();
+
+    public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        Levels.Add(logLevel);
+        Messages.Add(formatter(state, exception));
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+        public void Dispose() { }
     }
 }

--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -97,7 +97,8 @@ namespace InventoryManagementApp
                         Cache = SqliteCacheMode.Shared,
                         Mode = SqliteOpenMode.ReadWriteCreate
                     };
-                    return new SqliteConnectionFactory(builder.ToString());
+                    var logger = sp.GetRequiredService<ILogger<SqliteConnectionFactory>>();
+                    return new SqliteConnectionFactory(builder.ToString(), logger);
                 });
                 services.AddSingleton<IItemRepository, ItemRepository>();
                 services.AddSingleton<IUserContext, ApplicationUserContext>();

--- a/InventoryManagementApp/Data/SqliteConnectionFactory.cs
+++ b/InventoryManagementApp/Data/SqliteConnectionFactory.cs
@@ -3,22 +3,25 @@ using System.Data;
 using System.Globalization;
 using System.Text;
 using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
 
 namespace InventoryManagementApp.Data;
 
 public sealed class SqliteConnectionFactory
 {
     private readonly string _connectionString;
+    private readonly ILogger<SqliteConnectionFactory>? _logger;
     private static readonly object _lock = new();
     internal static int PragmasExecutionCount { get; private set; }
 
-    public SqliteConnectionFactory(string connectionString)
+    public SqliteConnectionFactory(string connectionString, ILogger<SqliteConnectionFactory>? logger = null)
     {
         var builder = new SqliteConnectionStringBuilder(connectionString)
         {
             Pooling = true
         };
         _connectionString = builder.ToString();
+        _logger = logger;
     }
 
     internal static void Reset()
@@ -62,6 +65,8 @@ public sealed class SqliteConnectionFactory
                     sb.AppendLine("CREATE INDEX IF NOT EXISTS IX_Items_AvailableQuantity ON Items(AvailableQuantity);");
                 if (columns.Contains("UpdatedAt"))
                     sb.AppendLine("CREATE INDEX IF NOT EXISTS IX_Items_UpdatedAt ON Items(UpdatedAt);");
+                else
+                    _logger?.LogWarning("Column 'UpdatedAt' not found in Items table; skipping index creation for IX_Items_UpdatedAt.");
                 if (sb.Length > 0)
                 {
                     cmd.CommandText = sb.ToString();


### PR DESCRIPTION
## Summary
- add optional logger to `SqliteConnectionFactory` and warn when `UpdatedAt` column missing
- register logger when configuring `SqliteConnectionFactory`
- test logging behavior when `UpdatedAt` column absent

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a99c49d86c83248c6c141ef0c34370