### PR TITLE
Explicitly alias WPF Brush types to avoid System.Drawing ambiguity

### DIFF
--- a/InventoryManagementApp/Models/Domain/User.cs
+++ b/InventoryManagementApp/Models/Domain/User.cs
@@ -1,5 +1,7 @@
 using System;
 using CommunityToolkit.Mvvm.ComponentModel;
+using MediaBrush = System.Windows.Media.Brush;
+using MediaBrushes = System.Windows.Media.Brushes;
 
 #nullable enable
 
@@ -49,7 +51,7 @@ namespace InventoryManagementApp.Models.Domain
         private bool _passwordExpired;
         public bool PasswordExpired { get => _passwordExpired; set => SetProperty(ref _passwordExpired, value); }
 
-        private Brush _initialsBrush = Brushes.Transparent;
-        public Brush InitialsBrush { get => _initialsBrush; set => SetProperty(ref _initialsBrush, value); }
+        private MediaBrush _initialsBrush = MediaBrushes.Transparent;
+        public MediaBrush InitialsBrush { get => _initialsBrush; set => SetProperty(ref _initialsBrush, value); }
     }
 }

--- a/InventoryManagementApp/ViewModels/LoginViewModel.cs
+++ b/InventoryManagementApp/ViewModels/LoginViewModel.cs
@@ -10,6 +10,8 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media.Imaging;
+using MediaBrush = System.Windows.Media.Brush;
+using MediaBrushes = System.Windows.Media.Brushes;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models;
 using InventoryManagementApp.Models.Domain;
@@ -208,22 +210,22 @@ namespace InventoryManagementApp.ViewModels
 
         static void AssignInitialsBrushes(IList<User> users)
         {
-            var palette = (Application.Current?.TryFindResource("UserInitialsBrushes") as IEnumerable<Brush>)?.ToList()
-                          ?? new List<Brush>();
+            var palette = (Application.Current?.TryFindResource("UserInitialsBrushes") as IEnumerable<MediaBrush>)?.ToList()
+                          ?? new List<MediaBrush>();
             var groups = users.GroupBy(u => GetInitials(u.UserName));
             foreach (var group in groups)
             {
                 if (group.Count() <= 1)
                 {
                     foreach (var user in group)
-                        user.InitialsBrush = Brushes.Transparent;
+                        user.InitialsBrush = MediaBrushes.Transparent;
                     continue;
                 }
 
                 var idx = 0;
                 foreach (var user in group)
                 {
-                    user.InitialsBrush = palette.Count > 0 ? palette[idx % palette.Count] : Brushes.Transparent;
+                    user.InitialsBrush = palette.Count > 0 ? palette[idx % palette.Count] : MediaBrushes.Transparent;
                     idx++;
                 }
             }

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -27,6 +27,8 @@ using InventoryManagementApp.Models.ImportExport;
 using InventoryManagementApp.Utilities;
 using InventoryManagementApp.Utilities.Helpers;
 using Application = System.Windows.Application;
+using MediaBrush = System.Windows.Media.Brush;
+using MediaBrushes = System.Windows.Media.Brushes;
 
 namespace InventoryManagementApp.ViewModels
 {
@@ -108,7 +110,7 @@ namespace InventoryManagementApp.ViewModels
 
         public bool HasCurrentUser => _userContext.CurrentUser != null;
 
-        public Brush? CurrentUserInitialsBrush => _userContext.CurrentUser?.InitialsBrush;
+        public MediaBrush? CurrentUserInitialsBrush => _userContext.CurrentUser?.InitialsBrush;
 
         private string _applicationName = string.Empty;
         public string ApplicationName

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -17,6 +17,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
 using Application = System.Windows.Application;
+using MediaBrush = System.Windows.Media.Brush;
+using MediaBrushes = System.Windows.Media.Brushes;
 
 namespace InventoryManagementApp.ViewModels
 {
@@ -125,22 +127,22 @@ namespace InventoryManagementApp.ViewModels
 
         static void AssignInitialsBrushes(IList<UserModel> users)
         {
-            var palette = (Application.Current?.TryFindResource("UserInitialsBrushes") as IEnumerable<Brush>)?.ToList()
-                          ?? new List<Brush>();
+            var palette = (Application.Current?.TryFindResource("UserInitialsBrushes") as IEnumerable<MediaBrush>)?.ToList()
+                          ?? new List<MediaBrush>();
             var groups = users.GroupBy(u => GetInitials(u.UserName));
             foreach (var group in groups)
             {
                 if (group.Count() <= 1)
                 {
                     foreach (var user in group)
-                        user.InitialsBrush = Brushes.Transparent;
+                        user.InitialsBrush = MediaBrushes.Transparent;
                     continue;
                 }
 
                 var idx = 0;
                 foreach (var user in group)
                 {
-                    user.InitialsBrush = palette.Count > 0 ? palette[idx % palette.Count] : Brushes.Transparent;
+                    user.InitialsBrush = palette.Count > 0 ? palette[idx % palette.Count] : MediaBrushes.Transparent;
                     idx++;
                 }
             }


### PR DESCRIPTION
## Summary
- Alias System.Windows.Media.Brush/Brushes and replace ambiguous Brush usages across user and view models
- Ensure initials color assignments use explicit WPF brush types

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aecf01d4848324aabe47373ceb3f29