### PR TITLE
feat: async initialize items view model

### DIFF
--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -31,6 +31,7 @@ namespace InventoryManagementApp.Tests
             var settings = new DummySettingsService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
+            await vm.InitializeAsync();
 
             Assert.NotNull(vm.EditItemCommand);
             Assert.True(vm.EditItemCommand.CanExecute(null));
@@ -63,6 +64,7 @@ namespace InventoryManagementApp.Tests
             var settings = new DummySettingsService();
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
+            await vm.InitializeAsync();
             var item1 = new ItemModel { ItemID = 1, Name = "A" };
             var item2 = new ItemModel { ItemID = 2, Name = "B" };
             vm.Items.Add(item1);
@@ -71,6 +73,28 @@ namespace InventoryManagementApp.Tests
             await vm.DeleteItemsCommand.ExecuteAsync(list);
             Assert.Single(vm.Items);
             Assert.Equal(2, vm.Items[0].ItemID);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_AppliesSettings()
+        {
+            var service = new DummyItemService();
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
+            var settingValues = new Dictionary<string, string>
+            {
+                ["PageSize"] = "50",
+                ["LastFilter"] = "abc",
+                ["LastSort"] = $"{SortField.ItemNumber}|{SortDirection.Descending}"
+            };
+            var settings = new DummySettingsService(settings: settingValues);
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
+            await vm.InitializeAsync();
+            Assert.Equal(50, vm.PageSize);
+            Assert.Equal("abc", vm.Filter);
+            Assert.Equal(SortField.ItemNumber, vm.SelectedSortOption.Field);
+            Assert.Equal(SortDirection.Descending, vm.SelectedSortOption.Direction);
         }
 
         [Fact]
@@ -417,7 +441,7 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void VisibleFields_LoadFromSettings()
+        public async Task VisibleFields_LoadFromSettings()
         {
             var visibility = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => false);
             var itemService = new DummyItemService();
@@ -426,11 +450,12 @@ namespace InventoryManagementApp.Tests
             var settings = new DummySettingsService(visibility);
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
+            await vm.InitializeAsync();
             Assert.All(vm.VisibleFields.Values, v => Assert.False(v));
         }
 
         [Fact]
-        public void VisibleFields_UpdateOnSettingsChange()
+        public async Task VisibleFields_UpdateOnSettingsChange()
         {
             var visibility = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => false);
             var itemService = new DummyItemService();
@@ -439,8 +464,9 @@ namespace InventoryManagementApp.Tests
             var settings = new DummySettingsService(visibility);
             using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
             using var vm = new ItemsViewModel(itemService, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
+            await vm.InitializeAsync();
             var updated = visibility.ToDictionary(kvp => kvp.Key, _ => true);
-            settings.SaveItemDetailVisibilityAsync(updated).GetAwaiter().GetResult();
+            await settings.SaveItemDetailVisibilityAsync(updated);
             Assert.All(vm.VisibleFields.Values, v => Assert.True(v));
         }
 
@@ -740,16 +766,33 @@ namespace InventoryManagementApp.Tests
         private sealed class DummySettingsService : ISettingsService
         {
             IDictionary<ItemDetailField, bool> _visibility;
-            public DummySettingsService(IDictionary<ItemDetailField, bool>? visibility = null)
+            readonly Dictionary<string, string> _settings;
+            public DummySettingsService(IDictionary<ItemDetailField, bool>? visibility = null, Dictionary<string, string>? settings = null)
             {
                 _visibility = visibility ?? Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true);
+                _settings = settings ?? new();
             }
             public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
-            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
-            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
-            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
+            {
+                _settings[key] = value;
+                return Task.CompletedTask;
+            }
+            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default)
+                => Task.FromResult(_settings.TryGetValue(key, out var v) ? v : null);
+            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult(new Dictionary<string, string>(_settings));
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
+            {
+                foreach (var kvp in settings)
+                    _settings[kvp.Key] = kvp.Value;
+                return Task.CompletedTask;
+            }
+            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
+            {
+                _settings.Remove(key);
+                return Task.CompletedTask;
+            }
             public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
             public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
             public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -84,16 +84,32 @@ namespace InventoryManagementApp.ViewModels
                 new SortOption(SortField.UpdatedAt, SortDirection.Descending, "Updated Desc")
             });
             selectedSortOption = SortOptions[0];
-            var psSetting = _settingsService.GetSettingAsync("PageSize").GetAwaiter().GetResult();
+            VisibleFields = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true);
+            _memoryBudget.SteadyExceeded += OnSteadyExceeded;
+            _memoryBudget.PeakExceeded += OnPeakExceeded;
+
+            EditItemCommand = new AsyncRelayCommand(ct => EditItemAsync(ct));
+            ViewDetailsCommand = new RelayCommand(ViewDetails);
+            OpenRentalHistoryCommand = new AsyncRelayCommand(ct => OpenRentalHistoryAsync(ct));
+            NewItemCommand = new AsyncRelayCommand(ct => NewItemAsync(ct));
+            DeleteItemsCommand = new AsyncRelayCommand<IList>(DeleteItemsAsync);
+            CommitChangesCommand = new AsyncRelayCommand(ct => CommitChangesAsync(ct));
+        }
+
+        public async Task InitializeAsync(CancellationToken ct = default)
+        {
+            var psSetting = await _settingsService.GetSettingAsync("PageSize", ct).ConfigureAwait(false);
             if (int.TryParse(psSetting, out var ps) && ps > 0)
             {
                 pageSize = ps;
                 Items.PageSize = ps;
             }
-            var filterSetting = _settingsService.GetSettingAsync("LastFilter").GetAwaiter().GetResult();
+
+            var filterSetting = await _settingsService.GetSettingAsync("LastFilter", ct).ConfigureAwait(false);
             if (!string.IsNullOrEmpty(filterSetting))
                 filter = filterSetting;
-            var sortSetting = _settingsService.GetSettingAsync("LastSort").GetAwaiter().GetResult();
+
+            var sortSetting = await _settingsService.GetSettingAsync("LastSort", ct).ConfigureAwait(false);
             if (!string.IsNullOrEmpty(sortSetting))
             {
                 var parts = sortSetting.Split('|');
@@ -104,19 +120,11 @@ namespace InventoryManagementApp.ViewModels
                         selectedSortOption = opt;
                 }
             }
-            var vis = _settingsService.GetItemDetailVisibilityAsync().GetAwaiter().GetResult();
+
+            var vis = await _settingsService.GetItemDetailVisibilityAsync(ct).ConfigureAwait(false);
             var complete = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, f => vis.TryGetValue(f, out var v) ? v : true);
             VisibleFields = complete;
             _settingsService.ItemDetailVisibilityChanged += OnItemDetailVisibilityChanged;
-            _memoryBudget.SteadyExceeded += OnSteadyExceeded;
-            _memoryBudget.PeakExceeded += OnPeakExceeded;
-
-            EditItemCommand = new AsyncRelayCommand(ct => EditItemAsync(ct));
-            ViewDetailsCommand = new RelayCommand(ViewDetails);
-            OpenRentalHistoryCommand = new AsyncRelayCommand(ct => OpenRentalHistoryAsync(ct));
-            NewItemCommand = new AsyncRelayCommand(ct => NewItemAsync(ct));
-            DeleteItemsCommand = new AsyncRelayCommand<IList>(DeleteItemsAsync);
-            CommitChangesCommand = new AsyncRelayCommand(ct => CommitChangesAsync(ct));
         }
 
         void OnItemDetailVisibilityChanged(object? sender, IDictionary<ItemDetailField, bool> visibility)

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -295,11 +295,12 @@ namespace InventoryManagementApp.ViewModels
             {
                 var plural = LabelProvider.Instance.ItemLabelPlural;
                 var page = new ManageItemsPage { Title = $"Manage {plural}" };
-                CurrentPage = page;
+                var vm = (ItemsViewModel)page.DataContext;
                 try
                 {
-                    var vm = (ItemsViewModel)page.DataContext;
+                    await vm.InitializeAsync();
                     await vm.LoadMoreAsync();
+                    CurrentPage = page;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary
- load item settings asynchronously with InitializeAsync
- await ItemsViewModel initialization before showing manage items page
- cover settings initialization in ItemsViewModel unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa67d0aac083248ff3fe26d53b365d