### PR TITLE
Use property accessors in ItemsViewModel

### DIFF
--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -113,7 +113,7 @@ namespace InventoryManagementApp.ViewModels
                 new SortOption(SortField.UpdatedAt, SortDirection.Ascending, "Updated Asc"),
                 new SortOption(SortField.UpdatedAt, SortDirection.Descending, "Updated Desc")
             });
-            selectedSortOption = SortOptions[0];
+            SelectedSortOption = SortOptions[0];
             VisibleFields = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true);
             _memoryBudget.SteadyExceeded += OnSteadyExceeded;
             _memoryBudget.PeakExceeded += OnPeakExceeded;
@@ -133,13 +133,13 @@ namespace InventoryManagementApp.ViewModels
                 var psSetting = await _settingsService.GetSettingAsync("PageSize", ct).ConfigureAwait(false);
                 if (int.TryParse(psSetting, out var ps) && ps > 0)
                 {
-                    pageSize = ps;
+                    PageSize = ps;
                     Items.PageSize = ps;
                 }
 
                 var filterSetting = await _settingsService.GetSettingAsync("LastFilter", ct).ConfigureAwait(false);
                 if (!string.IsNullOrEmpty(filterSetting))
-                    filter = filterSetting;
+                    Filter = filterSetting;
 
                 var sortSetting = await _settingsService.GetSettingAsync("LastSort", ct).ConfigureAwait(false);
                 if (!string.IsNullOrEmpty(sortSetting))
@@ -149,7 +149,7 @@ namespace InventoryManagementApp.ViewModels
                     {
                         var opt = SortOptions.FirstOrDefault(o => o.Field == sf && o.Direction == sd);
                         if (opt != default)
-                            selectedSortOption = opt;
+                            SelectedSortOption = opt;
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Replace direct backing field references with generated property accessors in `ItemsViewModel` to satisfy MVVMTK0034.

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01b627b508324a496bbbe8b79ec53