### PR TITLE
Refactor item lookup through repository with tests

### DIFF
--- a/InventoryManagementApp.Tests/DashboardViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DashboardViewModelTests.cs
@@ -31,6 +31,9 @@ public class DashboardViewModelTests
             return Task.FromResult(42);
         }
 
+        public Task<ItemModel?> GetByIdAsync(int id, CancellationToken ct)
+            => Task.FromResult<ItemModel?>(null);
+
         public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct)
             => Task.CompletedTask;
 
@@ -208,6 +211,7 @@ public class DashboardViewModelTests
         public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken ct) => Task.FromResult(new List<ItemModel>());
         public Task<List<ItemModel>> GetCheckedOutItemsAsync(CancellationToken ct) => Task.FromResult(new List<ItemModel>());
         public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken ct) => Task.CompletedTask;
+        public Task<ItemModel?> GetByIdAsync(int id, CancellationToken ct) => Task.FromResult<ItemModel?>(null);
     }
 
     private sealed class CancellableActivityLogService : ActivityLogService

--- a/InventoryManagementApp.Tests/ItemRepositoryGetByIdTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryGetByIdTests.cs
@@ -1,0 +1,67 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using InventoryManagementApp.Data;
+using InventoryManagementApp.Models.Domain;
+using Xunit;
+
+public class ItemRepositoryGetByIdTests
+{
+    private static SqliteConnectionFactory CreateFactory()
+        => new("Data Source=:memory:");
+
+    private static async Task SeedAsync(SqliteConnectionFactory factory)
+    {
+        using var conn = factory.Create();
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = @"CREATE TABLE Items (
+            ItemID INTEGER PRIMARY KEY AUTOINCREMENT,
+            ItemNumber TEXT,
+            NameDescription TEXT,
+            Location TEXT,
+            Brand TEXT,
+            PartNumber TEXT,
+            Supplier TEXT,
+            PurchasedDate TEXT,
+            Notes TEXT,
+            Keywords TEXT,
+            AvailableQuantity INTEGER,
+            RentedQuantity INTEGER,
+            IsRentalItem INTEGER,
+            Price NUMERIC NOT NULL DEFAULT 0,
+            ImagePath TEXT,
+            IsCheckedOut INTEGER,
+            CheckedOutBy TEXT,
+            CheckedOutTime TEXT,
+            CheckedInBy TEXT,
+            CheckedInTime TEXT,
+            IsPowered INTEGER,
+            UpdatedAt TEXT
+        );";
+        cmd.ExecuteNonQuery();
+        await conn.ExecuteAsync(
+            "INSERT INTO Items (ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsCheckedOut, IsPowered, UpdatedAt) VALUES (@ItemNumber,@Name,0,0,0,0,0,@UpdatedAt)",
+            new { ItemNumber = "A1", Name = "Saw", UpdatedAt = System.DateTime.UtcNow });
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_FindsItem()
+    {
+        var factory = CreateFactory();
+        await SeedAsync(factory);
+        var repo = new ItemRepository(factory);
+        var item = await repo.GetByIdAsync(1, CancellationToken.None);
+        Assert.NotNull(item);
+        Assert.Equal("A1", item!.ItemNumber);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNull_WhenMissing()
+    {
+        var factory = CreateFactory();
+        await SeedAsync(factory);
+        var repo = new ItemRepository(factory);
+        var item = await repo.GetByIdAsync(42, CancellationToken.None);
+        Assert.Null(item);
+    }
+}

--- a/InventoryManagementApp.Tests/ItemServiceRepositoryTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceRepositoryTests.cs
@@ -43,6 +43,7 @@ public class ItemServiceRepositoryTests
         public IAsyncEnumerable<ItemModel> GetPageAsync(ItemFilter filter, ItemPage page, CancellationToken ct)
             => AsyncEnumerable.Empty<ItemModel>();
         public Task<int> CountAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+        public Task<ItemModel?> GetByIdAsync(int id, CancellationToken ct) => Task.FromResult<ItemModel?>(null);
         public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct) => Task.CompletedTask;
         public Task<int> InsertAsync(ItemModel item, CancellationToken ct) => Task.FromResult(0);
         public Task UpdateAsync(ItemModel item, CancellationToken ct) => Task.CompletedTask;

--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -814,6 +814,7 @@ namespace InventoryManagementApp.Tests
             public List<ItemModel> Saved { get; } = new();
             public IAsyncEnumerable<ItemModel> GetPageAsync(ItemFilter filter, ItemPage page, CancellationToken ct) => AsyncEnumerable.Empty<ItemModel>();
             public Task<int> CountAsync(ItemFilter filter, CancellationToken ct) => Task.FromResult(0);
+            public Task<ItemModel?> GetByIdAsync(int id, CancellationToken ct) => Task.FromResult<ItemModel?>(null);
             public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct)
             {
                 Saved.AddRange(changes);

--- a/InventoryManagementApp/Data/IItemRepository.cs
+++ b/InventoryManagementApp/Data/IItemRepository.cs
@@ -9,6 +9,7 @@ public interface IItemRepository
 {
     IAsyncEnumerable<Item> GetPageAsync(ItemFilter filter, ItemPage page, CancellationToken ct);
     Task<int> CountAsync(ItemFilter filter, CancellationToken ct);
+    Task<Item?> GetByIdAsync(int id, CancellationToken ct);
     Task SaveChangesAsync(IEnumerable<Item> changes, CancellationToken ct);
     Task<int> InsertAsync(Item item, CancellationToken ct);
     Task UpdateAsync(Item item, CancellationToken ct);

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -152,6 +152,16 @@ public sealed class ItemRepository : IItemRepository
         return await conn.ExecuteScalarAsync<int>(new CommandDefinition(sql, parameters, cancellationToken: ct));
     }
 
+    public async Task<Item?> GetByIdAsync(int id, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        const string sql = @"SELECT ItemID, ItemNumber, NameDescription AS Name, Location, Brand, PartNumber, Supplier,
+            PurchasedDate, Notes, Keywords, AvailableQuantity AS QuantityOnHand, RentedQuantity, IsRentalItem, Price, ImagePath,
+            IsCheckedOut, CheckedOutBy, CheckedOutTime, CheckedInBy, CheckedInTime, IsPowered, UpdatedAt FROM Items WHERE ItemID=@ID";
+        await using var conn = (DbConnection)_factory.Create();
+        return await conn.QueryFirstOrDefaultAsync<Item>(new CommandDefinition(sql, new { ID = id }, cancellationToken: ct)).ConfigureAwait(false);
+    }
+
     public async Task SaveChangesAsync(IEnumerable<Item> changes, CancellationToken ct)
     {
         await using var conn = (DbConnection)_factory.Create();

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Data.Sqlite;
 using System;
 using System.IO;
-using System.Data;
 using System.Linq;
 using System.Collections.Generic;
 using System.Threading;
@@ -12,7 +11,6 @@ using InventoryManagementApp.Utilities.IO;
 using InventoryManagementApp.Models.ImportExport;
 using InventoryManagementApp.Interfaces;
 using System.Text;
-using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using InventoryManagementApp.Services.Users;
@@ -284,49 +282,6 @@ namespace InventoryManagementApp.Services.Items
             return count > 0;
         }
     
-        ItemModel MapItem(IDataRecord r) => new()
-        {
-            ItemID = r["ItemID"] is DBNull ? 0 : Convert.ToInt32(r["ItemID"]),
-            ItemNumber = r["ItemNumber"].ToString(),
-            PartNumber = r["PartNumber"].ToString(),
-            Name = r["NameDescription"].ToString(),
-            Brand = r["Brand"].ToString(),
-            Location = r["Location"].ToString(),
-            QuantityOnHand = r["AvailableQuantity"] is DBNull ? 0 : Convert.ToInt32(r["AvailableQuantity"]),
-            RentedQuantity = r["RentedQuantity"] is DBNull ? 0 : Convert.ToInt32(r["RentedQuantity"]),
-            Supplier = r["Supplier"].ToString(),
-            PurchasedDate = r["PurchasedDate"] is DBNull
-                ? (DateTime?)null
-                : ParseNullableDate(r["PurchasedDate"], "PurchasedDate"),
-            Notes = r["Notes"].ToString(),
-            IsCheckedOut = (r["IsCheckedOut"] is DBNull ? 0 : Convert.ToInt32(r["IsCheckedOut"])) == 1,
-            CheckedOutBy = r["CheckedOutBy"].ToString(),
-            CheckedOutTime = r["CheckedOutTime"] is DBNull
-                ? (DateTime?)null
-                : ParseNullableDate(r["CheckedOutTime"], "CheckedOutTime"),
-            CheckedInBy = r["CheckedInBy"].ToString(),
-            CheckedInTime = r["CheckedInTime"] is DBNull
-                ? (DateTime?)null
-                : ParseNullableDate(r["CheckedInTime"], "CheckedInTime"),
-            ImagePath = r["ImagePath"]?.ToString(),
-            Keywords = r["Keywords"]?.ToString(),
-            IsPowered = (r["IsPowered"] is DBNull ? 0 : Convert.ToInt32(r["IsPowered"])) == 1,
-            IsRentalItem = (r["IsRentalItem"] is DBNull ? 0 : Convert.ToInt32(r["IsRentalItem"])) == 1,
-            UpdatedAt = ParseNullableDate(r["UpdatedAt"], "UpdatedAt") ?? default
-        };
-
-        DateTime? ParseNullableDate(object? value, string field)
-        {
-            var text = value?.ToString();
-            if (string.IsNullOrWhiteSpace(text))
-                return null;
-            if (DateTime.TryParse(text, CultureInfo.InvariantCulture,
-                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dt))
-                return DateTime.SpecifyKind(dt, DateTimeKind.Utc).ToLocalTime();
-            _logger.LogError("Failed to parse {Field}: {Value}", field, text);
-            return null;
-        }
-
         private async Task AddItemInternalAsync(ItemModel item, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(item?.ItemNumber))
@@ -350,14 +305,8 @@ namespace InventoryManagementApp.Services.Items
             await _repository.DeleteAsync(itemID, cancellationToken);
         }
 
-        public async Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default)
-        {
-            using var conn = _dbService.CreateConnection();
-            var list = await SqliteHelper.ExecuteReaderAsync(conn, "SELECT * FROM Items WHERE ItemID=@ItemID",
-                MapItem,
-                new[] { new SqliteParameter("@ItemID", itemID) }, cancellationToken);
-            return list.FirstOrDefault();
-        }
+        public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default)
+            => _repository.GetByIdAsync(itemID, cancellationToken);
 
         public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default)
             => _repository.GetPageAsync(new ItemFilter(null, sortField, sortDirection, isRentalItem), page, cancellationToken);


### PR DESCRIPTION
## Summary
- add GetByIdAsync to item repository
- refactor ItemService to use repository for item lookup
- cover GetByIdAsync with unit tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aee1782a848324ab69e1cbec0bce82