### PR TITLE
Add delete items command

### DIFF
--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections;
 using Microsoft.Data.Sqlite;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -44,6 +45,30 @@ namespace InventoryManagementApp.Tests
             Assert.NotNull(vm.NewItemCommand);
             Assert.True(vm.NewItemCommand.CanExecute(null));
             await vm.NewItemCommand.ExecuteAsync(null);
+
+            var items = (IList)new List<ItemModel>();
+            Assert.NotNull(vm.DeleteItemsCommand);
+            Assert.True(vm.DeleteItemsCommand.CanExecute(items));
+            await vm.DeleteItemsCommand.ExecuteAsync(items);
+        }
+
+        [Fact]
+        public async Task DeleteItemsCommand_RemovesItems()
+        {
+            var service = new DummyItemService();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
+            var settings = new DummySettingsService();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings);
+            var item1 = new ItemModel { ItemID = 1, Name = "A" };
+            var item2 = new ItemModel { ItemID = 2, Name = "B" };
+            vm.Items.Add(item1);
+            vm.Items.Add(item2);
+            var list = (IList)new List<ItemModel> { item1 };
+            await vm.DeleteItemsCommand.ExecuteAsync(list);
+            Assert.Single(vm.Items);
+            Assert.Equal(2, vm.Items[0].ItemID);
         }
 
         [Fact]
@@ -520,7 +545,9 @@ namespace InventoryManagementApp.Tests
         private sealed class DummyDialogService : IDialogService
         {
             public void ShowInfo(string message, string title) { }
+            public Task ShowInfoAsync(string message, string title) => Task.CompletedTask;
             public bool ShowConfirmation(string message, string title) => true;
+            public Task<bool> ShowConfirmationAsync(string message, string title) => Task.FromResult(true);
             public ItemModel? ShowEditItemDialog(ItemModel item) => null;
             public void ShowItemDetails(ItemModel item) { }
             public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading;
@@ -11,6 +12,7 @@ using InventoryManagementApp.Data;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Utilities;
+using InventoryManagementApp.Utilities.Helpers;
 
 namespace InventoryManagementApp.ViewModels
 {
@@ -31,6 +33,7 @@ namespace InventoryManagementApp.ViewModels
         public IRelayCommand ViewDetailsCommand { get; }
         public IAsyncRelayCommand OpenRentalHistoryCommand { get; }
         public IAsyncRelayCommand NewItemCommand { get; }
+        public IAsyncRelayCommand<IList> DeleteItemsCommand { get; }
         public IAsyncRelayCommand CommitChangesCommand { get; }
 
         public IReadOnlyCollection<ItemModel> PendingEdits => _pendingEdits;
@@ -96,6 +99,7 @@ namespace InventoryManagementApp.ViewModels
             ViewDetailsCommand = new RelayCommand(ViewDetails);
             OpenRentalHistoryCommand = new AsyncRelayCommand(ct => OpenRentalHistoryAsync(ct));
             NewItemCommand = new AsyncRelayCommand(ct => NewItemAsync(ct));
+            DeleteItemsCommand = new AsyncRelayCommand<IList>(DeleteItemsAsync);
             CommitChangesCommand = new AsyncRelayCommand(ct => CommitChangesAsync(ct));
         }
 
@@ -279,6 +283,35 @@ namespace InventoryManagementApp.ViewModels
             }
             catch
             {
+            }
+        }
+
+        private async Task DeleteItemsAsync(IList? items, CancellationToken ct)
+        {
+            if (items == null || items.Count == 0) return;
+            var message = items.Count == 1
+                ? $"Delete {LabelProvider.Instance.ItemLabelSingular.ToLower()} '{((ItemModel)items[0]).Name}'?"
+                : $"Delete {items.Count} {LabelProvider.Instance.ItemLabelPlural.ToLower()}?";
+            var confirm = await _dialogService.ShowConfirmationAsync(message, "Confirm Delete").ConfigureAwait(false);
+            if (!confirm) return;
+            try
+            {
+                var toRemove = items.Cast<ItemModel>().ToList();
+                foreach (var item in toRemove)
+                {
+                    await _itemService.DeleteItemAsync(item.ItemID, ct).ConfigureAwait(false);
+                    Items.Remove(item);
+                }
+                if (SelectedItem != null && toRemove.Contains(SelectedItem))
+                    SelectedItem = null;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync($"You are not authorized to delete {LabelProvider.Instance.ItemLabelPlural.ToLower()}.", "Unauthorized").ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                await _dialogService.ShowInfoAsync($"Failed to delete {LabelProvider.Instance.ItemLabelPlural.ToLower()}: {ex.Message}", "Error").ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
## Summary
- add DeleteItemsCommand to ItemsViewModel
- handle item deletion with confirmation and error handling
- test delete command removes items

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a1524fcc8324b6690420c35503e8