### PR TITLE
Handle missing user avatar state gracefully

### DIFF
--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -111,7 +111,7 @@
                                           <Style.Triggers>
                                               <MultiDataTrigger>
                                                   <MultiDataTrigger.Conditions>
-                                                      <Condition Binding="{Binding HasCurrentUser}" Value="True"/>
+                                                      <Condition Binding="{Binding HasCurrentUser, FallbackValue=True}" Value="True"/>
                                                       <Condition Binding="{Binding CurrentUserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
                                                   </MultiDataTrigger.Conditions>
                                                   <Setter Property="Visibility" Value="Collapsed"/>
@@ -127,7 +127,7 @@
                                           <Style.Triggers>
                                               <MultiDataTrigger>
                                                   <MultiDataTrigger.Conditions>
-                                                      <Condition Binding="{Binding HasCurrentUser}" Value="True"/>
+                                                      <Condition Binding="{Binding HasCurrentUser, FallbackValue=True}" Value="True"/>
                                                       <Condition Binding="{Binding CurrentUserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
                                                   </MultiDataTrigger.Conditions>
                                                   <Setter Property="Visibility" Value="Visible"/>
@@ -144,7 +144,7 @@
                                               <Style.Triggers>
                                                   <MultiDataTrigger>
                                                       <MultiDataTrigger.Conditions>
-                                                          <Condition Binding="{Binding HasCurrentUser}" Value="True"/>
+                                                          <Condition Binding="{Binding HasCurrentUser, FallbackValue=True}" Value="True"/>
                                                           <Condition Binding="{Binding CurrentUserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
                                                       </MultiDataTrigger.Conditions>
                                                       <Setter Property="Visibility" Value="Visible"/>


### PR DESCRIPTION
## Summary
- ensure user avatar triggers fall back to showing initials when `HasCurrentUser` binding is unavailable

## Testing
- `dotnet test InventoryManagementApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af61dd99408324ae965215da02ee23