### PR TITLE
Handle null keys in settings lookup

### DIFF
--- a/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
+++ b/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
@@ -135,7 +135,7 @@ public class ItemDisplaySettingsTests
     {
         public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
         public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+        public Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
         public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
         public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/InventoryManagementApp.Tests/ItemManagementViewModelCommandTests.cs
+++ b/InventoryManagementApp.Tests/ItemManagementViewModelCommandTests.cs
@@ -130,7 +130,7 @@ namespace InventoryManagementApp.Tests
         {
             public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
             public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
             public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
             public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/InventoryManagementApp.Tests/ItemSearchPageTests.cs
+++ b/InventoryManagementApp.Tests/ItemSearchPageTests.cs
@@ -439,7 +439,7 @@ namespace InventoryManagementApp.Tests
         {
             public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
             public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
             public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
             public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -890,8 +890,8 @@ namespace InventoryManagementApp.Tests
                 _settings[key] = value;
                 return Task.CompletedTask;
             }
-            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default)
-                => Task.FromResult(_settings.TryGetValue(key, out var v) ? v : null);
+            public Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default)
+                => Task.FromResult(key != null && _settings.TryGetValue(key, out var v) ? v : null);
             public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default)
                 => Task.FromResult(new Dictionary<string, string>(_settings));
             public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default)

--- a/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
@@ -200,7 +200,7 @@ namespace InventoryManagementApp.Tests
         {
             public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
             public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
             public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
             public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/InventoryManagementApp.Tests/MainViewModelTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelTests.cs
@@ -439,7 +439,7 @@ namespace InventoryManagementApp.Tests
         {
             public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
             public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
             public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
             public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/InventoryManagementApp.Tests/ManageItemsPageTests.cs
+++ b/InventoryManagementApp.Tests/ManageItemsPageTests.cs
@@ -193,7 +193,7 @@ namespace InventoryManagementApp.Tests
         {
             public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
             public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
             public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
             public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/InventoryManagementApp.Tests/SettingsServiceTests.cs
+++ b/InventoryManagementApp.Tests/SettingsServiceTests.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using InventoryManagementApp.Services.Core;
+using InventoryManagementApp.Services.Settings;
+using Xunit;
+
+public class SettingsServiceTests
+{
+    [Fact]
+    public async Task GetSettingAsync_ReturnsNull_WhenKeyIsNull()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        var service = new SettingsService(db);
+
+        var value = await service.GetSettingAsync(null);
+
+        Assert.Null(value);
+    }
+}

--- a/InventoryManagementApp.Tests/UserInitialsBrushTests.cs
+++ b/InventoryManagementApp.Tests/UserInitialsBrushTests.cs
@@ -299,7 +299,7 @@ namespace InventoryManagementApp.Tests
         {
             public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
             public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
             public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
             public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/InventoryManagementApp/Interfaces/ISettingsService.cs
+++ b/InventoryManagementApp/Interfaces/ISettingsService.cs
@@ -10,7 +10,7 @@ namespace InventoryManagementApp.Interfaces
     {
         event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
         Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default);
-        Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default);
+        Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default);
         Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default);
         Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default);
         Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default);

--- a/InventoryManagementApp/Services/Settings/SettingsService.cs
+++ b/InventoryManagementApp/Services/Settings/SettingsService.cs
@@ -66,8 +66,11 @@ namespace InventoryManagementApp.Services.Settings
             }
         }
 
-        public async Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default)
+        public async Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default)
         {
+            if (key is null)
+                return null;
+
             try
             {
                 const string sql = "SELECT Value FROM Settings WHERE Key = @Key";


### PR DESCRIPTION
## Summary
- allow `GetSettingAsync` to accept nullable keys and return null for missing keys
- update ISettingsService and all test stubs for nullable key parameter
- add unit test verifying null-key setting retrieval

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b019bb92908324bb6b604e7267753a