### PR TITLE
Rename legacy items migration

### DIFF
--- a/InventoryManagementApp/Services/Core/DatabaseService.cs
+++ b/InventoryManagementApp/Services/Core/DatabaseService.cs
@@ -77,7 +77,7 @@ namespace InventoryManagementApp.Services.Core
             using var conn = CreateConnection();
 
             // Legacy migration: rename old legacy item table to Items
-            MigrateLegacyToolsTable(conn);
+            MigrateLegacyItemsTable(conn);
 
             var sql = @"
                 CREATE TABLE IF NOT EXISTS Items (
@@ -166,7 +166,7 @@ namespace InventoryManagementApp.Services.Core
             EnsureIndex(conn, "Rentals", new[] { "ItemID", "CustomerID" });
         }
 
-        void MigrateLegacyToolsTable(SqliteConnection conn)
+        void MigrateLegacyItemsTable(SqliteConnection conn)
         {
             // Legacy migration: rename old legacy item table to "Items"
             const string legacyTable = "To" + "ols";


### PR DESCRIPTION
## Summary
- rename legacy migration method to MigrateLegacyItemsTable

## Testing
- `dotnet test` *(fails: command not found)*
- `./scripts/check-banned-words.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b00ba0582c8324a280dc7bb439ad52