### PR TITLE
Avoid pipelined flag when reading items

### DIFF
--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -55,7 +55,7 @@ public sealed class ItemRepository : IItemRepository
         parameters.Add("Take", page.Size);
         parameters.Add("Skip", (page.Number - 1) * page.Size);
         await using var conn = (DbConnection)_factory.Create();
-        var command = new CommandDefinition(sql, parameters, flags: CommandFlags.Pipelined, cancellationToken: ct);
+        var command = new CommandDefinition(sql, parameters, flags: CommandFlags.None, cancellationToken: ct);
         DbDataReader reader;
         try
         {


### PR DESCRIPTION
## Summary
- avoid using CommandFlags.Pipelined when enumerating items

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aedc1daf488324992b072d6fa8f8be