### PR TITLE
Add dashboard item check-in command

### DIFF
--- a/InventoryManagementApp.Tests/DashboardViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DashboardViewModelTests.cs
@@ -126,6 +126,9 @@ public class DashboardViewModelTests
     {
         public List<ItemModel> Items { get; } = new();
         public int CheckedOutCalls { get; private set; }
+        public int ToggleCalls { get; private set; }
+        public int LastToggledItemID { get; private set; }
+        public bool ToggleResult { get; set; } = true;
 
         public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
         public Task<List<ItemModel>> GetCheckedOutItemsAsync(CancellationToken cancellationToken = default)
@@ -141,7 +144,12 @@ public class DashboardViewModelTests
         public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
         public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
         public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct) => Task.CompletedTask;
-        public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, CancellationToken cancellationToken = default)
+        {
+            ToggleCalls++;
+            LastToggledItemID = itemID;
+            return Task.FromResult(ToggleResult);
+        }
         public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
@@ -319,6 +327,66 @@ public class DashboardViewModelTests
         Assert.Equal("X1", vm.CheckedOutItems[0].ItemNumber);
         Assert.Equal("Alice", vm.CheckedOutItems[0].CheckedOutBy);
         Assert.Equal(1, itemService.CheckedOutCalls);
+    }
+
+    [Fact]
+    public async Task CheckInItemCommand_RemovesItemOnSuccess()
+    {
+        using var db = new DatabaseService(":memory:");
+        var itemService = new StubItemService();
+        var rentalService = new StubRentalService();
+        var customerService = new StubCustomerService();
+        var userService = new StubUserService();
+        var activityLogService = new StubActivityLogService(db);
+
+        var vm = new DashboardViewModel(
+            itemService,
+            rentalService,
+            customerService,
+            userService,
+            activityLogService,
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }));
+
+        var item = new ItemModel { ItemID = 1, ItemNumber = "X1", CheckedOutBy = "Alice" };
+        vm.CheckedOutItems.Add(item);
+
+        await vm.CheckInItemCommand.ExecuteAsync(item);
+
+        Assert.Empty(vm.CheckedOutItems);
+        Assert.Equal(1, itemService.ToggleCalls);
+        Assert.Equal(1, itemService.LastToggledItemID);
+    }
+
+    [Fact]
+    public async Task CheckInItemCommand_DoesNotRemoveWhenServiceFails()
+    {
+        using var db = new DatabaseService(":memory:");
+        var itemService = new StubItemService { ToggleResult = false };
+        var rentalService = new StubRentalService();
+        var customerService = new StubCustomerService();
+        var userService = new StubUserService();
+        var activityLogService = new StubActivityLogService(db);
+
+        var vm = new DashboardViewModel(
+            itemService,
+            rentalService,
+            customerService,
+            userService,
+            activityLogService,
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }));
+
+        var item = new ItemModel { ItemID = 2, ItemNumber = "Y1", CheckedOutBy = "Bob" };
+        vm.CheckedOutItems.Add(item);
+
+        await vm.CheckInItemCommand.ExecuteAsync(item);
+
+        Assert.Single(vm.CheckedOutItems);
+        Assert.Equal(1, itemService.ToggleCalls);
+        Assert.Equal(2, itemService.LastToggledItemID);
     }
 }
 

--- a/InventoryManagementApp/ViewModels/DashboardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DashboardViewModel.cs
@@ -34,6 +34,7 @@ namespace InventoryManagementApp.ViewModels
         public IRelayCommand NewItemCommand { get; }
         public IRelayCommand OpenRentalsCommand { get; }
         public IRelayCommand OpenImportExportCommand { get; }
+        public IAsyncRelayCommand<ItemModel> CheckInItemCommand { get; }
 
         public DashboardViewModel(IItemService itemService,
                                   IRentalService rentalService,
@@ -72,6 +73,8 @@ namespace InventoryManagementApp.ViewModels
                 try { _openImportExportCommand.Execute(null); }
                 catch (Exception ex) { _logger.LogError(ex, "Failed to open import/export page"); }
             });
+
+            CheckInItemCommand = new AsyncRelayCommand<ItemModel>(CheckInItemAsync);
         }
 
         public Task LoadAsync(CancellationToken cancellationToken)
@@ -150,6 +153,24 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load checked-out items");
+            }
+        }
+
+        private async Task CheckInItemAsync(ItemModel? item, CancellationToken token)
+        {
+            if (item == null) return;
+            try
+            {
+                var result = await _itemService.ToggleItemCheckOutStatusAsync(item.ItemID, token).ConfigureAwait(false);
+                if (result)
+                    CheckedOutItems.Remove(item);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to check in item {ItemID}", item.ItemID);
             }
         }
     }

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml
@@ -62,7 +62,11 @@
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal">
                                     <TextBlock Text="{Binding ItemNumber}" Margin="0,0,8,0"/>
-                                    <TextBlock Text="{Binding CheckedOutBy}"/>
+                                    <TextBlock Text="{Binding CheckedOutBy}" Margin="0,0,8,0"/>
+                                    <Button Content="Check In"
+                                            Command="{Binding DataContext.CheckInItemCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
+                                            CommandParameter="{Binding}"
+                                            Margin="0,0,0,0"/>
                                 </StackPanel>
                             </DataTemplate>
                         </ListView.ItemTemplate>


### PR DESCRIPTION
## Summary
- add CheckInItemCommand to DashboardViewModel to toggle item status and remove returned items
- display Check In button for each checked-out item in dashboard
- cover dashboard check-in flow with new unit tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3c5e74f88324bf6da9f3272f9af6