### PR TITLE
Refactor viewmodel initialization to async

### DIFF
--- a/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
+++ b/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
@@ -81,6 +81,12 @@ public class ItemDisplaySettingsTests
         public void ShowPrintLabelDialog() { }
     }
 
+    private sealed class DummyFileDialogService : IFileDialogService
+    {
+        public string? OpenFile(string filter, string? initialDirectory = null) => null;
+        public string? SaveFile(string filter) => null;
+    }
+
     [Fact]
     public async Task ItemManagementViewModel_ReflectsDisplaySettings()
     {
@@ -93,6 +99,7 @@ public class ItemDisplaySettingsTests
         await settings.SaveShowItemLocationAsync(false);
         await settings.SaveShowItemNotesAsync(false);
         var vmFalse = new ItemManagementViewModel(new DummyItemService(), new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
+        await vmFalse.InitializeAsync();
         Assert.False(vmFalse.ShowImage);
         Assert.False(vmFalse.ShowName);
         Assert.False(vmFalse.ShowItemNumber);
@@ -104,6 +111,7 @@ public class ItemDisplaySettingsTests
         await settings.SaveShowItemLocationAsync(true);
         await settings.SaveShowItemNotesAsync(true);
         var vmTrue = new ItemManagementViewModel(new DummyItemService(), new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
+        await vmTrue.InitializeAsync();
         Assert.True(vmTrue.ShowImage);
         Assert.True(vmTrue.ShowName);
         Assert.True(vmTrue.ShowItemNumber);
@@ -128,6 +136,7 @@ public class ItemDisplaySettingsTests
                 settings.SaveShowItemLocationAsync(false).GetAwaiter().GetResult();
                 settings.SaveShowItemNotesAsync(false).GetAwaiter().GetResult();
                 var vm = new ItemManagementViewModel(new DummyItemService(), new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
+                vm.InitializeAsync().GetAwaiter().GetResult();
                 var app = new Application();
                 app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
                 app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
@@ -145,6 +154,7 @@ public class ItemDisplaySettingsTests
                 Assert.Equal(Visibility.Collapsed, border.Visibility);
                 settings.SaveShowItemNameAsync(true).GetAwaiter().GetResult();
                 vm = new ItemManagementViewModel(new DummyItemService(), new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
+                vm.InitializeAsync().GetAwaiter().GetResult();
                 itemsControl.DataContext = vm;
                 itemsControl.UpdateLayout();
                 border = (Border)VisualTreeHelper.GetChild(container, 0);
@@ -164,5 +174,36 @@ public class ItemDisplaySettingsTests
         thread.Start();
         thread.Join();
         if (threadEx != null) throw threadEx;
+    }
+
+    [Fact]
+    public async Task SettingsViewModel_InitializeAsync_LoadsSettings()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        var settings = new SettingsService(db);
+        await settings.SaveSettingAsync("ApplicationName", "TestApp");
+        await settings.SaveShowItemNameAsync(true);
+        var vm = new SettingsViewModel(new DummyFileDialogService(), settings, new DummyDialogService());
+        await vm.InitializeAsync();
+        Assert.Equal("TestApp", vm.ApplicationName);
+        Assert.True(vm.ShowItemName);
+    }
+
+    [Fact]
+    public void SettingsViewModel_InitializeAsync_DoesNotDeadlock()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        using var db = new DatabaseService(dbPath);
+        var settings = new SettingsService(db);
+        var vm = new SettingsViewModel(new DummyFileDialogService(), settings, new DummyDialogService());
+        var thread = new Thread(() =>
+        {
+            SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+            vm.InitializeAsync().GetAwaiter().GetResult();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
     }
 }

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -143,11 +143,6 @@ namespace InventoryManagementApp.ViewModels
             OpenRentalsCommand = new AsyncRelayCommand(ct => OpenRentalsAsync(ct), () => SelectedItem != null);
             ViewDetailsCommand = new RelayCommand(ViewDetails, () => SelectedItem != null);
             OpenRentalHistoryCommand = new AsyncRelayCommand(OpenRentalHistoryAsync, () => SelectedItem != null);
-            ShowImage = _settingsService.GetShowItemImageAsync().GetAwaiter().GetResult();
-            ShowName = _settingsService.GetShowItemNameAsync().GetAwaiter().GetResult();
-            ShowItemNumber = _settingsService.GetShowItemNumberAsync().GetAwaiter().GetResult();
-            ShowLocation = _settingsService.GetShowItemLocationAsync().GetAwaiter().GetResult();
-            ShowNotes = _settingsService.GetShowItemNotesAsync().GetAwaiter().GetResult();
             // Ensure no duplicate event subscriptions when the view model is
             // constructed multiple times or the collection persists across
             // instances.
@@ -155,11 +150,52 @@ namespace InventoryManagementApp.ViewModels
             Items.CollectionChanged += Items_CollectionChanged;
         }
 
-        public bool ShowImage { get; }
-        public bool ShowName { get; }
-        public bool ShowItemNumber { get; }
-        public bool ShowLocation { get; }
-        public bool ShowNotes { get; }
+        bool _showImage;
+        public bool ShowImage
+        {
+            get => _showImage;
+            private set => SetProperty(ref _showImage, value);
+        }
+
+        bool _showName;
+        public bool ShowName
+        {
+            get => _showName;
+            private set => SetProperty(ref _showName, value);
+        }
+
+        bool _showItemNumber;
+        public bool ShowItemNumber
+        {
+            get => _showItemNumber;
+            private set => SetProperty(ref _showItemNumber, value);
+        }
+
+        bool _showLocation;
+        public bool ShowLocation
+        {
+            get => _showLocation;
+            private set => SetProperty(ref _showLocation, value);
+        }
+
+        bool _showNotes;
+        public bool ShowNotes
+        {
+            get => _showNotes;
+            private set => SetProperty(ref _showNotes, value);
+        }
+
+        bool _initialized;
+        public async Task InitializeAsync()
+        {
+            if (_initialized) return;
+            ShowImage = await _settingsService.GetShowItemImageAsync().ConfigureAwait(false);
+            ShowName = await _settingsService.GetShowItemNameAsync().ConfigureAwait(false);
+            ShowItemNumber = await _settingsService.GetShowItemNumberAsync().ConfigureAwait(false);
+            ShowLocation = await _settingsService.GetShowItemLocationAsync().ConfigureAwait(false);
+            ShowNotes = await _settingsService.GetShowItemNotesAsync().ConfigureAwait(false);
+            _initialized = true;
+        }
 
         void OnSearchDebounceTimerTick(object? s, EventArgs e)
         {

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -261,6 +261,7 @@ namespace InventoryManagementApp.ViewModels
             OpenSearchItemsCommand = new AsyncRelayCommand(async () =>
             {
                 var plural = LabelProvider.Instance.ItemLabelPlural;
+                await ItemManagement.InitializeAsync();
                 var page = new ItemSearchPage { DataContext = ItemManagement, Title = $"Search {plural}" };
                 CurrentPage = page;
                 try
@@ -345,13 +346,13 @@ namespace InventoryManagementApp.ViewModels
             {
                 try
                 {
+                    await Settings.InitializeAsync();
                     var page = new SettingsPage
                     {
                         DataContext = Settings,
                         Title = "Settings"
                     };
                     CurrentPage = page;
-                    await Task.CompletedTask;
                 }
                 catch (Exception ex)
                 {

--- a/InventoryManagementApp/ViewModels/SettingsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/SettingsViewModel.cs
@@ -29,25 +29,10 @@ namespace InventoryManagementApp.ViewModels
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<SettingsViewModel>.Instance;
 
-            var logoPath = _settingsService.GetSettingAsync("CompanyLogoPath").GetAwaiter().GetResult();
-            if (!string.IsNullOrWhiteSpace(logoPath))
-                CompanyLogoPath = logoPath;
-
-            var appName = _settingsService.GetSettingAsync("ApplicationName").GetAwaiter().GetResult();
-            if (!string.IsNullOrWhiteSpace(appName))
-                _applicationName = appName;
-
             ThemeOptions = new ObservableCollection<string> { "Light", "Dark" };
             _theme = ThemeOptions[0];
-            _passwordIterations = _settingsService.GetPasswordIterationsAsync().GetAwaiter().GetResult();
-            _autoLogoutMinutes = _settingsService.GetAutoLogoutMinutesAsync().GetAwaiter().GetResult();
             _itemLabelSingular = LabelProvider.Instance.ItemLabelSingular;
             _itemLabelPlural = LabelProvider.Instance.ItemLabelPlural;
-            _showItemImage = _settingsService.GetShowItemImageAsync().GetAwaiter().GetResult();
-            _showItemName = _settingsService.GetShowItemNameAsync().GetAwaiter().GetResult();
-            _showItemNumber = _settingsService.GetShowItemNumberAsync().GetAwaiter().GetResult();
-            _showItemLocation = _settingsService.GetShowItemLocationAsync().GetAwaiter().GetResult();
-            _showItemNotes = _settingsService.GetShowItemNotesAsync().GetAwaiter().GetResult();
             TestDbCommand = new RelayCommand(() =>
             {
                 var success = TestDbConnection(out var message);
@@ -72,6 +57,35 @@ namespace InventoryManagementApp.ViewModels
             });
         }
 
+        bool _initialized;
+        public async Task InitializeAsync()
+        {
+            if (_initialized) return;
+            var logoPath = await _settingsService.GetSettingAsync("CompanyLogoPath").ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(logoPath))
+                _companyLogoPath = logoPath;
+            var appName = await _settingsService.GetSettingAsync("ApplicationName").ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(appName))
+                _applicationName = appName;
+            _passwordIterations = await _settingsService.GetPasswordIterationsAsync().ConfigureAwait(false);
+            _autoLogoutMinutes = await _settingsService.GetAutoLogoutMinutesAsync().ConfigureAwait(false);
+            _showItemImage = await _settingsService.GetShowItemImageAsync().ConfigureAwait(false);
+            _showItemName = await _settingsService.GetShowItemNameAsync().ConfigureAwait(false);
+            _showItemNumber = await _settingsService.GetShowItemNumberAsync().ConfigureAwait(false);
+            _showItemLocation = await _settingsService.GetShowItemLocationAsync().ConfigureAwait(false);
+            _showItemNotes = await _settingsService.GetShowItemNotesAsync().ConfigureAwait(false);
+            OnPropertyChanged(nameof(CompanyLogoPath));
+            OnPropertyChanged(nameof(ApplicationName));
+            OnPropertyChanged(nameof(PasswordIterations));
+            OnPropertyChanged(nameof(AutoLogoutMinutes));
+            OnPropertyChanged(nameof(ShowItemImage));
+            OnPropertyChanged(nameof(ShowItemName));
+            OnPropertyChanged(nameof(ShowItemNumber));
+            OnPropertyChanged(nameof(ShowItemLocation));
+            OnPropertyChanged(nameof(ShowItemNotes));
+            _initialized = true;
+        }
+
         private string _applicationName = string.Empty;
         public string ApplicationName
         {
@@ -80,20 +94,25 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _applicationName, value))
                 {
-                    try
-                    {
-                        _settingsService.SaveSettingAsync("ApplicationName", value).GetAwaiter().GetResult();
-                    }
-                    catch (UnauthorizedAccessException ex)
-                    {
-                        _logger.LogWarning(ex, "Unauthorized to change settings.");
-                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to save application name.");
-                    }
+                    _ = SaveApplicationNameAsync(value);
                 }
+            }
+        }
+
+        async Task SaveApplicationNameAsync(string value)
+        {
+            try
+            {
+                await _settingsService.SaveSettingAsync("ApplicationName", value).ConfigureAwait(false);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogWarning(ex, "Unauthorized to change settings.");
+                _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save application name.");
             }
         }
 
@@ -112,21 +131,26 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _itemLabelSingular, value))
                 {
-                    try
-                    {
-                        _settingsService.SaveItemLabelSingularAsync(value).GetAwaiter().GetResult();
-                        LabelProvider.Instance.UpdateLabels(value, ItemLabelPlural);
-                    }
-                    catch (UnauthorizedAccessException ex)
-                    {
-                        _logger.LogWarning(ex, "Unauthorized to change settings.");
-                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to save item label singular.");
-                    }
+                    _ = SaveItemLabelSingularAsync(value);
                 }
+            }
+        }
+
+        async Task SaveItemLabelSingularAsync(string value)
+        {
+            try
+            {
+                await _settingsService.SaveItemLabelSingularAsync(value).ConfigureAwait(false);
+                LabelProvider.Instance.UpdateLabels(value, ItemLabelPlural);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogWarning(ex, "Unauthorized to change settings.");
+                _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save item label singular.");
             }
         }
 
@@ -138,21 +162,26 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _itemLabelPlural, value))
                 {
-                    try
-                    {
-                        _settingsService.SaveItemLabelPluralAsync(value).GetAwaiter().GetResult();
-                        LabelProvider.Instance.UpdateLabels(ItemLabelSingular, value);
-                    }
-                    catch (UnauthorizedAccessException ex)
-                    {
-                        _logger.LogWarning(ex, "Unauthorized to change settings.");
-                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to save item label plural.");
-                    }
+                    _ = SaveItemLabelPluralAsync(value);
                 }
+            }
+        }
+
+        async Task SaveItemLabelPluralAsync(string value)
+        {
+            try
+            {
+                await _settingsService.SaveItemLabelPluralAsync(value).ConfigureAwait(false);
+                LabelProvider.Instance.UpdateLabels(ItemLabelSingular, value);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogWarning(ex, "Unauthorized to change settings.");
+                _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save item label plural.");
             }
         }
 
@@ -182,7 +211,7 @@ namespace InventoryManagementApp.ViewModels
         public int PasswordIterations
         {
             get => _passwordIterations;
-            set => SetPasswordIterationsAsync(value).GetAwaiter().GetResult();
+            set => _ = SetPasswordIterationsAsync(value);
         }
 
         async Task SetPasswordIterationsAsync(int value, CancellationToken token = default)
@@ -227,7 +256,7 @@ namespace InventoryManagementApp.ViewModels
         public int AutoLogoutMinutes
         {
             get => _autoLogoutMinutes;
-            set => SetAutoLogoutMinutesAsync(value).GetAwaiter().GetResult();
+            set => _ = SetAutoLogoutMinutesAsync(value);
         }
 
         async Task SetAutoLogoutMinutesAsync(int value, CancellationToken token = default)
@@ -263,20 +292,25 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _showItemImage, value))
                 {
-                    try
-                    {
-                        _settingsService.SaveShowItemImageAsync(value).GetAwaiter().GetResult();
-                    }
-                    catch (UnauthorizedAccessException ex)
-                    {
-                        _logger.LogWarning(ex, "Unauthorized to change settings.");
-                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to save ShowItemImage setting.");
-                    }
+                    _ = SaveShowItemImageAsync(value);
                 }
+            }
+        }
+
+        async Task SaveShowItemImageAsync(bool value)
+        {
+            try
+            {
+                await _settingsService.SaveShowItemImageAsync(value).ConfigureAwait(false);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogWarning(ex, "Unauthorized to change settings.");
+                _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save ShowItemImage setting.");
             }
         }
 
@@ -288,20 +322,25 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _showItemName, value))
                 {
-                    try
-                    {
-                        _settingsService.SaveShowItemNameAsync(value).GetAwaiter().GetResult();
-                    }
-                    catch (UnauthorizedAccessException ex)
-                    {
-                        _logger.LogWarning(ex, "Unauthorized to change settings.");
-                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to save ShowItemName setting.");
-                    }
+                    _ = SaveShowItemNameAsync(value);
                 }
+            }
+        }
+
+        async Task SaveShowItemNameAsync(bool value)
+        {
+            try
+            {
+                await _settingsService.SaveShowItemNameAsync(value).ConfigureAwait(false);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogWarning(ex, "Unauthorized to change settings.");
+                _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save ShowItemName setting.");
             }
         }
 
@@ -313,20 +352,25 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _showItemNumber, value))
                 {
-                    try
-                    {
-                        _settingsService.SaveShowItemNumberAsync(value).GetAwaiter().GetResult();
-                    }
-                    catch (UnauthorizedAccessException ex)
-                    {
-                        _logger.LogWarning(ex, "Unauthorized to change settings.");
-                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to save ShowItemNumber setting.");
-                    }
+                    _ = SaveShowItemNumberAsync(value);
                 }
+            }
+        }
+
+        async Task SaveShowItemNumberAsync(bool value)
+        {
+            try
+            {
+                await _settingsService.SaveShowItemNumberAsync(value).ConfigureAwait(false);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogWarning(ex, "Unauthorized to change settings.");
+                _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save ShowItemNumber setting.");
             }
         }
 
@@ -338,20 +382,25 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _showItemLocation, value))
                 {
-                    try
-                    {
-                        _settingsService.SaveShowItemLocationAsync(value).GetAwaiter().GetResult();
-                    }
-                    catch (UnauthorizedAccessException ex)
-                    {
-                        _logger.LogWarning(ex, "Unauthorized to change settings.");
-                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to save ShowItemLocation setting.");
-                    }
+                    _ = SaveShowItemLocationAsync(value);
                 }
+            }
+        }
+
+        async Task SaveShowItemLocationAsync(bool value)
+        {
+            try
+            {
+                await _settingsService.SaveShowItemLocationAsync(value).ConfigureAwait(false);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogWarning(ex, "Unauthorized to change settings.");
+                _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save ShowItemLocation setting.");
             }
         }
 
@@ -363,20 +412,25 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _showItemNotes, value))
                 {
-                    try
-                    {
-                        _settingsService.SaveShowItemNotesAsync(value).GetAwaiter().GetResult();
-                    }
-                    catch (UnauthorizedAccessException ex)
-                    {
-                        _logger.LogWarning(ex, "Unauthorized to change settings.");
-                        _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to save ShowItemNotes setting.");
-                    }
+                    _ = SaveShowItemNotesAsync(value);
                 }
+            }
+        }
+
+        async Task SaveShowItemNotesAsync(bool value)
+        {
+            try
+            {
+                await _settingsService.SaveShowItemNotesAsync(value).ConfigureAwait(false);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogWarning(ex, "Unauthorized to change settings.");
+                _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save ShowItemNotes setting.");
             }
         }
 


### PR DESCRIPTION
## Summary
- load item display options via async InitializeAsync in ItemManagementViewModel
- async initialization and saves in SettingsViewModel
- await initialization when opening search and settings views
- add tests validating async initialization without deadlocks

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2925900483249b88d1c28d6be6a8