### PR TITLE
Guard list indexing in ItemsViewModel

### DIFF
--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -113,7 +113,8 @@ namespace InventoryManagementApp.ViewModels
                 new SortOption(SortField.UpdatedAt, SortDirection.Ascending, "Updated Asc"),
                 new SortOption(SortField.UpdatedAt, SortDirection.Descending, "Updated Desc")
             });
-            SelectedSortOption = SortOptions[0];
+            if (SortOptions.Count > 0)
+                SelectedSortOption = SortOptions[0];
             VisibleFields = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true);
             _memoryBudget.SteadyExceeded += OnSteadyExceeded;
             _memoryBudget.PeakExceeded += OnPeakExceeded;
@@ -145,11 +146,14 @@ namespace InventoryManagementApp.ViewModels
                 if (!string.IsNullOrEmpty(sortSetting))
                 {
                     var parts = sortSetting.Split('|');
-                    if (parts.Length == 2 && Enum.TryParse(parts[0], out SortField sf) && Enum.TryParse(parts[1], out SortDirection sd))
+                    if (parts.Length >= 2)
                     {
-                        var opt = SortOptions.FirstOrDefault(o => o.Field == sf && o.Direction == sd);
-                        if (opt != default)
-                            SelectedSortOption = opt;
+                        if (Enum.TryParse(parts[0], out SortField sf) && Enum.TryParse(parts[1], out SortDirection sd))
+                        {
+                            var opt = SortOptions.FirstOrDefault(o => o.Field == sf && o.Direction == sd);
+                            if (opt != default)
+                                SelectedSortOption = opt;
+                        }
                     }
                 }
 
@@ -403,8 +407,11 @@ namespace InventoryManagementApp.ViewModels
         private async Task DeleteItemsAsync(IList? items, CancellationToken ct)
         {
             if (items == null || items.Count == 0) return;
+            var firstItem = items[0] as ItemModel;
             var message = items.Count == 1
-                ? $"Delete {LabelProvider.Instance.ItemLabelSingular.ToLower()} '{((ItemModel)items[0]).Name}'?"
+                ? (firstItem != null
+                    ? $"Delete {LabelProvider.Instance.ItemLabelSingular.ToLower()} '{firstItem.Name}'?"
+                    : "Delete selected item?")
                 : $"Delete {items.Count} {LabelProvider.Instance.ItemLabelPlural.ToLower()}?";
             var confirm = await _dialogService.ShowConfirmationAsync(message, "Confirm Delete").ConfigureAwait(false);
             if (!confirm) return;
@@ -576,7 +583,7 @@ namespace InventoryManagementApp.ViewModels
         public void TrimToWindow(int max)
         {
             if (Count <= max) return;
-            while (Count > max)
+            while (Count > max && Count > 0)
                 RemoveAt(0);
         }
     }


### PR DESCRIPTION
## Summary
- Safeguard default sort option assignment by verifying `SortOptions` has values before indexing.
- Harden sorting preference restoration with explicit length checks before parsing.
- Improve item deletion confirmation and list trimming by safely handling potentially empty lists.

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b01d53b9e083248e4037e9d5e887e9