### PR TITLE
Trigger UserChanged on CurrentUser property updates

### DIFF
--- a/InventoryManagementApp.Tests/ApplicationUserContextTests.cs
+++ b/InventoryManagementApp.Tests/ApplicationUserContextTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Threading;
+using System.Windows;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Services.Users;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ApplicationUserContextTests
+    {
+        [Fact]
+        public void UserChanged_Fires_WhenCurrentUserPropertyChanges()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    var ctx = new ApplicationUserContext();
+                    var user = new User();
+                    int eventCount = 0;
+                    User? eventUser = null;
+                    ctx.UserChanged += (_, u) => { eventCount++; eventUser = u; };
+
+                    ctx.CurrentUser = user;
+                    eventCount = 0;
+                    eventUser = null;
+
+                    user.UserPhotoPath = "new.png";
+
+                    Assert.Equal(1, eventCount);
+                    Assert.Same(user, eventUser);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
+        public void UserChanged_DoesNotFire_ForPreviousUser()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    var ctx = new ApplicationUserContext();
+                    var user1 = new User();
+                    var user2 = new User();
+                    bool fired = false;
+                    ctx.UserChanged += (_, __) => fired = true;
+
+                    ctx.CurrentUser = user1;
+                    ctx.CurrentUser = user2; // switch users
+                    fired = false; // reset flag after setting user2
+
+                    user1.UserPhotoPath = "old.png";
+
+                    Assert.False(fired);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+    }
+}

--- a/InventoryManagementApp/Services/Users/ApplicationUserContext.cs
+++ b/InventoryManagementApp/Services/Users/ApplicationUserContext.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Windows;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
@@ -6,9 +7,11 @@ namespace InventoryManagementApp.Services.Users
 {
     public class ApplicationUserContext : IUserContext
     {
-        const string Key = "CurrentUser";
+        private const string Key = "CurrentUser";
 
         public event EventHandler<User?>? UserChanged;
+
+        private User? _subscribedUser;
 
         public User? CurrentUser
         {
@@ -16,13 +19,27 @@ namespace InventoryManagementApp.Services.Users
             set
             {
                 if (System.Windows.Application.Current == null) return;
+
+                if (_subscribedUser != null)
+                    _subscribedUser.PropertyChanged -= OnCurrentUserPropertyChanged;
+
                 if (value == null)
                     System.Windows.Application.Current.Properties.Remove(Key);
                 else
+                {
                     System.Windows.Application.Current.Properties[Key] = value;
+                    value.PropertyChanged += OnCurrentUserPropertyChanged;
+                }
 
+                _subscribedUser = value;
                 UserChanged?.Invoke(this, value);
             }
+        }
+
+        private void OnCurrentUserPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (sender is User user)
+                UserChanged?.Invoke(this, user);
         }
 
         public bool IsAdmin => CurrentUser?.IsAdmin ?? false;


### PR DESCRIPTION
## Summary
- Subscribe to and unsubscribe from `CurrentUser.PropertyChanged`
- Raise `UserChanged` when the active user's properties mutate
- Cover property-change notifications and unsubscribe behavior with unit tests

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68aeda095714832493246d947dcc032e