### PR TITLE
Include keywords in CSV imports

### DIFF
--- a/InventoryManagementApp.Tests/CsvHelperUtilTests.cs
+++ b/InventoryManagementApp.Tests/CsvHelperUtilTests.cs
@@ -26,6 +26,23 @@ public class CsvHelperUtilTests
     }
 
     [Fact]
+    public void LoadItemsFromCsv_PopulatesKeywords()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".csv");
+        File.WriteAllText(path, "ItemNumber,Keywords\nNUM1,tag1 tag2");
+        var map = new Dictionary<string, string>
+        {
+            ["ItemNumber"] = "ItemNumber",
+            [nameof(ItemImportDto.Keywords)] = "Keywords"
+        };
+        var items = CsvHelperUtil.LoadItemsFromCsv(path, map, out var invalid);
+        Assert.Single(items);
+        Assert.Equal("tag1 tag2", items[0].Keywords);
+        Assert.Empty(invalid);
+        File.Delete(path);
+    }
+
+    [Fact]
     public async Task LoadItemsFromCsvAsync_PopulatesName()
     {
         var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".csv");
@@ -38,6 +55,23 @@ public class CsvHelperUtilTests
         var (items, invalid) = await CsvHelperUtil.LoadItemsFromCsvAsync(path, map);
         Assert.Single(items);
         Assert.Equal("ItemName", items[0].Name);
+        Assert.Empty(invalid);
+        File.Delete(path);
+    }
+
+    [Fact]
+    public async Task LoadItemsFromCsvAsync_PopulatesKeywords()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".csv");
+        await File.WriteAllTextAsync(path, "ItemNumber,Keywords\nNUM1,tag1 tag2");
+        var map = new Dictionary<string, string>
+        {
+            ["ItemNumber"] = "ItemNumber",
+            [nameof(ItemImportDto.Keywords)] = "Keywords"
+        };
+        var (items, invalid) = await CsvHelperUtil.LoadItemsFromCsvAsync(path, map);
+        Assert.Single(items);
+        Assert.Equal("tag1 tag2", items[0].Keywords);
         Assert.Empty(invalid);
         File.Delete(path);
     }

--- a/InventoryManagementApp.Tests/ItemServiceCsvImportTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceCsvImportTests.cs
@@ -77,4 +77,33 @@ public class ItemServiceCsvImportTests
         File.Delete(csvPath);
         File.Delete(dbPath);
     }
+
+    [Fact]
+    public async Task ImportItemsFromCsv_PopulatesKeywords()
+    {
+        var csvPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".csv");
+        await File.WriteAllTextAsync(csvPath, "ItemNumber,Keywords\nNUM1,tag1 tag2");
+
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        var service = new ItemService(db, new DummyItemRepository());
+
+        var map = new Dictionary<string, string>
+        {
+            ["ItemNumber"] = "ItemNumber",
+            [nameof(ItemImportDto.Keywords)] = "Keywords"
+        };
+
+        var invalid = await service.ImportItemsFromCsvAsync(csvPath, map, CancellationToken.None);
+        Assert.Empty(invalid);
+
+        using var conn = db.CreateConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT Keywords FROM Items WHERE ItemNumber='NUM1'";
+        var keywords = cmd.ExecuteScalar()?.ToString();
+        Assert.Equal("tag1 tag2", keywords);
+
+        File.Delete(csvPath);
+        File.Delete(dbPath);
+    }
 }

--- a/InventoryManagementApp/Services/Core/CsvHelperUtil.cs
+++ b/InventoryManagementApp/Services/Core/CsvHelperUtil.cs
@@ -66,6 +66,7 @@ namespace InventoryManagementApp.Utilities.IO
                     Supplier = GetMapped(cols, headers, map, "Supplier"),
                     PurchasedDate = TryParseDate(GetMapped(cols, headers, map, "PurchasedDate")),
                     Notes = GetMapped(cols, headers, map, "Notes"),
+                    Keywords = GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords)),
                     QuantityOnHand = TryParseInt(GetMapped(cols, headers, map, "AvailableQuantity")),
                     IsPowered = TryParseBool(GetMapped(cols, headers, map, "IsPowered"))
                 });
@@ -79,8 +80,45 @@ namespace InventoryManagementApp.Utilities.IO
         {
             return await Task.Run(() =>
             {
-                var items = LoadItemsFromCsv(filePath, map, out var invalid);
-                return (items, invalid);
+                ValidateRequired(map, "ItemNumber");
+                var list = new List<ItemModel>();
+                var invalidRows = new List<int>();
+                using var parser = new TextFieldParser(filePath);
+                parser.SetDelimiters(",");
+                parser.HasFieldsEnclosedInQuotes = true;
+
+                if (parser.EndOfData) return (list, invalidRows);
+                var headers = parser.ReadFields();
+
+                var row = 1; // header already read
+                while (!parser.EndOfData)
+                {
+                    row++;
+                    var cols = parser.ReadFields();
+                    var itemNumber = GetMapped(cols, headers, map, "ItemNumber");
+                    if (string.IsNullOrWhiteSpace(itemNumber))
+                    {
+                        invalidRows.Add(row);
+                        continue;
+                    }
+
+                    list.Add(new ItemModel
+                    {
+                        ItemNumber = itemNumber,
+                        Name = GetMapped(cols, headers, map, nameof(ItemImportDto.Name)),
+                        Location = GetMapped(cols, headers, map, "Location"),
+                        Brand = GetMapped(cols, headers, map, "Brand"),
+                        PartNumber = GetMapped(cols, headers, map, "PartNumber"),
+                        Supplier = GetMapped(cols, headers, map, "Supplier"),
+                        PurchasedDate = TryParseDate(GetMapped(cols, headers, map, "PurchasedDate")),
+                        Notes = GetMapped(cols, headers, map, "Notes"),
+                        Keywords = GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords)),
+                        QuantityOnHand = TryParseInt(GetMapped(cols, headers, map, "AvailableQuantity")),
+                        IsPowered = TryParseBool(GetMapped(cols, headers, map, "IsPowered"))
+                    });
+                }
+
+                return (list, invalidRows);
             }, cancellationToken).ConfigureAwait(false);
         }
 

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -515,6 +515,7 @@ namespace InventoryManagementApp.Services.Items
                         Supplier = GetMapped(cols, headers, map, "Supplier"),
                         PurchasedDate = TryParseDate(GetMapped(cols, headers, map, "PurchasedDate")),
                         Notes = GetMapped(cols, headers, map, "Notes"),
+                        Keywords = GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords)),
                         QuantityOnHand = TryParseInt(GetMapped(cols, headers, map, "AvailableQuantity")),
                         IsPowered = TryParseBool(GetMapped(cols, headers, map, "IsPowered"))
                     };


### PR DESCRIPTION
## Summary
- ensure ItemService preserves Keywords when importing CSV
- extend CsvHelperUtil to parse Keywords in sync and async loaders
- test keywords mapping for CSV utilities and service

## Testing
- `dotnet test` *(fails: command not found: dotnet; apt-get 403 during install)*

------
https://chatgpt.com/codex/tasks/task_e_68a99fa0e9a08324a5e2edbd5157a6c1