### PR TITLE
Update user context on self-update and add test

### DIFF
--- a/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
@@ -40,7 +40,7 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public async Task EditUserUpdatesCurrentUserPhoto()
+        public async Task UpdateUserAsync_UpdatesCurrentUserPhotoAndRaisesEvent()
         {
             await RunOnStaThread(async () =>
             {
@@ -72,16 +72,13 @@ namespace InventoryManagementApp.Tests
                 allUsersField!.SetValue(um, allUsers);
                 um.SelectedUser = currentUser;
 
-                var clone = new User { UserID = 1, UserName = "u", UserPhotoPath = "new.png" };
-                await userService.UpdateUserAsync(clone);
-                var idx = um.Users.IndexOf(currentUser);
-                if (idx >= 0) um.Users[idx] = clone;
-                var idxAll = allUsers.IndexOf(currentUser);
-                if (idxAll >= 0) allUsers[idxAll] = clone;
-                if (ReferenceEquals(um.SelectedUser, currentUser)) um.SelectedUser = clone;
-                if (userContext.CurrentUser?.UserID == clone.UserID)
-                    userContext.CurrentUser = clone;
+                bool fired = false;
+                userContext.UserChanged += (_, _) => fired = true;
 
+                um.SelectedUser.UserPhotoPath = "new.png";
+                await um.UpdateUserAsync();
+
+                Assert.True(fired);
                 Assert.Equal("new.png", vm.CurrentUserPhotoPath);
             });
         }

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -191,6 +191,8 @@ namespace InventoryManagementApp.ViewModels
                 if (idxAll >= 0) _allUsers[idxAll] = SelectedUser;
                 var idx = Users.IndexOf(SelectedUser);
                 if (idx >= 0) Users[idx] = SelectedUser;
+                if (_userContext?.CurrentUser?.UserID == SelectedUser.UserID)
+                    _userContext.CurrentUser = SelectedUser;
             }
             catch (UnauthorizedAccessException)
             {


### PR DESCRIPTION
## Summary
- update current user in context when editing own profile
- test verifies user change event and photo path update

## Testing
- `dotnet test` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2ebaf9f0832492725793b75fea63