### PR TITLE
Add indexes for Notes and Keywords columns

### DIFF
--- a/InventoryManagementApp.Tests/SqliteConnectionFactoryTests.cs
+++ b/InventoryManagementApp.Tests/SqliteConnectionFactoryTests.cs
@@ -23,7 +23,7 @@ public class SqliteConnectionFactoryTests
         using (var conn = factory.Create())
         {
             using var cmd = conn.CreateCommand();
-            cmd.CommandText = "CREATE TABLE Items (ItemNumber TEXT, NameDescription TEXT, AvailableQuantity INTEGER, Price NUMERIC NOT NULL DEFAULT 0, UpdatedAt TEXT);";
+            cmd.CommandText = "CREATE TABLE Items (ItemNumber TEXT, NameDescription TEXT, AvailableQuantity INTEGER, Price NUMERIC NOT NULL DEFAULT 0, UpdatedAt TEXT, Notes TEXT, Keywords TEXT);";
             cmd.ExecuteNonQuery();
         }
 
@@ -38,6 +38,8 @@ public class SqliteConnectionFactoryTests
         Assert.Contains("IX_Items_NameDescription", indexes);
         Assert.Contains("IX_Items_AvailableQuantity", indexes);
         Assert.Contains("IX_Items_UpdatedAt", indexes);
+        Assert.Contains("IX_Items_Notes", indexes);
+        Assert.Contains("IX_Items_Keywords", indexes);
     }
 
     [Fact]
@@ -63,6 +65,8 @@ public class SqliteConnectionFactoryTests
         Assert.Contains("IX_Items_NameDescription", indexes);
         Assert.Contains("IX_Items_AvailableQuantity", indexes);
         Assert.DoesNotContain("IX_Items_UpdatedAt", indexes);
+        Assert.DoesNotContain("IX_Items_Notes", indexes);
+        Assert.DoesNotContain("IX_Items_Keywords", indexes);
     }
 
     [Fact]

--- a/InventoryManagementApp/Data/SqliteConnectionFactory.cs
+++ b/InventoryManagementApp/Data/SqliteConnectionFactory.cs
@@ -63,6 +63,10 @@ public sealed class SqliteConnectionFactory
                     sb.AppendLine("CREATE INDEX IF NOT EXISTS IX_Items_NameDescription ON Items(NameDescription);");
                 if (columns.Contains("AvailableQuantity"))
                     sb.AppendLine("CREATE INDEX IF NOT EXISTS IX_Items_AvailableQuantity ON Items(AvailableQuantity);");
+                if (columns.Contains("Notes"))
+                    sb.AppendLine("CREATE INDEX IF NOT EXISTS IX_Items_Notes ON Items(Notes);");
+                if (columns.Contains("Keywords"))
+                    sb.AppendLine("CREATE INDEX IF NOT EXISTS IX_Items_Keywords ON Items(Keywords);");
                 if (columns.Contains("UpdatedAt"))
                     sb.AppendLine("CREATE INDEX IF NOT EXISTS IX_Items_UpdatedAt ON Items(UpdatedAt);");
                 else


### PR DESCRIPTION
## Summary
- detect Notes and Keywords columns when creating SQLite connections
- create indexes on Items(Notes) and Items(Keywords) when columns are present
- test database initialization for Notes and Keywords indexes

## Testing
- ⚠️ `dotnet test` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1b40bf6c8324b9f69b383a6cbe10