### PR TITLE
Add theme switching support

### DIFF
--- a/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
+++ b/InventoryManagementApp.Tests/ItemDisplaySettingsTests.cs
@@ -51,6 +51,11 @@ public class ItemDisplaySettingsTests
         public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, Microsoft.Data.Sqlite.SqliteConnection? conn = null, Microsoft.Data.Sqlite.SqliteTransaction? tx = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 
+    private sealed class DummyThemeService : IThemeService
+    {
+        public void ApplyTheme(string? theme) { }
+    }
+
     private sealed class TrackingItemService : IItemService
     {
         public int CallCount { get; private set; }
@@ -141,6 +146,8 @@ public class ItemDisplaySettingsTests
         public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
         public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+        public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+        public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
         public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
@@ -266,7 +273,7 @@ public class ItemDisplaySettingsTests
         itemService.OnGetItems = () => searchTcs.TrySetResult(true);
         var itemVm = new ItemManagementViewModel(itemService, new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
         await itemVm.InitializeAsync();
-        var settingsVm = new SettingsViewModel(new DummyFileDialogService(), settings, new DummyDialogService());
+        var settingsVm = new SettingsViewModel(new DummyFileDialogService(), settings, new DummyDialogService(), new DummyThemeService());
         await settingsVm.InitializeAsync();
         var tcs = new TaskCompletionSource<bool>();
         itemVm.PropertyChanged += (s, e) =>
@@ -310,7 +317,7 @@ public class ItemDisplaySettingsTests
         itemService.OnGetItems = () => searchTcs.TrySetResult(true);
         var itemVm = new ItemManagementViewModel(itemService, new DummyCustomerService(), new DummyRentalService(), new DummyDialogService(), settings);
         await itemVm.InitializeAsync();
-        var settingsVm = new SettingsViewModel(new DummyFileDialogService(), settings, new DummyDialogService());
+        var settingsVm = new SettingsViewModel(new DummyFileDialogService(), settings, new DummyDialogService(), new DummyThemeService());
         await settingsVm.InitializeAsync();
         settingsVm.ItemLabelSingular = "Widget";
         await searchTcs.Task.WaitAsync(TimeSpan.FromSeconds(1));
@@ -326,7 +333,7 @@ public class ItemDisplaySettingsTests
         var vis = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => false);
         vis[ItemDetailField.Name] = true;
         await settings.SaveItemDetailVisibilityAsync(vis);
-        var vm = new SettingsViewModel(new DummyFileDialogService(), settings, new DummyDialogService());
+        var vm = new SettingsViewModel(new DummyFileDialogService(), settings, new DummyDialogService(), new DummyThemeService());
         await vm.InitializeAsync();
         Assert.Equal("TestApp", vm.ApplicationName);
         Assert.True(vm.ItemDetailOptions.Single(o => o.Field == ItemDetailField.Name).IsVisible);
@@ -340,7 +347,7 @@ public class ItemDisplaySettingsTests
         var settings = new SettingsService(db);
         var vis = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true);
         settings.SaveItemDetailVisibilityAsync(vis).GetAwaiter().GetResult();
-        var vm = new SettingsViewModel(new DummyFileDialogService(), settings, new DummyDialogService());
+        var vm = new SettingsViewModel(new DummyFileDialogService(), settings, new DummyDialogService(), new DummyThemeService());
         var thread = new Thread(() =>
         {
             SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());

--- a/InventoryManagementApp.Tests/ItemManagementViewModelCommandTests.cs
+++ b/InventoryManagementApp.Tests/ItemManagementViewModelCommandTests.cs
@@ -136,6 +136,8 @@ namespace InventoryManagementApp.Tests
             public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
             public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
             public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);

--- a/InventoryManagementApp.Tests/ItemSearchPageTests.cs
+++ b/InventoryManagementApp.Tests/ItemSearchPageTests.cs
@@ -445,6 +445,8 @@ namespace InventoryManagementApp.Tests
             public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
             public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
             public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);

--- a/InventoryManagementApp.Tests/ItemsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ItemsViewModelTests.cs
@@ -907,6 +907,13 @@ namespace InventoryManagementApp.Tests
             }
             public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
             public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult(_settings.TryGetValue("Theme", out var v) ? v : null);
+            public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default)
+            {
+                _settings["Theme"] = theme;
+                return Task.CompletedTask;
+            }
             public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
             public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);

--- a/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
@@ -60,6 +60,7 @@ namespace InventoryManagementApp.Tests
                     new DummyFileDialogService(),
                     activityLog,
                     new DummySettingsService(),
+                    new DummyThemeService(),
                     db,
                     new DummyDialogService(),
                     NullLogger<MainViewModel>.Instance,
@@ -97,6 +98,7 @@ namespace InventoryManagementApp.Tests
                 new DummyFileDialogService(),
                 activityLog,
                 new DummySettingsService(),
+                new DummyThemeService(),
                 db,
                 dialogService,
                 NullLogger<MainViewModel>.Instance,
@@ -206,6 +208,8 @@ namespace InventoryManagementApp.Tests
             public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
             public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
             public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
@@ -221,6 +225,11 @@ namespace InventoryManagementApp.Tests
                 ItemDetailVisibilityChanged?.Invoke(this, visibility);
                 return Task.CompletedTask;
             }
+        }
+
+        private sealed class DummyThemeService : IThemeService
+        {
+            public void ApplyTheme(string? theme) { }
         }
 
         private sealed class DummyDialogService : IDialogService

--- a/InventoryManagementApp.Tests/MainViewModelTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelTests.cs
@@ -42,6 +42,7 @@ namespace InventoryManagementApp.Tests
                     new DummyFileDialogService(),
                     new ActivityLogService(db),
                     new DummySettingsService(),
+                    new DummyThemeService(),
                     db,
                     new DummyDialogService(),
                     NullLogger<MainViewModel>.Instance,
@@ -83,6 +84,7 @@ namespace InventoryManagementApp.Tests
                     new DummyFileDialogService(),
                     new ActivityLogService(db),
                     new DummySettingsService(),
+                    new DummyThemeService(),
                     db,
                     new DummyDialogService(),
                     NullLogger<MainViewModel>.Instance,
@@ -145,6 +147,7 @@ namespace InventoryManagementApp.Tests
                     new DummyFileDialogService(),
                     new ActivityLogService(db),
                     new DummySettingsService(),
+                    new DummyThemeService(),
                     db,
                     new DummyDialogService(),
                     NullLogger<MainViewModel>.Instance,
@@ -179,6 +182,7 @@ namespace InventoryManagementApp.Tests
                     new DummyFileDialogService(),
                     new ActivityLogService(db),
                     new DummySettingsService(),
+                    new DummyThemeService(),
                     db,
                     new DummyDialogService(),
                     NullLogger<MainViewModel>.Instance,
@@ -215,6 +219,7 @@ namespace InventoryManagementApp.Tests
                     new DummyFileDialogService(),
                     new ActivityLogService(db),
                     new DummySettingsService(),
+                    new DummyThemeService(),
                     db,
                     new DummyDialogService(),
                     NullLogger<MainViewModel>.Instance,
@@ -279,6 +284,7 @@ namespace InventoryManagementApp.Tests
                         new DummyFileDialogService(),
                         new ActivityLogService(db),
                         new DummySettingsService(),
+                        new DummyThemeService(),
                         db,
                         dialogService,
                         NullLogger<MainViewModel>.Instance,
@@ -445,6 +451,8 @@ namespace InventoryManagementApp.Tests
             public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
             public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
             public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
@@ -460,6 +468,11 @@ namespace InventoryManagementApp.Tests
                 ItemDetailVisibilityChanged?.Invoke(this, visibility);
                 return Task.CompletedTask;
             }
+        }
+
+        private sealed class DummyThemeService : IThemeService
+        {
+            public void ApplyTheme(string? theme) { }
         }
 
         private sealed class DummyDialogService : IDialogService

--- a/InventoryManagementApp.Tests/ManageItemsPageTests.cs
+++ b/InventoryManagementApp.Tests/ManageItemsPageTests.cs
@@ -199,6 +199,8 @@ namespace InventoryManagementApp.Tests
             public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
             public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
             public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);

--- a/InventoryManagementApp.Tests/SettingsServiceTests.cs
+++ b/InventoryManagementApp.Tests/SettingsServiceTests.cs
@@ -18,4 +18,17 @@ public class SettingsServiceTests
 
         Assert.Null(value);
     }
+
+    [Fact]
+    public async Task SaveAndGetThemeAsync_RoundTrip()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        var service = new SettingsService(db);
+
+        await service.SaveThemeAsync("Dark");
+        var value = await service.GetThemeAsync();
+
+        Assert.Equal("Dark", value);
+    }
 }

--- a/InventoryManagementApp.Tests/UserInitialsBrushTests.cs
+++ b/InventoryManagementApp.Tests/UserInitialsBrushTests.cs
@@ -357,6 +357,8 @@ namespace InventoryManagementApp.Tests
             public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
             public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
             public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);

--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -112,6 +112,7 @@ namespace InventoryManagementApp
                 services.AddSingleton<ActivityLogService>();
                 services.AddSingleton<IFileDialogService, FileDialogService>();
                 services.AddSingleton<ISettingsService, SettingsService>();
+                services.AddSingleton<IThemeService, ThemeService>();
                 services.AddSingleton<IDialogService, DialogService>();
                 services.AddSingleton<IScannerService, ScannerService>();
                 services.AddSingleton<MemoryBudget>();
@@ -148,8 +149,11 @@ namespace InventoryManagementApp
             var loggerFactory = Host.Services.GetRequiredService<ILoggerFactory>();
             PathHelper.Configure(loggerFactory.CreateLogger("PathHelper"));
             var settingsService = Host.Services.GetRequiredService<ISettingsService>();
+            var themeService = Host.Services.GetRequiredService<IThemeService>();
             SecurityHelper.SettingsService = settingsService;
             await SecurityHelper.GetIterationsAsync().ConfigureAwait(false);
+            var theme = await settingsService.GetThemeAsync().ConfigureAwait(false);
+            themeService.ApplyTheme(theme);
             var setupDone = await settingsService.GetSettingAsync("SetupComplete").ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(setupDone))
             {

--- a/InventoryManagementApp/Interfaces/ISettingsService.cs
+++ b/InventoryManagementApp/Interfaces/ISettingsService.cs
@@ -17,6 +17,10 @@ namespace InventoryManagementApp.Interfaces
         Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default);
         Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default);
 
+        // Theme configuration
+        Task<string?> GetThemeAsync(CancellationToken cancellationToken = default);
+        Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default);
+
         // Password hashing configuration
         Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default);
         Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default);

--- a/InventoryManagementApp/Interfaces/IThemeService.cs
+++ b/InventoryManagementApp/Interfaces/IThemeService.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace InventoryManagementApp.Interfaces
+{
+    public interface IThemeService
+    {
+        void ApplyTheme(string? theme);
+    }
+}

--- a/InventoryManagementApp/InventoryManagementApp.csproj
+++ b/InventoryManagementApp/InventoryManagementApp.csproj
@@ -55,6 +55,7 @@
 
   <ItemGroup>
     <Page Remove="Resources\Colors.xaml" />
+    <Page Remove="Resources\Colors.Light.xaml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -91,6 +92,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Resource>
     <Resource Include="Resources\Colors.xaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Generator>MSBuild:Compile</Generator>
+    </Resource>
+    <Resource Include="Resources\Colors.Light.xaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Generator>MSBuild:Compile</Generator>
     </Resource>

--- a/InventoryManagementApp/Resources/Colors.Light.xaml
+++ b/InventoryManagementApp/Resources/Colors.Light.xaml
@@ -1,0 +1,37 @@
+<!-- Resources/Colors.Light.xaml -->
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="Col.Background">#FFFFFF</Color>
+    <Color x:Key="Col.Surface">#F5F5F5</Color>
+    <Color x:Key="Col.SurfaceAlt">#EEEEEE</Color>
+    <Color x:Key="Col.Border">#DDDDDD</Color>
+    <Color x:Key="Col.BorderAlt">#CCCCCC</Color>
+    <Color x:Key="Col.Fg">#1A1A1A</Color>
+    <Color x:Key="Col.FgMuted">#555555</Color>
+    <Color x:Key="Col.Success">#2ECC71</Color>
+    <Color x:Key="Col.Error">#ff6b6b</Color>
+    <SolidColorBrush x:Key="BackgroundBrush" Color="{StaticResource Col.Background}"/>
+    <SolidColorBrush x:Key="SurfaceBrush" Color="{StaticResource Col.Surface}"/>
+    <SolidColorBrush x:Key="SurfaceAltBrush" Color="{StaticResource Col.SurfaceAlt}"/>
+    <SolidColorBrush x:Key="BorderBrushBase" Color="{StaticResource Col.Border}"/>
+    <SolidColorBrush x:Key="BorderBrushAlt" Color="{StaticResource Col.BorderAlt}"/>
+    <SolidColorBrush x:Key="ForegroundBrush" Color="{StaticResource Col.Fg}"/>
+    <SolidColorBrush x:Key="ForegroundMutedBrush" Color="{StaticResource Col.FgMuted}"/>
+    <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource Col.Success}"/>
+    <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource Col.Error}"/>
+    <Color x:Key="Col.Accent">#0078D4</Color>
+    <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource Col.Accent}"/>
+    <Color x:Key="Col.CardBackground">#FFFFFF</Color>
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource Col.CardBackground}"/>
+    <SolidColorBrush x:Key="OverlayBrush" Color="#80000000"/>
+    <x:Array x:Key="UserInitialsBrushes" Type="SolidColorBrush">
+        <SolidColorBrush Color="#FF1ABC9C"/>
+        <SolidColorBrush Color="#FF3498DB"/>
+        <SolidColorBrush Color="#FF9B59B6"/>
+        <SolidColorBrush Color="#FFE74C3C"/>
+        <SolidColorBrush Color="#FFE67E22"/>
+        <SolidColorBrush Color="#FFF1C40F"/>
+        <SolidColorBrush Color="#FF2ECC71"/>
+        <SolidColorBrush Color="#FF34495E"/>
+    </x:Array>
+</ResourceDictionary>

--- a/InventoryManagementApp/Services/Settings/SettingsService.cs
+++ b/InventoryManagementApp/Services/Settings/SettingsService.cs
@@ -22,7 +22,7 @@ namespace InventoryManagementApp.Services.Settings
         readonly IAuthorizationService _auth;
         public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
         const string UpsertSql = @"
-            INSERT INTO Settings (Key, Value) 
+            INSERT INTO Settings (Key, Value)
             VALUES (@Key, @Value)
             ON CONFLICT(Key) DO UPDATE SET Value = @Value";
 
@@ -220,6 +220,7 @@ namespace InventoryManagementApp.Services.Settings
         const string ScannerIpKey = "ScannerIpAddresses";
         const string PasswordIterationsKey = "PasswordIterations";
         const string AutoLogoutMinutesKey = "AutoLogoutMinutes";
+        const string ThemeKey = "Theme";
         const string ItemLabelSingularKey = "ItemLabelSingular";
         const string ItemLabelPluralKey = "ItemLabelPlural";
         const string ItemDetailVisibilityKey = "ItemDetailVisibility";
@@ -274,6 +275,13 @@ namespace InventoryManagementApp.Services.Settings
 
             return invalid;
         }
+
+        // Theme configuration
+        public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default)
+            => GetSettingAsync(ThemeKey, cancellationToken);
+
+        public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default)
+            => SaveSettingAsync(ThemeKey, theme, cancellationToken);
 
         // Password hashing configuration
         public async Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default)

--- a/InventoryManagementApp/Services/ThemeService.cs
+++ b/InventoryManagementApp/Services/ThemeService.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Windows;
+using InventoryManagementApp.Interfaces;
+
+namespace InventoryManagementApp.Services
+{
+    public class ThemeService : IThemeService
+    {
+        public void ApplyTheme(string? theme)
+        {
+            var path = string.Equals(theme, "Light", StringComparison.OrdinalIgnoreCase)
+                ? "Resources/Colors.Light.xaml"
+                : "Resources/Colors.xaml";
+            var dict = new ResourceDictionary { Source = new Uri(path, UriKind.Relative) };
+            var app = Application.Current;
+            if (app != null && app.Resources.MergedDictionaries.Count > 0)
+            {
+                app.Resources.MergedDictionaries[0] = dict;
+            }
+        }
+    }
+}

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -43,6 +43,7 @@ namespace InventoryManagementApp.ViewModels
         readonly IFileDialogService _fileDialogService;
         readonly IDialogService _dialogService;
         readonly IScannerService _scannerService;
+        readonly IThemeService _themeService;
         readonly ILogger<MainViewModel> _logger;
         readonly Func<Task<bool>> _showLoginWindow;
         readonly IDispatcherTimer _autoLogoutTimer;
@@ -198,6 +199,7 @@ namespace InventoryManagementApp.ViewModels
                              IFileDialogService fileDialogService,
                              ActivityLogService activityLogService,
                              ISettingsService settingsService,
+                             IThemeService themeService,
                              IDatabaseBackupService databaseService,
                              IDialogService dialogService,
                              ILogger<MainViewModel>? logger = null,
@@ -213,6 +215,7 @@ namespace InventoryManagementApp.ViewModels
             _rentalService = rentalService;
             _activityLogService = activityLogService;
             _settingsService = settingsService;
+            _themeService = themeService;
             _dialogService = dialogService;
             _scannerService = scannerService ?? new DummyScannerService();
             _fileDialogService = fileDialogService;
@@ -246,7 +249,7 @@ namespace InventoryManagementApp.ViewModels
             ImportExport = new ImportExportViewModel(itemService, customerService, fileDialogService, databaseService, _dialogService, OpenImageImportMappingWindowCommand, _userContext);
             Reports = new ReportsViewModel(new ReportService(itemService, rentalService, activityLogService, customerService, userService));
             ActivityLogs = new ActivityLogsViewModel(activityLogService);
-            Settings = new SettingsViewModel(_fileDialogService, _settingsService, _dialogService);
+            Settings = new SettingsViewModel(_fileDialogService, _settingsService, _dialogService, _themeService);
             var logoPath = _settingsService.GetSettingAsync("CompanyLogoPath").GetAwaiter().GetResult();
             if (!string.IsNullOrWhiteSpace(logoPath))
                 CompanyLogoPath = logoPath;

--- a/InventoryManagementApp/ViewModels/SettingsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/SettingsViewModel.cs
@@ -25,15 +25,17 @@ namespace InventoryManagementApp.ViewModels
         readonly IFileDialogService _fileDialog;
         readonly ISettingsService _settingsService;
         readonly IDialogService _dialogService;
+        readonly IThemeService _themeService;
         readonly ILogger<SettingsViewModel> _logger;
         public ObservableCollection<ItemDetailOption> ItemDetailOptions { get; } = new();
         bool _bulkUpdating;
 
-        public SettingsViewModel(IFileDialogService fileDialog, ISettingsService settingsService, IDialogService dialogService, ILogger<SettingsViewModel>? logger = null)
+        public SettingsViewModel(IFileDialogService fileDialog, ISettingsService settingsService, IDialogService dialogService, IThemeService themeService, ILogger<SettingsViewModel>? logger = null)
         {
             _fileDialog = fileDialog;
             _settingsService = settingsService;
             _dialogService = dialogService;
+            _themeService = themeService;
             _logger = logger ?? NullLogger<SettingsViewModel>.Instance;
 
             ThemeOptions = new ObservableCollection<string> { "Light", "Dark" };
@@ -80,6 +82,10 @@ namespace InventoryManagementApp.ViewModels
             var appName = await _settingsService.GetSettingAsync("ApplicationName").ConfigureAwait(false);
             if (!string.IsNullOrWhiteSpace(appName))
                 _applicationName = appName;
+            var theme = await _settingsService.GetThemeAsync().ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(theme) && ThemeOptions.Contains(theme))
+                _theme = theme;
+            _themeService.ApplyTheme(_theme);
             _passwordIterations = await _settingsService.GetPasswordIterationsAsync().ConfigureAwait(false);
             _autoLogoutMinutes = await _settingsService.GetAutoLogoutMinutesAsync().ConfigureAwait(false);
             var vis = await _settingsService.GetItemDetailVisibilityAsync().ConfigureAwait(false);
@@ -91,6 +97,7 @@ namespace InventoryManagementApp.ViewModels
             }
             OnPropertyChanged(nameof(CompanyLogoPath));
             OnPropertyChanged(nameof(ApplicationName));
+            OnPropertyChanged(nameof(Theme));
             OnPropertyChanged(nameof(PasswordIterations));
             OnPropertyChanged(nameof(AutoLogoutMinutes));
             _initialized = true;
@@ -215,7 +222,35 @@ namespace InventoryManagementApp.ViewModels
         public string Theme
         {
             get => _theme;
-            set => SetProperty(ref _theme, value);
+            set
+            {
+                if (SetProperty(ref _theme, value))
+                {
+                    _ = SetThemeAsync(value);
+                }
+            }
+        }
+
+        async Task SetThemeAsync(string value, CancellationToken token = default)
+        {
+            try
+            {
+                await _settingsService.SaveThemeAsync(value, token).ConfigureAwait(false);
+                _themeService.ApplyTheme(value);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogWarning(ex, "Unauthorized to change settings.");
+                _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogInformation(ex, "Saving theme was canceled.");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save theme.");
+            }
         }
 
         private int _passwordIterations;


### PR DESCRIPTION
## Summary
- Save and apply persisted UI theme using new ThemeService
- Extend settings service and view models for theme selection
- Add light theme resources and accompanying tests

## Testing
- `dotnet test InventoryManagementApp.Tests` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e4ded4548324a98f6de9556a8748