### PR TITLE
Use file dialog for user image selection

### DIFF
--- a/InventoryManagementApp.Tests/UsersEditViewModelTests.cs
+++ b/InventoryManagementApp.Tests/UsersEditViewModelTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.ViewModels;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class UsersEditViewModelTests
+    {
+        private sealed class DummyFileDialogService : IFileDialogService
+        {
+            public string? Result { get; set; }
+            public string? OpenFile(string filter, string? initialDirectory = null) => Result;
+            public string? SaveFile(string filter) => null;
+        }
+
+        [Fact]
+        public void BrowseImageCommand_SetsPhotoPath()
+        {
+            var user = new User();
+            var dialog = new DummyFileDialogService { Result = "test.png" };
+            var vm = new UsersEditViewModel(user, dialog, onSave: () => Task.CompletedTask, onCancel: () => { });
+
+            vm.BrowseImageCommand.Execute(null);
+
+            Assert.Equal("test.png", user.UserPhotoPath);
+        }
+
+        [Fact]
+        public void RemoveImageCommand_ClearsPhotoPath()
+        {
+            var user = new User { UserPhotoPath = "test.png" };
+            var dialog = new DummyFileDialogService();
+            var vm = new UsersEditViewModel(user, dialog, onSave: () => Task.CompletedTask, onCancel: () => { });
+
+            vm.RemoveImageCommand.Execute(null);
+
+            Assert.Equal(string.Empty, user.UserPhotoPath);
+        }
+    }
+}
+

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -410,7 +410,7 @@ namespace InventoryManagementApp.ViewModels
                     if (win != null)
                         win.Close();
                 },
-                onRemoveAvatar: () => clone.UserPhotoPath = null);
+                fileDialogService: _fileDialogService);
 
             try { win.Owner = System.Windows.Application.Current?.MainWindow; } catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for UsersEditWindow"); }
             try { win.ShowDialog(); } catch (Exception ex) { _logger.LogError(ex, "Failed to show UsersEditWindow"); }

--- a/InventoryManagementApp/ViewModels/UsersEditViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UsersEditViewModel.cs
@@ -1,6 +1,7 @@
 ﻿// ViewModels/UsersEditViewModel.cs
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
 using System;
 using System.Threading.Tasks;
@@ -12,19 +13,36 @@ namespace InventoryManagementApp.ViewModels
         public string Title { get; }
         public User EditingUser { get; }
 
-        public IRelayCommand BrowseAvatarCommand { get; }
-        public IRelayCommand RemoveAvatarCommand { get; }
+        private readonly IFileDialogService _fileDialog;
+
+        public IRelayCommand BrowseImageCommand { get; }
+        public IRelayCommand RemoveImageCommand { get; }
         public IAsyncRelayCommand SaveCommand { get; }
         public IRelayCommand CancelCommand { get; }
 
-        public UsersEditViewModel(User user, Func<Task> onSave, Action onCancel, Action onBrowseAvatar, Action onRemoveAvatar)
+        public UsersEditViewModel(User user, IFileDialogService fileDialog, Func<Task> onSave, Action onCancel)
         {
             EditingUser = user ?? new User();
+            _fileDialog = fileDialog;
             Title = (EditingUser.UserID == 0) ? "Add User" : "Edit User";
-            BrowseAvatarCommand = new RelayCommand(onBrowseAvatar);
-            RemoveAvatarCommand = new RelayCommand(onRemoveAvatar);
+            BrowseImageCommand = new RelayCommand(BrowseImage);
+            RemoveImageCommand = new RelayCommand(RemoveImage);
             SaveCommand = new AsyncRelayCommand(onSave);
             CancelCommand = new RelayCommand(onCancel);
+        }
+
+        void BrowseImage()
+        {
+            var path = _fileDialog.OpenFile("Image Files|*.png;*.jpg;*.jpeg;*.bmp|All Files|*.*");
+            if (!string.IsNullOrEmpty(path))
+            {
+                EditingUser.UserPhotoPath = path;
+            }
+        }
+
+        void RemoveImage()
+        {
+            EditingUser.UserPhotoPath = string.Empty;
         }
     }
 }

--- a/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
@@ -75,8 +75,8 @@
             </Border>
 
             <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="0,0,0,8">
-                <Button Style="{StaticResource PrimaryButton}" Content="Browse Avatar" Command="{Binding BrowseAvatarCommand}" Margin="0,0,8,0"/>
-                <Button Style="{StaticResource PrimaryButton}" Width="130" Content="Remove Avatar" Command="{Binding RemoveAvatarCommand}"/>
+                <Button Style="{StaticResource PrimaryButton}" Content="Browse Image" Command="{Binding BrowseImageCommand}" Margin="0,0,8,0"/>
+                <Button Style="{StaticResource PrimaryButton}" Width="130" Content="Remove Image" Command="{Binding RemoveImageCommand}"/>
             </StackPanel>
 
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Username" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>

--- a/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml.cs
@@ -5,37 +5,17 @@ using System.Windows;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
 using InventoryManagementApp.Utilities.Extensions;
-using Microsoft.Extensions.DependencyInjection;
+using InventoryManagementApp.Interfaces;
 
 namespace InventoryManagementApp.Views.Windows
 {
     public partial class UsersEditWindow : Window
     {
-        public UsersEditWindow(User user, Func<Task> onSave, Action onCancel, Action onRemoveAvatar)
+        public UsersEditWindow(User user, Func<Task> onSave, Action onCancel, IFileDialogService fileDialogService)
         {
             InitializeComponent();
-            DataContext = new UsersEditViewModel(user, onSave, onCancel, BrowseAvatar, onRemoveAvatar);
+            DataContext = new UsersEditViewModel(user, fileDialogService, onSave, onCancel);
             this.DisposeDataContextOnUnload();
-        }
-
-        private void BrowseAvatar()
-        {
-            var vm = (UsersEditViewModel)DataContext;
-            var avatarWin = ((App)System.Windows.Application.Current).Host.Services.GetRequiredService<AvatarSelectionWindow>();
-
-            try { avatarWin.Owner = this; } catch { }
-
-            try
-            {
-                if (avatarWin.ShowDialog() == true && !string.IsNullOrEmpty(avatarWin.SelectedAvatarPath))
-                {
-                    vm.EditingUser.UserPhotoPath = avatarWin.SelectedAvatarPath;
-                }
-            }
-            catch
-            {
-                // Ignore UI errors in non-interactive environments
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace avatar browsing commands with image commands and wire up `IFileDialogService`
- Simplify `UsersEditWindow` to rely on file dialog service
- Update user management to pass file dialog service
- Add unit tests for `UsersEditViewModel` image commands

## Testing
- `dotnet test` *(failed: command not found; attempted apt-get but repository access was forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aec50a8acc8324a83e60f1f9a654b0