### PR TITLE
Add debounced global search

### DIFF
--- a/InventoryManagementApp.Tests/MainViewModelTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelTests.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
+using InventoryManagementApp.Data;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Services.Core;
+using InventoryManagementApp.Services.Users;
+using InventoryManagementApp.ViewModels;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class MainViewModelTests
+    {
+        [Fact]
+        public async Task GlobalSearchText_TriggersCommand_AfterDebounce()
+        {
+            await RunOnStaThread(async () =>
+            {
+                using var db = new DatabaseService(":memory:");
+                var debounceTimer = new MockDispatcherTimer();
+                bool executed = false;
+                using var vm = new MainViewModel(
+                    new DummyItemService(),
+                    new DummyUserService(),
+                    new DummyUserContext(),
+                    new DummyCustomerService(),
+                    new DummyRentalService(),
+                    new DummyFileDialogService(),
+                    new ActivityLogService(db),
+                    new DummySettingsService(),
+                    db,
+                    new DummyDialogService(),
+                    NullLogger<MainViewModel>.Instance,
+                    () => Task.FromResult(true),
+                    new DummyDispatcherTimer(),
+                    new DummyScannerService(),
+                    debounceTimer);
+
+                var field = typeof(MainViewModel).GetField("<GlobalSearchCommand>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+                field!.SetValue(vm, new AsyncRelayCommand(ct =>
+                {
+                    executed = true;
+                    return Task.CompletedTask;
+                }));
+
+                vm.GlobalSearchText = "test";
+                Assert.False(executed);
+
+                debounceTimer.Fire();
+
+                Assert.True(executed);
+            });
+        }
+
+        static Task RunOnStaThread(Func<Task> action)
+        {
+            var tcs = new TaskCompletionSource<object?>();
+            var thread = new Thread(async () =>
+            {
+                try
+                {
+                    await action();
+                    tcs.SetResult(null);
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            return tcs.Task;
+        }
+
+        private sealed class DummyItemService : IItemService
+        {
+            public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(null);
+            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+            public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+            public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult(false);
+            public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
+            public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, System.Data.Sqlite.SqliteConnection? conn = null, System.Data.Sqlite.SqliteTransaction? tx = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct) => Task.CompletedTask;
+        }
+
+        private sealed class DummyUserService : IUserService
+        {
+            public Task<List<User>> GetAllUsersAsync() => Task.FromResult(new List<User>());
+            public Task<int> CountUsersAsync() => Task.FromResult(0);
+            public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult<User?>(null);
+            public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult((AuthenticationResult.Failure, (User?)null));
+            public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
+            public Task AddUserAsync(User user) => Task.CompletedTask;
+            public Task UpdateUserAsync(User user) => Task.CompletedTask;
+            public Task<bool> TryDeleteUserAsync(int userID) => Task.FromResult(false);
+        }
+
+        private sealed class DummyUserContext : IUserContext
+        {
+            User? _currentUser;
+            public User? CurrentUser
+            {
+                get => _currentUser;
+                set
+                {
+                    _currentUser = value;
+                    UserChanged?.Invoke(this, value);
+                }
+            }
+            public event EventHandler<User?>? UserChanged;
+            public bool IsAdmin => false;
+            public string UserName => string.Empty;
+            public string Role => string.Empty;
+        }
+
+        private sealed class DummyCustomerService : ICustomerService
+        {
+            public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult(new Customer());
+            public Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
+            public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
+            public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default) => Task.FromResult(new CustomerImportResult());
+            public Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+
+        private sealed class DummyRentalService : IRentalService
+        {
+            public Task RentItemAsync(int itemID, int customerID, DateTime rentalDate, DateTime dueDate) => Task.CompletedTask;
+            public Task ReturnItemAsync(int rentalID, DateTime returnDate) => Task.CompletedTask;
+            public Task ExtendRentalAsync(int rentalID, DateTime newDueDate) => Task.CompletedTask;
+            public Task DeleteRentalAsync(int rentalID) => Task.CompletedTask;
+            public Task<List<Rental>> GetActiveRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<int> CountActiveRentalsAsync() => Task.FromResult(0);
+            public Task<List<Rental>> GetOverdueRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetAllRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetRentalHistoryForItemAsync(int itemID) => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID) => Task.FromResult(new List<Rental>());
+        }
+
+        private sealed class DummyFileDialogService : IFileDialogService
+        {
+            public string? OpenFile(string filter, string? initialDirectory = null) => null;
+            public string? SaveFile(string filter) => null;
+        }
+
+        private sealed class DummySettingsService : ISettingsService
+        {
+            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult<IDictionary<ItemDetailField, bool>>(Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true));
+            public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+        }
+
+        private sealed class DummyDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => false;
+            public ItemModel? ShowEditItemDialog(ItemModel item) => null;
+            public void ShowItemDetails(ItemModel item) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
+            public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+        }
+
+        private sealed class DummyScannerService : IScannerService
+        {
+            public Task<IEnumerable<ScannerDevice>> GetScannerDevicesAsync(CancellationToken cancellationToken) => Task.FromResult<IEnumerable<ScannerDevice>>(Array.Empty<ScannerDevice>());
+        }
+
+        private sealed class DummyDispatcherTimer : IDispatcherTimer
+        {
+            public event EventHandler? Tick;
+            public TimeSpan Interval { get; set; }
+            public bool IsEnabled { get; private set; }
+            public void Start() => IsEnabled = true;
+            public void Stop() => IsEnabled = false;
+        }
+
+        private sealed class MockDispatcherTimer : IDispatcherTimer
+        {
+            public event EventHandler? Tick;
+            public TimeSpan Interval { get; set; }
+            public bool IsEnabled { get; private set; }
+            public void Start() => IsEnabled = true;
+            public void Stop() => IsEnabled = false;
+            public void Fire() => Tick?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}
+

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -46,8 +46,10 @@ namespace InventoryManagementApp.ViewModels
         readonly ILogger<MainViewModel> _logger;
         readonly Func<Task<bool>> _showLoginWindow;
         readonly IDispatcherTimer _autoLogoutTimer;
+        readonly IDispatcherTimer _globalSearchDebounceTimer;
         int _autoLogoutMinutes;
         CancellationTokenSource? _pageLoadCts;
+        CancellationTokenSource? _globalSearchCts;
 
         EventHandler<User?>? _userContextChangedHandler;
         PropertyChangedEventHandler? _itemManagementPropertyChangedHandler;
@@ -84,7 +86,15 @@ namespace InventoryManagementApp.ViewModels
         public string GlobalSearchText
         {
             get => _globalSearchText;
-            set => SetProperty(ref _globalSearchText, value);
+            set
+            {
+                if (SetProperty(ref _globalSearchText, value))
+                {
+                    _globalSearchCts?.Cancel();
+                    _globalSearchDebounceTimer.Stop();
+                    _globalSearchDebounceTimer.Start();
+                }
+            }
         }
 
         public bool IsCurrentUserAdmin => _userContext.IsAdmin;
@@ -186,7 +196,8 @@ namespace InventoryManagementApp.ViewModels
                              ILogger<MainViewModel>? logger = null,
                              Func<Task<bool>>? showLoginWindow = null,
                              IDispatcherTimer? autoLogoutTimer = null,
-                             IScannerService? scannerService = null)
+                             IScannerService? scannerService = null,
+                             IDispatcherTimer? globalSearchDebounceTimer = null)
         {
             _itemService = itemService;
             _userService = userService;
@@ -413,6 +424,8 @@ namespace InventoryManagementApp.ViewModels
             OpenImportMappingWindowCommand = new AsyncRelayCommand(ct => OpenImportMappingWindowAsync(ct));
 
             GlobalSearchCommand = new AsyncRelayCommand(ct => GlobalSearchAsync(ct));
+            _globalSearchDebounceTimer = globalSearchDebounceTimer ?? new DispatcherTimerWrapper { Interval = TimeSpan.FromMilliseconds(300) };
+            _globalSearchDebounceTimer.Tick += OnGlobalSearchDebounceTimerTick;
 
             SwitchUserCommand = new AsyncRelayCommand(async () =>
             {
@@ -597,6 +610,14 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
+        void OnGlobalSearchDebounceTimerTick(object? s, EventArgs e)
+        {
+            _globalSearchDebounceTimer.Stop();
+            _globalSearchCts?.Dispose();
+            _globalSearchCts = new CancellationTokenSource();
+            _ = GlobalSearchCommand.ExecuteAsync(_globalSearchCts.Token);
+        }
+
         async Task GlobalSearchAsync(CancellationToken cancellationToken)
         {
             ItemManagement.SearchText = GlobalSearchText;
@@ -623,6 +644,10 @@ namespace InventoryManagementApp.ViewModels
             Settings.PropertyChanged -= Settings_PropertyChanged;
             _autoLogoutTimer.Tick -= OnAutoLogoutTimerTick;
             _autoLogoutTimer.Stop();
+            _globalSearchDebounceTimer.Tick -= OnGlobalSearchDebounceTimerTick;
+            _globalSearchDebounceTimer.Stop();
+            _globalSearchCts?.Cancel();
+            _globalSearchCts?.Dispose();
             ItemManagement.Dispose();
         }
 


### PR DESCRIPTION
## Summary
- debounce global search using dispatcher timer and cancellation token
- clean up timer/cts on dispose
- cover global search debounce with unit test using mock timer

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3e0fd4fc8324a074a511206f22ba