### PR TITLE
Validate CSV rows before mapping and default missing fields

### DIFF
--- a/InventoryManagementApp.Tests/ItemServiceCsvImportTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceCsvImportTests.cs
@@ -105,4 +105,36 @@ public class ItemServiceCsvImportTests
         File.Delete(csvPath);
         File.Delete(dbPath);
     }
+
+    [Fact]
+    public async Task ImportItemsFromCsv_DefaultsMissingColumns()
+    {
+        var csvPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".csv");
+        await File.WriteAllTextAsync(csvPath, "ItemNumber\nNUM1");
+
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        new MigrationRunner(db).Migrate();
+        var repository = new ItemRepository(new SqliteConnectionFactory(db.ConnectionString));
+        var service = new ItemService(db, repository);
+
+        var map = new Dictionary<string, string>
+        {
+            ["ItemNumber"] = "ItemNumber"
+        };
+
+        var invalid = await service.ImportItemsFromCsvAsync(csvPath, map, CancellationToken.None);
+        Assert.Empty(invalid);
+
+        using var conn = db.CreateConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT NameDescription, Location FROM Items WHERE ItemNumber='NUM1'";
+        using var reader = cmd.ExecuteReader();
+        Assert.True(reader.Read());
+        Assert.Equal(string.Empty, reader.GetString(0));
+        Assert.Equal(string.Empty, reader.GetString(1));
+
+        File.Delete(csvPath);
+        File.Delete(dbPath);
+    }
 }

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -350,6 +350,8 @@ namespace InventoryManagementApp.Services.Items
             if (parser.EndOfData)
                 return invalidRows;
             var headers = parser.ReadFields();
+            if (headers == null || headers.Length == 0)
+                throw new InvalidDataException("CSV header row is missing or empty.");
 
             using var conn = _dbService.CreateConnection();
             var existingNumbers = new HashSet<string>(
@@ -366,6 +368,11 @@ namespace InventoryManagementApp.Services.Items
                     cancellationToken.ThrowIfCancellationRequested();
                     row++;
                     var cols = parser.ReadFields();
+                    if (cols == null || cols.Length == 0 || headers == null)
+                    {
+                        invalidRows.Add(row);
+                        continue;
+                    }
                     var itemNumber = GetMapped(cols, headers, map, "ItemNumber");
                     if (string.IsNullOrWhiteSpace(itemNumber) || existingNumbers.Contains(itemNumber))
                     {
@@ -376,14 +383,14 @@ namespace InventoryManagementApp.Services.Items
                     var item = new ItemModel
                     {
                         ItemNumber = itemNumber,
-                        Name = GetMapped(cols, headers, map, nameof(ItemImportDto.Name)),
-                        Location = GetMapped(cols, headers, map, "Location"),
-                        Brand = GetMapped(cols, headers, map, "Brand"),
-                        PartNumber = GetMapped(cols, headers, map, "PartNumber"),
-                        Supplier = GetMapped(cols, headers, map, "Supplier"),
+                        Name = GetMapped(cols, headers, map, nameof(ItemImportDto.Name)) ?? string.Empty,
+                        Location = GetMapped(cols, headers, map, "Location") ?? string.Empty,
+                        Brand = GetMapped(cols, headers, map, "Brand") ?? string.Empty,
+                        PartNumber = GetMapped(cols, headers, map, "PartNumber") ?? string.Empty,
+                        Supplier = GetMapped(cols, headers, map, "Supplier") ?? string.Empty,
                         PurchasedDate = TryParseDate(GetMapped(cols, headers, map, "PurchasedDate")),
-                        Notes = GetMapped(cols, headers, map, "Notes"),
-                        Keywords = GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords)),
+                        Notes = GetMapped(cols, headers, map, "Notes") ?? string.Empty,
+                        Keywords = GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords)) ?? string.Empty,
                         QuantityOnHand = TryParseInt(GetMapped(cols, headers, map, "AvailableQuantity")),
                         IsPowered = TryParseBool(GetMapped(cols, headers, map, "IsPowered")),
                         IsRentalItem = TryParseBool(GetMapped(cols, headers, map, "IsRentalItem"))


### PR DESCRIPTION
## Summary
- ensure CSV headers and rows exist before mapping
- default unmapped CSV columns to empty strings during import
- cover defaulting behavior in CSV import tests

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b01aaed9988324a4781193a579096c