### PR TITLE
Load items on ManageItemsPage initialization

### DIFF
--- a/InventoryManagementApp.Tests/ManageItemsPageTests.cs
+++ b/InventoryManagementApp.Tests/ManageItemsPageTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Documents;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using InventoryManagementApp;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Data;
+using InventoryManagementApp.Utilities;
+using InventoryManagementApp.ViewModels;
+using InventoryManagementApp.Views.Pages;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ManageItemsPageTests
+    {
+        [Fact]
+        public void Loaded_PopulatesFirstPage()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var host = Host.CreateDefaultBuilder()
+                        .ConfigureServices(services =>
+                        {
+                            services.AddSingleton<IItemService, StubItemService>();
+                            services.AddSingleton<IDialogService, StubDialogService>();
+                            services.AddSingleton<IRentalService, StubRentalService>();
+                            services.AddSingleton<ISettingsService, StubSettingsService>();
+                            services.AddSingleton(sp => new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue));
+                            services.AddSingleton<ItemsViewModel>();
+                            services.AddSingleton<ILogger<ItemsViewModel>>(sp => NullLogger<ItemsViewModel>.Instance);
+                        })
+                        .Build();
+
+                    var app = new App(host);
+                    var page = new ManageItemsPage();
+                    var vm = (ItemsViewModel)page.DataContext;
+                    var method = typeof(ManageItemsPage).GetMethod("ManageItemsPage_Loaded", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                    method!.Invoke(page, new object[] { page, new RoutedEventArgs() });
+                    SpinWait.SpinUntil(() => vm.Items.Count > 0, TimeSpan.FromSeconds(5));
+                    Assert.Equal(2, vm.Items.Count);
+                    Assert.Equal(1, vm.Items[0].ItemID);
+                    Assert.Equal(2, vm.Items[1].ItemID);
+                    app.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        private sealed class StubItemService : IItemService
+        {
+            public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult<ItemModel?>(null);
+            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => EnumeratePage(page.Number, cancellationToken);
+            public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => EnumeratePage(page.Number, cancellationToken);
+            public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+            public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct) => Task.CompletedTask;
+            public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, CancellationToken cancellationToken = default) => Task.FromResult(false);
+            public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task<List<ItemModel>> GetCheckedOutItemsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<ItemModel>());
+            public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => Task.FromResult(new List<int>());
+            public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => Task.FromResult(new ImageImportResult());
+            public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, Microsoft.Data.Sqlite.SqliteConnection? conn = null, Microsoft.Data.Sqlite.SqliteTransaction? tx = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+            private async IAsyncEnumerable<ItemModel> EnumeratePage(int page, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+            {
+                for (int i = 0; i < 2; i++)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    yield return new ItemModel { ItemID = (page - 1) * 2 + i + 1 };
+                    await Task.Yield();
+                }
+            }
+        }
+
+        private sealed class StubDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => true;
+            public ItemModel? ShowEditItemDialog(ItemModel item) => null;
+            public void ShowItemDetails(ItemModel item) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
+            public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+        }
+
+        private sealed class StubRentalService : IRentalService
+        {
+            public Task RentItemAsync(int itemID, int customerID, DateTime rentalDate, DateTime dueDate) => Task.CompletedTask;
+            public Task ReturnItemAsync(int rentalID, DateTime returnDate) => Task.CompletedTask;
+            public Task ExtendRentalAsync(int rentalID, DateTime newDueDate) => Task.CompletedTask;
+            public Task DeleteRentalAsync(int rentalID) => Task.CompletedTask;
+            public Task<List<Rental>> GetActiveRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<int> CountActiveRentalsAsync() => Task.FromResult(0);
+            public Task<List<Rental>> GetOverdueRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetAllRentalsAsync() => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetRentalHistoryForItemAsync(int itemID) => Task.FromResult(new List<Rental>());
+            public Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID) => Task.FromResult(new List<Rental>());
+        }
+
+        private sealed class StubSettingsService : ISettingsService
+        {
+            public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
+            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default) => Task.FromResult<IDictionary<ItemDetailField, bool>>(new Dictionary<ItemDetailField, bool>());
+            public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+    }
+}

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -12,10 +13,14 @@ namespace InventoryManagementApp.Views.Pages
 {
     public partial class ManageItemsPage : Page
     {
+        private CancellationTokenSource _loadCts = new();
+
         public ManageItemsPage()
         {
             InitializeComponent();
             DataContext = ((App)Application.Current).Host.Services.GetRequiredService<ItemsViewModel>();
+            Loaded += ManageItemsPage_Loaded;
+            Unloaded += ManageItemsPage_Unloaded;
         }
 
         private void DataGridRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
@@ -75,6 +80,24 @@ namespace InventoryManagementApp.Views.Pages
                     return descendant;
             }
             return null;
+        }
+
+        private async void ManageItemsPage_Loaded(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                await ((ItemsViewModel)DataContext).LoadMoreAsync(_loadCts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        private void ManageItemsPage_Unloaded(object sender, RoutedEventArgs e)
+        {
+            _loadCts.Cancel();
+            _loadCts.Dispose();
+            _loadCts = new CancellationTokenSource();
         }
     }
 }


### PR DESCRIPTION
## Summary
- begin loading items when ManageItemsPage is loaded, honoring cancellation
- test that initial page load populates the first page of items

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6d3faa408324b44cb5fe1cbca481