### PR TITLE
Add missing item detail columns with visibility persistence

### DIFF
--- a/InventoryManagementApp.Tests/ManageItemsPageTests.cs
+++ b/InventoryManagementApp.Tests/ManageItemsPageTests.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Documents;
+using System.Windows.Media;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -63,6 +66,63 @@ namespace InventoryManagementApp.Tests
             thread.Start();
             thread.Join();
             if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
+        public void Columns_AreVisible_WhenFlagsTrue()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var host = Host.CreateDefaultBuilder()
+                        .ConfigureServices(services =>
+                        {
+                            services.AddSingleton<IItemService, StubItemService>();
+                            services.AddSingleton<IDialogService, StubDialogService>();
+                            services.AddSingleton<IRentalService, StubRentalService>();
+                            services.AddSingleton<ISettingsService, StubSettingsService>();
+                            services.AddSingleton(sp => new MemoryBudget(TimeSpan.FromMinutes(1), long.MaxValue, long.MaxValue));
+                            services.AddSingleton<ItemsViewModel>();
+                            services.AddSingleton<ILogger<ItemsViewModel>>(sp => NullLogger<ItemsViewModel>.Instance);
+                        })
+                        .Build();
+
+                    var app = new App(host);
+                    var page = new ManageItemsPage();
+                    var method = typeof(ManageItemsPage).GetMethod("ManageItemsPage_Loaded", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                    method!.Invoke(page, new object[] { page, new RoutedEventArgs() });
+                    var dataGrid = FindVisualChild<DataGrid>(page) ?? throw new InvalidOperationException("DataGrid not found");
+                    foreach (var col in dataGrid.Columns)
+                        Assert.Equal(Visibility.Visible, col.Visibility);
+                    Assert.Contains(dataGrid.Columns, c => Equals("Part #", c.Header));
+                    Assert.Contains(dataGrid.Columns, c => Equals("Notes", c.Header));
+                    app.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                if (child is T t)
+                    return t;
+                var result = FindVisualChild<T>(child);
+                if (result != null)
+                    return result;
+            }
+            return null;
         }
 
         private sealed class StubItemService : IItemService

--- a/InventoryManagementApp.Tests/ManageItemsPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ManageItemsPageXamlTests.cs
@@ -89,11 +89,13 @@ namespace InventoryManagementApp.Tests
             var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml"));
             var xaml = File.ReadAllText(path);
             Assert.Contains("ShowItemNumber", xaml);
+            Assert.Contains("ShowPartNumber", xaml);
             Assert.Contains("ShowName", xaml);
             Assert.Contains("ShowBrand", xaml);
             Assert.Contains("ShowQuantityOnHand", xaml);
             Assert.Contains("ShowLocation", xaml);
             Assert.Contains("ShowPrice", xaml);
+            Assert.Contains("ShowNotes", xaml);
         }
 
         private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -155,6 +155,8 @@ namespace InventoryManagementApp.ViewModels
                 var vis = await _settingsService.GetItemDetailVisibilityAsync(ct).ConfigureAwait(false);
                 var complete = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, f => vis.TryGetValue(f, out var v) ? v : true);
                 VisibleFields = complete;
+                if (vis.Count != complete.Count)
+                    await _settingsService.SaveItemDetailVisibilityAsync(complete, ct).ConfigureAwait(false);
                 _settingsService.ItemDetailVisibilityChanged += OnItemDetailVisibilityChanged;
             }
             catch (OperationCanceledException)

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -49,11 +49,13 @@
                         </DataGrid.RowStyle>
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Number" Visibility="{Binding Data.ShowItemNumber, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding ItemNumber, Mode=OneWay}" Width="140"/>
+                            <DataGridTextColumn Header="Part #" Visibility="{Binding Data.ShowPartNumber, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding PartNumber, Mode=OneWay}" Width="140"/>
                             <DataGridTextColumn Header="Name" Visibility="{Binding Data.ShowName, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Name, Mode=OneWay}" Width="280"/>
                             <DataGridTextColumn Header="Brand" Visibility="{Binding Data.ShowBrand, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Brand, Mode=OneWay}" Width="160"/>
                             <DataGridTextColumn Header="Qty" Visibility="{Binding Data.ShowQuantityOnHand, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding QuantityOnHand, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100"/>
                             <DataGridTextColumn Header="Location" Visibility="{Binding Data.ShowLocation, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Location, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="180"/>
                             <DataGridTextColumn Header="Price" Visibility="{Binding Data.ShowPrice, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Price, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="120"/>
+                            <DataGridTextColumn Header="Notes" Visibility="{Binding Data.ShowNotes, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Notes, Mode=OneWay}" Width="300"/>
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"


### PR DESCRIPTION
## Summary
- show Part Number and Notes columns on ManageItemsPage
- persist newly added visibility settings in ItemsViewModel
- test that all columns are visible when enabled

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac37d8e09c83249a2539de4471a18b