### PR TITLE
Replace Tools brand with Hardware/Equipment in tests

### DIFF
--- a/InventoryManagementApp.Tests/ItemSearchPageTests.cs
+++ b/InventoryManagementApp.Tests/ItemSearchPageTests.cs
@@ -355,8 +355,8 @@ namespace InventoryManagementApp.Tests
         {
             private readonly List<ItemModel> _items = new()
             {
-                new ItemModel { ItemID = 1, Name = "Hammer", Brand = "Tools" },
-                new ItemModel { ItemID = 2, Name = "Screwdriver", Brand = "Tools" },
+                new ItemModel { ItemID = 1, Name = "Hammer", Brand = "Hardware" },
+                new ItemModel { ItemID = 2, Name = "Screwdriver", Brand = "Equipment" },
                 new ItemModel { ItemID = 3, Name = "Paint", Brand = "Paints" }
             };
 


### PR DESCRIPTION
## Summary
- update `StubItemService` test data to use "Hardware" and "Equipment" brands instead of banned term

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68affa2cd3bc832487cbab92274e210a