### PR TITLE
Fix right-click selection and enable multi-select in ManageItemsPage

### DIFF
--- a/InventoryManagementApp.Tests/ManageItemsPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ManageItemsPageXamlTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Windows;
@@ -52,6 +53,34 @@ namespace InventoryManagementApp.Tests
             thread.Join();
 
             if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
+        public void DataGrid_AllowsMultiSelection()
+        {
+            var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml"));
+            var xaml = File.ReadAllText(path);
+            Assert.Contains("SelectionMode=\"Extended\"", xaml);
+
+            xaml = Regex.Replace(xaml, "x:Class=\"[^\"]*\"\\s*", string.Empty);
+            var page = (Page)XamlReader.Parse(xaml);
+            var dataGrid = FindVisualChild<DataGrid>(page) ?? throw new InvalidOperationException("DataGrid not found");
+            Assert.Equal(DataGridSelectionMode.Extended, dataGrid.SelectionMode);
+        }
+
+        [Fact]
+        public void DataGridRow_RightClickSelectHandlerIsWired()
+        {
+            var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml"));
+            var xaml = File.ReadAllText(path);
+            xaml = Regex.Replace(xaml, "x:Class=\"[^\"]*\"\\s*", string.Empty);
+
+            var page = (Page)XamlReader.Parse(xaml);
+            var dataGrid = FindVisualChild<DataGrid>(page) ?? throw new InvalidOperationException("DataGrid not found");
+            var rowStyle = dataGrid.RowStyle ?? throw new InvalidOperationException("RowStyle not found");
+            var eventSetter = rowStyle.Setters.OfType<EventSetter>().FirstOrDefault(es => es.Event == UIElement.PreviewMouseRightButtonDownEvent);
+            Assert.NotNull(eventSetter);
+            Assert.Equal("DataGridRow_PreviewMouseRightButtonDown", eventSetter!.Handler);
         }
 
         private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -28,6 +28,7 @@
                 <Grid Grid.Row="1">
                     <DataGrid ItemsSource="{Binding Items}"
                               SelectedItem="{Binding SelectedItem}"
+                              SelectionMode="Extended"
                               IsReadOnly="False"
                               AutoGenerateColumns="False"
                               EnableColumnVirtualization="True"

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
@@ -20,12 +20,9 @@ namespace InventoryManagementApp.Views.Pages
 
         private void DataGridRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            if (sender is DataGridRow row)
+            if (sender is DataGridRow row && !row.IsSelected)
             {
-                if (!row.IsSelected)
-                {
-                    row.IsSelected = true;
-                }
+                row.IsSelected = true;
                 e.Handled = true;
             }
         }


### PR DESCRIPTION
## Summary
- handle right-click selection only when row isn't already selected
- set DataGrid SelectionMode to Extended for multi-select
- add XAML tests for multi-select and right-click handler wiring

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a17b03bc8324881546d05bb5aa11