### PR TITLE
Add reusable UserAvatar control with tests

### DIFF
--- a/InventoryManagementApp.Tests/UserAvatarTests.cs
+++ b/InventoryManagementApp.Tests/UserAvatarTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class UserAvatarTests
+    {
+        [Fact]
+        public void ShowsInitialsWhenNoPhoto()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
+
+                    var avatar = new Controls.UserAvatar
+                    {
+                        UserName = "John Doe",
+                        UserPhotoPath = null,
+                        Foreground = Brushes.Black,
+                        FontSize = 20
+                    };
+                    avatar.Measure(new Size(36, 36));
+                    avatar.Arrange(new Rect(0, 0, 36, 36));
+                    avatar.UpdateLayout();
+
+                    var textBlock = FindVisualChild<TextBlock>(avatar) ?? throw new InvalidOperationException("TextBlock not found");
+                    var image = FindVisualChild<Image>(avatar) ?? throw new InvalidOperationException("Image not found");
+                    Assert.Equal("JD", textBlock.Text);
+                    Assert.Equal(Visibility.Visible, textBlock.Visibility);
+                    Assert.Equal(Visibility.Collapsed, image.Visibility);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
+        public void ShowsDefaultImageWhenNameBlank()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
+
+                    var avatar = new Controls.UserAvatar
+                    {
+                        UserName = string.Empty,
+                        UserPhotoPath = null
+                    };
+                    avatar.Measure(new Size(36, 36));
+                    avatar.Arrange(new Rect(0, 0, 36, 36));
+                    avatar.UpdateLayout();
+
+                    var textBlock = FindVisualChild<TextBlock>(avatar) ?? throw new InvalidOperationException("TextBlock not found");
+                    var image = FindVisualChild<Image>(avatar) ?? throw new InvalidOperationException("Image not found");
+                    Assert.Equal(Visibility.Collapsed, textBlock.Visibility);
+                    Assert.Equal(Visibility.Visible, image.Visibility);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
+        public void ShowsPhotoWhenPhotoPathExists()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
+
+                    var photoPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "Avatars", "40.png"));
+                    var avatar = new Controls.UserAvatar
+                    {
+                        UserName = "John Doe",
+                        UserPhotoPath = photoPath
+                    };
+                    avatar.Measure(new Size(36, 36));
+                    avatar.Arrange(new Rect(0, 0, 36, 36));
+                    avatar.UpdateLayout();
+
+                    var textBlock = FindVisualChild<TextBlock>(avatar) ?? throw new InvalidOperationException("TextBlock not found");
+                    var image = FindVisualChild<Image>(avatar) ?? throw new InvalidOperationException("Image not found");
+                    Assert.Equal(Visibility.Collapsed, textBlock.Visibility);
+                    Assert.Equal(Visibility.Visible, image.Visibility);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                if (child is T t)
+                    return t;
+                var result = FindVisualChild<T>(child);
+                if (result != null)
+                    return result;
+            }
+            return null;
+        }
+    }
+}

--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -102,62 +102,10 @@
                 <DockPanel>
                     <TextBlock Text="{Binding CurrentPageTitle}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="10" Style="{StaticResource PageTitleTextBlock}"/>
                     <Border Width="60" Height="60" DockPanel.Dock="Right"  CornerRadius="16" ClipToBounds="True" Margin="0,0,8,0">
-                        <Grid>
-                              <Image Source="{Binding CurrentUserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
-                                     Stretch="Uniform">
-                                  <Image.Style>
-                                      <Style TargetType="Image">
-                                          <Setter Property="Visibility" Value="Visible"/>
-                                          <Style.Triggers>
-                                              <MultiDataTrigger>
-                                                  <MultiDataTrigger.Conditions>
-                                                      <Condition Binding="{Binding HasCurrentUser, FallbackValue=True}" Value="True"/>
-                                                      <Condition Binding="{Binding CurrentUserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
-                                                      <Condition Binding="{Binding CurrentUserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
-                                                  </MultiDataTrigger.Conditions>
-                                                  <Setter Property="Visibility" Value="Collapsed"/>
-                                              </MultiDataTrigger>
-                                          </Style.Triggers>
-                                      </Style>
-                                  </Image.Style>
-                              </Image>
-                              <Border Background="Transparent">
-                                  <Border.Style>
-                                      <Style TargetType="Border">
-                                          <Setter Property="Visibility" Value="Collapsed"/>
-                                          <Style.Triggers>
-                                              <MultiDataTrigger>
-                                                  <MultiDataTrigger.Conditions>
-                                                      <Condition Binding="{Binding HasCurrentUser, FallbackValue=True}" Value="True"/>
-                                                      <Condition Binding="{Binding CurrentUserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
-                                                      <Condition Binding="{Binding CurrentUserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
-                                                  </MultiDataTrigger.Conditions>
-                                                  <Setter Property="Visibility" Value="Visible"/>
-                                              </MultiDataTrigger>
-                                          </Style.Triggers>
-                                      </Style>
-                                  </Border.Style>
-                                  <TextBlock Text="{Binding CurrentUserName, Converter={StaticResource NameToInitialsConverter}}"
-                                             HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" FontSize="28"
-                                             Foreground="{Binding CurrentUserInitialsBrush}">
-                                      <TextBlock.Style>
-                                          <Style TargetType="TextBlock">
-                                              <Setter Property="Visibility" Value="Collapsed"/>
-                                              <Style.Triggers>
-                                                  <MultiDataTrigger>
-                                                      <MultiDataTrigger.Conditions>
-                                                          <Condition Binding="{Binding HasCurrentUser, FallbackValue=True}" Value="True"/>
-                                                          <Condition Binding="{Binding CurrentUserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
-                                                          <Condition Binding="{Binding CurrentUserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
-                                                      </MultiDataTrigger.Conditions>
-                                                      <Setter Property="Visibility" Value="Visible"/>
-                                                  </MultiDataTrigger>
-                                              </Style.Triggers>
-                                          </Style>
-                                      </TextBlock.Style>
-                                  </TextBlock>
-                              </Border>
-                        </Grid>
+                        <controls:UserAvatar UserName="{Binding CurrentUserName}"
+                                              UserPhotoPath="{Binding CurrentUserPhotoPath}"
+                                              Foreground="{Binding CurrentUserInitialsBrush}"
+                                              FontSize="28"/>
                     </Border>
                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         

--- a/InventoryManagementApp/Views/Controls/UserAvatar.xaml
+++ b/InventoryManagementApp/Views/Controls/UserAvatar.xaml
@@ -1,0 +1,60 @@
+<UserControl x:Class="InventoryManagementApp.Controls.UserAvatar"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="Root">
+    <Grid>
+        <Image Source="{Binding UserPhotoPath, ElementName=Root, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
+               Stretch="Uniform">
+            <Image.Style>
+                <Style TargetType="Image">
+                    <Setter Property="Visibility" Value="Visible"/>
+                    <Style.Triggers>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding UserPhotoPath, ElementName=Root, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
+                                <Condition Binding="{Binding UserName, ElementName=Root, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                        </MultiDataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Image.Style>
+        </Image>
+        <Border Background="Transparent">
+            <Border.Style>
+                <Style TargetType="Border">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                    <Style.Triggers>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding UserPhotoPath, ElementName=Root, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
+                                <Condition Binding="{Binding UserName, ElementName=Root, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </MultiDataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Border.Style>
+            <TextBlock Text="{Binding UserName, ElementName=Root, Converter={StaticResource NameToInitialsConverter}}"
+                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                       FontWeight="Bold"
+                       FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding UserPhotoPath, ElementName=Root, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
+                                    <Condition Binding="{Binding UserName, ElementName=Root, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
+                                </MultiDataTrigger.Conditions>
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </MultiDataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
+        </Border>
+    </Grid>
+</UserControl>

--- a/InventoryManagementApp/Views/Controls/UserAvatar.xaml.cs
+++ b/InventoryManagementApp/Views/Controls/UserAvatar.xaml.cs
@@ -1,0 +1,31 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace InventoryManagementApp.Controls
+{
+    public partial class UserAvatar : UserControl
+    {
+        public UserAvatar()
+        {
+            InitializeComponent();
+        }
+
+        public string? UserName
+        {
+            get => (string?)GetValue(UserNameProperty);
+            set => SetValue(UserNameProperty, value);
+        }
+
+        public static readonly DependencyProperty UserNameProperty =
+            DependencyProperty.Register(nameof(UserName), typeof(string), typeof(UserAvatar));
+
+        public string? UserPhotoPath
+        {
+            get => (string?)GetValue(UserPhotoPathProperty);
+            set => SetValue(UserPhotoPathProperty, value);
+        }
+
+        public static readonly DependencyProperty UserPhotoPathProperty =
+            DependencyProperty.Register(nameof(UserPhotoPath), typeof(string), typeof(UserAvatar));
+    }
+}

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml
@@ -2,6 +2,7 @@
 <Page x:Class="InventoryManagementApp.Views.Pages.UsersPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
       Background="{StaticResource BackgroundBrush}">
 
     <Grid Margin="8">
@@ -39,58 +40,10 @@
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Grid Width="36" Height="36">
-                                    <Image Source="{Binding UserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
-                                           Stretch="Uniform">
-                                        <Image.Style>
-                                            <Style TargetType="Image">
-                                                <Setter Property="Visibility" Value="Visible"/>
-                                                <Style.Triggers>
-                                                    <MultiDataTrigger>
-                                                        <MultiDataTrigger.Conditions>
-                                                            <Condition Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
-                                                            <Condition Binding="{Binding UserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
-                                                        </MultiDataTrigger.Conditions>
-                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                    </MultiDataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </Image.Style>
-                                    </Image>
-                                    <Border Background="Transparent">
-                                        <Border.Style>
-                                            <Style TargetType="Border">
-                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                                <Style.Triggers>
-                                                    <MultiDataTrigger>
-                                                        <MultiDataTrigger.Conditions>
-                                                            <Condition Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
-                                                            <Condition Binding="{Binding UserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
-                                                        </MultiDataTrigger.Conditions>
-                                                        <Setter Property="Visibility" Value="Visible"/>
-                                                    </MultiDataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </Border.Style>
-                                        <TextBlock Text="{Binding UserName, Converter={StaticResource NameToInitialsConverter}}"
-                                                   HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                   FontWeight="Bold" FontSize="20"
-                                                   Foreground="{Binding InitialsBrush}">
-                                            <TextBlock.Style>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="Visibility" Value="Collapsed"/>
-                                                    <Style.Triggers>
-                                                        <MultiDataTrigger>
-                                                            <MultiDataTrigger.Conditions>
-                                                                <Condition Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
-                                                                <Condition Binding="{Binding UserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
-                                                            </MultiDataTrigger.Conditions>
-                                                            <Setter Property="Visibility" Value="Visible"/>
-                                                        </MultiDataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </TextBlock.Style>
-                                        </TextBlock>
-                                    </Border>
+                                    <controls:UserAvatar UserName="{Binding UserName}"
+                                                        UserPhotoPath="{Binding UserPhotoPath}"
+                                                        Foreground="{Binding InitialsBrush}"
+                                                        FontSize="20"/>
                                 </Grid>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>

--- a/InventoryManagementApp/Views/Windows/LoginWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/LoginWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:av="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         mc:Ignorable="av"
         x:Class="InventoryManagementApp.Views.Windows.LoginWindow"
         Title="{Binding WindowTitle}"
@@ -59,61 +60,10 @@
                                             BorderBrush="{StaticResource BorderBrushAlt}"
                                             BorderThickness="1"
                                             ClipToBounds="True">
-                                        <Grid>
-                                            <Image Stretch="Uniform"
-                                                   Source="{Binding UserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}">
-                                                <Image.Style>
-                                                    <Style TargetType="Image">
-                                                        <Setter Property="Visibility" Value="Visible"/>
-                                                        <Style.Triggers>
-                                                            <MultiDataTrigger>
-                                                                <MultiDataTrigger.Conditions>
-                                                                    <Condition Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
-                                                                    <Condition Binding="{Binding UserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
-                                                                </MultiDataTrigger.Conditions>
-                                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                                            </MultiDataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </Image.Style>
-                                            </Image>
-                                            <Border Background="Transparent">
-                                                <Border.Style>
-                                                    <Style TargetType="Border">
-                                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                                        <Style.Triggers>
-                                                            <MultiDataTrigger>
-                                                                <MultiDataTrigger.Conditions>
-                                                                    <Condition Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
-                                                                    <Condition Binding="{Binding UserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
-                                                                </MultiDataTrigger.Conditions>
-                                                                <Setter Property="Visibility" Value="Visible"/>
-                                                            </MultiDataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </Border.Style>
-                                                <TextBlock Text="{Binding UserName, Converter={StaticResource NameToInitialsConverter}}"
-                                                           FontSize="48"
-                                                           Foreground="{Binding InitialsBrush}"
-                                                           HorizontalAlignment="Center"
-                                                           VerticalAlignment="Center">
-                                                    <TextBlock.Style>
-                                                        <Style TargetType="TextBlock">
-                                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                                            <Style.Triggers>
-                                                                <MultiDataTrigger>
-                                                                    <MultiDataTrigger.Conditions>
-                                                                        <Condition Binding="{Binding UserPhotoPath, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="False"/>
-                                                                        <Condition Binding="{Binding UserName, Converter={StaticResource NonEmptyStringToBoolConverter}}" Value="True"/>
-                                                                    </MultiDataTrigger.Conditions>
-                                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                                </MultiDataTrigger>
-                                                            </Style.Triggers>
-                                                        </Style>
-                                                    </TextBlock.Style>
-                                                </TextBlock>
-                                            </Border>
-                                        </Grid>
+                                        <controls:UserAvatar UserName="{Binding UserName}"
+                                                            UserPhotoPath="{Binding UserPhotoPath}"
+                                                            Foreground="{Binding InitialsBrush}"
+                                                            FontSize="48"/>
                                     </Border>
                                     <TextBlock Grid.Row="1"
                                                Text="{Binding UserName}"


### PR DESCRIPTION
## Summary
- add `UserAvatar` control to encapsulate photo/initial logic
- swap inline avatar markup in MainWindow, LoginWindow, and UsersPage for `UserAvatar`
- test avatar to ensure photos, initials, and default images render correctly

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af983889a4832484f68f8ba279e7b4