### PR TITLE
Use nameof for CSV item name mapping

### DIFF
--- a/InventoryManagementApp.Tests/CsvHelperUtilTests.cs
+++ b/InventoryManagementApp.Tests/CsvHelperUtilTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using InventoryManagementApp.Models.ImportExport;
+using InventoryManagementApp.Utilities.IO;
+using Xunit;
+
+public class CsvHelperUtilTests
+{
+    [Fact]
+    public void LoadItemsFromCsv_PopulatesName()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".csv");
+        File.WriteAllText(path, "ItemNumber,NameDescription\nNUM1,ItemName");
+        var map = new Dictionary<string, string>
+        {
+            ["ItemNumber"] = "ItemNumber",
+            [nameof(ItemImportDto.Name)] = "NameDescription"
+        };
+        var items = CsvHelperUtil.LoadItemsFromCsv(path, map, out var invalid);
+        Assert.Single(items);
+        Assert.Equal("ItemName", items[0].Name);
+        Assert.Empty(invalid);
+        File.Delete(path);
+    }
+
+    [Fact]
+    public async Task LoadItemsFromCsvAsync_PopulatesName()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".csv");
+        await File.WriteAllTextAsync(path, "ItemNumber,NameDescription\nNUM1,ItemName");
+        var map = new Dictionary<string, string>
+        {
+            ["ItemNumber"] = "ItemNumber",
+            [nameof(ItemImportDto.Name)] = "NameDescription"
+        };
+        var (items, invalid) = await CsvHelperUtil.LoadItemsFromCsvAsync(path, map);
+        Assert.Single(items);
+        Assert.Equal("ItemName", items[0].Name);
+        Assert.Empty(invalid);
+        File.Delete(path);
+    }
+}

--- a/InventoryManagementApp.Tests/ItemServiceCsvImportTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceCsvImportTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Linq;
 using InventoryManagementApp.Data;
 using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Models.ImportExport;
 using InventoryManagementApp.Services.Core;
 using InventoryManagementApp.Services.Items;
 using Xunit;
@@ -43,6 +44,35 @@ public class ItemServiceCsvImportTests
 
         Assert.Empty(invalid);
         Assert.True(after - before < 80_000_000);
+
+        File.Delete(csvPath);
+        File.Delete(dbPath);
+    }
+
+    [Fact]
+    public async Task ImportItemsFromCsv_PopulatesNames()
+    {
+        var csvPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".csv");
+        await File.WriteAllTextAsync(csvPath, "ItemNumber,NameDescription\nNUM1,ItemName");
+
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        var service = new ItemService(db, new DummyItemRepository());
+
+        var map = new Dictionary<string, string>
+        {
+            ["ItemNumber"] = "ItemNumber",
+            [nameof(ItemImportDto.Name)] = "NameDescription"
+        };
+
+        var invalid = await service.ImportItemsFromCsvAsync(csvPath, map, CancellationToken.None);
+        Assert.Empty(invalid);
+
+        using var conn = db.CreateConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT NameDescription FROM Items WHERE ItemNumber='NUM1'";
+        var name = cmd.ExecuteScalar()?.ToString();
+        Assert.Equal("ItemName", name);
 
         File.Delete(csvPath);
         File.Delete(dbPath);

--- a/InventoryManagementApp/Services/Core/CsvHelperUtil.cs
+++ b/InventoryManagementApp/Services/Core/CsvHelperUtil.cs
@@ -59,7 +59,7 @@ namespace InventoryManagementApp.Utilities.IO
                 list.Add(new ItemModel
                 {
                     ItemNumber = itemNumber,
-                    Name = GetMapped(cols, headers, map, "NameDescription"),
+                    Name = GetMapped(cols, headers, map, nameof(ItemImportDto.Name)),
                     Location = GetMapped(cols, headers, map, "Location"),
                     Brand = GetMapped(cols, headers, map, "Brand"),
                     PartNumber = GetMapped(cols, headers, map, "PartNumber"),

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -508,7 +508,7 @@ namespace InventoryManagementApp.Services.Items
                     var item = new ItemModel
                     {
                         ItemNumber = itemNumber,
-                        Name = GetMapped(cols, headers, map, "NameDescription"),
+                        Name = GetMapped(cols, headers, map, nameof(ItemImportDto.Name)),
                         Location = GetMapped(cols, headers, map, "Location"),
                         Brand = GetMapped(cols, headers, map, "Brand"),
                         PartNumber = GetMapped(cols, headers, map, "PartNumber"),


### PR DESCRIPTION
## Summary
- Use `nameof(ItemImportDto.Name)` when importing items to map CSV name column
- Apply `nameof(ItemImportDto.Name)` in CSV helper item loading
- Add tests ensuring CSV imports populate item names

## Testing
- `dotnet test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a99e31513c8324933f7bceb53e73c9