### PR TITLE
Add initial setup wizard

### DIFF
--- a/InventoryManagementApp.Tests/SetupWizardViewModelTests.cs
+++ b/InventoryManagementApp.Tests/SetupWizardViewModelTests.cs
@@ -1,0 +1,26 @@
+using InventoryManagementApp.ViewModels;
+using Xunit;
+
+public class SetupWizardViewModelTests
+{
+    [Fact]
+    public void Defaults_AreCorrect()
+    {
+        var vm = new SetupWizardViewModel(() => { }, () => { }, _ => { });
+        Assert.Equal(string.Empty, vm.ApplicationName);
+        Assert.Equal("Item", vm.ItemLabelSingular);
+        Assert.Equal("Items", vm.ItemLabelPlural);
+        Assert.False(vm.IsRandom);
+    }
+
+    [Fact]
+    public void GenerateCommand_SetsPasswordAndFlags()
+    {
+        string? generated = null;
+        var vm = new SetupWizardViewModel(() => { }, () => { }, s => generated = s);
+        vm.GenerateCommand.Execute(null);
+        Assert.True(vm.IsRandom);
+        Assert.Equal(generated, vm.NewPassword);
+        Assert.Equal(generated, vm.ConfirmPassword);
+    }
+}

--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -26,6 +27,7 @@ using InventoryManagementApp.Services.Devices;
 using InventoryManagementApp.Data;
 using InventoryManagementApp.Utilities;
 using Microsoft.Data.Sqlite;
+using InventoryManagementApp.Models.Domain;
 
 namespace InventoryManagementApp
 {
@@ -148,6 +150,36 @@ namespace InventoryManagementApp
             var settingsService = Host.Services.GetRequiredService<ISettingsService>();
             SecurityHelper.SettingsService = settingsService;
             await SecurityHelper.GetIterationsAsync().ConfigureAwait(false);
+            var setupDone = await settingsService.GetSettingAsync("SetupComplete").ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(setupDone))
+            {
+                var wizard = Host.Services.GetRequiredService<ISetupWizard>();
+                var result = await wizard.RunAsync().ConfigureAwait(false);
+                if (result == null)
+                {
+                    Shutdown();
+                    return;
+                }
+                var userService = Host.Services.GetRequiredService<IUserService>();
+                var users = await userService.GetAllUsersAsync(System.Threading.CancellationToken.None).ConfigureAwait(false);
+                var admin = users.FirstOrDefault(u => u.IsAdmin);
+                if (admin == null)
+                {
+                    admin = new User
+                    {
+                        UserName = "admin",
+                        PasswordHash = "admin",
+                        IsAdmin = true,
+                        PasswordExpired = true
+                    };
+                    await userService.AddUserAsync(admin).ConfigureAwait(false);
+                }
+                await userService.ChangeUserPasswordAsync(admin.UserID, result.Password).ConfigureAwait(false);
+                await settingsService.SaveSettingAsync("ApplicationName", result.ApplicationName).ConfigureAwait(false);
+                await settingsService.SaveItemLabelSingularAsync(result.ItemLabelSingular).ConfigureAwait(false);
+                await settingsService.SaveItemLabelPluralAsync(result.ItemLabelPlural).ConfigureAwait(false);
+                await settingsService.SaveSettingAsync("SetupComplete", "true").ConfigureAwait(false);
+            }
             await LabelProvider.Instance.InitializeAsync(settingsService).ConfigureAwait(false);
 
             var main = (Window)Host.Services.GetRequiredService<IMainWindow>();

--- a/InventoryManagementApp/Interfaces/ISetupWizard.cs
+++ b/InventoryManagementApp/Interfaces/ISetupWizard.cs
@@ -7,5 +7,10 @@ namespace InventoryManagementApp.Interfaces
         Task<SetupWizardResult?> RunAsync();
     }
 
-    public record SetupWizardResult(string Password, bool IsRandom);
+    public record SetupWizardResult(
+        string Password,
+        bool IsRandom,
+        string ApplicationName,
+        string ItemLabelSingular,
+        string ItemLabelPlural);
 }

--- a/InventoryManagementApp/ViewModels/SetupWizardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/SetupWizardViewModel.cs
@@ -14,6 +14,27 @@ namespace InventoryManagementApp.ViewModels
             private set => SetProperty(ref _isRandom, value);
         }
 
+        string _applicationName = string.Empty;
+        public string ApplicationName
+        {
+            get => _applicationName;
+            set => SetProperty(ref _applicationName, value);
+        }
+
+        string _itemLabelSingular = "Item";
+        public string ItemLabelSingular
+        {
+            get => _itemLabelSingular;
+            set => SetProperty(ref _itemLabelSingular, value);
+        }
+
+        string _itemLabelPlural = "Items";
+        public string ItemLabelPlural
+        {
+            get => _itemLabelPlural;
+            set => SetProperty(ref _itemLabelPlural, value);
+        }
+
         public IRelayCommand GenerateCommand { get; }
 
         public SetupWizardViewModel(Action onSave, Action onCancel, Action<string> onGenerated)

--- a/InventoryManagementApp/Views/Windows/SetupWizardWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/SetupWizardWindow.xaml
@@ -15,14 +15,26 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" Text="Admin Password" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
-        <PasswordBox Grid.Row="1" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
-        <TextBlock Grid.Row="2" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
-        <PasswordBox Grid.Row="3" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
-        <TextBlock Grid.Row="4" Text="{Binding ValidationMessage}" Margin="0,10,0,0" Style="{StaticResource ErrorTextBlock}" HorizontalAlignment="Center"/>
-        <Button Grid.Row="5" Content="Generate Random" Style="{StaticResource PrimaryButton}" Margin="0,10,0,0" Command="{Binding GenerateCommand}" HorizontalAlignment="Center"/>
-        <controls:DialogButtonBar Grid.Row="6"
+        <TextBlock Grid.Row="0" Text="Application Name" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
+        <TextBox Grid.Row="1" Width="200" Text="{Binding ApplicationName}" HorizontalAlignment="Center"/>
+        <TextBlock Grid.Row="2" Text="Item Label Singular" Margin="0,10,0,0" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
+        <TextBox Grid.Row="3" Width="200" Text="{Binding ItemLabelSingular}" HorizontalAlignment="Center"/>
+        <TextBlock Grid.Row="4" Text="Item Label Plural" Margin="0,10,0,0" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
+        <TextBox Grid.Row="5" Width="200" Text="{Binding ItemLabelPlural}" HorizontalAlignment="Center"/>
+        <TextBlock Grid.Row="6" Text="Admin Password" Margin="0,10,0,0" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
+        <PasswordBox Grid.Row="7" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
+        <TextBlock Grid.Row="8" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
+        <PasswordBox Grid.Row="9" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
+        <TextBlock Grid.Row="10" Text="{Binding ValidationMessage}" Margin="0,10,0,0" Style="{StaticResource ErrorTextBlock}" HorizontalAlignment="Center"/>
+        <Button Grid.Row="11" Content="Generate Random" Style="{StaticResource PrimaryButton}" Margin="0,10,0,0" Command="{Binding GenerateCommand}" HorizontalAlignment="Center"/>
+        <controls:DialogButtonBar Grid.Row="12"
                                   LeftButtonText="Cancel"
                                   LeftCommand="{Binding CancelCommand}"
                                   RightButtonText="OK"

--- a/InventoryManagementApp/Views/Windows/SetupWizardWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/SetupWizardWindow.xaml.cs
@@ -33,7 +33,14 @@ namespace InventoryManagementApp.Views.Windows
 
         public Task<SetupWizardResult?> RunAsync()
         {
-            var result = ShowDialog() == true ? new SetupWizardResult(_viewModel.NewPassword, _viewModel.IsRandom) : null;
+            var result = ShowDialog() == true
+                ? new SetupWizardResult(
+                    _viewModel.NewPassword,
+                    _viewModel.IsRandom,
+                    _viewModel.ApplicationName,
+                    _viewModel.ItemLabelSingular,
+                    _viewModel.ItemLabelPlural)
+                : null;
             return Task.FromResult(result);
         }
 


### PR DESCRIPTION
## Summary
- run a setup wizard on first launch to collect application name, item labels, and admin password
- extend setup wizard UI and view model for new fields
- add basic unit tests for the setup wizard view model

## Testing
- `dotnet test` *(command failed: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cc41ea9c83249fd7decb10a08ac5