### PR TITLE
Handle null rental fields safely

### DIFF
--- a/InventoryManagementApp.Tests/RentalServiceNullMappingTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceNullMappingTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Data;
+using System.Reflection;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Services.Core;
+using InventoryManagementApp.Services.Rentals;
+using Xunit;
+
+public class RentalServiceNullMappingTests
+{
+    [Fact]
+    public void MapRental_CoalescesNullStrings()
+    {
+        var table = new DataTable();
+        table.Columns.Add("RentalID", typeof(int));
+        table.Columns.Add("ItemID", typeof(int));
+        table.Columns.Add("CustomerID", typeof(int));
+        table.Columns.Add("RentalDate", typeof(DateTime));
+        table.Columns.Add("DueDate", typeof(DateTime));
+        table.Columns.Add("ReturnDate", typeof(DateTime));
+        table.Columns.Add("Status", typeof(string));
+        table.Columns.Add("ItemNumber", typeof(string));
+        table.Columns.Add("Company", typeof(string));
+        table.Columns.Add("Contact", typeof(string));
+        table.Columns.Add("Email", typeof(string));
+        table.Columns.Add("Phone", typeof(string));
+        table.Columns.Add("Mobile", typeof(string));
+        table.Columns.Add("Address", typeof(string));
+        table.Columns.Add("ImagePath", typeof(string));
+        table.Columns.Add("ItemLocation", typeof(string));
+
+        table.Rows.Add(1, 2, 3, DateTime.UtcNow, DateTime.UtcNow.AddDays(1), DBNull.Value,
+            DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value,
+            DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value);
+
+        using var reader = table.CreateDataReader();
+        reader.Read();
+
+        using var db = new DatabaseService(":memory:");
+        var service = new RentalService(db);
+
+        var method = typeof(RentalService).GetMethod("MapRental", BindingFlags.NonPublic | BindingFlags.Instance);
+        var rental = (Rental?)method!.Invoke(service, new object[] { reader });
+
+        Assert.NotNull(rental);
+        Assert.Equal(string.Empty, rental!.Status);
+        Assert.Equal(string.Empty, rental.ItemNumber);
+        Assert.Equal(string.Empty, rental.CustomerName);
+        Assert.Equal(string.Empty, rental.CustomerContact);
+        Assert.Equal(string.Empty, rental.CustomerEmail);
+        Assert.Equal(string.Empty, rental.CustomerPhone);
+        Assert.Equal(string.Empty, rental.CustomerMobile);
+        Assert.Equal(string.Empty, rental.CustomerAddress);
+        Assert.Equal(string.Empty, rental.ImagePath);
+        Assert.Equal(string.Empty, rental.ItemLocation);
+    }
+}
+

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -82,16 +82,16 @@ namespace InventoryManagementApp.Services.Rentals
                     RentalDate = ParseDateOrDefault(r["RentalDate"], "RentalDate"),
                     DueDate = ParseDateOrDefault(r["DueDate"], "DueDate"),
                     ReturnDate = r["ReturnDate"] is DBNull ? null : ParseNullableDate(r["ReturnDate"], "ReturnDate"),
-                    Status = r["Status"].ToString(),
-                    ItemNumber = r["ItemNumber"].ToString(),
-                    CustomerName = r["Company"].ToString(),
-                    CustomerContact = r["Contact"].ToString(),
-                    CustomerEmail = r["Email"].ToString(),
-                    CustomerPhone = r["Phone"].ToString(),
-                    CustomerMobile = r["Mobile"].ToString(),
-                    CustomerAddress = r["Address"].ToString(),
-                    ImagePath = r["ImagePath"].ToString(),
-                    ItemLocation = r["ItemLocation"].ToString()
+                    Status = ValidateString(r["Status"], "Status"),
+                    ItemNumber = ValidateString(r["ItemNumber"], "ItemNumber"),
+                    CustomerName = ValidateString(r["Company"], "Company"),
+                    CustomerContact = ValidateString(r["Contact"], "Contact"),
+                    CustomerEmail = ValidateString(r["Email"], "Email"),
+                    CustomerPhone = ValidateString(r["Phone"], "Phone"),
+                    CustomerMobile = ValidateString(r["Mobile"], "Mobile"),
+                    CustomerAddress = ValidateString(r["Address"], "Address"),
+                    ImagePath = ValidateString(r["ImagePath"], "ImagePath"),
+                    ItemLocation = ValidateString(r["ItemLocation"], "ItemLocation")
                 };
             }
             catch (FormatException ex)
@@ -119,6 +119,17 @@ namespace InventoryManagementApp.Services.Rentals
                 return DateTime.SpecifyKind(dt, DateTimeKind.Utc).ToLocalTime();
             _logger.LogError("Failed to parse {Field}: {Value}", field, text);
             return null;
+        }
+
+        string ValidateString(object? value, string field)
+        {
+            var text = value?.ToString();
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                _logger.LogWarning("{Field} was null or empty while mapping rental", field);
+                return string.Empty;
+            }
+            return text;
         }
 
         public async Task RentItemAsync(int itemID, int customerID, DateTime rentalDate, DateTime dueDate)


### PR DESCRIPTION
## Summary
- validate string fields when mapping rentals to avoid null values
- add regression test ensuring null database values map to empty strings

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0181c4adc8324bf43ce02cbe1a216