### PR TITLE
Refactor ItemService to use repository methods

### DIFF
--- a/InventoryManagementApp.Tests/DashboardViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DashboardViewModelTests.cs
@@ -38,6 +38,9 @@ public class DashboardViewModelTests
         public Task UpdateAsync(ItemModel item, CancellationToken ct) => Task.CompletedTask;
         public Task DeleteAsync(int itemID, CancellationToken ct) => Task.CompletedTask;
         public Task<bool> ToggleCheckOutStatusAsync(int itemID, string currentUser, bool isAdmin, CancellationToken ct) => Task.FromResult(false);
+        public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken ct) => Task.FromResult(new List<ItemModel>());
+        public Task<List<ItemModel>> GetCheckedOutItemsAsync(CancellationToken ct) => Task.FromResult(new List<ItemModel>());
+        public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken ct) => Task.CompletedTask;
     }
 
     private sealed class StubRentalService : IRentalService
@@ -202,6 +205,9 @@ public class DashboardViewModelTests
         public Task UpdateAsync(ItemModel item, CancellationToken ct) => Task.CompletedTask;
         public Task DeleteAsync(int itemID, CancellationToken ct) => Task.CompletedTask;
         public Task<bool> ToggleCheckOutStatusAsync(int itemID, string currentUser, bool isAdmin, CancellationToken ct) => Task.FromResult(false);
+        public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken ct) => Task.FromResult(new List<ItemModel>());
+        public Task<List<ItemModel>> GetCheckedOutItemsAsync(CancellationToken ct) => Task.FromResult(new List<ItemModel>());
+        public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken ct) => Task.CompletedTask;
     }
 
     private sealed class CancellableActivityLogService : ActivityLogService

--- a/InventoryManagementApp.Tests/ItemServiceRepositoryTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceRepositoryTests.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using InventoryManagementApp.Data;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Services.Core;
+using InventoryManagementApp.Services.Items;
+using Xunit;
+
+public class ItemServiceRepositoryTests
+{
+    private sealed class RecordingRepository : IItemRepository
+    {
+        public int GetByUserCalls { get; private set; }
+        public string? LastUser { get; private set; }
+        public int GetCheckedOutCalls { get; private set; }
+        public int UpdateImageCalls { get; private set; }
+        public int? LastImageItemId { get; private set; }
+        public string? LastImagePath { get; private set; }
+
+        public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken ct)
+        {
+            GetByUserCalls++;
+            LastUser = userName;
+            return Task.FromResult(new List<ItemModel> { new ItemModel { ItemID = 1 } });
+        }
+
+        public Task<List<ItemModel>> GetCheckedOutItemsAsync(CancellationToken ct)
+        {
+            GetCheckedOutCalls++;
+            return Task.FromResult(new List<ItemModel> { new ItemModel { ItemID = 2 } });
+        }
+
+        public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken ct)
+        {
+            UpdateImageCalls++;
+            LastImageItemId = itemID;
+            LastImagePath = imagePath;
+            return Task.CompletedTask;
+        }
+
+        public IAsyncEnumerable<ItemModel> GetPageAsync(ItemFilter filter, ItemPage page, CancellationToken ct)
+            => AsyncEnumerable.Empty<ItemModel>();
+        public Task<int> CountAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+        public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct) => Task.CompletedTask;
+        public Task<int> InsertAsync(ItemModel item, CancellationToken ct) => Task.FromResult(0);
+        public Task UpdateAsync(ItemModel item, CancellationToken ct) => Task.CompletedTask;
+        public Task DeleteAsync(int itemID, CancellationToken ct) => Task.CompletedTask;
+        public Task<bool> ToggleCheckOutStatusAsync(int itemID, string currentUser, bool isAdmin, CancellationToken ct) => Task.FromResult(false);
+    }
+
+    [Fact]
+    public async Task GetItemsCheckedOutByAsync_DelegatesToRepository()
+    {
+        using var db = new DatabaseService(":memory:");
+        var repo = new RecordingRepository();
+        var service = new ItemService(db, repo);
+        var result = await service.GetItemsCheckedOutByAsync("Alice");
+        Assert.Single(result);
+        Assert.Equal(1, repo.GetByUserCalls);
+        Assert.Equal("Alice", repo.LastUser);
+    }
+
+    [Fact]
+    public async Task GetCheckedOutItemsAsync_DelegatesToRepository()
+    {
+        using var db = new DatabaseService(":memory:");
+        var repo = new RecordingRepository();
+        var service = new ItemService(db, repo);
+        var result = await service.GetCheckedOutItemsAsync();
+        Assert.Single(result);
+        Assert.Equal(1, repo.GetCheckedOutCalls);
+    }
+
+    [Fact]
+    public async Task UpdateItemImageAsync_DelegatesToRepository()
+    {
+        using var db = new DatabaseService(":memory:");
+        var repo = new RecordingRepository();
+        var service = new ItemService(db, repo);
+        await service.UpdateItemImageAsync(5, "img.png");
+        Assert.Equal(1, repo.UpdateImageCalls);
+        Assert.Equal(5, repo.LastImageItemId);
+        Assert.Equal("img.png", repo.LastImagePath);
+    }
+}

--- a/InventoryManagementApp.Tests/ItemServiceUpdatedAtTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceUpdatedAtTests.cs
@@ -12,17 +12,6 @@ using Xunit;
 
 public class ItemServiceUpdatedAtTests
 {
-    private sealed class DummyItemRepository : IItemRepository
-    {
-        public IAsyncEnumerable<ItemModel> GetPageAsync(ItemFilter filter, ItemPage page, CancellationToken ct) => AsyncEnumerable.Empty<ItemModel>();
-        public Task<int> CountAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
-        public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct) => Task.CompletedTask;
-        public Task<int> InsertAsync(ItemModel item, CancellationToken ct) => Task.FromResult(0);
-        public Task UpdateAsync(ItemModel item, CancellationToken ct) => Task.CompletedTask;
-        public Task DeleteAsync(int itemID, CancellationToken ct) => Task.CompletedTask;
-        public Task<bool> ToggleCheckOutStatusAsync(int itemID, string currentUser, bool isAdmin, CancellationToken ct) => Task.FromResult(false);
-    }
-
     [Theory]
     [InlineData(null)]
     [InlineData("")]
@@ -31,8 +20,10 @@ public class ItemServiceUpdatedAtTests
     {
         var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
         using var db = new DatabaseService(dbPath);
+        var factory = new SqliteConnectionFactory(db.ConnectionString);
+        var repository = new ItemRepository(factory);
         var logger = new ListLogger<ItemService>();
-        var service = new ItemService(db, new DummyItemRepository(), logger: logger);
+        var service = new ItemService(db, repository, logger: logger);
 
         using (var conn = db.CreateConnection())
         using (var cmd = conn.CreateCommand())

--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -823,6 +823,9 @@ namespace InventoryManagementApp.Tests
             public Task UpdateAsync(ItemModel item, CancellationToken ct) => Task.CompletedTask;
             public Task DeleteAsync(int itemID, CancellationToken ct) => Task.CompletedTask;
             public Task<bool> ToggleCheckOutStatusAsync(int itemID, string currentUser, bool isAdmin, CancellationToken ct) => Task.FromResult(false);
+            public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken ct) => Task.FromResult(new List<ItemModel>());
+            public Task<List<ItemModel>> GetCheckedOutItemsAsync(CancellationToken ct) => Task.FromResult(new List<ItemModel>());
+            public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken ct) => Task.CompletedTask;
         }
 
         private sealed class DummyDialogService : IDialogService

--- a/InventoryManagementApp/Data/IItemRepository.cs
+++ b/InventoryManagementApp/Data/IItemRepository.cs
@@ -14,4 +14,7 @@ public interface IItemRepository
     Task UpdateAsync(Item item, CancellationToken ct);
     Task DeleteAsync(int itemID, CancellationToken ct);
     Task<bool> ToggleCheckOutStatusAsync(int itemID, string currentUser, bool isAdmin, CancellationToken ct);
+    Task<List<Item>> GetItemsCheckedOutByAsync(string userName, CancellationToken ct);
+    Task<List<Item>> GetCheckedOutItemsAsync(CancellationToken ct);
+    Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken ct);
 }

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -302,4 +302,28 @@ public sealed class ItemRepository : IItemRepository
 
         return true;
     }
+
+    public async Task<List<Item>> GetItemsCheckedOutByAsync(string userName, CancellationToken ct)
+    {
+        const string sql = @"SELECT ItemID, ItemNumber, NameDescription AS Name, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity AS QuantityOnHand, RentedQuantity, IsRentalItem, Price, ImagePath, IsCheckedOut, CheckedOutBy, CheckedOutTime, CheckedInBy, CheckedInTime, IsPowered, UpdatedAt FROM Items WHERE CheckedOutBy=@User AND IsCheckedOut=1 AND IFNULL(IsRentalItem,0)=0";
+        await using var conn = (DbConnection)_factory.Create();
+        var items = await conn.QueryAsync<Item>(new CommandDefinition(sql, new { User = userName }, cancellationToken: ct)).ConfigureAwait(false);
+        return items.AsList();
+    }
+
+    public async Task<List<Item>> GetCheckedOutItemsAsync(CancellationToken ct)
+    {
+        const string sql = @"SELECT ItemID, ItemNumber, NameDescription AS Name, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity AS QuantityOnHand, RentedQuantity, IsRentalItem, Price, ImagePath, IsCheckedOut, CheckedOutBy, CheckedOutTime, CheckedInBy, CheckedInTime, IsPowered, UpdatedAt FROM Items WHERE IsCheckedOut=1 AND IFNULL(IsRentalItem,0)=0";
+        await using var conn = (DbConnection)_factory.Create();
+        var items = await conn.QueryAsync<Item>(new CommandDefinition(sql, cancellationToken: ct)).ConfigureAwait(false);
+        return items.AsList();
+    }
+
+    public async Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken ct)
+    {
+        await using var conn = (DbConnection)_factory.Create();
+        var rows = await conn.ExecuteAsync(new CommandDefinition("UPDATE Items SET ImagePath=@Img WHERE ItemID=@ID", new { Img = imagePath, ID = itemID }, cancellationToken: ct));
+        if (rows == 0)
+            throw new InvalidOperationException($"Failed to update image for item {itemID}.");
+    }
 }

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -102,32 +102,15 @@ namespace InventoryManagementApp.Services.Items
         }
 
         public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default)
-        {
-            using var conn = _dbService.CreateConnection();
-            return SqliteHelper.ExecuteReaderAsync(conn,
-                "SELECT * FROM Items WHERE CheckedOutBy=@User AND IsCheckedOut=1 AND IFNULL(IsRentalItem,0)=0",
-                MapItem,
-                new[] { new SqliteParameter("@User", userName) }, cancellationToken);
-        }
+            => _repository.GetItemsCheckedOutByAsync(userName, cancellationToken);
 
         public Task<List<ItemModel>> GetCheckedOutItemsAsync(CancellationToken cancellationToken = default)
-        {
-            using var conn = _dbService.CreateConnection();
-            const string sql = "SELECT * FROM Items WHERE IsCheckedOut=1 AND IFNULL(IsRentalItem,0)=0";
-            return SqliteHelper.ExecuteReaderAsync(conn, sql, MapItem, null, cancellationToken);
-        }
+            => _repository.GetCheckedOutItemsAsync(cancellationToken);
 
         public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
-            const string sql = "UPDATE Items SET ImagePath=@Img WHERE ItemID=@ID";
-            var p = new[]
-            {
-                new SqliteParameter("@Img", imagePath),
-                new SqliteParameter("@ID", itemID)
-            };
-            using var conn = _dbService.CreateConnection();
-            return SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);
+            return _repository.UpdateItemImageAsync(itemID, imagePath, cancellationToken);
         }
 
         public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- extend IItemRepository with methods for checked out items and image updates
- refactor ItemService to call repository for these operations
- add unit tests verifying ItemService delegates to repository

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aedefd1ecc8324b204f90cfe91c82b