### PR TITLE
Handle empty UpdatedAt without logging

### DIFF
--- a/InventoryManagementApp.Tests/ItemServiceUpdatedAtTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceUpdatedAtTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using InventoryManagementApp.Data;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Services.Core;
+using InventoryManagementApp.Services.Items;
+using Xunit;
+
+public class ItemServiceUpdatedAtTests
+{
+    private sealed class DummyItemRepository : IItemRepository
+    {
+        public IAsyncEnumerable<ItemModel> GetPageAsync(ItemFilter filter, ItemPage page, CancellationToken ct) => AsyncEnumerable.Empty<ItemModel>();
+        public Task<int> CountAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+        public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task GetItemsCheckedOutByAsync_HandlesEmptyUpdatedAt(string? updatedAt)
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        using var db = new DatabaseService(dbPath);
+        var logger = new ListLogger<ItemService>();
+        var service = new ItemService(db, new DummyItemRepository(), logger: logger);
+
+        using (var conn = db.CreateConnection())
+        using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, CheckedOutBy, IsPowered, UpdatedAt) VALUES ('A1','Test',1,0,0,1,'User',0,@UpdatedAt);";
+            var p = cmd.CreateParameter();
+            p.ParameterName = "@UpdatedAt";
+            p.Value = updatedAt ?? (object)DBNull.Value;
+            cmd.Parameters.Add(p);
+            cmd.ExecuteNonQuery();
+        }
+
+        var items = await service.GetItemsCheckedOutByAsync("User");
+
+        Assert.Single(items);
+        Assert.Equal(default, items[0].UpdatedAt);
+        Assert.Empty(logger.Messages);
+
+        File.Delete(dbPath);
+    }
+}
+

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -337,6 +337,8 @@ namespace InventoryManagementApp.Services.Items
         DateTime? ParseNullableDate(object? value, string field)
         {
             var text = value?.ToString();
+            if (string.IsNullOrWhiteSpace(text))
+                return null;
             if (DateTime.TryParse(text, CultureInfo.InvariantCulture,
                     DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dt))
                 return DateTime.SpecifyKind(dt, DateTimeKind.Utc).ToLocalTime();


### PR DESCRIPTION
## Summary
- prevent ItemService.ParseNullableDate from logging when input is null or whitespace
- test ItemService behavior with empty UpdatedAt values

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa42a94ae483249294c00573a141b8