### PR TITLE
Allow admin item check-in override

### DIFF
--- a/InventoryManagementApp.Tests/ItemServiceToggleTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceToggleTests.cs
@@ -29,6 +29,18 @@ public class ItemServiceToggleTests
         public string Role => IsAdmin ? "Admin" : "User";
     }
 
+    private sealed class NonAdminAuthorizationService : IAuthorizationService
+    {
+        public bool IsAdmin => false;
+        public void EnsureAdmin() => throw new UnauthorizedAccessException();
+    }
+
+    private sealed class AdminAuthorizationService : IAuthorizationService
+    {
+        public bool IsAdmin => true;
+        public void EnsureAdmin() { }
+    }
+
     private static async Task InitializeAsync(DatabaseService db)
     {
         using var conn = db.CreateConnection();
@@ -67,7 +79,7 @@ public class ItemServiceToggleTests
         await using var db = new DatabaseService(dbPath);
         await InitializeAsync(db);
         var userContext = new DummyUserContext { CurrentUser = new User { UserID = 1, UserName = "user1", IsAdmin = false } };
-        var service = new ItemService(db, new DummyItemRepository(), userContext: userContext);
+        var service = new ItemService(db, new DummyItemRepository(), new NonAdminAuthorizationService(), userContext: userContext);
 
         var checkout = await service.ToggleItemCheckOutStatusAsync(1, CancellationToken.None);
         Assert.True(checkout);
@@ -96,20 +108,47 @@ public class ItemServiceToggleTests
     }
 
     [Fact]
-    public async Task OtherUserCannotToggleWhenItemCheckedOutBySomeoneElse()
+    public async Task NonAdminCannotCheckInItemCheckedOutByAnotherUser()
     {
         var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
         await using var db = new DatabaseService(dbPath);
         await InitializeAsync(db);
         var userContext1 = new DummyUserContext { CurrentUser = new User { UserID = 1, UserName = "user1", IsAdmin = false } };
-        var service1 = new ItemService(db, new DummyItemRepository(), userContext: userContext1);
+        var service1 = new ItemService(db, new DummyItemRepository(), new NonAdminAuthorizationService(), userContext: userContext1);
         var checkout = await service1.ToggleItemCheckOutStatusAsync(1, CancellationToken.None);
         Assert.True(checkout);
 
         var userContext2 = new DummyUserContext { CurrentUser = new User { UserID = 2, UserName = "user2", IsAdmin = false } };
-        var service2 = new ItemService(db, new DummyItemRepository(), userContext: userContext2);
+        var service2 = new ItemService(db, new DummyItemRepository(), new NonAdminAuthorizationService(), userContext: userContext2);
         var attempt = await service2.ToggleItemCheckOutStatusAsync(1, CancellationToken.None);
         Assert.False(attempt);
+
+        File.Delete(dbPath);
+    }
+
+    [Fact]
+    public async Task AdminCanCheckInItemCheckedOutByAnotherUser()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        await InitializeAsync(db);
+        var userContext1 = new DummyUserContext { CurrentUser = new User { UserID = 1, UserName = "user1", IsAdmin = false } };
+        var service1 = new ItemService(db, new DummyItemRepository(), new NonAdminAuthorizationService(), userContext: userContext1);
+        var checkout = await service1.ToggleItemCheckOutStatusAsync(1, CancellationToken.None);
+        Assert.True(checkout);
+
+        var adminContext = new DummyUserContext { CurrentUser = new User { UserID = 3, UserName = "admin", IsAdmin = true } };
+        var adminService = new ItemService(db, new DummyItemRepository(), new AdminAuthorizationService(), userContext: adminContext);
+        var checkin = await adminService.ToggleItemCheckOutStatusAsync(1, CancellationToken.None);
+        Assert.True(checkin);
+
+        using (var conn = db.CreateConnection())
+        {
+            var record = await conn.QuerySingleAsync("SELECT IsCheckedOut, AvailableQuantity, CheckedOutBy FROM Items WHERE ItemID=1");
+            Assert.Equal(0L, record.IsCheckedOut);
+            Assert.Equal(1L, record.AvailableQuantity);
+            Assert.Null(record.CheckedOutBy);
+        }
 
         File.Delete(dbPath);
     }
@@ -121,7 +160,7 @@ public class ItemServiceToggleTests
         await using var db = new DatabaseService(dbPath);
         await InitializeAsync(db);
         var userContext = new DummyUserContext { CurrentUser = new User { UserID = 1, UserName = "user1", IsAdmin = false } };
-        var service = new ItemService(db, new DummyItemRepository(), userContext: userContext);
+        var service = new ItemService(db, new DummyItemRepository(), new NonAdminAuthorizationService(), userContext: userContext);
 
         var result = await service.ToggleItemCheckOutStatusAsync(2, CancellationToken.None);
         Assert.False(result);
@@ -142,7 +181,7 @@ public class ItemServiceToggleTests
         await using var db = new DatabaseService(dbPath);
         await InitializeAsync(db);
         var userContext = new DummyUserContext { CurrentUser = new User { UserID = 1, UserName = "user1", IsAdmin = false } };
-        var service = new ItemService(db, new DummyItemRepository(), userContext: userContext);
+        var service = new ItemService(db, new DummyItemRepository(), new NonAdminAuthorizationService(), userContext: userContext);
 
         await service.ToggleItemCheckOutStatusAsync(1, CancellationToken.None);
 

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -92,7 +92,7 @@ namespace InventoryManagementApp.Services.Items
                 throw new InvalidOperationException("Current user is not available.");
 
             var caller = _context.UserName;
-            var result = await ToggleItemCheckOutStatusInternalAsync(itemID, caller, cancellationToken).ConfigureAwait(false);
+            var result = await ToggleItemCheckOutStatusInternalAsync(itemID, caller, _auth.IsAdmin, cancellationToken).ConfigureAwait(false);
             if (!result)
                 return false;
 
@@ -446,7 +446,7 @@ namespace InventoryManagementApp.Services.Items
         public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct)
             => _repository.CountAsync(filter, ct);
 
-        private async Task<bool> ToggleItemCheckOutStatusInternalAsync(int itemID, string currentUser, CancellationToken cancellationToken)
+        private async Task<bool> ToggleItemCheckOutStatusInternalAsync(int itemID, string currentUser, bool isAdmin, CancellationToken cancellationToken)
         {
             using var conn = _dbService.CreateConnection();
             var record = (await SqliteHelper.ExecuteReaderAsync(conn,
@@ -471,7 +471,7 @@ namespace InventoryManagementApp.Services.Items
                 if (record.Qty <= 0)
                     return false;
             }
-            else if (!string.Equals(record.By, currentUser, StringComparison.OrdinalIgnoreCase))
+            else if (!isAdmin && !string.Equals(record.By, currentUser, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }


### PR DESCRIPTION
## Summary
- Allow administrators to check in items regardless of who checked them out
- Cover admin vs non-admin check-in scenarios in ItemService toggle tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa42c27db8832499db1e092e632473