### PR TITLE
Align item card layout for consistent rows

### DIFF
--- a/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
+++ b/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
@@ -145,10 +145,9 @@ public class ItemDisplaySettingsTests
                 itemsControl.UpdateLayout();
                 border = (Border)VisualTreeHelper.GetChild(container, 0);
                 Assert.Equal(Visibility.Visible, border.Visibility);
-                var grid = (Grid)VisualTreeHelper.GetChild(border, 0);
-                var stack = (StackPanel)grid.Children[1];
-                var brandBlock = (TextBlock)stack.Children[2];
-                Assert.Equal(Visibility.Visible, brandBlock.Visibility);
+                var brandBlock = FindVisualChild<TextBlock>(border, tb => tb.Text == "B");
+                Assert.NotNull(brandBlock);
+                Assert.Equal(Visibility.Visible, brandBlock!.Visibility);
                 window.Close();
             }
             catch (Exception ex)
@@ -223,5 +222,19 @@ public class ItemDisplaySettingsTests
         thread.Start();
         thread.Join();
         Assert.True(vm.ItemDetailOptions.Single(o => o.Field == ItemDetailField.Name).IsVisible);
+    }
+
+    private static T? FindVisualChild<T>(DependencyObject parent, Func<T, bool> predicate) where T : DependencyObject
+    {
+        for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+            if (child is T t && predicate(t))
+                return t;
+            var result = FindVisualChild(child, predicate);
+            if (result != null)
+                return result;
+        }
+        return null;
     }
 }

--- a/InventoryManagementApp/Resources/Templates.xaml
+++ b/InventoryManagementApp/Resources/Templates.xaml
@@ -34,20 +34,28 @@
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="140"/>
-                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="120"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <Border Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" CornerRadius="8" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Image}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
                     <Image Stretch="UniformToFill" Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
                 </Border>
-                <StackPanel Grid.Row="1" Margin="0,6,0,0">
-                    <TextBlock Text="{Binding Name}" Style="{StaticResource ListItemTitleTextBlock}" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Name}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding ItemNumber}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.ItemNumber}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding Brand}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Brand}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding Location}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Location}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding Price, StringFormat={}{0:C}}" Style="{StaticResource CaptionTextBlock}" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Price}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Text="{Binding Notes}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Notes}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                </StackPanel>
+                <Grid Grid.Row="1" Margin="0,6,0,0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="20"/>
+                        <RowDefinition Height="20"/>
+                        <RowDefinition Height="20"/>
+                        <RowDefinition Height="20"/>
+                        <RowDefinition Height="20"/>
+                        <RowDefinition Height="20"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock Grid.Row="0" Text="{Binding Name}" Style="{StaticResource ListItemTitleTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Name}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Grid.Row="1" Text="{Binding ItemNumber}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.ItemNumber}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Grid.Row="2" Text="{Binding Brand}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Brand}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Grid.Row="3" Text="{Binding Location}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Location}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Grid.Row="4" Text="{Binding Price, StringFormat={}{0:C}}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Price}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Grid.Row="5" Text="{Binding Notes}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Notes}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                </Grid>
                 <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,6,0,0">
                     <Button Content="Rent"
                             Style="{StaticResource PrimaryButton}"


### PR DESCRIPTION
## Summary
- use fixed-height grid rows in ItemCardTemplate for uniform image alignment
- trim and cap item text to keep card heights consistent
- adjust visibility test to search visual tree and add helper

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4456c43c8324971282069b6e7adf