### PR TITLE
Propagate cancellation tokens through user service

### DIFF
--- a/InventoryManagementApp.Tests/DashboardViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DashboardViewModelTests.cs
@@ -114,19 +114,19 @@ public class DashboardViewModelTests
         public int CountCalls { get; private set; }
         public int GetCalls { get; private set; }
 
-        public Task<int> CountUsersAsync()
+        public Task<int> CountUsersAsync(CancellationToken cancellationToken = default)
         {
             CountCalls++;
             return Task.FromResult(5);
         }
 
-        public Task<List<User>> GetAllUsersAsync()
+        public Task<List<User>> GetAllUsersAsync(CancellationToken cancellationToken = default)
         {
             GetCalls++;
             return Task.FromResult(new List<User>());
         }
 
-        public Task<User?> GetUserByIDAsync(int userID) => throw new NotImplementedException();
+        public Task<User?> GetUserByIDAsync(int userID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => throw new NotImplementedException();
         public Task<User?> GetCurrentUserAsync() => throw new NotImplementedException();
         public Task AddUserAsync(User user) => throw new NotImplementedException();

--- a/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
@@ -152,9 +152,9 @@ namespace InventoryManagementApp.Tests
 
         private sealed class DummyUserService : IUserService
         {
-            public Task<List<User>> GetAllUsersAsync() => Task.FromResult(new List<User>());
-            public Task<int> CountUsersAsync() => Task.FromResult(0);
-            public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult<User?>(null);
+            public Task<List<User>> GetAllUsersAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<User>());
+            public Task<int> CountUsersAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task<User?> GetUserByIDAsync(int userID, CancellationToken cancellationToken = default) => Task.FromResult<User?>(null);
             public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult((AuthenticationResult.Failure, (User?)null));
             public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
             public Task AddUserAsync(User user) => Task.CompletedTask;

--- a/InventoryManagementApp.Tests/MainViewModelTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelTests.cs
@@ -339,14 +339,15 @@ namespace InventoryManagementApp.Tests
 
         private sealed class DummyUserService : IUserService
         {
-            public Task<List<User>> GetAllUsersAsync() => Task.FromResult(new List<User>());
-            public Task<int> CountUsersAsync() => Task.FromResult(0);
-            public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult<User?>(null);
+            public Task<List<User>> GetAllUsersAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<User>());
+            public Task<int> CountUsersAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task<User?> GetUserByIDAsync(int userID, CancellationToken cancellationToken = default) => Task.FromResult<User?>(null);
             public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => Task.FromResult((AuthenticationResult.Failure, (User?)null));
             public Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
             public Task AddUserAsync(User user) => Task.CompletedTask;
             public Task UpdateUserAsync(User user) => Task.CompletedTask;
             public Task<bool> TryDeleteUserAsync(int userID) => Task.FromResult(false);
+            public Task<bool> ChangeUserPasswordAsync(int userID, string newPassword) => Task.FromResult(false);
         }
 
         private sealed class AuthStubUserService : IUserService
@@ -354,9 +355,9 @@ namespace InventoryManagementApp.Tests
             private readonly User _user;
             public AuthStubUserService(User user) => _user = user;
 
-            public Task<List<User>> GetAllUsersAsync() => Task.FromResult(new List<User> { _user });
-            public Task<int> CountUsersAsync() => Task.FromResult(1);
-            public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult(userID == _user.UserID ? _user : null);
+            public Task<List<User>> GetAllUsersAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<User> { _user });
+            public Task<int> CountUsersAsync(CancellationToken cancellationToken = default) => Task.FromResult(1);
+            public Task<User?> GetUserByIDAsync(int userID, CancellationToken cancellationToken = default) => Task.FromResult(userID == _user.UserID ? _user : null);
             public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password)
                 => Task.FromResult<(AuthenticationResult, User?)>((AuthenticationResult.Success, new User
                 {

--- a/InventoryManagementApp.Tests/UserInitialsBrushTests.cs
+++ b/InventoryManagementApp.Tests/UserInitialsBrushTests.cs
@@ -106,9 +106,9 @@ namespace InventoryManagementApp.Tests
         {
             private readonly List<User> _users;
             public StubUserService(List<User> users) => _users = users;
-            public Task<List<User>> GetAllUsersAsync() => Task.FromResult(_users);
-            public Task<int> CountUsersAsync() => throw new NotImplementedException();
-            public Task<User?> GetUserByIDAsync(int userID) => Task.FromResult(_users.FirstOrDefault(u => u.UserID == userID));
+            public Task<List<User>> GetAllUsersAsync(CancellationToken cancellationToken = default) => Task.FromResult(_users);
+            public Task<int> CountUsersAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<User?> GetUserByIDAsync(int userID, CancellationToken cancellationToken = default) => Task.FromResult(_users.FirstOrDefault(u => u.UserID == userID));
             public Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password) => throw new NotImplementedException();
             public Task<User?> GetCurrentUserAsync() => throw new NotImplementedException();
             public Task AddUserAsync(User user) => throw new NotImplementedException();

--- a/InventoryManagementApp/Interfaces/IUserService.cs
+++ b/InventoryManagementApp/Interfaces/IUserService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Models;
 using InventoryManagementApp.Models.Domain;
@@ -7,9 +8,9 @@ namespace InventoryManagementApp.Interfaces
 {
     public interface IUserService
     {
-        Task<List<User>> GetAllUsersAsync();
-        Task<int> CountUsersAsync();
-        Task<User?> GetUserByIDAsync(int userID);
+        Task<List<User>> GetAllUsersAsync(CancellationToken cancellationToken = default);
+        Task<int> CountUsersAsync(CancellationToken cancellationToken = default);
+        Task<User?> GetUserByIDAsync(int userID, CancellationToken cancellationToken = default);
         Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync(string userName, string password);
         Task<User?> GetCurrentUserAsync();
         Task AddUserAsync(User user);

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Documents;
 using System.Windows.Media;
+using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Generic;
 using InventoryManagementApp.Data;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Models;
@@ -80,7 +80,7 @@ namespace InventoryManagementApp.Services.Items
 
         public async Task<FlowDocument> GenerateUserReport()
         {
-            var users = await _userService.GetAllUsersAsync().ConfigureAwait(false);
+            var users = await _userService.GetAllUsersAsync(CancellationToken.None).ConfigureAwait(false);
             var lines = users.Select(u =>
                 $"UserID: {u.UserID} | UserName: {u.UserName} | IsAdmin: {u.IsAdmin}");
             return BuildReport("User Report", lines);
@@ -92,7 +92,7 @@ namespace InventoryManagementApp.Services.Items
             var totalRentalsTask = _rentalService.GetAllRentalsAsync();
             var totalActiveRentalsTask = _rentalService.GetActiveRentalsAsync();
             var totalCustomersTask = _customerService.GetAllCustomersAsync();
-            var totalUsersTask = _userService.GetAllUsersAsync();
+            var totalUsersTask = _userService.GetAllUsersAsync(CancellationToken.None);
 
             await Task.WhenAll(
                 totalItemsTask,

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.Data.Sqlite;
 using System.Data;
+using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Models;
 using InventoryManagementApp.Models.Domain;
@@ -95,27 +96,28 @@ namespace InventoryManagementApp.Services.Users
         }
 
 
-        public async Task<List<User>> GetAllUsersAsync()
+        public async Task<List<User>> GetAllUsersAsync(CancellationToken cancellationToken = default)
         {
             using var conn = _dbService.CreateConnection();
             const string sql = "SELECT UserID, UserName, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, PasswordExpired FROM Users";
-            return await SqliteHelper.ExecuteReaderAsync(conn, sql, MapUser);
+            return await SqliteHelper.ExecuteReaderAsync(conn, sql, MapUser, cancellationToken: cancellationToken);
         }
 
-        public async Task<int> CountUsersAsync()
+        public async Task<int> CountUsersAsync(CancellationToken cancellationToken = default)
         {
             using var conn = _dbService.CreateConnection();
             const string sql = "SELECT COUNT(*) FROM Users";
-            var result = await SqliteHelper.ExecuteScalarAsync(conn, sql);
+            var result = await SqliteHelper.ExecuteScalarAsync(conn, sql, cancellationToken: cancellationToken);
             return Convert.ToInt32(result);
         }
 
-        public async Task<User?> GetUserByIDAsync(int userID)
+        public async Task<User?> GetUserByIDAsync(int userID, CancellationToken cancellationToken = default)
         {
             using var conn = _dbService.CreateConnection();
             var list = await SqliteHelper.ExecuteReaderAsync(conn, "SELECT * FROM Users WHERE UserID=@ID",
                 MapUser,
-                new[] { new SqliteParameter("@ID", userID) });
+                new[] { new SqliteParameter("@ID", userID) },
+                cancellationToken: cancellationToken);
             return list.FirstOrDefault();
         }
 
@@ -172,13 +174,13 @@ namespace InventoryManagementApp.Services.Users
         public async Task<User?> GetCurrentUserAsync()
         {
             if (_context.CurrentUser is User u)
-                return await GetUserByIDAsync(u.UserID);
+                return await GetUserByIDAsync(u.UserID, CancellationToken.None);
             return null;
         }
 
         public async Task AddUserAsync(User user)
         {
-            var existingUsers = await GetAllUsersAsync();
+            var existingUsers = await GetAllUsersAsync(CancellationToken.None);
             if (existingUsers.Count == 0)
             {
                 // Seed first user as an administrator regardless of input flag
@@ -262,7 +264,7 @@ namespace InventoryManagementApp.Services.Users
 
             if (string.IsNullOrWhiteSpace(user.PasswordHash) || string.IsNullOrWhiteSpace(user.PasswordSalt))
             {
-                var existing = await GetUserByIDAsync(user.UserID);
+                var existing = await GetUserByIDAsync(user.UserID, CancellationToken.None);
                 if (existing != null)
                 {
                     if (string.IsNullOrWhiteSpace(user.PasswordHash))
@@ -341,7 +343,7 @@ namespace InventoryManagementApp.Services.Users
         public async Task<bool> TryDeleteUserAsync(int userID)
         {
             _auth.EnsureAdmin();
-            var user = await GetUserByIDAsync(userID);
+            var user = await GetUserByIDAsync(userID, CancellationToken.None);
             if (user == null) return false;
             if (user.IsAdmin)
             {

--- a/InventoryManagementApp/ViewModels/DashboardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DashboardViewModel.cs
@@ -95,7 +95,7 @@ namespace InventoryManagementApp.ViewModels
                 var itemCountTask = _itemService.CountItemsAsync(new ItemFilter(null), cancellationToken);
                 var rentalCountTask = _rentalService.CountActiveRentalsAsync();
                 var customerCountTask = _customerService.CountCustomersAsync(cancellationToken);
-                var userCountTask = _userService.CountUsersAsync();
+                var userCountTask = _userService.CountUsersAsync(cancellationToken);
 
                 await Task.WhenAll(itemCountTask, rentalCountTask, customerCountTask, userCountTask).ConfigureAwait(false);
 

--- a/InventoryManagementApp/ViewModels/LoginViewModel.cs
+++ b/InventoryManagementApp/ViewModels/LoginViewModel.cs
@@ -179,7 +179,7 @@ namespace InventoryManagementApp.ViewModels
 
         async Task LoadUsersAsync()
         {
-            var users = await _userService.GetAllUsersAsync();
+            var users = await _userService.GetAllUsersAsync(CancellationToken.None);
             if (users.Count == 0)
             {
                 var admin = new User
@@ -191,7 +191,7 @@ namespace InventoryManagementApp.ViewModels
                 };
                 await _userService.AddUserAsync(admin);
                 _logger.LogInformation("Created admin user {UserName}", admin.UserName);
-                users = await _userService.GetAllUsersAsync();
+                users = await _userService.GetAllUsersAsync(CancellationToken.None);
             }
 
             AssignInitialsBrushes(users);
@@ -247,7 +247,7 @@ namespace InventoryManagementApp.ViewModels
         {
             if (user == null) return;
 
-            var dbUser = await _userService.GetUserByIDAsync(user.UserID);
+            var dbUser = await _userService.GetUserByIDAsync(user.UserID, cancellationToken);
             if (dbUser == null) return;
             user = dbUser;
 
@@ -262,7 +262,7 @@ namespace InventoryManagementApp.ViewModels
                     _logger.LogWarning(ex, "Failed to set default password for admin user {UserID}", user.UserID);
                 }
 
-                var refreshed = await _userService.GetUserByIDAsync(user.UserID);
+                var refreshed = await _userService.GetUserByIDAsync(user.UserID, cancellationToken);
                 if (refreshed != null)
                 {
                     user.PasswordHash = refreshed.PasswordHash;
@@ -306,7 +306,7 @@ namespace InventoryManagementApp.ViewModels
                 if (promptResult.IsPasswordResetRequested)
                 {
                     await _userService.ChangeUserPasswordAsync(user.UserID, "admin");
-                    var refreshed = await _userService.GetUserByIDAsync(user.UserID);
+                    var refreshed = await _userService.GetUserByIDAsync(user.UserID, cancellationToken);
                     if (refreshed != null)
                     {
                         user.PasswordHash = refreshed.PasswordHash;
@@ -371,7 +371,7 @@ namespace InventoryManagementApp.ViewModels
                 await _dialogService.ShowInfoAsync("Failed to update password.", "Error");
                 return false;
             }
-            var refreshed = await _userService.GetUserByIDAsync(user.UserID);
+            var refreshed = await _userService.GetUserByIDAsync(user.UserID, CancellationToken.None);
             if (refreshed != null)
             {
                 user.PasswordHash = refreshed.PasswordHash;

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using InventoryManagementApp.Interfaces;
@@ -104,7 +105,7 @@ namespace InventoryManagementApp.ViewModels
         {
             try
             {
-                _allUsers = await _userService.GetAllUsersAsync();
+                _allUsers = await _userService.GetAllUsersAsync(CancellationToken.None);
                 AssignInitialsBrushes(_allUsers);
                 Users.ReplaceRange(_allUsers);
             }
@@ -251,7 +252,7 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 existingNames = new HashSet<string>(
-                    (await _userService.GetAllUsersAsync()).Select(u => u.UserName),
+                    (await _userService.GetAllUsersAsync(CancellationToken.None)).Select(u => u.UserName),
                     StringComparer.OrdinalIgnoreCase);
             }
             catch (Exception ex)
@@ -356,7 +357,7 @@ namespace InventoryManagementApp.ViewModels
             UserModel source = user;
             try
             {
-                var loaded = await _userService.GetUserByIDAsync(user.UserID);
+                var loaded = await _userService.GetUserByIDAsync(user.UserID, CancellationToken.None);
                 if (loaded != null)
                     source = loaded;
             }
@@ -428,7 +429,7 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 await _userService.ChangeUserPasswordAsync(user.UserID, newPassword);
-                var refreshed = await _userService.GetUserByIDAsync(user.UserID);
+                var refreshed = await _userService.GetUserByIDAsync(user.UserID, CancellationToken.None);
                 if (refreshed != null)
                 {
                     refreshed.PasswordExpired = true;


### PR DESCRIPTION
## Summary
- extend IUserService and UserService to accept CancellationToken for common queries
- pass tokens to SqliteHelper and update view models to forward cancellation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aee63934f48324b5c6bada7bac084e