### PR TITLE
Add cancellation pre-checks to ItemRepository

### DIFF
--- a/InventoryManagementApp.Tests/ItemRepositoryCountTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryCountTests.cs
@@ -76,4 +76,15 @@ public class ItemRepositoryCountTests
         var count = await repo.CountAsync(new ItemFilter(null, IsRentalItem: true), CancellationToken.None);
         Assert.Equal(1, count);
     }
+
+    [Fact]
+    public async Task CountAsync_Cancelled_Throws()
+    {
+        var factory = CreateFactory();
+        await SeedAsync(factory);
+        var repo = new ItemRepository(factory);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => repo.CountAsync(new ItemFilter(null), cts.Token));
+    }
 }

--- a/InventoryManagementApp.Tests/ItemRepositoryPaginationTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryPaginationTests.cs
@@ -75,4 +75,18 @@ public class ItemRepositoryPaginationTests
         Assert.True(await enumerator.MoveNextAsync());
         Assert.Equal("Item 1", enumerator.Current.Name);
     }
+
+    [Fact]
+    public async Task GetPageAsync_Cancelled_Throws()
+    {
+        var factory = CreateFactory();
+        await SeedAsync(factory);
+        var repo = new ItemRepository(factory);
+        var page = new ItemPage(1, 5);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var enumerable = repo.GetPageAsync(new ItemFilter(null), page, cts.Token);
+        await using var enumerator = enumerable.GetAsyncEnumerator();
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await enumerator.MoveNextAsync());
+    }
 }

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -18,6 +18,7 @@ public sealed class ItemRepository : IItemRepository
 
     public async IAsyncEnumerable<Item> GetPageAsync(ItemFilter filter, ItemPage page, [EnumeratorCancellation] CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
         var sql = "SELECT ItemID, ItemNumber, NameDescription AS Name, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity AS QuantityOnHand, RentedQuantity, IsRentalItem, Price, ImagePath, IsCheckedOut, CheckedOutBy, CheckedOutTime, CheckedInBy, CheckedInTime, IsPowered, UpdatedAt FROM Items";
         var parameters = new DynamicParameters();
         var conditions = new List<string>();
@@ -55,63 +56,74 @@ public sealed class ItemRepository : IItemRepository
         parameters.Add("Skip", (page.Number - 1) * page.Size);
         await using var conn = (DbConnection)_factory.Create();
         var command = new CommandDefinition(sql, parameters, flags: CommandFlags.Pipelined, cancellationToken: ct);
-        await using var reader = await conn.ExecuteReaderAsync(command).ConfigureAwait(false);
-
-        var ordinalItemID = reader.GetOrdinal("ItemID");
-        var ordinalItemNumber = reader.GetOrdinal("ItemNumber");
-        var ordinalName = reader.GetOrdinal("Name");
-        var ordinalLocation = reader.GetOrdinal("Location");
-        var ordinalBrand = reader.GetOrdinal("Brand");
-        var ordinalPartNumber = reader.GetOrdinal("PartNumber");
-        var ordinalSupplier = reader.GetOrdinal("Supplier");
-        var ordinalPurchasedDate = reader.GetOrdinal("PurchasedDate");
-        var ordinalNotes = reader.GetOrdinal("Notes");
-        var ordinalKeywords = reader.GetOrdinal("Keywords");
-        var ordinalQuantityOnHand = reader.GetOrdinal("QuantityOnHand");
-        var ordinalRentedQuantity = reader.GetOrdinal("RentedQuantity");
-        var ordinalIsRental = reader.GetOrdinal("IsRentalItem");
-        var ordinalPrice = reader.GetOrdinal("Price");
-        var ordinalImagePath = reader.GetOrdinal("ImagePath");
-        var ordinalIsCheckedOut = reader.GetOrdinal("IsCheckedOut");
-        var ordinalCheckedOutBy = reader.GetOrdinal("CheckedOutBy");
-        var ordinalCheckedOutTime = reader.GetOrdinal("CheckedOutTime");
-        var ordinalCheckedInBy = reader.GetOrdinal("CheckedInBy");
-        var ordinalCheckedInTime = reader.GetOrdinal("CheckedInTime");
-        var ordinalIsPowered = reader.GetOrdinal("IsPowered");
-        var ordinalUpdatedAt = reader.GetOrdinal("UpdatedAt");
-
-        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        DbDataReader reader;
+        try
         {
-            yield return new Item
+            reader = await conn.ExecuteReaderAsync(command).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            yield break;
+        }
+        await using (reader)
+        {
+            var ordinalItemID = reader.GetOrdinal("ItemID");
+            var ordinalItemNumber = reader.GetOrdinal("ItemNumber");
+            var ordinalName = reader.GetOrdinal("Name");
+            var ordinalLocation = reader.GetOrdinal("Location");
+            var ordinalBrand = reader.GetOrdinal("Brand");
+            var ordinalPartNumber = reader.GetOrdinal("PartNumber");
+            var ordinalSupplier = reader.GetOrdinal("Supplier");
+            var ordinalPurchasedDate = reader.GetOrdinal("PurchasedDate");
+            var ordinalNotes = reader.GetOrdinal("Notes");
+            var ordinalKeywords = reader.GetOrdinal("Keywords");
+            var ordinalQuantityOnHand = reader.GetOrdinal("QuantityOnHand");
+            var ordinalRentedQuantity = reader.GetOrdinal("RentedQuantity");
+            var ordinalIsRental = reader.GetOrdinal("IsRentalItem");
+            var ordinalPrice = reader.GetOrdinal("Price");
+            var ordinalImagePath = reader.GetOrdinal("ImagePath");
+            var ordinalIsCheckedOut = reader.GetOrdinal("IsCheckedOut");
+            var ordinalCheckedOutBy = reader.GetOrdinal("CheckedOutBy");
+            var ordinalCheckedOutTime = reader.GetOrdinal("CheckedOutTime");
+            var ordinalCheckedInBy = reader.GetOrdinal("CheckedInBy");
+            var ordinalCheckedInTime = reader.GetOrdinal("CheckedInTime");
+            var ordinalIsPowered = reader.GetOrdinal("IsPowered");
+            var ordinalUpdatedAt = reader.GetOrdinal("UpdatedAt");
+
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
             {
-                ItemID = !reader.IsDBNull(ordinalItemID) ? reader.GetInt32(ordinalItemID) : 0,
-                ItemNumber = reader.IsDBNull(ordinalItemNumber) ? string.Empty : reader.GetString(ordinalItemNumber),
-                Name = reader.IsDBNull(ordinalName) ? string.Empty : reader.GetString(ordinalName),
-                Location = reader.IsDBNull(ordinalLocation) ? string.Empty : reader.GetString(ordinalLocation),
-                Brand = reader.IsDBNull(ordinalBrand) ? string.Empty : reader.GetString(ordinalBrand),
-                PartNumber = reader.IsDBNull(ordinalPartNumber) ? string.Empty : reader.GetString(ordinalPartNumber),
-                Supplier = reader.IsDBNull(ordinalSupplier) ? string.Empty : reader.GetString(ordinalSupplier),
-                PurchasedDate = reader.IsDBNull(ordinalPurchasedDate) ? null : reader.GetDateTime(ordinalPurchasedDate),
-                Notes = reader.IsDBNull(ordinalNotes) ? string.Empty : reader.GetString(ordinalNotes),
-                Keywords = reader.IsDBNull(ordinalKeywords) ? string.Empty : reader.GetString(ordinalKeywords),
-                QuantityOnHand = reader.IsDBNull(ordinalQuantityOnHand) ? 0 : reader.GetInt32(ordinalQuantityOnHand),
-                RentedQuantity = reader.IsDBNull(ordinalRentedQuantity) ? 0 : reader.GetInt32(ordinalRentedQuantity),
-                IsRentalItem = !reader.IsDBNull(ordinalIsRental) && reader.GetInt32(ordinalIsRental) == 1,
-                Price = reader.IsDBNull(ordinalPrice) ? 0m : reader.GetDecimal(ordinalPrice),
-                ImagePath = reader.IsDBNull(ordinalImagePath) ? string.Empty : reader.GetString(ordinalImagePath),
-                IsCheckedOut = !reader.IsDBNull(ordinalIsCheckedOut) && reader.GetInt32(ordinalIsCheckedOut) == 1,
-                CheckedOutBy = reader.IsDBNull(ordinalCheckedOutBy) ? string.Empty : reader.GetString(ordinalCheckedOutBy),
-                CheckedOutTime = reader.IsDBNull(ordinalCheckedOutTime) ? null : reader.GetDateTime(ordinalCheckedOutTime),
-                CheckedInBy = reader.IsDBNull(ordinalCheckedInBy) ? string.Empty : reader.GetString(ordinalCheckedInBy),
-                CheckedInTime = reader.IsDBNull(ordinalCheckedInTime) ? null : reader.GetDateTime(ordinalCheckedInTime),
-                IsPowered = !reader.IsDBNull(ordinalIsPowered) && reader.GetInt32(ordinalIsPowered) == 1,
-                UpdatedAt = reader.IsDBNull(ordinalUpdatedAt) ? default : reader.GetDateTime(ordinalUpdatedAt)
-            };
+                yield return new Item
+                {
+                    ItemID = !reader.IsDBNull(ordinalItemID) ? reader.GetInt32(ordinalItemID) : 0,
+                    ItemNumber = reader.IsDBNull(ordinalItemNumber) ? string.Empty : reader.GetString(ordinalItemNumber),
+                    Name = reader.IsDBNull(ordinalName) ? string.Empty : reader.GetString(ordinalName),
+                    Location = reader.IsDBNull(ordinalLocation) ? string.Empty : reader.GetString(ordinalLocation),
+                    Brand = reader.IsDBNull(ordinalBrand) ? string.Empty : reader.GetString(ordinalBrand),
+                    PartNumber = reader.IsDBNull(ordinalPartNumber) ? string.Empty : reader.GetString(ordinalPartNumber),
+                    Supplier = reader.IsDBNull(ordinalSupplier) ? string.Empty : reader.GetString(ordinalSupplier),
+                    PurchasedDate = reader.IsDBNull(ordinalPurchasedDate) ? null : reader.GetDateTime(ordinalPurchasedDate),
+                    Notes = reader.IsDBNull(ordinalNotes) ? string.Empty : reader.GetString(ordinalNotes),
+                    Keywords = reader.IsDBNull(ordinalKeywords) ? string.Empty : reader.GetString(ordinalKeywords),
+                    QuantityOnHand = reader.IsDBNull(ordinalQuantityOnHand) ? 0 : reader.GetInt32(ordinalQuantityOnHand),
+                    RentedQuantity = reader.IsDBNull(ordinalRentedQuantity) ? 0 : reader.GetInt32(ordinalRentedQuantity),
+                    IsRentalItem = !reader.IsDBNull(ordinalIsRental) && reader.GetInt32(ordinalIsRental) == 1,
+                    Price = reader.IsDBNull(ordinalPrice) ? 0m : reader.GetDecimal(ordinalPrice),
+                    ImagePath = reader.IsDBNull(ordinalImagePath) ? string.Empty : reader.GetString(ordinalImagePath),
+                    IsCheckedOut = !reader.IsDBNull(ordinalIsCheckedOut) && reader.GetInt32(ordinalIsCheckedOut) == 1,
+                    CheckedOutBy = reader.IsDBNull(ordinalCheckedOutBy) ? string.Empty : reader.GetString(ordinalCheckedOutBy),
+                    CheckedOutTime = reader.IsDBNull(ordinalCheckedOutTime) ? null : reader.GetDateTime(ordinalCheckedOutTime),
+                    CheckedInBy = reader.IsDBNull(ordinalCheckedInBy) ? string.Empty : reader.GetString(ordinalCheckedInBy),
+                    CheckedInTime = reader.IsDBNull(ordinalCheckedInTime) ? null : reader.GetDateTime(ordinalCheckedInTime),
+                    IsPowered = !reader.IsDBNull(ordinalIsPowered) && reader.GetInt32(ordinalIsPowered) == 1,
+                    UpdatedAt = reader.IsDBNull(ordinalUpdatedAt) ? default : reader.GetDateTime(ordinalUpdatedAt)
+                };
+            }
         }
     }
 
     public async Task<int> CountAsync(ItemFilter filter, CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
         var sql = "SELECT COUNT(*) FROM Items";
         var parameters = new DynamicParameters();
         var conditions = new List<string>();


### PR DESCRIPTION
## Summary
- guard database calls with early `CancellationToken` checks
- swallow `OperationCanceledException` from `ExecuteReaderAsync`
- test repository cancellation behaviors

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2c7376e08324903580d5317789e2