### PR TITLE
Tokenized item search with order-independent matching

### DIFF
--- a/InventoryManagementApp.Tests/ItemRepositorySearchTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositorySearchTests.cs
@@ -46,6 +46,9 @@ public class ItemRepositorySearchTests
         await conn.ExecuteAsync(
             "INSERT INTO Items (ItemNumber, NameDescription, Notes, Keywords, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,@Notes,@Keywords,0,0,1,0,0,@UpdatedAt)",
             new { ItemNumber = "CAFÉ1", Name = "Café Table", Notes = "Sturdy café furniture", Keywords = "table,café", UpdatedAt = System.DateTime.UtcNow });
+        await conn.ExecuteAsync(
+            "INSERT INTO Items (ItemNumber, NameDescription, Notes, Keywords, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,@Notes,@Keywords,0,0,0,0,0,@UpdatedAt)",
+            new { ItemNumber = "DRL1", Name = "Red Drill", Notes = "Powerful red drill", Keywords = "drill,red", UpdatedAt = System.DateTime.UtcNow });
     }
 
     [Fact]
@@ -150,5 +153,32 @@ public class ItemRepositorySearchTests
         Assert.Single(result);
         Assert.False(result[0].IsRentalItem);
         Assert.Equal("Hand Saw", result[0].Name);
+    }
+
+    [Fact]
+    public async Task GetPageAsync_SearchMultipleTokens_OrderInsensitive()
+    {
+        var factory = CreateFactory();
+        await SeedAsync(factory);
+        var repo = new ItemRepository(factory);
+        var first = new List<ItemModel>();
+        await foreach (var item in repo.GetPageAsync(new ItemFilter("red drill"), new ItemPage(1, 10), CancellationToken.None))
+            first.Add(item);
+        var second = new List<ItemModel>();
+        await foreach (var item in repo.GetPageAsync(new ItemFilter("drill red"), new ItemPage(1, 10), CancellationToken.None))
+            second.Add(item);
+        Assert.Equal(first.Count, second.Count);
+        Assert.Equal(first[0].ItemID, second[0].ItemID);
+    }
+
+    [Fact]
+    public async Task CountAsync_SearchMultipleTokens_OrderInsensitive()
+    {
+        var factory = CreateFactory();
+        await SeedAsync(factory);
+        var repo = new ItemRepository(factory);
+        var first = await repo.CountAsync(new ItemFilter("red drill"), CancellationToken.None);
+        var second = await repo.CountAsync(new ItemFilter("drill red"), CancellationToken.None);
+        Assert.Equal(first, second);
     }
 }

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Runtime.CompilerServices;
@@ -22,12 +23,16 @@ public sealed class ItemRepository : IItemRepository
         var conditions = new List<string>();
         if (!string.IsNullOrWhiteSpace(filter.Search))
         {
-            conditions.Add("(ItemNumber LIKE @ItemNumberPrefix COLLATE NOCASE_NOACCENT OR ItemNumber LIKE @ItemNumberSubstring COLLATE NOCASE_NOACCENT OR NameDescription LIKE @NameSubstring COLLATE NOCASE_NOACCENT OR Notes LIKE @NotesSubstring COLLATE NOCASE_NOACCENT OR Keywords LIKE @KeywordsSubstring COLLATE NOCASE_NOACCENT)");
-            parameters.Add("ItemNumberPrefix", $"{filter.Search}%");
-            parameters.Add("ItemNumberSubstring", $"%{filter.Search}%");
-            parameters.Add("NameSubstring", $"%{filter.Search}%");
-            parameters.Add("NotesSubstring", $"%{filter.Search}%");
-            parameters.Add("KeywordsSubstring", $"%{filter.Search}%");
+            var tokens = filter.Search.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            for (var i = 0; i < tokens.Length; i++)
+            {
+                conditions.Add("(ItemNumber LIKE @ItemNumberPrefix" + i + " COLLATE NOCASE_NOACCENT OR ItemNumber LIKE @ItemNumberSubstring" + i + " COLLATE NOCASE_NOACCENT OR NameDescription LIKE @NameSubstring" + i + " COLLATE NOCASE_NOACCENT OR Notes LIKE @NotesSubstring" + i + " COLLATE NOCASE_NOACCENT OR Keywords LIKE @KeywordsSubstring" + i + " COLLATE NOCASE_NOACCENT)");
+                parameters.Add("ItemNumberPrefix" + i, tokens[i] + "%");
+                parameters.Add("ItemNumberSubstring" + i, "%" + tokens[i] + "%");
+                parameters.Add("NameSubstring" + i, "%" + tokens[i] + "%");
+                parameters.Add("NotesSubstring" + i, "%" + tokens[i] + "%");
+                parameters.Add("KeywordsSubstring" + i, "%" + tokens[i] + "%");
+            }
         }
         if (filter.IsRentalItem.HasValue)
         {
@@ -112,12 +117,16 @@ public sealed class ItemRepository : IItemRepository
         var conditions = new List<string>();
         if (!string.IsNullOrWhiteSpace(filter.Search))
         {
-            conditions.Add("(ItemNumber LIKE @ItemNumberPrefix COLLATE NOCASE_NOACCENT OR ItemNumber LIKE @ItemNumberSubstring COLLATE NOCASE_NOACCENT OR NameDescription LIKE @NameSubstring COLLATE NOCASE_NOACCENT OR Notes LIKE @NotesSubstring COLLATE NOCASE_NOACCENT OR Keywords LIKE @KeywordsSubstring COLLATE NOCASE_NOACCENT)");
-            parameters.Add("ItemNumberPrefix", $"{filter.Search}%");
-            parameters.Add("ItemNumberSubstring", $"%{filter.Search}%");
-            parameters.Add("NameSubstring", $"%{filter.Search}%");
-            parameters.Add("NotesSubstring", $"%{filter.Search}%");
-            parameters.Add("KeywordsSubstring", $"%{filter.Search}%");
+            var tokens = filter.Search.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            for (var i = 0; i < tokens.Length; i++)
+            {
+                conditions.Add("(ItemNumber LIKE @ItemNumberPrefix" + i + " COLLATE NOCASE_NOACCENT OR ItemNumber LIKE @ItemNumberSubstring" + i + " COLLATE NOCASE_NOACCENT OR NameDescription LIKE @NameSubstring" + i + " COLLATE NOCASE_NOACCENT OR Notes LIKE @NotesSubstring" + i + " COLLATE NOCASE_NOACCENT OR Keywords LIKE @KeywordsSubstring" + i + " COLLATE NOCASE_NOACCENT)");
+                parameters.Add("ItemNumberPrefix" + i, tokens[i] + "%");
+                parameters.Add("ItemNumberSubstring" + i, "%" + tokens[i] + "%");
+                parameters.Add("NameSubstring" + i, "%" + tokens[i] + "%");
+                parameters.Add("NotesSubstring" + i, "%" + tokens[i] + "%");
+                parameters.Add("KeywordsSubstring" + i, "%" + tokens[i] + "%");
+            }
         }
         if (filter.IsRentalItem.HasValue)
         {


### PR DESCRIPTION
## Summary
- Split search strings into tokens and build per-token OR clauses across key item fields
- Ensure page and count queries require all tokens and use unique parameters
- Add repository tests verifying multi-token search returns same results regardless of token order

## Testing
- `dotnet test` *(fails: command not found; apt repositories unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1a58185483249ca80ccb7163dd77