### PR TITLE
Mark uninitialized view model fields as nullable

### DIFF
--- a/InventoryManagementApp/ViewModels/LoginViewModel.cs
+++ b/InventoryManagementApp/ViewModels/LoginViewModel.cs
@@ -47,15 +47,15 @@ namespace InventoryManagementApp.ViewModels
 
         public ObservableCollection<User> Users { get; } = new();
 
-        User _selectedUser;
-        public User SelectedUser
+        User? _selectedUser;
+        public User? SelectedUser
         {
             get => _selectedUser;
             set => SetProperty(ref _selectedUser, value);
         }
 
-        BitmapImage _companyLogo;
-        public BitmapImage CompanyLogo
+        BitmapImage? _companyLogo;
+        public BitmapImage? CompanyLogo
         {
             get => _companyLogo;
             private set => SetProperty(ref _companyLogo, value);
@@ -73,7 +73,7 @@ namespace InventoryManagementApp.ViewModels
         /// <see cref="OnUserSelected"/> to perform authentication, including prompting
         /// for passwords and handling resets.
         /// </summary>
-        public IAsyncRelayCommand<User> SelectUserCommand { get; }
+        public IAsyncRelayCommand<User?> SelectUserCommand { get; }
 
         public IAsyncRelayCommand LoadUsersCommand { get; }
 
@@ -101,7 +101,7 @@ namespace InventoryManagementApp.ViewModels
             _logger = logger ?? NullLogger<LoginViewModel>.Instance;
             _serviceProvider = serviceProvider;
 
-            SelectUserCommand = new AsyncRelayCommand<User>(OnUserSelected);
+            SelectUserCommand = new AsyncRelayCommand<User?>(OnUserSelected);
 
             PromptForPasswordAsync = (u, ct) =>
             {
@@ -243,7 +243,7 @@ namespace InventoryManagementApp.ViewModels
         /// </summary>
         /// <param name="user">The account to authenticate.</param>
         /// <param name="cancellationToken">Token used to cancel the authentication loop.</param>
-        async Task OnUserSelected(User user, CancellationToken cancellationToken)
+        async Task OnUserSelected(User? user, CancellationToken cancellationToken)
         {
             if (user == null) return;
 

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -64,8 +64,8 @@ namespace InventoryManagementApp.ViewModels
         public ReportsViewModel Reports { get; }
         public SettingsViewModel Settings { get; }
 
-        private Page _currentPage;
-        public Page CurrentPage
+        private Page? _currentPage;
+        public Page? CurrentPage
         {
             get => _currentPage;
             set

--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -74,8 +74,8 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        private RentalModel _selectedRental;
-        public RentalModel SelectedRental
+        private RentalModel? _selectedRental;
+        public RentalModel? SelectedRental
         {
             get => _selectedRental;
             set

--- a/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
+++ b/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
@@ -32,8 +32,8 @@ namespace InventoryManagementApp.ViewModels.Rental
             set => SetProperty(ref _searchText, value);
         }
 
-        private RentalModel _selectedEntry;
-        public RentalModel SelectedEntry
+        private RentalModel? _selectedEntry;
+        public RentalModel? SelectedEntry
         {
             get => _selectedEntry;
             set => SetProperty(ref _selectedEntry, value);


### PR DESCRIPTION
## Summary
- Mark LoginViewModel fields for selected user and company logo as nullable and handle null-safe command invocation
- Allow null selections in ManageRentalsViewModel and RentalHistoryViewModel
- Permit MainViewModel's CurrentPage to be null before navigation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01a9a3e288324ba89655812f7c638