### PR TITLE
Refactor edit handlers to async commands

### DIFF
--- a/InventoryManagementApp.Tests/CustomerManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/CustomerManagementViewModelTests.cs
@@ -39,7 +39,7 @@ namespace InventoryManagementApp.Tests
             await vm.LoadCustomersAsync();
             vm.SelectedCustomer = vm.Customers.First();
 
-            vm.EditCustomerCommand.Execute(null);
+            await vm.EditCustomerCommand.ExecuteAsync(null);
 
             Assert.Equal("B", vm.Customers[0].Company);
         }

--- a/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
@@ -28,6 +28,7 @@ namespace InventoryManagementApp.ViewModels
                 {
                     ((AsyncRelayCommand)UpdateCustomerCommand).NotifyCanExecuteChanged();
                     ((AsyncRelayCommand)DeleteCustomerCommand).NotifyCanExecuteChanged();
+                    ((AsyncRelayCommand)EditCustomerCommand).NotifyCanExecuteChanged();
 
                     if (value != null)
                     {
@@ -70,8 +71,8 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand UpdateCustomerCommand { get; }
         public IAsyncRelayCommand SearchCustomersCommand { get; }
         public IAsyncRelayCommand DeleteCustomerCommand { get; }
-        public IRelayCommand EditCustomerCommand { get; }
-        public IRelayCommand<CustomerModel> EditCustomerFromRowCommand { get; }
+        public IAsyncRelayCommand EditCustomerCommand { get; }
+        public IAsyncRelayCommand<CustomerModel> EditCustomerFromRowCommand { get; }
         public IAsyncRelayCommand<CustomerModel> DeleteCustomerFromRowCommand { get; }
         public IAsyncRelayCommand ClearCustomerSearchCommand { get; }
 
@@ -84,8 +85,8 @@ namespace InventoryManagementApp.ViewModels
             UpdateCustomerCommand = new AsyncRelayCommand(UpdateCustomerAsync, () => SelectedCustomer != null);
             SearchCustomersCommand = new AsyncRelayCommand(SearchCustomersAsync);
             DeleteCustomerCommand = new AsyncRelayCommand(() => DeleteCustomerAsync(), () => SelectedCustomer != null);
-            EditCustomerCommand = new RelayCommand(() => EditCustomer(SelectedCustomer), () => SelectedCustomer != null);
-            EditCustomerFromRowCommand = new RelayCommand<CustomerModel>(EditCustomer);
+            EditCustomerCommand = new AsyncRelayCommand(() => EditCustomerAsync(SelectedCustomer), () => SelectedCustomer != null);
+            EditCustomerFromRowCommand = new AsyncRelayCommand<CustomerModel>(EditCustomerAsync);
             DeleteCustomerFromRowCommand = new AsyncRelayCommand<CustomerModel>(c => DeleteCustomerAsync(c));
             ClearCustomerSearchCommand = new AsyncRelayCommand(ClearCustomerSearchAsync);
         }
@@ -191,7 +192,7 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        async void EditCustomer(CustomerModel? customer)
+        public async Task EditCustomerAsync(CustomerModel? customer)
         {
             if (customer == null || _dialogService == null || _customerService == null) return;
             var edited = _dialogService.ShowEditCustomerDialog(customer);

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -51,7 +51,7 @@ namespace InventoryManagementApp.ViewModels
                 if (SetProperty(ref _selectedUser, value))
                 {
                     ((AsyncRelayCommand)UpdateUserCommand).NotifyCanExecuteChanged();
-                    ((RelayCommand)EditUserCommand).NotifyCanExecuteChanged();
+                    ((AsyncRelayCommand)EditUserCommand).NotifyCanExecuteChanged();
                 }
             }
         }
@@ -64,8 +64,8 @@ namespace InventoryManagementApp.ViewModels
         public IRelayCommand SearchUsersCommand { get; }
         public IRelayCommand ClearUserSearchCommand { get; }
 
-        public IRelayCommand EditUserCommand { get; }
-        public IRelayCommand EditUserFromRowCommand { get; }
+        public IAsyncRelayCommand EditUserCommand { get; }
+        public IAsyncRelayCommand<UserModel> EditUserFromRowCommand { get; }
         public IAsyncRelayCommand<UserModel> ResetPasswordFromRowCommand { get; }
         public IAsyncRelayCommand<UserModel> DeleteUserFromRowCommand { get; }
 
@@ -94,8 +94,8 @@ namespace InventoryManagementApp.ViewModels
             SearchUsersCommand = new RelayCommand(SearchUsers);
             ClearUserSearchCommand = new RelayCommand(ClearUserSearch);
 
-            EditUserCommand = new RelayCommand(() => EditUser(SelectedUser), () => SelectedUser != null);
-            EditUserFromRowCommand = new RelayCommand<UserModel>(EditUser);
+            EditUserCommand = new AsyncRelayCommand(() => EditUserAsync(SelectedUser), () => SelectedUser != null);
+            EditUserFromRowCommand = new AsyncRelayCommand<UserModel>(EditUserAsync);
             ResetPasswordFromRowCommand = new AsyncRelayCommand<UserModel>(ResetPasswordFor);
             DeleteUserFromRowCommand = new AsyncRelayCommand<UserModel>(DeleteUserAsync);
         }
@@ -349,7 +349,7 @@ namespace InventoryManagementApp.ViewModels
             Users.ReplaceRange(_allUsers);
         }
 
-        async void EditUser(UserModel? user)
+        public async Task EditUserAsync(UserModel? user)
         {
             if (user == null) return;
 


### PR DESCRIPTION
## Summary
- expose UserManagementViewModel.EditUserAsync via IAsyncRelayCommand
- convert CustomerManagementViewModel.EditCustomer to async and bind with AsyncRelayCommand
- adjust tests for async customer editing

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aee671f95483249925495a54d3ecf3