### PR TITLE
Add default theme dictionary and ensure runtime replacement

### DIFF
--- a/InventoryManagementApp.Tests/ThemeServiceTests.cs
+++ b/InventoryManagementApp.Tests/ThemeServiceTests.cs
@@ -37,6 +37,22 @@ namespace InventoryManagementApp.Tests
             });
         }
 
+        [Fact]
+        public async Task ApplyTheme_ReplacesExistingDictionary()
+        {
+            await RunOnStaThread(async () =>
+            {
+                var app = new Application();
+                app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("Resources/Colors.Dark.xaml", UriKind.Relative) });
+                var service = new ThemeService();
+                service.ApplyTheme("Light");
+                Assert.DoesNotContain(app.Resources.MergedDictionaries, d => d.Source?.OriginalString.Contains("Colors.Dark.xaml") == true);
+                Assert.Contains("Colors.Light.xaml", app.Resources.MergedDictionaries[0].Source.OriginalString);
+                app.Shutdown();
+                await Task.CompletedTask;
+            });
+        }
+
         static Task RunOnStaThread(Func<Task> action)
         {
             var tcs = new TaskCompletionSource();

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -4,9 +4,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              ShutdownMode="OnMainWindowClose">
     <Application.Resources>
-        <ResourceDictionary>
+            <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <!-- Theme dictionary added at runtime -->
+                <ResourceDictionary Source="Resources/Colors.Dark.xaml"/>
                 <ResourceDictionary Source="Resources/Styles.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
                 <ResourceDictionary Source="Resources/Templates.xaml"/>

--- a/InventoryManagementApp/Services/ThemeService.cs
+++ b/InventoryManagementApp/Services/ThemeService.cs
@@ -17,16 +17,18 @@ namespace InventoryManagementApp.Services
 
             var dictionaries = app.Resources.MergedDictionaries;
             var dict = string.Equals(theme, "Light", StringComparison.OrdinalIgnoreCase) ? _light : _dark;
-            var other = dict == _light ? _dark : _light;
 
-            if (!dictionaries.Contains(dict))
+            // Remove any existing theme dictionaries
+            for (int i = dictionaries.Count - 1; i >= 0; i--)
             {
-                dictionaries.Insert(0, dict);
+                var source = dictionaries[i].Source?.OriginalString;
+                if (source == _light.Source.OriginalString || source == _dark.Source.OriginalString)
+                {
+                    dictionaries.RemoveAt(i);
+                }
             }
-            if (dictionaries.Contains(other))
-            {
-                dictionaries.Remove(other);
-            }
+
+            dictionaries.Insert(0, dict);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Load default dark theme resources before Styles.xaml
- Replace existing theme dictionary when applying user-selected themes
- Test that switching themes removes previous dictionary

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b39b69e4d88324870472446148ea48