### PR TITLE
Ensure user photo paths are local and relative

### DIFF
--- a/InventoryManagementApp.Tests/UsersEditViewModelTests.cs
+++ b/InventoryManagementApp.Tests/UsersEditViewModelTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
@@ -17,15 +18,44 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void BrowseImageCommand_SetsPhotoPath()
+        public void BrowseImageCommand_UsesRelativePathForBaseDirectoryFile()
         {
             var user = new User();
-            var dialog = new DummyFileDialogService { Result = "test.png" };
+            var dialog = new DummyFileDialogService();
+            var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+            var filePath = Path.Combine(baseDir, Guid.NewGuid() + ".png");
+            File.WriteAllText(filePath, "test");
+            dialog.Result = filePath;
             var vm = new UsersEditViewModel(user, dialog, onSave: () => Task.CompletedTask, onCancel: () => { });
 
             vm.BrowseImageCommand.Execute(null);
 
-            Assert.Equal("test.png", user.UserPhotoPath);
+            Assert.Equal(Path.GetFileName(filePath), user.UserPhotoPath);
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void BrowseImageCommand_CopiesExternalFileToAssets()
+        {
+            var user = new User();
+            var dialog = new DummyFileDialogService();
+            var tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".png");
+            File.WriteAllText(tempFile, "test");
+            dialog.Result = tempFile;
+            var vm = new UsersEditViewModel(user, dialog, onSave: () => Task.CompletedTask, onCancel: () => { });
+
+            vm.BrowseImageCommand.Execute(null);
+
+            var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+            var expectedRelative = Path.Combine("Assets", "UserPhotos", Path.GetFileName(tempFile));
+            var destPath = Path.Combine(baseDir, expectedRelative);
+
+            Assert.Equal(expectedRelative, user.UserPhotoPath);
+            Assert.True(File.Exists(destPath));
+
+            File.Delete(tempFile);
+            File.Delete(destPath);
         }
 
         [Fact]

--- a/InventoryManagementApp/ViewModels/UsersEditViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UsersEditViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.Input;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
 using System;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace InventoryManagementApp.ViewModels
@@ -34,10 +35,26 @@ namespace InventoryManagementApp.ViewModels
         void BrowseImage()
         {
             var path = _fileDialog.OpenFile("Image Files|*.png;*.jpg;*.jpeg;*.bmp|All Files|*.*");
-            if (!string.IsNullOrEmpty(path))
+            if (string.IsNullOrEmpty(path))
             {
-                EditingUser.UserPhotoPath = path;
+                return;
             }
+
+            var fullPath = Path.GetFullPath(path);
+            var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+            var targetPath = fullPath;
+
+            if (!fullPath.StartsWith(baseDir, StringComparison.OrdinalIgnoreCase))
+            {
+                var assetsDir = Path.Combine(baseDir, "Assets", "UserPhotos");
+                Directory.CreateDirectory(assetsDir);
+                var fileName = Path.GetFileName(fullPath);
+                targetPath = Path.Combine(assetsDir, fileName);
+                File.Copy(fullPath, targetPath, true);
+            }
+
+            var relativePath = Path.GetRelativePath(baseDir, targetPath);
+            EditingUser.UserPhotoPath = relativePath;
         }
 
         void RemoveImage()


### PR DESCRIPTION
## Summary
- Copy selected user images into `Assets/UserPhotos` when they are outside the app folder
- Save photo paths relative to the application base directory
- Add tests covering relative paths and external image copies

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6376eb5483248a14e321de9598a6