### PR TITLE
fix: initialize items viewmodel on load

### DIFF
--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
@@ -84,9 +84,10 @@ namespace InventoryManagementApp.Views.Pages
 
         private async void ManageItemsPage_Loaded(object sender, RoutedEventArgs e)
         {
-            if (DataContext is not ItemsViewModel)
+            if (DataContext is not ItemsViewModel vm)
             {
-                DataContext = ((App)Application.Current).Host.Services.GetRequiredService<ItemsViewModel>();
+                vm = ((App)Application.Current).Host.Services.GetRequiredService<ItemsViewModel>();
+                DataContext = vm;
             }
 
             try


### PR DESCRIPTION
## Summary
- ensure ItemsViewModel retrieved via DI in ManageItemsPage_Loaded
- call InitializeAsync and LoadMoreAsync on retrieved ItemsViewModel

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8319964c8324b98a1a9fecc7c97a