### PR TITLE
refactor: migrate index creation to startup

### DIFF
--- a/InventoryManagementApp.Tests/DatabaseServiceIndexTests.cs
+++ b/InventoryManagementApp.Tests/DatabaseServiceIndexTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using InventoryManagementApp.Services.Core;
 using Xunit;
@@ -6,7 +7,7 @@ using Xunit;
 public class DatabaseServiceIndexTests
 {
     [Fact]
-    public void Initialize_CreatesIsRentalItemIndex()
+    public void Initialize_CreatesExpectedItemIndexes()
     {
         var dbPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.db");
         try
@@ -14,9 +15,15 @@ public class DatabaseServiceIndexTests
             using var db = new DatabaseService(dbPath);
             using var conn = db.CreateConnection();
             using var check = conn.CreateCommand();
-            check.CommandText = "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_Items_IsRentalItem';";
-            var result = check.ExecuteScalar();
-            Assert.NotNull(result);
+            check.CommandText = "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='Items' ORDER BY name;";
+            using var reader = check.ExecuteReader();
+            var indexes = new List<string>();
+            while (reader.Read())
+                indexes.Add(reader.GetString(0));
+            Assert.Contains("idx_Items_IsRentalItem", indexes);
+            Assert.Contains("idx_Items_AvailableQuantity", indexes);
+            Assert.Contains("idx_Items_Keywords", indexes);
+            Assert.Contains("idx_Items_UpdatedAt", indexes);
         }
         finally
         {

--- a/InventoryManagementApp.Tests/SqliteConnectionFactoryTests.cs
+++ b/InventoryManagementApp.Tests/SqliteConnectionFactoryTests.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using InventoryManagementApp.Data;
-using Microsoft.Extensions.Logging;
 using Xunit;
 
 public class SqliteConnectionFactoryTests
@@ -13,101 +11,5 @@ public class SqliteConnectionFactoryTests
         using var first = factory.Create();
         using var second = factory.Create();
         Assert.Equal(2, SqliteConnectionFactory.PragmasExecutionCount);
-    }
-
-    [Fact]
-    public void Create_CreatesIndexesWhenItemsTableExists()
-    {
-        SqliteConnectionFactory.Reset();
-        var factory = new SqliteConnectionFactory("Data Source=:memory:");
-        using (var conn = factory.Create())
-        {
-            using var cmd = conn.CreateCommand();
-            cmd.CommandText = "CREATE TABLE Items (ItemNumber TEXT, NameDescription TEXT, AvailableQuantity INTEGER, Price NUMERIC NOT NULL DEFAULT 0, UpdatedAt TEXT, Notes TEXT, Keywords TEXT);";
-            cmd.ExecuteNonQuery();
-        }
-
-        using var verify = factory.Create();
-        using var check = verify.CreateCommand();
-        check.CommandText = "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='Items' ORDER BY name;";
-        using var reader = check.ExecuteReader();
-        var indexes = new List<string>();
-        while (reader.Read())
-            indexes.Add(reader.GetString(0));
-        Assert.Contains("IX_Items_ItemNumber", indexes);
-        Assert.Contains("IX_Items_NameDescription", indexes);
-        Assert.Contains("IX_Items_AvailableQuantity", indexes);
-        Assert.Contains("IX_Items_UpdatedAt", indexes);
-        Assert.Contains("IX_Items_Notes", indexes);
-        Assert.Contains("IX_Items_Keywords", indexes);
-    }
-
-    [Fact]
-    public void Create_DoesNotCreateIndexWhenColumnMissing()
-    {
-        SqliteConnectionFactory.Reset();
-        var factory = new SqliteConnectionFactory("Data Source=:memory:");
-        using (var conn = factory.Create())
-        {
-            using var cmd = conn.CreateCommand();
-            cmd.CommandText = "CREATE TABLE Items (ItemNumber TEXT, NameDescription TEXT, AvailableQuantity INTEGER);";
-            cmd.ExecuteNonQuery();
-        }
-
-        using var verify = factory.Create();
-        using var check = verify.CreateCommand();
-        check.CommandText = "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='Items' ORDER BY name;";
-        using var reader = check.ExecuteReader();
-        var indexes = new List<string>();
-        while (reader.Read())
-            indexes.Add(reader.GetString(0));
-        Assert.Contains("IX_Items_ItemNumber", indexes);
-        Assert.Contains("IX_Items_NameDescription", indexes);
-        Assert.Contains("IX_Items_AvailableQuantity", indexes);
-        Assert.DoesNotContain("IX_Items_UpdatedAt", indexes);
-        Assert.DoesNotContain("IX_Items_Notes", indexes);
-        Assert.DoesNotContain("IX_Items_Keywords", indexes);
-    }
-
-    [Fact]
-    public void Create_LogsWarningWhenUpdatedAtColumnMissing()
-    {
-        SqliteConnectionFactory.Reset();
-        var logger = new ListLogger<SqliteConnectionFactory>();
-        var factory = new SqliteConnectionFactory("Data Source=:memory:", logger);
-        using (var conn = factory.Create())
-        {
-            using var cmd = conn.CreateCommand();
-            cmd.CommandText = "CREATE TABLE Items (ItemNumber TEXT, NameDescription TEXT, AvailableQuantity INTEGER);";
-            cmd.ExecuteNonQuery();
-        }
-
-        using (factory.Create()) { }
-
-        Assert.Contains(LogLevel.Warning, logger.Levels);
-        Assert.Contains(logger.Messages, m => m.Contains("UpdatedAt"));
-    }
-}
-
-internal sealed class ListLogger<T> : ILogger<T>
-{
-    public List<LogLevel> Levels { get; } = new();
-    public List<string> Messages { get; } = new();
-
-    public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
-
-    public bool IsEnabled(LogLevel logLevel) => true;
-
-    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
-        Func<TState, Exception?, string> formatter)
-    {
-        Levels.Add(logLevel);
-        Messages.Add(formatter(state, exception));
-    }
-
-    private sealed class NullScope : IDisposable
-    {
-        public static readonly NullScope Instance = new();
-        public void Dispose() { }
     }
 }

--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -97,8 +97,7 @@ namespace InventoryManagementApp
                         Cache = SqliteCacheMode.Shared,
                         Mode = SqliteOpenMode.ReadWriteCreate
                     };
-                    var logger = sp.GetRequiredService<ILogger<SqliteConnectionFactory>>();
-                    return new SqliteConnectionFactory(builder.ToString(), logger);
+                    return new SqliteConnectionFactory(builder.ToString());
                 });
                 services.AddSingleton<IItemRepository, ItemRepository>();
                 services.AddSingleton<IUserContext, ApplicationUserContext>();

--- a/InventoryManagementApp/Data/SqliteConnectionFactory.cs
+++ b/InventoryManagementApp/Data/SqliteConnectionFactory.cs
@@ -1,27 +1,22 @@
-using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
-using System.Text;
 using Microsoft.Data.Sqlite;
-using Microsoft.Extensions.Logging;
 
 namespace InventoryManagementApp.Data;
 
 public sealed class SqliteConnectionFactory
 {
     private readonly string _connectionString;
-    private readonly ILogger<SqliteConnectionFactory>? _logger;
     private static readonly object _lock = new();
     internal static int PragmasExecutionCount { get; private set; }
 
-    public SqliteConnectionFactory(string connectionString, ILogger<SqliteConnectionFactory>? logger = null)
+    public SqliteConnectionFactory(string connectionString)
     {
         var builder = new SqliteConnectionStringBuilder(connectionString)
         {
             Pooling = true
         };
         _connectionString = builder.ToString();
-        _logger = logger;
     }
 
     internal static void Reset()
@@ -44,38 +39,10 @@ public sealed class SqliteConnectionFactory
             cmd.CommandText = "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;";
             cmd.ExecuteNonQuery();
 
-            cmd.CommandText = "SELECT 1 FROM sqlite_master WHERE type='table' AND name='Items';";
-            var exists = cmd.ExecuteScalar() != null;
-
-            if (exists)
+            if (PragmasExecutionCount == 0)
             {
-                cmd.CommandText = "PRAGMA table_info('Items');";
-                using var reader = cmd.ExecuteReader();
-                var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                while (reader.Read())
-                    columns.Add(reader.GetString(1));
-                reader.Close();
-
-                var sb = new StringBuilder();
-                if (columns.Contains("ItemNumber"))
-                    sb.AppendLine("CREATE INDEX IF NOT EXISTS IX_Items_ItemNumber ON Items(ItemNumber);");
-                if (columns.Contains("NameDescription"))
-                    sb.AppendLine("CREATE INDEX IF NOT EXISTS IX_Items_NameDescription ON Items(NameDescription);");
-                if (columns.Contains("AvailableQuantity"))
-                    sb.AppendLine("CREATE INDEX IF NOT EXISTS IX_Items_AvailableQuantity ON Items(AvailableQuantity);");
-                if (columns.Contains("Notes"))
-                    sb.AppendLine("CREATE INDEX IF NOT EXISTS IX_Items_Notes ON Items(Notes);");
-                if (columns.Contains("Keywords"))
-                    sb.AppendLine("CREATE INDEX IF NOT EXISTS IX_Items_Keywords ON Items(Keywords);");
-                if (columns.Contains("UpdatedAt"))
-                    sb.AppendLine("CREATE INDEX IF NOT EXISTS IX_Items_UpdatedAt ON Items(UpdatedAt);");
-                else
-                    _logger?.LogWarning("Column 'UpdatedAt' not found in Items table; skipping index creation for IX_Items_UpdatedAt.");
-                if (sb.Length > 0)
-                {
-                    cmd.CommandText = sb.ToString();
-                    cmd.ExecuteNonQuery();
-                }
+                cmd.CommandText = "SELECT 1 FROM sqlite_master WHERE type='table' AND name='Items';";
+                cmd.ExecuteScalar();
             }
 
             PragmasExecutionCount++;

--- a/InventoryManagementApp/Services/Core/DatabaseService.cs
+++ b/InventoryManagementApp/Services/Core/DatabaseService.cs
@@ -55,7 +55,9 @@ namespace InventoryManagementApp.Services.Core
             // Ensure indexes that depend on newly added columns
             using (var conn = CreateConnection())
             {
+                EnsureIndex(conn, "Items", "AvailableQuantity");
                 EnsureIndex(conn, "Items", "Keywords");
+                EnsureIndex(conn, "Items", "UpdatedAt");
                 EnsureIndex(conn, "Items", "IsRentalItem");
             }
             EnsureColumn("Users", "PasswordHash", "TEXT");


### PR DESCRIPTION
## Summary
- run per-connection PRAGMAs without redundant schema checks
- migrate index creation to DatabaseService initialization
- add and update tests for startup indexes

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aedae50fbc83248a3d171cbb6198bd