### PR TITLE
Dispose ItemsViewModel on page unload

### DIFF
--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
@@ -84,6 +84,11 @@ namespace InventoryManagementApp.Views.Pages
 
         private async void ManageItemsPage_Loaded(object sender, RoutedEventArgs e)
         {
+            if (DataContext is not ItemsViewModel)
+            {
+                DataContext = ((App)Application.Current).Host.Services.GetRequiredService<ItemsViewModel>();
+            }
+
             try
             {
                 await ((ItemsViewModel)DataContext).LoadMoreAsync(_loadCts.Token);
@@ -96,6 +101,11 @@ namespace InventoryManagementApp.Views.Pages
         private void ManageItemsPage_Unloaded(object sender, RoutedEventArgs e)
         {
             _loadCts.Cancel();
+            if (DataContext is ItemsViewModel vm)
+            {
+                vm.Dispose();
+                DataContext = null;
+            }
             _loadCts.Dispose();
             _loadCts = new CancellationTokenSource();
         }


### PR DESCRIPTION
## Summary
- Dispose and clear `ItemsViewModel` when `ManageItemsPage` unloads and reinitialize with a new instance on load

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8195d60c83248af224bafe18851c