### PR TITLE
Handle cancellation and async search results

### DIFF
--- a/InventoryManagementApp.Tests/ItemSearchPageTests.cs
+++ b/InventoryManagementApp.Tests/ItemSearchPageTests.cs
@@ -53,6 +53,8 @@ namespace InventoryManagementApp.Tests
                     var vm = host.Services.GetRequiredService<ItemManagementViewModel>();
                     vm.LoadItemsAsync(new ItemPage(1, 50)).GetAwaiter().GetResult();
 
+                    var initialCount = vm.Items.Count;
+
                     var page = new ItemSearchPage { DataContext = vm };
                     var searchBar = FindVisualChild<InventoryManagementApp.Controls.SearchBar>(page) ?? throw new InvalidOperationException("SearchBar not found");
                     searchBar.Text = "Screw";
@@ -64,6 +66,7 @@ namespace InventoryManagementApp.Tests
                     SpinWait.SpinUntil(() => vm.SearchResults.Count == 1, TimeSpan.FromSeconds(5));
                     Assert.Single(vm.SearchResults);
                     Assert.Equal("Screwdriver", vm.SearchResults[0].Name);
+                    Assert.Equal(initialCount, vm.Items.Count);
 
                     app.Shutdown();
                 }

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -251,13 +251,18 @@ namespace InventoryManagementApp.ViewModels
         /// </summary>
         async Task FilterItemsAsync()
         {
+            var cancellationToken = _searchCts?.Token ?? CancellationToken.None;
+            if (cancellationToken.IsCancellationRequested)
+                return;
+
+            var term = string.IsNullOrWhiteSpace(SearchTerm) ? string.Empty : SearchTerm.Trim();
+            var page = new ItemPage(1, PageSize);
+            var list = new List<ItemModel>();
+
+            SearchResults.Clear();
+
             try
             {
-                var cancellationToken = _searchCts?.Token ?? CancellationToken.None;
-                var term = string.IsNullOrWhiteSpace(SearchTerm) ? string.Empty : SearchTerm.Trim();
-                var page = new ItemPage(1, PageSize);
-                var list = new List<ItemModel>();
-
                 if (!string.IsNullOrEmpty(term))
                 {
                     await foreach (var item in _itemService.SearchItemsAsync(term, page, SortField.Name, SortDirection.Ascending, isRentalItem: false, cancellationToken: cancellationToken))
@@ -268,19 +273,27 @@ namespace InventoryManagementApp.ViewModels
                     await foreach (var item in _itemService.GetItemsAsync(page, SortField.Name, SortDirection.Ascending, isRentalItem: false, cancellationToken: cancellationToken))
                         list.Add(item);
                 }
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogDebug(ex, "Item search cancelled");
+                return;
+            }
 
-                if (!string.IsNullOrEmpty(SelectedCategory) && SelectedCategory != "All")
-                {
-                    list = list.Where(t => string.Equals(t.Brand, SelectedCategory, StringComparison.OrdinalIgnoreCase)).ToList();
-                }
+            if (!string.IsNullOrEmpty(SelectedCategory) && SelectedCategory != "All")
+            {
+                list = list.Where(t => string.Equals(t.Brand, SelectedCategory, StringComparison.OrdinalIgnoreCase)).ToList();
+            }
 
+            if (string.IsNullOrEmpty(term))
+            {
                 Items.ReplaceRange(list);
                 SearchResults.ReplaceRange(list);
                 LoadCategories(list, suppressSearch: true);
             }
-            catch (OperationCanceledException)
+            else
             {
-                return;
+                SearchResults.ReplaceRange(list);
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid starting cancelled queries and clear search results before new search
- keep unfiltered items list intact while showing search results
- test ensures item list remains after searching

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2bb548f083248696d0a189b4f957