### PR TITLE
Remove redundant item load from search command

### DIFF
--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -26,7 +26,6 @@ using Microsoft.Extensions.DependencyInjection;
 using InventoryManagementApp.Models.ImportExport;
 using InventoryManagementApp.Utilities;
 using InventoryManagementApp.Utilities.Helpers;
-using InventoryManagementApp.Data;
 using Application = System.Windows.Application;
 
 namespace InventoryManagementApp.ViewModels
@@ -274,12 +273,11 @@ namespace InventoryManagementApp.ViewModels
             OpenSearchItemsCommand = new AsyncRelayCommand(async () =>
             {
                 var plural = LabelProvider.Instance.ItemLabelPlural;
-                await ItemManagement.InitializeAsync();
                 var page = new ItemSearchPage { DataContext = ItemManagement, Title = $"Search {plural}" };
-                CurrentPage = page;
                 try
                 {
-                    await ItemManagement.LoadItemsAsync(new ItemPage(1, 50));
+                    await ItemManagement.InitializeAsync();
+                    CurrentPage = page;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary
- Avoid duplicate initial item loading by removing redundant `LoadItemsAsync` call from `OpenSearchItemsCommand`
- Let `InitializeAsync` handle initial item loading when opening item search

## Testing
- `dotnet test` *(fails: `bash: command not found: dotnet`)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac29fd91b48324a09f5f6ba6c34df2