### PR TITLE
Refactor initials color binding

### DIFF
--- a/InventoryManagementApp.Tests/UserInitialsBrushTests.cs
+++ b/InventoryManagementApp.Tests/UserInitialsBrushTests.cs
@@ -35,7 +35,8 @@ namespace InventoryManagementApp.Tests
                     var vm = new UserManagementViewModel(svc, new DummyFileDialogService(), new DummyDialogService());
                     vm.LoadUsersAsync().GetAwaiter().GetResult();
                     Assert.NotEqual(vm.Users[0].InitialsBrush, vm.Users[1].InitialsBrush);
-                    Assert.Equal(Brushes.Transparent, vm.Users[2].InitialsBrush);
+                    var defaultBrush = Application.Current.TryFindResource("ForegroundBrush") as Brush;
+                    Assert.Equal(defaultBrush, vm.Users[2].InitialsBrush);
                 }
                 catch (Exception ex)
                 {

--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -120,7 +120,7 @@
                                       </Style>
                                   </Image.Style>
                               </Image>
-                              <Border Background="{Binding CurrentUserInitialsBrush}">
+                              <Border Background="Transparent">
                                   <Border.Style>
                                       <Style TargetType="Border">
                                           <Setter Property="Visibility" Value="Collapsed"/>
@@ -137,7 +137,7 @@
                                   </Border.Style>
                                   <TextBlock Text="{Binding CurrentUserName, Converter={StaticResource NameToInitialsConverter}}"
                                              HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" FontSize="28"
-                                             Foreground="{StaticResource ForegroundBrush}">
+                                             Foreground="{Binding CurrentUserInitialsBrush}">
                                       <TextBlock.Style>
                                           <Style TargetType="TextBlock">
                                               <Setter Property="Visibility" Value="Collapsed"/>

--- a/InventoryManagementApp/ViewModels/LoginViewModel.cs
+++ b/InventoryManagementApp/ViewModels/LoginViewModel.cs
@@ -212,13 +212,15 @@ namespace InventoryManagementApp.ViewModels
         {
             var palette = (Application.Current?.TryFindResource("UserInitialsBrushes") as IEnumerable<MediaBrush>)?.ToList()
                           ?? new List<MediaBrush>();
+            var defaultBrush = Application.Current?.TryFindResource("ForegroundBrush") as MediaBrush
+                               ?? MediaBrushes.Transparent;
             var groups = users.GroupBy(u => GetInitials(u.UserName));
             foreach (var group in groups)
             {
                 if (group.Count() <= 1)
                 {
                     foreach (var user in group)
-                        user.InitialsBrush = MediaBrushes.Transparent;
+                        user.InitialsBrush = defaultBrush;
                     continue;
                 }
 

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -129,13 +129,15 @@ namespace InventoryManagementApp.ViewModels
         {
             var palette = (Application.Current?.TryFindResource("UserInitialsBrushes") as IEnumerable<MediaBrush>)?.ToList()
                           ?? new List<MediaBrush>();
+            var defaultBrush = Application.Current?.TryFindResource("ForegroundBrush") as MediaBrush
+                               ?? MediaBrushes.Transparent;
             var groups = users.GroupBy(u => GetInitials(u.UserName));
             foreach (var group in groups)
             {
                 if (group.Count() <= 1)
                 {
                     foreach (var user in group)
-                        user.InitialsBrush = MediaBrushes.Transparent;
+                        user.InitialsBrush = defaultBrush;
                     continue;
                 }
 

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml
@@ -52,7 +52,7 @@
                                             </Style>
                                         </Image.Style>
                                     </Image>
-                                    <Border Background="{Binding InitialsBrush}">
+                                    <Border Background="Transparent">
                                         <Border.Style>
                                             <Style TargetType="Border">
                                                 <Setter Property="Visibility" Value="Visible"/>
@@ -66,7 +66,7 @@
                                         <TextBlock Text="{Binding UserName, Converter={StaticResource NameToInitialsConverter}}"
                                                    HorizontalAlignment="Center" VerticalAlignment="Center"
                                                    FontWeight="Bold" FontSize="20"
-                                                   Foreground="{StaticResource ForegroundBrush}">
+                                                   Foreground="{Binding InitialsBrush}">
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">
                                                     <Setter Property="Visibility" Value="Visible"/>

--- a/InventoryManagementApp/Views/Windows/LoginWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/LoginWindow.xaml
@@ -76,7 +76,7 @@
                                                     </Style>
                                                 </Image.Style>
                                             </Image>
-                                            <Border Background="{Binding InitialsBrush}">
+                                            <Border Background="Transparent">
                                                 <Border.Style>
                                                     <Style TargetType="Border">
                                                         <Setter Property="Visibility" Value="Collapsed"/>
@@ -92,7 +92,7 @@
                                                 </Border.Style>
                                                 <TextBlock Text="{Binding UserName, Converter={StaticResource NameToInitialsConverter}}"
                                                            FontSize="48"
-                                                           Foreground="{StaticResource ForegroundBrush}"
+                                                           Foreground="{Binding InitialsBrush}"
                                                            HorizontalAlignment="Center"
                                                            VerticalAlignment="Center">
                                                     <TextBlock.Style>

--- a/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
@@ -45,7 +45,7 @@
                             </Style>
                         </Image.Style>
                     </Image>
-                    <Border Background="{Binding EditingUser.InitialsBrush}">
+                    <Border Background="Transparent">
                         <Border.Style>
                             <Style TargetType="Border">
                                 <Setter Property="Visibility" Value="Visible"/>
@@ -58,7 +58,7 @@
                         </Border.Style>
                         <TextBlock Text="{Binding EditingUser.UserName, Converter={StaticResource NameToInitialsConverter}}"
                                    HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" FontSize="48"
-                                   Foreground="{StaticResource ForegroundBrush}">
+                                   Foreground="{Binding EditingUser.InitialsBrush}">
                             <TextBlock.Style>
                                 <Style TargetType="TextBlock">
                                     <Setter Property="Visibility" Value="Visible"/>


### PR DESCRIPTION
## Summary
- remove avatar background bindings and apply initials brush to text
- assign default foreground brush when initials are unique
- update tests for new initials brush behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aed2805dc08324bd790bcec60f8ea9