### PR TITLE
Handle missing required CSV fields during item import

### DIFF
--- a/InventoryManagementApp.Tests/ItemServiceCsvImportTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceCsvImportTests.cs
@@ -137,4 +137,35 @@ public class ItemServiceCsvImportTests
         File.Delete(csvPath);
         File.Delete(dbPath);
     }
+
+    [Fact]
+    public async Task ImportItemsFromCsv_SkipsRowsWithMissingMappedFields()
+    {
+        var csvPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".csv");
+        await File.WriteAllTextAsync(csvPath, "ItemNumber\nNUM1");
+
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        new MigrationRunner(db).Migrate();
+        var repository = new ItemRepository(new SqliteConnectionFactory(db.ConnectionString));
+        var service = new ItemService(db, repository);
+
+        var map = new Dictionary<string, string>
+        {
+            ["ItemNumber"] = "ItemNumber",
+            [nameof(ItemImportDto.Name)] = "NameDescription"
+        };
+
+        var invalid = await service.ImportItemsFromCsvAsync(csvPath, map, CancellationToken.None);
+        Assert.Contains(2, invalid);
+
+        using var conn = db.CreateConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM Items";
+        var count = Convert.ToInt32(cmd.ExecuteScalar());
+        Assert.Equal(0, count);
+
+        File.Delete(csvPath);
+        File.Delete(dbPath);
+    }
 }

--- a/InventoryManagementApp/Services/Core/CsvHelperUtil.cs
+++ b/InventoryManagementApp/Services/Core/CsvHelperUtil.cs
@@ -243,7 +243,7 @@ namespace InventoryManagementApp.Utilities.IO
             File.WriteAllLines(filePath, lines);
         }
 
-        private static string? GetMapped(string[] row, string[] headers, IDictionary<string, string> map, string key)
+        public static string? GetMapped(string[] row, string[] headers, IDictionary<string, string> map, string key)
         {
             ArgumentNullException.ThrowIfNull(row);
             ArgumentNullException.ThrowIfNull(headers);

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -374,8 +374,60 @@ namespace InventoryManagementApp.Services.Items
                         invalidRows.Add(row);
                         continue;
                     }
-                    var itemNumber = GetMapped(cols, headers, map, "ItemNumber");
-                    if (string.IsNullOrWhiteSpace(itemNumber) || existingNumbers.Contains(itemNumber))
+                    var itemNumber = CsvHelperUtil.GetMapped(cols, headers, map, "ItemNumber");
+                    var name = CsvHelperUtil.GetMapped(cols, headers, map, nameof(ItemImportDto.Name));
+                    var location = CsvHelperUtil.GetMapped(cols, headers, map, "Location");
+                    var brand = CsvHelperUtil.GetMapped(cols, headers, map, "Brand");
+                    var partNumber = CsvHelperUtil.GetMapped(cols, headers, map, "PartNumber");
+                    var supplier = CsvHelperUtil.GetMapped(cols, headers, map, "Supplier");
+                    var purchased = CsvHelperUtil.GetMapped(cols, headers, map, "PurchasedDate");
+                    var notes = CsvHelperUtil.GetMapped(cols, headers, map, "Notes");
+                    var keywords = CsvHelperUtil.GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords));
+                    var quantity = CsvHelperUtil.GetMapped(cols, headers, map, "AvailableQuantity");
+                    var powered = CsvHelperUtil.GetMapped(cols, headers, map, "IsPowered");
+                    var rental = CsvHelperUtil.GetMapped(cols, headers, map, "IsRentalItem");
+
+                    bool skip = false;
+                    if (string.IsNullOrWhiteSpace(itemNumber))
+                    {
+                        _logger.LogWarning("Skipping row {Row}: ItemNumber is missing.", row);
+                        skip = true;
+                    }
+                    else if (existingNumbers.Contains(itemNumber))
+                    {
+                        _logger.LogWarning("Skipping row {Row}: duplicate ItemNumber {ItemNumber}.", row, itemNumber);
+                        skip = true;
+                    }
+
+                    if (!skip)
+                    {
+                        var requiredChecks = new List<(string Key, string? Value)>
+                        {
+                            (nameof(ItemImportDto.Name), name),
+                            ("Location", location),
+                            ("Brand", brand),
+                            ("PartNumber", partNumber),
+                            ("Supplier", supplier),
+                            ("PurchasedDate", purchased),
+                            ("Notes", notes),
+                            (nameof(ItemImportDto.Keywords), keywords),
+                            ("AvailableQuantity", quantity),
+                            ("IsPowered", powered),
+                            ("IsRentalItem", rental)
+                        };
+
+                        foreach (var (key, value) in requiredChecks)
+                        {
+                            if (map.ContainsKey(key) && value == null)
+                            {
+                                _logger.LogWarning("Skipping row {Row}: field {Field} is missing.", row, key);
+                                skip = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (skip)
                     {
                         invalidRows.Add(row);
                         continue;
@@ -383,22 +435,22 @@ namespace InventoryManagementApp.Services.Items
 
                     var item = new ItemModel
                     {
-                        ItemNumber = itemNumber,
-                        Name = GetMapped(cols, headers, map, nameof(ItemImportDto.Name)) ?? string.Empty,
-                        Location = GetMapped(cols, headers, map, "Location") ?? string.Empty,
-                        Brand = GetMapped(cols, headers, map, "Brand") ?? string.Empty,
-                        PartNumber = GetMapped(cols, headers, map, "PartNumber") ?? string.Empty,
-                        Supplier = GetMapped(cols, headers, map, "Supplier") ?? string.Empty,
-                        PurchasedDate = TryParseDate(GetMapped(cols, headers, map, "PurchasedDate")),
-                        Notes = GetMapped(cols, headers, map, "Notes") ?? string.Empty,
-                        Keywords = GetMapped(cols, headers, map, nameof(ItemImportDto.Keywords)) ?? string.Empty,
-                        QuantityOnHand = TryParseInt(GetMapped(cols, headers, map, "AvailableQuantity")),
-                        IsPowered = TryParseBool(GetMapped(cols, headers, map, "IsPowered")),
-                        IsRentalItem = TryParseBool(GetMapped(cols, headers, map, "IsRentalItem"))
+                        ItemNumber = itemNumber!,
+                        Name = name ?? string.Empty,
+                        Location = location ?? string.Empty,
+                        Brand = brand ?? string.Empty,
+                        PartNumber = partNumber ?? string.Empty,
+                        Supplier = supplier ?? string.Empty,
+                        PurchasedDate = TryParseDate(purchased),
+                        Notes = notes ?? string.Empty,
+                        Keywords = keywords ?? string.Empty,
+                        QuantityOnHand = TryParseInt(quantity),
+                        IsPowered = TryParseBool(powered),
+                        IsRentalItem = TryParseBool(rental)
                     };
 
                     await _repository.InsertAsync(item, cancellationToken);
-                    existingNumbers.Add(itemNumber);
+                    existingNumbers.Add(itemNumber!);
                 }
 
                 return invalidRows;
@@ -407,14 +459,6 @@ namespace InventoryManagementApp.Services.Items
             {
                 _logger.LogError(ex, "Failed to import items from CSV");
                 throw;
-            }
-
-            static string? GetMapped(string[] row, string[] headers, IDictionary<string, string> map, string key)
-            {
-                if (!map.TryGetValue(key, out var column))
-                    return null;
-                var index = Array.FindIndex(headers, h => string.Equals(h, column, StringComparison.OrdinalIgnoreCase));
-                return index >= 0 && index < row.Length ? row[index].Trim() : null;
             }
 
             static int TryParseInt(string? input) => int.TryParse(input, out var result) ? result : 0;


### PR DESCRIPTION
## Summary
- coalesce CSV-mapped values before assigning to item properties
- log and skip rows when required fields are missing
- expose CsvHelperUtil.GetMapped for reuse and cover missing-field scenario with a new test

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b0225c9ed48324a5588bc741a57dcb