### PR TITLE
Display user initials if photo file missing

### DIFF
--- a/InventoryManagementApp.Tests/UserInitialsDisplayTests.cs
+++ b/InventoryManagementApp.Tests/UserInitialsDisplayTests.cs
@@ -103,6 +103,51 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void MainWindow_ShowsInitialsWhenPhotoPathMissing()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
+
+                    var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "InventoryManagementApp", "MainWindow.xaml"));
+                    var xaml = File.ReadAllText(path);
+                    xaml = Regex.Replace(xaml, "x:Class=\\\"[^\\\"]*\\\"\\s*", string.Empty);
+                    var window = (Window)XamlReader.Parse(xaml);
+                    var missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".png");
+                    window.DataContext = new { CurrentUserName = "John Doe", CurrentUserPhotoPath = missing };
+                    window.Measure(new Size(100, 100));
+                    window.Arrange(new Rect(0, 0, 100, 100));
+                    window.UpdateLayout();
+                    var border = FindVisualChildren<Border>(window).First(b => b.Width == 60 && b.Height == 60);
+                    var grid = VisualTreeHelper.GetChild(border, 0) as Grid ?? throw new InvalidOperationException("Grid not found");
+                    var textBlock = grid.Children.OfType<TextBlock>().Single();
+                    var image = grid.Children.OfType<Image>().Single();
+                    Assert.Equal("JD", textBlock.Text);
+                    Assert.Equal(Visibility.Visible, textBlock.Visibility);
+                    Assert.Equal(Visibility.Collapsed, image.Visibility);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
         public void UsersEditWindow_ShowsInitialsWhenNoPhotoPath()
         {
             Exception? threadEx = null;

--- a/InventoryManagementApp/Utilities/Converters/NonEmptyStringToBoolConverter.cs
+++ b/InventoryManagementApp/Utilities/Converters/NonEmptyStringToBoolConverter.cs
@@ -1,6 +1,7 @@
 ﻿// NonEmptyStringToBoolConverter.cs
 using System;
 using System.Globalization;
+using System.IO;
 using System.Windows.Data;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -16,8 +17,11 @@ namespace InventoryManagementApp.Utilities.Converters
         public NonEmptyStringToBoolConverter(ILogger<NonEmptyStringToBoolConverter>? logger = null)
             => _logger = logger ?? NullLogger<NonEmptyStringToBoolConverter>.Instance;
 
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
-            !string.IsNullOrEmpty(value as string);
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var path = value as string;
+            return !string.IsNullOrWhiteSpace(path) && File.Exists(path);
+        }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {


### PR DESCRIPTION
## Summary
- ensure initials are shown when a user's photo file is absent by verifying file existence
- add unit test for missing photo path on MainWindow

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aed3ada06483249954aa1c4ebc2f9f