### PR TITLE
Bind item grid column visibility to settings

### DIFF
--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -416,6 +416,34 @@ namespace InventoryManagementApp.Tests
             Assert.Equal(false, itemService.LastIsRentalItem);
         }
 
+        [Fact]
+        public void VisibleFields_LoadFromSettings()
+        {
+            var visibility = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => false);
+            var itemService = new DummyItemService();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
+            var settings = new DummySettingsService(visibility);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
+            Assert.All(vm.VisibleFields.Values, v => Assert.False(v));
+        }
+
+        [Fact]
+        public void VisibleFields_UpdateOnSettingsChange()
+        {
+            var visibility = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => false);
+            var itemService = new DummyItemService();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
+            var settings = new DummySettingsService(visibility);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
+            using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
+            var updated = visibility.ToDictionary(kvp => kvp.Key, _ => true);
+            settings.SaveItemDetailVisibilityAsync(updated).GetAwaiter().GetResult();
+            Assert.All(vm.VisibleFields.Values, v => Assert.True(v));
+        }
+
         private sealed class PagingItemService : IItemService
         {
             private const int PageSize = 200;
@@ -711,6 +739,11 @@ namespace InventoryManagementApp.Tests
 
         private sealed class DummySettingsService : ISettingsService
         {
+            IDictionary<ItemDetailField, bool> _visibility;
+            public DummySettingsService(IDictionary<ItemDetailField, bool>? visibility = null)
+            {
+                _visibility = visibility ?? Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true);
+            }
             public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
             public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
@@ -728,9 +761,10 @@ namespace InventoryManagementApp.Tests
             public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
             public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default)
-                => Task.FromResult<IDictionary<ItemDetailField, bool>>(Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true));
+                => Task.FromResult(_visibility);
             public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
             {
+                _visibility = visibility;
                 ItemDetailVisibilityChanged?.Invoke(this, visibility);
                 return Task.CompletedTask;
             }

--- a/InventoryManagementApp.Tests/ManageItemsPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ManageItemsPageXamlTests.cs
@@ -83,6 +83,19 @@ namespace InventoryManagementApp.Tests
             Assert.Equal("DataGridRow_PreviewMouseRightButtonDown", eventSetter!.Handler);
         }
 
+        [Fact]
+        public void Columns_BindVisibilityToVisibleFields()
+        {
+            var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml"));
+            var xaml = File.ReadAllText(path);
+            Assert.Contains("VisibleFields[(models:ItemDetailField)ItemNumber]", xaml);
+            Assert.Contains("VisibleFields[(models:ItemDetailField)Name]", xaml);
+            Assert.Contains("VisibleFields[(models:ItemDetailField)Brand]", xaml);
+            Assert.Contains("VisibleFields[(models:ItemDetailField)QuantityOnHand]", xaml);
+            Assert.Contains("VisibleFields[(models:ItemDetailField)Location]", xaml);
+            Assert.Contains("VisibleFields[(models:ItemDetailField)Price]", xaml);
+        }
+
         private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
         {
             for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)

--- a/InventoryManagementApp/Models/ItemDetailField.cs
+++ b/InventoryManagementApp/Models/ItemDetailField.cs
@@ -9,6 +9,7 @@ namespace InventoryManagementApp.Models
         ItemNumber,
         PartNumber,
         Brand,
+        QuantityOnHand,
         Location,
         Price,
         Notes

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -11,6 +11,7 @@ using CommunityToolkit.Mvvm.Input;
 using InventoryManagementApp.Data;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Models;
 using InventoryManagementApp.Utilities;
 using InventoryManagementApp.Utilities.Helpers;
 using Microsoft.Extensions.Logging;
@@ -40,6 +41,13 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand CommitChangesCommand { get; }
 
         public IReadOnlyCollection<ItemModel> PendingEdits => _pendingEdits;
+
+        Dictionary<ItemDetailField, bool> _visibleFields = new();
+        public Dictionary<ItemDetailField, bool> VisibleFields
+        {
+            get => _visibleFields;
+            private set => SetProperty(ref _visibleFields, value);
+        }
 
         [ObservableProperty]
         private ItemModel? selectedItem;
@@ -96,6 +104,10 @@ namespace InventoryManagementApp.ViewModels
                         selectedSortOption = opt;
                 }
             }
+            var vis = _settingsService.GetItemDetailVisibilityAsync().GetAwaiter().GetResult();
+            var complete = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, f => vis.TryGetValue(f, out var v) ? v : true);
+            VisibleFields = complete;
+            _settingsService.ItemDetailVisibilityChanged += OnItemDetailVisibilityChanged;
             _memoryBudget.SteadyExceeded += OnSteadyExceeded;
             _memoryBudget.PeakExceeded += OnPeakExceeded;
 
@@ -105,6 +117,19 @@ namespace InventoryManagementApp.ViewModels
             NewItemCommand = new AsyncRelayCommand(ct => NewItemAsync(ct));
             DeleteItemsCommand = new AsyncRelayCommand<IList>(DeleteItemsAsync);
             CommitChangesCommand = new AsyncRelayCommand(ct => CommitChangesAsync(ct));
+        }
+
+        void OnItemDetailVisibilityChanged(object? sender, IDictionary<ItemDetailField, bool> visibility)
+        {
+            try
+            {
+                var complete = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, f => visibility.TryGetValue(f, out var v) ? v : true);
+                VisibleFields = complete;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to handle visibility change");
+            }
         }
 
         private async Task<IList<ItemModel>> LoadPageAsync(int page, CancellationToken ct)

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -3,6 +3,7 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
+      xmlns:models="clr-namespace:InventoryManagementApp.Models"
       Background="{StaticResource BackgroundBrush}">
     <Grid Margin="8">
         <Border Style="{StaticResource Card}">
@@ -46,12 +47,12 @@
                             </Style>
                         </DataGrid.RowStyle>
                         <DataGrid.Columns>
-                            <DataGridTextColumn Header="Number" Binding="{Binding ItemNumber, Mode=OneWay}" Width="140"/>
-                            <DataGridTextColumn Header="Name" Binding="{Binding Name, Mode=OneWay}" Width="280"/>
-                            <DataGridTextColumn Header="Brand" Binding="{Binding Brand, Mode=OneWay}" Width="160"/>
-                            <DataGridTextColumn Header="Qty" Binding="{Binding QuantityOnHand, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100"/>
-                            <DataGridTextColumn Header="Location" Binding="{Binding Location, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="180"/>
-                            <DataGridTextColumn Header="Price" Binding="{Binding Price, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="120"/>
+                            <DataGridTextColumn Header="Number" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)ItemNumber], RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource BoolToVis}}" Binding="{Binding ItemNumber, Mode=OneWay}" Width="140"/>
+                            <DataGridTextColumn Header="Name" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)Name], RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource BoolToVis}}" Binding="{Binding Name, Mode=OneWay}" Width="280"/>
+                            <DataGridTextColumn Header="Brand" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)Brand], RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource BoolToVis}}" Binding="{Binding Brand, Mode=OneWay}" Width="160"/>
+                            <DataGridTextColumn Header="Qty" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)QuantityOnHand], RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource BoolToVis}}" Binding="{Binding QuantityOnHand, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100"/>
+                            <DataGridTextColumn Header="Location" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)Location], RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource BoolToVis}}" Binding="{Binding Location, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="180"/>
+                            <DataGridTextColumn Header="Price" Visibility="{Binding DataContext.VisibleFields[(models:ItemDetailField)Price], RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource BoolToVis}}" Binding="{Binding Price, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="120"/>
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"


### PR DESCRIPTION
## Summary
- expose VisibleFields dictionary in ItemsViewModel and refresh from settings
- bind ManageItemsPage DataGrid columns to VisibleFields with BoolToVis converter
- cover visibility behavior with new unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa637dfcc083249ed6409560f77a3c