### PR TITLE
Use default initials brush on login

### DIFF
--- a/InventoryManagementApp.Tests/UserInitialsBrushTests.cs
+++ b/InventoryManagementApp.Tests/UserInitialsBrushTests.cs
@@ -206,6 +206,58 @@ namespace InventoryManagementApp.Tests
             if (threadEx != null) throw threadEx;
         }
 
+        [Fact]
+        public void LoginAssignsDefaultBrushWhenInitialsBrushNull()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+
+                    var hash = SecurityHelper.HashPassword("pass", out var salt);
+                    var users = new List<User>
+                    {
+                        new User { UserID = 1, UserName = "John Doe", PasswordHash = hash, PasswordSalt = salt, IsActive = true }
+                    };
+                    var svc = new StubUserService(users);
+                    var settings = new DummySettingsService();
+                    var dialog = new DummyDialogService();
+                    var context = new ApplicationUserContext();
+
+                    var vm = new LoginViewModel(svc, settings, dialog, context);
+                    vm.LoadUsersCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+                    var loginUser = vm.Users[0];
+                    loginUser.InitialsBrush = null!;
+
+                    bool eventFired = false;
+                    context.UserChanged += (_, __) => eventFired = true;
+
+                    vm.PromptForPasswordAsync = (_, __) => Task.FromResult<PasswordPromptResult?>(new PasswordPromptResult("pass", false));
+                    vm.SelectUserCommand.ExecuteAsync(loginUser).GetAwaiter().GetResult();
+
+                    var defaultBrush = Application.Current.TryFindResource("ForegroundBrush") as Brush;
+                    Assert.True(eventFired);
+                    Assert.NotNull(context.CurrentUser);
+                    Assert.Equal(defaultBrush, context.CurrentUser!.InitialsBrush);
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
         private sealed class StubUserService : IUserService
         {
             private readonly List<User> _users;

--- a/InventoryManagementApp/ViewModels/LoginViewModel.cs
+++ b/InventoryManagementApp/ViewModels/LoginViewModel.cs
@@ -336,7 +336,9 @@ namespace InventoryManagementApp.ViewModels
                     case AuthenticationResult.Success:
                         if (authResult.User != null)
                         {
-                            authResult.User.InitialsBrush = user.InitialsBrush;
+                            var defaultBrush = Application.Current?.TryFindResource("ForegroundBrush") as MediaBrush
+                                               ?? MediaBrushes.Transparent;
+                            authResult.User.InitialsBrush = user.InitialsBrush ?? defaultBrush;
                             if (authResult.User.InitialsBrush == null)
                                 AssignInitialsBrushes(new[] { authResult.User });
                             user = authResult.User;


### PR DESCRIPTION
## Summary
- ensure login falls back to default initials brush when none is supplied
- add unit test for default brush assignment during login

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b01e6f01908324aacb9327ef644f43