### PR TITLE
Handle null keys and values when loading settings

### DIFF
--- a/InventoryManagementApp/Services/Settings/SettingsService.cs
+++ b/InventoryManagementApp/Services/Settings/SettingsService.cs
@@ -106,7 +106,12 @@ namespace InventoryManagementApp.Services.Settings
                 using var cmd = new SqliteCommand(sql, conn);
                 using var rdr = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
                 while (await rdr.ReadAsync(cancellationToken).ConfigureAwait(false))
-                    dict[rdr["Key"].ToString()] = rdr["Value"].ToString();
+                {
+                    var key = rdr["Key"]?.ToString();
+                    var value = rdr["Value"]?.ToString();
+                    if (key != null && value != null)
+                        dict[key] = value;
+                }
                 return dict;
             }
             catch (OperationCanceledException ex)


### PR DESCRIPTION
## Summary
- ensure `GetAllSettingsAsync` validates keys and values before storing them

## Testing
- `dotnet test` *(fails: bash: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b01d7fc9548324a3329f2fa2920226