### PR TITLE
Display initials on login when photo missing

### DIFF
--- a/InventoryManagementApp.Tests/UserInitialsDisplayTests.cs
+++ b/InventoryManagementApp.Tests/UserInitialsDisplayTests.cs
@@ -146,6 +146,54 @@ namespace InventoryManagementApp.Tests
             if (threadEx != null) throw threadEx;
         }
 
+        [Fact]
+        public void LoginWindow_ShowsInitialsWhenNoPhotoPath()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
+
+                    var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "InventoryManagementApp", "Views", "Windows", "LoginWindow.xaml"));
+                    var xaml = File.ReadAllText(path);
+                    xaml = Regex.Replace(xaml, "x:Class=\\\"[^\\\"]*\\\"\\s*", string.Empty);
+                    var window = (Window)XamlReader.Parse(xaml);
+                    window.DataContext = new { WindowTitle = "", Users = new[] { new { UserName = "John Doe", UserPhotoPath = (string?)null } } };
+                    window.Measure(new Size(120, 120));
+                    window.Arrange(new Rect(0, 0, 120, 120));
+                    window.UpdateLayout();
+                    var itemsControl = FindVisualChildren<ItemsControl>(window).First(i => i.Name == "UsersListBox");
+                    var element = (FrameworkElement)itemsControl.ItemTemplate.LoadContent();
+                    element.DataContext = new { UserName = "John Doe", UserPhotoPath = (string?)null };
+                    element.Measure(new Size(100, 100));
+                    element.Arrange(new Rect(0, 0, 100, 100));
+                    element.UpdateLayout();
+                    var textBlock = FindVisualChild<TextBlock>(element) ?? throw new InvalidOperationException("TextBlock not found");
+                    var image = FindVisualChild<Image>(element) ?? throw new InvalidOperationException("Image not found");
+                    Assert.Equal("JD", textBlock.Text);
+                    Assert.Equal(Visibility.Visible, textBlock.Visibility);
+                    Assert.Equal(Visibility.Collapsed, image.Visibility);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
         private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
         {
             for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)

--- a/InventoryManagementApp/Views/Windows/LoginWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/LoginWindow.xaml
@@ -59,7 +59,43 @@
                                             BorderBrush="{StaticResource BorderBrushAlt}"
                                             BorderThickness="1"
                                             ClipToBounds="True">
-                                        <Image Stretch="Uniform" Source="{Binding UserPhotoPath, ConverterParameter=user, Converter={StaticResource NullToDefaultImageConverter}}"/>
+                                        <Grid>
+                                            <Image Stretch="Uniform"
+                                                   Source="{Binding UserPhotoPath}">
+                                                <Image.Style>
+                                                    <Style TargetType="Image">
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding UserPhotoPath}" Value="">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding UserPhotoPath}" Value="{x:Null}">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Image.Style>
+                                            </Image>
+                                            <TextBlock Text="{Binding UserName, Converter={StaticResource NameToInitialsConverter}}"
+                                                       FontSize="48"
+                                                       Foreground="{StaticResource ForegroundBrush}"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding UserPhotoPath}" Value="">
+                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding UserPhotoPath}" Value="{x:Null}">
+                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </Grid>
                                     </Border>
                                     <TextBlock Grid.Row="1"
                                                Text="{Binding UserName}"


### PR DESCRIPTION
## Summary
- show user initials in login tiles when no photo is available
- test LoginWindow to ensure initials display in absence of user photo

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad873091a883248ad45b57673a5055