### PR TITLE
feat: move item action buttons to top toolbar

### DIFF
--- a/InventoryManagementApp.Tests/ManageItemsPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ManageItemsPageXamlTests.cs
@@ -98,6 +98,17 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("ShowNotes", xaml);
         }
 
+        [Fact]
+        public void ActionButtons_AppearAtTop()
+        {
+            var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml"));
+            var xaml = File.ReadAllText(path);
+            Assert.DoesNotContain("Grid.Row=\"3\"", xaml);
+            var editIndex = xaml.IndexOf("Content=\"Edit\"");
+            var dataGridIndex = xaml.IndexOf("<DataGrid");
+            Assert.True(editIndex >= 0 && dataGridIndex >= 0 && editIndex < dataGridIndex);
+        }
+
         private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
         {
             for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml
@@ -4,115 +4,109 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
-      xmlns:models="clr-namespace:InventoryManagementApp.Models"
       xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
       Background="{StaticResource BackgroundBrush}">
     <Grid Margin="8">
-        <Border Style="{StaticResource Card}">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
 
-                <StackPanel Margin="0,0,0,8">
+        <Border Style="{StaticResource Card}" Padding="12">
+            <DockPanel LastChildFill="False">
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
                     <TextBlock
                         Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}"
-                        Style="{StaticResource SubheadingTextBlock}"/>
-                    <controls:SearchBar Text="{Binding Filter}" SearchCommand="{Binding SearchCommand}" />
+                        Style="{StaticResource SubheadingTextBlock}"
+                        Margin="0,0,8,0"/>
+                    <Button Style="{StaticResource PrimaryButton}"
+                            Content="Edit"
+                            Command="{Binding EditItemCommand}"
+                            Margin="0,0,8,0"/>
+                    <Button Style="{StaticResource PrimaryButton}"
+                            Content="View Details"
+                            Command="{Binding ViewDetailsCommand}"
+                            Margin="0,0,8,0"/>
+                    <Button Style="{StaticResource PrimaryButton}"
+                            Content="Rental History"
+                            Command="{Binding OpenRentalHistoryCommand}"
+                            Margin="0,0,8,0"/>
+                    <Button Style="{StaticResource PrimaryButton}"
+                            Content="New"
+                            Command="{Binding NewItemCommand}"/>
                 </StackPanel>
+                <controls:SearchBar DockPanel.Dock="Right"
+                                    Text="{Binding Filter}"
+                                    SearchCommand="{Binding SearchCommand}"/>
+            </DockPanel>
+        </Border>
 
-                <Grid Grid.Row="1">
-                    <DataGrid ItemsSource="{Binding Items}"
-                              SelectedItem="{Binding SelectedItem}"
-                              SelectionMode="Extended"
-                              IsReadOnly="False"
-                              AutoGenerateColumns="False"
-                              EnableColumnVirtualization="True"
-                              Background="{StaticResource SurfaceBrush}"
-                              BorderBrush="{StaticResource BorderBrushAlt}"
-                              Style="{StaticResource VirtualizedDataGridStyle}">
-                        <DataGrid.Resources>
-                            <helpers:BindingProxy x:Key="VmProxy" Data="{Binding}"/>
-                        </DataGrid.Resources>
-                        <DataGrid.RowStyle>
-                            <Style TargetType="DataGridRow">
-                                <EventSetter Event="PreviewMouseRightButtonDown"
-                                             Handler="DataGridRow_PreviewMouseRightButtonDown"/>
-                                <EventSetter Event="Loaded"
-                                             Handler="DataGridRow_Loaded"/>
-                                <EventSetter Event="Unloaded"
-                                             Handler="DataGridRow_Unloaded"/>
-                            </Style>
-                        </DataGrid.RowStyle>
-                        <DataGrid.Columns>
-                            <DataGridTextColumn Header="Number" Visibility="{Binding Data.ShowItemNumber, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding ItemNumber, Mode=OneWay}" Width="140"/>
-                            <DataGridTextColumn Header="Part #" Visibility="{Binding Data.ShowPartNumber, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding PartNumber, Mode=OneWay}" Width="140"/>
-                            <DataGridTextColumn Header="Name" Visibility="{Binding Data.ShowName, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Name, Mode=OneWay}" Width="280"/>
-                            <DataGridTextColumn Header="Brand" Visibility="{Binding Data.ShowBrand, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Brand, Mode=OneWay}" Width="160"/>
-                            <DataGridTextColumn Header="Qty" Visibility="{Binding Data.ShowQuantityOnHand, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding QuantityOnHand, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100"/>
-                            <DataGridTextColumn Header="Location" Visibility="{Binding Data.ShowLocation, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Location, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="180"/>
-                            <DataGridTextColumn Header="Price" Visibility="{Binding Data.ShowPrice, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Price, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="120"/>
-                            <DataGridTextColumn Header="Notes" Visibility="{Binding Data.ShowNotes, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Notes, Mode=OneWay}" Width="300"/>
-                        </DataGrid.Columns>
-                        <DataGrid.ContextMenu>
-                            <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
-                                        DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                                <MenuItem Header="Delete"
-                                          Command="{Binding PlacementTarget.DataContext.DeleteItemsCommand,
-                                                            RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                                          CommandParameter="{Binding PlacementTarget.SelectedItems,
-                                                            RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                            </ContextMenu>
-                        </DataGrid.ContextMenu>
-                    </DataGrid>
-                    <TextBlock Text="No results"
-                               HorizontalAlignment="Center"
-                               VerticalAlignment="Center"
-                               FontSize="16"
-                               FontWeight="SemiBold">
-                        <TextBlock.Style>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="Visibility" Value="Collapsed"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Items.Count}" Value="0">
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
-                </Grid>
-
-                <ProgressBar Grid.Row="2"
+        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <DataGrid ItemsSource="{Binding Items}"
+                          SelectedItem="{Binding SelectedItem}"
+                          SelectionMode="Extended"
+                          IsReadOnly="False"
+                          AutoGenerateColumns="False"
+                          EnableColumnVirtualization="True"
+                          Background="{StaticResource SurfaceBrush}"
+                          BorderBrush="{StaticResource BorderBrushAlt}"
+                          Style="{StaticResource VirtualizedDataGridStyle}">
+                    <DataGrid.Resources>
+                        <helpers:BindingProxy x:Key="VmProxy" Data="{Binding}"/>
+                    </DataGrid.Resources>
+                    <DataGrid.RowStyle>
+                        <Style TargetType="DataGridRow">
+                            <EventSetter Event="PreviewMouseRightButtonDown"
+                                         Handler="DataGridRow_PreviewMouseRightButtonDown"/>
+                            <EventSetter Event="Loaded" Handler="DataGridRow_Loaded"/>
+                            <EventSetter Event="Unloaded" Handler="DataGridRow_Unloaded"/>
+                        </Style>
+                    </DataGrid.RowStyle>
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Number" Visibility="{Binding Data.ShowItemNumber, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding ItemNumber, Mode=OneWay}" Width="140"/>
+                        <DataGridTextColumn Header="Part #" Visibility="{Binding Data.ShowPartNumber, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding PartNumber, Mode=OneWay}" Width="140"/>
+                        <DataGridTextColumn Header="Name" Visibility="{Binding Data.ShowName, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Name, Mode=OneWay}" Width="280"/>
+                        <DataGridTextColumn Header="Brand" Visibility="{Binding Data.ShowBrand, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Brand, Mode=OneWay}" Width="160"/>
+                        <DataGridTextColumn Header="Qty" Visibility="{Binding Data.ShowQuantityOnHand, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding QuantityOnHand, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100"/>
+                        <DataGridTextColumn Header="Location" Visibility="{Binding Data.ShowLocation, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Location, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="180"/>
+                        <DataGridTextColumn Header="Price" Visibility="{Binding Data.ShowPrice, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Price, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="120"/>
+                        <DataGridTextColumn Header="Notes" Visibility="{Binding Data.ShowNotes, Source={StaticResource VmProxy}, Converter={StaticResource BoolToVis}}" Binding="{Binding Notes, Mode=OneWay}" Width="300"/>
+                    </DataGrid.Columns>
+                    <DataGrid.ContextMenu>
+                        <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
+                                    DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                            <MenuItem Header="Delete"
+                                      Command="{Binding PlacementTarget.DataContext.DeleteItemsCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                      CommandParameter="{Binding PlacementTarget.SelectedItems, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                        </ContextMenu>
+                    </DataGrid.ContextMenu>
+                </DataGrid>
+                <TextBlock Text="No results"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           FontSize="16"
+                           FontWeight="SemiBold">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Items.Count}" Value="0">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+                <ProgressBar Grid.Row="1"
                              IsIndeterminate="True"
                              Height="4"
                              Margin="0,8,0,0"
                              Visibility="{Binding Items.IsLoading, Converter={StaticResource BoolToVis}}"/>
-
-                <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
-                    <Button
-                        Style="{StaticResource PrimaryButton}"
-                        Content="Edit"
-                        Command="{Binding EditItemCommand}"/>
-                    <Button
-                        Style="{StaticResource PrimaryButton}"
-                        Content="View Details"
-                        Command="{Binding ViewDetailsCommand}"
-                        Margin="8,0,0,0"/>
-                    <Button
-                        Style="{StaticResource PrimaryButton}"
-                        Content="Rental History"
-                        Command="{Binding OpenRentalHistoryCommand}"
-                        Margin="8,0,0,0"/>
-                    <Button
-                        Style="{StaticResource PrimaryButton}"
-                        Content="New"
-                        Command="{Binding NewItemCommand}"
-                        Margin="8,0,0,0"/>
-                </StackPanel>
             </Grid>
         </Border>
     </Grid>


### PR DESCRIPTION
## Summary
- move Manage Items buttons into top DockPanel toolbar and align styling with Users page
- add UI test verifying action buttons precede the data grid

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad550eddec8324b004a80f3c1befc7