### PR TITLE
Assign unique user avatar brushes

### DIFF
--- a/InventoryManagementApp.Tests/UserInitialsBrushTests.cs
+++ b/InventoryManagementApp.Tests/UserInitialsBrushTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Documents;
+using System.Windows.Media;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.ViewModels;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class UserInitialsBrushTests
+    {
+        [Fact]
+        public void UsersWithSameInitialsGetDifferentBrushes()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    var users = new List<User>
+                    {
+                        new User { UserID = 1, UserName = "John Doe" },
+                        new User { UserID = 2, UserName = "Jane Doe" },
+                        new User { UserID = 3, UserName = "Alice Smith" }
+                    };
+                    var svc = new StubUserService(users);
+                    var vm = new UserManagementViewModel(svc, new DummyFileDialogService(), new DummyDialogService());
+                    vm.LoadUsersAsync().GetAwaiter().GetResult();
+                    Assert.NotEqual(vm.Users[0].InitialsBrush, vm.Users[1].InitialsBrush);
+                    Assert.Equal(Brushes.Transparent, vm.Users[2].InitialsBrush);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        private sealed class StubUserService : IUserService
+        {
+            private readonly List<User> _users;
+            public StubUserService(List<User> users) => _users = users;
+            public Task<List<User>> GetAllUsersAsync() => Task.FromResult(_users);
+            public Task<int> CountUsersAsync() => throw new NotImplementedException();
+            public Task<User?> GetUserByIDAsync(int userID) => throw new NotImplementedException();
+            public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => throw new NotImplementedException();
+            public Task<User?> GetCurrentUserAsync() => throw new NotImplementedException();
+            public Task AddUserAsync(User user) => throw new NotImplementedException();
+            public Task UpdateUserAsync(User user) => throw new NotImplementedException();
+            public Task<bool> TryDeleteUserAsync(int userID) => throw new NotImplementedException();
+            public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => throw new NotImplementedException();
+        }
+
+        private sealed class DummyFileDialogService : IFileDialogService
+        {
+            public string? OpenFile(string filter, string? initialDirectory = null) => null;
+            public string? SaveFile(string filter) => null;
+        }
+
+        private sealed class DummyDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => false;
+            public ItemModel? ShowEditItemDialog(ItemModel item) => null;
+            public void ShowItemDetails(ItemModel item) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+            public CustomerModel? ShowEditCustomerDialog(CustomerModel customer) => null;
+            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
+            public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+        }
+    }
+}

--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -120,11 +120,9 @@
                                       </Style>
                                   </Image.Style>
                               </Image>
-                              <TextBlock Text="{Binding CurrentUserName, Converter={StaticResource NameToInitialsConverter}}"
-                                         HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" FontSize="28"
-                                         Foreground="{StaticResource ForegroundBrush}">
-                                  <TextBlock.Style>
-                                      <Style TargetType="TextBlock">
+                              <Border Background="{Binding CurrentUserInitialsBrush}">
+                                  <Border.Style>
+                                      <Style TargetType="Border">
                                           <Setter Property="Visibility" Value="Collapsed"/>
                                           <Style.Triggers>
                                               <MultiDataTrigger>
@@ -136,8 +134,26 @@
                                               </MultiDataTrigger>
                                           </Style.Triggers>
                                       </Style>
-                                  </TextBlock.Style>
-                              </TextBlock>
+                                  </Border.Style>
+                                  <TextBlock Text="{Binding CurrentUserName, Converter={StaticResource NameToInitialsConverter}}"
+                                             HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" FontSize="28"
+                                             Foreground="{StaticResource ForegroundBrush}">
+                                      <TextBlock.Style>
+                                          <Style TargetType="TextBlock">
+                                              <Setter Property="Visibility" Value="Collapsed"/>
+                                              <Style.Triggers>
+                                                  <MultiDataTrigger>
+                                                      <MultiDataTrigger.Conditions>
+                                                          <Condition Binding="{Binding HasCurrentUser}" Value="True"/>
+                                                          <Condition Binding="{Binding CurrentUserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
+                                                      </MultiDataTrigger.Conditions>
+                                                      <Setter Property="Visibility" Value="Visible"/>
+                                                  </MultiDataTrigger>
+                                              </Style.Triggers>
+                                          </Style>
+                                      </TextBlock.Style>
+                                  </TextBlock>
+                              </Border>
                         </Grid>
                     </Border>
                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">

--- a/InventoryManagementApp/Models/Domain/User.cs
+++ b/InventoryManagementApp/Models/Domain/User.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Windows.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 #nullable enable
@@ -48,5 +49,8 @@ namespace InventoryManagementApp.Models.Domain
 
         private bool _passwordExpired;
         public bool PasswordExpired { get => _passwordExpired; set => SetProperty(ref _passwordExpired, value); }
+
+        private Brush _initialsBrush = Brushes.Transparent;
+        public Brush InitialsBrush { get => _initialsBrush; set => SetProperty(ref _initialsBrush, value); }
     }
 }

--- a/InventoryManagementApp/Models/ModelAliases.cs
+++ b/InventoryManagementApp/Models/ModelAliases.cs
@@ -1,4 +1,5 @@
-﻿global using ItemModel = InventoryManagementApp.Models.Domain.ItemModel;
+global using System.Windows.Media;
+global using ItemModel = InventoryManagementApp.Models.Domain.ItemModel;
 global using UserModel = InventoryManagementApp.Models.Domain.User;
 global using CustomerModel = InventoryManagementApp.Models.Domain.Customer;
 global using RentalModel = InventoryManagementApp.Models.Domain.Rental;

--- a/InventoryManagementApp/Resources/Colors.xaml
+++ b/InventoryManagementApp/Resources/Colors.xaml
@@ -24,4 +24,14 @@
     <Color x:Key="Col.CardBackground">#1F1F1F</Color>
     <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource Col.CardBackground}"/>
     <SolidColorBrush x:Key="OverlayBrush" Color="#80000000"/>
+    <x:Array x:Key="UserInitialsBrushes" Type="SolidColorBrush">
+        <SolidColorBrush Color="#FF1ABC9C"/>
+        <SolidColorBrush Color="#FF3498DB"/>
+        <SolidColorBrush Color="#FF9B59B6"/>
+        <SolidColorBrush Color="#FFE74C3C"/>
+        <SolidColorBrush Color="#FFE67E22"/>
+        <SolidColorBrush Color="#FFF1C40F"/>
+        <SolidColorBrush Color="#FF2ECC71"/>
+        <SolidColorBrush Color="#FF34495E"/>
+    </x:Array>
 </ResourceDictionary>

--- a/InventoryManagementApp/ViewModels/LoginViewModel.cs
+++ b/InventoryManagementApp/ViewModels/LoginViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
@@ -190,7 +191,41 @@ namespace InventoryManagementApp.ViewModels
                 users = await _userService.GetAllUsersAsync();
             }
 
+            AssignInitialsBrushes(users);
             Users.ReplaceRange(users.Where(u => u.IsActive));
+        }
+
+        static string GetInitials(string? name)
+        {
+            var n = name?.Trim();
+            if (string.IsNullOrEmpty(n)) return string.Empty;
+            var parts = n.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 0) return string.Empty;
+            if (parts.Length == 1) return parts[0][0].ToString().ToUpperInvariant();
+            return string.Concat(char.ToUpperInvariant(parts[0][0]), char.ToUpperInvariant(parts[^1][0]));
+        }
+
+        static void AssignInitialsBrushes(IList<User> users)
+        {
+            var palette = (Application.Current?.TryFindResource("UserInitialsBrushes") as IEnumerable<Brush>)?.ToList()
+                          ?? new List<Brush>();
+            var groups = users.GroupBy(u => GetInitials(u.UserName));
+            foreach (var group in groups)
+            {
+                if (group.Count() <= 1)
+                {
+                    foreach (var user in group)
+                        user.InitialsBrush = Brushes.Transparent;
+                    continue;
+                }
+
+                var idx = 0;
+                foreach (var user in group)
+                {
+                    user.InitialsBrush = palette.Count > 0 ? palette[idx % palette.Count] : Brushes.Transparent;
+                    idx++;
+                }
+            }
         }
 
         /// <summary>

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -108,6 +108,8 @@ namespace InventoryManagementApp.ViewModels
 
         public bool HasCurrentUser => _userContext.CurrentUser != null;
 
+        public Brush? CurrentUserInitialsBrush => _userContext.CurrentUser?.InitialsBrush;
+
         private string _applicationName = string.Empty;
         public string ApplicationName
         {
@@ -154,6 +156,7 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(CurrentUserName));
             OnPropertyChanged(nameof(CurrentUserRole));
             OnPropertyChanged(nameof(CurrentUserPhotoPath));
+            OnPropertyChanged(nameof(CurrentUserInitialsBrush));
             OnPropertyChanged(nameof(HasCurrentUser));
         }
 

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Utilities.Extensions;
@@ -101,12 +102,46 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 _allUsers = await _userService.GetAllUsersAsync();
+                AssignInitialsBrushes(_allUsers);
                 Users.ReplaceRange(_allUsers);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load users");
                 await _dialogService.ShowInfoAsync($"Failed to load users: {ex.Message}", "Error");
+            }
+        }
+
+        static string GetInitials(string? name)
+        {
+            var n = name?.Trim();
+            if (string.IsNullOrEmpty(n)) return string.Empty;
+            var parts = n.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 0) return string.Empty;
+            if (parts.Length == 1) return parts[0][0].ToString().ToUpperInvariant();
+            return string.Concat(char.ToUpperInvariant(parts[0][0]), char.ToUpperInvariant(parts[^1][0]));
+        }
+
+        static void AssignInitialsBrushes(IList<UserModel> users)
+        {
+            var palette = (Application.Current?.TryFindResource("UserInitialsBrushes") as IEnumerable<Brush>)?.ToList()
+                          ?? new List<Brush>();
+            var groups = users.GroupBy(u => GetInitials(u.UserName));
+            foreach (var group in groups)
+            {
+                if (group.Count() <= 1)
+                {
+                    foreach (var user in group)
+                        user.InitialsBrush = Brushes.Transparent;
+                    continue;
+                }
+
+                var idx = 0;
+                foreach (var user in group)
+                {
+                    user.InitialsBrush = palette.Count > 0 ? palette[idx % palette.Count] : Brushes.Transparent;
+                    idx++;
+                }
             }
         }
 

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml
@@ -52,12 +52,9 @@
                                             </Style>
                                         </Image.Style>
                                     </Image>
-                                    <TextBlock Text="{Binding UserName, Converter={StaticResource NameToInitialsConverter}}"
-                                               HorizontalAlignment="Center" VerticalAlignment="Center"
-                                               FontWeight="Bold" FontSize="20"
-                                               Foreground="{StaticResource ForegroundBrush}">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
+                                    <Border Background="{Binding InitialsBrush}">
+                                        <Border.Style>
+                                            <Style TargetType="Border">
                                                 <Setter Property="Visibility" Value="Visible"/>
                                                 <Style.Triggers>
                                                     <DataTrigger Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True">
@@ -65,8 +62,23 @@
                                                     </DataTrigger>
                                                 </Style.Triggers>
                                             </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
+                                        </Border.Style>
+                                        <TextBlock Text="{Binding UserName, Converter={StaticResource NameToInitialsConverter}}"
+                                                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                   FontWeight="Bold" FontSize="20"
+                                                   Foreground="{StaticResource ForegroundBrush}">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                    </Border>
                                 </Grid>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>

--- a/InventoryManagementApp/Views/Windows/LoginWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/LoginWindow.xaml
@@ -76,13 +76,9 @@
                                                     </Style>
                                                 </Image.Style>
                                             </Image>
-                                            <TextBlock Text="{Binding UserName, Converter={StaticResource NameToInitialsConverter}}"
-                                                       FontSize="48"
-                                                       Foreground="{StaticResource ForegroundBrush}"
-                                                       HorizontalAlignment="Center"
-                                                       VerticalAlignment="Center">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
+                                            <Border Background="{Binding InitialsBrush}">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
                                                         <Setter Property="Visibility" Value="Collapsed"/>
                                                         <Style.Triggers>
                                                             <DataTrigger Binding="{Binding UserPhotoPath}" Value="">
@@ -93,8 +89,27 @@
                                                             </DataTrigger>
                                                         </Style.Triggers>
                                                     </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
+                                                </Border.Style>
+                                                <TextBlock Text="{Binding UserName, Converter={StaticResource NameToInitialsConverter}}"
+                                                           FontSize="48"
+                                                           Foreground="{StaticResource ForegroundBrush}"
+                                                           HorizontalAlignment="Center"
+                                                           VerticalAlignment="Center">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding UserPhotoPath}" Value="">
+                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                </DataTrigger>
+                                                                <DataTrigger Binding="{Binding UserPhotoPath}" Value="{x:Null}">
+                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </Border>
                                         </Grid>
                                     </Border>
                                     <TextBlock Grid.Row="1"

--- a/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
@@ -45,11 +45,9 @@
                             </Style>
                         </Image.Style>
                     </Image>
-                    <TextBlock Text="{Binding EditingUser.UserName, Converter={StaticResource NameToInitialsConverter}}"
-                               HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" FontSize="48"
-                               Foreground="{StaticResource ForegroundBrush}">
-                        <TextBlock.Style>
-                            <Style TargetType="TextBlock">
+                    <Border Background="{Binding EditingUser.InitialsBrush}">
+                        <Border.Style>
+                            <Style TargetType="Border">
                                 <Setter Property="Visibility" Value="Visible"/>
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True">
@@ -57,8 +55,22 @@
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
+                        </Border.Style>
+                        <TextBlock Text="{Binding EditingUser.UserName, Converter={StaticResource NameToInitialsConverter}}"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" FontSize="48"
+                                   Foreground="{StaticResource ForegroundBrush}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </Border>
                 </Grid>
             </Border>
 


### PR DESCRIPTION
## Summary
- add `InitialsBrush` to `User` and expose via aliases
- color duplicate initials via palette in `UserManagementViewModel` and `LoginViewModel`
- display colored avatar backgrounds across user views
- add tests ensuring users with matching initials get distinct brushes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9af488a88324b3743a2a52a5deb5