### PR TITLE
Add inline rental filters with auto-apply functionality

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsViewModelTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Windows.Documents;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.ViewModels;
+using Xunit;
+using ItemModel = InventoryManagementApp.Models.Domain.ItemModel;
+using CustomerModel = InventoryManagementApp.Models.Domain.Customer;
+using RentalModel = InventoryManagementApp.Models.Domain.Rental;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ManageRentalsViewModelTests
+    {
+        [Fact]
+        public async Task SettingFilters_UpdatesResults()
+        {
+            var rentals = new List<RentalModel>
+            {
+                new RentalModel { RentalID = 1, ItemNumber = "A1", CustomerName = "John", RentalDate = DateTime.Today, Status = "Rented" },
+                new RentalModel { RentalID = 2, ItemNumber = "B1", CustomerName = "Jane", RentalDate = DateTime.Today, Status = "Returned" }
+            };
+            var rentalService = new StubRentalService(rentals);
+            var dialogService = new StubDialogService();
+            var vm = new ManageRentalsViewModel(rentalService, dialogService);
+
+            await vm.LoadRentalsAsync();
+            Assert.Equal(2, vm.Rentals.Count);
+
+            vm.SearchText = "A1";
+
+            Assert.Single(vm.Rentals);
+            Assert.Equal(1, vm.Rentals[0].RentalID);
+        }
+
+        private sealed class StubRentalService : IRentalService
+        {
+            private readonly List<RentalModel> _rentals;
+            public StubRentalService(List<RentalModel> rentals) => _rentals = rentals;
+            public Task RentItemAsync(int itemID, int customerID, DateTime rentalDate, DateTime dueDate) => Task.CompletedTask;
+            public Task ReturnItemAsync(int rentalID, DateTime returnDate) => Task.CompletedTask;
+            public Task ExtendRentalAsync(int rentalID, DateTime newDueDate) => Task.CompletedTask;
+            public Task DeleteRentalAsync(int rentalID) => Task.CompletedTask;
+            public Task<List<RentalModel>> GetActiveRentalsAsync() => Task.FromResult(new List<RentalModel>());
+            public Task<int> CountActiveRentalsAsync() => Task.FromResult(0);
+            public Task<List<RentalModel>> GetOverdueRentalsAsync() => Task.FromResult(new List<RentalModel>());
+            public Task<List<RentalModel>> GetAllRentalsAsync() => Task.FromResult(_rentals);
+            public Task<List<RentalModel>> GetRentalHistoryForItemAsync(int itemID) => Task.FromResult(new List<RentalModel>());
+            public Task<List<RentalModel>> GetRentalHistoryForCustomerAsync(int customerID) => Task.FromResult(new List<RentalModel>());
+        }
+
+        private sealed class StubDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public Task ShowInfoAsync(string message, string title) => Task.CompletedTask;
+            public bool ShowConfirmation(string message, string title) => true;
+            public Task<bool> ShowConfirmationAsync(string message, string title) => Task.FromResult(true);
+            public ItemModel? ShowEditItemDialog(ItemModel item) => null;
+            public Task<ItemModel?> ShowEditItemDialogAsync(ItemModel item) => Task.FromResult<ItemModel?>(null);
+            public void ShowItemDetails(ItemModel item) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
+            public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+        }
+    }
+}
+

--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -31,21 +31,33 @@ namespace InventoryManagementApp.ViewModels
         public string SearchText
         {
             get => _searchText;
-            set => SetProperty(ref _searchText, value);
+            set
+            {
+                if (SetProperty(ref _searchText, value))
+                    ApplyFilterCommand.Execute(null);
+            }
         }
 
         private DateTime? _filterFrom;
         public DateTime? FilterFrom
         {
             get => _filterFrom;
-            set => SetProperty(ref _filterFrom, value);
+            set
+            {
+                if (SetProperty(ref _filterFrom, value))
+                    ApplyFilterCommand.Execute(null);
+            }
         }
 
         private DateTime? _filterTo;
         public DateTime? FilterTo
         {
             get => _filterTo;
-            set => SetProperty(ref _filterTo, value);
+            set
+            {
+                if (SetProperty(ref _filterTo, value))
+                    ApplyFilterCommand.Execute(null);
+            }
         }
 
         public ObservableCollection<string> StatusOptions { get; } =
@@ -55,7 +67,11 @@ namespace InventoryManagementApp.ViewModels
         public string SelectedStatus
         {
             get => _selectedStatus;
-            set => SetProperty(ref _selectedStatus, value);
+            set
+            {
+                if (SetProperty(ref _selectedStatus, value))
+                    ApplyFilterCommand.Execute(null);
+            }
         }
 
         private RentalModel _selectedRental;
@@ -77,8 +93,6 @@ namespace InventoryManagementApp.ViewModels
 
         public IRelayCommand ApplyFilterCommand { get; }
         public IRelayCommand ClearFilterCommand { get; }
-        public IRelayCommand OpenFilterWindowCommand { get; }
-        public IRelayCommand CloseCommand { get; }
         public IAsyncRelayCommand CheckInCommand { get; }
         public IAsyncRelayCommand ExtendCommand { get; }
         public IAsyncRelayCommand OpenHistoryCommand { get; }
@@ -93,8 +107,6 @@ namespace InventoryManagementApp.ViewModels
 
             ApplyFilterCommand = new RelayCommand(ApplyFilter);
             ClearFilterCommand = new RelayCommand(ClearFilter);
-            OpenFilterWindowCommand = new RelayCommand(OpenFilterWindow);
-            CloseCommand = new RelayCommand(CloseFilterWindow);
             CheckInCommand = new AsyncRelayCommand(CheckInAsync, () => SelectedRental != null);
             ExtendCommand = new AsyncRelayCommand(ExtendAsync, () => SelectedRental != null);
             OpenHistoryCommand = new AsyncRelayCommand(OpenHistoryAsync, () => SelectedRental != null);
@@ -152,21 +164,6 @@ namespace InventoryManagementApp.ViewModels
             FilterTo = null;
             SelectedStatus = StatusOptions.First();
             Rentals.ReplaceRange(_allRentals);
-        }
-
-        void OpenFilterWindow()
-        {
-            _dialogService.ShowRentalsFilter(this);
-        }
-
-        void CloseFilterWindow()
-        {
-            if (System.Windows.Application.Current == null) return;
-            var window = System.Windows.Application.Current.Windows
-                .OfType<Window>()
-                .FirstOrDefault(w => w.DataContext == this);
-            if (window != null)
-                window.Close();
         }
 
         async Task CheckInAsync()

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
@@ -9,10 +9,18 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <ToolBar HorizontalAlignment="Right">
-            <Button Style="{StaticResource PrimaryButton}" Content="Filter" Command="{Binding OpenFilterWindowCommand}"/>
-            <Button Style="{StaticResource PrimaryButton}" Content="Check In" Command="{Binding CheckInCommand}" Margin="8,0,0,0"/>
-        </ToolBar>
+        <Border Style="{StaticResource Card}" Padding="8">
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                <TextBlock Text="Rentals" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,16,0"/>
+                <TextBox Width="160" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0"/>
+                <DatePicker SelectedDate="{Binding FilterFrom, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0"/>
+                <DatePicker SelectedDate="{Binding FilterTo, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0"/>
+                <ComboBox ItemsSource="{Binding StatusOptions}" SelectedItem="{Binding SelectedStatus, UpdateSourceTrigger=PropertyChanged}" Width="120" Margin="0,0,8,0"/>
+                <Button Style="{StaticResource PrimaryButton}" Content="Apply" Command="{Binding ApplyFilterCommand}" Margin="0,0,8,0"/>
+                <Button Style="{StaticResource PrimaryButton}" Content="Clear" Command="{Binding ClearFilterCommand}" Margin="0,0,8,0"/>
+                <Button Style="{StaticResource PrimaryButton}" Content="Check In" Command="{Binding CheckInCommand}"/>
+            </StackPanel>
+        </Border>
 
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
             <DataGrid ItemsSource="{Binding Rentals}"
@@ -42,7 +50,5 @@
                 </DataGrid.ContextMenu>
             </DataGrid>
         </Border>
-
-        <!-- Filter overlay removed; filtering handled by RentalsFilterWindow -->
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- Replace rentals page toolbar with card header containing inline filters and actions
- Auto-apply rental filters on property changes and remove filter window commands
- Add unit test covering automatic filter application

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa27e3098c832486fbd5ee401a7a46