### PR TITLE
Center search results and support vertical scrolling

### DIFF
--- a/InventoryManagementApp.Tests/ItemCardTemplateTests.cs
+++ b/InventoryManagementApp.Tests/ItemCardTemplateTests.cs
@@ -17,8 +17,8 @@ namespace InventoryManagementApp.Tests
             XNamespace x = "http://schemas.microsoft.com/winfx/2006/xaml";
             var template = doc.Root?.Elements(ns + "DataTemplate").First(e => e.Attribute(x + "Key")?.Value == "ItemCardTemplate");
             var image = template!.Descendants(ns + "Image").First();
-            Assert.Equal("96", image.Attribute("Width")?.Value);
-            Assert.Equal("96", image.Attribute("Height")?.Value);
+            Assert.Equal("280", image.Attribute("Width")?.Value);
+            Assert.Equal("280", image.Attribute("Height")?.Value);
             Assert.Contains("NullToDefaultImageConverter", image.Attribute("Source")?.Value);
         }
     }

--- a/InventoryManagementApp/Resources/Templates.xaml
+++ b/InventoryManagementApp/Resources/Templates.xaml
@@ -19,7 +19,7 @@
         <WrapPanel Orientation="Horizontal" ItemWidth="260" ItemHeight="100"/>
     </ItemsPanelTemplate>
     <DataTemplate x:Key="ItemCardTemplate">
-        <Border Style="{StaticResource Card}" Width="256" Padding="0" Margin="4">
+        <Border Style="{StaticResource Card}" Width="280" Padding="0" Margin="4">
             <Border.Visibility>
                 <MultiBinding Converter="{StaticResource AnyTrueToVisibilityConverter}">
                     <Binding Path="DataContext.ShowImage" RelativeSource="{RelativeSource AncestorType=Page}"/>
@@ -33,12 +33,12 @@
             </Border.Visibility>
             <Grid>
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="256"/>
+                    <RowDefinition Height="280"/>
                     <RowDefinition Height="120"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <Border Background="{StaticResource SurfaceAltBrush}" BorderBrush="{StaticResource BorderBrushAlt}" BorderThickness="1" CornerRadius="8" Visibility="{Binding DataContext.ShowImage, RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource BoolToVis}}">
-                    <Image Width="256" Height="256" Stretch="Uniform" Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
+                    <Image Width="280" Height="280" Stretch="Uniform" Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
                 </Border>
                 <Grid Grid.Row="1" Margin="0,6,0,0">
                     <Grid.RowDefinitions>

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
@@ -28,7 +28,7 @@
                  av:ItemsSource="{av:SampleData ItemCount=5}">
             <ListBox.ItemsPanel>
                 <ItemsPanelTemplate>
-                    <WrapPanel Orientation="Horizontal"/>
+                    <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center"/>
                 </ItemsPanelTemplate>
             </ListBox.ItemsPanel>
         </ListBox>

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
@@ -38,7 +38,7 @@ namespace InventoryManagementApp.Views.Pages
                 var scrollViewer = FindScrollViewer(d);
                 if (scrollViewer != null)
                 {
-                    scrollViewer.ScrollToHorizontalOffset(scrollViewer.HorizontalOffset - e.Delta * ScrollFactor);
+                    scrollViewer.ScrollToVerticalOffset(scrollViewer.VerticalOffset - e.Delta * ScrollFactor);
                     e.Handled = true;
                 }
             }


### PR DESCRIPTION
## Summary
- center search results within ItemSearchPage
- enable slower vertical mouse wheel scrolling
- widen item cards for improved button layout

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2edd631883249697664d2c5ef632