### PR TITLE
Remove cancellation token from check-out dialog invocation

### DIFF
--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -426,7 +426,7 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to toggle check out status for item {ItemID}", item.ItemID);
-                await _dialogService.ShowInfoAsync($"Failed to update check-out status: {ex.Message}", "Error", ct).ConfigureAwait(false);
+                await _dialogService.ShowInfoAsync($"Failed to update check-out status: {ex.Message}", "Error").ConfigureAwait(false);
                 return;
             }
             finally


### PR DESCRIPTION
## Summary
- Fix ItemsViewModel check-out status error dialog by removing obsolete CancellationToken parameter.

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa34a1c54883248059fa273519b3a7