### PR TITLE
fix: ensure default images initialized

### DIFF
--- a/InventoryManagementApp/Utilities/Converters/NullToDefaultImageConverter.cs
+++ b/InventoryManagementApp/Utilities/Converters/NullToDefaultImageConverter.cs
@@ -11,8 +11,8 @@ namespace InventoryManagementApp.Utilities.Converters
 {
     public class NullToDefaultImageConverter : IValueConverter
     {
-        private static BitmapImage _defaultItem;
-        private static BitmapImage _defaultLogo;
+        private static BitmapImage? _defaultItem;
+        private static BitmapImage? _defaultLogo;
         private const int MaxCacheEntries = 100;
         private static readonly MemoryCache _imageCache = new(new MemoryCacheOptions { SizeLimit = MaxCacheEntries });
         private static readonly ConcurrentDictionary<string, byte> _invalidPaths =
@@ -91,14 +91,12 @@ namespace InventoryManagementApp.Utilities.Converters
             switch (type)
             {
                 case "item":
-                    if (_defaultItem == null)
-                        _defaultItem = LoadFromResource("DefaultItemImage.png");
-                    return _defaultItem;
+                    _defaultItem ??= LoadFromResource("DefaultItemImage.png");
+                    return _defaultItem ?? new BitmapImage();
 
                 case "logo":
-                    if (_defaultLogo == null)
-                        _defaultLogo = LoadFromResource("DefaultLogo.png");
-                    return _defaultLogo;
+                    _defaultLogo ??= LoadFromResource("DefaultLogo.png");
+                    return _defaultLogo ?? new BitmapImage();
 
                 default:
                     return new BitmapImage();


### PR DESCRIPTION
## Summary
- ensure NullToDefaultImageConverter lazily initializes default item and logo images and always returns a BitmapImage

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 forbidden)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b019b9390083248b6af8c4873aa24d