### PR TITLE
Add rent and check out actions to item cards

### DIFF
--- a/InventoryManagementApp.Tests/ItemManagementViewModelCommandTests.cs
+++ b/InventoryManagementApp.Tests/ItemManagementViewModelCommandTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.ViewModels;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ItemManagementViewModelCommandTests
+    {
+        [Fact]
+        public async Task RentItemCommand_RentsItem()
+        {
+            var rental = new RecordingRentalService();
+            var dialog = new RecordingDialogService
+            {
+                RentItemDialogResult = (new CustomerModel { CustomerID = 2 }, DateTime.Today)
+            };
+            var customer = new RecordingCustomerService();
+            var settings = new DummySettingsService();
+            var itemService = new ToggleItemService();
+            var vm = new ItemManagementViewModel(itemService, customer, rental, dialog, settings, NullLogger<ItemManagementViewModel>.Instance);
+            var item = new ItemModel { ItemID = 5 };
+
+            await vm.RentItemCommand.ExecuteAsync(item);
+
+            Assert.True(customer.GetAllCalled);
+            Assert.True(dialog.RentItemDialogCalled);
+            Assert.True(rental.RentCalled);
+            Assert.Equal(5, rental.ItemId);
+            Assert.Equal(2, rental.CustomerId);
+        }
+
+        [Fact]
+        public async Task ToggleCheckOutCommand_TogglesItem()
+        {
+            var itemService = new RecordingToggleItemService();
+            var dialog = new RecordingDialogService();
+            var rental = new RecordingRentalService();
+            var customer = new RecordingCustomerService();
+            var settings = new DummySettingsService();
+            var vm = new ItemManagementViewModel(itemService, customer, rental, dialog, settings, NullLogger<ItemManagementViewModel>.Instance);
+            var item = new ItemModel { ItemID = 1, QuantityOnHand = 3 };
+
+            await vm.ToggleCheckOutCommand.ExecuteAsync(item);
+
+            Assert.True(itemService.ToggleCalled);
+            Assert.True(item.IsCheckedOut);
+            Assert.Equal(2, item.QuantityOnHand);
+
+            await vm.ToggleCheckOutCommand.ExecuteAsync(item);
+
+            Assert.False(item.IsCheckedOut);
+            Assert.Equal(3, item.QuantityOnHand);
+        }
+
+        private sealed class RecordingRentalService : IRentalService
+        {
+            public bool RentCalled { get; private set; }
+            public int ItemId { get; private set; }
+            public int CustomerId { get; private set; }
+            public Task RentItemAsync(int itemID, int customerID, DateTime rentalDate, DateTime dueDate)
+            {
+                RentCalled = true;
+                ItemId = itemID;
+                CustomerId = customerID;
+                return Task.CompletedTask;
+            }
+            public Task ReturnItemAsync(int rentalID, DateTime returnDate) => Task.CompletedTask;
+            public Task ExtendRentalAsync(int rentalID, DateTime newDueDate) => Task.CompletedTask;
+            public Task DeleteRentalAsync(int rentalID) => Task.CompletedTask;
+            public Task<List<Rental>> GetActiveRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<int> CountActiveRentalsAsync() => Task.FromResult(0);
+            public Task<List<Rental>> GetOverdueRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetAllRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetRentalHistoryForItemAsync(int itemID) => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID) => Task.FromResult(new List<Rental>());
+        }
+
+        private sealed class RecordingCustomerService : ICustomerService
+        {
+            public bool GetAllCalled { get; private set; }
+            public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult(new Customer());
+            public Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default)
+            {
+                GetAllCalled = true;
+                return Task.FromResult(new List<Customer> { new Customer { CustomerID = 2 } });
+            }
+            public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
+            public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default) => Task.FromResult(new CustomerImportResult());
+            public Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+
+        private sealed class RecordingDialogService : IDialogService
+        {
+            public bool RentItemDialogCalled { get; private set; }
+            public (CustomerModel customer, DateTime dueDate)? RentItemDialogResult { get; set; }
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => true;
+            public ItemModel? ShowEditItemDialog(ItemModel item) => null;
+            public void ShowItemDetails(ItemModel item) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers)
+            {
+                RentItemDialogCalled = true;
+                return RentItemDialogResult;
+            }
+            public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
+            public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+        }
+
+        private sealed class DummySettingsService : ISettingsService
+        {
+            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default) => Task.FromResult<IDictionary<ItemDetailField, bool>>(Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true));
+            public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+
+        private sealed class ToggleItemService : IItemService
+        {
+            public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(null);
+            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+            public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct) => Task.CompletedTask;
+            public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult(true);
+            public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task<List<ItemModel>> GetCheckedOutItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
+            public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, Microsoft.Data.Sqlite.SqliteConnection? conn = null, Microsoft.Data.Sqlite.SqliteTransaction? tx = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+
+        private sealed class RecordingToggleItemService : IItemService
+        {
+            public bool ToggleCalled { get; private set; }
+            public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(null);
+            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+            public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct) => Task.CompletedTask;
+            public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, CancellationToken cancellationToken = default)
+            {
+                ToggleCalled = true;
+                return Task.FromResult(true);
+            }
+            public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task<List<ItemModel>> GetCheckedOutItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
+            public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, Microsoft.Data.Sqlite.SqliteConnection? conn = null, Microsoft.Data.Sqlite.SqliteTransaction? tx = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+    }
+}
+

--- a/InventoryManagementApp/Resources/Templates.xaml
+++ b/InventoryManagementApp/Resources/Templates.xaml
@@ -35,6 +35,7 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="140"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <Border Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" CornerRadius="8" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)Image], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
                     <Image Stretch="UniformToFill" Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
@@ -46,6 +47,25 @@
                     <TextBlock Text="{Binding Location}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)Location], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
                     <TextBlock Text="{Binding Price, StringFormat={}{0:C}}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)Price], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
                     <TextBlock Text="{Binding Notes}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)Notes], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                </StackPanel>
+                <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,6,0,0">
+                    <Button Content="Rent"
+                            Style="{StaticResource PrimaryButton}"
+                            Command="{Binding DataContext.RentItemCommand, RelativeSource={RelativeSource AncestorType=Page}}"
+                            CommandParameter="{Binding}"/>
+                    <Button Command="{Binding DataContext.ToggleCheckOutCommand, RelativeSource={RelativeSource AncestorType=Page}}"
+                            CommandParameter="{Binding}" Margin="6,0,0,0">
+                        <Button.Style>
+                            <Style TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
+                                <Setter Property="Content" Value="Check Out"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsCheckedOut}" Value="True">
+                                        <Setter Property="Content" Value="Check In"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
+                    </Button>
                 </StackPanel>
             </Grid>
         </Border>

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -96,6 +96,8 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand OpenRentalsCommand { get; }
         public IRelayCommand ViewDetailsCommand { get; }
         public IAsyncRelayCommand OpenRentalHistoryCommand { get; }
+        public IAsyncRelayCommand<ItemModel> RentItemCommand { get; }
+        public IAsyncRelayCommand<ItemModel> ToggleCheckOutCommand { get; }
 
         readonly IDispatcherTimer _searchDebounceTimer;
         CancellationTokenSource? _searchCts = new();
@@ -144,6 +146,8 @@ namespace InventoryManagementApp.ViewModels
             OpenRentalsCommand = new AsyncRelayCommand(ct => OpenRentalsAsync(ct), () => SelectedItem != null);
             ViewDetailsCommand = new RelayCommand(ViewDetails, () => SelectedItem != null);
             OpenRentalHistoryCommand = new AsyncRelayCommand(OpenRentalHistoryAsync, () => SelectedItem != null);
+            RentItemCommand = new AsyncRelayCommand<ItemModel>(RentItemAsync);
+            ToggleCheckOutCommand = new AsyncRelayCommand<ItemModel>(ToggleCheckOutAsync);
             // Ensure no duplicate event subscriptions when the view model is
             // constructed multiple times or the collection persists across
             // instances.
@@ -392,6 +396,59 @@ namespace InventoryManagementApp.ViewModels
             {
                 _logger.LogError(ex, "Failed to rent {ItemLabelSingular} {ItemID}", LabelProvider.Instance.ItemLabelSingular, item.ItemID);
                 await _dialogService.ShowInfoAsync($"Failed to rent {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {ex.Message}", "Error");
+            }
+        }
+
+        private async Task RentItemAsync(ItemModel? item, CancellationToken cancellationToken)
+        {
+            if (item == null) return;
+            try
+            {
+                var customers = await _customerService.GetAllCustomersAsync(cancellationToken);
+                var result = _dialogService.ShowRentItemDialog(item, customers);
+                if (result != null)
+                {
+                    var (customer, dueDate) = result.Value;
+                    await _rentalService.RentItemAsync(item.ItemID, customer.CustomerID, DateTime.Today, dueDate);
+                    await LoadItemsAsync(new ItemPage(1, PageSize));
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync($"You are not authorized to rent {LabelProvider.Instance.ItemLabelPlural.ToLower()}.", "Unauthorized");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to rent {ItemLabelSingular} {ItemID}", LabelProvider.Instance.ItemLabelSingular, item.ItemID);
+                await _dialogService.ShowInfoAsync($"Failed to rent {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {ex.Message}", "Error");
+            }
+        }
+
+        private async Task ToggleCheckOutAsync(ItemModel? item, CancellationToken cancellationToken)
+        {
+            if (item == null) return;
+            try
+            {
+                var result = await _itemService.ToggleItemCheckOutStatusAsync(item.ItemID, cancellationToken).ConfigureAwait(false);
+                if (!result) return;
+                var checkedOut = !item.IsCheckedOut;
+                item.IsCheckedOut = checkedOut;
+                item.QuantityOnHand += checkedOut ? -1 : 1;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await _dialogService.ShowInfoAsync("You are not authorized to update check-out status.", "Unauthorized");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to toggle check out status for item {ItemID}", item.ItemID);
+                await _dialogService.ShowInfoAsync($"Failed to update check-out status: {ex.Message}", "Error");
             }
         }
 

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
@@ -40,7 +40,7 @@
                  Background="{StaticResource SurfaceBrush}"
                  ItemsSource="{Binding SearchResults}"
                  ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                 ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
                  VirtualizingPanel.IsVirtualizing="True"
                  VirtualizingPanel.VirtualizationMode="Recycling"
                  ItemTemplate="{StaticResource ItemCardTemplate}"


### PR DESCRIPTION
## Summary
- add Rent and Check Out/In actions on item cards with command bindings
- implement RentItemCommand and ToggleCheckOutCommand in item management view model
- extend item search page and add unit tests for new commands

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3956f7948324b538e81401acbc58