### PR TITLE
Add rental filter tests and viewmodel check-out coverage

### DIFF
--- a/InventoryManagementApp.Tests/DashboardViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DashboardViewModelTests.cs
@@ -264,6 +264,35 @@ public class DashboardViewModelTests
     }
 
     [Fact]
+    public async Task LoadCheckedOutItemsAsync_PopulatesCollection()
+    {
+        using var db = new DatabaseService(":memory:");
+        var itemService = new StubItemService();
+        itemService.Items.Add(new ItemModel { ItemNumber = "Y1", CheckedOutBy = "Bob" });
+        var rentalService = new StubRentalService();
+        var customerService = new StubCustomerService();
+        var userService = new StubUserService();
+        var activityLogService = new StubActivityLogService(db);
+
+        var vm = new DashboardViewModel(
+            itemService,
+            rentalService,
+            customerService,
+            userService,
+            activityLogService,
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }));
+
+        await vm.LoadCheckedOutItemsAsync(CancellationToken.None);
+
+        Assert.Single(vm.CheckedOutItems);
+        Assert.Equal("Y1", vm.CheckedOutItems[0].ItemNumber);
+        Assert.Equal("Bob", vm.CheckedOutItems[0].CheckedOutBy);
+        Assert.Equal(1, itemService.CheckedOutCalls);
+    }
+
+    [Fact]
     public async Task LoadAsync_PopulatesCheckedOutItems()
     {
         using var db = new DatabaseService(":memory:");

--- a/InventoryManagementApp.Tests/ItemRepositoryPaginationTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryPaginationTests.cs
@@ -41,8 +41,8 @@ public class ItemRepositoryPaginationTests
         for (int i = 1; i <= 5; i++)
         {
             await conn.ExecuteAsync(
-                "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,0,0,0,@UpdatedAt)",
-                new { ItemNumber = $"I{i}", Name = $"Item {i}", UpdatedAt = System.DateTime.UtcNow });
+                "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,@IsRental,0,0,@UpdatedAt)",
+                new { ItemNumber = $"I{i}", Name = $"Item {i}", IsRental = i % 2, UpdatedAt = System.DateTime.UtcNow });
         }
     }
 

--- a/InventoryManagementApp.Tests/ItemRepositorySearchTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositorySearchTests.cs
@@ -42,7 +42,7 @@ public class ItemRepositorySearchTests
             "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,0,0,0,@UpdatedAt)",
             new { ItemNumber = "ABC123", Name = "Hand Saw", UpdatedAt = System.DateTime.UtcNow });
         await conn.ExecuteAsync(
-            "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,0,0,0,@UpdatedAt)",
+            "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,1,0,0,@UpdatedAt)",
             new { ItemNumber = "CAFÉ1", Name = "Café Table", UpdatedAt = System.DateTime.UtcNow });
     }
 
@@ -94,5 +94,33 @@ public class ItemRepositorySearchTests
         await foreach (var item in repo.GetPageAsync(new ItemFilter("cafe"), new ItemPage(1, 10), CancellationToken.None))
             result.Add(item);
         Assert.Contains(result, i => i.ItemNumber == "CAFÉ1");
+    }
+
+    [Fact]
+    public async Task GetPageAsync_FilterByIsRentalItem_True_ReturnsRentalItemsOnly()
+    {
+        var factory = CreateFactory();
+        await SeedAsync(factory);
+        var repo = new ItemRepository(factory);
+        var result = new List<ItemModel>();
+        await foreach (var item in repo.GetPageAsync(new ItemFilter(null, IsRentalItem: true), new ItemPage(1, 10), CancellationToken.None))
+            result.Add(item);
+        Assert.Single(result);
+        Assert.True(result[0].IsRentalItem);
+        Assert.Equal("Café Table", result[0].Name);
+    }
+
+    [Fact]
+    public async Task GetPageAsync_FilterByIsRentalItem_False_ReturnsNonRentalItemsOnly()
+    {
+        var factory = CreateFactory();
+        await SeedAsync(factory);
+        var repo = new ItemRepository(factory);
+        var result = new List<ItemModel>();
+        await foreach (var item in repo.GetPageAsync(new ItemFilter(null, IsRentalItem: false), new ItemPage(1, 10), CancellationToken.None))
+            result.Add(item);
+        Assert.Single(result);
+        Assert.False(result[0].IsRentalItem);
+        Assert.Equal("Hand Saw", result[0].Name);
     }
 }

--- a/InventoryManagementApp.Tests/ItemServiceToggleTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceToggleTests.cs
@@ -57,6 +57,7 @@ public class ItemServiceToggleTests
         );";
         cmd.ExecuteNonQuery();
         await conn.ExecuteAsync("INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,1,0,0,0,0,@UpdatedAt)", new { ItemNumber = "A1", Name = "Saw", UpdatedAt = DateTime.UtcNow });
+        await conn.ExecuteAsync("INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,1,0,1,0,0,@UpdatedAt)", new { ItemNumber = "B1", Name = "Drill", UpdatedAt = DateTime.UtcNow });
     }
 
     [Fact]

--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -101,6 +101,32 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task ToggleCheckOutCommand_UpdatesSelectedItemState()
+        {
+            var service = new ToggleItemService();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
+            var customer = new DummyCustomerService();
+            var settings = new DummySettingsService();
+            var userContext = new DummyUserContext { CurrentUser = new User { UserName = "user1" } };
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, userContext);
+            var item = new ItemModel { ItemID = 1 };
+            vm.Items.Add(item);
+            vm.SelectedItem = item;
+
+            await vm.ToggleCheckOutCommand.ExecuteAsync(item);
+
+            Assert.True(vm.SelectedItem!.IsCheckedOut);
+            Assert.Equal("user1", vm.SelectedItem.CheckedOutBy);
+
+            await vm.ToggleCheckOutCommand.ExecuteAsync(item);
+
+            Assert.False(vm.SelectedItem!.IsCheckedOut);
+            Assert.Equal(string.Empty, vm.SelectedItem.CheckedOutBy);
+        }
+
+        [Fact]
         public void SteadyExceeded_TrimsToThreePages()
         {
             var service = new DummyItemService();


### PR DESCRIPTION
## Summary
- seed test databases with both rental and non-rental items
- add repository tests verifying IsRentalItem filtering
- add Dashboard and Items page tests for checked-out items and check-out command

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2295d7f8832491ec49cedad54e26