### PR TITLE
Sync item column visibility with settings changes

### DIFF
--- a/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
+++ b/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
@@ -167,6 +167,29 @@ public class ItemDisplaySettingsTests
     }
 
     [Fact]
+    public async Task ChangingVisibilityInSettingsUpdatesItemManagement()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        var settings = new SettingsService(db);
+        var initial = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true);
+        await settings.SaveItemDetailVisibilityAsync(initial);
+        var itemVm = new ItemManagementViewModel(new DummyItemService(), new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
+        await itemVm.InitializeAsync();
+        var settingsVm = new SettingsViewModel(new DummyFileDialogService(), settings, new DummyDialogService());
+        await settingsVm.InitializeAsync();
+        var tcs = new TaskCompletionSource<bool>();
+        itemVm.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(ItemManagementViewModel.VisibleFields))
+                tcs.TrySetResult(true);
+        };
+        settingsVm.ItemDetailOptions.Single(o => o.Field == ItemDetailField.Name).IsVisible = false;
+        await tcs.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.False(itemVm.VisibleFields[ItemDetailField.Name]);
+    }
+
+    [Fact]
     public async Task SettingsViewModel_InitializeAsync_LoadsSettings()
     {
         var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");

--- a/InventoryManagementApp.Tests/ItemManagementViewModelCommandTests.cs
+++ b/InventoryManagementApp.Tests/ItemManagementViewModelCommandTests.cs
@@ -125,6 +125,7 @@ namespace InventoryManagementApp.Tests
 
         private sealed class DummySettingsService : ISettingsService
         {
+            public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
             public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
             public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
@@ -141,7 +142,11 @@ namespace InventoryManagementApp.Tests
             public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
             public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default) => Task.FromResult<IDictionary<ItemDetailField, bool>>(Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true));
-            public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
+            {
+                ItemDetailVisibilityChanged?.Invoke(this, visibility);
+                return Task.CompletedTask;
+            }
         }
 
         private sealed class ToggleItemService : IItemService

--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -711,6 +711,7 @@ namespace InventoryManagementApp.Tests
 
         private sealed class DummySettingsService : ISettingsService
         {
+            public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
             public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
             public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
@@ -729,7 +730,10 @@ namespace InventoryManagementApp.Tests
             public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default)
                 => Task.FromResult<IDictionary<ItemDetailField, bool>>(Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true));
             public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
-                => Task.CompletedTask;
+            {
+                ItemDetailVisibilityChanged?.Invoke(this, visibility);
+                return Task.CompletedTask;
+            }
         }
 
         private sealed class RecordingDialogService : IDialogService

--- a/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
@@ -196,6 +196,7 @@ namespace InventoryManagementApp.Tests
 
         private sealed class DummySettingsService : ISettingsService
         {
+            public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
             public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
             public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
@@ -214,7 +215,10 @@ namespace InventoryManagementApp.Tests
             public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default)
                 => Task.FromResult<IDictionary<ItemDetailField, bool>>(Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true));
             public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
-                => Task.CompletedTask;
+            {
+                ItemDetailVisibilityChanged?.Invoke(this, visibility);
+                return Task.CompletedTask;
+            }
         }
 
         private sealed class DummyDialogService : IDialogService

--- a/InventoryManagementApp.Tests/MainViewModelTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelTests.cs
@@ -165,6 +165,7 @@ namespace InventoryManagementApp.Tests
 
         private sealed class DummySettingsService : ISettingsService
         {
+            public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
             public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
             public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
@@ -183,7 +184,10 @@ namespace InventoryManagementApp.Tests
             public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default)
                 => Task.FromResult<IDictionary<ItemDetailField, bool>>(Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true));
             public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
-                => Task.CompletedTask;
+            {
+                ItemDetailVisibilityChanged?.Invoke(this, visibility);
+                return Task.CompletedTask;
+            }
         }
 
         private sealed class DummyDialogService : IDialogService

--- a/InventoryManagementApp/Interfaces/ISettingsService.cs
+++ b/InventoryManagementApp/Interfaces/ISettingsService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Models;
@@ -7,6 +8,7 @@ namespace InventoryManagementApp.Interfaces
 {
     public interface ISettingsService
     {
+        event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
         Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default);
         Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default);
         Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default);

--- a/InventoryManagementApp/Resources/Templates.xaml
+++ b/InventoryManagementApp/Resources/Templates.xaml
@@ -22,13 +22,13 @@
         <Border Style="{StaticResource Card}" Width="220" Padding="0">
             <Border.Visibility>
                 <MultiBinding Converter="{StaticResource AnyTrueToVisibilityConverter}">
-                    <Binding Path="DataContext.VisibleFields[(models:ItemDetailField)Image]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
-                    <Binding Path="DataContext.VisibleFields[(models:ItemDetailField)Name]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
-                    <Binding Path="DataContext.VisibleFields[(models:ItemDetailField)ItemNumber]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
-                    <Binding Path="DataContext.VisibleFields[(models:ItemDetailField)Brand]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
-                    <Binding Path="DataContext.VisibleFields[(models:ItemDetailField)Location]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
-                    <Binding Path="DataContext.VisibleFields[(models:ItemDetailField)Price]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
-                    <Binding Path="DataContext.VisibleFields[(models:ItemDetailField)Notes]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Image}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Name}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.ItemNumber}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Brand}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Location}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Price}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Notes}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
                 </MultiBinding>
             </Border.Visibility>
             <Grid>
@@ -37,16 +37,16 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <Border Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" CornerRadius="8" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)Image], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
+                <Border Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" CornerRadius="8" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Image}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
                     <Image Stretch="UniformToFill" Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
                 </Border>
                 <StackPanel Grid.Row="1" Margin="0,6,0,0">
-                    <TextBlock Text="{Binding Name}" Style="{StaticResource ListItemTitleTextBlock}" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)Name], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding ItemNumber}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)ItemNumber], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding Brand}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)Brand], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding Location}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)Location], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding Price, StringFormat={}{0:C}}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)Price], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding Notes}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)Notes], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding Name}" Style="{StaticResource ListItemTitleTextBlock}" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Name}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding ItemNumber}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.ItemNumber}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding Brand}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Brand}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding Location}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Location}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding Price, StringFormat={}{0:C}}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Price}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding Notes}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Notes}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
                 </StackPanel>
                 <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,6,0,0">
                     <Button Content="Rent"

--- a/InventoryManagementApp/Services/Settings/SettingsService.cs
+++ b/InventoryManagementApp/Services/Settings/SettingsService.cs
@@ -20,6 +20,7 @@ namespace InventoryManagementApp.Services.Settings
         readonly DatabaseService _dbService;
         readonly ILogger<SettingsService> _logger;
         readonly IAuthorizationService _auth;
+        public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
         const string UpsertSql = @"
             INSERT INTO Settings (Key, Value) 
             VALUES (@Key, @Value)
@@ -347,12 +348,13 @@ namespace InventoryManagementApp.Services.Settings
             return visibility;
         }
 
-        public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
+        public async Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
             var dict = visibility.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value);
             var json = JsonSerializer.Serialize(dict);
-            return SaveSettingAsync(ItemDetailVisibilityKey, json, cancellationToken);
+            await SaveSettingAsync(ItemDetailVisibilityKey, json, cancellationToken).ConfigureAwait(false);
+            ItemDetailVisibilityChanged?.Invoke(this, new Dictionary<ItemDetailField, bool>(visibility));
         }
     }
 }

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -155,8 +155,8 @@ namespace InventoryManagementApp.ViewModels
             Items.CollectionChanged += Items_CollectionChanged;
         }
 
-        ReadOnlyDictionary<ItemDetailField, bool> _visibleFields = new(new Dictionary<ItemDetailField, bool>());
-        public ReadOnlyDictionary<ItemDetailField, bool> VisibleFields
+        Dictionary<ItemDetailField, bool> _visibleFields = new();
+        public Dictionary<ItemDetailField, bool> VisibleFields
         {
             get => _visibleFields;
             private set => SetProperty(ref _visibleFields, value);
@@ -167,8 +167,14 @@ namespace InventoryManagementApp.ViewModels
         {
             if (_initialized) return;
             var vis = await _settingsService.GetItemDetailVisibilityAsync().ConfigureAwait(false);
-            VisibleFields = new ReadOnlyDictionary<ItemDetailField, bool>(new Dictionary<ItemDetailField, bool>(vis));
+            VisibleFields = new Dictionary<ItemDetailField, bool>(vis);
+            _settingsService.ItemDetailVisibilityChanged += OnItemDetailVisibilityChanged;
             _initialized = true;
+        }
+
+        void OnItemDetailVisibilityChanged(object? sender, IDictionary<ItemDetailField, bool> e)
+        {
+            VisibleFields = new Dictionary<ItemDetailField, bool>(e);
         }
 
         void OnSearchDebounceTimerTick(object? s, EventArgs e)
@@ -505,6 +511,7 @@ namespace InventoryManagementApp.ViewModels
             cts?.Dispose();
 
             Items.CollectionChanged -= Items_CollectionChanged;
+            _settingsService.ItemDetailVisibilityChanged -= OnItemDetailVisibilityChanged;
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace read-only VisibleFields with dictionary and watch for settings updates
- bind templates to new indexable visibility map
- test that settings view toggles immediately update item listings

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden; repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa42b9562083249f07fd962284648a