### PR TITLE
Gracefully handle invalid image paths

### DIFF
--- a/InventoryManagementApp.Tests/NullToDefaultImageConverterTests.cs
+++ b/InventoryManagementApp.Tests/NullToDefaultImageConverterTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Windows;
+using System.Windows.Media.Imaging;
+using InventoryManagementApp.Utilities.Converters;
+using InventoryManagementApp.Utilities.Helpers;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class NullToDefaultImageConverterTests
+    {
+        [Fact]
+        public void Convert_InvalidPath_UsesDefaultImage()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var converter = new NullToDefaultImageConverter();
+                    Assert.Null(PathHelper.GetAbsolutePath("../nonexistent.png", false));
+                    var defaultImage = Assert.IsType<BitmapImage>(converter.Convert(null, typeof(BitmapImage), "user", CultureInfo.InvariantCulture));
+                    var result = Assert.IsType<BitmapImage>(converter.Convert("../nonexistent.png", typeof(BitmapImage), "user", CultureInfo.InvariantCulture));
+                    Assert.Same(defaultImage, result);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+    }
+}

--- a/InventoryManagementApp/Utilities/Converters/NullToDefaultImageConverter.cs
+++ b/InventoryManagementApp/Utilities/Converters/NullToDefaultImageConverter.cs
@@ -40,7 +40,7 @@ namespace InventoryManagementApp.Utilities.Converters
                 {
                     var absPath = Uri.IsWellFormedUriString(path, UriKind.Absolute)
                         ? path
-                        : Helpers.PathHelper.GetAbsolutePath(path, true);
+                        : Helpers.PathHelper.GetAbsolutePath(path, false);
 
                     if (!string.IsNullOrEmpty(absPath))
                     {


### PR DESCRIPTION
## Summary
- Prevent `NullToDefaultImageConverter` from throwing on invalid image paths by treating them as null
- Cover converter default-image behavior when path resolution fails

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa497342ac832485fe13c1556e6898