### PR TITLE
Add configurable item display settings and template bindings

### DIFF
--- a/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
+++ b/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using InventoryManagementApp.Data;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Services.Core;
+using InventoryManagementApp.Services.Settings;
+using InventoryManagementApp.ViewModels;
+using Xunit;
+
+public class ItemDisplaySettingsTests
+{
+    private sealed class DummyItemService : IItemService
+    {
+        public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(null);
+        public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+        public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+        public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+        public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct) => Task.CompletedTask;
+        public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => Task.FromResult(false);
+        public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task<List<ItemModel>> GetCheckedOutItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+        public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
+        public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+        public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+        public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, Microsoft.Data.Sqlite.SqliteConnection? conn = null, Microsoft.Data.Sqlite.SqliteTransaction? tx = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class DummyCustomerService : ICustomerService
+    {
+        public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult(new Customer());
+        public Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
+        public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+        public Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
+        public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default) => Task.FromResult(new CustomerImportResult());
+        public Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class DummyRentalService : IRentalService
+    {
+        public Task RentItemAsync(int itemID, int customerID, DateTime rentalDate, DateTime dueDate) => Task.CompletedTask;
+        public Task ReturnItemAsync(int rentalID, DateTime returnDate) => Task.CompletedTask;
+        public Task ExtendRentalAsync(int rentalID, DateTime newDueDate) => Task.CompletedTask;
+        public Task DeleteRentalAsync(int rentalID) => Task.CompletedTask;
+        public Task<List<Rental>> GetActiveRentalsAsync() => Task.FromResult(new List<Rental>());
+        public Task<int> CountActiveRentalsAsync() => Task.FromResult(0);
+        public Task<List<Rental>> GetOverdueRentalsAsync() => Task.FromResult(new List<Rental>());
+        public Task<List<Rental>> GetAllRentalsAsync() => Task.FromResult(new List<Rental>());
+        public Task<List<Rental>> GetRentalHistoryForItemAsync(int itemID) => Task.FromResult(new List<Rental>());
+        public Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID) => Task.FromResult(new List<Rental>());
+    }
+
+    private sealed class DummyDialogService : IDialogService
+    {
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => false;
+        public ItemModel? ShowEditItemDialog(ItemModel item) => null;
+        public void ShowItemDetails(ItemModel item) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
+        public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
+        public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+    }
+
+    [Fact]
+    public async Task ItemManagementViewModel_ReflectsDisplaySettings()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        var settings = new SettingsService(db);
+        await settings.SaveShowItemImageAsync(false);
+        await settings.SaveShowItemNameAsync(false);
+        await settings.SaveShowItemNumberAsync(false);
+        await settings.SaveShowItemLocationAsync(false);
+        await settings.SaveShowItemNotesAsync(false);
+        var vmFalse = new ItemManagementViewModel(new DummyItemService(), new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
+        Assert.False(vmFalse.ShowImage);
+        Assert.False(vmFalse.ShowName);
+        Assert.False(vmFalse.ShowItemNumber);
+        Assert.False(vmFalse.ShowLocation);
+        Assert.False(vmFalse.ShowNotes);
+        await settings.SaveShowItemImageAsync(true);
+        await settings.SaveShowItemNameAsync(true);
+        await settings.SaveShowItemNumberAsync(true);
+        await settings.SaveShowItemLocationAsync(true);
+        await settings.SaveShowItemNotesAsync(true);
+        var vmTrue = new ItemManagementViewModel(new DummyItemService(), new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
+        Assert.True(vmTrue.ShowImage);
+        Assert.True(vmTrue.ShowName);
+        Assert.True(vmTrue.ShowItemNumber);
+        Assert.True(vmTrue.ShowLocation);
+        Assert.True(vmTrue.ShowNotes);
+    }
+
+    [Fact]
+    public void ItemCardTemplate_VisibilityFollowsSettings()
+    {
+        Exception? threadEx = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+                using var db = new DatabaseService(dbPath);
+                var settings = new SettingsService(db);
+                settings.SaveShowItemImageAsync(false).GetAwaiter().GetResult();
+                settings.SaveShowItemNameAsync(false).GetAwaiter().GetResult();
+                settings.SaveShowItemNumberAsync(false).GetAwaiter().GetResult();
+                settings.SaveShowItemLocationAsync(false).GetAwaiter().GetResult();
+                settings.SaveShowItemNotesAsync(false).GetAwaiter().GetResult();
+                var vm = new ItemManagementViewModel(new DummyItemService(), new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
+                var app = new Application();
+                app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
+                app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
+                app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Templates.xaml", UriKind.Absolute) });
+                var template = (DataTemplate)app.Resources["ItemCardTemplate"];
+                var item = new ItemModel { Name = "A", ItemNumber = "1", Location = "L", Notes = "N" };
+                var itemsControl = new ItemsControl { DataContext = vm, ItemTemplate = template };
+                itemsControl.Items.Add(item);
+                var window = new Window { Content = itemsControl };
+                window.Show();
+                itemsControl.UpdateLayout();
+                var container = (ContentPresenter)itemsControl.ItemContainerGenerator.ContainerFromIndex(0)!;
+                container.ApplyTemplate();
+                var border = (Border)VisualTreeHelper.GetChild(container, 0);
+                Assert.Equal(Visibility.Collapsed, border.Visibility);
+                settings.SaveShowItemNameAsync(true).GetAwaiter().GetResult();
+                vm = new ItemManagementViewModel(new DummyItemService(), new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
+                itemsControl.DataContext = vm;
+                itemsControl.UpdateLayout();
+                border = (Border)VisualTreeHelper.GetChild(container, 0);
+                Assert.Equal(Visibility.Visible, border.Visibility);
+                window.Close();
+            }
+            catch (Exception ex)
+            {
+                threadEx = ex;
+            }
+            finally
+            {
+                Application.Current?.Shutdown();
+            }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (threadEx != null) throw threadEx;
+    }
+}

--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -732,6 +732,16 @@ namespace InventoryManagementApp.Tests
             public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
             public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<bool> GetShowItemImageAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+            public Task SaveShowItemImageAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<bool> GetShowItemNameAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+            public Task SaveShowItemNameAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<bool> GetShowItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+            public Task SaveShowItemNumberAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<bool> GetShowItemLocationAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+            public Task SaveShowItemLocationAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<bool> GetShowItemNotesAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+            public Task SaveShowItemNotesAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
         }
 
         private sealed class RecordingDialogService : IDialogService

--- a/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
@@ -166,6 +166,16 @@ namespace InventoryManagementApp.Tests
             public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
             public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<bool> GetShowItemImageAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+            public Task SaveShowItemImageAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<bool> GetShowItemNameAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+            public Task SaveShowItemNameAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<bool> GetShowItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+            public Task SaveShowItemNumberAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<bool> GetShowItemLocationAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+            public Task SaveShowItemLocationAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<bool> GetShowItemNotesAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+            public Task SaveShowItemNotesAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
         }
 
         private sealed class DummyDialogService : IDialogService

--- a/InventoryManagementApp/Interfaces/ISettingsService.cs
+++ b/InventoryManagementApp/Interfaces/ISettingsService.cs
@@ -27,5 +27,17 @@ namespace InventoryManagementApp.Interfaces
         Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default);
         Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default);
         Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default);
+
+        // Item display configuration
+        Task<bool> GetShowItemImageAsync(CancellationToken cancellationToken = default);
+        Task SaveShowItemImageAsync(bool value, CancellationToken cancellationToken = default);
+        Task<bool> GetShowItemNameAsync(CancellationToken cancellationToken = default);
+        Task SaveShowItemNameAsync(bool value, CancellationToken cancellationToken = default);
+        Task<bool> GetShowItemNumberAsync(CancellationToken cancellationToken = default);
+        Task SaveShowItemNumberAsync(bool value, CancellationToken cancellationToken = default);
+        Task<bool> GetShowItemLocationAsync(CancellationToken cancellationToken = default);
+        Task SaveShowItemLocationAsync(bool value, CancellationToken cancellationToken = default);
+        Task<bool> GetShowItemNotesAsync(CancellationToken cancellationToken = default);
+        Task SaveShowItemNotesAsync(bool value, CancellationToken cancellationToken = default);
     }
 }

--- a/InventoryManagementApp/Resources/Converters.xaml
+++ b/InventoryManagementApp/Resources/Converters.xaml
@@ -4,4 +4,5 @@
     <conv:NullToDefaultImageConverter x:Key="NullToDefaultImageConverter"/>
     <conv:BooleanToAdminConverter x:Key="BooleanToAdminConverter"/>
     <conv:DateTimeMinToEmptyStringConverter x:Key="DateTimeMinToEmptyStringConverter"/>
+    <conv:AnyTrueToVisibilityConverter x:Key="AnyTrueToVisibilityConverter"/>
 </ResourceDictionary>

--- a/InventoryManagementApp/Resources/Templates.xaml
+++ b/InventoryManagementApp/Resources/Templates.xaml
@@ -19,17 +19,28 @@
     </ItemsPanelTemplate>
     <DataTemplate x:Key="ItemCardTemplate">
         <Border Style="{StaticResource Card}" Width="220" Padding="0">
+            <Border.Visibility>
+                <MultiBinding Converter="{StaticResource AnyTrueToVisibilityConverter}">
+                    <Binding Path="DataContext.ShowImage" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.ShowName" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.ShowItemNumber" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.ShowLocation" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.ShowNotes" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                </MultiBinding>
+            </Border.Visibility>
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="140"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <Border Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" CornerRadius="8">
+                <Border Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" CornerRadius="8" Visibility="{Binding DataContext.ShowImage, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
                     <Image Stretch="UniformToFill" Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
                 </Border>
                 <StackPanel Grid.Row="1" Margin="0,6,0,0">
-                    <TextBlock Text="{Binding Name}" Style="{StaticResource ListItemTitleTextBlock}"/>
-                    <TextBlock Text="{Binding ItemNumber}" Style="{StaticResource CaptionTextBlock}"/>
+                    <TextBlock Text="{Binding Name}" Style="{StaticResource ListItemTitleTextBlock}" Visibility="{Binding DataContext.ShowName, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding ItemNumber}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.ShowItemNumber, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding Location}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.ShowLocation, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding Notes}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis" Visibility="{Binding DataContext.ShowNotes, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
                 </StackPanel>
             </Grid>
         </Border>

--- a/InventoryManagementApp/Services/Settings/SettingsService.cs
+++ b/InventoryManagementApp/Services/Settings/SettingsService.cs
@@ -209,6 +209,11 @@ namespace InventoryManagementApp.Services.Settings
         const string AutoLogoutMinutesKey = "AutoLogoutMinutes";
         const string ItemLabelSingularKey = "ItemLabelSingular";
         const string ItemLabelPluralKey = "ItemLabelPlural";
+        const string ShowItemImageKey = "ShowItemImage";
+        const string ShowItemNameKey = "ShowItemName";
+        const string ShowItemNumberKey = "ShowItemNumber";
+        const string ShowItemLocationKey = "ShowItemLocation";
+        const string ShowItemNotesKey = "ShowItemNotes";
 
         public async Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default)
         {
@@ -313,5 +318,48 @@ namespace InventoryManagementApp.Services.Settings
             _auth.EnsureAdmin();
             await SaveSettingAsync(ItemLabelPluralKey, label, cancellationToken).ConfigureAwait(false);
         }
+
+        static bool ParseBool(string? value, bool defaultValue) => bool.TryParse(value, out var b) ? b : defaultValue;
+
+        async Task<bool> GetBoolSettingAsync(string key, bool defaultValue, CancellationToken cancellationToken)
+        {
+            var value = await GetSettingAsync(key, cancellationToken).ConfigureAwait(false);
+            if (value is null)
+            {
+                await SaveSettingAsync(key, defaultValue.ToString(), cancellationToken).ConfigureAwait(false);
+                return defaultValue;
+            }
+            return ParseBool(value, defaultValue);
+        }
+
+        public Task<bool> GetShowItemImageAsync(CancellationToken cancellationToken = default)
+            => GetBoolSettingAsync(ShowItemImageKey, true, cancellationToken);
+
+        public Task SaveShowItemImageAsync(bool value, CancellationToken cancellationToken = default)
+            => SaveSettingAsync(ShowItemImageKey, value.ToString(), cancellationToken);
+
+        public Task<bool> GetShowItemNameAsync(CancellationToken cancellationToken = default)
+            => GetBoolSettingAsync(ShowItemNameKey, true, cancellationToken);
+
+        public Task SaveShowItemNameAsync(bool value, CancellationToken cancellationToken = default)
+            => SaveSettingAsync(ShowItemNameKey, value.ToString(), cancellationToken);
+
+        public Task<bool> GetShowItemNumberAsync(CancellationToken cancellationToken = default)
+            => GetBoolSettingAsync(ShowItemNumberKey, true, cancellationToken);
+
+        public Task SaveShowItemNumberAsync(bool value, CancellationToken cancellationToken = default)
+            => SaveSettingAsync(ShowItemNumberKey, value.ToString(), cancellationToken);
+
+        public Task<bool> GetShowItemLocationAsync(CancellationToken cancellationToken = default)
+            => GetBoolSettingAsync(ShowItemLocationKey, true, cancellationToken);
+
+        public Task SaveShowItemLocationAsync(bool value, CancellationToken cancellationToken = default)
+            => SaveSettingAsync(ShowItemLocationKey, value.ToString(), cancellationToken);
+
+        public Task<bool> GetShowItemNotesAsync(CancellationToken cancellationToken = default)
+            => GetBoolSettingAsync(ShowItemNotesKey, true, cancellationToken);
+
+        public Task SaveShowItemNotesAsync(bool value, CancellationToken cancellationToken = default)
+            => SaveSettingAsync(ShowItemNotesKey, value.ToString(), cancellationToken);
     }
 }

--- a/InventoryManagementApp/Utilities/Converters/AnyTrueToVisibilityConverter.cs
+++ b/InventoryManagementApp/Utilities/Converters/AnyTrueToVisibilityConverter.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows;
+using System.Windows.Data;
+
+namespace InventoryManagementApp.Utilities.Converters
+{
+    public class AnyTrueToVisibilityConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
+            => values.OfType<bool>().Any(b => b) ? Visibility.Visible : Visibility.Collapsed;
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
+            => throw new NotSupportedException();
+    }
+}

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -25,6 +25,7 @@ namespace InventoryManagementApp.ViewModels
         private readonly ICustomerService _customerService;
         private readonly IRentalService _rentalService;
         private readonly IDialogService _dialogService;
+        private readonly ISettingsService _settingsService;
         private readonly ILogger<ItemManagementViewModel> _logger;
 
         public ObservableCollection<ItemModel> Items { get; } = new();
@@ -123,6 +124,7 @@ namespace InventoryManagementApp.ViewModels
                                        ICustomerService customerService,
                                        IRentalService rentalService,
                                        IDialogService dialogService,
+                                       ISettingsService settingsService,
                                        ILogger<ItemManagementViewModel>? logger = null,
                                        IDispatcherTimer? searchDebounceTimer = null)
         {
@@ -130,6 +132,7 @@ namespace InventoryManagementApp.ViewModels
             _customerService = customerService;
             _rentalService = rentalService;
             _dialogService = dialogService;
+            _settingsService = settingsService;
             _logger = logger ?? NullLogger<ItemManagementViewModel>.Instance;
             SearchCommand = new AsyncRelayCommand(FilterItemsAsync);
             _searchDebounceTimer = searchDebounceTimer ?? new DispatcherTimerWrapper { Interval = TimeSpan.FromMilliseconds(300) };
@@ -140,12 +143,23 @@ namespace InventoryManagementApp.ViewModels
             OpenRentalsCommand = new AsyncRelayCommand(ct => OpenRentalsAsync(ct), () => SelectedItem != null);
             ViewDetailsCommand = new RelayCommand(ViewDetails, () => SelectedItem != null);
             OpenRentalHistoryCommand = new AsyncRelayCommand(OpenRentalHistoryAsync, () => SelectedItem != null);
+            ShowImage = _settingsService.GetShowItemImageAsync().GetAwaiter().GetResult();
+            ShowName = _settingsService.GetShowItemNameAsync().GetAwaiter().GetResult();
+            ShowItemNumber = _settingsService.GetShowItemNumberAsync().GetAwaiter().GetResult();
+            ShowLocation = _settingsService.GetShowItemLocationAsync().GetAwaiter().GetResult();
+            ShowNotes = _settingsService.GetShowItemNotesAsync().GetAwaiter().GetResult();
             // Ensure no duplicate event subscriptions when the view model is
             // constructed multiple times or the collection persists across
             // instances.
             Items.CollectionChanged -= Items_CollectionChanged;
             Items.CollectionChanged += Items_CollectionChanged;
         }
+
+        public bool ShowImage { get; }
+        public bool ShowName { get; }
+        public bool ShowItemNumber { get; }
+        public bool ShowLocation { get; }
+        public bool ShowNotes { get; }
 
         void OnSearchDebounceTimerTick(object? s, EventArgs e)
         {

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -213,7 +213,7 @@ namespace InventoryManagementApp.ViewModels
 
             OpenImageImportMappingWindowCommand = new AsyncRelayCommand(ct => OpenImageImportMappingWindowAsync(ct));
 
-            ItemManagement = new ItemManagementViewModel(itemService, customerService, rentalService, _dialogService);
+            ItemManagement = new ItemManagementViewModel(itemService, customerService, rentalService, _dialogService, _settingsService);
             _itemManagementPropertyChangedHandler = (s, e) =>
             {
                 if (e.PropertyName == nameof(ItemManagementViewModel.SelectedItem))

--- a/InventoryManagementApp/ViewModels/SettingsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/SettingsViewModel.cs
@@ -43,6 +43,11 @@ namespace InventoryManagementApp.ViewModels
             _autoLogoutMinutes = _settingsService.GetAutoLogoutMinutesAsync().GetAwaiter().GetResult();
             _itemLabelSingular = LabelProvider.Instance.ItemLabelSingular;
             _itemLabelPlural = LabelProvider.Instance.ItemLabelPlural;
+            _showItemImage = _settingsService.GetShowItemImageAsync().GetAwaiter().GetResult();
+            _showItemName = _settingsService.GetShowItemNameAsync().GetAwaiter().GetResult();
+            _showItemNumber = _settingsService.GetShowItemNumberAsync().GetAwaiter().GetResult();
+            _showItemLocation = _settingsService.GetShowItemLocationAsync().GetAwaiter().GetResult();
+            _showItemNotes = _settingsService.GetShowItemNotesAsync().GetAwaiter().GetResult();
             TestDbCommand = new RelayCommand(() =>
             {
                 var success = TestDbConnection(out var message);
@@ -57,6 +62,14 @@ namespace InventoryManagementApp.ViewModels
             });
             BrowseCompanyLogoCommand = new RelayCommand(BrowseCompanyLogo);
             SaveCompanyLogoCommand = new AsyncRelayCommand(SaveCompanyLogoAsync);
+            SelectAllItemDisplayCommand = new RelayCommand(() =>
+            {
+                ShowItemImage = ShowItemName = ShowItemNumber = ShowItemLocation = ShowItemNotes = true;
+            });
+            SelectNoneItemDisplayCommand = new RelayCommand(() =>
+            {
+                ShowItemImage = ShowItemName = ShowItemNumber = ShowItemLocation = ShowItemNotes = false;
+            });
         }
 
         private string _applicationName = string.Empty;
@@ -242,11 +255,138 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
+        private bool _showItemImage;
+        public bool ShowItemImage
+        {
+            get => _showItemImage;
+            set
+            {
+                if (SetProperty(ref _showItemImage, value))
+                {
+                    try
+                    {
+                        _settingsService.SaveShowItemImageAsync(value).GetAwaiter().GetResult();
+                    }
+                    catch (UnauthorizedAccessException ex)
+                    {
+                        _logger.LogWarning(ex, "Unauthorized to change settings.");
+                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to save ShowItemImage setting.");
+                    }
+                }
+            }
+        }
+
+        private bool _showItemName;
+        public bool ShowItemName
+        {
+            get => _showItemName;
+            set
+            {
+                if (SetProperty(ref _showItemName, value))
+                {
+                    try
+                    {
+                        _settingsService.SaveShowItemNameAsync(value).GetAwaiter().GetResult();
+                    }
+                    catch (UnauthorizedAccessException ex)
+                    {
+                        _logger.LogWarning(ex, "Unauthorized to change settings.");
+                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to save ShowItemName setting.");
+                    }
+                }
+            }
+        }
+
+        private bool _showItemNumber;
+        public bool ShowItemNumber
+        {
+            get => _showItemNumber;
+            set
+            {
+                if (SetProperty(ref _showItemNumber, value))
+                {
+                    try
+                    {
+                        _settingsService.SaveShowItemNumberAsync(value).GetAwaiter().GetResult();
+                    }
+                    catch (UnauthorizedAccessException ex)
+                    {
+                        _logger.LogWarning(ex, "Unauthorized to change settings.");
+                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to save ShowItemNumber setting.");
+                    }
+                }
+            }
+        }
+
+        private bool _showItemLocation;
+        public bool ShowItemLocation
+        {
+            get => _showItemLocation;
+            set
+            {
+                if (SetProperty(ref _showItemLocation, value))
+                {
+                    try
+                    {
+                        _settingsService.SaveShowItemLocationAsync(value).GetAwaiter().GetResult();
+                    }
+                    catch (UnauthorizedAccessException ex)
+                    {
+                        _logger.LogWarning(ex, "Unauthorized to change settings.");
+                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to save ShowItemLocation setting.");
+                    }
+                }
+            }
+        }
+
+        private bool _showItemNotes;
+        public bool ShowItemNotes
+        {
+            get => _showItemNotes;
+            set
+            {
+                if (SetProperty(ref _showItemNotes, value))
+                {
+                    try
+                    {
+                        _settingsService.SaveShowItemNotesAsync(value).GetAwaiter().GetResult();
+                    }
+                    catch (UnauthorizedAccessException ex)
+                    {
+                        _logger.LogWarning(ex, "Unauthorized to change settings.");
+                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to save ShowItemNotes setting.");
+                    }
+                }
+            }
+        }
+
         public ObservableCollection<string> ThemeOptions { get; }
 
         public IRelayCommand TestDbCommand { get; }
         public IRelayCommand BrowseCompanyLogoCommand { get; }
         public IAsyncRelayCommand SaveCompanyLogoCommand { get; }
+        public IRelayCommand SelectAllItemDisplayCommand { get; }
+        public IRelayCommand SelectNoneItemDisplayCommand { get; }
 
         internal bool TestDbConnection(out string message)
         {

--- a/InventoryManagementApp/Views/Pages/SettingsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/SettingsPage.xaml
@@ -66,6 +66,23 @@
                 </StackPanel>
             </Border>
 
+            <Border Style="{StaticResource Card}" Padding="12" Margin="0,0,0,8">
+                <StackPanel Orientation="Vertical">
+                    <TextBlock Text="Item Display" Style="{StaticResource SectionHeader}"/>
+                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                        <Button Style="{StaticResource PrimaryButton}" Content="Select All" Command="{Binding SelectAllItemDisplayCommand}" Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource PrimaryButton}" Content="Select None" Command="{Binding SelectNoneItemDisplayCommand}"/>
+                    </StackPanel>
+                    <StackPanel Margin="0,8,0,0">
+                        <CheckBox Content="Show Image" IsChecked="{Binding ShowItemImage}"/>
+                        <CheckBox Content="Show Name" IsChecked="{Binding ShowItemName}"/>
+                        <CheckBox Content="Show Item Number" IsChecked="{Binding ShowItemNumber}"/>
+                        <CheckBox Content="Show Location" IsChecked="{Binding ShowItemLocation}"/>
+                        <CheckBox Content="Show Notes" IsChecked="{Binding ShowItemNotes}"/>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
             <Border Style="{StaticResource Card}" Padding="12">
                 <StackPanel Orientation="Vertical">
                     <TextBlock Text="Branding" Style="{StaticResource SectionHeader}"/>


### PR DESCRIPTION
## Summary
- Add typed item display settings (image, name, number, location, notes)
- Bind new settings through view models and settings UI with select-all/none helpers
- Expand item card template with visibility bindings and default-collapsed behavior
- Introduce tests for settings propagation and template visibility

## Testing
- `dotnet test` *(failed: command not found)*
- `apt-get update` *(failed: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa25eb846c8324b185e6d0722e7751