### PR TITLE
Bypass authorization during first-run setup

### DIFF
--- a/InventoryManagementApp.Tests/AppStartupTests.cs
+++ b/InventoryManagementApp.Tests/AppStartupTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Documents;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using InventoryManagementApp;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Services.Core;
+using InventoryManagementApp.Services.Settings;
+using InventoryManagementApp.Services.Users;
+using InventoryManagementApp.ViewModels;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class AppStartupTests
+    {
+        [Fact]
+        public void FirstRun_DoesNotRequireAdmin()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".db");
+                    var host = Host.CreateDefaultBuilder()
+                        .ConfigureAppConfiguration(builder =>
+                        {
+                            builder.AddInMemoryCollection(new Dictionary<string, string>
+                            {
+                                ["Database:Path"] = dbPath
+                            });
+                        })
+                        .ConfigureServices(services =>
+                        {
+                            services.AddSingleton<DatabaseService>(sp => new DatabaseService(dbPath, NullLogger<DatabaseService>.Instance));
+                            services.AddSingleton<IDatabaseService>(sp => sp.GetRequiredService<DatabaseService>());
+                            services.AddSingleton<MigrationRunner>();
+                            services.AddSingleton<IUserContext, ApplicationUserContext>();
+                            services.AddSingleton<IAuthorizationService, FailingAuthorizationService>();
+                            services.AddSingleton<IUserService, UserService>();
+                            services.AddSingleton<ISettingsService, SettingsService>();
+                            services.AddSingleton<IThemeService, StubThemeService>();
+                            services.AddSingleton<IDialogService, StubDialogService>();
+                            services.AddSingleton<ILoginViewModel, StubLoginViewModel>();
+                            services.AddTransient<IMainWindow, StubMainWindow>();
+                            services.AddTransient<ILoginWindow, StubLoginWindow>();
+                            services.AddTransient<ISetupWizard, StubSetupWizard>();
+                            services.AddSingleton<ILogger<App>>(sp => NullLogger<App>.Instance);
+                            services.AddSingleton<ILogger<DatabaseService>>(sp => NullLogger<DatabaseService>.Instance);
+                            services.AddSingleton<ILogger<UserService>>(sp => NullLogger<UserService>.Instance);
+                            services.AddSingleton<ILogger<SettingsService>>(sp => NullLogger<SettingsService>.Instance);
+                            services.AddSingleton<ILogger<MigrationRunner>>(sp => NullLogger<MigrationRunner>.Instance);
+                        })
+                        .Build();
+
+                    var app = new App(host);
+                    app.StartAsync().GetAwaiter().GetResult();
+
+                    var settings = host.Services.GetRequiredService<ISettingsService>();
+                    var setup = settings.GetSettingAsync("SetupComplete").GetAwaiter().GetResult();
+                    Assert.Equal("true", setup);
+
+                    app.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        private sealed class FailingAuthorizationService : IAuthorizationService
+        {
+            public bool IsAdmin => false;
+            public void EnsureAdmin() => throw new InvalidOperationException("Authorization should be bypassed during setup");
+        }
+
+        private sealed class StubThemeService : IThemeService
+        {
+            public void ApplyTheme(string? theme) { }
+        }
+
+        private sealed class StubDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => true;
+            public ItemModel? ShowEditItemDialog(ItemModel item) => null;
+            public void ShowItemDetails(ItemModel item) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+            public CustomerModel? ShowEditCustomerDialog(CustomerModel customer) => null;
+            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
+            public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+        }
+
+        private sealed class StubLoginViewModel : ILoginViewModel
+        {
+            public event EventHandler? LoginSucceeded;
+            public Task InitializeAsync()
+            {
+                LoginSucceeded?.Invoke(this, EventArgs.Empty);
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class StubMainWindow : Window, IMainWindow { }
+
+        private sealed class StubLoginWindow : Window, ILoginWindow
+        {
+            public StubLoginWindow()
+            {
+                ViewModel = new StubLoginViewModel();
+            }
+
+            public ILoginViewModel ViewModel { get; }
+
+            public new bool? ShowDialog() => true;
+        }
+
+        private sealed class StubSetupWizard : ISetupWizard
+        {
+            public Task<SetupWizardResult?> RunAsync() =>
+                Task.FromResult<SetupWizardResult?>(new SetupWizardResult("password", false, "App", "Item", "Items"));
+        }
+    }
+}
+

--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -159,6 +159,20 @@ namespace InventoryManagementApp
             var setupDone = await settingsService.GetSettingAsync("SetupComplete").ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(setupDone))
             {
+                // Bypass authorization during initial setup
+                var db = Host.Services.GetRequiredService<DatabaseService>();
+                var context = Host.Services.GetRequiredService<IUserContext>();
+                var bypassUsers = new UserService(
+                    db,
+                    context,
+                    new NoOpAuthorizationService(),
+                    Host.Services.GetService<ILogger<UserService>>(),
+                    Host.Services.GetService<ActivityLogService>());
+                var bypassSettings = new SettingsService(
+                    db,
+                    new NoOpAuthorizationService(),
+                    Host.Services.GetService<ILogger<SettingsService>>());
+
                 var wizard = Host.Services.GetRequiredService<ISetupWizard>();
                 var result = await wizard.RunAsync().ConfigureAwait(false);
                 if (result == null)
@@ -166,8 +180,8 @@ namespace InventoryManagementApp
                     Shutdown();
                     return;
                 }
-                var userService = Host.Services.GetRequiredService<IUserService>();
-                var users = await userService.GetAllUsersAsync(System.Threading.CancellationToken.None).ConfigureAwait(false);
+
+                var users = await bypassUsers.GetAllUsersAsync(System.Threading.CancellationToken.None).ConfigureAwait(false);
                 var admin = users.FirstOrDefault(u => u.IsAdmin);
                 if (admin == null)
                 {
@@ -178,13 +192,16 @@ namespace InventoryManagementApp
                         IsAdmin = true,
                         PasswordExpired = true
                     };
-                    await userService.AddUserAsync(admin).ConfigureAwait(false);
+                    await bypassUsers.AddUserAsync(admin).ConfigureAwait(false);
                 }
-                await userService.ChangeUserPasswordAsync(admin.UserID, result.Password).ConfigureAwait(false);
-                await settingsService.SaveSettingAsync("ApplicationName", result.ApplicationName).ConfigureAwait(false);
-                await settingsService.SaveItemLabelSingularAsync(result.ItemLabelSingular).ConfigureAwait(false);
-                await settingsService.SaveItemLabelPluralAsync(result.ItemLabelPlural).ConfigureAwait(false);
-                await settingsService.SaveSettingAsync("SetupComplete", "true").ConfigureAwait(false);
+                await bypassUsers.ChangeUserPasswordAsync(admin.UserID, result.Password).ConfigureAwait(false);
+                await bypassSettings.SaveSettingAsync("ApplicationName", result.ApplicationName).ConfigureAwait(false);
+                await bypassSettings.SaveItemLabelSingularAsync(result.ItemLabelSingular).ConfigureAwait(false);
+                await bypassSettings.SaveItemLabelPluralAsync(result.ItemLabelPlural).ConfigureAwait(false);
+                await bypassSettings.SaveSettingAsync("SetupComplete", "true").ConfigureAwait(false);
+
+                // Refresh settings service for normal operations
+                settingsService = Host.Services.GetRequiredService<ISettingsService>();
             }
             await LabelProvider.Instance.InitializeAsync(settingsService).ConfigureAwait(false);
 


### PR DESCRIPTION
## Summary
- Bypass admin checks in initial setup by creating temporary UserService and SettingsService instances with NoOpAuthorizationService
- Revert to default services after setup completes
- Add startup test ensuring first-run setup no longer demands admin rights

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b39d30b8048324b64f7c62ed796d71