### PR TITLE
Remove rental and checkout actions from items page

### DIFF
--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -28,10 +28,9 @@ namespace InventoryManagementApp.Tests
             var service = new DummyItemService();
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             var settings = new DummySettingsService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
 
             Assert.NotNull(vm.EditItemCommand);
             Assert.True(vm.EditItemCommand.CanExecute(null));
@@ -44,10 +43,6 @@ namespace InventoryManagementApp.Tests
             Assert.NotNull(vm.OpenRentalHistoryCommand);
             Assert.True(vm.OpenRentalHistoryCommand.CanExecute(null));
             await vm.OpenRentalHistoryCommand.ExecuteAsync(null);
-
-            Assert.NotNull(vm.OpenRentalsCommand);
-            Assert.True(vm.OpenRentalsCommand.CanExecute(null));
-            await vm.OpenRentalsCommand.ExecuteAsync(null);
 
             Assert.NotNull(vm.NewItemCommand);
             Assert.True(vm.NewItemCommand.CanExecute(null));
@@ -65,10 +60,9 @@ namespace InventoryManagementApp.Tests
             var service = new DummyItemService();
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             var settings = new DummySettingsService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
             var item1 = new ItemModel { ItemID = 1, Name = "A" };
             var item2 = new ItemModel { ItemID = 2, Name = "B" };
             vm.Items.Add(item1);
@@ -80,107 +74,14 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public async Task ToggleCheckOutCommand_TogglesItem()
-        {
-            var service = new ToggleItemService();
-            var dialog = new DummyDialogService();
-            var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
-            var settings = new DummySettingsService();
-            var userContext = new DummyUserContext { CurrentUser = new User { UserName = "user1" } };
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, userContext, NullLogger<ItemsViewModel>.Instance);
-            var item = new ItemModel { ItemID = 1, QuantityOnHand = 5 };
-            vm.Items.Add(item);
-
-            await vm.ToggleCheckOutCommand.ExecuteAsync(item);
-            Assert.True(item.IsCheckedOut);
-            Assert.Equal("user1", item.CheckedOutBy);
-            Assert.Equal(4, item.QuantityOnHand);
-
-            await vm.ToggleCheckOutCommand.ExecuteAsync(item);
-            Assert.False(item.IsCheckedOut);
-            Assert.Equal(string.Empty, item.CheckedOutBy);
-            Assert.Equal(5, item.QuantityOnHand);
-        }
-
-        [Fact]
-        public async Task ToggleCheckOutCommand_UpdatesSelectedItemState()
-        {
-            var service = new ToggleItemService();
-            var dialog = new DummyDialogService();
-            var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
-            var settings = new DummySettingsService();
-            var userContext = new DummyUserContext { CurrentUser = new User { UserName = "user1" } };
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, userContext, NullLogger<ItemsViewModel>.Instance);
-            var item = new ItemModel { ItemID = 1, QuantityOnHand = 3 };
-            vm.Items.Add(item);
-            vm.SelectedItem = item;
-
-            await vm.ToggleCheckOutCommand.ExecuteAsync(item);
-
-            Assert.True(vm.SelectedItem!.IsCheckedOut);
-            Assert.Equal("user1", vm.SelectedItem.CheckedOutBy);
-            Assert.Equal(2, vm.SelectedItem.QuantityOnHand);
-
-            await vm.ToggleCheckOutCommand.ExecuteAsync(item);
-
-            Assert.False(vm.SelectedItem!.IsCheckedOut);
-            Assert.Equal(string.Empty, vm.SelectedItem.CheckedOutBy);
-            Assert.Equal(3, vm.SelectedItem.QuantityOnHand);
-        }
-
-        [Fact]
-        public async Task ToggleCheckOutCommand_DoesNotAddPendingEdits()
-        {
-            var service = new ToggleItemService();
-            var dialog = new DummyDialogService();
-            var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
-            var settings = new DummySettingsService();
-            var userContext = new DummyUserContext { CurrentUser = new User { UserName = "user1" } };
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, userContext, NullLogger<ItemsViewModel>.Instance);
-            var item = new ItemModel { ItemID = 1, QuantityOnHand = 5 };
-            vm.Items.Add(item);
-
-            await vm.ToggleCheckOutCommand.ExecuteAsync(item);
-            Assert.Empty(vm.PendingEdits);
-
-            await vm.ToggleCheckOutCommand.ExecuteAsync(item);
-            Assert.Empty(vm.PendingEdits);
-        }
-
-        [Fact]
-        public async Task ToggleCheckOutCommand_OnError_ShowsDialog()
-        {
-            var service = new ThrowingItemService();
-            var dialog = new RecordingDialogService();
-            var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
-            var settings = new DummySettingsService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, new DummyUserContext());
-            var item = new ItemModel { ItemID = 1 };
-            vm.Items.Add(item);
-
-            await vm.ToggleCheckOutCommand.ExecuteAsync(item);
-
-            Assert.Single(dialog.Infos);
-        }
-
-        [Fact]
         public void SteadyExceeded_TrimsToThreePages()
         {
             var service = new DummyItemService();
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             var settings = new DummySettingsService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
             var pageField = typeof(ItemsViewModel).GetField("pageSize", BindingFlags.NonPublic | BindingFlags.Instance);
             pageField!.SetValue(vm, 2);
             vm.Items.PageSize = 2;
@@ -198,10 +99,9 @@ namespace InventoryManagementApp.Tests
             var service = new DummyItemService();
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             var settings = new DummySettingsService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
             var pageField = typeof(ItemsViewModel).GetField("pageSize", BindingFlags.NonPublic | BindingFlags.Instance);
             pageField!.SetValue(vm, 2);
             vm.Items.PageSize = 2;
@@ -224,10 +124,9 @@ namespace InventoryManagementApp.Tests
             var service = new RecordingItemService(data);
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             var settings = new DummySettingsService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
 
             vm.Filter = "first";
             await Task.Delay(100);
@@ -253,10 +152,9 @@ namespace InventoryManagementApp.Tests
             var service = new RecordingItemService(data, defaults);
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             var settings = new DummySettingsService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
 
             await vm.LoadMoreAsync();
             Assert.Single(vm.Items);
@@ -278,10 +176,9 @@ namespace InventoryManagementApp.Tests
             var service = new PagingItemService();
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             var settings = new DummySettingsService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
 
             var tasks = new[]
             {
@@ -303,10 +200,9 @@ namespace InventoryManagementApp.Tests
             var service = new RecordingItemService(new Dictionary<string, List<ItemModel>>(), new List<ItemModel> { new ItemModel { ItemID = 1 } });
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             var settings = new DummySettingsService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
             var loadTask = vm.LoadMoreAsync();
             Assert.True(vm.Items.IsLoading);
             await loadTask;
@@ -319,10 +215,9 @@ namespace InventoryManagementApp.Tests
             var service = new DummyItemService();
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
-            var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
             vm.Items.Add(new ItemModel { ItemID = 1 });
             var ctsField = typeof(ItemsViewModel).GetField("_filterCts", BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.NotNull(ctsField);
@@ -341,10 +236,9 @@ namespace InventoryManagementApp.Tests
             var service = new StaticItemService(item);
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
             await vm.LoadMoreAsync();
             var loaded = vm.Items[0];
             loaded.QuantityOnHand = 5;
@@ -360,10 +254,9 @@ namespace InventoryManagementApp.Tests
             var service = new StaticItemService(item, repository);
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
-            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
             await vm.LoadMoreAsync();
             var loaded = vm.Items[0];
             loaded.Location = "B";
@@ -379,10 +272,9 @@ namespace InventoryManagementApp.Tests
             var dialog = new RecordingDialogService { EditItemDialogResult = new ItemModel { ItemID = 1 } };
             var itemService = new RecordingItemService2();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
             vm.SelectedItem = item;
             await vm.EditItemCommand.ExecuteAsync(null);
             Assert.True(dialog.EditItemDialogCalled);
@@ -396,10 +288,9 @@ namespace InventoryManagementApp.Tests
             var dialog = new RecordingDialogService { EditItemDialogResult = new ItemModel { ItemID = 1 } };
             var itemService = new RecordingItemService2 { UpdateException = new OperationCanceledException() };
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
             vm.SelectedItem = item;
             await vm.EditItemCommand.ExecuteAsync(null);
             Assert.True(dialog.EditItemDialogCalled);
@@ -412,10 +303,9 @@ namespace InventoryManagementApp.Tests
             var dialog = new RecordingDialogService();
             var itemService = new DummyItemService();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
             vm.SelectedItem = new ItemModel();
             vm.ViewDetailsCommand.Execute(null);
             Assert.True(dialog.ItemDetailsCalled);
@@ -427,10 +317,9 @@ namespace InventoryManagementApp.Tests
             var dialog = new RecordingDialogService { DetailsException = new InvalidOperationException() };
             var itemService = new DummyItemService();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
             vm.SelectedItem = new ItemModel();
             vm.ViewDetailsCommand.Execute(null);
             Assert.True(dialog.ItemDetailsCalled);
@@ -443,10 +332,9 @@ namespace InventoryManagementApp.Tests
             var dialog = new RecordingDialogService();
             var rentalService = new RecordingRentalService();
             var itemService = new DummyItemService();
-            var customer = new DummyCustomerService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rentalService, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rentalService, settings, NullLogger<ItemsViewModel>.Instance);
             vm.SelectedItem = item;
             await vm.OpenRentalHistoryCommand.ExecuteAsync(null);
             Assert.True(rentalService.HistoryCalled);
@@ -460,50 +348,13 @@ namespace InventoryManagementApp.Tests
             var dialog = new RecordingDialogService();
             var rentalService = new RecordingRentalService { HistoryException = new OperationCanceledException() };
             var itemService = new DummyItemService();
-            var customer = new DummyCustomerService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rentalService, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rentalService, settings, NullLogger<ItemsViewModel>.Instance);
             vm.SelectedItem = item;
             await vm.OpenRentalHistoryCommand.ExecuteAsync(null);
             Assert.True(rentalService.HistoryCalled);
             Assert.False(dialog.RentalHistoryCalled);
-        }
-
-        [Fact]
-        public async Task OpenRentalsCommand_InvokesServices()
-        {
-            var item = new ItemModel { ItemID = 1 };
-            var dialog = new RecordingDialogService { RentItemDialogResult = (new Customer { CustomerID = 1 }, DateTime.Today) };
-            var rentalService = new RecordingRentalService();
-            var customerService = new RecordingCustomerService();
-            var itemService = new DummyItemService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
-            var settings = new DummySettingsService();
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rentalService, customerService, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
-            vm.SelectedItem = item;
-            await vm.OpenRentalsCommand.ExecuteAsync(null);
-            Assert.True(customerService.GetAllCalled);
-            Assert.True(dialog.RentItemDialogCalled);
-            Assert.True(rentalService.RentCalled);
-        }
-
-        [Fact]
-        public async Task OpenRentalsCommand_HandlesCancellation()
-        {
-            var item = new ItemModel { ItemID = 1 };
-            var dialog = new RecordingDialogService();
-            var rentalService = new RecordingRentalService();
-            var customerService = new RecordingCustomerService { GetAllException = new OperationCanceledException() };
-            var itemService = new DummyItemService();
-            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
-            var settings = new DummySettingsService();
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rentalService, customerService, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
-            vm.SelectedItem = item;
-            await vm.OpenRentalsCommand.ExecuteAsync(null);
-            Assert.True(customerService.GetAllCalled);
-            Assert.False(dialog.RentItemDialogCalled);
-            Assert.False(rentalService.RentCalled);
         }
 
         [Fact]
@@ -512,10 +363,9 @@ namespace InventoryManagementApp.Tests
             var dialog = new RecordingDialogService { EditItemDialogResult = new ItemModel { ItemID = 2 } };
             var itemService = new RecordingItemService2();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
             await vm.NewItemCommand.ExecuteAsync(null);
             Assert.True(dialog.EditItemDialogCalled);
             Assert.Single(itemService.Added);
@@ -527,10 +377,9 @@ namespace InventoryManagementApp.Tests
             var dialog = new RecordingDialogService { EditItemDialogResult = new ItemModel { ItemID = 2 } };
             var itemService = new RecordingItemService2 { AddException = new OperationCanceledException() };
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             var settings = new DummySettingsService();
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
             await vm.NewItemCommand.ExecuteAsync(null);
             Assert.True(dialog.EditItemDialogCalled);
             Assert.Single(itemService.Added);
@@ -542,10 +391,9 @@ namespace InventoryManagementApp.Tests
             var itemService = new RentalFilteringItemService();
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             var settings = new DummySettingsService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
             await vm.LoadMoreAsync();
             Assert.Single(vm.Items);
             Assert.False(vm.Items[0].IsRentalItem);
@@ -558,10 +406,9 @@ namespace InventoryManagementApp.Tests
             var itemService = new RentalFilteringItemService();
             var dialog = new DummyDialogService();
             var rental = new DummyRentalService();
-            var customer = new DummyCustomerService();
             var settings = new DummySettingsService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
-            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, customer, settings, new DummyUserContext(), NullLogger<ItemsViewModel>.Instance);
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
             vm.Filter = "abc";
             await vm.LoadMoreAsync();
             Assert.Single(vm.Items);

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using InventoryManagementApp.Data;
@@ -25,25 +24,20 @@ namespace InventoryManagementApp.ViewModels
         private readonly MemoryBudget _memoryBudget;
         private readonly IDialogService _dialogService;
         private readonly IRentalService _rentalService;
-        private readonly ICustomerService _customerService;
         private readonly ISettingsService _settingsService;
-        private readonly IUserContext _userContext;
         private readonly ILogger<ItemsViewModel> _logger;
         private CancellationTokenSource _filterCts = new();
         private bool _disposed;
         private readonly List<ItemModel> _pendingEdits = new();
-        private readonly HashSet<ItemModel> _togglingItems = new();
 
         public IncrementalLoadingCollection<ItemModel> Items { get; }
 
         public IAsyncRelayCommand EditItemCommand { get; }
         public IRelayCommand ViewDetailsCommand { get; }
         public IAsyncRelayCommand OpenRentalHistoryCommand { get; }
-        public IAsyncRelayCommand OpenRentalsCommand { get; }
         public IAsyncRelayCommand NewItemCommand { get; }
         public IAsyncRelayCommand<IList> DeleteItemsCommand { get; }
         public IAsyncRelayCommand CommitChangesCommand { get; }
-        public IAsyncRelayCommand<ItemModel> ToggleCheckOutCommand { get; }
 
         public IReadOnlyCollection<ItemModel> PendingEdits => _pendingEdits;
 
@@ -61,15 +55,13 @@ namespace InventoryManagementApp.ViewModels
 
         public ObservableCollection<SortOption> SortOptions { get; }
 
-        public ItemsViewModel(IItemService itemService, MemoryBudget memoryBudget, IDialogService dialogService, IRentalService rentalService, ICustomerService customerService, ISettingsService settingsService, IUserContext userContext, ILogger<ItemsViewModel> logger)
+        public ItemsViewModel(IItemService itemService, MemoryBudget memoryBudget, IDialogService dialogService, IRentalService rentalService, ISettingsService settingsService, ILogger<ItemsViewModel> logger)
         {
             _itemService = itemService;
             _memoryBudget = memoryBudget;
             _dialogService = dialogService;
             _rentalService = rentalService;
-            _customerService = customerService;
             _settingsService = settingsService;
-            _userContext = userContext;
             _logger = logger;
             Items = new IncrementalLoadingCollection<ItemModel>(LoadPageAsync, PageSize);
             SortOptions = new ObservableCollection<SortOption>(new[]
@@ -110,11 +102,9 @@ namespace InventoryManagementApp.ViewModels
             EditItemCommand = new AsyncRelayCommand(ct => EditItemAsync(ct));
             ViewDetailsCommand = new RelayCommand(ViewDetails);
             OpenRentalHistoryCommand = new AsyncRelayCommand(ct => OpenRentalHistoryAsync(ct));
-            OpenRentalsCommand = new AsyncRelayCommand(ct => OpenRentalsAsync(ct));
             NewItemCommand = new AsyncRelayCommand(ct => NewItemAsync(ct));
             DeleteItemsCommand = new AsyncRelayCommand<IList>(DeleteItemsAsync);
             CommitChangesCommand = new AsyncRelayCommand(ct => CommitChangesAsync(ct));
-            ToggleCheckOutCommand = new AsyncRelayCommand<ItemModel>(ToggleCheckOutAsync);
         }
 
         private async Task<IList<ItemModel>> LoadPageAsync(int page, CancellationToken ct)
@@ -184,7 +174,6 @@ namespace InventoryManagementApp.ViewModels
         private void Item_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (sender is not ItemModel item) return;
-            if (_togglingItems.Contains(item)) return;
             if (e.PropertyName == nameof(ItemModel.QuantityOnHand) || e.PropertyName == nameof(ItemModel.Location) || e.PropertyName == nameof(ItemModel.Price))
             {
                 if (!_pendingEdits.Contains(item))
@@ -263,34 +252,6 @@ namespace InventoryManagementApp.ViewModels
             {
                 var history = await _rentalService.GetRentalHistoryForItemAsync(SelectedItem.ItemID).ConfigureAwait(false);
                 _dialogService.ShowRentalHistory(SelectedItem, history);
-            }
-            catch (OperationCanceledException)
-            {
-            }
-            catch
-            {
-            }
-        }
-
-        private async Task OpenRentalsAsync(CancellationToken ct)
-        {
-            if (SelectedItem == null) return;
-            try
-            {
-                var customers = await _customerService.GetAllCustomersAsync(ct).ConfigureAwait(false);
-                var result = _dialogService.ShowRentItemDialog(SelectedItem, customers);
-                if (result != null)
-                {
-                    var (customer, dueDate) = result.Value;
-                    await _rentalService.RentItemAsync(SelectedItem.ItemID, customer.CustomerID, DateTime.Today, dueDate).ConfigureAwait(false);
-                    var refreshed = await _itemService.GetItemByIDAsync(SelectedItem.ItemID, ct).ConfigureAwait(false);
-                    if (refreshed != null)
-                    {
-                        SelectedItem.QuantityOnHand = refreshed.QuantityOnHand;
-                        SelectedItem.RentedQuantity = refreshed.RentedQuantity;
-                        SelectedItem.UpdatedAt = refreshed.UpdatedAt;
-                    }
-                }
             }
             catch (OperationCanceledException)
             {
@@ -403,35 +364,6 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 await _dialogService.ShowInfoAsync($"Failed to save changes: {ex.Message}", "Error").ConfigureAwait(false);
-            }
-        }
-
-        private async Task ToggleCheckOutAsync(ItemModel? item, CancellationToken ct)
-        {
-            if (item == null) return;
-            _togglingItems.Add(item);
-            try
-            {
-                var result = await _itemService.ToggleItemCheckOutStatusAsync(item.ItemID, ct).ConfigureAwait(false);
-                if (!result) return;
-                var checkedOut = !item.IsCheckedOut;
-                item.IsCheckedOut = checkedOut;
-                item.CheckedOutBy = checkedOut ? _userContext.UserName : string.Empty;
-                item.QuantityOnHand += checkedOut ? -1 : 1;
-            }
-            catch (OperationCanceledException)
-            {
-                return;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to toggle check out status for item {ItemID}", item.ItemID);
-                await _dialogService.ShowInfoAsync($"Failed to update check-out status: {ex.Message}", "Error").ConfigureAwait(false);
-                return;
-            }
-            finally
-            {
-                _togglingItems.Remove(item);
             }
         }
 

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -3,11 +3,7 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
-      xmlns:converters="clr-namespace:InventoryManagementApp.Utilities.Converters"
       Background="{StaticResource BackgroundBrush}">
-    <Page.Resources>
-        <converters:CheckOutStatusConverter x:Key="CheckOutStatusConverter"/>
-    </Page.Resources>
     <Grid Margin="8">
         <Border Style="{StaticResource Card}">
             <Grid>
@@ -56,28 +52,10 @@
                             <DataGridTextColumn Header="Qty" Binding="{Binding QuantityOnHand, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100"/>
                             <DataGridTextColumn Header="Location" Binding="{Binding Location, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="180"/>
                             <DataGridTextColumn Header="Price" Binding="{Binding Price, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="120"/>
-                            <DataGridTemplateColumn Header="Status" Width="120">
-                                <DataGridTemplateColumn.CellTemplate>
-                                    <DataTemplate>
-                                        <Button Content="{Binding IsCheckedOut, Converter={StaticResource CheckOutStatusConverter}}"
-                                                Command="{Binding DataContext.ToggleCheckOutCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
-                                                CommandParameter="{Binding}"/>
-                                    </DataTemplate>
-                                </DataGridTemplateColumn.CellTemplate>
-                            </DataGridTemplateColumn>
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
                                         DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                                <MenuItem
-                                    Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}"
-                                    HeaderStringFormat="Rent {0}"
-                                    Command="{Binding OpenRentalsCommand}"/>
-                
-                                <MenuItem Header="{Binding SelectedItem.IsCheckedOut, Converter={StaticResource CheckOutStatusConverter}}"
-                                          Command="{Binding ToggleCheckOutCommand}"
-                                          CommandParameter="{Binding SelectedItem}"/>
-
                                 <MenuItem Header="Delete"
                                           Command="{Binding PlacementTarget.DataContext.DeleteItemsCommand,
                                                             RelativeSource={RelativeSource AncestorType=ContextMenu}}"


### PR DESCRIPTION
## Summary
- drop Status column and rental/checkout menu options from ManageItemsPage
- remove OpenRentalsCommand and ToggleCheckOutCommand from ItemsViewModel
- update ItemsViewModel tests for removed commands

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa394fd30c83249b0f94898a8ab02a