### PR TITLE
Respect admin status when persisting default settings

### DIFF
--- a/InventoryManagementApp.Tests/SettingsServiceAuthorizationTests.cs
+++ b/InventoryManagementApp.Tests/SettingsServiceAuthorizationTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Services.Core;
+using InventoryManagementApp.Services.Settings;
+using Xunit;
+
+public class SettingsServiceAuthorizationTests
+{
+    private sealed class NonAdminAuthorizationService : IAuthorizationService
+    {
+        public bool IsAdmin => false;
+        public void EnsureAdmin() => throw new UnauthorizedAccessException();
+    }
+
+    [Fact]
+    public async Task NonAdmin_LoadsDefaultWithoutSaving()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        var auth = new NonAdminAuthorizationService();
+        var settings = new SettingsService(db, auth);
+
+        var value = await settings.GetShowItemImageAsync();
+
+        Assert.True(value);
+        Assert.Null(await settings.GetSettingAsync("ShowItemImage"));
+    }
+}
+

--- a/InventoryManagementApp/Interfaces/IAuthorizationService.cs
+++ b/InventoryManagementApp/Interfaces/IAuthorizationService.cs
@@ -2,6 +2,7 @@ namespace InventoryManagementApp.Interfaces
 {
     public interface IAuthorizationService
     {
+        bool IsAdmin { get; }
         void EnsureAdmin();
     }
 }

--- a/InventoryManagementApp/Services/Settings/SettingsService.cs
+++ b/InventoryManagementApp/Services/Settings/SettingsService.cs
@@ -326,7 +326,10 @@ namespace InventoryManagementApp.Services.Settings
             var value = await GetSettingAsync(key, cancellationToken).ConfigureAwait(false);
             if (value is null)
             {
-                await SaveSettingAsync(key, defaultValue.ToString(), cancellationToken).ConfigureAwait(false);
+                if (_auth.IsAdmin)
+                {
+                    await SaveSettingAsync(key, defaultValue.ToString(), cancellationToken).ConfigureAwait(false);
+                }
                 return defaultValue;
             }
             return ParseBool(value, defaultValue);

--- a/InventoryManagementApp/Services/Users/AuthorizationService.cs
+++ b/InventoryManagementApp/Services/Users/AuthorizationService.cs
@@ -16,6 +16,8 @@ namespace InventoryManagementApp.Services.Users
             _logger = logger ?? NullLogger<AuthorizationService>.Instance;
         }
 
+        public bool IsAdmin => _userContext.IsAdmin;
+
         public void EnsureAdmin()
         {
             if (!_userContext.IsAdmin)

--- a/InventoryManagementApp/Services/Users/NoOpAuthorizationService.cs
+++ b/InventoryManagementApp/Services/Users/NoOpAuthorizationService.cs
@@ -4,6 +4,7 @@ namespace InventoryManagementApp.Services.Users
 {
     public class NoOpAuthorizationService : IAuthorizationService
     {
+        public bool IsAdmin => true;
         public void EnsureAdmin() { }
     }
 }


### PR DESCRIPTION
## Summary
- expose IsAdmin on authorization service
- guard settings persistence behind admin check and add unit test

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa291605b0832499bc223a80cfe1de