### PR TITLE
Allow users to toggle their own check-out status

### DIFF
--- a/InventoryManagementApp.Tests/ItemServiceToggleTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceToggleTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Data;
+using System.Linq;
+using Dapper;
+using InventoryManagementApp.Data;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Services.Items;
+using Xunit;
+
+public class ItemServiceToggleTests
+{
+    private sealed class DummyItemRepository : IItemRepository
+    {
+        public IAsyncEnumerable<ItemModel> GetPageAsync(ItemFilter filter, ItemPage page, CancellationToken ct) => AsyncEnumerable.Empty<ItemModel>();
+        public Task<int> CountAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+        public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class DummyUserContext : IUserContext
+    {
+        public User? CurrentUser { get; set; }
+        public event EventHandler<User?>? UserChanged;
+        public bool IsAdmin => CurrentUser?.IsAdmin ?? false;
+        public string UserName => CurrentUser?.UserName ?? string.Empty;
+        public string Role => IsAdmin ? "Admin" : "User";
+    }
+
+    private static async Task InitializeAsync(DatabaseService db)
+    {
+        using var conn = db.CreateConnection();
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = @"CREATE TABLE Items (
+            ItemID INTEGER PRIMARY KEY AUTOINCREMENT,
+            ItemNumber TEXT,
+            NameDescription TEXT,
+            Location TEXT,
+            Brand TEXT,
+            PartNumber TEXT,
+            Supplier TEXT,
+            PurchasedDate TEXT,
+            Notes TEXT,
+            Keywords TEXT,
+            AvailableQuantity INTEGER,
+            RentedQuantity INTEGER,
+            IsRentalItem INTEGER,
+            Price NUMERIC NOT NULL DEFAULT 0,
+            ImagePath TEXT,
+            IsCheckedOut INTEGER,
+            CheckedOutBy TEXT,
+            CheckedOutTime TEXT,
+            IsPowered INTEGER,
+            UpdatedAt TEXT
+        );";
+        cmd.ExecuteNonQuery();
+        await conn.ExecuteAsync("INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,1,0,0,0,0,@UpdatedAt)", new { ItemNumber = "A1", Name = "Saw", UpdatedAt = DateTime.UtcNow });
+    }
+
+    [Fact]
+    public async Task NonAdminUserCanToggleStatusAndQuantityUpdates()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        await InitializeAsync(db);
+        var userContext = new DummyUserContext { CurrentUser = new User { UserID = 1, UserName = "user1", IsAdmin = false } };
+        var service = new ItemService(db, new DummyItemRepository(), userContext: userContext);
+
+        var checkout = await service.ToggleItemCheckOutStatusAsync(1, "user1", CancellationToken.None);
+        Assert.True(checkout);
+
+        using (var conn = db.CreateConnection())
+        {
+            var record = await conn.QuerySingleAsync("SELECT IsCheckedOut, AvailableQuantity, CheckedOutBy FROM Items WHERE ItemID=1");
+            Assert.Equal(1L, record.IsCheckedOut);
+            Assert.Equal(0L, record.AvailableQuantity);
+            Assert.Equal("user1", (string)record.CheckedOutBy);
+        }
+
+        var checkin = await service.ToggleItemCheckOutStatusAsync(1, "user1", CancellationToken.None);
+        Assert.True(checkin);
+
+        using (var conn = db.CreateConnection())
+        {
+            var record = await conn.QuerySingleAsync("SELECT IsCheckedOut, AvailableQuantity, CheckedOutBy FROM Items WHERE ItemID=1");
+            Assert.Equal(0L, record.IsCheckedOut);
+            Assert.Equal(1L, record.AvailableQuantity);
+            Assert.Null(record.CheckedOutBy);
+        }
+
+
+        File.Delete(dbPath);
+    }
+
+    [Fact]
+    public async Task OtherUserCannotToggleWhenItemCheckedOutBySomeoneElse()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        await InitializeAsync(db);
+        var userContext1 = new DummyUserContext { CurrentUser = new User { UserID = 1, UserName = "user1", IsAdmin = false } };
+        var service1 = new ItemService(db, new DummyItemRepository(), userContext: userContext1);
+        var checkout = await service1.ToggleItemCheckOutStatusAsync(1, "user1", CancellationToken.None);
+        Assert.True(checkout);
+
+        var userContext2 = new DummyUserContext { CurrentUser = new User { UserID = 2, UserName = "user2", IsAdmin = false } };
+        var service2 = new ItemService(db, new DummyItemRepository(), userContext: userContext2);
+        var attempt = await service2.ToggleItemCheckOutStatusAsync(1, "user2", CancellationToken.None);
+        Assert.False(attempt);
+
+        File.Delete(dbPath);
+    }
+}

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -88,12 +88,15 @@ namespace InventoryManagementApp.Services.Items
 
         public async Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default)
         {
-            _auth.EnsureAdmin();
-            var result = await ToggleItemCheckOutStatusInternalAsync(itemID, currentUser, cancellationToken).ConfigureAwait(false);
+            if (_context?.CurrentUser == null)
+                throw new InvalidOperationException("Current user is not available.");
+
+            var caller = _context.UserName;
+            var result = await ToggleItemCheckOutStatusInternalAsync(itemID, caller, cancellationToken).ConfigureAwait(false);
             if (result && _activityLog != null)
             {
-                int userId = _context?.CurrentUser?.UserID ?? 0;
-                await _activityLog.LogActionAsync(userId, currentUser, $"Toggled item {itemID} check-out status", cancellationToken).ConfigureAwait(false);
+                int userId = _context.CurrentUser?.UserID ?? 0;
+                await _activityLog.LogActionAsync(userId, caller, $"Toggled item {itemID} check-out status", cancellationToken).ConfigureAwait(false);
             }
             return result;
         }
@@ -437,15 +440,22 @@ namespace InventoryManagementApp.Services.Items
         {
             using var conn = _dbService.CreateConnection();
             var record = (await SqliteHelper.ExecuteReaderAsync(conn,
-                "SELECT IsCheckedOut, AvailableQuantity FROM Items WHERE ItemID=@ID",
-                r => new { Out = Convert.ToInt32(r["IsCheckedOut"]) == 1, Qty = Convert.ToInt32(r["AvailableQuantity"]) },
+                "SELECT IsCheckedOut, AvailableQuantity, CheckedOutBy FROM Items WHERE ItemID=@ID",
+                r => new { Out = Convert.ToInt32(r["IsCheckedOut"]) == 1, Qty = Convert.ToInt32(r["AvailableQuantity"]), By = r["CheckedOutBy"]?.ToString() },
                 new[] { new SqliteParameter("@ID", itemID) }, cancellationToken)).FirstOrDefault();
 
             if (record == null)
                 throw new InvalidOperationException($"ItemModel {itemID} not found.");
 
-            if (!record.Out && record.Qty <= 0)
+            if (!record.Out)
+            {
+                if (record.Qty <= 0)
+                    return false;
+            }
+            else if (!string.Equals(record.By, currentUser, StringComparison.OrdinalIgnoreCase))
+            {
                 return false;
+            }
 
             var newStatus = record.Out ? 0 : 1;
             var time = record.Out ? (object)DBNull.Value : DateTime.UtcNow;


### PR DESCRIPTION
## Summary
- Allow item check-out toggling based on current user context instead of admin-only, recording the acting user and preventing multiple holders
- Add tests ensuring non-admin users can check items in and out and that conflicting users are blocked

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1ea8a0d083249f3c0300936a9704