### PR TITLE
Use neutral language for legacy table comments

### DIFF
--- a/InventoryManagementApp/Services/Core/DatabaseService.cs
+++ b/InventoryManagementApp/Services/Core/DatabaseService.cs
@@ -76,7 +76,7 @@ namespace InventoryManagementApp.Services.Core
         {
             using var conn = CreateConnection();
 
-            // Legacy migration: rename old Tools table to Items
+            // Legacy migration: rename old legacy item table to Items
             MigrateLegacyToolsTable(conn);
 
             var sql = @"
@@ -168,7 +168,7 @@ namespace InventoryManagementApp.Services.Core
 
         void MigrateLegacyToolsTable(SqliteConnection conn)
         {
-            // Legacy migration: rename old "Tools" table to "Items"
+            // Legacy migration: rename old legacy item table to "Items"
             using var check = new SqliteCommand("SELECT name FROM sqlite_master WHERE type='table' AND name='Tools';", conn);
             var legacyToolsTableExists = check.ExecuteScalar();
             if (legacyToolsTableExists != null)


### PR DESCRIPTION
## Summary
- Replace references to "Tools" in database initialization comments with neutral phrase "legacy item table"

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68affa3aed388324aff02233a9454b75