### PR TITLE
Replace invalid-path cache with MemoryCache

### DIFF
--- a/InventoryManagementApp.Tests/NullToDefaultImageConverterTests.cs
+++ b/InventoryManagementApp.Tests/NullToDefaultImageConverterTests.cs
@@ -5,7 +5,6 @@ using System.Windows;
 using System.Windows.Media.Imaging;
 using InventoryManagementApp.Utilities.Converters;
 using InventoryManagementApp.Utilities.Helpers;
-using System.Collections.Concurrent;
 using System.Reflection;
 using System.IO;
 using Microsoft.Extensions.Caching.Memory;
@@ -53,12 +52,12 @@ namespace InventoryManagementApp.Tests
                 {
                     var converter = new NullToDefaultImageConverter();
                     var field = typeof(NullToDefaultImageConverter).GetField("_invalidPaths", BindingFlags.NonPublic | BindingFlags.Static);
-                    var cache = (ConcurrentDictionary<string, byte>)field!.GetValue(null)!;
-                    cache.Clear();
+                    var cache = (MemoryCache)field!.GetValue(null)!;
+                    cache.Compact(1.0);
                     var path = "../nonexistent.png";
                     Assert.Null(PathHelper.GetAbsolutePath(path, false));
                     converter.Convert(path, typeof(BitmapImage), "user", CultureInfo.InvariantCulture);
-                    Assert.True(cache.ContainsKey(path));
+                    Assert.True(cache.TryGetValue(path, out _));
                 }
                 catch (Exception ex)
                 {
@@ -112,6 +111,47 @@ namespace InventoryManagementApp.Tests
                 finally
                 {
                     try { Directory.Delete(tempDir, true); } catch { }
+                    Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
+        public void Convert_InvalidPathCacheEvictsLeastRecentlyUsed()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var converter = new NullToDefaultImageConverter();
+                    var cacheField = typeof(NullToDefaultImageConverter).GetField("_invalidPaths", BindingFlags.NonPublic | BindingFlags.Static);
+                    var cache = (MemoryCache)cacheField!.GetValue(null)!;
+                    cache.Compact(1.0);
+
+                    var firstPath = "../nonexistent0.png";
+                    Assert.Null(PathHelper.GetAbsolutePath(firstPath, false));
+                    converter.Convert(firstPath, typeof(BitmapImage), "user", CultureInfo.InvariantCulture);
+
+                    for (int i = 1; i <= 100; i++)
+                    {
+                        var path = $"../nonexistent{i}.png";
+                        Assert.Null(PathHelper.GetAbsolutePath(path, false));
+                        converter.Convert(path, typeof(BitmapImage), "user", CultureInfo.InvariantCulture);
+                    }
+
+                    Assert.False(cache.TryGetValue(firstPath, out _));
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
                     Application.Current?.Shutdown();
                 }
             });

--- a/InventoryManagementApp/Utilities/Converters/NullToDefaultImageConverter.cs
+++ b/InventoryManagementApp/Utilities/Converters/NullToDefaultImageConverter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Media.Imaging;
-using System.Collections.Concurrent;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -15,8 +14,7 @@ namespace InventoryManagementApp.Utilities.Converters
         private static BitmapImage? _defaultLogo;
         private const int MaxCacheEntries = 100;
         private static readonly MemoryCache _imageCache = new(new MemoryCacheOptions { SizeLimit = MaxCacheEntries });
-        private static readonly ConcurrentDictionary<string, byte> _invalidPaths =
-            new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
+        private static readonly MemoryCache _invalidPaths = new(new MemoryCacheOptions { SizeLimit = MaxCacheEntries });
         private readonly ILogger<NullToDefaultImageConverter> _logger;
 
         public NullToDefaultImageConverter() : this(null) { }
@@ -43,13 +41,17 @@ namespace InventoryManagementApp.Utilities.Converters
                     }
                     else
                     {
-                        if (_invalidPaths.ContainsKey(path))
+                        if (_invalidPaths.TryGetValue(path, out _))
                             return GetDefaultImage(parameter);
 
                         absPath = Helpers.PathHelper.GetAbsolutePath(path, false);
                         if (absPath == null)
                         {
-                            _invalidPaths.TryAdd(path, 0);
+                            _invalidPaths.Set(path, (byte)0, new MemoryCacheEntryOptions
+                            {
+                                Size = 1,
+                                Priority = CacheItemPriority.Low
+                            });
                             return GetDefaultImage(parameter);
                         }
                     }
@@ -77,7 +79,11 @@ namespace InventoryManagementApp.Utilities.Converters
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to load image from {Path}", path);
-                    _invalidPaths.TryAdd(path, 0);
+                    _invalidPaths.Set(path, (byte)0, new MemoryCacheEntryOptions
+                    {
+                        Size = 1,
+                        Priority = CacheItemPriority.Low
+                    });
                     // fall-through to default
                 }
             }


### PR DESCRIPTION
## Summary
- use MemoryCache instead of ConcurrentDictionary for invalid image paths with LRU-style eviction
- exercise invalid-path cache in tests and confirm eviction behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b02103563c8324b833ad7c3560546d