### PR TITLE
feat: add item detail visibility settings

### DIFF
--- a/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
+++ b/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -93,30 +94,16 @@ public class ItemDisplaySettingsTests
         var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
         await using var db = new DatabaseService(dbPath);
         var settings = new SettingsService(db);
-        await settings.SaveShowItemImageAsync(false);
-        await settings.SaveShowItemNameAsync(false);
-        await settings.SaveShowItemNumberAsync(false);
-        await settings.SaveShowItemLocationAsync(false);
-        await settings.SaveShowItemNotesAsync(false);
+        var allFalse = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => false);
+        await settings.SaveItemDetailVisibilityAsync(allFalse);
         var vmFalse = new ItemManagementViewModel(new DummyItemService(), new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
         await vmFalse.InitializeAsync();
-        Assert.False(vmFalse.ShowImage);
-        Assert.False(vmFalse.ShowName);
-        Assert.False(vmFalse.ShowItemNumber);
-        Assert.False(vmFalse.ShowLocation);
-        Assert.False(vmFalse.ShowNotes);
-        await settings.SaveShowItemImageAsync(true);
-        await settings.SaveShowItemNameAsync(true);
-        await settings.SaveShowItemNumberAsync(true);
-        await settings.SaveShowItemLocationAsync(true);
-        await settings.SaveShowItemNotesAsync(true);
+        Assert.All(vmFalse.VisibleFields.Values, v => Assert.False(v));
+        var allTrue = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true);
+        await settings.SaveItemDetailVisibilityAsync(allTrue);
         var vmTrue = new ItemManagementViewModel(new DummyItemService(), new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
         await vmTrue.InitializeAsync();
-        Assert.True(vmTrue.ShowImage);
-        Assert.True(vmTrue.ShowName);
-        Assert.True(vmTrue.ShowItemNumber);
-        Assert.True(vmTrue.ShowLocation);
-        Assert.True(vmTrue.ShowNotes);
+        Assert.All(vmTrue.VisibleFields.Values, v => Assert.True(v));
     }
 
     [Fact]
@@ -130,11 +117,8 @@ public class ItemDisplaySettingsTests
                 var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
                 using var db = new DatabaseService(dbPath);
                 var settings = new SettingsService(db);
-                settings.SaveShowItemImageAsync(false).GetAwaiter().GetResult();
-                settings.SaveShowItemNameAsync(false).GetAwaiter().GetResult();
-                settings.SaveShowItemNumberAsync(false).GetAwaiter().GetResult();
-                settings.SaveShowItemLocationAsync(false).GetAwaiter().GetResult();
-                settings.SaveShowItemNotesAsync(false).GetAwaiter().GetResult();
+                var allFalse = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => false);
+                settings.SaveItemDetailVisibilityAsync(allFalse).GetAwaiter().GetResult();
                 var vm = new ItemManagementViewModel(new DummyItemService(), new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
                 vm.InitializeAsync().GetAwaiter().GetResult();
                 var app = new Application();
@@ -142,7 +126,7 @@ public class ItemDisplaySettingsTests
                 app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
                 app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Templates.xaml", UriKind.Absolute) });
                 var template = (DataTemplate)app.Resources["ItemCardTemplate"];
-                var item = new ItemModel { Name = "A", ItemNumber = "1", Location = "L", Notes = "N" };
+                var item = new ItemModel { Name = "A", ItemNumber = "1", Brand = "B", Location = "L", Notes = "N", Price = 1m };
                 var itemsControl = new ItemsControl { DataContext = vm, ItemTemplate = template };
                 itemsControl.Items.Add(item);
                 var window = new Window { Content = itemsControl };
@@ -152,13 +136,19 @@ public class ItemDisplaySettingsTests
                 container.ApplyTemplate();
                 var border = (Border)VisualTreeHelper.GetChild(container, 0);
                 Assert.Equal(Visibility.Collapsed, border.Visibility);
-                settings.SaveShowItemNameAsync(true).GetAwaiter().GetResult();
+                var vis = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => false);
+                vis[ItemDetailField.Brand] = true;
+                settings.SaveItemDetailVisibilityAsync(vis).GetAwaiter().GetResult();
                 vm = new ItemManagementViewModel(new DummyItemService(), new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
                 vm.InitializeAsync().GetAwaiter().GetResult();
                 itemsControl.DataContext = vm;
                 itemsControl.UpdateLayout();
                 border = (Border)VisualTreeHelper.GetChild(container, 0);
                 Assert.Equal(Visibility.Visible, border.Visibility);
+                var grid = (Grid)VisualTreeHelper.GetChild(border, 0);
+                var stack = (StackPanel)grid.Children[1];
+                var brandBlock = (TextBlock)stack.Children[2];
+                Assert.Equal(Visibility.Visible, brandBlock.Visibility);
                 window.Close();
             }
             catch (Exception ex)
@@ -183,11 +173,13 @@ public class ItemDisplaySettingsTests
         await using var db = new DatabaseService(dbPath);
         var settings = new SettingsService(db);
         await settings.SaveSettingAsync("ApplicationName", "TestApp");
-        await settings.SaveShowItemNameAsync(true);
+        var vis = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => false);
+        vis[ItemDetailField.Name] = true;
+        await settings.SaveItemDetailVisibilityAsync(vis);
         var vm = new SettingsViewModel(new DummyFileDialogService(), settings, new DummyDialogService());
         await vm.InitializeAsync();
         Assert.Equal("TestApp", vm.ApplicationName);
-        Assert.True(vm.ShowItemName);
+        Assert.True(vm.ItemDetailOptions.Single(o => o.Field == ItemDetailField.Name).IsVisible);
     }
 
     [Fact]
@@ -196,6 +188,8 @@ public class ItemDisplaySettingsTests
         var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
         using var db = new DatabaseService(dbPath);
         var settings = new SettingsService(db);
+        var vis = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true);
+        settings.SaveItemDetailVisibilityAsync(vis).GetAwaiter().GetResult();
         var vm = new SettingsViewModel(new DummyFileDialogService(), settings, new DummyDialogService());
         var thread = new Thread(() =>
         {
@@ -205,5 +199,6 @@ public class ItemDisplaySettingsTests
         thread.SetApartmentState(ApartmentState.STA);
         thread.Start();
         thread.Join();
+        Assert.True(vm.ItemDetailOptions.Single(o => o.Field == ItemDetailField.Name).IsVisible);
     }
 }

--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -10,6 +10,7 @@ using InventoryManagementApp.Data;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Models.ImportExport;
+using InventoryManagementApp.Models;
 using InventoryManagementApp.Utilities;
 using InventoryManagementApp.ViewModels;
 using Xunit;
@@ -818,16 +819,10 @@ namespace InventoryManagementApp.Tests
             public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
             public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<bool> GetShowItemImageAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
-            public Task SaveShowItemImageAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<bool> GetShowItemNameAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
-            public Task SaveShowItemNameAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<bool> GetShowItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
-            public Task SaveShowItemNumberAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<bool> GetShowItemLocationAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
-            public Task SaveShowItemLocationAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<bool> GetShowItemNotesAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
-            public Task SaveShowItemNotesAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult<IDictionary<ItemDetailField, bool>>(Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true));
+            public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
         }
 
         private sealed class RecordingDialogService : IDialogService

--- a/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
@@ -166,16 +166,10 @@ namespace InventoryManagementApp.Tests
             public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
             public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<bool> GetShowItemImageAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
-            public Task SaveShowItemImageAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<bool> GetShowItemNameAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
-            public Task SaveShowItemNameAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<bool> GetShowItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
-            public Task SaveShowItemNumberAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<bool> GetShowItemLocationAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
-            public Task SaveShowItemLocationAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<bool> GetShowItemNotesAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
-            public Task SaveShowItemNotesAsync(bool value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult<IDictionary<ItemDetailField, bool>>(Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true));
+            public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
         }
 
         private sealed class DummyDialogService : IDialogService

--- a/InventoryManagementApp.Tests/SettingsServiceAuthorizationTests.cs
+++ b/InventoryManagementApp.Tests/SettingsServiceAuthorizationTests.cs
@@ -22,10 +22,10 @@ public class SettingsServiceAuthorizationTests
         var auth = new NonAdminAuthorizationService();
         var settings = new SettingsService(db, auth);
 
-        var value = await settings.GetShowItemImageAsync();
+        var dict = await settings.GetItemDetailVisibilityAsync();
 
-        Assert.True(value);
-        Assert.Null(await settings.GetSettingAsync("ShowItemImage"));
+        Assert.All(dict.Values, Assert.True);
+        Assert.Null(await settings.GetSettingAsync("ItemDetailVisibility"));
     }
 }
 

--- a/InventoryManagementApp/Interfaces/ISettingsService.cs
+++ b/InventoryManagementApp/Interfaces/ISettingsService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using InventoryManagementApp.Models;
 
 namespace InventoryManagementApp.Interfaces
 {
@@ -29,15 +30,7 @@ namespace InventoryManagementApp.Interfaces
         Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default);
 
         // Item display configuration
-        Task<bool> GetShowItemImageAsync(CancellationToken cancellationToken = default);
-        Task SaveShowItemImageAsync(bool value, CancellationToken cancellationToken = default);
-        Task<bool> GetShowItemNameAsync(CancellationToken cancellationToken = default);
-        Task SaveShowItemNameAsync(bool value, CancellationToken cancellationToken = default);
-        Task<bool> GetShowItemNumberAsync(CancellationToken cancellationToken = default);
-        Task SaveShowItemNumberAsync(bool value, CancellationToken cancellationToken = default);
-        Task<bool> GetShowItemLocationAsync(CancellationToken cancellationToken = default);
-        Task SaveShowItemLocationAsync(bool value, CancellationToken cancellationToken = default);
-        Task<bool> GetShowItemNotesAsync(CancellationToken cancellationToken = default);
-        Task SaveShowItemNotesAsync(bool value, CancellationToken cancellationToken = default);
+        Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default);
+        Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default);
     }
 }

--- a/InventoryManagementApp/Models/ItemDetailField.cs
+++ b/InventoryManagementApp/Models/ItemDetailField.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace InventoryManagementApp.Models
+{
+    public enum ItemDetailField
+    {
+        Image,
+        Name,
+        ItemNumber,
+        PartNumber,
+        Brand,
+        Location,
+        Price,
+        Notes
+    }
+}

--- a/InventoryManagementApp/Models/ItemDetailOption.cs
+++ b/InventoryManagementApp/Models/ItemDetailOption.cs
@@ -1,0 +1,22 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace InventoryManagementApp.Models
+{
+    public class ItemDetailOption : ObservableObject
+    {
+        public ItemDetailOption(ItemDetailField field, bool isVisible)
+        {
+            Field = field;
+            _isVisible = isVisible;
+        }
+
+        public ItemDetailField Field { get; }
+
+        bool _isVisible;
+        public bool IsVisible
+        {
+            get => _isVisible;
+            set => SetProperty(ref _isVisible, value);
+        }
+    }
+}

--- a/InventoryManagementApp/Resources/Templates.xaml
+++ b/InventoryManagementApp/Resources/Templates.xaml
@@ -1,7 +1,8 @@
 <!-- Resources/Templates.xaml -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers">
+                    xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
+                    xmlns:models="clr-namespace:InventoryManagementApp.Models">
     <DataTemplate x:Key="StatCardTemplate">
         <Border Style="{StaticResource Card}">
             <Grid>
@@ -21,11 +22,13 @@
         <Border Style="{StaticResource Card}" Width="220" Padding="0">
             <Border.Visibility>
                 <MultiBinding Converter="{StaticResource AnyTrueToVisibilityConverter}">
-                    <Binding Path="DataContext.ShowImage" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
-                    <Binding Path="DataContext.ShowName" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
-                    <Binding Path="DataContext.ShowItemNumber" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
-                    <Binding Path="DataContext.ShowLocation" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
-                    <Binding Path="DataContext.ShowNotes" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Image}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Name}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.ItemNumber}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Brand}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Location}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Price}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Notes}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
                 </MultiBinding>
             </Border.Visibility>
             <Grid>
@@ -33,14 +36,16 @@
                     <RowDefinition Height="140"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <Border Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" CornerRadius="8" Visibility="{Binding DataContext.ShowImage, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
+                <Border Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" CornerRadius="8" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Image}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
                     <Image Stretch="UniformToFill" Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
                 </Border>
                 <StackPanel Grid.Row="1" Margin="0,6,0,0">
-                    <TextBlock Text="{Binding Name}" Style="{StaticResource ListItemTitleTextBlock}" Visibility="{Binding DataContext.ShowName, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding ItemNumber}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.ShowItemNumber, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding Location}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.ShowLocation, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding Notes}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis" Visibility="{Binding DataContext.ShowNotes, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding Name}" Style="{StaticResource ListItemTitleTextBlock}" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Name}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding ItemNumber}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.ItemNumber}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding Brand}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Brand}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding Location}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Location}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding Price, StringFormat={}{0:C}}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Price}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding Notes}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Notes}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
                 </StackPanel>
             </Grid>
         </Border>

--- a/InventoryManagementApp/Services/Settings/SettingsService.cs
+++ b/InventoryManagementApp/Services/Settings/SettingsService.cs
@@ -3,8 +3,12 @@ using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Text.Json;
+using System.Collections.Generic;
+using System.Linq;
 using InventoryManagementApp.Services.Core;
 using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using InventoryManagementApp.Services.Users;
@@ -209,11 +213,7 @@ namespace InventoryManagementApp.Services.Settings
         const string AutoLogoutMinutesKey = "AutoLogoutMinutes";
         const string ItemLabelSingularKey = "ItemLabelSingular";
         const string ItemLabelPluralKey = "ItemLabelPlural";
-        const string ShowItemImageKey = "ShowItemImage";
-        const string ShowItemNameKey = "ShowItemName";
-        const string ShowItemNumberKey = "ShowItemNumber";
-        const string ShowItemLocationKey = "ShowItemLocation";
-        const string ShowItemNotesKey = "ShowItemNotes";
+        const string ItemDetailVisibilityKey = "ItemDetailVisibility";
 
         public async Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default)
         {
@@ -319,50 +319,40 @@ namespace InventoryManagementApp.Services.Settings
             await SaveSettingAsync(ItemLabelPluralKey, label, cancellationToken).ConfigureAwait(false);
         }
 
-        static bool ParseBool(string? value, bool defaultValue) => bool.TryParse(value, out var b) ? b : defaultValue;
-
-        async Task<bool> GetBoolSettingAsync(string key, bool defaultValue, CancellationToken cancellationToken)
+        public async Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default)
         {
-            var value = await GetSettingAsync(key, cancellationToken).ConfigureAwait(false);
-            if (value is null)
+            var json = await GetSettingAsync(ItemDetailVisibilityKey, cancellationToken).ConfigureAwait(false);
+            Dictionary<ItemDetailField, bool> visibility;
+            if (!string.IsNullOrWhiteSpace(json))
             {
+                try
+                {
+                    var dict = JsonSerializer.Deserialize<Dictionary<string, bool>>(json!) ?? new();
+                    visibility = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, f => dict.TryGetValue(f.ToString(), out var v) ? v : true);
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogError(ex, "Failed to parse item detail visibility settings");
+                    visibility = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true);
+                }
+            }
+            else
+            {
+                visibility = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true);
                 if (_auth.IsAdmin)
                 {
-                    await SaveSettingAsync(key, defaultValue.ToString(), cancellationToken).ConfigureAwait(false);
+                    await SaveItemDetailVisibilityAsync(visibility, cancellationToken).ConfigureAwait(false);
                 }
-                return defaultValue;
             }
-            return ParseBool(value, defaultValue);
+            return visibility;
         }
 
-        public Task<bool> GetShowItemImageAsync(CancellationToken cancellationToken = default)
-            => GetBoolSettingAsync(ShowItemImageKey, true, cancellationToken);
-
-        public Task SaveShowItemImageAsync(bool value, CancellationToken cancellationToken = default)
-            => SaveSettingAsync(ShowItemImageKey, value.ToString(), cancellationToken);
-
-        public Task<bool> GetShowItemNameAsync(CancellationToken cancellationToken = default)
-            => GetBoolSettingAsync(ShowItemNameKey, true, cancellationToken);
-
-        public Task SaveShowItemNameAsync(bool value, CancellationToken cancellationToken = default)
-            => SaveSettingAsync(ShowItemNameKey, value.ToString(), cancellationToken);
-
-        public Task<bool> GetShowItemNumberAsync(CancellationToken cancellationToken = default)
-            => GetBoolSettingAsync(ShowItemNumberKey, true, cancellationToken);
-
-        public Task SaveShowItemNumberAsync(bool value, CancellationToken cancellationToken = default)
-            => SaveSettingAsync(ShowItemNumberKey, value.ToString(), cancellationToken);
-
-        public Task<bool> GetShowItemLocationAsync(CancellationToken cancellationToken = default)
-            => GetBoolSettingAsync(ShowItemLocationKey, true, cancellationToken);
-
-        public Task SaveShowItemLocationAsync(bool value, CancellationToken cancellationToken = default)
-            => SaveSettingAsync(ShowItemLocationKey, value.ToString(), cancellationToken);
-
-        public Task<bool> GetShowItemNotesAsync(CancellationToken cancellationToken = default)
-            => GetBoolSettingAsync(ShowItemNotesKey, true, cancellationToken);
-
-        public Task SaveShowItemNotesAsync(bool value, CancellationToken cancellationToken = default)
-            => SaveSettingAsync(ShowItemNotesKey, value.ToString(), cancellationToken);
+        public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
+        {
+            _auth.EnsureAdmin();
+            var dict = visibility.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value);
+            var json = JsonSerializer.Serialize(dict);
+            return SaveSettingAsync(ItemDetailVisibilityKey, json, cancellationToken);
+        }
     }
 }

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Data;
 using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
 using InventoryManagementApp.Utilities;
 using InventoryManagementApp.Utilities.Extensions;
 using InventoryManagementApp.Services;
@@ -150,50 +151,19 @@ namespace InventoryManagementApp.ViewModels
             Items.CollectionChanged += Items_CollectionChanged;
         }
 
-        bool _showImage;
-        public bool ShowImage
+        ReadOnlyDictionary<ItemDetailField, bool> _visibleFields = new(new Dictionary<ItemDetailField, bool>());
+        public ReadOnlyDictionary<ItemDetailField, bool> VisibleFields
         {
-            get => _showImage;
-            private set => SetProperty(ref _showImage, value);
-        }
-
-        bool _showName;
-        public bool ShowName
-        {
-            get => _showName;
-            private set => SetProperty(ref _showName, value);
-        }
-
-        bool _showItemNumber;
-        public bool ShowItemNumber
-        {
-            get => _showItemNumber;
-            private set => SetProperty(ref _showItemNumber, value);
-        }
-
-        bool _showLocation;
-        public bool ShowLocation
-        {
-            get => _showLocation;
-            private set => SetProperty(ref _showLocation, value);
-        }
-
-        bool _showNotes;
-        public bool ShowNotes
-        {
-            get => _showNotes;
-            private set => SetProperty(ref _showNotes, value);
+            get => _visibleFields;
+            private set => SetProperty(ref _visibleFields, value);
         }
 
         bool _initialized;
         public async Task InitializeAsync()
         {
             if (_initialized) return;
-            ShowImage = await _settingsService.GetShowItemImageAsync().ConfigureAwait(false);
-            ShowName = await _settingsService.GetShowItemNameAsync().ConfigureAwait(false);
-            ShowItemNumber = await _settingsService.GetShowItemNumberAsync().ConfigureAwait(false);
-            ShowLocation = await _settingsService.GetShowItemLocationAsync().ConfigureAwait(false);
-            ShowNotes = await _settingsService.GetShowItemNotesAsync().ConfigureAwait(false);
+            var vis = await _settingsService.GetItemDetailVisibilityAsync().ConfigureAwait(false);
+            VisibleFields = new ReadOnlyDictionary<ItemDetailField, bool>(new Dictionary<ItemDetailField, bool>(vis));
             _initialized = true;
         }
 

--- a/InventoryManagementApp/ViewModels/SettingsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/SettingsViewModel.cs
@@ -3,6 +3,8 @@ using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
+using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Interfaces;
@@ -10,6 +12,7 @@ using InventoryManagementApp.Services.Core;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using InventoryManagementApp.Utilities.Helpers;
+using InventoryManagementApp.Models;
 
 #nullable enable
 
@@ -21,6 +24,8 @@ namespace InventoryManagementApp.ViewModels
         readonly ISettingsService _settingsService;
         readonly IDialogService _dialogService;
         readonly ILogger<SettingsViewModel> _logger;
+        public ObservableCollection<ItemDetailOption> ItemDetailOptions { get; } = new();
+        bool _bulkUpdating;
 
         public SettingsViewModel(IFileDialogService fileDialog, ISettingsService settingsService, IDialogService dialogService, ILogger<SettingsViewModel>? logger = null)
         {
@@ -49,11 +54,17 @@ namespace InventoryManagementApp.ViewModels
             SaveCompanyLogoCommand = new AsyncRelayCommand(SaveCompanyLogoAsync);
             SelectAllItemDisplayCommand = new RelayCommand(() =>
             {
-                ShowItemImage = ShowItemName = ShowItemNumber = ShowItemLocation = ShowItemNotes = true;
+                _bulkUpdating = true;
+                foreach (var o in ItemDetailOptions) o.IsVisible = true;
+                _bulkUpdating = false;
+                _ = SaveVisibilityAsync();
             });
             SelectNoneItemDisplayCommand = new RelayCommand(() =>
             {
-                ShowItemImage = ShowItemName = ShowItemNumber = ShowItemLocation = ShowItemNotes = false;
+                _bulkUpdating = true;
+                foreach (var o in ItemDetailOptions) o.IsVisible = false;
+                _bulkUpdating = false;
+                _ = SaveVisibilityAsync();
             });
         }
 
@@ -69,20 +80,17 @@ namespace InventoryManagementApp.ViewModels
                 _applicationName = appName;
             _passwordIterations = await _settingsService.GetPasswordIterationsAsync().ConfigureAwait(false);
             _autoLogoutMinutes = await _settingsService.GetAutoLogoutMinutesAsync().ConfigureAwait(false);
-            _showItemImage = await _settingsService.GetShowItemImageAsync().ConfigureAwait(false);
-            _showItemName = await _settingsService.GetShowItemNameAsync().ConfigureAwait(false);
-            _showItemNumber = await _settingsService.GetShowItemNumberAsync().ConfigureAwait(false);
-            _showItemLocation = await _settingsService.GetShowItemLocationAsync().ConfigureAwait(false);
-            _showItemNotes = await _settingsService.GetShowItemNotesAsync().ConfigureAwait(false);
+            var vis = await _settingsService.GetItemDetailVisibilityAsync().ConfigureAwait(false);
+            foreach (var field in Enum.GetValues<ItemDetailField>())
+            {
+                var option = new ItemDetailOption(field, vis.TryGetValue(field, out var v) ? v : true);
+                option.PropertyChanged += ItemDetailOption_PropertyChanged;
+                ItemDetailOptions.Add(option);
+            }
             OnPropertyChanged(nameof(CompanyLogoPath));
             OnPropertyChanged(nameof(ApplicationName));
             OnPropertyChanged(nameof(PasswordIterations));
             OnPropertyChanged(nameof(AutoLogoutMinutes));
-            OnPropertyChanged(nameof(ShowItemImage));
-            OnPropertyChanged(nameof(ShowItemName));
-            OnPropertyChanged(nameof(ShowItemNumber));
-            OnPropertyChanged(nameof(ShowItemLocation));
-            OnPropertyChanged(nameof(ShowItemNotes));
             _initialized = true;
         }
 
@@ -284,24 +292,20 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        private bool _showItemImage;
-        public bool ShowItemImage
+        void ItemDetailOption_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            get => _showItemImage;
-            set
+            if (e.PropertyName == nameof(ItemDetailOption.IsVisible) && !_bulkUpdating)
             {
-                if (SetProperty(ref _showItemImage, value))
-                {
-                    _ = SaveShowItemImageAsync(value);
-                }
+                _ = SaveVisibilityAsync();
             }
         }
 
-        async Task SaveShowItemImageAsync(bool value)
+        async Task SaveVisibilityAsync()
         {
             try
             {
-                await _settingsService.SaveShowItemImageAsync(value).ConfigureAwait(false);
+                var dict = ItemDetailOptions.ToDictionary(o => o.Field, o => o.IsVisible);
+                await _settingsService.SaveItemDetailVisibilityAsync(dict).ConfigureAwait(false);
             }
             catch (UnauthorizedAccessException ex)
             {
@@ -310,127 +314,7 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to save ShowItemImage setting.");
-            }
-        }
-
-        private bool _showItemName;
-        public bool ShowItemName
-        {
-            get => _showItemName;
-            set
-            {
-                if (SetProperty(ref _showItemName, value))
-                {
-                    _ = SaveShowItemNameAsync(value);
-                }
-            }
-        }
-
-        async Task SaveShowItemNameAsync(bool value)
-        {
-            try
-            {
-                await _settingsService.SaveShowItemNameAsync(value).ConfigureAwait(false);
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                _logger.LogWarning(ex, "Unauthorized to change settings.");
-                _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to save ShowItemName setting.");
-            }
-        }
-
-        private bool _showItemNumber;
-        public bool ShowItemNumber
-        {
-            get => _showItemNumber;
-            set
-            {
-                if (SetProperty(ref _showItemNumber, value))
-                {
-                    _ = SaveShowItemNumberAsync(value);
-                }
-            }
-        }
-
-        async Task SaveShowItemNumberAsync(bool value)
-        {
-            try
-            {
-                await _settingsService.SaveShowItemNumberAsync(value).ConfigureAwait(false);
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                _logger.LogWarning(ex, "Unauthorized to change settings.");
-                _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to save ShowItemNumber setting.");
-            }
-        }
-
-        private bool _showItemLocation;
-        public bool ShowItemLocation
-        {
-            get => _showItemLocation;
-            set
-            {
-                if (SetProperty(ref _showItemLocation, value))
-                {
-                    _ = SaveShowItemLocationAsync(value);
-                }
-            }
-        }
-
-        async Task SaveShowItemLocationAsync(bool value)
-        {
-            try
-            {
-                await _settingsService.SaveShowItemLocationAsync(value).ConfigureAwait(false);
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                _logger.LogWarning(ex, "Unauthorized to change settings.");
-                _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to save ShowItemLocation setting.");
-            }
-        }
-
-        private bool _showItemNotes;
-        public bool ShowItemNotes
-        {
-            get => _showItemNotes;
-            set
-            {
-                if (SetProperty(ref _showItemNotes, value))
-                {
-                    _ = SaveShowItemNotesAsync(value);
-                }
-            }
-        }
-
-        async Task SaveShowItemNotesAsync(bool value)
-        {
-            try
-            {
-                await _settingsService.SaveShowItemNotesAsync(value).ConfigureAwait(false);
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                _logger.LogWarning(ex, "Unauthorized to change settings.");
-                _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to save ShowItemNotes setting.");
+                _logger.LogError(ex, "Failed to save item detail visibility.");
             }
         }
 

--- a/InventoryManagementApp/Views/Pages/SettingsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/SettingsPage.xaml
@@ -73,13 +73,13 @@
                         <Button Style="{StaticResource PrimaryButton}" Content="Select All" Command="{Binding SelectAllItemDisplayCommand}" Margin="0,0,8,0"/>
                         <Button Style="{StaticResource PrimaryButton}" Content="Select None" Command="{Binding SelectNoneItemDisplayCommand}"/>
                     </StackPanel>
-                    <StackPanel Margin="0,8,0,0">
-                        <CheckBox Content="Show Image" IsChecked="{Binding ShowItemImage}"/>
-                        <CheckBox Content="Show Name" IsChecked="{Binding ShowItemName}"/>
-                        <CheckBox Content="Show Item Number" IsChecked="{Binding ShowItemNumber}"/>
-                        <CheckBox Content="Show Location" IsChecked="{Binding ShowItemLocation}"/>
-                        <CheckBox Content="Show Notes" IsChecked="{Binding ShowItemNotes}"/>
-                    </StackPanel>
+                    <ItemsControl ItemsSource="{Binding ItemDetailOptions}" Margin="0,8,0,0">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <CheckBox Content="{Binding Field}" IsChecked="{Binding IsVisible, Mode=TwoWay}"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                 </StackPanel>
             </Border>
 


### PR DESCRIPTION
## Summary
- add `ItemDetailField` enum and option model to configure item card details
- persist item detail visibility via dictionary-based settings
- expose visibility options in settings UI and item card template
- revise tests for flexible detail visibility

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2dd85f14832486fd411ea53693e9