### PR TITLE
Add theme service with light and dark color resources

### DIFF
--- a/InventoryManagementApp.Tests/MainViewModelTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelTests.cs
@@ -249,7 +249,7 @@ namespace InventoryManagementApp.Tests
                 var app = new Application();
                 app.Resources.MergedDictionaries.Add(new ResourceDictionary
                 {
-                    Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute)
+                    Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute)
                 });
 
                 try

--- a/InventoryManagementApp.Tests/ThemeServiceTests.cs
+++ b/InventoryManagementApp.Tests/ThemeServiceTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using InventoryManagementApp.Services;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ThemeServiceTests
+    {
+        [Fact]
+        public async Task ApplyTheme_LoadsDarkDictionary()
+        {
+            await RunOnStaThread(async () =>
+            {
+                var app = new Application();
+                var service = new ThemeService();
+                service.ApplyTheme("Dark");
+                Assert.Contains("Colors.Dark.xaml", app.Resources.MergedDictionaries[0].Source.OriginalString);
+                app.Shutdown();
+                await Task.CompletedTask;
+            });
+        }
+
+        [Fact]
+        public async Task ApplyTheme_LoadsLightDictionary()
+        {
+            await RunOnStaThread(async () =>
+            {
+                var app = new Application();
+                var service = new ThemeService();
+                service.ApplyTheme("Light");
+                Assert.Contains("Colors.Light.xaml", app.Resources.MergedDictionaries[0].Source.OriginalString);
+                app.Shutdown();
+                await Task.CompletedTask;
+            });
+        }
+
+        static Task RunOnStaThread(Func<Task> action)
+        {
+            var tcs = new TaskCompletionSource();
+            var thread = new Thread(async () =>
+            {
+                try
+                {
+                    await action();
+                    tcs.SetResult();
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            return tcs.Task;
+        }
+    }
+}

--- a/InventoryManagementApp.Tests/UserAvatarTests.cs
+++ b/InventoryManagementApp.Tests/UserAvatarTests.cs
@@ -19,7 +19,7 @@ namespace InventoryManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
 
@@ -64,7 +64,7 @@ namespace InventoryManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
 
@@ -109,7 +109,7 @@ namespace InventoryManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
 
@@ -151,7 +151,7 @@ namespace InventoryManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
 

--- a/InventoryManagementApp.Tests/UserInitialsBrushTests.cs
+++ b/InventoryManagementApp.Tests/UserInitialsBrushTests.cs
@@ -28,7 +28,7 @@ namespace InventoryManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute) });
                     var users = new List<User>
                     {
                         new User { UserID = 1, UserName = "John Doe" },
@@ -66,7 +66,7 @@ namespace InventoryManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute) });
                     var users = new List<User>
                     {
                         new User { UserID = 1, UserName = "John Doe" }
@@ -113,7 +113,7 @@ namespace InventoryManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute) });
                     var users = new List<User>
                     {
                         new User { UserID = 1, UserName = "John Doe" },
@@ -164,7 +164,7 @@ namespace InventoryManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute) });
 
                     var hash = SecurityHelper.HashPassword("pass", out var salt);
                     var users = new List<User>
@@ -215,7 +215,7 @@ namespace InventoryManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute) });
 
                     var hash = SecurityHelper.HashPassword("pass", out var salt);
                     var users = new List<User>

--- a/InventoryManagementApp.Tests/UserInitialsDisplayTests.cs
+++ b/InventoryManagementApp.Tests/UserInitialsDisplayTests.cs
@@ -22,7 +22,7 @@ namespace InventoryManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
 
@@ -67,7 +67,7 @@ namespace InventoryManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
 
@@ -111,7 +111,7 @@ namespace InventoryManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
 
@@ -155,7 +155,7 @@ namespace InventoryManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
 
@@ -200,7 +200,7 @@ namespace InventoryManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
 
@@ -244,7 +244,7 @@ namespace InventoryManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
 
@@ -292,7 +292,7 @@ namespace InventoryManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.xaml", UriKind.Absolute) });
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute) });
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Converters.xaml", UriKind.Absolute) });
 

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -6,7 +6,7 @@
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Resources/Colors.xaml"/>
+                <!-- Theme dictionary added at runtime -->
                 <ResourceDictionary Source="Resources/Styles.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
                 <ResourceDictionary Source="Resources/Templates.xaml"/>

--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -45,6 +45,11 @@ namespace InventoryManagementApp
             _logger = Host.Services.GetRequiredService<ILogger<App>>();
             _dialogService = Host.Services.GetRequiredService<IDialogService>();
 
+            var settingsService = Host.Services.GetRequiredService<ISettingsService>();
+            var themeService = Host.Services.GetRequiredService<IThemeService>();
+            var theme = settingsService.GetThemeAsync().GetAwaiter().GetResult();
+            themeService.ApplyTheme(theme);
+
             DispatcherUnhandledException += (s, e) => HandleDispatcherException(e.Exception, e);
             AppDomain.CurrentDomain.UnhandledException += (s, e) =>
                 HandleDomainException(e.ExceptionObject as Exception ?? new Exception("Unknown"), e);
@@ -149,11 +154,8 @@ namespace InventoryManagementApp
             var loggerFactory = Host.Services.GetRequiredService<ILoggerFactory>();
             PathHelper.Configure(loggerFactory.CreateLogger("PathHelper"));
             var settingsService = Host.Services.GetRequiredService<ISettingsService>();
-            var themeService = Host.Services.GetRequiredService<IThemeService>();
             SecurityHelper.SettingsService = settingsService;
             await SecurityHelper.GetIterationsAsync().ConfigureAwait(false);
-            var theme = await settingsService.GetThemeAsync().ConfigureAwait(false);
-            themeService.ApplyTheme(theme);
             var setupDone = await settingsService.GetSettingAsync("SetupComplete").ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(setupDone))
             {

--- a/InventoryManagementApp/InventoryManagementApp.csproj
+++ b/InventoryManagementApp/InventoryManagementApp.csproj
@@ -54,7 +54,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Page Remove="Resources\Colors.xaml" />
+    <Page Remove="Resources\Colors.Dark.xaml" />
     <Page Remove="Resources\Colors.Light.xaml" />
   </ItemGroup>
 
@@ -91,7 +91,7 @@
     <Resource Include="Resources\DefaultItemImage.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Resource>
-    <Resource Include="Resources\Colors.xaml">
+    <Resource Include="Resources\Colors.Dark.xaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Generator>MSBuild:Compile</Generator>
     </Resource>

--- a/InventoryManagementApp/Resources/Colors.Dark.xaml
+++ b/InventoryManagementApp/Resources/Colors.Dark.xaml
@@ -1,4 +1,4 @@
-<!-- Resources/Colors.xaml -->
+<!-- Resources/Colors.Dark.xaml -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Color x:Key="Col.Background">#0F141A</Color>

--- a/InventoryManagementApp/Services/ThemeService.cs
+++ b/InventoryManagementApp/Services/ThemeService.cs
@@ -6,16 +6,25 @@ namespace InventoryManagementApp.Services
 {
     public class ThemeService : IThemeService
     {
+        readonly ResourceDictionary _light = new() { Source = new Uri("Resources/Colors.Light.xaml", UriKind.Relative) };
+        readonly ResourceDictionary _dark = new() { Source = new Uri("Resources/Colors.Dark.xaml", UriKind.Relative) };
+
         public void ApplyTheme(string? theme)
         {
-            var path = string.Equals(theme, "Light", StringComparison.OrdinalIgnoreCase)
-                ? "Resources/Colors.Light.xaml"
-                : "Resources/Colors.xaml";
-            var dict = new ResourceDictionary { Source = new Uri(path, UriKind.Relative) };
             var app = Application.Current;
-            if (app != null && app.Resources.MergedDictionaries.Count > 0)
+            if (app == null) return;
+
+            var dictionaries = app.Resources.MergedDictionaries;
+            var dict = string.Equals(theme, "Light", StringComparison.OrdinalIgnoreCase) ? _light : _dark;
+            var other = dict == _light ? _dark : _light;
+
+            if (!dictionaries.Contains(dict))
             {
-                app.Resources.MergedDictionaries[0] = dict;
+                dictionaries.Insert(0, dict);
+            }
+            if (dictionaries.Contains(other))
+            {
+                dictionaries.Remove(other);
             }
         }
     }


### PR DESCRIPTION
## Summary
- rename Colors.xaml to Colors.Dark.xaml and include new light theme resource
- load theme dictionaries through an updated ThemeService based on saved settings
- add ThemeService unit tests and update existing tests to reference new dictionary

## Testing
- `dotnet test InventoryManagementApp.Tests` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b2e6e48d8c832499ed3c7ce6d6a0c2