### PR TITLE
Guard DeleteItemsAsync against invalid item types

### DIFF
--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -403,13 +403,13 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        async Task DeleteItemsAsync(IList items, CancellationToken cancellationToken)
+        async Task DeleteItemsAsync(IList? items, CancellationToken cancellationToken)
         {
             if (items == null || items.Count == 0) return;
-            string message = items.Count == 1
-                ? $"Delete {LabelProvider.Instance.ItemLabelSingular.ToLower()} '{((ItemModel)items[0]).Name}'?"
+            var message = items.Count == 1 && items[0] is ItemModel { Name: { } name }
+                ? $"Delete {LabelProvider.Instance.ItemLabelSingular.ToLower()} '{name}'?"
                 : $"Delete {items.Count} {LabelProvider.Instance.ItemLabelPlural.ToLower()}?";
-            var confirm = await _dialogService.ShowConfirmationAsync(message, "Confirm Delete");
+            var confirm = await _dialogService.ShowConfirmationAsync(message, "Confirm Delete").ConfigureAwait(false);
             if (!confirm)
                 return;
 


### PR DESCRIPTION
## Summary
- Handle nullable lists in `DeleteItemsAsync`
- Use pattern matching to safely read item name during delete confirmation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b01d618e9c83249d34213d2f2a012a