### PR TITLE
Add rented items section to dashboard

### DIFF
--- a/InventoryManagementApp.Tests/DashboardViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DashboardViewModelTests.cs
@@ -39,6 +39,9 @@ public class DashboardViewModelTests
     {
         public int CountCalls { get; private set; }
         public int GetCalls { get; private set; }
+        public int ReturnCalls { get; private set; }
+        public List<Rental> Rentals { get; } = new();
+        public bool ReturnShouldThrow { get; set; }
 
         public Task<int> CountActiveRentalsAsync()
         {
@@ -49,7 +52,15 @@ public class DashboardViewModelTests
         public Task<List<Rental>> GetActiveRentalsAsync()
         {
             GetCalls++;
-            return Task.FromResult(new List<Rental>());
+            return Task.FromResult(Rentals);
+        }
+
+        public Task ReturnItemAsync(int rentalID, DateTime returnDate)
+        {
+            ReturnCalls++;
+            if (ReturnShouldThrow)
+                throw new Exception("fail");
+            return Task.CompletedTask;
         }
 
         public Task DeleteRentalAsync(int rentalID) => throw new NotImplementedException();
@@ -59,7 +70,6 @@ public class DashboardViewModelTests
         public Task<List<Rental>> GetRentalHistoryForItemAsync(int itemID) => throw new NotImplementedException();
         public Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID) => throw new NotImplementedException();
         public Task RentItemAsync(int itemID, int customerID, DateTime rentalDate, DateTime dueDate) => throw new NotImplementedException();
-        public Task ReturnItemAsync(int rentalID, DateTime returnDate) => throw new NotImplementedException();
     }
 
     private sealed class StubCustomerService : ICustomerService
@@ -387,6 +397,122 @@ public class DashboardViewModelTests
         Assert.Single(vm.CheckedOutItems);
         Assert.Equal(1, itemService.ToggleCalls);
         Assert.Equal(2, itemService.LastToggledItemID);
+    }
+
+    [Fact]
+    public async Task LoadRentedItemsAsync_PopulatesCollection()
+    {
+        using var db = new DatabaseService(":memory:");
+        var itemService = new StubItemService();
+        var rentalService = new StubRentalService();
+        rentalService.Rentals.Add(new Rental { RentalID = 1, ItemNumber = "R1", CustomerName = "Carl" });
+        var customerService = new StubCustomerService();
+        var userService = new StubUserService();
+        var activityLogService = new StubActivityLogService(db);
+
+        var vm = new DashboardViewModel(
+            itemService,
+            rentalService,
+            customerService,
+            userService,
+            activityLogService,
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }));
+
+        await vm.LoadRentedItemsAsync(CancellationToken.None);
+
+        Assert.Single(vm.RentedItems);
+        Assert.Equal("R1", vm.RentedItems[0].ItemNumber);
+        Assert.Equal("Carl", vm.RentedItems[0].CustomerName);
+        Assert.Equal(1, rentalService.GetCalls);
+    }
+
+    [Fact]
+    public async Task LoadAsync_PopulatesRentedItems()
+    {
+        using var db = new DatabaseService(":memory:");
+        var itemService = new StubItemService();
+        var rentalService = new StubRentalService();
+        rentalService.Rentals.Add(new Rental { RentalID = 2, ItemNumber = "R2", CustomerName = "Dana" });
+        var customerService = new StubCustomerService();
+        var userService = new StubUserService();
+        var activityLogService = new StubActivityLogService(db);
+
+        var vm = new DashboardViewModel(
+            itemService,
+            rentalService,
+            customerService,
+            userService,
+            activityLogService,
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }));
+
+        await vm.LoadAsync(CancellationToken.None);
+
+        Assert.Single(vm.RentedItems);
+        Assert.Equal("R2", vm.RentedItems[0].ItemNumber);
+        Assert.Equal("Dana", vm.RentedItems[0].CustomerName);
+    }
+
+    [Fact]
+    public async Task ReturnRentalCommand_RemovesRentalOnSuccess()
+    {
+        using var db = new DatabaseService(":memory:");
+        var itemService = new StubItemService();
+        var rentalService = new StubRentalService();
+        var customerService = new StubCustomerService();
+        var userService = new StubUserService();
+        var activityLogService = new StubActivityLogService(db);
+
+        var vm = new DashboardViewModel(
+            itemService,
+            rentalService,
+            customerService,
+            userService,
+            activityLogService,
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }));
+
+        var rental = new Rental { RentalID = 3, ItemNumber = "R3", CustomerName = "Eve" };
+        vm.RentedItems.Add(rental);
+
+        await vm.ReturnRentalCommand.ExecuteAsync(rental);
+
+        Assert.Empty(vm.RentedItems);
+        Assert.Equal(1, rentalService.ReturnCalls);
+    }
+
+    [Fact]
+    public async Task ReturnRentalCommand_DoesNotRemoveWhenServiceFails()
+    {
+        using var db = new DatabaseService(":memory:");
+        var itemService = new StubItemService();
+        var rentalService = new StubRentalService { ReturnShouldThrow = true };
+        var customerService = new StubCustomerService();
+        var userService = new StubUserService();
+        var activityLogService = new StubActivityLogService(db);
+
+        var vm = new DashboardViewModel(
+            itemService,
+            rentalService,
+            customerService,
+            userService,
+            activityLogService,
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }),
+            new RelayCommand(() => { }));
+
+        var rental = new Rental { RentalID = 4, ItemNumber = "R4", CustomerName = "Frank" };
+        vm.RentedItems.Add(rental);
+
+        await vm.ReturnRentalCommand.ExecuteAsync(rental);
+
+        Assert.Single(vm.RentedItems);
+        Assert.Equal(rental, vm.RentedItems[0]);
+        Assert.Equal(1, rentalService.ReturnCalls);
     }
 }
 

--- a/InventoryManagementApp/ViewModels/DashboardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DashboardViewModel.cs
@@ -30,11 +30,13 @@ namespace InventoryManagementApp.ViewModels
         public ObservableCollection<StatCard> StatCards { get; } = new();
         public ObservableCollection<ActivityLog> RecentActivity { get; } = new();
         public ObservableCollection<ItemModel> CheckedOutItems { get; } = new();
+        public ObservableCollection<RentalModel> RentedItems { get; } = new();
 
         public IRelayCommand NewItemCommand { get; }
         public IRelayCommand OpenRentalsCommand { get; }
         public IRelayCommand OpenImportExportCommand { get; }
         public IAsyncRelayCommand<ItemModel> CheckInItemCommand { get; }
+        public IAsyncRelayCommand<RentalModel> ReturnRentalCommand { get; }
 
         public DashboardViewModel(IItemService itemService,
                                   IRentalService rentalService,
@@ -75,13 +77,15 @@ namespace InventoryManagementApp.ViewModels
             });
 
             CheckInItemCommand = new AsyncRelayCommand<ItemModel>(CheckInItemAsync);
+            ReturnRentalCommand = new AsyncRelayCommand<RentalModel>(ReturnRentalAsync);
         }
 
         public Task LoadAsync(CancellationToken cancellationToken)
             => Task.WhenAll(
                 LoadStatsAsync(cancellationToken),
                 LoadRecentActivityAsync(cancellationToken),
-                LoadCheckedOutItemsAsync(cancellationToken));
+                LoadCheckedOutItemsAsync(cancellationToken),
+                LoadRentedItemsAsync(cancellationToken));
 
         internal async Task LoadStatsAsync(CancellationToken cancellationToken)
         {
@@ -156,6 +160,25 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
+        internal async Task LoadRentedItemsAsync(CancellationToken token)
+        {
+            try
+            {
+                token.ThrowIfCancellationRequested();
+                RentedItems.Clear();
+                var rentals = await _rentalService.GetActiveRentalsAsync().ConfigureAwait(false);
+                foreach (var rental in rentals)
+                    RentedItems.Add(rental);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load rented items");
+            }
+        }
+
         private async Task CheckInItemAsync(ItemModel? item, CancellationToken token)
         {
             if (item == null) return;
@@ -171,6 +194,23 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to check in item {ItemID}", item.ItemID);
+            }
+        }
+
+        private async Task ReturnRentalAsync(RentalModel? rental, CancellationToken token)
+        {
+            if (rental == null) return;
+            try
+            {
+                await _rentalService.ReturnItemAsync(rental.RentalID, DateTime.Today).ConfigureAwait(false);
+                RentedItems.Remove(rental);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to return rental {RentalID}", rental.RentalID);
             }
         }
     }

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml
@@ -17,6 +17,7 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
             <Border Style="{StaticResource Card}" Grid.Column="0">
                 <StackPanel>
@@ -65,6 +66,33 @@
                                     <TextBlock Text="{Binding CheckedOutBy}" Margin="0,0,8,0"/>
                                     <Button Content="Check In"
                                             Command="{Binding DataContext.CheckInItemCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
+                                            CommandParameter="{Binding}"
+                                            Margin="0,0,0,0"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                        <ListView.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel/>
+                            </ItemsPanelTemplate>
+                        </ListView.ItemsPanel>
+                    </ListView>
+                </StackPanel>
+            </Border>
+            <Border Style="{StaticResource Card}" Grid.Column="3">
+                <StackPanel>
+                    <TextBlock Text="Rented Items" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
+                    <ListView ItemsSource="{Binding RentedItems}"
+                              Style="{StaticResource CardListView}"
+                              VirtualizingPanel.IsVirtualizing="True"
+                              VirtualizingPanel.VirtualizationMode="Recycling">
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="{Binding ItemNumber}" Margin="0,0,8,0"/>
+                                    <TextBlock Text="{Binding CustomerName}" Margin="0,0,8,0"/>
+                                    <Button Content="Return"
+                                            Command="{Binding DataContext.ReturnRentalCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
                                             CommandParameter="{Binding}"
                                             Margin="0,0,0,0"/>
                                 </StackPanel>


### PR DESCRIPTION
## Summary
- track active rentals in `DashboardViewModel` and support returning items
- show "Rented Items" list on dashboard with return buttons
- test dashboard rental loading and return scenarios

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4e1e789083248ddf3c62e2c69438