### PR TITLE
Resolve photo path bindings

### DIFF
--- a/InventoryManagementApp.Tests/ExistingFilePathToBoolConverterTests.cs
+++ b/InventoryManagementApp.Tests/ExistingFilePathToBoolConverterTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Globalization;
+using System.IO;
+using InventoryManagementApp.Utilities.Converters;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ExistingFilePathToBoolConverterTests
+    {
+        [Fact]
+        public void Convert_RelativeExistingPath_ReturnsTrue()
+        {
+            var baseDir = AppContext.BaseDirectory;
+            var tempDir = Path.Combine(baseDir, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var filePath = Path.Combine(tempDir, "file.txt");
+                File.WriteAllText(filePath, "test");
+                var relative = Path.GetRelativePath(baseDir, filePath);
+                var converter = new ExistingFilePathToBoolConverter();
+                var result = converter.Convert(relative, typeof(bool), null, CultureInfo.InvariantCulture);
+                Assert.True(result is bool b && b);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void Convert_RelativeMissingPath_ReturnsFalse()
+        {
+            var relative = Path.Combine("nonexistent", "file.txt");
+            var converter = new ExistingFilePathToBoolConverter();
+            var result = converter.Convert(relative, typeof(bool), null, CultureInfo.InvariantCulture);
+            Assert.False(result is bool b && b);
+        }
+    }
+}
+

--- a/InventoryManagementApp/Utilities/Converters/ExistingFilePathToBoolConverter.cs
+++ b/InventoryManagementApp/Utilities/Converters/ExistingFilePathToBoolConverter.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Windows.Data;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using InventoryManagementApp.Utilities.Helpers;
 using Binding = System.Windows.Data.Binding;
 
 namespace InventoryManagementApp.Utilities.Converters
@@ -27,7 +28,11 @@ namespace InventoryManagementApp.Utilities.Converters
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var path = value as string;
-            return !string.IsNullOrWhiteSpace(path) && File.Exists(path);
+            if (string.IsNullOrWhiteSpace(path))
+                return false;
+
+            var absPath = Helpers.PathHelper.GetAbsolutePath(path, false);
+            return !string.IsNullOrWhiteSpace(absPath) && File.Exists(absPath);
         }
 
         /// <summary>

--- a/InventoryManagementApp/Views/Controls/UserAvatar.xaml
+++ b/InventoryManagementApp/Views/Controls/UserAvatar.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Name="Root">
     <Grid>
-        <Image Source="{Binding UserPhotoPath, ElementName=Root}"
+        <Image Source="{Binding UserPhotoPath, ElementName=Root, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
                Stretch="Uniform">
             <Image.Style>
                 <Style TargetType="Image">


### PR DESCRIPTION
## Summary
- Resolve file paths via `PathHelper` in `ExistingFilePathToBoolConverter`
- Use `NullToDefaultImageConverter` for user avatar image source
- Add unit tests verifying file path resolution

## Testing
- `dotnet test` *(fails: dotnet command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afafd5fba48324b7b2a45d2ce1bc9d