### PR TITLE
Preserve global search text after item search

### DIFF
--- a/InventoryManagementApp.Tests/MainViewModelTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelTests.cs
@@ -61,7 +61,7 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public async Task GlobalSearchAsync_ClearsTextWithoutTriggeringNewSearch()
+        public async Task GlobalSearchAsync_PreservesTextWithoutTriggeringNewSearch()
         {
             await RunOnStaThread(async () =>
             {
@@ -117,7 +117,7 @@ namespace InventoryManagementApp.Tests
                 globalDebounceTimer.Fire();
 
                 Assert.Equal("hammer", itemManagement.SearchText);
-                Assert.Equal(string.Empty, vm.GlobalSearchText);
+                Assert.Equal("hammer", vm.GlobalSearchText);
                 Assert.Equal(1, searchExecuted);
                 Assert.Equal(1, openSearchCalls);
             });

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -50,7 +50,6 @@ namespace InventoryManagementApp.ViewModels
         int _autoLogoutMinutes;
         CancellationTokenSource? _pageLoadCts;
         CancellationTokenSource? _globalSearchCts;
-        bool _suppressGlobalSearch;
 
         EventHandler<User?>? _userContextChangedHandler;
         PropertyChangedEventHandler? _itemManagementPropertyChangedHandler;
@@ -91,12 +90,9 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _globalSearchText, value))
                 {
-                    if (!_suppressGlobalSearch)
-                    {
-                        _globalSearchCts?.Cancel();
-                        _globalSearchDebounceTimer.Stop();
-                        _globalSearchDebounceTimer.Start();
-                    }
+                    _globalSearchCts?.Cancel();
+                    _globalSearchDebounceTimer.Stop();
+                    _globalSearchDebounceTimer.Start();
                 }
             }
         }
@@ -629,15 +625,6 @@ namespace InventoryManagementApp.ViewModels
             await OpenSearchItemsCommand.ExecuteAsync(null);
             if (ItemManagement.SearchCommand != null)
                 await ItemManagement.SearchCommand.ExecuteAsync(cancellationToken);
-            try
-            {
-                _suppressGlobalSearch = true;
-                GlobalSearchText = string.Empty;
-            }
-            finally
-            {
-                _suppressGlobalSearch = false;
-            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary
- Keep global search term after item search completes
- Align tests with persistent global search behavior

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa83a479a8832484d255214ff902d6