### PR TITLE
Stream item pagination with cancellation support

### DIFF
--- a/InventoryManagementApp.Tests/ItemRepositoryPaginationTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryPaginationTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
 using Dapper;
 using InventoryManagementApp.Data;
 using InventoryManagementApp.Models.Domain;
@@ -56,7 +57,8 @@ public class ItemRepositoryPaginationTests
         var repo = new ItemRepository(factory);
         var page = new ItemPage(2, 2);
         var result = new List<ItemModel>();
-        await foreach (var item in repo.GetPageAsync(new ItemFilter(null), page, CancellationToken.None))
+        await foreach (var item in repo.GetPageAsync(new ItemFilter(null), page, CancellationToken.None)
+            .WithCancellation(CancellationToken.None))
             result.Add(item);
         Assert.Collection(result,
             i => Assert.Equal("Item 3", i.Name),

--- a/InventoryManagementApp.Tests/ItemRepositorySearchTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositorySearchTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
 using Dapper;
 using InventoryManagementApp.Data;
 using InventoryManagementApp.Models.Domain;
@@ -58,7 +59,8 @@ public class ItemRepositorySearchTests
         await SeedAsync(factory);
         var repo = new ItemRepository(factory);
         var result = new List<ItemModel>();
-        await foreach (var item in repo.GetPageAsync(new ItemFilter("abc"), new ItemPage(1, 10), CancellationToken.None))
+        await foreach (var item in repo.GetPageAsync(new ItemFilter("abc"), new ItemPage(1, 10), CancellationToken.None)
+            .WithCancellation(CancellationToken.None))
             result.Add(item);
         Assert.Single(result);
         Assert.Equal("ABC123", result[0].ItemNumber);
@@ -71,7 +73,8 @@ public class ItemRepositorySearchTests
         await SeedAsync(factory);
         var repo = new ItemRepository(factory);
         var result = new List<ItemModel>();
-        await foreach (var item in repo.GetPageAsync(new ItemFilter("saw"), new ItemPage(1, 10), CancellationToken.None))
+        await foreach (var item in repo.GetPageAsync(new ItemFilter("saw"), new ItemPage(1, 10), CancellationToken.None)
+            .WithCancellation(CancellationToken.None))
             result.Add(item);
         Assert.Single(result);
         Assert.Equal("Hand Saw", result[0].Name);
@@ -84,7 +87,8 @@ public class ItemRepositorySearchTests
         await SeedAsync(factory);
         var repo = new ItemRepository(factory);
         var result = new List<ItemModel>();
-        await foreach (var item in repo.GetPageAsync(new ItemFilter("cafe"), new ItemPage(1, 10), CancellationToken.None))
+        await foreach (var item in repo.GetPageAsync(new ItemFilter("cafe"), new ItemPage(1, 10), CancellationToken.None)
+            .WithCancellation(CancellationToken.None))
             result.Add(item);
         Assert.Contains(result, i => i.Name == "Café Table");
     }
@@ -96,7 +100,8 @@ public class ItemRepositorySearchTests
         await SeedAsync(factory);
         var repo = new ItemRepository(factory);
         var result = new List<ItemModel>();
-        await foreach (var item in repo.GetPageAsync(new ItemFilter("cafe"), new ItemPage(1, 10), CancellationToken.None))
+        await foreach (var item in repo.GetPageAsync(new ItemFilter("cafe"), new ItemPage(1, 10), CancellationToken.None)
+            .WithCancellation(CancellationToken.None))
             result.Add(item);
         Assert.Contains(result, i => i.ItemNumber == "CAFÉ1");
     }
@@ -108,7 +113,8 @@ public class ItemRepositorySearchTests
         await SeedAsync(factory);
         var repo = new ItemRepository(factory);
         var result = new List<ItemModel>();
-        await foreach (var item in repo.GetPageAsync(new ItemFilter("SHARP"), new ItemPage(1, 10), CancellationToken.None))
+        await foreach (var item in repo.GetPageAsync(new ItemFilter("SHARP"), new ItemPage(1, 10), CancellationToken.None)
+            .WithCancellation(CancellationToken.None))
             result.Add(item);
         Assert.Single(result);
         Assert.Equal("Hand Saw", result[0].Name);
@@ -121,7 +127,8 @@ public class ItemRepositorySearchTests
         await SeedAsync(factory);
         var repo = new ItemRepository(factory);
         var result = new List<ItemModel>();
-        await foreach (var item in repo.GetPageAsync(new ItemFilter("ITEM"), new ItemPage(1, 10), CancellationToken.None))
+        await foreach (var item in repo.GetPageAsync(new ItemFilter("ITEM"), new ItemPage(1, 10), CancellationToken.None)
+            .WithCancellation(CancellationToken.None))
             result.Add(item);
         Assert.Single(result);
         Assert.Equal("Hand Saw", result[0].Name);
@@ -134,7 +141,8 @@ public class ItemRepositorySearchTests
         await SeedAsync(factory);
         var repo = new ItemRepository(factory);
         var result = new List<ItemModel>();
-        await foreach (var item in repo.GetPageAsync(new ItemFilter(null, IsRentalItem: true), new ItemPage(1, 10), CancellationToken.None))
+        await foreach (var item in repo.GetPageAsync(new ItemFilter(null, IsRentalItem: true), new ItemPage(1, 10), CancellationToken.None)
+            .WithCancellation(CancellationToken.None))
             result.Add(item);
         Assert.Single(result);
         Assert.True(result[0].IsRentalItem);
@@ -148,7 +156,8 @@ public class ItemRepositorySearchTests
         await SeedAsync(factory);
         var repo = new ItemRepository(factory);
         var result = new List<ItemModel>();
-        await foreach (var item in repo.GetPageAsync(new ItemFilter(null, IsRentalItem: false), new ItemPage(1, 10), CancellationToken.None))
+        await foreach (var item in repo.GetPageAsync(new ItemFilter(null, IsRentalItem: false), new ItemPage(1, 10), CancellationToken.None)
+            .WithCancellation(CancellationToken.None))
             result.Add(item);
         Assert.Single(result);
         Assert.False(result[0].IsRentalItem);
@@ -162,10 +171,12 @@ public class ItemRepositorySearchTests
         await SeedAsync(factory);
         var repo = new ItemRepository(factory);
         var first = new List<ItemModel>();
-        await foreach (var item in repo.GetPageAsync(new ItemFilter("red drill"), new ItemPage(1, 10), CancellationToken.None))
+        await foreach (var item in repo.GetPageAsync(new ItemFilter("red drill"), new ItemPage(1, 10), CancellationToken.None)
+            .WithCancellation(CancellationToken.None))
             first.Add(item);
         var second = new List<ItemModel>();
-        await foreach (var item in repo.GetPageAsync(new ItemFilter("drill red"), new ItemPage(1, 10), CancellationToken.None))
+        await foreach (var item in repo.GetPageAsync(new ItemFilter("drill red"), new ItemPage(1, 10), CancellationToken.None)
+            .WithCancellation(CancellationToken.None))
             second.Add(item);
         Assert.Equal(first.Count, second.Count);
         Assert.Equal(first[0].ItemID, second[0].ItemID);

--- a/InventoryManagementApp/Data/IItemRepository.cs
+++ b/InventoryManagementApp/Data/IItemRepository.cs
@@ -8,15 +8,18 @@ namespace InventoryManagementApp.Data;
 
 public interface IItemRepository
 {
-    IAsyncEnumerable<Item> GetPageAsync(ItemFilter filter, ItemPage page, [EnumeratorCancellation] CancellationToken ct);
-    Task<int> CountAsync(ItemFilter filter, CancellationToken ct);
-    Task<Item?> GetByIdAsync(int id, CancellationToken ct);
-    Task SaveChangesAsync(IEnumerable<Item> changes, CancellationToken ct);
-    Task<int> InsertAsync(Item item, CancellationToken ct);
-    Task UpdateAsync(Item item, CancellationToken ct);
-    Task DeleteAsync(int itemID, CancellationToken ct);
-    Task<bool> ToggleCheckOutStatusAsync(int itemID, string currentUser, bool isAdmin, CancellationToken ct);
-    Task<List<Item>> GetItemsCheckedOutByAsync(string userName, CancellationToken ct);
-    Task<List<Item>> GetCheckedOutItemsAsync(CancellationToken ct);
-    Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken ct);
+    /// <summary>
+    /// Streams a page of items that match the supplied filter.
+    /// </summary>
+    IAsyncEnumerable<Item> GetPageAsync(ItemFilter filter, ItemPage page, [EnumeratorCancellation] CancellationToken cancellationToken);
+    Task<int> CountAsync(ItemFilter filter, CancellationToken cancellationToken);
+    Task<Item?> GetByIdAsync(int id, CancellationToken cancellationToken);
+    Task SaveChangesAsync(IEnumerable<Item> changes, CancellationToken cancellationToken);
+    Task<int> InsertAsync(Item item, CancellationToken cancellationToken);
+    Task UpdateAsync(Item item, CancellationToken cancellationToken);
+    Task DeleteAsync(int itemID, CancellationToken cancellationToken);
+    Task<bool> ToggleCheckOutStatusAsync(int itemID, string currentUser, bool isAdmin, CancellationToken cancellationToken);
+    Task<List<Item>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken);
+    Task<List<Item>> GetCheckedOutItemsAsync(CancellationToken cancellationToken);
+    Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken);
 }

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -16,9 +16,9 @@ public sealed class ItemRepository : IItemRepository
     public ItemRepository(SqliteConnectionFactory factory)
         => _factory = factory;
 
-    public async IAsyncEnumerable<Item> GetPageAsync(ItemFilter filter, ItemPage page, [EnumeratorCancellation] CancellationToken ct)
+    public async IAsyncEnumerable<Item> GetPageAsync(ItemFilter filter, ItemPage page, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        ct.ThrowIfCancellationRequested();
+        cancellationToken.ThrowIfCancellationRequested();
         var sql = "SELECT ItemID, ItemNumber, NameDescription AS Name, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity AS QuantityOnHand, RentedQuantity, IsRentalItem, Price, ImagePath, IsCheckedOut, CheckedOutBy, CheckedOutTime, CheckedInBy, CheckedInTime, IsPowered, UpdatedAt FROM Items";
         var (whereClause, parameters) = BuildFilter(filter);
         sql += whereClause;
@@ -35,10 +35,10 @@ public sealed class ItemRepository : IItemRepository
         parameters.Add("Take", page.Size);
         parameters.Add("Skip", (page.Number - 1) * page.Size);
         await using var conn = (DbConnection)_factory.Create();
-        var command = new CommandDefinition(sql, parameters, flags: CommandFlags.None, cancellationToken: ct);
+        var command = new CommandDefinition(sql, parameters, flags: CommandFlags.None, cancellationToken: cancellationToken);
         await using var reader = await conn.ExecuteReaderAsync(command).ConfigureAwait(false);
         var parser = reader.GetRowParser<Item>();
-        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
             yield return parser(reader);
         }

--- a/InventoryManagementApp/Interfaces/IItemService.cs
+++ b/InventoryManagementApp/Interfaces/IItemService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Data.Sqlite;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
 using InventoryManagementApp.Data;
 using InventoryManagementApp.Models;
 using InventoryManagementApp.Models.ImportExport;
@@ -15,8 +16,8 @@ namespace InventoryManagementApp.Interfaces
         Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default);
         Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default);
         Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default);
-        IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default);
-        IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default);
+        IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, [EnumeratorCancellation] CancellationToken cancellationToken = default);
+        IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, [EnumeratorCancellation] CancellationToken cancellationToken = default);
         Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct);
         Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct);
         Task<bool> ToggleItemCheckOutStatusAsync(int itemID, CancellationToken cancellationToken = default);

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
 using InventoryManagementApp.Services.Core;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Utilities.IO;
@@ -143,7 +144,8 @@ namespace InventoryManagementApp.Services.Items
 
             cancellationToken.ThrowIfCancellationRequested();
             var items = new List<ItemModel>();
-            await foreach (var item in GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken))
+            await foreach (var item in GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken)
+                .WithCancellation(cancellationToken))
                 items.Add(item);
             var groups = new Dictionary<string, List<ItemModel>>(StringComparer.OrdinalIgnoreCase);
             foreach (var item in items)
@@ -308,11 +310,27 @@ namespace InventoryManagementApp.Services.Items
         public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default)
             => _repository.GetByIdAsync(itemID, cancellationToken);
 
-        public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default)
-            => _repository.GetPageAsync(new ItemFilter(null, sortField, sortDirection, isRentalItem), page, cancellationToken);
+        public async IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await foreach (var item in _repository
+                .GetPageAsync(new ItemFilter(null, sortField, sortDirection, isRentalItem), page, cancellationToken)
+                .WithCancellation(cancellationToken)
+                .ConfigureAwait(false))
+            {
+                yield return item;
+            }
+        }
 
-        public IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default)
-            => _repository.GetPageAsync(new ItemFilter(searchText, sortField, sortDirection, isRentalItem), page, cancellationToken);
+        public async IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await foreach (var item in _repository
+                .GetPageAsync(new ItemFilter(searchText, sortField, sortDirection, isRentalItem), page, cancellationToken)
+                .WithCancellation(cancellationToken)
+                .ConfigureAwait(false))
+            {
+                yield return item;
+            }
+        }
 
         public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct)
             => _repository.CountAsync(filter, ct);
@@ -401,7 +419,8 @@ namespace InventoryManagementApp.Services.Items
         private async Task ExportItemsToCsvInternalAsync(string filePath, CancellationToken cancellationToken)
         {
             var items = new List<ItemModel>();
-            await foreach (var item in GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken))
+            await foreach (var item in GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken)
+                .WithCancellation(cancellationToken))
                 items.Add(item);
             await CsvHelperUtil.ExportItemsToCsvAsync(filePath, items);
         }

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -5,6 +5,7 @@ using System.Windows.Documents;
 using System.Windows.Media;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
 using InventoryManagementApp.Data;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Models;
@@ -40,7 +41,8 @@ namespace InventoryManagementApp.Services.Items
         public async Task<FlowDocument> GenerateInventoryReport()
         {
             var items = new List<ItemModel>();
-            await foreach (var item in _itemService.GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, isRentalItem: false).ConfigureAwait(false))
+            await foreach (var item in _itemService.GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, isRentalItem: false)
+                .WithCancellation(CancellationToken.None).ConfigureAwait(false))
                 items.Add(item);
             var lines = items.Select(t =>
                 $"ItemModel ID: {t.ItemID} | ItemNumber: {t.ItemNumber} | Qty: {t.QuantityOnHand} | Location: {t.Location} | Supplier: {t.Supplier}");
@@ -122,7 +124,8 @@ namespace InventoryManagementApp.Services.Items
         private async Task<int> CountItemsAsync()
         {
             var count = 0;
-            await foreach (var _ in _itemService.GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, isRentalItem: false))
+            await foreach (var _ in _itemService.GetItemsAsync(new ItemPage(1, int.MaxValue), SortField.Name, SortDirection.Ascending, isRentalItem: false)
+                .WithCancellation(CancellationToken.None))
                 count++;
             return count;
         }

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -8,6 +8,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
 using InventoryManagementApp.Data;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models;
@@ -232,7 +233,8 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 var list = new List<ItemModel>();
-                await foreach (var item in _itemService.GetItemsAsync(page, SortField.Name, SortDirection.Ascending, isRentalItem: false))
+                await foreach (var item in _itemService.GetItemsAsync(page, SortField.Name, SortDirection.Ascending, isRentalItem: false)
+                    .WithCancellation(CancellationToken.None))
                     list.Add(item);
                 Items.ReplaceRange(list);
                 SearchResults.ReplaceRange(list);
@@ -265,12 +267,14 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (!string.IsNullOrEmpty(term))
                 {
-                    await foreach (var item in _itemService.SearchItemsAsync(term, page, SortField.Name, SortDirection.Ascending, isRentalItem: false, cancellationToken: cancellationToken))
+                    await foreach (var item in _itemService.SearchItemsAsync(term, page, SortField.Name, SortDirection.Ascending, isRentalItem: false, cancellationToken: cancellationToken)
+                        .WithCancellation(cancellationToken))
                         list.Add(item);
                 }
                 else
                 {
-                    await foreach (var item in _itemService.GetItemsAsync(page, SortField.Name, SortDirection.Ascending, isRentalItem: false, cancellationToken: cancellationToken))
+                    await foreach (var item in _itemService.GetItemsAsync(page, SortField.Name, SortDirection.Ascending, isRentalItem: false, cancellationToken: cancellationToken)
+                        .WithCancellation(cancellationToken))
                         list.Add(item);
                 }
             }

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using InventoryManagementApp.Data;
@@ -187,7 +188,7 @@ namespace InventoryManagementApp.ViewModels
                 var source = string.IsNullOrWhiteSpace(Filter)
                     ? _itemService.GetItemsAsync(pageInfo, SelectedSortOption.Field, SelectedSortOption.Direction, isRentalItem: false, cancellationToken: ct)
                     : _itemService.SearchItemsAsync(Filter, pageInfo, SelectedSortOption.Field, SelectedSortOption.Direction, isRentalItem: false, cancellationToken: ct);
-                await foreach (var item in source.ConfigureAwait(false))
+                await foreach (var item in source.WithCancellation(ct).ConfigureAwait(false))
                 {
                     item.PropertyChanged += Item_PropertyChanged;
                     result.Add(item);


### PR DESCRIPTION
## Summary
- stream repository pages as IAsyncEnumerable with cancellation-aware token
- propagate cancellation through service and view model enumerations
- adjust tests to enumerate streams with WithCancellation

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b017ee088883249add77f1c38a8f7c