### PR TITLE
Expose rental flag in item editor

### DIFF
--- a/InventoryManagementApp.Tests/ItemEditWindowXamlTests.cs
+++ b/InventoryManagementApp.Tests/ItemEditWindowXamlTests.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ItemEditWindowXamlTests
+    {
+        [Fact]
+        public void ContainsRentalItemCheckBoxBinding()
+        {
+            var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "InventoryManagementApp", "Views", "Windows", "ItemEditWindow.xaml"));
+            var doc = XDocument.Load(path);
+            XNamespace ns = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+            var hasBinding = doc
+                .Descendants(ns + "CheckBox")
+                .Any(cb => (string?)cb.Attribute("IsChecked")?.Contains("ItemModel.IsRentalItem") == true);
+            Assert.True(hasBinding, "CheckBox bound to ItemModel.IsRentalItem not found");
+        }
+    }
+}

--- a/InventoryManagementApp/Views/Windows/ItemEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ItemEditWindow.xaml
@@ -26,6 +26,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
@@ -49,7 +50,9 @@
 
             <CheckBox Grid.Row="6" Grid.ColumnSpan="2" Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Power {0}'}" IsChecked="{Binding ItemModel.IsPowered}" Margin="0,0,0,8"/>
 
-            <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,0,0,8">
+            <CheckBox Grid.Row="7" Grid.ColumnSpan="2" Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Rental {0}'}" IsChecked="{Binding ItemModel.IsRentalItem}" Margin="0,0,0,8"/>
+
+            <StackPanel Grid.Row="8" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,0,0,8">
                 <Image Width="100" Height="100" Stretch="Uniform"
                        Source="{Binding ItemModel.ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
                 <StackPanel Orientation="Vertical" Margin="8,0,0,0">
@@ -58,7 +61,7 @@
                 </StackPanel>
             </StackPanel>
 
-            <StackPanel Grid.Row="8" Grid.ColumnSpan="2" Orientation="Vertical">
+            <StackPanel Grid.Row="9" Grid.ColumnSpan="2" Orientation="Vertical">
                 <TextBlock Text="Notes" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/>
                 <TextBox Text="{Binding ItemModel.Notes, UpdateSourceTrigger=PropertyChanged}" Height="90" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
             </StackPanel>


### PR DESCRIPTION
## Summary
- expose rental flag in ItemEditWindow and adjust row layout
- add regression test ensuring rental checkbox binding exists

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7bad06f48324865cd5fa7a80e3fc