### PR TITLE
Prevent rental items from manual checkout

### DIFF
--- a/InventoryManagementApp.Tests/ItemServiceToggleTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceToggleTests.cs
@@ -113,4 +113,48 @@ public class ItemServiceToggleTests
 
         File.Delete(dbPath);
     }
+
+    [Fact]
+    public async Task RentalItemCannotBeToggled()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        await InitializeAsync(db);
+        var userContext = new DummyUserContext { CurrentUser = new User { UserID = 1, UserName = "user1", IsAdmin = false } };
+        var service = new ItemService(db, new DummyItemRepository(), userContext: userContext);
+
+        var result = await service.ToggleItemCheckOutStatusAsync(2, "user1", CancellationToken.None);
+        Assert.False(result);
+
+        using (var conn = db.CreateConnection())
+        {
+            var record = await conn.QuerySingleAsync("SELECT IsCheckedOut FROM Items WHERE ItemID=2");
+            Assert.Equal(0L, record.IsCheckedOut);
+        }
+
+        File.Delete(dbPath);
+    }
+
+    [Fact]
+    public async Task GetItemsCheckedOutByAsyncExcludesRentalItems()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        await InitializeAsync(db);
+        var userContext = new DummyUserContext { CurrentUser = new User { UserID = 1, UserName = "user1", IsAdmin = false } };
+        var service = new ItemService(db, new DummyItemRepository(), userContext: userContext);
+
+        await service.ToggleItemCheckOutStatusAsync(1, "user1", CancellationToken.None);
+
+        using (var conn = db.CreateConnection())
+        {
+            await conn.ExecuteAsync("UPDATE Items SET IsCheckedOut=1, CheckedOutBy='user1' WHERE ItemID=2");
+        }
+
+        var items = await service.GetItemsCheckedOutByAsync("user1", CancellationToken.None);
+        Assert.Single(items);
+        Assert.Equal(1, items[0].ItemID);
+
+        File.Delete(dbPath);
+    }
 }

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -93,19 +93,22 @@ namespace InventoryManagementApp.Services.Items
 
             var caller = _context.UserName;
             var result = await ToggleItemCheckOutStatusInternalAsync(itemID, caller, cancellationToken).ConfigureAwait(false);
-            if (result && _activityLog != null)
+            if (!result)
+                return false;
+
+            if (_activityLog != null)
             {
                 int userId = _context.CurrentUser?.UserID ?? 0;
                 await _activityLog.LogActionAsync(userId, caller, $"Toggled item {itemID} check-out status", cancellationToken).ConfigureAwait(false);
             }
-            return result;
+            return true;
         }
 
         public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default)
         {
             using var conn = _dbService.CreateConnection();
             return SqliteHelper.ExecuteReaderAsync(conn,
-                "SELECT * FROM Items WHERE CheckedOutBy=@User AND IsCheckedOut=1",
+                "SELECT * FROM Items WHERE CheckedOutBy=@User AND IsCheckedOut=1 AND IFNULL(IsRentalItem,0)=0",
                 MapItem,
                 new[] { new SqliteParameter("@User", userName) }, cancellationToken);
         }
@@ -447,12 +450,21 @@ namespace InventoryManagementApp.Services.Items
         {
             using var conn = _dbService.CreateConnection();
             var record = (await SqliteHelper.ExecuteReaderAsync(conn,
-                "SELECT IsCheckedOut, AvailableQuantity, CheckedOutBy FROM Items WHERE ItemID=@ID",
-                r => new { Out = Convert.ToInt32(r["IsCheckedOut"]) == 1, Qty = Convert.ToInt32(r["AvailableQuantity"]), By = r["CheckedOutBy"]?.ToString() },
+                "SELECT IsRentalItem, IsCheckedOut, AvailableQuantity, CheckedOutBy FROM Items WHERE ItemID=@ID",
+                r => new
+                {
+                    Rental = Convert.ToInt32(r["IsRentalItem"]) == 1,
+                    Out = Convert.ToInt32(r["IsCheckedOut"]) == 1,
+                    Qty = Convert.ToInt32(r["AvailableQuantity"]),
+                    By = r["CheckedOutBy"]?.ToString()
+                },
                 new[] { new SqliteParameter("@ID", itemID) }, cancellationToken)).FirstOrDefault();
 
             if (record == null)
                 throw new InvalidOperationException($"ItemModel {itemID} not found.");
+
+            if (record.Rental)
+                return false;
 
             if (!record.Out)
             {


### PR DESCRIPTION
## Summary
- block check-out toggling for rental items
- filter rental items from user-specific check-out lists
- test rental items cannot be toggled or returned by GetItemsCheckedOutByAsync

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2bb3262883249940cbf0fefa6542