### PR TITLE
Ensure IsRentalItem index and add test

### DIFF
--- a/InventoryManagementApp.Tests/DatabaseServiceIndexTests.cs
+++ b/InventoryManagementApp.Tests/DatabaseServiceIndexTests.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using InventoryManagementApp.Services.Core;
+using Xunit;
+
+public class DatabaseServiceIndexTests
+{
+    [Fact]
+    public void Initialize_CreatesIsRentalItemIndex()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.db");
+        try
+        {
+            using var db = new DatabaseService(dbPath);
+            using var conn = db.CreateConnection();
+            using var check = conn.CreateCommand();
+            check.CommandText = "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_Items_IsRentalItem';";
+            var result = check.ExecuteScalar();
+            Assert.NotNull(result);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+}
+

--- a/InventoryManagementApp/Services/Core/DatabaseService.cs
+++ b/InventoryManagementApp/Services/Core/DatabaseService.cs
@@ -54,6 +54,7 @@ namespace InventoryManagementApp.Services.Core
             using (var conn = CreateConnection())
             {
                 EnsureIndex(conn, "Items", "Keywords");
+                EnsureIndex(conn, "Items", "IsRentalItem");
             }
             EnsureColumn("Users", "PasswordHash", "TEXT");
             EnsureColumn("Users", "PasswordSalt", "TEXT");


### PR DESCRIPTION
## Summary
- index Items.IsRentalItem during database initialization
- add integration test verifying idx_Items_IsRentalItem exists

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2fd774a883248a38ae9ed66f2746