### PR TITLE
Retain brush on user edit and recompute after name change

### DIFF
--- a/InventoryManagementApp.Tests/UserInitialsBrushTests.cs
+++ b/InventoryManagementApp.Tests/UserInitialsBrushTests.cs
@@ -105,6 +105,57 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void EditUserNameReassignsBrushes()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    var users = new List<User>
+                    {
+                        new User { UserID = 1, UserName = "John Doe" },
+                        new User { UserID = 2, UserName = "Jane Doe" }
+                    };
+                    var svc = new StubUserService(users);
+                    var vm = new UserManagementViewModel(svc, new DummyFileDialogService(), new DummyDialogService());
+                    vm.LoadUsersAsync().GetAwaiter().GetResult();
+                    vm.SelectedUser = vm.Users[0];
+                    var defaultBrush = Application.Current.TryFindResource("ForegroundBrush") as Brush;
+                    Assert.NotEqual(defaultBrush, vm.Users[1].InitialsBrush);
+
+                    app.Dispatcher.InvokeAsync(async () =>
+                    {
+                        await Task.Delay(100);
+                        var win = app.Windows.OfType<UsersEditWindow>().First();
+                        var editVm = (UsersEditViewModel)win.DataContext;
+                        editVm.EditingUser.UserName = "Alice Smith";
+                        await editVm.SaveCommand.ExecuteAsync(null);
+                    });
+
+                    vm.EditUserCommand.Execute(null);
+
+                    Assert.Equal(defaultBrush, vm.Users[0].InitialsBrush);
+                    Assert.Equal(defaultBrush, vm.Users[1].InitialsBrush);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
         public void LoginRetainsInitialsBrush()
         {
             Exception? threadEx = null;

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -359,7 +359,10 @@ namespace InventoryManagementApp.ViewModels
             {
                 var loaded = await _userService.GetUserByIDAsync(user.UserID, CancellationToken.None);
                 if (loaded != null)
+                {
+                    loaded.InitialsBrush = user.InitialsBrush;
                     source = loaded;
+                }
             }
             catch (Exception ex)
             {
@@ -391,10 +394,13 @@ namespace InventoryManagementApp.ViewModels
                     try
                     {
                         await _userService.UpdateUserAsync(clone);
+                        var nameChanged = !string.Equals(user.UserName, clone.UserName, StringComparison.Ordinal);
                         var idx = Users.IndexOf(user);
                         if (idx >= 0) Users[idx] = clone;
                         var idxAll = _allUsers.IndexOf(user);
                         if (idxAll >= 0) _allUsers[idxAll] = clone;
+                        if (nameChanged)
+                            AssignInitialsBrushes(_allUsers);
                         if (ReferenceEquals(SelectedUser, user)) SelectedUser = clone;
                         if (_userContext?.CurrentUser?.UserID == clone.UserID)
                             _userContext.CurrentUser = clone;


### PR DESCRIPTION
## Summary
- Preserve user's initials brush when editing by applying the existing brush to the loaded record and cloning
- After saving, update collections and current user while optionally recomputing initials brushes when names change
- Add regression tests covering brush reassignment when a user's name changes

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afaae62060832486f6935ef670171e