### PR TITLE
Ignore checkout-triggered edits

### DIFF
--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -131,6 +131,27 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task ToggleCheckOutCommand_DoesNotAddPendingEdits()
+        {
+            var service = new ToggleItemService();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
+            var customer = new DummyCustomerService();
+            var settings = new DummySettingsService();
+            var userContext = new DummyUserContext { CurrentUser = new User { UserName = "user1" } };
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, userContext);
+            var item = new ItemModel { ItemID = 1, QuantityOnHand = 5 };
+            vm.Items.Add(item);
+
+            await vm.ToggleCheckOutCommand.ExecuteAsync(item);
+            Assert.Empty(vm.PendingEdits);
+
+            await vm.ToggleCheckOutCommand.ExecuteAsync(item);
+            Assert.Empty(vm.PendingEdits);
+        }
+
+        [Fact]
         public void SteadyExceeded_TrimsToThreePages()
         {
             var service = new DummyItemService();

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -30,6 +30,7 @@ namespace InventoryManagementApp.ViewModels
         private CancellationTokenSource _filterCts = new();
         private bool _disposed;
         private readonly List<ItemModel> _pendingEdits = new();
+        private readonly HashSet<ItemModel> _togglingItems = new();
 
         public IncrementalLoadingCollection<ItemModel> Items { get; }
 
@@ -180,6 +181,7 @@ namespace InventoryManagementApp.ViewModels
         private void Item_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (sender is not ItemModel item) return;
+            if (_togglingItems.Contains(item)) return;
             if (e.PropertyName == nameof(ItemModel.QuantityOnHand) || e.PropertyName == nameof(ItemModel.Location) || e.PropertyName == nameof(ItemModel.Price))
             {
                 if (!_pendingEdits.Contains(item))
@@ -404,10 +406,15 @@ namespace InventoryManagementApp.ViewModels
         private async Task ToggleCheckOutAsync(ItemModel? item, CancellationToken ct)
         {
             if (item == null) return;
-            bool result;
+            _togglingItems.Add(item);
             try
             {
-                result = await _itemService.ToggleItemCheckOutStatusAsync(item.ItemID, ct).ConfigureAwait(false);
+                var result = await _itemService.ToggleItemCheckOutStatusAsync(item.ItemID, ct).ConfigureAwait(false);
+                if (!result) return;
+                var checkedOut = !item.IsCheckedOut;
+                item.IsCheckedOut = checkedOut;
+                item.CheckedOutBy = checkedOut ? _userContext.UserName : string.Empty;
+                item.QuantityOnHand += checkedOut ? -1 : 1;
             }
             catch (OperationCanceledException)
             {
@@ -417,11 +424,10 @@ namespace InventoryManagementApp.ViewModels
             {
                 return;
             }
-            if (!result) return;
-            var checkedOut = !item.IsCheckedOut;
-            item.IsCheckedOut = checkedOut;
-            item.CheckedOutBy = checkedOut ? _userContext.UserName : string.Empty;
-            item.QuantityOnHand += checkedOut ? -1 : 1;
+            finally
+            {
+                _togglingItems.Remove(item);
+            }
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary
- avoid queuing PendingEdits during check-out toggle operations
- test that toggling check-out doesn't add items to PendingEdits

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2fd300a8832496198985817e7cb8