### PR TITLE
Add rental item flag filtering

### DIFF
--- a/InventoryManagementApp.Tests/ItemRepositoryCountTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryCountTests.cs
@@ -14,7 +14,7 @@ public class ItemRepositoryCountTests
     {
         using var conn = factory.Create();
         var cmd = conn.CreateCommand();
-        cmd.CommandText = @"CREATE TABLE Items (
+            cmd.CommandText = @"CREATE TABLE Items (
             ItemID INTEGER PRIMARY KEY AUTOINCREMENT,
             ItemNumber TEXT,
             NameDescription TEXT,
@@ -27,6 +27,7 @@ public class ItemRepositoryCountTests
             Keywords TEXT,
             AvailableQuantity INTEGER,
             RentedQuantity INTEGER,
+            IsRentalItem INTEGER,
             Price NUMERIC NOT NULL DEFAULT 0,
             ImagePath TEXT,
             IsCheckedOut INTEGER,
@@ -37,10 +38,10 @@ public class ItemRepositoryCountTests
         );";
         cmd.ExecuteNonQuery();
         await conn.ExecuteAsync(
-            "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,0,0,@UpdatedAt)",
+            "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,1,0,0,@UpdatedAt)",
             new { ItemNumber = "A1", Name = "Hand Saw", UpdatedAt = System.DateTime.UtcNow });
         await conn.ExecuteAsync(
-            "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,0,0,@UpdatedAt)",
+            "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,0,0,0,@UpdatedAt)",
             new { ItemNumber = "B2", Name = "Hammer", UpdatedAt = System.DateTime.UtcNow });
     }
 
@@ -61,6 +62,16 @@ public class ItemRepositoryCountTests
         await SeedAsync(factory);
         var repo = new ItemRepository(factory);
         var count = await repo.CountAsync(new ItemFilter("saw"), CancellationToken.None);
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task CountAsync_FilterByIsRentalItem()
+    {
+        var factory = CreateFactory();
+        await SeedAsync(factory);
+        var repo = new ItemRepository(factory);
+        var count = await repo.CountAsync(new ItemFilter(null, IsRentalItem: true), CancellationToken.None);
         Assert.Equal(1, count);
     }
 }

--- a/InventoryManagementApp.Tests/ItemRepositoryPaginationTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryPaginationTests.cs
@@ -15,7 +15,7 @@ public class ItemRepositoryPaginationTests
     {
         using var conn = factory.Create();
         var cmd = conn.CreateCommand();
-        cmd.CommandText = @"CREATE TABLE Items (
+            cmd.CommandText = @"CREATE TABLE Items (
             ItemID INTEGER PRIMARY KEY AUTOINCREMENT,
             ItemNumber TEXT,
             NameDescription TEXT,
@@ -28,6 +28,7 @@ public class ItemRepositoryPaginationTests
             Keywords TEXT,
             AvailableQuantity INTEGER,
             RentedQuantity INTEGER,
+            IsRentalItem INTEGER,
             Price NUMERIC NOT NULL DEFAULT 0,
             ImagePath TEXT,
             IsCheckedOut INTEGER,
@@ -40,7 +41,7 @@ public class ItemRepositoryPaginationTests
         for (int i = 1; i <= 5; i++)
         {
             await conn.ExecuteAsync(
-                "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,0,0,@UpdatedAt)",
+                "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,0,0,0,@UpdatedAt)",
                 new { ItemNumber = $"I{i}", Name = $"Item {i}", UpdatedAt = System.DateTime.UtcNow });
         }
     }

--- a/InventoryManagementApp.Tests/ItemRepositorySearchTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositorySearchTests.cs
@@ -15,7 +15,7 @@ public class ItemRepositorySearchTests
     {
         using var conn = factory.Create();
         var cmd = conn.CreateCommand();
-        cmd.CommandText = @"CREATE TABLE Items (
+            cmd.CommandText = @"CREATE TABLE Items (
             ItemID INTEGER PRIMARY KEY AUTOINCREMENT,
             ItemNumber TEXT,
             NameDescription TEXT,
@@ -28,6 +28,7 @@ public class ItemRepositorySearchTests
             Keywords TEXT,
             AvailableQuantity INTEGER,
             RentedQuantity INTEGER,
+            IsRentalItem INTEGER,
             Price NUMERIC NOT NULL DEFAULT 0,
             ImagePath TEXT,
             IsCheckedOut INTEGER,
@@ -38,10 +39,10 @@ public class ItemRepositorySearchTests
         );";
         cmd.ExecuteNonQuery();
         await conn.ExecuteAsync(
-            "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,0,0,@UpdatedAt)",
+            "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,0,0,0,@UpdatedAt)",
             new { ItemNumber = "ABC123", Name = "Hand Saw", UpdatedAt = System.DateTime.UtcNow });
         await conn.ExecuteAsync(
-            "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,0,0,@UpdatedAt)",
+            "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,0,0,0,@UpdatedAt)",
             new { ItemNumber = "CAFÉ1", Name = "Café Table", UpdatedAt = System.DateTime.UtcNow });
     }
 

--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -452,13 +452,13 @@ namespace InventoryManagementApp.Tests
             public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(_item);
 
-            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default)
+            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default)
             {
                 Pages.Add(page.Number);
                 return EnumeratePageAsync(page.Number, cancellationToken);
             }
 
-            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
             public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
             public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => Task.FromResult(false);
             public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
@@ -487,8 +487,8 @@ namespace InventoryManagementApp.Tests
             public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(null);
-            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
-            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
             public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
             public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => Task.FromResult(false);
             public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
@@ -520,13 +520,13 @@ namespace InventoryManagementApp.Tests
             public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(null);
 
-            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default)
+            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default)
             {
                 GetCalls++;
                 return EnumerateAsync(_defaultItems, cancellationToken);
             }
 
-            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default)
+            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default)
             {
                 SearchRequests.Add(searchText);
                 _searchData.TryGetValue(searchText ?? string.Empty, out var list);
@@ -568,8 +568,8 @@ namespace InventoryManagementApp.Tests
             public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(null);
-            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default) => Enumerate(cancellationToken);
-            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default) => Enumerate(cancellationToken);
+            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => Enumerate(cancellationToken);
+            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => Enumerate(cancellationToken);
             public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
             public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => Task.FromResult(false);
             public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
@@ -777,8 +777,8 @@ namespace InventoryManagementApp.Tests
             }
             public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(null);
-            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
-            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
             public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
             public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => Task.FromResult(false);
             public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());

--- a/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
@@ -84,8 +84,8 @@ namespace InventoryManagementApp.Tests
             public virtual Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public virtual Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public virtual Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(null);
-            public virtual IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
-            public virtual IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public virtual IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public virtual IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
             public virtual Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
             public virtual Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => Task.FromResult(false);
             public virtual Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
@@ -100,7 +100,7 @@ namespace InventoryManagementApp.Tests
 
         private sealed class FailingItemService : DummyItemService
         {
-            public override IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default) => AsyncEnumerable.Throw<ItemModel>(new InvalidOperationException("fail"));
+            public override IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Throw<ItemModel>(new InvalidOperationException("fail"));
         }
 
         private sealed class DummyUserService : IUserService

--- a/InventoryManagementApp/Data/ItemFilter.cs
+++ b/InventoryManagementApp/Data/ItemFilter.cs
@@ -14,4 +14,4 @@ public enum SortDirection
     Descending
 }
 
-public readonly record struct ItemFilter(string? Search, SortField SortField = SortField.Name, SortDirection SortDirection = SortDirection.Ascending);
+public readonly record struct ItemFilter(string? Search, SortField SortField = SortField.Name, SortDirection SortDirection = SortDirection.Ascending, bool? IsRentalItem = null);

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -17,15 +17,23 @@ public sealed class ItemRepository : IItemRepository
 
     public async IAsyncEnumerable<Item> GetPageAsync(ItemFilter filter, ItemPage page, [EnumeratorCancellation] CancellationToken ct)
     {
-        var sql = "SELECT ItemID, ItemNumber, NameDescription AS Name, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity AS QuantityOnHand, RentedQuantity, Price, ImagePath, IsCheckedOut, CheckedOutBy, CheckedOutTime, IsPowered, UpdatedAt FROM Items";
+        var sql = "SELECT ItemID, ItemNumber, NameDescription AS Name, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity AS QuantityOnHand, RentedQuantity, IsRentalItem, Price, ImagePath, IsCheckedOut, CheckedOutBy, CheckedOutTime, IsPowered, UpdatedAt FROM Items";
         var parameters = new DynamicParameters();
+        var conditions = new List<string>();
         if (!string.IsNullOrWhiteSpace(filter.Search))
         {
-            sql += " WHERE ItemNumber LIKE @ItemNumberPrefix COLLATE NOCASE_NOACCENT OR ItemNumber LIKE @ItemNumberSubstring COLLATE NOCASE_NOACCENT OR NameDescription LIKE @NameSubstring COLLATE NOCASE_NOACCENT";
+            conditions.Add("(ItemNumber LIKE @ItemNumberPrefix COLLATE NOCASE_NOACCENT OR ItemNumber LIKE @ItemNumberSubstring COLLATE NOCASE_NOACCENT OR NameDescription LIKE @NameSubstring COLLATE NOCASE_NOACCENT)");
             parameters.Add("ItemNumberPrefix", $"{filter.Search}%");
             parameters.Add("ItemNumberSubstring", $"%{filter.Search}%");
             parameters.Add("NameSubstring", $"%{filter.Search}%");
         }
+        if (filter.IsRentalItem.HasValue)
+        {
+            conditions.Add("IsRentalItem=@IsRental");
+            parameters.Add("IsRental", filter.IsRentalItem.Value ? 1 : 0);
+        }
+        if (conditions.Count > 0)
+            sql += " WHERE " + string.Join(" AND ", conditions);
         var orderColumn = filter.SortField switch
         {
             SortField.Name => "NameDescription",
@@ -54,6 +62,7 @@ public sealed class ItemRepository : IItemRepository
         var ordinalKeywords = reader.GetOrdinal("Keywords");
         var ordinalQuantityOnHand = reader.GetOrdinal("QuantityOnHand");
         var ordinalRentedQuantity = reader.GetOrdinal("RentedQuantity");
+        var ordinalIsRental = reader.GetOrdinal("IsRentalItem");
         var ordinalPrice = reader.GetOrdinal("Price");
         var ordinalImagePath = reader.GetOrdinal("ImagePath");
         var ordinalIsCheckedOut = reader.GetOrdinal("IsCheckedOut");
@@ -78,6 +87,7 @@ public sealed class ItemRepository : IItemRepository
                 Keywords = reader.IsDBNull(ordinalKeywords) ? string.Empty : reader.GetString(ordinalKeywords),
                 QuantityOnHand = reader.IsDBNull(ordinalQuantityOnHand) ? 0 : reader.GetInt32(ordinalQuantityOnHand),
                 RentedQuantity = reader.IsDBNull(ordinalRentedQuantity) ? 0 : reader.GetInt32(ordinalRentedQuantity),
+                IsRentalItem = !reader.IsDBNull(ordinalIsRental) && reader.GetInt32(ordinalIsRental) == 1,
                 Price = reader.IsDBNull(ordinalPrice) ? 0m : reader.GetDecimal(ordinalPrice),
                 ImagePath = reader.IsDBNull(ordinalImagePath) ? string.Empty : reader.GetString(ordinalImagePath),
                 IsCheckedOut = !reader.IsDBNull(ordinalIsCheckedOut) && reader.GetInt32(ordinalIsCheckedOut) == 1,
@@ -93,13 +103,21 @@ public sealed class ItemRepository : IItemRepository
     {
         var sql = "SELECT COUNT(*) FROM Items";
         var parameters = new DynamicParameters();
+        var conditions = new List<string>();
         if (!string.IsNullOrWhiteSpace(filter.Search))
         {
-            sql += " WHERE ItemNumber LIKE @ItemNumberPrefix COLLATE NOCASE_NOACCENT OR ItemNumber LIKE @ItemNumberSubstring COLLATE NOCASE_NOACCENT OR NameDescription LIKE @NameSubstring COLLATE NOCASE_NOACCENT";
+            conditions.Add("(ItemNumber LIKE @ItemNumberPrefix COLLATE NOCASE_NOACCENT OR ItemNumber LIKE @ItemNumberSubstring COLLATE NOCASE_NOACCENT OR NameDescription LIKE @NameSubstring COLLATE NOCASE_NOACCENT)");
             parameters.Add("ItemNumberPrefix", $"{filter.Search}%");
             parameters.Add("ItemNumberSubstring", $"%{filter.Search}%");
             parameters.Add("NameSubstring", $"%{filter.Search}%");
         }
+        if (filter.IsRentalItem.HasValue)
+        {
+            conditions.Add("IsRentalItem=@IsRental");
+            parameters.Add("IsRental", filter.IsRentalItem.Value ? 1 : 0);
+        }
+        if (conditions.Count > 0)
+            sql += " WHERE " + string.Join(" AND ", conditions);
         await using var conn = (DbConnection)_factory.Create();
         return await conn.ExecuteScalarAsync<int>(new CommandDefinition(sql, parameters, flags: CommandFlags.Pipelined, cancellationToken: ct));
     }

--- a/InventoryManagementApp/Interfaces/IItemService.cs
+++ b/InventoryManagementApp/Interfaces/IItemService.cs
@@ -15,8 +15,8 @@ namespace InventoryManagementApp.Interfaces
         Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default);
         Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default);
         Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default);
-        IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default);
-        IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default);
+        IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default);
+        IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default);
         Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct);
         Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct);
         Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default);

--- a/InventoryManagementApp/Models/DTOs/ItemImportDto.cs
+++ b/InventoryManagementApp/Models/DTOs/ItemImportDto.cs
@@ -13,5 +13,6 @@
         public string? Keywords { get; set; }
         public int AvailableQuantity { get; set; }
         public int RentedQuantity { get; set; }
+        public bool IsRentalItem { get; set; }
     }
 }

--- a/InventoryManagementApp/Models/Domain/ItemModel.cs
+++ b/InventoryManagementApp/Models/Domain/ItemModel.cs
@@ -73,6 +73,13 @@ namespace InventoryManagementApp.Models.Domain
             set => SetProperty(ref _rentedQuantity, value);
         }
 
+        private bool _isRentalItem;
+        public bool IsRentalItem
+        {
+            get => _isRentalItem;
+            set => SetProperty(ref _isRentalItem, value);
+        }
+
         private string _supplier = string.Empty;
         public string Supplier
         {

--- a/InventoryManagementApp/Services/Core/CsvHelperUtil.cs
+++ b/InventoryManagementApp/Services/Core/CsvHelperUtil.cs
@@ -68,7 +68,8 @@ namespace InventoryManagementApp.Utilities.IO
                     Notes = GetMapped(cols, headers, map, "Notes"),
                     Keywords = GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords)),
                     QuantityOnHand = TryParseInt(GetMapped(cols, headers, map, "AvailableQuantity")),
-                    IsPowered = TryParseBool(GetMapped(cols, headers, map, "IsPowered"))
+                    IsPowered = TryParseBool(GetMapped(cols, headers, map, "IsPowered")),
+                    IsRentalItem = TryParseBool(GetMapped(cols, headers, map, nameof(ItemImportDto.IsRentalItem)))
                 });
             }
 
@@ -112,10 +113,11 @@ namespace InventoryManagementApp.Utilities.IO
                         Supplier = GetMapped(cols, headers, map, "Supplier"),
                         PurchasedDate = TryParseDate(GetMapped(cols, headers, map, "PurchasedDate")),
                         Notes = GetMapped(cols, headers, map, "Notes"),
-                        Keywords = GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords)),
-                        QuantityOnHand = TryParseInt(GetMapped(cols, headers, map, "AvailableQuantity")),
-                        IsPowered = TryParseBool(GetMapped(cols, headers, map, "IsPowered"))
-                    });
+                    Keywords = GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords)),
+                    QuantityOnHand = TryParseInt(GetMapped(cols, headers, map, "AvailableQuantity")),
+                    IsPowered = TryParseBool(GetMapped(cols, headers, map, "IsPowered")),
+                    IsRentalItem = TryParseBool(GetMapped(cols, headers, map, nameof(ItemImportDto.IsRentalItem)))
+                });
                 }
 
                 return (list, invalidRows);
@@ -126,7 +128,7 @@ namespace InventoryManagementApp.Utilities.IO
         {
             var lines = new List<string>
             {
-                "ItemNumber,NameDescription,Location,Brand,PartNumber,Supplier,PurchasedDate,Notes,AvailableQuantity,IsPowered"
+                "ItemNumber,NameDescription,Location,Brand,PartNumber,Supplier,PurchasedDate,Notes,AvailableQuantity,IsPowered,IsRentalItem"
             };
             lines.AddRange(items.Select(t =>
                 string.Join(",",
@@ -139,7 +141,8 @@ namespace InventoryManagementApp.Utilities.IO
                     Quote(t.PurchasedDate?.ToString("yyyy-MM-dd")),
                     Quote(t.Notes),
                     Quote(t.QuantityOnHand.ToString()),
-                    Quote(t.IsPowered ? "1" : "0"))));
+                    Quote(t.IsPowered ? "1" : "0"),
+                    Quote(t.IsRentalItem ? "1" : "0"))));
             File.WriteAllLines(filePath, lines);
         }
 
@@ -147,7 +150,7 @@ namespace InventoryManagementApp.Utilities.IO
         {
             var lines = new List<string>
             {
-                "ItemNumber,NameDescription,Location,Brand,PartNumber,Supplier,PurchasedDate,Notes,AvailableQuantity,IsPowered"
+                "ItemNumber,NameDescription,Location,Brand,PartNumber,Supplier,PurchasedDate,Notes,AvailableQuantity,IsPowered,IsRentalItem"
             };
             lines.AddRange(items.Select(t =>
                 string.Join(",",
@@ -160,7 +163,8 @@ namespace InventoryManagementApp.Utilities.IO
                     Quote(t.PurchasedDate?.ToString("yyyy-MM-dd")),
                     Quote(t.Notes),
                     Quote(t.QuantityOnHand.ToString()),
-                    Quote(t.IsPowered ? "1" : "0"))));
+                    Quote(t.IsPowered ? "1" : "0"),
+                    Quote(t.IsRentalItem ? "1" : "0"))));
             await File.WriteAllLinesAsync(filePath, lines).ConfigureAwait(false);
         }
 

--- a/InventoryManagementApp/Services/Core/DatabaseService.cs
+++ b/InventoryManagementApp/Services/Core/DatabaseService.cs
@@ -47,6 +47,7 @@ namespace InventoryManagementApp.Services.Core
             EnsureColumn("Items", "Keywords", "TEXT");
             EnsureColumn("Items", "IsPowered", "INTEGER", "0");
             EnsureColumn("Items", "IsCheckedOut", "INTEGER", "0");
+            EnsureColumn("Items", "IsRentalItem", "INTEGER", "0");
             EnsureColumn("Items", "Price", "NUMERIC", "0");
             EnsureColumn("Items", "UpdatedAt", "DATETIME");
             // Ensure indexes that depend on newly added columns
@@ -118,6 +119,7 @@ namespace InventoryManagementApp.Services.Core
                     Notes TEXT,
                     AvailableQuantity INTEGER NOT NULL DEFAULT 0,
                     RentedQuantity INTEGER NOT NULL DEFAULT 0,
+                    IsRentalItem INTEGER NOT NULL DEFAULT 0,
                     Price NUMERIC NOT NULL DEFAULT 0,
                     IsPowered INTEGER NOT NULL DEFAULT 0,
                     IsCheckedOut INTEGER NOT NULL DEFAULT 0,

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -27,8 +27,8 @@ namespace InventoryManagementApp.Services.Items
         readonly IItemRepository _repository;
         const string UpsertItemCsv = @"
             INSERT INTO Items
-              (ItemNumber, NameDescription, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity, RentedQuantity, ImagePath, IsCheckedOut, IsPowered)
-            VALUES (@ItemNumber,@Desc,@Loc,@Brand,@PN,@Sup,@PD,@Notes,@Keywords,@Avail,@Rent,@Img,0,@Powered);
+              (ItemNumber, NameDescription, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity, RentedQuantity, IsRentalItem, ImagePath, IsCheckedOut, IsPowered)
+            VALUES (@ItemNumber,@Desc,@Loc,@Brand,@PN,@Sup,@PD,@Notes,@Keywords,@Avail,@Rent,@Rental,@Img,0,@Powered);
             SELECT last_insert_rowid();";
         const int MaxQuantityOnHand = 10000;
     
@@ -160,6 +160,7 @@ namespace InventoryManagementApp.Services.Items
                 new SqliteParameter("@Keywords", (object)item.Keywords ?? DBNull.Value),
                 new SqliteParameter("@Avail", item.QuantityOnHand),
                 new SqliteParameter("@Rent", item.RentedQuantity),
+                new SqliteParameter("@Rental", item.IsRentalItem ? 1 : 0),
                 new SqliteParameter("@Img", (object)item.ImagePath ?? DBNull.Value),
                 new SqliteParameter("@Powered", item.IsPowered ? 1 : 0)
             };
@@ -178,7 +179,7 @@ namespace InventoryManagementApp.Services.Items
 
             cancellationToken.ThrowIfCancellationRequested();
             var items = new List<ItemModel>();
-            await foreach (var item in GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, cancellationToken))
+            await foreach (var item in GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken))
                 items.Add(item);
             var groups = new Dictionary<string, List<ItemModel>>(StringComparer.OrdinalIgnoreCase);
             foreach (var item in items)
@@ -316,6 +317,7 @@ namespace InventoryManagementApp.Services.Items
             ImagePath = r["ImagePath"]?.ToString(),
             Keywords = r["Keywords"]?.ToString(),
             IsPowered = (r["IsPowered"] is DBNull ? 0 : Convert.ToInt32(r["IsPowered"])) == 1,
+            IsRentalItem = (r["IsRentalItem"] is DBNull ? 0 : Convert.ToInt32(r["IsRentalItem"])) == 1,
             UpdatedAt = ParseNullableDate(r["UpdatedAt"], "UpdatedAt") ?? default
         };
 
@@ -359,6 +361,7 @@ namespace InventoryManagementApp.Services.Items
                   Keywords = @Keywords,
                   AvailableQuantity = @Avail,
                   RentedQuantity = @Rent,
+                  IsRentalItem = @Rental,
                   IsPowered = @Powered,
                   IsCheckedOut = @Out,
                   CheckedOutBy = @By,
@@ -379,6 +382,7 @@ namespace InventoryManagementApp.Services.Items
                 new SqliteParameter("@Keywords", (object)item.Keywords ?? DBNull.Value),
                 new SqliteParameter("@Avail", item.QuantityOnHand),
                 new SqliteParameter("@Rent", item.RentedQuantity),
+                new SqliteParameter("@Rental", item.IsRentalItem ? 1 : 0),
                 new SqliteParameter("@Powered", item.IsPowered ? 1 : 0),
                 new SqliteParameter("@Out", item.IsCheckedOut ? 1 : 0),
                 new SqliteParameter("@By", (object)item.CheckedOutBy ?? DBNull.Value),
@@ -420,11 +424,11 @@ namespace InventoryManagementApp.Services.Items
             return list.FirstOrDefault();
         }
 
-        public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default)
-            => _repository.GetPageAsync(new ItemFilter(null, sortField, sortDirection), page, cancellationToken);
+        public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default)
+            => _repository.GetPageAsync(new ItemFilter(null, sortField, sortDirection, isRentalItem), page, cancellationToken);
 
-        public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, CancellationToken cancellationToken = default)
-            => _repository.GetPageAsync(new ItemFilter(searchText, sortField, sortDirection), page, cancellationToken);
+        public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default)
+            => _repository.GetPageAsync(new ItemFilter(searchText, sortField, sortDirection, isRentalItem), page, cancellationToken);
 
         public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct)
             => _repository.CountAsync(filter, ct);
@@ -517,7 +521,8 @@ namespace InventoryManagementApp.Services.Items
                         Notes = GetMapped(cols, headers, map, "Notes"),
                         Keywords = GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords)),
                         QuantityOnHand = TryParseInt(GetMapped(cols, headers, map, "AvailableQuantity")),
-                        IsPowered = TryParseBool(GetMapped(cols, headers, map, "IsPowered"))
+                        IsPowered = TryParseBool(GetMapped(cols, headers, map, "IsPowered")),
+                        IsRentalItem = TryParseBool(GetMapped(cols, headers, map, "IsRentalItem"))
                     };
 
                     await InsertItemAsync(conn, tran, item, cancellationToken);
@@ -552,7 +557,7 @@ namespace InventoryManagementApp.Services.Items
         private async Task ExportItemsToCsvInternalAsync(string filePath, CancellationToken cancellationToken)
         {
             var items = new List<ItemModel>();
-            await foreach (var item in GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, cancellationToken))
+            await foreach (var item in GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken))
                 items.Add(item);
             await CsvHelperUtil.ExportItemsToCsvAsync(filePath, items);
         }

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -187,12 +187,12 @@ namespace InventoryManagementApp.ViewModels
 
             if (!string.IsNullOrEmpty(term))
             {
-                await foreach (var item in _itemService.SearchItemsAsync(term, page, SortField.Name, SortDirection.Ascending, cancellationToken))
+                await foreach (var item in _itemService.SearchItemsAsync(term, page, SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken))
                     list.Add(item);
             }
             else
             {
-                await foreach (var item in _itemService.GetItemsAsync(page, SortField.Name, SortDirection.Ascending, cancellationToken))
+                await foreach (var item in _itemService.GetItemsAsync(page, SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken))
                     list.Add(item);
             }
 
@@ -257,6 +257,7 @@ namespace InventoryManagementApp.ViewModels
                 Notes = selected.Notes,
                 Keywords = selected.Keywords,
                 IsPowered = selected.IsPowered,
+                IsRentalItem = selected.IsRentalItem,
                 IsCheckedOut = selected.IsCheckedOut,
                 CheckedOutBy = selected.CheckedOutBy,
                 CheckedOutTime = selected.CheckedOutTime,

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -114,8 +114,8 @@ namespace InventoryManagementApp.ViewModels
             var result = new List<ItemModel>();
             var pageInfo = new ItemPage(page, PageSize);
             var source = string.IsNullOrWhiteSpace(Filter)
-                ? _itemService.GetItemsAsync(pageInfo, SelectedSortOption.Field, SelectedSortOption.Direction, ct)
-                : _itemService.SearchItemsAsync(Filter, pageInfo, SelectedSortOption.Field, SelectedSortOption.Direction, ct);
+                ? _itemService.GetItemsAsync(pageInfo, SelectedSortOption.Field, SelectedSortOption.Direction, cancellationToken: ct)
+                : _itemService.SearchItemsAsync(Filter, pageInfo, SelectedSortOption.Field, SelectedSortOption.Direction, cancellationToken: ct);
             await foreach (var item in source.ConfigureAwait(false))
             {
                 item.PropertyChanged += Item_PropertyChanged;
@@ -204,6 +204,7 @@ namespace InventoryManagementApp.ViewModels
                     Notes = SelectedItem.Notes,
                     Keywords = SelectedItem.Keywords,
                     IsPowered = SelectedItem.IsPowered,
+                    IsRentalItem = SelectedItem.IsRentalItem,
                     IsCheckedOut = SelectedItem.IsCheckedOut,
                     CheckedOutBy = SelectedItem.CheckedOutBy,
                     CheckedOutTime = SelectedItem.CheckedOutTime,


### PR DESCRIPTION
## Summary
- Add `IsRentalItem` column and property throughout database and models
- Support rental-only filtering in repository and item services
- Extend CSV import/export and tests for rental flag

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b52d21e88324b8d9403789a1d410