### PR TITLE
Suppress redundant global search resets

### DIFF
--- a/InventoryManagementApp.Tests/MainViewModelTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelTests.cs
@@ -60,6 +60,69 @@ namespace InventoryManagementApp.Tests
             });
         }
 
+        [Fact]
+        public async Task GlobalSearchAsync_ClearsTextWithoutTriggeringNewSearch()
+        {
+            await RunOnStaThread(async () =>
+            {
+                using var db = new DatabaseService(":memory:");
+                var globalDebounceTimer = new MockDispatcherTimer();
+                var searchDebounceTimer = new MockDispatcherTimer();
+                using var vm = new MainViewModel(
+                    new DummyItemService(),
+                    new DummyUserService(),
+                    new DummyUserContext(),
+                    new DummyCustomerService(),
+                    new DummyRentalService(),
+                    new DummyFileDialogService(),
+                    new ActivityLogService(db),
+                    new DummySettingsService(),
+                    db,
+                    new DummyDialogService(),
+                    NullLogger<MainViewModel>.Instance,
+                    () => Task.FromResult(true),
+                    new DummyDispatcherTimer(),
+                    new DummyScannerService(),
+                    globalDebounceTimer);
+
+                var itemManagement = new ItemManagementViewModel(
+                    new DummyItemService(),
+                    new DummyCustomerService(),
+                    new DummyRentalService(),
+                    new DummyDialogService(),
+                    new DummySettingsService(),
+                    NullLogger<ItemManagementViewModel>.Instance,
+                    searchDebounceTimer);
+
+                int searchExecuted = 0;
+                var searchField = typeof(ItemManagementViewModel).GetField("<SearchCommand>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+                searchField!.SetValue(itemManagement, new AsyncRelayCommand(ct =>
+                {
+                    searchExecuted++;
+                    return Task.CompletedTask;
+                }));
+
+                var itemManagementField = typeof(MainViewModel).GetField("<ItemManagement>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+                itemManagementField!.SetValue(vm, itemManagement);
+
+                int openSearchCalls = 0;
+                var openSearchField = typeof(MainViewModel).GetField("<OpenSearchItemsCommand>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+                openSearchField!.SetValue(vm, new AsyncRelayCommand(ct =>
+                {
+                    openSearchCalls++;
+                    return Task.CompletedTask;
+                }));
+
+                vm.GlobalSearchText = "hammer";
+                globalDebounceTimer.Fire();
+
+                Assert.Equal("hammer", itemManagement.SearchText);
+                Assert.Equal(string.Empty, vm.GlobalSearchText);
+                Assert.Equal(1, searchExecuted);
+                Assert.Equal(1, openSearchCalls);
+            });
+        }
+
         static Task RunOnStaThread(Func<Task> action)
         {
             var tcs = new TaskCompletionSource<object?>();

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -50,6 +50,7 @@ namespace InventoryManagementApp.ViewModels
         int _autoLogoutMinutes;
         CancellationTokenSource? _pageLoadCts;
         CancellationTokenSource? _globalSearchCts;
+        bool _suppressGlobalSearch;
 
         EventHandler<User?>? _userContextChangedHandler;
         PropertyChangedEventHandler? _itemManagementPropertyChangedHandler;
@@ -90,9 +91,12 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _globalSearchText, value))
                 {
-                    _globalSearchCts?.Cancel();
-                    _globalSearchDebounceTimer.Stop();
-                    _globalSearchDebounceTimer.Start();
+                    if (!_suppressGlobalSearch)
+                    {
+                        _globalSearchCts?.Cancel();
+                        _globalSearchDebounceTimer.Stop();
+                        _globalSearchDebounceTimer.Start();
+                    }
                 }
             }
         }
@@ -624,7 +628,15 @@ namespace InventoryManagementApp.ViewModels
             await OpenSearchItemsCommand.ExecuteAsync(null);
             if (ItemManagement.SearchCommand != null)
                 await ItemManagement.SearchCommand.ExecuteAsync(cancellationToken);
-            GlobalSearchText = string.Empty;
+            try
+            {
+                _suppressGlobalSearch = true;
+                GlobalSearchText = string.Empty;
+            }
+            finally
+            {
+                _suppressGlobalSearch = false;
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary
- avoid re-triggering global search when clearing search box
- add test ensuring global search clears text without rerunning

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5f3e7180832488c250ea3799c492