### PR TITLE
Reassign user initials brushes after edits

### DIFF
--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -394,13 +394,11 @@ namespace InventoryManagementApp.ViewModels
                     try
                     {
                         await _userService.UpdateUserAsync(clone);
-                        var nameChanged = !string.Equals(user.UserName, clone.UserName, StringComparison.Ordinal);
                         var idx = Users.IndexOf(user);
                         if (idx >= 0) Users[idx] = clone;
                         var idxAll = _allUsers.IndexOf(user);
                         if (idxAll >= 0) _allUsers[idxAll] = clone;
-                        if (nameChanged)
-                            AssignInitialsBrushes(_allUsers);
+                        AssignInitialsBrushes(_allUsers);
                         if (ReferenceEquals(SelectedUser, user)) SelectedUser = clone;
                         if (_userContext?.CurrentUser?.UserID == clone.UserID)
                             _userContext.CurrentUser = clone;


### PR DESCRIPTION
## Summary
- Ensure initials brushes are reassigned after any user edit
- Refresh current user's context after edit so UI reflects new brush

## Testing
- `dotnet test` *(command not found: dotnet)*
- `apt-get update` *(403 Forbidden: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68afafdd1fe48324a9f7e7b835343258