### PR TITLE
Cache invalid image paths in NullToDefaultImageConverter

### DIFF
--- a/InventoryManagementApp.Tests/NullToDefaultImageConverterTests.cs
+++ b/InventoryManagementApp.Tests/NullToDefaultImageConverterTests.cs
@@ -5,6 +5,8 @@ using System.Windows;
 using System.Windows.Media.Imaging;
 using InventoryManagementApp.Utilities.Converters;
 using InventoryManagementApp.Utilities.Helpers;
+using System.Collections.Concurrent;
+using System.Reflection;
 using Xunit;
 
 namespace InventoryManagementApp.Tests
@@ -24,6 +26,38 @@ namespace InventoryManagementApp.Tests
                     var defaultImage = Assert.IsType<BitmapImage>(converter.Convert(null, typeof(BitmapImage), "user", CultureInfo.InvariantCulture));
                     var result = Assert.IsType<BitmapImage>(converter.Convert("../nonexistent.png", typeof(BitmapImage), "user", CultureInfo.InvariantCulture));
                     Assert.Same(defaultImage, result);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
+        public void Convert_InvalidPath_IsCached()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var converter = new NullToDefaultImageConverter();
+                    var field = typeof(NullToDefaultImageConverter).GetField("_invalidPaths", BindingFlags.NonPublic | BindingFlags.Static);
+                    var cache = (ConcurrentDictionary<string, byte>)field!.GetValue(null)!;
+                    cache.Clear();
+                    var path = "../nonexistent.png";
+                    Assert.Null(PathHelper.GetAbsolutePath(path, false));
+                    converter.Convert(path, typeof(BitmapImage), "user", CultureInfo.InvariantCulture);
+                    Assert.True(cache.ContainsKey(path));
                 }
                 catch (Exception ex)
                 {

--- a/InventoryManagementApp/Utilities/Converters/NullToDefaultImageConverter.cs
+++ b/InventoryManagementApp/Utilities/Converters/NullToDefaultImageConverter.cs
@@ -19,6 +19,8 @@ namespace InventoryManagementApp.Utilities.Converters
         private static readonly ConcurrentDictionary<string, BitmapImage> _imageCache =
             new ConcurrentDictionary<string, BitmapImage>(StringComparer.OrdinalIgnoreCase);
         private static readonly ConcurrentQueue<string> _cacheOrder = new ConcurrentQueue<string>();
+        private static readonly ConcurrentDictionary<string, byte> _invalidPaths =
+            new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
         private readonly ILogger<NullToDefaultImageConverter> _logger;
 
         public NullToDefaultImageConverter() : this(null) { }
@@ -38,42 +40,58 @@ namespace InventoryManagementApp.Utilities.Converters
             {
                 try
                 {
-                    var absPath = Uri.IsWellFormedUriString(path, UriKind.Absolute)
-                        ? path
-                        : Helpers.PathHelper.GetAbsolutePath(path, false);
-
-                    if (!string.IsNullOrEmpty(absPath))
+                    string absPath;
+                    if (Uri.IsWellFormedUriString(path, UriKind.Absolute))
                     {
-                        if (_imageCache.TryGetValue(absPath, out var cached))
-                            return cached;
-
-                        var image = new BitmapImage();
-                        image.BeginInit();
-                        image.CacheOption = BitmapCacheOption.OnLoad;
-                        image.UriSource = new Uri(absPath, UriKind.Absolute);
-                        image.EndInit();
-                        image.Freeze();
-
-                        if (_imageCache.TryAdd(absPath, image))
-                        {
-                            _cacheOrder.Enqueue(absPath);
-                            while (_cacheOrder.Count > MaxCacheEntries && _cacheOrder.TryDequeue(out var oldKey))
-                            {
-                                _imageCache.TryRemove(oldKey, out _);
-                            }
-                        }
-
-                        return image;
+                        absPath = path;
                     }
+                    else
+                    {
+                        if (_invalidPaths.ContainsKey(path))
+                            return GetDefaultImage(parameter);
+
+                        absPath = Helpers.PathHelper.GetAbsolutePath(path, false);
+                        if (string.IsNullOrEmpty(absPath))
+                        {
+                            _invalidPaths.TryAdd(path, 0);
+                            return GetDefaultImage(parameter);
+                        }
+                    }
+
+                    if (_imageCache.TryGetValue(absPath, out var cached))
+                        return cached;
+
+                    var image = new BitmapImage();
+                    image.BeginInit();
+                    image.CacheOption = BitmapCacheOption.OnLoad;
+                    image.UriSource = new Uri(absPath, UriKind.Absolute);
+                    image.EndInit();
+                    image.Freeze();
+
+                    if (_imageCache.TryAdd(absPath, image))
+                    {
+                        _cacheOrder.Enqueue(absPath);
+                        while (_cacheOrder.Count > MaxCacheEntries && _cacheOrder.TryDequeue(out var oldKey))
+                        {
+                            _imageCache.TryRemove(oldKey, out _);
+                        }
+                    }
+
+                    return image;
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to load image from {Path}", path);
+                    _invalidPaths.TryAdd(path, 0);
                     // fall-through to default
                 }
             }
 
-            // Figure out which default we need
+            return GetDefaultImage(parameter);
+        }
+
+        private BitmapImage GetDefaultImage(object parameter)
+        {
             string type = (parameter as string)?.ToLowerInvariant() ?? "user";
             switch (type)
             {
@@ -87,7 +105,7 @@ namespace InventoryManagementApp.Utilities.Converters
                         _defaultLogo = LoadFromResource("DefaultLogo.png");
                     return _defaultLogo;
 
-                default: // user
+                default:
                     if (_defaultUser == null)
                         _defaultUser = LoadFromResource("DefaultUserPhoto.png");
                     return _defaultUser;


### PR DESCRIPTION
## Summary
- cache invalid image paths to skip repeated PathHelper lookups
- add unit test verifying invalid paths are cached

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4a86cfa483248efb98482db35d26