### PR TITLE
Ensure SQLite PRAGMAs run only once and init schema at startup

### DIFF
--- a/InventoryManagementApp.Tests/SqliteConnectionFactoryTests.cs
+++ b/InventoryManagementApp.Tests/SqliteConnectionFactoryTests.cs
@@ -4,12 +4,12 @@ using Xunit;
 public class SqliteConnectionFactoryTests
 {
     [Fact]
-    public void Create_ExecutesPragmasEachTime()
+    public void Create_ExecutesPragmasOnlyOnce()
     {
         SqliteConnectionFactory.Reset();
         var factory = new SqliteConnectionFactory("Data Source=:memory:");
         using var first = factory.Create();
         using var second = factory.Create();
-        Assert.Equal(2, SqliteConnectionFactory.PragmasExecutionCount);
+        Assert.Equal(1, SqliteConnectionFactory.PragmasExecutionCount);
     }
 }

--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -139,6 +139,9 @@ namespace InventoryManagementApp
 
             await Host.StartAsync();
 
+            // Ensure database initialization and migrations are executed at startup
+            Host.Services.GetRequiredService<DatabaseService>();
+
             var loggerFactory = Host.Services.GetRequiredService<ILoggerFactory>();
             PathHelper.Configure(loggerFactory.CreateLogger("PathHelper"));
             var settingsService = Host.Services.GetRequiredService<ISettingsService>();

--- a/InventoryManagementApp/Data/SqliteConnectionFactory.cs
+++ b/InventoryManagementApp/Data/SqliteConnectionFactory.cs
@@ -35,17 +35,13 @@ public sealed class SqliteConnectionFactory
 
         lock (_lock)
         {
-            using var cmd = connection.CreateCommand();
-            cmd.CommandText = "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;";
-            cmd.ExecuteNonQuery();
-
             if (PragmasExecutionCount == 0)
             {
-                cmd.CommandText = "SELECT 1 FROM sqlite_master WHERE type='table' AND name='Items';";
-                cmd.ExecuteScalar();
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;";
+                cmd.ExecuteNonQuery();
+                PragmasExecutionCount++;
             }
-
-            PragmasExecutionCount++;
         }
 
         return connection;


### PR DESCRIPTION
## Summary
- Run WAL and synchronous PRAGMAs only on first connection from SqliteConnectionFactory
- Initialize database during application startup instead of on first connection
- Update tests to reflect one-time PRAGMA execution

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aee484813c83248b6c715837b4e5d2