### PR TITLE
Validate null item when adding

### DIFF
--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -286,7 +286,8 @@ namespace InventoryManagementApp.Services.Items
     
         private async Task AddItemInternalAsync(ItemModel item, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrWhiteSpace(item?.ItemNumber))
+            ArgumentNullException.ThrowIfNull(item);
+            if (string.IsNullOrWhiteSpace(item.ItemNumber))
                 item.ItemNumber = await GenerateNextItemNumberAsync(cancellationToken);
             if (await ItemExistsAsync(itemNumber: item.ItemNumber, exceptId: null, cancellationToken: cancellationToken))
                 throw new InvalidOperationException($"ItemModel {item.ItemNumber} already exists.");


### PR DESCRIPTION
## Summary
- Ensure AddItemInternalAsync throws when item is null
- Remove null-conditional access from item number assignment

## Testing
- `dotnet test` *(fails: bash: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b01d6e0f608324a5c7fbf84e10d239