### PR TITLE
Show checked-out items on dashboard

### DIFF
--- a/InventoryManagementApp.Tests/DashboardViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DashboardViewModelTests.cs
@@ -13,6 +13,7 @@ using InventoryManagementApp.Services.Core;
 using InventoryManagementApp.Services.Items;
 using InventoryManagementApp.Services.Users;
 using InventoryManagementApp.ViewModels;
+using Microsoft.Data.Sqlite;
 using Xunit;
 
 public class DashboardViewModelTests
@@ -119,6 +120,35 @@ public class DashboardViewModelTests
 
         public override Task<Result<List<ActivityLog>>> GetRecentLogsAsync(int count = 50, CancellationToken cancellationToken = default)
             => Task.FromResult(new Result<List<ActivityLog>>(new List<ActivityLog>(), true));
+    }
+
+    private sealed class StubItemService : IItemService
+    {
+        public List<ItemModel> Items { get; } = new();
+        public int CheckedOutCalls { get; private set; }
+
+        public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+        public Task<List<ItemModel>> GetCheckedOutItemsAsync(CancellationToken cancellationToken = default)
+        {
+            CheckedOutCalls++;
+            return Task.FromResult(Items);
+        }
+
+        public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+        public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+        public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct) => Task.CompletedTask;
+        public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, SqliteConnection? conn = null, SqliteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 
     private sealed class SlowItemRepository : IItemRepository
@@ -231,6 +261,35 @@ public class DashboardViewModelTests
         Assert.True(activityLogService.Canceled);
         Assert.Empty(vm.StatCards);
         Assert.Empty(vm.RecentActivity);
+    }
+
+    [Fact]
+    public async Task LoadAsync_PopulatesCheckedOutItems()
+    {
+        using var db = new DatabaseService(":memory:");
+        var itemService = new StubItemService();
+        itemService.Items.Add(new ItemModel { ItemNumber = "X1", CheckedOutBy = "Alice" });
+        var rentalService = new StubRentalService();
+        var customerService = new StubCustomerService();
+        var userService = new StubUserService();
+        var activityLogService = new StubActivityLogService(db);
+
+        var vm = new DashboardViewModel(
+            itemService,
+            rentalService,
+            customerService,
+            userService,
+            activityLogService,
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }));
+
+        await vm.LoadAsync(CancellationToken.None);
+
+        Assert.Single(vm.CheckedOutItems);
+        Assert.Equal("X1", vm.CheckedOutItems[0].ItemNumber);
+        Assert.Equal("Alice", vm.CheckedOutItems[0].CheckedOutBy);
+        Assert.Equal(1, itemService.CheckedOutCalls);
     }
 }
 

--- a/InventoryManagementApp/Interfaces/IItemService.cs
+++ b/InventoryManagementApp/Interfaces/IItemService.cs
@@ -21,6 +21,7 @@ namespace InventoryManagementApp.Interfaces
         Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct);
         Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default);
         Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default);
+        Task<List<ItemModel>> GetCheckedOutItemsAsync(CancellationToken cancellationToken = default);
         Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default);
         Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken);
         Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default);

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -110,6 +110,13 @@ namespace InventoryManagementApp.Services.Items
                 new[] { new SqliteParameter("@User", userName) }, cancellationToken);
         }
 
+        public Task<List<ItemModel>> GetCheckedOutItemsAsync(CancellationToken cancellationToken = default)
+        {
+            using var conn = _dbService.CreateConnection();
+            const string sql = "SELECT * FROM Items WHERE IsCheckedOut=1 AND IFNULL(IsRentalItem,0)=0";
+            return SqliteHelper.ExecuteReaderAsync(conn, sql, MapItem, null, cancellationToken);
+        }
+
         public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();

--- a/InventoryManagementApp/ViewModels/DashboardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DashboardViewModel.cs
@@ -29,6 +29,7 @@ namespace InventoryManagementApp.ViewModels
 
         public ObservableCollection<StatCard> StatCards { get; } = new();
         public ObservableCollection<ActivityLog> RecentActivity { get; } = new();
+        public ObservableCollection<ItemModel> CheckedOutItems { get; } = new();
 
         public IRelayCommand NewItemCommand { get; }
         public IRelayCommand OpenRentalsCommand { get; }
@@ -76,7 +77,8 @@ namespace InventoryManagementApp.ViewModels
         public Task LoadAsync(CancellationToken cancellationToken)
             => Task.WhenAll(
                 LoadStatsAsync(cancellationToken),
-                LoadRecentActivityAsync(cancellationToken));
+                LoadRecentActivityAsync(cancellationToken),
+                LoadCheckedOutItemsAsync(cancellationToken));
 
         internal async Task LoadStatsAsync(CancellationToken cancellationToken)
         {
@@ -130,6 +132,24 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load recent activity");
+            }
+        }
+
+        internal async Task LoadCheckedOutItemsAsync(CancellationToken token)
+        {
+            try
+            {
+                CheckedOutItems.Clear();
+                var items = await _itemService.GetCheckedOutItemsAsync(token).ConfigureAwait(false);
+                foreach (var item in items)
+                    CheckedOutItems.Add(item);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load checked-out items");
             }
         }
     }

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml
@@ -16,6 +16,7 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
             <Border Style="{StaticResource Card}" Grid.Column="0">
                 <StackPanel>
@@ -48,6 +49,29 @@
                                 Command="{Binding OpenRentalsCommand}"
                                 Margin="0,0,8,8"/>
                     </WrapPanel>
+                </StackPanel>
+            </Border>
+            <Border Style="{StaticResource Card}" Grid.Column="2">
+                <StackPanel>
+                    <TextBlock Text="Checked-Out Items" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
+                    <ListView ItemsSource="{Binding CheckedOutItems}"
+                              Style="{StaticResource CardListView}"
+                              VirtualizingPanel.IsVirtualizing="True"
+                              VirtualizingPanel.VirtualizationMode="Recycling">
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="{Binding ItemNumber}" Margin="0,0,8,0"/>
+                                    <TextBlock Text="{Binding CheckedOutBy}"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                        <ListView.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel/>
+                            </ItemsPanelTemplate>
+                        </ListView.ItemsPanel>
+                    </ListView>
                 </StackPanel>
             </Border>
         </Grid>


### PR DESCRIPTION
## Summary
- expose checked-out non-rental items via IItemService and ItemService
- display checked-out items on dashboard with loading logic
- test DashboardViewModel populates CheckedOutItems on load

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa219f39d08324aa3dc75c61b69f2b