### PR TITLE
Expand item search to notes and keywords

### DIFF
--- a/InventoryManagementApp.Tests/ItemRepositorySearchTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositorySearchTests.cs
@@ -41,11 +41,11 @@ public class ItemRepositorySearchTests
         );";
         cmd.ExecuteNonQuery();
         await conn.ExecuteAsync(
-            "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,0,0,0,@UpdatedAt)",
-            new { ItemNumber = "ABC123", Name = "Hand Saw", UpdatedAt = System.DateTime.UtcNow });
+            "INSERT INTO Items (ItemNumber, NameDescription, Notes, Keywords, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,@Notes,@Keywords,0,0,0,0,0,@UpdatedAt)",
+            new { ItemNumber = "ABC123", Name = "Hand Saw", Notes = "A sharp saw", Keywords = "tool,cutting", UpdatedAt = System.DateTime.UtcNow });
         await conn.ExecuteAsync(
-            "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,1,0,0,@UpdatedAt)",
-            new { ItemNumber = "CAFÉ1", Name = "Café Table", UpdatedAt = System.DateTime.UtcNow });
+            "INSERT INTO Items (ItemNumber, NameDescription, Notes, Keywords, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,@Notes,@Keywords,0,0,1,0,0,@UpdatedAt)",
+            new { ItemNumber = "CAFÉ1", Name = "Café Table", Notes = "Sturdy café furniture", Keywords = "table,café", UpdatedAt = System.DateTime.UtcNow });
     }
 
     [Fact]
@@ -96,6 +96,32 @@ public class ItemRepositorySearchTests
         await foreach (var item in repo.GetPageAsync(new ItemFilter("cafe"), new ItemPage(1, 10), CancellationToken.None))
             result.Add(item);
         Assert.Contains(result, i => i.ItemNumber == "CAFÉ1");
+    }
+
+    [Fact]
+    public async Task GetPageAsync_SearchNotes_IgnoresCase()
+    {
+        var factory = CreateFactory();
+        await SeedAsync(factory);
+        var repo = new ItemRepository(factory);
+        var result = new List<ItemModel>();
+        await foreach (var item in repo.GetPageAsync(new ItemFilter("SHARP"), new ItemPage(1, 10), CancellationToken.None))
+            result.Add(item);
+        Assert.Single(result);
+        Assert.Equal("Hand Saw", result[0].Name);
+    }
+
+    [Fact]
+    public async Task GetPageAsync_SearchKeywords_IgnoresCase()
+    {
+        var factory = CreateFactory();
+        await SeedAsync(factory);
+        var repo = new ItemRepository(factory);
+        var result = new List<ItemModel>();
+        await foreach (var item in repo.GetPageAsync(new ItemFilter("TOOL"), new ItemPage(1, 10), CancellationToken.None))
+            result.Add(item);
+        Assert.Single(result);
+        Assert.Equal("Hand Saw", result[0].Name);
     }
 
     [Fact]

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -22,10 +22,12 @@ public sealed class ItemRepository : IItemRepository
         var conditions = new List<string>();
         if (!string.IsNullOrWhiteSpace(filter.Search))
         {
-            conditions.Add("(ItemNumber LIKE @ItemNumberPrefix COLLATE NOCASE_NOACCENT OR ItemNumber LIKE @ItemNumberSubstring COLLATE NOCASE_NOACCENT OR NameDescription LIKE @NameSubstring COLLATE NOCASE_NOACCENT)");
+            conditions.Add("(ItemNumber LIKE @ItemNumberPrefix COLLATE NOCASE_NOACCENT OR ItemNumber LIKE @ItemNumberSubstring COLLATE NOCASE_NOACCENT OR NameDescription LIKE @NameSubstring COLLATE NOCASE_NOACCENT OR Notes LIKE @NotesSubstring COLLATE NOCASE_NOACCENT OR Keywords LIKE @KeywordsSubstring COLLATE NOCASE_NOACCENT)");
             parameters.Add("ItemNumberPrefix", $"{filter.Search}%");
             parameters.Add("ItemNumberSubstring", $"%{filter.Search}%");
             parameters.Add("NameSubstring", $"%{filter.Search}%");
+            parameters.Add("NotesSubstring", $"%{filter.Search}%");
+            parameters.Add("KeywordsSubstring", $"%{filter.Search}%");
         }
         if (filter.IsRentalItem.HasValue)
         {
@@ -110,10 +112,12 @@ public sealed class ItemRepository : IItemRepository
         var conditions = new List<string>();
         if (!string.IsNullOrWhiteSpace(filter.Search))
         {
-            conditions.Add("(ItemNumber LIKE @ItemNumberPrefix COLLATE NOCASE_NOACCENT OR ItemNumber LIKE @ItemNumberSubstring COLLATE NOCASE_NOACCENT OR NameDescription LIKE @NameSubstring COLLATE NOCASE_NOACCENT)");
+            conditions.Add("(ItemNumber LIKE @ItemNumberPrefix COLLATE NOCASE_NOACCENT OR ItemNumber LIKE @ItemNumberSubstring COLLATE NOCASE_NOACCENT OR NameDescription LIKE @NameSubstring COLLATE NOCASE_NOACCENT OR Notes LIKE @NotesSubstring COLLATE NOCASE_NOACCENT OR Keywords LIKE @KeywordsSubstring COLLATE NOCASE_NOACCENT)");
             parameters.Add("ItemNumberPrefix", $"{filter.Search}%");
             parameters.Add("ItemNumberSubstring", $"%{filter.Search}%");
             parameters.Add("NameSubstring", $"%{filter.Search}%");
+            parameters.Add("NotesSubstring", $"%{filter.Search}%");
+            parameters.Add("KeywordsSubstring", $"%{filter.Search}%");
         }
         if (filter.IsRentalItem.HasValue)
         {


### PR DESCRIPTION
## Summary
- extend repository search to also match notes and keywords using case- and accent-insensitive collation
- add tests confirming notes and keywords are searched

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1768843883248b23110bb5f55d31