### PR TITLE
Add tooltip image previews in dashboard lists

### DIFF
--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml
@@ -62,6 +62,12 @@
                         <ListView.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal">
+                                    <StackPanel.ToolTip>
+                                        <Image Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"
+                                               MaxWidth="150"
+                                               MaxHeight="150"
+                                               Stretch="Uniform"/>
+                                    </StackPanel.ToolTip>
                                     <TextBlock Text="{Binding ItemNumber}" Margin="0,0,8,0"/>
                                     <TextBlock Text="{Binding CheckedOutBy}" Margin="0,0,8,0"/>
                                     <Button Content="Check In"
@@ -89,6 +95,12 @@
                         <ListView.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal">
+                                    <StackPanel.ToolTip>
+                                        <Image Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"
+                                               MaxWidth="150"
+                                               MaxHeight="150"
+                                               Stretch="Uniform"/>
+                                    </StackPanel.ToolTip>
                                     <TextBlock Text="{Binding ItemNumber}" Margin="0,0,8,0"/>
                                     <TextBlock Text="{Binding CustomerName}" Margin="0,0,8,0"/>
                                     <Button Content="Return"


### PR DESCRIPTION
## Summary
- Show image preview on hover for checked-out items on the dashboard
- Show image preview on hover for rented items on the dashboard

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4ff304f08324bc3c060210bd4bef