### PR TITLE
Add current user presence binding for avatar display

### DIFF
--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -103,33 +103,41 @@
                     <TextBlock Text="{Binding CurrentPageTitle}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="10" Style="{StaticResource PageTitleTextBlock}"/>
                     <Border Width="60" Height="60" DockPanel.Dock="Right"  CornerRadius="16" ClipToBounds="True" Margin="0,0,8,0">
                         <Grid>
-                            <Image Source="{Binding CurrentUserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
-                                   Stretch="Uniform">
-                                <Image.Style>
-                                    <Style TargetType="Image">
-                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding CurrentUserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True">
-                                                <Setter Property="Visibility" Value="Visible"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </Image.Style>
-                            </Image>
-                            <TextBlock Text="{Binding CurrentUserName, Converter={StaticResource NameToInitialsConverter}}"
-                                       HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" FontSize="28"
-                                       Foreground="{StaticResource ForegroundBrush}">
-                                <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding CurrentUserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True">
-                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </TextBlock.Style>
-                            </TextBlock>
+                              <Image Source="{Binding CurrentUserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
+                                     Stretch="Uniform">
+                                  <Image.Style>
+                                      <Style TargetType="Image">
+                                          <Setter Property="Visibility" Value="Visible"/>
+                                          <Style.Triggers>
+                                              <MultiDataTrigger>
+                                                  <MultiDataTrigger.Conditions>
+                                                      <Condition Binding="{Binding HasCurrentUser}" Value="True"/>
+                                                      <Condition Binding="{Binding CurrentUserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
+                                                  </MultiDataTrigger.Conditions>
+                                                  <Setter Property="Visibility" Value="Collapsed"/>
+                                              </MultiDataTrigger>
+                                          </Style.Triggers>
+                                      </Style>
+                                  </Image.Style>
+                              </Image>
+                              <TextBlock Text="{Binding CurrentUserName, Converter={StaticResource NameToInitialsConverter}}"
+                                         HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" FontSize="28"
+                                         Foreground="{StaticResource ForegroundBrush}">
+                                  <TextBlock.Style>
+                                      <Style TargetType="TextBlock">
+                                          <Setter Property="Visibility" Value="Collapsed"/>
+                                          <Style.Triggers>
+                                              <MultiDataTrigger>
+                                                  <MultiDataTrigger.Conditions>
+                                                      <Condition Binding="{Binding HasCurrentUser}" Value="True"/>
+                                                      <Condition Binding="{Binding CurrentUserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
+                                                  </MultiDataTrigger.Conditions>
+                                                  <Setter Property="Visibility" Value="Visible"/>
+                                              </MultiDataTrigger>
+                                          </Style.Triggers>
+                                      </Style>
+                                  </TextBlock.Style>
+                              </TextBlock>
                         </Grid>
                     </Border>
                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -106,6 +106,8 @@ namespace InventoryManagementApp.ViewModels
 
         public string? CurrentUserPhotoPath => _userContext.CurrentUser?.UserPhotoPath;
 
+        public bool HasCurrentUser => _userContext.CurrentUser != null;
+
         private string _applicationName = string.Empty;
         public string ApplicationName
         {
@@ -152,6 +154,7 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(CurrentUserName));
             OnPropertyChanged(nameof(CurrentUserRole));
             OnPropertyChanged(nameof(CurrentUserPhotoPath));
+            OnPropertyChanged(nameof(HasCurrentUser));
         }
 
         void CloseNonMainWindows()
@@ -429,11 +432,12 @@ namespace InventoryManagementApp.ViewModels
             _globalSearchDebounceTimer.Tick += OnGlobalSearchDebounceTimerTick;
 
             SwitchUserCommand = new AsyncRelayCommand(async () =>
-            {
-                var previousUser = _userContext.CurrentUser;
-                _userContext.CurrentUser = null;
-                CloseNonMainWindows();
-                ClearSearch();
+                {
+                    var previousUser = _userContext.CurrentUser;
+                    _userContext.CurrentUser = null;
+                    RefreshCurrentUser();
+                    CloseNonMainWindows();
+                    ClearSearch();
                 try
                 {
                     await _settingsService.DeleteSettingAsync("LastFilter").ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- expose `HasCurrentUser` in `MainViewModel` and refresh when user changes
- update avatar display logic in `MainWindow.xaml` to show initials when no photo
- ensure `SwitchUserCommand` refreshes user bindings immediately

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad88fbc98c832488c250422cd2281d