### PR TITLE
Fix DateTime converter to return empty string instead of null

### DIFF
--- a/InventoryManagementApp/Utilities/Converters/DateTimeMinToEmptyStringConverter.cs
+++ b/InventoryManagementApp/Utilities/Converters/DateTimeMinToEmptyStringConverter.cs
@@ -15,15 +15,15 @@ namespace InventoryManagementApp.Utilities.Converters
         public DateTimeMinToEmptyStringConverter(ILogger<DateTimeMinToEmptyStringConverter>? logger = null)
             => _logger = logger ?? NullLogger<DateTimeMinToEmptyStringConverter>.Instance;
 
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             try
             {
                 if (value is DateTime ndt)
-                    return ndt == DateTime.MinValue ? null : ndt;
+                    return ndt == DateTime.MinValue ? string.Empty : ndt;
 
                 if (value == null)
-                    return null;
+                    return string.Empty;
             }
             catch (Exception ex)
             {
@@ -33,7 +33,7 @@ namespace InventoryManagementApp.Utilities.Converters
             return System.Windows.Data.Binding.DoNothing;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             try
             {


### PR DESCRIPTION
## Summary
- Return an empty string when DateTime.MinValue or null is encountered in DateTimeMinToEmptyStringConverter
- Allow nullable input parameters in the converter methods

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b01a9610e4832495c535dd4dcd96e9