### PR TITLE
Stop pending global search on user switch

### DIFF
--- a/InventoryManagementApp.Tests/MainViewModelTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelTests.cs
@@ -158,6 +158,43 @@ namespace InventoryManagementApp.Tests
                 Assert.Null(ex2);
             });
         }
+
+        [Fact]
+        public async Task SwitchUserCommand_ClearsGlobalSearchText()
+        {
+            await RunOnStaThread(async () =>
+            {
+                using var db = new DatabaseService(":memory:");
+                var debounceTimer = new MockDispatcherTimer();
+                using var vm = new MainViewModel(
+                    new DummyItemService(),
+                    new DummyUserService(),
+                    new DummyUserContext(),
+                    new DummyCustomerService(),
+                    new DummyRentalService(),
+                    new DummyFileDialogService(),
+                    new ActivityLogService(db),
+                    new DummySettingsService(),
+                    db,
+                    new DummyDialogService(),
+                    NullLogger<MainViewModel>.Instance,
+                    () => Task.FromResult(true),
+                    new DummyDispatcherTimer(),
+                    new DummyScannerService(),
+                    debounceTimer);
+
+                var openDashboardField = typeof(MainViewModel).GetField("<OpenDashboardCommand>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+                openDashboardField!.SetValue(vm, new AsyncRelayCommand(() => Task.CompletedTask));
+
+                vm.GlobalSearchText = "test";
+
+                await vm.SwitchUserCommand.ExecuteAsync(null);
+
+                Assert.Equal(string.Empty, vm.GlobalSearchText);
+                Assert.False(debounceTimer.IsEnabled);
+            });
+        }
+
         [Fact]
         public async Task SwitchUserCommand_ClearsItemsViewModelFilter()
         {

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -433,7 +433,7 @@ namespace InventoryManagementApp.ViewModels
                 var previousUser = _userContext.CurrentUser;
                 _userContext.CurrentUser = null;
                 CloseNonMainWindows();
-                GlobalSearchText = string.Empty;
+                ClearSearch();
                 try
                 {
                     await _settingsService.DeleteSettingAsync("LastFilter").ConfigureAwait(false);
@@ -564,6 +564,7 @@ namespace InventoryManagementApp.ViewModels
         async void OnAutoLogoutTimerTick(object? s, EventArgs e)
         {
             _autoLogoutTimer.Stop();
+            ClearSearch();
             await SwitchUserCommand.ExecuteAsync(null);
         }
 
@@ -636,6 +637,12 @@ namespace InventoryManagementApp.ViewModels
             await OpenSearchItemsCommand.ExecuteAsync(null);
             if (ItemManagement.SearchCommand != null)
                 await ItemManagement.SearchCommand.ExecuteAsync(cancellationToken);
+        }
+
+        public void ClearSearch()
+        {
+            GlobalSearchText = string.Empty;
+            _globalSearchDebounceTimer.Stop();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary
- Stop global search debounce when switching users and on auto logout
- Add ClearSearch helper to reset search state
- Test that switching users clears global search text and stops the timer

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68acaff9c18c83249726293d2ab211c4