### PR TITLE
Remove random password option from setup wizard

### DIFF
--- a/InventoryManagementApp.Tests/SetupWizardViewModelTests.cs
+++ b/InventoryManagementApp.Tests/SetupWizardViewModelTests.cs
@@ -6,21 +6,9 @@ public class SetupWizardViewModelTests
     [Fact]
     public void Defaults_AreCorrect()
     {
-        var vm = new SetupWizardViewModel(() => { }, () => { }, _ => { });
+        var vm = new SetupWizardViewModel(() => { }, () => { });
         Assert.Equal(string.Empty, vm.ApplicationName);
         Assert.Equal("Item", vm.ItemLabelSingular);
         Assert.Equal("Items", vm.ItemLabelPlural);
-        Assert.False(vm.IsRandom);
-    }
-
-    [Fact]
-    public void GenerateCommand_SetsPasswordAndFlags()
-    {
-        string? generated = null;
-        var vm = new SetupWizardViewModel(() => { }, () => { }, s => generated = s);
-        vm.GenerateCommand.Execute(null);
-        Assert.True(vm.IsRandom);
-        Assert.Equal(generated, vm.NewPassword);
-        Assert.Equal(generated, vm.ConfirmPassword);
     }
 }

--- a/InventoryManagementApp/Interfaces/ISetupWizard.cs
+++ b/InventoryManagementApp/Interfaces/ISetupWizard.cs
@@ -9,7 +9,6 @@ namespace InventoryManagementApp.Interfaces
 
     public record SetupWizardResult(
         string Password,
-        bool IsRandom,
         string ApplicationName,
         string ItemLabelSingular,
         string ItemLabelPlural);

--- a/InventoryManagementApp/ViewModels/SetupWizardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/SetupWizardViewModel.cs
@@ -1,19 +1,9 @@
-using CommunityToolkit.Mvvm.Input;
 using System;
-using InventoryManagementApp.Utilities.Helpers;
 
 namespace InventoryManagementApp.ViewModels
 {
     public class SetupWizardViewModel : ChangePasswordViewModel
     {
-        readonly Action<string> _onGenerated;
-        bool _isRandom;
-        public bool IsRandom
-        {
-            get => _isRandom;
-            private set => SetProperty(ref _isRandom, value);
-        }
-
         string _applicationName = string.Empty;
         public string ApplicationName
         {
@@ -35,20 +25,9 @@ namespace InventoryManagementApp.ViewModels
             set => SetProperty(ref _itemLabelPlural, value);
         }
 
-        public IRelayCommand GenerateCommand { get; }
-
-        public SetupWizardViewModel(Action onSave, Action onCancel, Action<string> onGenerated)
+        public SetupWizardViewModel(Action onSave, Action onCancel)
             : base(onSave, onCancel)
         {
-            _onGenerated = onGenerated;
-            GenerateCommand = new RelayCommand(() =>
-            {
-                var pwd = SecurityHelper.GeneratePassword(16);
-                NewPassword = pwd;
-                ConfirmPassword = pwd;
-                IsRandom = true;
-                _onGenerated(pwd);
-            });
         }
     }
 }

--- a/InventoryManagementApp/Views/Windows/SetupWizardWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/SetupWizardWindow.xaml
@@ -20,7 +20,6 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0" Text="Application Name" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
         <TextBox Grid.Row="1" Width="200" Text="{Binding ApplicationName}" HorizontalAlignment="Center"/>
@@ -33,8 +32,7 @@
         <TextBlock Grid.Row="8" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
         <PasswordBox Grid.Row="9" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
         <TextBlock Grid.Row="10" Text="{Binding ValidationMessage}" Margin="0,10,0,0" Style="{StaticResource ErrorTextBlock}" HorizontalAlignment="Center"/>
-        <Button Grid.Row="11" Content="Generate Random" Style="{StaticResource PrimaryButton}" Margin="0,10,0,0" Command="{Binding GenerateCommand}" HorizontalAlignment="Center"/>
-        <controls:DialogButtonBar Grid.Row="12"
+        <controls:DialogButtonBar Grid.Row="11"
                                   LeftButtonText="Cancel"
                                   LeftCommand="{Binding CancelCommand}"
                                   RightButtonText="OK"

--- a/InventoryManagementApp/Views/Windows/SetupWizardWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/SetupWizardWindow.xaml.cs
@@ -16,11 +16,7 @@ namespace InventoryManagementApp.Views.Windows
         public SetupWizardWindow()
         {
             InitializeComponent();
-            _viewModel = new SetupWizardViewModel(() => DialogResult = true, () => DialogResult = false, pwd =>
-            {
-                NewPasswordBox.Password = pwd;
-                ConfirmPasswordBox.Password = pwd;
-            });
+            _viewModel = new SetupWizardViewModel(() => DialogResult = true, () => DialogResult = false);
             DataContext = _viewModel;
             this.DisposeDataContextOnUnload();
         }
@@ -36,7 +32,6 @@ namespace InventoryManagementApp.Views.Windows
             var result = ShowDialog() == true
                 ? new SetupWizardResult(
                     _viewModel.NewPassword,
-                    _viewModel.IsRandom,
                     _viewModel.ApplicationName,
                     _viewModel.ItemLabelSingular,
                     _viewModel.ItemLabelPlural)


### PR DESCRIPTION
## Summary
- remove random password generation UI from setup wizard
- simplify SetupWizardViewModel and ISetupWizard contract
- update window code-behind and tests for new setup wizard flow

## Testing
- ⚠️ `dotnet test` (missing .NET SDK: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68b39d2cddbc83248b554e81d4000d56