### PR TITLE
Use name/photo triggers for user avatars

### DIFF
--- a/InventoryManagementApp.Tests/UserInitialsDisplayTests.cs
+++ b/InventoryManagementApp.Tests/UserInitialsDisplayTests.cs
@@ -59,6 +59,50 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void UsersPage_ShowsDefaultPhotoWhenNameBlank()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
+
+                    var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "InventoryManagementApp", "Views", "Pages", "UsersPage.xaml"));
+                    var xaml = File.ReadAllText(path);
+                    xaml = Regex.Replace(xaml, "x:Class=\\\"[^\\\"]*\\\"\\s*", string.Empty);
+                    var page = (Page)XamlReader.Parse(xaml);
+                    var dataGrid = FindVisualChild<DataGrid>(page) ?? throw new InvalidOperationException("DataGrid not found");
+                    var col = (DataGridTemplateColumn)dataGrid.Columns[0];
+                    var element = (FrameworkElement)col.CellTemplate.LoadContent();
+                    element.DataContext = new { UserName = string.Empty, UserPhotoPath = (string?)null };
+                    element.Measure(new Size(36, 36));
+                    element.Arrange(new Rect(0, 0, 36, 36));
+                    element.UpdateLayout();
+                    var textBlock = FindVisualChild<TextBlock>(element) ?? throw new InvalidOperationException("TextBlock not found");
+                    var image = FindVisualChild<Image>(element) ?? throw new InvalidOperationException("Image not found");
+                    Assert.Equal(Visibility.Collapsed, textBlock.Visibility);
+                    Assert.Equal(Visibility.Visible, image.Visibility);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
         public void MainWindow_ShowsInitialsWhenNoPhotoPath()
         {
             Exception? threadEx = null;

--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -113,6 +113,7 @@
                                                   <MultiDataTrigger.Conditions>
                                                       <Condition Binding="{Binding HasCurrentUser, FallbackValue=True}" Value="True"/>
                                                       <Condition Binding="{Binding CurrentUserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
+                                                      <Condition Binding="{Binding CurrentUserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
                                                   </MultiDataTrigger.Conditions>
                                                   <Setter Property="Visibility" Value="Collapsed"/>
                                               </MultiDataTrigger>
@@ -129,6 +130,7 @@
                                                   <MultiDataTrigger.Conditions>
                                                       <Condition Binding="{Binding HasCurrentUser, FallbackValue=True}" Value="True"/>
                                                       <Condition Binding="{Binding CurrentUserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
+                                                      <Condition Binding="{Binding CurrentUserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
                                                   </MultiDataTrigger.Conditions>
                                                   <Setter Property="Visibility" Value="Visible"/>
                                               </MultiDataTrigger>
@@ -146,6 +148,7 @@
                                                       <MultiDataTrigger.Conditions>
                                                           <Condition Binding="{Binding HasCurrentUser, FallbackValue=True}" Value="True"/>
                                                           <Condition Binding="{Binding CurrentUserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
+                                                          <Condition Binding="{Binding CurrentUserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
                                                       </MultiDataTrigger.Conditions>
                                                       <Setter Property="Visibility" Value="Visible"/>
                                                   </MultiDataTrigger>

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml
@@ -43,11 +43,15 @@
                                            Stretch="Uniform">
                                         <Image.Style>
                                             <Style TargetType="Image">
-                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                <Setter Property="Visibility" Value="Visible"/>
                                                 <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True">
-                                                        <Setter Property="Visibility" Value="Visible"/>
-                                                    </DataTrigger>
+                                                    <MultiDataTrigger>
+                                                        <MultiDataTrigger.Conditions>
+                                                            <Condition Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
+                                                            <Condition Binding="{Binding UserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
+                                                        </MultiDataTrigger.Conditions>
+                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                    </MultiDataTrigger>
                                                 </Style.Triggers>
                                             </Style>
                                         </Image.Style>
@@ -55,11 +59,15 @@
                                     <Border Background="Transparent">
                                         <Border.Style>
                                             <Style TargetType="Border">
-                                                <Setter Property="Visibility" Value="Visible"/>
+                                                <Setter Property="Visibility" Value="Collapsed"/>
                                                 <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True">
-                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                    </DataTrigger>
+                                                    <MultiDataTrigger>
+                                                        <MultiDataTrigger.Conditions>
+                                                            <Condition Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
+                                                            <Condition Binding="{Binding UserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
+                                                        </MultiDataTrigger.Conditions>
+                                                        <Setter Property="Visibility" Value="Visible"/>
+                                                    </MultiDataTrigger>
                                                 </Style.Triggers>
                                             </Style>
                                         </Border.Style>
@@ -69,11 +77,15 @@
                                                    Foreground="{Binding InitialsBrush}">
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">
-                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
                                                     <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True">
-                                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                                        </DataTrigger>
+                                                        <MultiDataTrigger>
+                                                            <MultiDataTrigger.Conditions>
+                                                                <Condition Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
+                                                                <Condition Binding="{Binding UserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
+                                                            </MultiDataTrigger.Conditions>
+                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                        </MultiDataTrigger>
                                                     </Style.Triggers>
                                                 </Style>
                                             </TextBlock.Style>

--- a/InventoryManagementApp/Views/Windows/LoginWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/LoginWindow.xaml
@@ -66,12 +66,13 @@
                                                     <Style TargetType="Image">
                                                         <Setter Property="Visibility" Value="Visible"/>
                                                         <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding UserPhotoPath}" Value="">
+                                                            <MultiDataTrigger>
+                                                                <MultiDataTrigger.Conditions>
+                                                                    <Condition Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
+                                                                    <Condition Binding="{Binding UserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
+                                                                </MultiDataTrigger.Conditions>
                                                                 <Setter Property="Visibility" Value="Collapsed"/>
-                                                            </DataTrigger>
-                                                            <DataTrigger Binding="{Binding UserPhotoPath}" Value="{x:Null}">
-                                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                                            </DataTrigger>
+                                                            </MultiDataTrigger>
                                                         </Style.Triggers>
                                                     </Style>
                                                 </Image.Style>
@@ -81,12 +82,13 @@
                                                     <Style TargetType="Border">
                                                         <Setter Property="Visibility" Value="Collapsed"/>
                                                         <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding UserPhotoPath}" Value="">
+                                                            <MultiDataTrigger>
+                                                                <MultiDataTrigger.Conditions>
+                                                                    <Condition Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
+                                                                    <Condition Binding="{Binding UserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
+                                                                </MultiDataTrigger.Conditions>
                                                                 <Setter Property="Visibility" Value="Visible"/>
-                                                            </DataTrigger>
-                                                            <DataTrigger Binding="{Binding UserPhotoPath}" Value="{x:Null}">
-                                                                <Setter Property="Visibility" Value="Visible"/>
-                                                            </DataTrigger>
+                                                            </MultiDataTrigger>
                                                         </Style.Triggers>
                                                     </Style>
                                                 </Border.Style>
@@ -99,12 +101,13 @@
                                                         <Style TargetType="TextBlock">
                                                             <Setter Property="Visibility" Value="Collapsed"/>
                                                             <Style.Triggers>
-                                                                <DataTrigger Binding="{Binding UserPhotoPath}" Value="">
+                                                                <MultiDataTrigger>
+                                                                    <MultiDataTrigger.Conditions>
+                                                                        <Condition Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
+                                                                        <Condition Binding="{Binding UserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
+                                                                    </MultiDataTrigger.Conditions>
                                                                     <Setter Property="Visibility" Value="Visible"/>
-                                                                </DataTrigger>
-                                                                <DataTrigger Binding="{Binding UserPhotoPath}" Value="{x:Null}">
-                                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                                </DataTrigger>
+                                                                </MultiDataTrigger>
                                                             </Style.Triggers>
                                                         </Style>
                                                     </TextBlock.Style>


### PR DESCRIPTION
## Summary
- Only show user initials when a photo is missing and a name is present across main window, login tiles, and user list rows
- Ensure default avatar shows when both photo and name are missing
- Test that a blank user name without a photo falls back to the default image

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 errors while attempting to install .NET SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68af944075688324a3f863a944f6733e