### PR TITLE
feat: react to item settings changes

### DIFF
--- a/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
+++ b/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
@@ -20,12 +20,22 @@ public class ItemDisplaySettingsTests
 {
     private sealed class DummyItemService : IItemService
     {
+        public Action? OnGetItems;
+        public Action? OnSearchItems;
         public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(null);
-        public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
-        public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => AsyncEnumerable.Empty<ItemModel>();
+        public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default)
+        {
+            OnGetItems?.Invoke();
+            return AsyncEnumerable.Empty<ItemModel>();
+        }
+        public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default)
+        {
+            OnSearchItems?.Invoke();
+            return AsyncEnumerable.Empty<ItemModel>();
+        }
         public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
         public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct) => Task.CompletedTask;
         public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult(false);
@@ -167,14 +177,17 @@ public class ItemDisplaySettingsTests
     }
 
     [Fact]
-    public async Task ChangingVisibilityInSettingsUpdatesItemManagement()
+    public async Task ChangingVisibilityInSettingsRefreshesItemManagement()
     {
         var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
         await using var db = new DatabaseService(dbPath);
         var settings = new SettingsService(db);
         var initial = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true);
         await settings.SaveItemDetailVisibilityAsync(initial);
-        var itemVm = new ItemManagementViewModel(new DummyItemService(), new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
+        var itemService = new DummyItemService();
+        var searchTcs = new TaskCompletionSource<bool>();
+        itemService.OnGetItems = () => searchTcs.TrySetResult(true);
+        var itemVm = new ItemManagementViewModel(itemService, new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
         await itemVm.InitializeAsync();
         var settingsVm = new SettingsViewModel(new DummyFileDialogService(), settings, new DummyDialogService());
         await settingsVm.InitializeAsync();
@@ -185,8 +198,25 @@ public class ItemDisplaySettingsTests
                 tcs.TrySetResult(true);
         };
         settingsVm.ItemDetailOptions.Single(o => o.Field == ItemDetailField.Name).IsVisible = false;
-        await tcs.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await Task.WhenAll(tcs.Task.WaitAsync(TimeSpan.FromSeconds(1)), searchTcs.Task.WaitAsync(TimeSpan.FromSeconds(1)));
         Assert.False(itemVm.VisibleFields[ItemDetailField.Name]);
+    }
+
+    [Fact]
+    public async Task ChangingItemLabelRefreshesItemManagement()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        var settings = new SettingsService(db);
+        var itemService = new DummyItemService();
+        var searchTcs = new TaskCompletionSource<bool>();
+        itemService.OnGetItems = () => searchTcs.TrySetResult(true);
+        var itemVm = new ItemManagementViewModel(itemService, new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
+        await itemVm.InitializeAsync();
+        var settingsVm = new SettingsViewModel(new DummyFileDialogService(), settings, new DummyDialogService());
+        await settingsVm.InitializeAsync();
+        settingsVm.ItemLabelSingular = "Widget";
+        await searchTcs.Task.WaitAsync(TimeSpan.FromSeconds(1));
     }
 
     [Fact]

--- a/InventoryManagementApp/Messages/ItemSettingsChangedMessage.cs
+++ b/InventoryManagementApp/Messages/ItemSettingsChangedMessage.cs
@@ -1,0 +1,6 @@
+namespace InventoryManagementApp.Messages
+{
+    public sealed class ItemSettingsChangedMessage
+    {
+    }
+}

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -15,6 +16,7 @@ using InventoryManagementApp.Utilities;
 using InventoryManagementApp.Utilities.Extensions;
 using InventoryManagementApp.Services;
 using InventoryManagementApp.Utilities.Helpers;
+using InventoryManagementApp.Messages;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -168,13 +170,25 @@ namespace InventoryManagementApp.ViewModels
             if (_initialized) return;
             var vis = await _settingsService.GetItemDetailVisibilityAsync().ConfigureAwait(false);
             VisibleFields = new Dictionary<ItemDetailField, bool>(vis);
-            _settingsService.ItemDetailVisibilityChanged += OnItemDetailVisibilityChanged;
+            WeakReferenceMessenger.Default.Register<ItemSettingsChangedMessage>(this, (r, m) => r.OnItemSettingsChanged());
             _initialized = true;
         }
 
-        void OnItemDetailVisibilityChanged(object? sender, IDictionary<ItemDetailField, bool> e)
+        async void OnItemSettingsChanged()
         {
-            VisibleFields = new Dictionary<ItemDetailField, bool>(e);
+            try
+            {
+                var vis = await _settingsService.GetItemDetailVisibilityAsync().ConfigureAwait(false);
+                VisibleFields = new Dictionary<ItemDetailField, bool>(vis);
+                _searchCts?.Cancel();
+                _searchCts?.Dispose();
+                _searchCts = new CancellationTokenSource();
+                await SearchCommand.ExecuteAsync(null);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to handle settings change");
+            }
         }
 
         void OnSearchDebounceTimerTick(object? s, EventArgs e)
@@ -511,7 +525,7 @@ namespace InventoryManagementApp.ViewModels
             cts?.Dispose();
 
             Items.CollectionChanged -= Items_CollectionChanged;
-            _settingsService.ItemDetailVisibilityChanged -= OnItemDetailVisibilityChanged;
+            WeakReferenceMessenger.Default.Unregister<ItemSettingsChangedMessage>(this);
         }
     }
 }

--- a/InventoryManagementApp/ViewModels/SettingsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/SettingsViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -13,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using InventoryManagementApp.Utilities.Helpers;
 using InventoryManagementApp.Models;
+using InventoryManagementApp.Messages;
 
 #nullable enable
 
@@ -150,6 +152,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 await _settingsService.SaveItemLabelSingularAsync(value).ConfigureAwait(false);
                 LabelProvider.Instance.UpdateLabels(value, ItemLabelPlural);
+                WeakReferenceMessenger.Default.Send(new ItemSettingsChangedMessage());
             }
             catch (UnauthorizedAccessException ex)
             {
@@ -181,6 +184,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 await _settingsService.SaveItemLabelPluralAsync(value).ConfigureAwait(false);
                 LabelProvider.Instance.UpdateLabels(ItemLabelSingular, value);
+                WeakReferenceMessenger.Default.Send(new ItemSettingsChangedMessage());
             }
             catch (UnauthorizedAccessException ex)
             {
@@ -306,6 +310,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 var dict = ItemDetailOptions.ToDictionary(o => o.Field, o => o.IsVisible);
                 await _settingsService.SaveItemDetailVisibilityAsync(dict).ConfigureAwait(false);
+                WeakReferenceMessenger.Default.Send(new ItemSettingsChangedMessage());
             }
             catch (UnauthorizedAccessException ex)
             {


### PR DESCRIPTION
## Summary
- notify app via ItemSettingsChangedMessage when labels or visibility options are saved
- refresh ItemManagementViewModel visible fields and search on settings updates
- add integration tests for settings-driven refresh

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa445cafe88324a72849ca2ca32817