### PR TITLE
Add check-in tracking and fix item settings messaging

### DIFF
--- a/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
+++ b/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
@@ -137,9 +137,11 @@ public class ItemDisplaySettingsTests
                 app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Templates.xaml", UriKind.Absolute) });
                 var template = (DataTemplate)app.Resources["ItemCardTemplate"];
                 var item = new ItemModel { Name = "A", ItemNumber = "1", Brand = "B", Location = "L", Notes = "N", Price = 1m };
-                var itemsControl = new ItemsControl { DataContext = vm, ItemTemplate = template };
+                var page = new Page { DataContext = vm };
+                var itemsControl = new ItemsControl { ItemTemplate = template };
+                page.Content = itemsControl;
                 itemsControl.Items.Add(item);
-                var window = new Window { Content = itemsControl };
+                var window = new Window { Content = page };
                 window.Show();
                 itemsControl.UpdateLayout();
                 var container = (ContentPresenter)itemsControl.ItemContainerGenerator.ContainerFromIndex(0)!;
@@ -151,7 +153,7 @@ public class ItemDisplaySettingsTests
                 settings.SaveItemDetailVisibilityAsync(vis).GetAwaiter().GetResult();
                 vm = new ItemManagementViewModel(new DummyItemService(), new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
                 vm.InitializeAsync().GetAwaiter().GetResult();
-                itemsControl.DataContext = vm;
+                page.DataContext = vm;
                 itemsControl.UpdateLayout();
                 border = (Border)VisualTreeHelper.GetChild(container, 0);
                 Assert.Equal(Visibility.Visible, border.Visibility);

--- a/InventoryManagementApp.Tests/ItemRepositoryCountTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryCountTests.cs
@@ -33,6 +33,8 @@ public class ItemRepositoryCountTests
             IsCheckedOut INTEGER,
             CheckedOutBy TEXT,
             CheckedOutTime TEXT,
+            CheckedInBy TEXT,
+            CheckedInTime TEXT,
             IsPowered INTEGER,
             UpdatedAt TEXT
         );";

--- a/InventoryManagementApp.Tests/ItemRepositoryPaginationTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryPaginationTests.cs
@@ -34,6 +34,8 @@ public class ItemRepositoryPaginationTests
             IsCheckedOut INTEGER,
             CheckedOutBy TEXT,
             CheckedOutTime TEXT,
+            CheckedInBy TEXT,
+            CheckedInTime TEXT,
             IsPowered INTEGER,
             UpdatedAt TEXT
         );";

--- a/InventoryManagementApp.Tests/ItemRepositorySearchTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositorySearchTests.cs
@@ -34,6 +34,8 @@ public class ItemRepositorySearchTests
             IsCheckedOut INTEGER,
             CheckedOutBy TEXT,
             CheckedOutTime TEXT,
+            CheckedInBy TEXT,
+            CheckedInTime TEXT,
             IsPowered INTEGER,
             UpdatedAt TEXT
         );";

--- a/InventoryManagementApp.Tests/ItemServiceToggleTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceToggleTests.cs
@@ -64,6 +64,8 @@ public class ItemServiceToggleTests
             IsCheckedOut INTEGER,
             CheckedOutBy TEXT,
             CheckedOutTime TEXT,
+            CheckedInBy TEXT,
+            CheckedInTime TEXT,
             IsPowered INTEGER,
             UpdatedAt TEXT
         );";
@@ -86,10 +88,12 @@ public class ItemServiceToggleTests
 
         using (var conn = db.CreateConnection())
         {
-            var record = await conn.QuerySingleAsync("SELECT IsCheckedOut, AvailableQuantity, CheckedOutBy FROM Items WHERE ItemID=1");
+            var record = await conn.QuerySingleAsync("SELECT IsCheckedOut, AvailableQuantity, CheckedOutBy, CheckedInBy, CheckedInTime FROM Items WHERE ItemID=1");
             Assert.Equal(1L, record.IsCheckedOut);
             Assert.Equal(0L, record.AvailableQuantity);
             Assert.Equal("user1", (string)record.CheckedOutBy);
+            Assert.Null(record.CheckedInBy);
+            Assert.Null(record.CheckedInTime);
         }
 
         var checkin = await service.ToggleItemCheckOutStatusAsync(1, CancellationToken.None);
@@ -97,10 +101,12 @@ public class ItemServiceToggleTests
 
         using (var conn = db.CreateConnection())
         {
-            var record = await conn.QuerySingleAsync("SELECT IsCheckedOut, AvailableQuantity, CheckedOutBy FROM Items WHERE ItemID=1");
+            var record = await conn.QuerySingleAsync("SELECT IsCheckedOut, AvailableQuantity, CheckedOutBy, CheckedInBy, CheckedInTime FROM Items WHERE ItemID=1");
             Assert.Equal(0L, record.IsCheckedOut);
             Assert.Equal(1L, record.AvailableQuantity);
             Assert.Null(record.CheckedOutBy);
+            Assert.Equal("user1", (string)record.CheckedInBy);
+            Assert.NotNull(record.CheckedInTime);
         }
 
 
@@ -144,10 +150,12 @@ public class ItemServiceToggleTests
 
         using (var conn = db.CreateConnection())
         {
-            var record = await conn.QuerySingleAsync("SELECT IsCheckedOut, AvailableQuantity, CheckedOutBy FROM Items WHERE ItemID=1");
+            var record = await conn.QuerySingleAsync("SELECT IsCheckedOut, AvailableQuantity, CheckedOutBy, CheckedInBy, CheckedInTime FROM Items WHERE ItemID=1");
             Assert.Equal(0L, record.IsCheckedOut);
             Assert.Equal(1L, record.AvailableQuantity);
             Assert.Null(record.CheckedOutBy);
+            Assert.Equal("admin", (string)record.CheckedInBy);
+            Assert.NotNull(record.CheckedInTime);
         }
 
         File.Delete(dbPath);

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -17,7 +17,7 @@ public sealed class ItemRepository : IItemRepository
 
     public async IAsyncEnumerable<Item> GetPageAsync(ItemFilter filter, ItemPage page, [EnumeratorCancellation] CancellationToken ct)
     {
-        var sql = "SELECT ItemID, ItemNumber, NameDescription AS Name, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity AS QuantityOnHand, RentedQuantity, IsRentalItem, Price, ImagePath, IsCheckedOut, CheckedOutBy, CheckedOutTime, IsPowered, UpdatedAt FROM Items";
+        var sql = "SELECT ItemID, ItemNumber, NameDescription AS Name, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity AS QuantityOnHand, RentedQuantity, IsRentalItem, Price, ImagePath, IsCheckedOut, CheckedOutBy, CheckedOutTime, CheckedInBy, CheckedInTime, IsPowered, UpdatedAt FROM Items";
         var parameters = new DynamicParameters();
         var conditions = new List<string>();
         if (!string.IsNullOrWhiteSpace(filter.Search))
@@ -68,6 +68,8 @@ public sealed class ItemRepository : IItemRepository
         var ordinalIsCheckedOut = reader.GetOrdinal("IsCheckedOut");
         var ordinalCheckedOutBy = reader.GetOrdinal("CheckedOutBy");
         var ordinalCheckedOutTime = reader.GetOrdinal("CheckedOutTime");
+        var ordinalCheckedInBy = reader.GetOrdinal("CheckedInBy");
+        var ordinalCheckedInTime = reader.GetOrdinal("CheckedInTime");
         var ordinalIsPowered = reader.GetOrdinal("IsPowered");
         var ordinalUpdatedAt = reader.GetOrdinal("UpdatedAt");
 
@@ -93,6 +95,8 @@ public sealed class ItemRepository : IItemRepository
                 IsCheckedOut = !reader.IsDBNull(ordinalIsCheckedOut) && reader.GetInt32(ordinalIsCheckedOut) == 1,
                 CheckedOutBy = reader.IsDBNull(ordinalCheckedOutBy) ? string.Empty : reader.GetString(ordinalCheckedOutBy),
                 CheckedOutTime = reader.IsDBNull(ordinalCheckedOutTime) ? null : reader.GetDateTime(ordinalCheckedOutTime),
+                CheckedInBy = reader.IsDBNull(ordinalCheckedInBy) ? string.Empty : reader.GetString(ordinalCheckedInBy),
+                CheckedInTime = reader.IsDBNull(ordinalCheckedInTime) ? null : reader.GetDateTime(ordinalCheckedInTime),
                 IsPowered = !reader.IsDBNull(ordinalIsPowered) && reader.GetInt32(ordinalIsPowered) == 1,
                 UpdatedAt = reader.IsDBNull(ordinalUpdatedAt) ? default : reader.GetDateTime(ordinalUpdatedAt)
             };

--- a/InventoryManagementApp/Models/Domain/ItemModel.cs
+++ b/InventoryManagementApp/Models/Domain/ItemModel.cs
@@ -142,6 +142,20 @@ namespace InventoryManagementApp.Models.Domain
             set => SetProperty(ref _checkedOutTime, value);
         }
 
+        private string _checkedInBy = string.Empty;
+        public string CheckedInBy
+        {
+            get => _checkedInBy;
+            set => SetProperty(ref _checkedInBy, value);
+        }
+
+        private DateTime? _checkedInTime;
+        public DateTime? CheckedInTime
+        {
+            get => _checkedInTime;
+            set => SetProperty(ref _checkedInTime, value);
+        }
+
         private string _imagePath = string.Empty;
         public string ImagePath
         {

--- a/InventoryManagementApp/Resources/Templates.xaml
+++ b/InventoryManagementApp/Resources/Templates.xaml
@@ -22,13 +22,13 @@
         <Border Style="{StaticResource Card}" Width="220" Padding="0">
             <Border.Visibility>
                 <MultiBinding Converter="{StaticResource AnyTrueToVisibilityConverter}">
-                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Image}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
-                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Name}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
-                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.ItemNumber}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
-                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Brand}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
-                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Location}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
-                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Price}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
-                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Notes}]" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Image}]" RelativeSource="{RelativeSource AncestorType=Page}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Name}]" RelativeSource="{RelativeSource AncestorType=Page}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.ItemNumber}]" RelativeSource="{RelativeSource AncestorType=Page}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Brand}]" RelativeSource="{RelativeSource AncestorType=Page}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Location}]" RelativeSource="{RelativeSource AncestorType=Page}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Price}]" RelativeSource="{RelativeSource AncestorType=Page}"/>
+                    <Binding Path="DataContext.VisibleFields[{x:Static models:ItemDetailField.Notes}]" RelativeSource="{RelativeSource AncestorType=Page}"/>
                 </MultiBinding>
             </Border.Visibility>
             <Grid>
@@ -37,7 +37,7 @@
                     <RowDefinition Height="120"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <Border Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" CornerRadius="8" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Image}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
+                <Border Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" CornerRadius="8" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Image}], RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource BoolToVis}}">
                     <Image Stretch="UniformToFill" Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
                 </Border>
                 <Grid Grid.Row="1" Margin="0,6,0,0">
@@ -49,12 +49,12 @@
                         <RowDefinition Height="20"/>
                         <RowDefinition Height="20"/>
                     </Grid.RowDefinitions>
-                    <TextBlock Grid.Row="0" Text="{Binding Name}" Style="{StaticResource ListItemTitleTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Name}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Grid.Row="1" Text="{Binding ItemNumber}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.ItemNumber}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Grid.Row="2" Text="{Binding Brand}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Brand}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Grid.Row="3" Text="{Binding Location}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Location}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Grid.Row="4" Text="{Binding Price, StringFormat={}{0:C}}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Price}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
-                    <TextBlock Grid.Row="5" Text="{Binding Notes}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Notes}], RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Grid.Row="0" Text="{Binding Name}" Style="{StaticResource ListItemTitleTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Name}], RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Grid.Row="1" Text="{Binding ItemNumber}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.ItemNumber}], RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Grid.Row="2" Text="{Binding Brand}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Brand}], RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Grid.Row="3" Text="{Binding Location}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Location}], RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Grid.Row="4" Text="{Binding Price, StringFormat={}{0:C}}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Price}], RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Grid.Row="5" Text="{Binding Notes}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" MaxHeight="20" Visibility="{Binding DataContext.VisibleFields[{x:Static models:ItemDetailField.Notes}], RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource BoolToVis}}"/>
                 </Grid>
                 <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,6,0,0">
                     <Button Content="Rent"

--- a/InventoryManagementApp/Services/Core/DatabaseService.cs
+++ b/InventoryManagementApp/Services/Core/DatabaseService.cs
@@ -44,6 +44,8 @@ namespace InventoryManagementApp.Services.Core
             EnsureColumn("Items", "ImagePath", "TEXT");
             EnsureColumn("Items", "CheckedOutBy", "TEXT");
             EnsureColumn("Items", "CheckedOutTime", "DATETIME");
+            EnsureColumn("Items", "CheckedInBy", "TEXT");
+            EnsureColumn("Items", "CheckedInTime", "DATETIME");
             EnsureColumn("Items", "Keywords", "TEXT");
             EnsureColumn("Items", "IsPowered", "INTEGER", "0");
             EnsureColumn("Items", "IsCheckedOut", "INTEGER", "0");
@@ -126,6 +128,8 @@ namespace InventoryManagementApp.Services.Core
                     IsCheckedOut INTEGER NOT NULL DEFAULT 0,
                     CheckedOutBy TEXT,
                     CheckedOutTime DATETIME,
+                    CheckedInBy TEXT,
+                    CheckedInTime DATETIME,
                     UpdatedAt DATETIME
                 );
                 CREATE TABLE IF NOT EXISTS Users (

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -327,6 +327,10 @@ namespace InventoryManagementApp.Services.Items
             CheckedOutTime = r["CheckedOutTime"] is DBNull
                 ? (DateTime?)null
                 : ParseNullableDate(r["CheckedOutTime"], "CheckedOutTime"),
+            CheckedInBy = r["CheckedInBy"].ToString(),
+            CheckedInTime = r["CheckedInTime"] is DBNull
+                ? (DateTime?)null
+                : ParseNullableDate(r["CheckedInTime"], "CheckedInTime"),
             ImagePath = r["ImagePath"]?.ToString(),
             Keywords = r["Keywords"]?.ToString(),
             IsPowered = (r["IsPowered"] is DBNull ? 0 : Convert.ToInt32(r["IsPowered"])) == 1,
@@ -381,6 +385,8 @@ namespace InventoryManagementApp.Services.Items
                   IsCheckedOut = @Out,
                   CheckedOutBy = @By,
                   CheckedOutTime = @Time,
+                  CheckedInBy = @InBy,
+                  CheckedInTime = @InTime,
                   ImagePath = @Img
                 WHERE ItemID = @ID";
             var p = new[]
@@ -402,6 +408,8 @@ namespace InventoryManagementApp.Services.Items
                 new SqliteParameter("@Out", item.IsCheckedOut ? 1 : 0),
                 new SqliteParameter("@By", (object)item.CheckedOutBy ?? DBNull.Value),
                 new SqliteParameter("@Time", (object)item.CheckedOutTime ?? DBNull.Value),
+                new SqliteParameter("@InBy", (object)item.CheckedInBy ?? DBNull.Value),
+                new SqliteParameter("@InTime", (object)item.CheckedInTime ?? DBNull.Value),
                 new SqliteParameter("@Img", (object)item.ImagePath ?? DBNull.Value)
             };
             try
@@ -479,8 +487,10 @@ namespace InventoryManagementApp.Services.Items
             }
 
             var newStatus = record.Out ? 0 : 1;
-            var time = record.Out ? (object)DBNull.Value : DateTime.UtcNow;
-            var by = record.Out ? (object)DBNull.Value : currentUser;
+            var outTime = record.Out ? (object)DBNull.Value : DateTime.UtcNow;
+            var outBy = record.Out ? (object)DBNull.Value : currentUser;
+            var inTime = record.Out ? DateTime.UtcNow : (object)DBNull.Value;
+            var inBy = record.Out ? (object)currentUser : DBNull.Value;
             var qtyChange = record.Out ? 1 : -1;
 
             var rows = await SqliteHelper.ExecuteNonQueryAsync(conn, @"
@@ -488,12 +498,16 @@ namespace InventoryManagementApp.Services.Items
                   IsCheckedOut = @Out,
                   CheckedOutBy = @By,
                   CheckedOutTime = @Time,
+                  CheckedInBy = @InBy,
+                  CheckedInTime = @InTime,
                   AvailableQuantity = AvailableQuantity + @Q
                 WHERE ItemID = @ID", new[]
             {
                 new SqliteParameter("@Out", newStatus),
-                new SqliteParameter("@By", by),
-                new SqliteParameter("@Time", time),
+                new SqliteParameter("@By", outBy),
+                new SqliteParameter("@Time", outTime),
+                new SqliteParameter("@InBy", inBy),
+                new SqliteParameter("@InTime", inTime),
                 new SqliteParameter("@Q", qtyChange),
                 new SqliteParameter("@ID", itemID)
             }, cancellationToken);

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -170,7 +170,7 @@ namespace InventoryManagementApp.ViewModels
             if (_initialized) return;
             var vis = await _settingsService.GetItemDetailVisibilityAsync().ConfigureAwait(false);
             VisibleFields = new Dictionary<ItemDetailField, bool>(vis);
-            WeakReferenceMessenger.Default.Register<ItemSettingsChangedMessage>(this, (r, m) => r.OnItemSettingsChanged());
+            WeakReferenceMessenger.Default.Register<ItemManagementViewModel, ItemSettingsChangedMessage>(this, static (r, m) => r.OnItemSettingsChanged());
             _initialized = true;
         }
 
@@ -305,6 +305,8 @@ namespace InventoryManagementApp.ViewModels
                 IsCheckedOut = selected.IsCheckedOut,
                 CheckedOutBy = selected.CheckedOutBy,
                 CheckedOutTime = selected.CheckedOutTime,
+                CheckedInBy = selected.CheckedInBy,
+                CheckedInTime = selected.CheckedInTime,
                 ImagePath = selected.ImagePath
             };
 
@@ -457,6 +459,14 @@ namespace InventoryManagementApp.ViewModels
                 var checkedOut = !item.IsCheckedOut;
                 item.IsCheckedOut = checkedOut;
                 item.QuantityOnHand += checkedOut ? -1 : 1;
+                var refreshed = await _itemService.GetItemByIDAsync(item.ItemID, cancellationToken).ConfigureAwait(false);
+                if (refreshed != null)
+                {
+                    item.CheckedOutBy = refreshed.CheckedOutBy;
+                    item.CheckedOutTime = refreshed.CheckedOutTime;
+                    item.CheckedInBy = refreshed.CheckedInBy;
+                    item.CheckedInTime = refreshed.CheckedInTime;
+                }
             }
             catch (OperationCanceledException)
             {

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -206,6 +206,8 @@ namespace InventoryManagementApp.ViewModels
                     IsCheckedOut = SelectedItem.IsCheckedOut,
                     CheckedOutBy = SelectedItem.CheckedOutBy,
                     CheckedOutTime = SelectedItem.CheckedOutTime,
+                    CheckedInBy = SelectedItem.CheckedInBy,
+                    CheckedInTime = SelectedItem.CheckedInTime,
                     ImagePath = SelectedItem.ImagePath,
                     Price = SelectedItem.Price,
                     UpdatedAt = SelectedItem.UpdatedAt
@@ -351,6 +353,8 @@ namespace InventoryManagementApp.ViewModels
                     item.IsCheckedOut = refreshed.IsCheckedOut;
                     item.CheckedOutBy = refreshed.CheckedOutBy;
                     item.CheckedOutTime = refreshed.CheckedOutTime;
+                    item.CheckedInBy = refreshed.CheckedInBy;
+                    item.CheckedInTime = refreshed.CheckedInTime;
                     item.ImagePath = refreshed.ImagePath;
                     item.Price = refreshed.Price;
                     item.UpdatedAt = refreshed.UpdatedAt;

--- a/Items.csv
+++ b/Items.csv
@@ -1,4 +1,4 @@
-ItemID,OnHand,Purchased,Brand,Description,PartNumber,Supplier,Notes,Location,ImagePath,IsCheckedOut,CheckedOutBy,CheckedOutTime
+ItemID,OnHand,Purchased,Brand,Description,PartNumber,Supplier,Notes,Location,ImagePath,IsCheckedOut,CheckedOutBy,CheckedOutTime,CheckedInBy,CheckedInTime
 ?,1,?,?,Ear stethoscope,?,?,doctors listening noises noise listen hearing,A6,Assets\ItemImages\63691_I.jpg,0,,
 T1,1,?,T&E Tools,VANOS Camshaft Locking Plates,B1021,T&E Tools,M62 m60 4.4L,C3,Assets\ItemImages\T1.jpg,0,,
 T10,1,?,Endeavour,BMW Timing Kit N62 | N73,ETN62N73,All Euro,"A vital timing chain tool kit for 3.6L | 4.0L | 4.4L | 4.8L V8 engines, and new generation V12 engines. These tools align intake & exhaust cams in the correct timing position by holding the valve timing whilst loosening & tightening the camshaft adjuster nut for assembly plus damper tools.",D2,Assets\ItemImages\T10.jpg,0,,


### PR DESCRIPTION
## Summary
- track item check-ins with CheckedInBy and CheckedInTime fields throughout the model, services, repository, and database
- fix WeakReferenceMessenger registration in ItemManagementViewModel and refresh item details after toggling check-in/out
- resolve binding errors by binding templates to page-level DataContext

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa45ec2d00832497e5fdad9e0f5bd4