### PR TITLE
Remove EnumeratorCancellation attributes from item interfaces

### DIFF
--- a/InventoryManagementApp/Data/IItemRepository.cs
+++ b/InventoryManagementApp/Data/IItemRepository.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Item = InventoryManagementApp.Models.Domain.ItemModel;
@@ -11,7 +10,7 @@ public interface IItemRepository
     /// <summary>
     /// Streams a page of items that match the supplied filter.
     /// </summary>
-    IAsyncEnumerable<Item> GetPageAsync(ItemFilter filter, ItemPage page, [EnumeratorCancellation] CancellationToken cancellationToken);
+    IAsyncEnumerable<Item> GetPageAsync(ItemFilter filter, ItemPage page, CancellationToken cancellationToken);
     Task<int> CountAsync(ItemFilter filter, CancellationToken cancellationToken);
     Task<Item?> GetByIdAsync(int id, CancellationToken cancellationToken);
     Task SaveChangesAsync(IEnumerable<Item> changes, CancellationToken cancellationToken);

--- a/InventoryManagementApp/Interfaces/IItemService.cs
+++ b/InventoryManagementApp/Interfaces/IItemService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Microsoft.Data.Sqlite;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Runtime.CompilerServices;
 using InventoryManagementApp.Data;
 using InventoryManagementApp.Models;
 using InventoryManagementApp.Models.ImportExport;
@@ -16,8 +15,8 @@ namespace InventoryManagementApp.Interfaces
         Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default);
         Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default);
         Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default);
-        IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, [EnumeratorCancellation] CancellationToken cancellationToken = default);
-        IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, [EnumeratorCancellation] CancellationToken cancellationToken = default);
+        IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default);
+        IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default);
         Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct);
         Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct);
         Task<bool> ToggleItemCheckOutStatusAsync(int itemID, CancellationToken cancellationToken = default);


### PR DESCRIPTION
## Summary
- Drop EnumeratorCancellation attribute from repository and service interfaces to avoid signature issues.

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01e769b608324929c21730e09dde8