### PR TITLE
Add loading indicator and empty rentals message

### DIFF
--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -91,6 +91,13 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
+        private bool _isLoading;
+        public bool IsLoading
+        {
+            get => _isLoading;
+            set => SetProperty(ref _isLoading, value);
+        }
+
         public IRelayCommand ApplyFilterCommand { get; }
         public IRelayCommand ClearFilterCommand { get; }
         public IAsyncRelayCommand CheckInCommand { get; }
@@ -117,6 +124,7 @@ namespace InventoryManagementApp.ViewModels
         /// <summary>Loads all rentals from the service.</summary>
         public async Task LoadRentalsAsync()
         {
+            IsLoading = true;
             try
             {
                 _allRentals = await _rentalService.GetAllRentalsAsync();
@@ -126,6 +134,10 @@ namespace InventoryManagementApp.ViewModels
             {
                 _logger.LogError(ex, "Failed to load rentals");
                 await _dialogService.ShowInfoAsync($"Failed to load rentals: {ex.Message}", "Error");
+            }
+            finally
+            {
+                IsLoading = false;
             }
         }
 
@@ -172,6 +184,7 @@ namespace InventoryManagementApp.ViewModels
                 return;
             try
             {
+                IsLoading = true;
                 await _rentalService.ReturnItemAsync(SelectedRental.RentalID, DateTime.Today);
                 await LoadRentalsAsync();
             }
@@ -184,6 +197,10 @@ namespace InventoryManagementApp.ViewModels
                 _logger.LogError(ex, "Failed to check in rental {RentalID}", SelectedRental.RentalID);
                 await _dialogService.ShowInfoAsync($"Failed to check in rental: {ex.Message}", "Error");
             }
+            finally
+            {
+                IsLoading = false;
+            }
         }
 
         async Task ExtendAsync()
@@ -192,6 +209,7 @@ namespace InventoryManagementApp.ViewModels
                 return;
             try
             {
+                IsLoading = true;
                 var newDueDate = SelectedRental.DueDate.AddDays(7);
                 await _rentalService.ExtendRentalAsync(SelectedRental.RentalID, newDueDate);
                 await LoadRentalsAsync();
@@ -204,6 +222,10 @@ namespace InventoryManagementApp.ViewModels
             {
                 _logger.LogError(ex, "Failed to extend rental {RentalID}", SelectedRental.RentalID);
                 await _dialogService.ShowInfoAsync($"Failed to extend rental: {ex.Message}", "Error");
+            }
+            finally
+            {
+                IsLoading = false;
             }
         }
 
@@ -296,6 +318,7 @@ namespace InventoryManagementApp.ViewModels
                 return;
             try
             {
+                IsLoading = true;
                 var rentalToDelete = SelectedRental;
                 await _rentalService.DeleteRentalAsync(rentalToDelete.RentalID);
                 _allRentals.Remove(rentalToDelete);
@@ -310,6 +333,10 @@ namespace InventoryManagementApp.ViewModels
             {
                 _logger.LogError(ex, "Failed to delete rental {RentalID}", SelectedRental.RentalID);
                 await _dialogService.ShowInfoAsync($"Failed to delete rental: {ex.Message}", "Error");
+            }
+            finally
+            {
+                IsLoading = false;
             }
         }
     }

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
@@ -7,6 +7,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <Border Style="{StaticResource Card}" Padding="8">
@@ -23,32 +24,56 @@
         </Border>
 
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
-            <DataGrid ItemsSource="{Binding Rentals}"
-                      SelectedItem="{Binding SelectedRental}"
-                      IsReadOnly="True"
-                      AutoGenerateColumns="False"
-                      Style="{StaticResource VirtualizedDataGridStyle}">
-                <DataGrid.Columns>
-                    <StaticResource ResourceKey="RentalIdColumn"/>
-                    <StaticResource ResourceKey="RentalItemNumberColumn"/>
-                    <StaticResource ResourceKey="RentalItemNameColumn"/>
-                    <StaticResource ResourceKey="RentalCustomerColumn"/>
-                    <StaticResource ResourceKey="RentalOutColumn"/>
-                    <StaticResource ResourceKey="RentalDueColumn"/>
-                    <StaticResource ResourceKey="RentalReturnedColumn"/>
-                    <StaticResource ResourceKey="RentalStatusColumn"/>
-                </DataGrid.Columns>
-                <DataGrid.ContextMenu>
-                    <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
-                                DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                        <MenuItem Header="Check In" Command="{Binding CheckInCommand}"/>
-                        <MenuItem Header="Extend" Command="{Binding ExtendCommand}"/>
-                        <MenuItem Header="History" Command="{Binding OpenHistoryCommand}"/>
-                        <MenuItem Header="Print" Command="{Binding PrintRentalCommand}"/>
-                        <MenuItem Header="Delete" Command="{Binding DeleteRentalCommand}"/>
-                    </ContextMenu>
-                </DataGrid.ContextMenu>
-            </DataGrid>
+            <Grid>
+                <DataGrid ItemsSource="{Binding Rentals}"
+                          SelectedItem="{Binding SelectedRental}"
+                          IsReadOnly="True"
+                          AutoGenerateColumns="False"
+                          Style="{StaticResource VirtualizedDataGridStyle}">
+                    <DataGrid.Columns>
+                        <StaticResource ResourceKey="RentalIdColumn"/>
+                        <StaticResource ResourceKey="RentalItemNumberColumn"/>
+                        <StaticResource ResourceKey="RentalItemNameColumn"/>
+                        <StaticResource ResourceKey="RentalCustomerColumn"/>
+                        <StaticResource ResourceKey="RentalOutColumn"/>
+                        <StaticResource ResourceKey="RentalDueColumn"/>
+                        <StaticResource ResourceKey="RentalReturnedColumn"/>
+                        <StaticResource ResourceKey="RentalStatusColumn"/>
+                    </DataGrid.Columns>
+                    <DataGrid.ContextMenu>
+                        <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
+                                    DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                            <MenuItem Header="Check In" Command="{Binding CheckInCommand}"/>
+                            <MenuItem Header="Extend" Command="{Binding ExtendCommand}"/>
+                            <MenuItem Header="History" Command="{Binding OpenHistoryCommand}"/>
+                            <MenuItem Header="Print" Command="{Binding PrintRentalCommand}"/>
+                            <MenuItem Header="Delete" Command="{Binding DeleteRentalCommand}"/>
+                        </ContextMenu>
+                    </DataGrid.ContextMenu>
+                </DataGrid>
+                <TextBlock Text="No rentals"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           FontSize="16"
+                           FontWeight="SemiBold">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Rentals.Count}" Value="0">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+            </Grid>
         </Border>
+
+        <ProgressBar Grid.Row="2"
+                     IsIndeterminate="True"
+                     Height="4"
+                     Margin="0,8,0,0"
+                     Visibility="{Binding IsLoading, Converter={StaticResource BoolToVis}}"/>
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- show progress bar while rentals load or refresh
- display placeholder text when no rentals exist

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aa290908408324b181e8b322b29b1a