### PR TITLE
Exclude rental items from item listings

### DIFF
--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -491,6 +491,39 @@ namespace InventoryManagementApp.Tests
             Assert.Single(itemService.Added);
         }
 
+        [Fact]
+        public async Task LoadMoreAsync_ExcludesRentalItems()
+        {
+            var itemService = new RentalFilteringItemService();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
+            var customer = new DummyCustomerService();
+            var settings = new DummySettingsService();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, customer, settings, new DummyUserContext());
+            await vm.LoadMoreAsync();
+            Assert.Single(vm.Items);
+            Assert.False(vm.Items[0].IsRentalItem);
+            Assert.Equal(false, itemService.LastIsRentalItem);
+        }
+
+        [Fact]
+        public async Task LoadMoreAsync_SearchExcludesRentalItems()
+        {
+            var itemService = new RentalFilteringItemService();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
+            var customer = new DummyCustomerService();
+            var settings = new DummySettingsService();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, customer, settings, new DummyUserContext());
+            vm.Filter = "abc";
+            await vm.LoadMoreAsync();
+            Assert.Single(vm.Items);
+            Assert.False(vm.Items[0].IsRentalItem);
+            Assert.Equal(false, itemService.LastIsRentalItem);
+        }
+
         private sealed class PagingItemService : IItemService
         {
             private const int PageSize = 200;
@@ -526,6 +559,55 @@ namespace InventoryManagementApp.Tests
                     await Task.Yield();
                     ct.ThrowIfCancellationRequested();
                     yield return new ItemModel { ItemID = (page - 1) * PageSize + i + 1 };
+                }
+            }
+        }
+
+        private sealed class RentalFilteringItemService : IItemService
+        {
+            public bool? LastIsRentalItem { get; private set; }
+            public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(null);
+
+            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default)
+            {
+                LastIsRentalItem = isRentalItem;
+                return Enumerate(isRentalItem, cancellationToken);
+            }
+
+            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default)
+            {
+                LastIsRentalItem = isRentalItem;
+                return Enumerate(isRentalItem, cancellationToken);
+            }
+
+            public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+            public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, string currentUser, CancellationToken cancellationToken = default) => Task.FromResult(false);
+            public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
+            public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, SqliteConnection? conn = null, SqliteTransaction? tx = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct) => Task.CompletedTask;
+
+            private async IAsyncEnumerable<ItemModel> Enumerate(bool? isRentalItem, [EnumeratorCancellation] CancellationToken ct = default)
+            {
+                var items = new[]
+                {
+                    new ItemModel { ItemID = 1, IsRentalItem = false },
+                    new ItemModel { ItemID = 2, IsRentalItem = true }
+                };
+                foreach (var item in items)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    if (isRentalItem == false && item.IsRentalItem)
+                        continue;
+                    yield return item;
+                    await Task.Yield();
                 }
             }
         }

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -40,7 +40,7 @@ namespace InventoryManagementApp.Services.Items
         public async Task<FlowDocument> GenerateInventoryReport()
         {
             var items = new List<ItemModel>();
-            await foreach (var item in _itemService.GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending).ConfigureAwait(false))
+            await foreach (var item in _itemService.GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, isRentalItem: false).ConfigureAwait(false))
                 items.Add(item);
             var lines = items.Select(t =>
                 $"ItemModel ID: {t.ItemID} | ItemNumber: {t.ItemNumber} | Qty: {t.QuantityOnHand} | Location: {t.Location} | Supplier: {t.Supplier}");
@@ -122,7 +122,7 @@ namespace InventoryManagementApp.Services.Items
         private async Task<int> CountItemsAsync()
         {
             var count = 0;
-            await foreach (var _ in _itemService.GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending))
+            await foreach (var _ in _itemService.GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, isRentalItem: false))
                 count++;
             return count;
         }

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -175,7 +175,7 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 var list = new List<ItemModel>();
-                await foreach (var item in _itemService.GetItemsAsync(page, SortField.Name, SortDirection.Ascending))
+                await foreach (var item in _itemService.GetItemsAsync(page, SortField.Name, SortDirection.Ascending, isRentalItem: false))
                     list.Add(item);
                 Items.ReplaceRange(list);
                 SearchResults.ReplaceRange(list);
@@ -201,12 +201,12 @@ namespace InventoryManagementApp.ViewModels
 
             if (!string.IsNullOrEmpty(term))
             {
-                await foreach (var item in _itemService.SearchItemsAsync(term, page, SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken))
+                await foreach (var item in _itemService.SearchItemsAsync(term, page, SortField.Name, SortDirection.Ascending, isRentalItem: false, cancellationToken: cancellationToken))
                     list.Add(item);
             }
             else
             {
-                await foreach (var item in _itemService.GetItemsAsync(page, SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken))
+                await foreach (var item in _itemService.GetItemsAsync(page, SortField.Name, SortDirection.Ascending, isRentalItem: false, cancellationToken: cancellationToken))
                     list.Add(item);
             }
 

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -118,8 +118,8 @@ namespace InventoryManagementApp.ViewModels
             var result = new List<ItemModel>();
             var pageInfo = new ItemPage(page, PageSize);
             var source = string.IsNullOrWhiteSpace(Filter)
-                ? _itemService.GetItemsAsync(pageInfo, SelectedSortOption.Field, SelectedSortOption.Direction, cancellationToken: ct)
-                : _itemService.SearchItemsAsync(Filter, pageInfo, SelectedSortOption.Field, SelectedSortOption.Direction, cancellationToken: ct);
+                ? _itemService.GetItemsAsync(pageInfo, SelectedSortOption.Field, SelectedSortOption.Direction, isRentalItem: false, cancellationToken: ct)
+                : _itemService.SearchItemsAsync(Filter, pageInfo, SelectedSortOption.Field, SelectedSortOption.Direction, isRentalItem: false, cancellationToken: ct);
             await foreach (var item in source.ConfigureAwait(false))
             {
                 item.PropertyChanged += Item_PropertyChanged;


### PR DESCRIPTION
## Summary
- ensure item queries exclude rental items by passing `isRentalItem: false`
- extend item management and reporting routines to omit rentals
- add tests confirming rental items are not loaded

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aa2a43da60832492a861da0049cb9d