### PR TITLE
Use size-bounded image cache

### DIFF
--- a/InventoryManagementApp.Tests/NullToDefaultImageConverterTests.cs
+++ b/InventoryManagementApp.Tests/NullToDefaultImageConverterTests.cs
@@ -7,6 +7,8 @@ using InventoryManagementApp.Utilities.Converters;
 using InventoryManagementApp.Utilities.Helpers;
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.IO;
+using Microsoft.Extensions.Caching.Memory;
 using Xunit;
 
 namespace InventoryManagementApp.Tests
@@ -65,6 +67,52 @@ namespace InventoryManagementApp.Tests
                 }
                 finally
                 {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
+        public void Convert_CacheEvictsLeastRecentlyUsed()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(tempDir);
+                try
+                {
+                    var converter = new NullToDefaultImageConverter();
+                    var cacheField = typeof(NullToDefaultImageConverter).GetField("_imageCache", BindingFlags.NonPublic | BindingFlags.Static);
+                    var cache = (MemoryCache)cacheField!.GetValue(null)!;
+                    cache.Compact(1.0);
+
+                    var pngBytes = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAAC0lEQVQI12NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=");
+                    var firstPath = Path.Combine(tempDir, "0.png");
+                    File.WriteAllBytes(firstPath, pngBytes);
+                    var firstImage = Assert.IsType<BitmapImage>(converter.Convert(firstPath, typeof(BitmapImage), "user", CultureInfo.InvariantCulture));
+
+                    for (int i = 1; i <= 100; i++)
+                    {
+                        var path = Path.Combine(tempDir, $"{i}.png");
+                        File.WriteAllBytes(path, pngBytes);
+                        converter.Convert(path, typeof(BitmapImage), "user", CultureInfo.InvariantCulture);
+                    }
+
+                    var secondImage = Assert.IsType<BitmapImage>(converter.Convert(firstPath, typeof(BitmapImage), "user", CultureInfo.InvariantCulture));
+                    Assert.NotSame(firstImage, secondImage);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    try { Directory.Delete(tempDir, true); } catch { }
                     Application.Current?.Shutdown();
                 }
             });

--- a/InventoryManagementApp/InventoryManagementApp.csproj
+++ b/InventoryManagementApp/InventoryManagementApp.csproj
@@ -112,6 +112,7 @@
     <PackageReference Include="Extended.Wpf.Toolkit" Version="4.7.25104.5739" />
     <PackageReference Include="MaterialDesignThemes" Version="5.2.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.8" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />

--- a/InventoryManagementApp/Utilities/Converters/NullToDefaultImageConverter.cs
+++ b/InventoryManagementApp/Utilities/Converters/NullToDefaultImageConverter.cs
@@ -1,10 +1,10 @@
-﻿// Revised NullToDefaultImageConverter.cs
 using System;
 using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Media.Imaging;
 using System.IO;
 using System.Collections.Concurrent;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -16,9 +16,7 @@ namespace InventoryManagementApp.Utilities.Converters
         private static BitmapImage _defaultItem;
         private static BitmapImage _defaultLogo;
         private const int MaxCacheEntries = 100;
-        private static readonly ConcurrentDictionary<string, BitmapImage> _imageCache =
-            new ConcurrentDictionary<string, BitmapImage>(StringComparer.OrdinalIgnoreCase);
-        private static readonly ConcurrentQueue<string> _cacheOrder = new ConcurrentQueue<string>();
+        private static readonly MemoryCache _imageCache = new(new MemoryCacheOptions { SizeLimit = MaxCacheEntries });
         private static readonly ConcurrentDictionary<string, byte> _invalidPaths =
             new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
         private readonly ILogger<NullToDefaultImageConverter> _logger;
@@ -58,24 +56,23 @@ namespace InventoryManagementApp.Utilities.Converters
                         }
                     }
 
-                    if (_imageCache.TryGetValue(absPath, out var cached))
+                    if (_imageCache.TryGetValue(absPath, out BitmapImage cached))
                         return cached;
 
                     var image = new BitmapImage();
                     image.BeginInit();
-                    image.CacheOption = BitmapCacheOption.OnLoad;
+                    image.CacheOption = BitmapCacheOption.OnDemand;
+                    image.DecodePixelWidth = 96;
+                    image.CreateOptions = BitmapCreateOptions.DelayCreation;
                     image.UriSource = new Uri(absPath, UriKind.Absolute);
                     image.EndInit();
                     image.Freeze();
 
-                    if (_imageCache.TryAdd(absPath, image))
+                    _imageCache.Set(absPath, image, new MemoryCacheEntryOptions
                     {
-                        _cacheOrder.Enqueue(absPath);
-                        while (_cacheOrder.Count > MaxCacheEntries && _cacheOrder.TryDequeue(out var oldKey))
-                        {
-                            _imageCache.TryRemove(oldKey, out _);
-                        }
-                    }
+                        Size = 1,
+                        Priority = CacheItemPriority.Low
+                    });
 
                     return image;
                 }


### PR DESCRIPTION
## Summary
- switch NullToDefaultImageConverter to MemoryCache with 100-entry limit and on-demand 96px decoding
- add Microsoft.Extensions.Caching.Memory dependency
- add regression tests for image cache eviction

## Testing
- ⚠️ `dotnet test` *(dotnet CLI not available in container; attempted installation but apt sources return 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab69f5c2c483249696feb0228d55ee