### PR TITLE
style: adjust user initials text styling

### DIFF
--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -117,7 +117,8 @@
                                 </Image.Style>
                             </Image>
                             <TextBlock Text="{Binding CurrentUserName, Converter={StaticResource NameToInitialsConverter}}"
-                                       HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold">
+                                       HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" FontSize="28"
+                                       Foreground="{StaticResource ForegroundBrush}">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock">
                                         <Setter Property="Visibility" Value="Visible"/>

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml
@@ -54,7 +54,8 @@
                                     </Image>
                                     <TextBlock Text="{Binding UserName, Converter={StaticResource NameToInitialsConverter}}"
                                                HorizontalAlignment="Center" VerticalAlignment="Center"
-                                               FontWeight="Bold">
+                                               FontWeight="Bold" FontSize="20"
+                                               Foreground="{StaticResource ForegroundBrush}">
                                         <TextBlock.Style>
                                             <Style TargetType="TextBlock">
                                                 <Setter Property="Visibility" Value="Visible"/>

--- a/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
@@ -46,7 +46,8 @@
                         </Image.Style>
                     </Image>
                     <TextBlock Text="{Binding EditingUser.UserName, Converter={StaticResource NameToInitialsConverter}}"
-                               HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold">
+                               HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" FontSize="48"
+                               Foreground="{StaticResource ForegroundBrush}">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock">
                                 <Setter Property="Visibility" Value="Visible"/>


### PR DESCRIPTION
## Summary
- enlarge user initials in user lists and profile windows
- apply standard foreground color to initials across views

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad86a4a0d8832485eb42b3db26edb8