### PR TITLE
Ensure initials show when user image removed

### DIFF
--- a/InventoryManagementApp.Tests/UsersEditViewModelTests.cs
+++ b/InventoryManagementApp.Tests/UsersEditViewModelTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
+using System.Windows.Media;
 using Xunit;
 
 namespace InventoryManagementApp.Tests
@@ -68,6 +69,18 @@ namespace InventoryManagementApp.Tests
             vm.RemoveImageCommand.Execute(null);
 
             Assert.Equal(string.Empty, user.UserPhotoPath);
+        }
+
+        [Fact]
+        public void RemoveImageCommand_SetsInitialsBrushToVisibleBrush()
+        {
+            var user = new User { UserPhotoPath = "test.png", InitialsBrush = Brushes.Transparent };
+            var dialog = new DummyFileDialogService();
+            var vm = new UsersEditViewModel(user, dialog, onSave: () => Task.CompletedTask, onCancel: () => { });
+
+            vm.RemoveImageCommand.Execute(null);
+
+            Assert.Equal(Brushes.Black, user.InitialsBrush);
         }
     }
 }

--- a/InventoryManagementApp/ViewModels/UsersEditViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UsersEditViewModel.cs
@@ -6,6 +6,9 @@ using InventoryManagementApp.Models.Domain;
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using System.Windows;
+using MediaBrush = System.Windows.Media.Brush;
+using MediaBrushes = System.Windows.Media.Brushes;
 
 namespace InventoryManagementApp.ViewModels
 {
@@ -60,6 +63,8 @@ namespace InventoryManagementApp.ViewModels
         void RemoveImage()
         {
             EditingUser.UserPhotoPath = string.Empty;
+            var brush = Application.Current?.TryFindResource("ForegroundBrush") as MediaBrush;
+            EditingUser.InitialsBrush = brush ?? MediaBrushes.Black;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Set `InitialsBrush` to a visible brush when clearing user photo
- Default to black brush if `ForegroundBrush` resource is missing
- Test that Remove Image command updates initials brush

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6f20c004832494b12fbc9dcf1fb1