### PR TITLE
Handle missing customer lookup

### DIFF
--- a/InventoryManagementApp.Tests/CustomerManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/CustomerManagementViewModelTests.cs
@@ -97,8 +97,8 @@ namespace InventoryManagementApp.Tests
                 Customers.RemoveAll(c => c.CustomerID == customerID);
                 return Task.CompletedTask;
             }
-            public Task<CustomerModel> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default)
-                => Task.FromResult(Customers.First(c => c.CustomerID == customerID));
+            public Task<CustomerModel?> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default)
+                => Task.FromResult<CustomerModel?>(Customers.First(c => c.CustomerID == customerID));
             public Task<List<CustomerModel>> GetAllCustomersAsync(CancellationToken cancellationToken = default)
                 => Task.FromResult(Customers.ToList());
             public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default)

--- a/InventoryManagementApp.Tests/DashboardViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DashboardViewModelTests.cs
@@ -103,7 +103,7 @@ public class DashboardViewModelTests
         public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<Customer?> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<CustomerImportResult> ImportCustomersFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task ExportCustomersToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();

--- a/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
+++ b/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
@@ -86,7 +86,7 @@ public class ItemDisplaySettingsTests
         public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult(new Customer());
+        public Task<Customer?> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult<Customer?>(new Customer());
         public Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
         public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
         public Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());

--- a/InventoryManagementApp.Tests/ItemManagementViewModelCommandTests.cs
+++ b/InventoryManagementApp.Tests/ItemManagementViewModelCommandTests.cs
@@ -91,7 +91,7 @@ namespace InventoryManagementApp.Tests
             public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult(new Customer());
+            public Task<Customer?> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult<Customer?>(new Customer());
             public Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default)
             {
                 GetAllCalled = true;

--- a/InventoryManagementApp.Tests/ItemSearchPageTests.cs
+++ b/InventoryManagementApp.Tests/ItemSearchPageTests.cs
@@ -396,7 +396,7 @@ namespace InventoryManagementApp.Tests
             public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult(new Customer());
+            public Task<Customer?> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult<Customer?>(new Customer());
             public Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
             public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
             public Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());

--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -867,7 +867,7 @@ namespace InventoryManagementApp.Tests
             public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult(new Customer());
+            public Task<Customer?> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult<Customer?>(new Customer());
             public Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
             public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
             public Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
@@ -1006,7 +1006,7 @@ namespace InventoryManagementApp.Tests
             public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult(new Customer());
+            public Task<Customer?> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult<Customer?>(new Customer());
             public Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default)
             {
                 GetAllCalled = true;

--- a/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
@@ -168,7 +168,7 @@ namespace InventoryManagementApp.Tests
             public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult(new Customer());
+            public Task<Customer?> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult<Customer?>(new Customer());
             public Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
             public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
             public Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());

--- a/InventoryManagementApp.Tests/MainViewModelTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelTests.cs
@@ -407,7 +407,7 @@ namespace InventoryManagementApp.Tests
             public Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult(new Customer());
+            public Task<Customer?> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => Task.FromResult<Customer?>(new Customer());
             public Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());
             public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
             public Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => Task.FromResult(new List<Customer>());

--- a/InventoryManagementApp.Tests/RentItemPopupViewModelTests.cs
+++ b/InventoryManagementApp.Tests/RentItemPopupViewModelTests.cs
@@ -40,7 +40,7 @@ namespace InventoryManagementApp.Tests
             }
             public Task UpdateCustomerAsync(CustomerModel customer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-            public Task<CustomerModel> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<CustomerModel?> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<CustomerModel>> GetAllCustomersAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public Task<List<CustomerModel>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default) => throw new NotImplementedException();

--- a/InventoryManagementApp/Interfaces/ICustomerService.cs
+++ b/InventoryManagementApp/Interfaces/ICustomerService.cs
@@ -12,7 +12,7 @@ namespace InventoryManagementApp.Interfaces
         Task AddCustomerAsync(Customer customer, CancellationToken cancellationToken = default);
         Task UpdateCustomerAsync(Customer customer, CancellationToken cancellationToken = default);
         Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default);
-        Task<Customer> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default);
+        Task<CustomerModel?> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default);
         Task<List<Customer>> GetAllCustomersAsync(CancellationToken cancellationToken = default);
         Task<int> CountCustomersAsync(CancellationToken cancellationToken = default);
         Task<List<Customer>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default);

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -48,7 +48,7 @@ namespace InventoryManagementApp.Services.Customers
             return DeleteCustomerInternalAsync(customerID, cancellationToken);
         }
 
-        public Task<CustomerModel> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) =>
+        public Task<CustomerModel?> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default) =>
             GetCustomerByIDInternalAsync(customerID, cancellationToken);
 
         public Task<List<CustomerModel>> GetAllCustomersAsync(CancellationToken cancellationToken = default) =>
@@ -128,7 +128,7 @@ namespace InventoryManagementApp.Services.Customers
             }
         }
 
-        async Task<CustomerModel> GetCustomerByIDInternalAsync(int customerID, CancellationToken cancellationToken)
+        async Task<CustomerModel?> GetCustomerByIDInternalAsync(int customerID, CancellationToken cancellationToken)
         {
             const string sql = "SELECT * FROM Customers WHERE CustomerID = @id";
             var p = new[] { new SqliteParameter("@id", customerID) };
@@ -136,6 +136,10 @@ namespace InventoryManagementApp.Services.Customers
             try
             {
                 var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapCustomer, p, cancellationToken);
+                if (list.Count == 0)
+                {
+                    throw new KeyNotFoundException($"Customer {customerID} not found.");
+                }
                 return list.FirstOrDefault();
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- Return nullable `CustomerModel` when fetching customer by ID
- Throw `KeyNotFoundException` if customer ID not found
- Update interface and tests for new nullable signature

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01e71969c8324b117720a24dd40ef