### PR TITLE
Remove pipelined flag from CountAsync

### DIFF
--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -149,7 +149,7 @@ public sealed class ItemRepository : IItemRepository
         if (conditions.Count > 0)
             sql += " WHERE " + string.Join(" AND ", conditions);
         await using var conn = (DbConnection)_factory.Create();
-        return await conn.ExecuteScalarAsync<int>(new CommandDefinition(sql, parameters, flags: CommandFlags.Pipelined, cancellationToken: ct));
+        return await conn.ExecuteScalarAsync<int>(new CommandDefinition(sql, parameters, cancellationToken: ct));
     }
 
     public async Task SaveChangesAsync(IEnumerable<Item> changes, CancellationToken ct)


### PR DESCRIPTION
## Summary
- remove use of Dapper's `CommandFlags.Pipelined` in `CountAsync`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68aedee48ff48324af5c55edbd2eccb7