### PR TITLE
Handle cancellation in item search

### DIFF
--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -224,30 +224,37 @@ namespace InventoryManagementApp.ViewModels
         /// </summary>
         async Task FilterItemsAsync()
         {
-            var cancellationToken = _searchCts?.Token ?? CancellationToken.None;
-            var term = string.IsNullOrWhiteSpace(SearchTerm) ? string.Empty : SearchTerm.Trim();
-            var page = new ItemPage(1, PageSize);
-            var list = new List<ItemModel>();
-
-            if (!string.IsNullOrEmpty(term))
+            try
             {
-                await foreach (var item in _itemService.SearchItemsAsync(term, page, SortField.Name, SortDirection.Ascending, isRentalItem: false, cancellationToken: cancellationToken))
-                    list.Add(item);
-            }
-            else
-            {
-                await foreach (var item in _itemService.GetItemsAsync(page, SortField.Name, SortDirection.Ascending, isRentalItem: false, cancellationToken: cancellationToken))
-                    list.Add(item);
-            }
+                var cancellationToken = _searchCts?.Token ?? CancellationToken.None;
+                var term = string.IsNullOrWhiteSpace(SearchTerm) ? string.Empty : SearchTerm.Trim();
+                var page = new ItemPage(1, PageSize);
+                var list = new List<ItemModel>();
 
-            if (!string.IsNullOrEmpty(SelectedCategory) && SelectedCategory != "All")
-            {
-                list = list.Where(t => string.Equals(t.Brand, SelectedCategory, StringComparison.OrdinalIgnoreCase)).ToList();
-            }
+                if (!string.IsNullOrEmpty(term))
+                {
+                    await foreach (var item in _itemService.SearchItemsAsync(term, page, SortField.Name, SortDirection.Ascending, isRentalItem: false, cancellationToken: cancellationToken))
+                        list.Add(item);
+                }
+                else
+                {
+                    await foreach (var item in _itemService.GetItemsAsync(page, SortField.Name, SortDirection.Ascending, isRentalItem: false, cancellationToken: cancellationToken))
+                        list.Add(item);
+                }
 
-            Items.ReplaceRange(list);
-            SearchResults.ReplaceRange(list);
-            LoadCategories(list, suppressSearch: true);
+                if (!string.IsNullOrEmpty(SelectedCategory) && SelectedCategory != "All")
+                {
+                    list = list.Where(t => string.Equals(t.Brand, SelectedCategory, StringComparison.OrdinalIgnoreCase)).ToList();
+                }
+
+                Items.ReplaceRange(list);
+                SearchResults.ReplaceRange(list);
+                LoadCategories(list, suppressSearch: true);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
         }
 
         async Task AddItemAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- Wrap item search filtering in try/catch to quietly handle cancellations

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa495dc9a883248a5b3167264fc077