### PR TITLE
Handle nullable scalar database results

### DIFF
--- a/InventoryManagementApp/Services/Core/SqliteHelper.cs
+++ b/InventoryManagementApp/Services/Core/SqliteHelper.cs
@@ -32,7 +32,7 @@ namespace InventoryManagementApp.Services.Core
             return cmd.ExecuteNonQuery();
         }
 
-        public static object ExecuteScalar(string connStr, string sql, SqliteParameter[]? parameters = null)
+        public static object? ExecuteScalar(string connStr, string sql, SqliteParameter[]? parameters = null)
         {
             using var conn = new SqliteConnection(connStr);
             conn.Open();
@@ -41,7 +41,7 @@ namespace InventoryManagementApp.Services.Core
             return cmd.ExecuteScalar();
         }
 
-        public static object ExecuteScalar(SqliteConnection conn, string sql, SqliteParameter[]? parameters = null)
+        public static object? ExecuteScalar(SqliteConnection conn, string sql, SqliteParameter[]? parameters = null)
         {
             using var cmd = new SqliteCommand(sql, conn);
             if (parameters != null) cmd.Parameters.AddRange(parameters);
@@ -122,7 +122,7 @@ namespace InventoryManagementApp.Services.Core
             return await cmd.ExecuteNonQueryAsync(cancellationToken);
         }
 
-        public static async Task<object> ExecuteScalarAsync(string connStr, string sql, SqliteParameter[]? parameters = null, CancellationToken cancellationToken = default)
+        public static async Task<object?> ExecuteScalarAsync(string connStr, string sql, SqliteParameter[]? parameters = null, CancellationToken cancellationToken = default)
         {
             using var conn = new SqliteConnection(connStr);
             await conn.OpenAsync(cancellationToken);
@@ -131,7 +131,7 @@ namespace InventoryManagementApp.Services.Core
             return await cmd.ExecuteScalarAsync(cancellationToken);
         }
 
-        public static async Task<object> ExecuteScalarAsync(SqliteConnection conn, string sql, SqliteParameter[]? parameters = null, CancellationToken cancellationToken = default)
+        public static async Task<object?> ExecuteScalarAsync(SqliteConnection conn, string sql, SqliteParameter[]? parameters = null, CancellationToken cancellationToken = default)
         {
             using var cmd = new SqliteCommand(sql, conn);
             if (parameters != null) cmd.Parameters.AddRange(parameters);

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -167,7 +167,7 @@ namespace InventoryManagementApp.Services.Customers
             try
             {
                 var result = await SqliteHelper.ExecuteScalarAsync(conn, sql, null, cancellationToken);
-                return Convert.ToInt32(result);
+                return Convert.ToInt32(result ?? 0);
             }
             catch (Exception ex)
             {
@@ -287,7 +287,7 @@ namespace InventoryManagementApp.Services.Customers
                     new SqliteParameter("@Contact", contact),
                     new SqliteParameter("@Phone", phone ?? string.Empty),
                     new SqliteParameter("@Mobile", mobile ?? string.Empty)
-                }, cancellationToken));
+                }, cancellationToken) ?? 0);
                 return count > 0;
             }
             catch (Exception ex)

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -278,7 +278,7 @@ namespace InventoryManagementApp.Services.Items
             }
 
             using var conn = _dbService.CreateConnection();
-            var count = Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql, parameters.ToArray(), cancellationToken));
+            var count = Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql, parameters.ToArray(), cancellationToken) ?? 0);
             return count > 0;
         }
     

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -249,7 +249,7 @@ namespace InventoryManagementApp.Services.Rentals
         {
             using var conn = _dbService.CreateConnection();
             const string sql = "SELECT COUNT(*) FROM Rentals WHERE Status='Rented'";
-            return Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql).ConfigureAwait(false));
+            return Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql).ConfigureAwait(false) ?? 0);
         }
 
         public async Task<List<Rental>> GetActiveRentalsAsync()

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -108,7 +108,7 @@ namespace InventoryManagementApp.Services.Users
             using var conn = _dbService.CreateConnection();
             const string sql = "SELECT COUNT(*) FROM Users";
             var result = await SqliteHelper.ExecuteScalarAsync(conn, sql, cancellationToken: cancellationToken);
-            return Convert.ToInt32(result);
+            return Convert.ToInt32(result ?? 0);
         }
 
         public async Task<User?> GetUserByIDAsync(int userID, CancellationToken cancellationToken = default)
@@ -349,7 +349,7 @@ namespace InventoryManagementApp.Services.Users
             {
                 const string sql = "SELECT COUNT(*) FROM Users WHERE IsAdmin = 1";
                 using var conn = _dbService.CreateConnection();
-                var adminCount = Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql));
+                var adminCount = Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql) ?? 0);
                 if (adminCount <= 1) return false;
             }
             await DeleteUserInternalAsync(userID);


### PR DESCRIPTION
## Summary
- return nullable results from SqliteHelper.ExecuteScalar methods
- handle null scalar values across services

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b018085a24832484b8a4296592c8ae