### PR TITLE
Enable adding customers during item rental

### DIFF
--- a/InventoryManagementApp.Tests/RentItemPopupViewModelTests.cs
+++ b/InventoryManagementApp.Tests/RentItemPopupViewModelTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.ViewModels.Rental;
+using InventoryManagementApp.Models.ImportExport;
+using InventoryManagementApp.ViewModels;
+using System.Windows.Documents;
+using CustomerModel = InventoryManagementApp.Models.Domain.Customer;
+
+namespace InventoryManagementApp.Tests
+{
+    public class RentItemPopupViewModelTests
+    {
+        [Fact]
+        public async Task AddCustomerCommand_InsertsAndSelectsCustomer()
+        {
+            var existing = new CustomerModel { CustomerID = 1, Company = "Old" };
+            var newCustomer = new CustomerModel { CustomerID = 2, Company = "New" };
+            var cs = new RecordingCustomerService();
+            var ds = new StubDialogService { AddCustomerDialogResult = newCustomer };
+            var vm = new RentItemPopupViewModel(new ItemModel(), new[] { existing }, cs, ds);
+
+            await vm.AddCustomerCommand.ExecuteAsync(null);
+
+            Assert.Equal(2, vm.Customers.Count);
+            Assert.Same(newCustomer, vm.SelectedCustomer);
+            Assert.Same(newCustomer, cs.AddedCustomer);
+        }
+
+        private sealed class RecordingCustomerService : ICustomerService
+        {
+            public CustomerModel? AddedCustomer { get; private set; }
+            public Task AddCustomerAsync(CustomerModel customer, CancellationToken cancellationToken = default)
+            {
+                AddedCustomer = customer;
+                return Task.CompletedTask;
+            }
+            public Task UpdateCustomerAsync(CustomerModel customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<CustomerModel> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<CustomerModel>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<CustomerModel>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        }
+
+        private sealed class StubDialogService : IDialogService
+        {
+            public CustomerModel? AddCustomerDialogResult { get; set; }
+            public CustomerModel? ShowAddCustomerDialog() => AddCustomerDialogResult;
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => true;
+            public ItemModel? ShowEditItemDialog(ItemModel item) => null;
+            public void ShowItemDetails(ItemModel item) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
+            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
+            public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+        }
+    }
+}

--- a/InventoryManagementApp/Services/DialogService.cs
+++ b/InventoryManagementApp/Services/DialogService.cs
@@ -97,7 +97,7 @@ namespace InventoryManagementApp.Services
         {
             ArgumentNullException.ThrowIfNull(item);
             ArgumentNullException.ThrowIfNull(customers);
-            var vm = new RentItemPopupViewModel(item, customers);
+            var vm = ActivatorUtilities.CreateInstance<RentItemPopupViewModel>(_serviceProvider, item, customers, this);
             var win = new RentItemPopupWindow { DataContext = vm };
 
             EventHandler handler = (_, _) => win.Close();

--- a/InventoryManagementApp/ViewModels/RentItemPopupViewModel.cs
+++ b/InventoryManagementApp/ViewModels/RentItemPopupViewModel.cs
@@ -2,14 +2,25 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
 
 namespace InventoryManagementApp.ViewModels.Rental
 {
     public class RentItemPopupViewModel : ObservableObject
     {
+        readonly ICustomerService _customerService;
+        readonly IDialogService _dialogService;
+
         public ObservableCollection<CustomerModel> Customers { get; }
-        public CustomerModel? SelectedCustomer { get; set; }
+        CustomerModel? _selectedCustomer;
+        public CustomerModel? SelectedCustomer
+        {
+            get => _selectedCustomer;
+            set => SetProperty(ref _selectedCustomer, value);
+        }
         public DateTime SelectedDueDate { get; set; } = DateTime.Today.AddDays(7);
         public event EventHandler? RequestClose;
 
@@ -18,12 +29,16 @@ namespace InventoryManagementApp.ViewModels.Rental
 
         public IRelayCommand CheckOutCommand { get; }
         public IRelayCommand CancelCommand { get; }
+        public IAsyncRelayCommand AddCustomerCommand { get; }
 
-        public RentItemPopupViewModel(ItemModel item, IEnumerable<CustomerModel> customers)
+        public RentItemPopupViewModel(ItemModel item, IEnumerable<CustomerModel> customers, ICustomerService customerService, IDialogService dialogService)
         {
+            _customerService = customerService;
+            _dialogService = dialogService;
             Customers = new ObservableCollection<CustomerModel>(customers);
             CheckOutCommand = new RelayCommand(Confirm);
             CancelCommand = new RelayCommand(Cancel);
+            AddCustomerCommand = new AsyncRelayCommand(AddCustomerAsync);
         }
 
         void Confirm()
@@ -36,6 +51,15 @@ namespace InventoryManagementApp.ViewModels.Rental
         void Cancel()
         {
             RequestClose?.Invoke(this, EventArgs.Empty);
+        }
+
+        async Task AddCustomerAsync()
+        {
+            var customer = _dialogService.ShowAddCustomerDialog();
+            if (customer == null) return;
+            await _customerService.AddCustomerAsync(customer);
+            Customers.Add(customer);
+            SelectedCustomer = customer;
         }
     }
 }

--- a/InventoryManagementApp/Views/Windows/RentItemPopupWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/RentItemPopupWindow.xaml
@@ -21,6 +21,7 @@
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="200"/>
                     <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
                 <TextBlock Grid.Row="0" Grid.Column="0" Text="Customer" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
@@ -29,9 +30,10 @@
                           DisplayMemberPath="Company"
                           SelectedItem="{Binding SelectedCustomer, Mode=TwoWay}" Margin="8,4"
                           ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
+                <Button Grid.Row="0" Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Add Customer" Command="{Binding AddCustomerCommand}" Margin="8,4,0,4"/>
 
                 <TextBlock Grid.Row="1" Grid.Column="0" Text="Due Date" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                <DatePicker Grid.Row="1" Grid.Column="1"
+                <DatePicker Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2"
                             SelectedDate="{Binding SelectedDueDate, Mode=TwoWay}" Margin="8,4"/>
             </Grid>
         </Border>


### PR DESCRIPTION
## Summary
- Add "Add Customer" button to rent item popup
- Allow adding customers directly from rent item dialog
- Resolve rent item dialog view model via DI
- Cover AddCustomerCommand with unit test

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4d23eef08324a715593e7dc47160