### PR TITLE
Handle null values in activity log

### DIFF
--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -141,8 +141,8 @@ namespace InventoryManagementApp.Services.Users
             var log = new ActivityLog
             {
                 LogID = Convert.ToInt32(r["LogID"]),
-                UserName = r["UserName"].ToString(),
-                Action = r["Action"].ToString(),
+                UserName = r["UserName"]?.ToString() ?? string.Empty,
+                Action   = r["Action"]?.ToString() ?? string.Empty,
                 Timestamp = timestamp
             };
 


### PR DESCRIPTION
## Summary
- Default to empty strings when mapping activity logs missing `UserName` or `Action`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b01e6cd1808324ab5cf01e9aff999c