### PR TITLE
Preserve keywords on CSV import

### DIFF
--- a/InventoryManagementApp.Tests/CsvHelperUtilTests.cs
+++ b/InventoryManagementApp.Tests/CsvHelperUtilTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using InventoryManagementApp.Models.ImportExport;
+using InventoryManagementApp.Utilities.IO;
+using Xunit;
+
+public class CsvHelperUtilTests
+{
+    [Fact]
+    public async Task LoadItemsFromCsv_PreservesKeywords()
+    {
+        var csvPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".csv");
+        await File.WriteAllTextAsync(csvPath, "ItemNumber,Keywords\nA1,\"tag1 tag2\"");
+
+        var map = new Dictionary<string, string>
+        {
+            ["ItemNumber"] = "ItemNumber",
+            [nameof(ItemImportDto.Keywords)] = "Keywords"
+        };
+
+        var items = CsvHelperUtil.LoadItemsFromCsv(csvPath, map, out var invalid);
+        Assert.Empty(invalid);
+        Assert.Single(items);
+        Assert.Equal("tag1 tag2", items[0].Keywords);
+
+        var (itemsAsync, invalidAsync) = await CsvHelperUtil.LoadItemsFromCsvAsync(csvPath, map, CancellationToken.None);
+        Assert.Empty(invalidAsync);
+        Assert.Single(itemsAsync);
+        Assert.Equal("tag1 tag2", itemsAsync[0].Keywords);
+
+        File.Delete(csvPath);
+    }
+}

--- a/InventoryManagementApp.Tests/ItemServiceCsvImportTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceCsvImportTests.cs
@@ -8,6 +8,8 @@ using InventoryManagementApp.Data;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Services.Core;
 using InventoryManagementApp.Services.Items;
+using InventoryManagementApp.Models.ImportExport;
+using Microsoft.Data.Sqlite;
 using Xunit;
 
 public class ItemServiceCsvImportTests
@@ -43,6 +45,36 @@ public class ItemServiceCsvImportTests
 
         Assert.Empty(invalid);
         Assert.True(after - before < 80_000_000);
+
+        File.Delete(csvPath);
+        File.Delete(dbPath);
+    }
+
+    [Fact]
+    public async Task ImportItemsFromCsvAsync_PersistsKeywords()
+    {
+        var csvPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".csv");
+        await File.WriteAllTextAsync(csvPath, "ItemNumber,Keywords\nNUM1,\"drill hammer\"");
+
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        var service = new ItemService(db, new DummyItemRepository());
+        var map = new Dictionary<string, string>
+        {
+            ["ItemNumber"] = "ItemNumber",
+            [nameof(ItemImportDto.Keywords)] = "Keywords"
+        };
+
+        var invalid = await service.ImportItemsFromCsvAsync(csvPath, map, CancellationToken.None);
+        Assert.Empty(invalid);
+
+        using var conn = db.CreateConnection();
+        var result = await SqliteHelper.ExecuteScalarAsync(conn,
+            "SELECT Keywords FROM Items WHERE ItemNumber=@num",
+            new[] { new SqliteParameter("@num", "NUM1") },
+            CancellationToken.None);
+
+        Assert.Equal("drill hammer", result?.ToString());
 
         File.Delete(csvPath);
         File.Delete(dbPath);

--- a/InventoryManagementApp/Services/Core/CsvHelperUtil.cs
+++ b/InventoryManagementApp/Services/Core/CsvHelperUtil.cs
@@ -66,6 +66,7 @@ namespace InventoryManagementApp.Utilities.IO
                     Supplier = GetMapped(cols, headers, map, "Supplier"),
                     PurchasedDate = TryParseDate(GetMapped(cols, headers, map, "PurchasedDate")),
                     Notes = GetMapped(cols, headers, map, "Notes"),
+                    Keywords = GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords)),
                     QuantityOnHand = TryParseInt(GetMapped(cols, headers, map, "AvailableQuantity")),
                     IsPowered = TryParseBool(GetMapped(cols, headers, map, "IsPowered"))
                 });
@@ -79,8 +80,45 @@ namespace InventoryManagementApp.Utilities.IO
         {
             return await Task.Run(() =>
             {
-                var items = LoadItemsFromCsv(filePath, map, out var invalid);
-                return (items, invalid);
+                ValidateRequired(map, "ItemNumber");
+                var list = new List<ItemModel>();
+                var invalidRows = new List<int>();
+                using var parser = new TextFieldParser(filePath);
+                parser.SetDelimiters(",");
+                parser.HasFieldsEnclosedInQuotes = true;
+
+                if (parser.EndOfData) return (list, invalidRows);
+                var headers = parser.ReadFields();
+
+                var row = 1; // header already read
+                while (!parser.EndOfData)
+                {
+                    row++;
+                    var cols = parser.ReadFields();
+                    var itemNumber = GetMapped(cols, headers, map, "ItemNumber");
+                    if (string.IsNullOrWhiteSpace(itemNumber))
+                    {
+                        invalidRows.Add(row);
+                        continue;
+                    }
+
+                    list.Add(new ItemModel
+                    {
+                        ItemNumber = itemNumber,
+                        Name = GetMapped(cols, headers, map, "NameDescription"),
+                        Location = GetMapped(cols, headers, map, "Location"),
+                        Brand = GetMapped(cols, headers, map, "Brand"),
+                        PartNumber = GetMapped(cols, headers, map, "PartNumber"),
+                        Supplier = GetMapped(cols, headers, map, "Supplier"),
+                        PurchasedDate = TryParseDate(GetMapped(cols, headers, map, "PurchasedDate")),
+                        Notes = GetMapped(cols, headers, map, "Notes"),
+                        Keywords = GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords)),
+                        QuantityOnHand = TryParseInt(GetMapped(cols, headers, map, "AvailableQuantity")),
+                        IsPowered = TryParseBool(GetMapped(cols, headers, map, "IsPowered"))
+                    });
+                }
+
+                return (list, invalidRows);
             }, cancellationToken).ConfigureAwait(false);
         }
 

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -515,6 +515,7 @@ namespace InventoryManagementApp.Services.Items
                         Supplier = GetMapped(cols, headers, map, "Supplier"),
                         PurchasedDate = TryParseDate(GetMapped(cols, headers, map, "PurchasedDate")),
                         Notes = GetMapped(cols, headers, map, "Notes"),
+                        Keywords = GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords)),
                         QuantityOnHand = TryParseInt(GetMapped(cols, headers, map, "AvailableQuantity")),
                         IsPowered = TryParseBool(GetMapped(cols, headers, map, "IsPowered"))
                     };


### PR DESCRIPTION
## Summary
- map Keywords when importing items from CSV files
- include Keywords field in CSV parsing utilities
- test item import and CSV utilities retain keyword values

## Testing
- `dotnet test` *(command not found)*
- `apt-get update` *(403 Forbidden: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a99e4938688324a8e51c967f8673c7