### PR TITLE
Show initials when user photos are missing

### DIFF
--- a/InventoryManagementApp.Tests/NameToInitialsConverterTests.cs
+++ b/InventoryManagementApp.Tests/NameToInitialsConverterTests.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+using InventoryManagementApp.Utilities.Converters;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class NameToInitialsConverterTests
+    {
+        [Theory]
+        [InlineData("John Doe", "JD")]
+        [InlineData("alice", "A")]
+        [InlineData(" Bob Charles David ", "BD")]
+        [InlineData("", "")]
+        public void Convert_ReturnsExpectedInitials(string? name, string expected)
+        {
+            var converter = new NameToInitialsConverter();
+            var result = converter.Convert(name, typeof(string), null, CultureInfo.InvariantCulture);
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/InventoryManagementApp.Tests/UserInitialsDisplayTests.cs
+++ b/InventoryManagementApp.Tests/UserInitialsDisplayTests.cs
@@ -1,0 +1,175 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Markup;
+using System.Windows.Media;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class UserInitialsDisplayTests
+    {
+        [Fact]
+        public void UsersPage_ShowsInitialsWhenNoPhotoPath()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
+
+                    var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "InventoryManagementApp", "Views", "Pages", "UsersPage.xaml"));
+                    var xaml = File.ReadAllText(path);
+                    xaml = Regex.Replace(xaml, "x:Class=\\\"[^\\\"]*\\\"\\s*", string.Empty);
+                    var page = (Page)XamlReader.Parse(xaml);
+                    var dataGrid = FindVisualChild<DataGrid>(page) ?? throw new InvalidOperationException("DataGrid not found");
+                    var col = (DataGridTemplateColumn)dataGrid.Columns[0];
+                    var element = (FrameworkElement)col.CellTemplate.LoadContent();
+                    element.DataContext = new { UserName = "John Doe", UserPhotoPath = (string?)null };
+                    element.Measure(new Size(36, 36));
+                    element.Arrange(new Rect(0, 0, 36, 36));
+                    element.UpdateLayout();
+                    var textBlock = FindVisualChild<TextBlock>(element) ?? throw new InvalidOperationException("TextBlock not found");
+                    var image = FindVisualChild<Image>(element) ?? throw new InvalidOperationException("Image not found");
+                    Assert.Equal("JD", textBlock.Text);
+                    Assert.Equal(Visibility.Visible, textBlock.Visibility);
+                    Assert.Equal(Visibility.Collapsed, image.Visibility);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
+        public void MainWindow_ShowsInitialsWhenNoPhotoPath()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
+
+                    var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "InventoryManagementApp", "MainWindow.xaml"));
+                    var xaml = File.ReadAllText(path);
+                    xaml = Regex.Replace(xaml, "x:Class=\\\"[^\\\"]*\\\"\\s*", string.Empty);
+                    var window = (Window)XamlReader.Parse(xaml);
+                    window.DataContext = new { CurrentUserName = "John Doe", CurrentUserPhotoPath = (string?)null };
+                    window.Measure(new Size(100, 100));
+                    window.Arrange(new Rect(0, 0, 100, 100));
+                    window.UpdateLayout();
+                    var border = FindVisualChildren<Border>(window).First(b => b.Width == 60 && b.Height == 60);
+                    var grid = VisualTreeHelper.GetChild(border, 0) as Grid ?? throw new InvalidOperationException("Grid not found");
+                    var textBlock = grid.Children.OfType<TextBlock>().Single();
+                    var image = grid.Children.OfType<Image>().Single();
+                    Assert.Equal("JD", textBlock.Text);
+                    Assert.Equal(Visibility.Visible, textBlock.Visibility);
+                    Assert.Equal(Visibility.Collapsed, image.Visibility);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
+        public void UsersEditWindow_ShowsInitialsWhenNoPhotoPath()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
+
+                    var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "InventoryManagementApp", "Views", "Windows", "UsersEditWindow.xaml"));
+                    var xaml = File.ReadAllText(path);
+                    xaml = Regex.Replace(xaml, "x:Class=\\\"[^\\\"]*\\\"\\s*", string.Empty);
+                    var window = (Window)XamlReader.Parse(xaml);
+                    window.DataContext = new { EditingUser = new { UserName = "John Doe", UserPhotoPath = (string?)null } };
+                    window.Measure(new Size(120, 120));
+                    window.Arrange(new Rect(0, 0, 120, 120));
+                    window.UpdateLayout();
+                    var border = FindVisualChildren<Border>(window).First(b => b.Width == 96 && b.Height == 96);
+                    var grid = VisualTreeHelper.GetChild(border, 0) as Grid ?? throw new InvalidOperationException("Grid not found");
+                    var textBlock = grid.Children.OfType<TextBlock>().Single();
+                    var image = grid.Children.OfType<Image>().Single();
+                    Assert.Equal("JD", textBlock.Text);
+                    Assert.Equal(Visibility.Visible, textBlock.Visibility);
+                    Assert.Equal(Visibility.Collapsed, image.Visibility);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                if (child is T t)
+                    return t;
+                var result = FindVisualChild<T>(child);
+                if (result != null)
+                    return result;
+            }
+            return null;
+        }
+
+        private static System.Collections.Generic.IEnumerable<T> FindVisualChildren<T>(DependencyObject parent) where T : DependencyObject
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                if (child is T t)
+                    yield return t;
+                foreach (var grand in FindVisualChildren<T>(child))
+                    yield return grand;
+            }
+        }
+    }
+}

--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -102,7 +102,34 @@
                 <DockPanel>
                     <TextBlock Text="{Binding CurrentPageTitle}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="10" Style="{StaticResource PageTitleTextBlock}"/>
                     <Border Width="60" Height="60" DockPanel.Dock="Right"  CornerRadius="16" ClipToBounds="True" Margin="0,0,8,0">
-                        <Image Source="{Binding CurrentUserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}" Stretch="Uniform"/>
+                        <Grid>
+                            <Image Source="{Binding CurrentUserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
+                                   Stretch="Uniform">
+                                <Image.Style>
+                                    <Style TargetType="Image">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding CurrentUserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Image.Style>
+                            </Image>
+                            <TextBlock Text="{Binding CurrentUserName, Converter={StaticResource NameToInitialsConverter}}"
+                                       HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding CurrentUserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </Grid>
                     </Border>
                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         

--- a/InventoryManagementApp/Resources/Converters.xaml
+++ b/InventoryManagementApp/Resources/Converters.xaml
@@ -5,4 +5,6 @@
     <conv:BooleanToAdminConverter x:Key="BooleanToAdminConverter"/>
     <conv:DateTimeMinToEmptyStringConverter x:Key="DateTimeMinToEmptyStringConverter"/>
     <conv:AnyTrueToVisibilityConverter x:Key="AnyTrueToVisibilityConverter"/>
+    <conv:NonEmptyStringToBoolConverter x:Key="NonEmptyStringToBoolConverter"/>
+    <conv:NameToInitialsConverter x:Key="NameToInitialsConverter"/>
 </ResourceDictionary>

--- a/InventoryManagementApp/Utilities/Converters/NameToInitialsConverter.cs
+++ b/InventoryManagementApp/Utilities/Converters/NameToInitialsConverter.cs
@@ -1,0 +1,48 @@
+// NameToInitialsConverter.cs
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Data;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace InventoryManagementApp.Utilities.Converters
+{
+    public class NameToInitialsConverter : IValueConverter
+    {
+        private readonly ILogger<NameToInitialsConverter> _logger;
+
+        public NameToInitialsConverter() : this(null) { }
+
+        public NameToInitialsConverter(ILogger<NameToInitialsConverter>? logger = null)
+            => _logger = logger ?? NullLogger<NameToInitialsConverter>.Instance;
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            try
+            {
+                var name = (value as string)?.Trim();
+                if (string.IsNullOrEmpty(name))
+                    return string.Empty;
+
+                var parts = name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 0)
+                    return string.Empty;
+                if (parts.Length == 1)
+                    return parts[0][0].ToString().ToUpperInvariant();
+
+                var first = parts[0][0];
+                var last = parts[^1][0];
+                return string.Concat(char.ToUpperInvariant(first), char.ToUpperInvariant(last));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to convert name to initials");
+                return string.Empty;
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => throw new NotSupportedException();
+    }
+}

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml
@@ -38,9 +38,35 @@
                     <DataGridTemplateColumn Header="Avatar" Width="60">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <Image Width="36" Height="36"
-                                       Source="{Binding UserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
-                                       Stretch="Uniform"/>
+                                <Grid Width="36" Height="36">
+                                    <Image Source="{Binding UserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
+                                           Stretch="Uniform">
+                                        <Image.Style>
+                                            <Style TargetType="Image">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Image.Style>
+                                    </Image>
+                                    <TextBlock Text="{Binding UserName, Converter={StaticResource NameToInitialsConverter}}"
+                                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                                               FontWeight="Bold">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True">
+                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </Grid>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>

--- a/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
@@ -30,9 +30,35 @@
             </Grid.RowDefinitions>
 
             <Border Grid.RowSpan="7" Width="96" Height="96" CornerRadius="8" VerticalAlignment="top" Background="{StaticResource SurfaceAltBrush}" Margin="0,0,12,0">
-                <Image Width="96" Height="96"
-                       Source="{Binding EditingUser.UserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
-                       Stretch="UniformToFill" ClipToBounds="True"/>
+                <Grid>
+                    <Image Width="96" Height="96"
+                           Source="{Binding EditingUser.UserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
+                           Stretch="UniformToFill" ClipToBounds="True">
+                        <Image.Style>
+                            <Style TargetType="Image">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Image.Style>
+                    </Image>
+                    <TextBlock Text="{Binding EditingUser.UserName, Converter={StaticResource NameToInitialsConverter}}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Visible"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Grid>
             </Border>
 
             <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="0,0,0,8">


### PR DESCRIPTION
## Summary
- Convert full names to initials via NameToInitialsConverter
- Display initials over avatar areas when no photo path exists
- Test converter and UI initials behaviour

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8487595c83248a573896c75379d6