### PR TITLE
Cancel stale item loads on filter changes

### DIFF
--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -195,6 +195,32 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task NoUnfilteredItemsAfterRapidFilterChanges()
+        {
+            var defaults = new List<ItemModel> { new ItemModel { ItemID = 1 } };
+            var data = new Dictionary<string, List<ItemModel>>
+            {
+                ["new"] = new() { new ItemModel { ItemID = 2 } }
+            };
+            var service = new RecordingItemService(data, defaults, delayMs:100);
+            var dialog = new DummyDialogService();
+            var rental = new DummyRentalService();
+            var settings = new DummySettingsService();
+            using var memoryBudget = new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue);
+            using var vm = new ItemsViewModel(service, memoryBudget, dialog, rental, settings, NullLogger<ItemsViewModel>.Instance);
+
+            var loadTask = vm.LoadMoreAsync();
+            vm.Filter = "new";
+
+            await Task.Delay(700);
+            await loadTask;
+
+            Assert.Single(vm.Items);
+            Assert.Equal(2, vm.Items[0].ItemID);
+            Assert.DoesNotContain(vm.Items, i => i.ItemID == 1);
+        }
+
+        [Fact]
         public async Task ConcurrentLoadMoreCallsDoNotDuplicateOrSkipPages()
         {
             var service = new PagingItemService();
@@ -670,14 +696,16 @@ namespace InventoryManagementApp.Tests
         {
             private readonly Dictionary<string, List<ItemModel>> _searchData;
             private readonly List<ItemModel> _defaultItems;
+            private readonly int _delay;
 
             public List<string?> SearchRequests { get; } = new();
             public int GetCalls { get; private set; }
 
-            public RecordingItemService(Dictionary<string, List<ItemModel>> searchData, List<ItemModel>? defaultItems = null)
+            public RecordingItemService(Dictionary<string, List<ItemModel>> searchData, List<ItemModel>? defaultItems = null, int delayMs = 10)
             {
                 _searchData = searchData;
                 _defaultItems = defaultItems ?? new List<ItemModel>();
+                _delay = delayMs;
             }
 
             public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => Task.CompletedTask;
@@ -714,7 +742,7 @@ namespace InventoryManagementApp.Tests
             {
                 foreach (var item in items)
                 {
-                    await Task.Delay(10, ct);
+                    await Task.Delay(_delay, ct);
                     yield return item;
                 }
             }

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -28,6 +28,7 @@ namespace InventoryManagementApp.ViewModels
         private readonly ISettingsService _settingsService;
         private readonly ILogger<ItemsViewModel> _logger;
         private CancellationTokenSource _filterCts = new();
+        private CancellationTokenSource _loadCts = new();
         private bool _disposed;
         private readonly List<ItemModel> _pendingEdits = new();
 
@@ -200,7 +201,8 @@ namespace InventoryManagementApp.ViewModels
         {
             try
             {
-                await Items.LoadMoreAsync(ct).ConfigureAwait(false);
+                using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, _loadCts.Token);
+                await Items.LoadMoreAsync(linked.Token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -213,6 +215,9 @@ namespace InventoryManagementApp.ViewModels
             _filterCts.Cancel();
             _filterCts.Dispose();
             _filterCts = new CancellationTokenSource();
+            _loadCts.Cancel();
+            _loadCts.Dispose();
+            _loadCts = new CancellationTokenSource();
             _ = ApplyFilterAsync(_filterCts.Token);
         }
 
@@ -221,7 +226,8 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 await Task.Delay(300, token).ConfigureAwait(false);
-                var firstPage = await LoadPageAsync(1, token).ConfigureAwait(false);
+                using var linked = CancellationTokenSource.CreateLinkedTokenSource(token, _loadCts.Token);
+                var firstPage = await LoadPageAsync(1, linked.Token).ConfigureAwait(false);
                 Items.ResetWith(firstPage);
                 await _settingsService.SaveSettingAsync("LastFilter", Filter, token).ConfigureAwait(false);
             }
@@ -239,7 +245,7 @@ namespace InventoryManagementApp.ViewModels
 
         private async Task ApplySortAsync(SortOption value)
         {
-            var firstPage = await LoadPageAsync(1, CancellationToken.None).ConfigureAwait(false);
+            var firstPage = await LoadPageAsync(1, _loadCts.Token).ConfigureAwait(false);
             Items.ResetWith(firstPage);
             await _settingsService.SaveSettingAsync("LastSort", $"{value.Field}|{value.Direction}").ConfigureAwait(false);
         }
@@ -250,7 +256,7 @@ namespace InventoryManagementApp.ViewModels
         {
             Items.PageSize = value;
             Items.TrimToWindow(value * 3);
-            var firstPage = await LoadPageAsync(1, CancellationToken.None).ConfigureAwait(false);
+            var firstPage = await LoadPageAsync(1, _loadCts.Token).ConfigureAwait(false);
             Items.ResetWith(firstPage);
             await _settingsService.SaveSettingAsync("PageSize", value.ToString()).ConfigureAwait(false);
         }
@@ -476,6 +482,8 @@ namespace InventoryManagementApp.ViewModels
             Items.Reset();
             _filterCts.Cancel();
             _filterCts.Dispose();
+            _loadCts.Cancel();
+            _loadCts.Dispose();
         }
     }
 


### PR DESCRIPTION
## Summary
- add dedicated cancellation token for page loading and connect it to filter and load more operations
- ensure incremental loaders respect latest filter state
- test that rapid filter changes don't leave stale items

## Testing
- `dotnet test` *(fails: dotnet not installed)*
- `apt-get update` *(fails: repository not signed)*
- `curl -L https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh` *(fails: CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1760aa388324b1561ca3b8e70340