### PR TITLE
Avoid double disposal of global search token

### DIFF
--- a/InventoryManagementApp.Tests/MainViewModelTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelTests.cs
@@ -123,6 +123,40 @@ namespace InventoryManagementApp.Tests
             });
         }
 
+        [Fact]
+        public async Task Dispose_NullifiesGlobalSearchToken()
+        {
+            await RunOnStaThread(async () =>
+            {
+                using var db = new DatabaseService(":memory:");
+                var debounceTimer = new MockDispatcherTimer();
+                var vm = new MainViewModel(
+                    new DummyItemService(),
+                    new DummyUserService(),
+                    new DummyUserContext(),
+                    new DummyCustomerService(),
+                    new DummyRentalService(),
+                    new DummyFileDialogService(),
+                    new ActivityLogService(db),
+                    new DummySettingsService(),
+                    db,
+                    new DummyDialogService(),
+                    NullLogger<MainViewModel>.Instance,
+                    () => Task.FromResult(true),
+                    new DummyDispatcherTimer(),
+                    new DummyScannerService(),
+                    debounceTimer);
+
+                vm.Dispose();
+
+                var ex = Record.Exception(() => vm.GlobalSearchText = "test");
+                Assert.Null(ex);
+
+                var ex2 = Record.Exception(() => vm.Dispose());
+                Assert.Null(ex2);
+            });
+        }
+
         static Task RunOnStaThread(Func<Task> action)
         {
             var tcs = new TaskCompletionSource<object?>();

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -90,7 +90,9 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _globalSearchText, value))
                 {
-                    _globalSearchCts?.Cancel();
+                    var cts = Interlocked.Exchange(ref _globalSearchCts, null);
+                    cts?.Cancel();
+                    cts?.Dispose();
                     _globalSearchDebounceTimer.Stop();
                     _globalSearchDebounceTimer.Start();
                 }
@@ -614,8 +616,9 @@ namespace InventoryManagementApp.ViewModels
         void OnGlobalSearchDebounceTimerTick(object? s, EventArgs e)
         {
             _globalSearchDebounceTimer.Stop();
-            _globalSearchCts?.Dispose();
-            _globalSearchCts = new CancellationTokenSource();
+            var old = Interlocked.Exchange(ref _globalSearchCts, new CancellationTokenSource());
+            old?.Cancel();
+            old?.Dispose();
             _ = GlobalSearchCommand.ExecuteAsync(_globalSearchCts.Token);
         }
 
@@ -646,8 +649,9 @@ namespace InventoryManagementApp.ViewModels
             _autoLogoutTimer.Stop();
             _globalSearchDebounceTimer.Tick -= OnGlobalSearchDebounceTimerTick;
             _globalSearchDebounceTimer.Stop();
-            _globalSearchCts?.Cancel();
-            _globalSearchCts?.Dispose();
+            var cts = Interlocked.Exchange(ref _globalSearchCts, null);
+            cts?.Cancel();
+            cts?.Dispose();
             ItemManagement.Dispose();
         }
 


### PR DESCRIPTION
## Summary
- Safely swap and dispose the global search CancellationTokenSource using Interlocked.Exchange to prevent double-disposal
- Add regression test ensuring global search token is cleared and multiple disposals are safe

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8aa70dbc8324a66028324c4478e0