### PR TITLE
Handle checkout toggle errors with logging and dialog

### DIFF
--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -131,6 +131,25 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task ToggleCheckOutCommand_OnError_ShowsDialog()
+        {
+            var service = new ThrowingItemService();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
+            var customer = new DummyCustomerService();
+            var settings = new DummySettingsService();
+            var userContext = new DummyUserContext { CurrentUser = new User { UserName = "user1" } };
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, userContext);
+            var item = new ItemModel { ItemID = 1, QuantityOnHand = 3 };
+            vm.Items.Add(item);
+
+            await vm.ToggleCheckOutCommand.ExecuteAsync(item);
+
+            Assert.Single(dialog.Infos);
+        }
+
+        [Fact]
         public void SteadyExceeded_TrimsToThreePages()
         {
             var service = new DummyItemService();
@@ -616,7 +635,7 @@ namespace InventoryManagementApp.Tests
             }
         }
 
-        private sealed class DummyItemService : IItemService
+        private class DummyItemService : IItemService
         {
             public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
@@ -625,7 +644,7 @@ namespace InventoryManagementApp.Tests
             public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
             public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
             public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
-            public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult(false);
+            public virtual Task<bool> ToggleItemCheckOutStatusAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult(false);
             public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
             public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
@@ -758,8 +777,13 @@ namespace InventoryManagementApp.Tests
 
         private sealed class DummyDialogService : IDialogService
         {
-            public void ShowInfo(string message, string title) { }
-            public Task ShowInfoAsync(string message, string title) => Task.CompletedTask;
+            public List<(string message, string title)> Infos { get; } = new();
+            public void ShowInfo(string message, string title) => Infos.Add((message, title));
+            public Task ShowInfoAsync(string message, string title)
+            {
+                Infos.Add((message, title));
+                return Task.CompletedTask;
+            }
             public bool ShowConfirmation(string message, string title) => true;
             public Task<bool> ShowConfirmationAsync(string message, string title) => Task.FromResult(true);
             public ItemModel? ShowEditItemDialog(ItemModel item) => null;
@@ -772,6 +796,11 @@ namespace InventoryManagementApp.Tests
             public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }
+        }
+
+        private sealed class ThrowingItemService : DummyItemService
+        {
+            public override Task<bool> ToggleItemCheckOutStatusAsync(int itemID, CancellationToken cancellationToken = default) => throw new Exception("error");
         }
 
         private sealed class DummyRentalService : IRentalService

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -14,6 +14,8 @@ using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Utilities;
 using InventoryManagementApp.Utilities.Helpers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Application = System.Windows.Application;
 
 namespace InventoryManagementApp.ViewModels
@@ -27,6 +29,7 @@ namespace InventoryManagementApp.ViewModels
         private readonly ICustomerService _customerService;
         private readonly ISettingsService _settingsService;
         private readonly IUserContext _userContext;
+        private readonly ILogger<ItemsViewModel> _logger;
         private CancellationTokenSource _filterCts = new();
         private bool _disposed;
         private readonly List<ItemModel> _pendingEdits = new();
@@ -58,7 +61,7 @@ namespace InventoryManagementApp.ViewModels
 
         public ObservableCollection<SortOption> SortOptions { get; }
 
-        public ItemsViewModel(IItemService itemService, MemoryBudget memoryBudget, IDialogService dialogService, IRentalService rentalService, ICustomerService customerService, ISettingsService settingsService, IUserContext userContext)
+        public ItemsViewModel(IItemService itemService, MemoryBudget memoryBudget, IDialogService dialogService, IRentalService rentalService, ICustomerService customerService, ISettingsService settingsService, IUserContext userContext, ILogger<ItemsViewModel>? logger = null)
         {
             _itemService = itemService;
             _memoryBudget = memoryBudget;
@@ -67,6 +70,7 @@ namespace InventoryManagementApp.ViewModels
             _customerService = customerService;
             _settingsService = settingsService;
             _userContext = userContext;
+            _logger = logger ?? NullLogger<ItemsViewModel>.Instance;
             Items = new IncrementalLoadingCollection<ItemModel>(LoadPageAsync, PageSize);
             SortOptions = new ObservableCollection<SortOption>(new[]
             {
@@ -413,8 +417,10 @@ namespace InventoryManagementApp.ViewModels
             {
                 return;
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Failed to toggle check out status for item {ItemID}", item.ItemID);
+                await _dialogService.ShowInfoAsync($"Failed to update check-out status: {ex.Message}", "Error").ConfigureAwait(false);
                 return;
             }
             if (!result) return;


### PR DESCRIPTION
## Summary
- log and notify users when toggling an item's check-out status fails
- test that check-out errors trigger a dialog message

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2fbe863c83248b19739f6457f351