### PR TITLE
Resize imported item images

### DIFF
--- a/InventoryManagementApp.Tests/ItemServiceImageResizeTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceImageResizeTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using InventoryManagementApp.Services.Items;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ItemServiceImageResizeTests
+    {
+        [Fact]
+        public void CopyFileAsync_ResizesImage()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+                    Directory.CreateDirectory(tempDir);
+                    var source = Path.Combine(tempDir, "src.png");
+                    var dest = Path.Combine(tempDir, "dest.jpg");
+                    CreateTestImage(source);
+                    var service = new TestItemService();
+                    service.InvokeCopyFileAsync(source, dest, 96, 96).GetAwaiter().GetResult();
+                    Assert.True(File.Exists(dest));
+                    var img = new BitmapImage();
+                    img.BeginInit();
+                    img.CacheOption = BitmapCacheOption.OnLoad;
+                    img.UriSource = new Uri(dest);
+                    img.EndInit();
+                    Assert.Equal(96, img.PixelWidth);
+                    Assert.Equal(48, img.PixelHeight);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        static void CreateTestImage(string path)
+        {
+            const int width = 200;
+            const int height = 100;
+            var pixels = new byte[width * height * 4];
+            for (int i = 0; i < pixels.Length; i += 4)
+            {
+                pixels[i] = 255;     // B
+                pixels[i + 1] = 0;   // G
+                pixels[i + 2] = 0;   // R
+                pixels[i + 3] = 255; // A
+            }
+            var bitmap = BitmapSource.Create(width, height, 96, 96, PixelFormats.Bgra32, null, pixels, width * 4);
+            var encoder = new PngBitmapEncoder();
+            encoder.Frames.Add(BitmapFrame.Create(bitmap));
+            using var fs = File.Create(path);
+            encoder.Save(fs);
+        }
+
+        class TestItemService : ItemService
+        {
+            public TestItemService() : base(null!, null!) { }
+
+            public Task InvokeCopyFileAsync(string src, string dest, int maxW, int maxH)
+                => CopyFileAsync(src, dest, maxW, maxH, CancellationToken.None);
+        }
+    }
+}

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -18,6 +18,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using InventoryManagementApp.Services.Users;
 using InventoryManagementApp.Data;
 using Microsoft.VisualBasic.FileIO;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
 
 namespace InventoryManagementApp.Services.Items
 {
@@ -254,12 +256,13 @@ namespace InventoryManagementApp.Services.Items
                     result.ConflictingFiles.Add(file);
                     continue;
                 }
-                var dest = Path.Combine(destDir, Path.GetFileName(file));
+                var fileName = Path.GetFileNameWithoutExtension(file) + ".jpg";
+                var dest = Path.Combine(destDir, fileName);
                 if (!File.Exists(dest))
                 {
                     try
                     {
-                        await CopyFileAsync(file, dest, cancellationToken);
+                        await CopyFileAsync(file, dest, 96, 96, cancellationToken);
                     }
                     catch (IOException ex)
                     {
@@ -268,7 +271,7 @@ namespace InventoryManagementApp.Services.Items
                         continue;
                     }
                 }
-                var relative = $"Assets/ItemImages/{Path.GetFileName(dest)}";
+                var relative = $"Assets/ItemImages/{fileName}";
                 await UpdateItemImageAsync(item.ItemID, relative, cancellationToken);
                 result.ImportedCount++;
                 processed++;
@@ -278,11 +281,34 @@ namespace InventoryManagementApp.Services.Items
             return result;
         }
 
-        protected virtual async Task CopyFileAsync(string sourceFileName, string destFileName, CancellationToken cancellationToken)
+        protected virtual Task CopyFileAsync(string sourceFileName, string destFileName, int maxWidth, int maxHeight, CancellationToken cancellationToken)
         {
-            await using var source = new FileStream(sourceFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, true);
-            await using var destination = new FileStream(destFileName, FileMode.Create, FileAccess.Write, FileShare.None, 81920, true);
-            await source.CopyToAsync(destination, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var bitmap = new BitmapImage();
+            bitmap.BeginInit();
+            bitmap.CacheOption = BitmapCacheOption.OnLoad;
+            bitmap.UriSource = new Uri(sourceFileName);
+            bitmap.EndInit();
+            bitmap.Freeze();
+
+            double scale = Math.Min((double)maxWidth / bitmap.PixelWidth, (double)maxHeight / bitmap.PixelHeight);
+            if (scale > 1.0)
+                scale = 1.0;
+
+            BitmapSource source = bitmap;
+            if (scale < 1.0)
+            {
+                source = new TransformedBitmap(bitmap, new ScaleTransform(scale, scale));
+                source.Freeze();
+            }
+
+            var encoder = new JpegBitmapEncoder();
+            encoder.Frames.Add(BitmapFrame.Create(source));
+
+            using var stream = new FileStream(destFileName, FileMode.Create, FileAccess.Write, FileShare.None);
+            encoder.Save(stream);
+            return Task.CompletedTask;
         }
 
         private async Task<bool> ItemExistsAsync(string itemNumber, int? exceptId = null, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- Generate 96px JPEG thumbnails when importing item images
- Store resized thumbnail path for items
- Add unit test ensuring thumbnail resizing

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab69fcac3483249400481cc9d928fb