### PR TITLE
Ensure main window shown before assigning login owner

### DIFF
--- a/InventoryManagementApp.Tests/AppStartupTests.cs
+++ b/InventoryManagementApp.Tests/AppStartupTests.cs
@@ -51,10 +51,11 @@ namespace InventoryManagementApp.Tests
                             services.AddSingleton<ISettingsService, SettingsService>();
                             services.AddSingleton<IThemeService, StubThemeService>();
                             services.AddSingleton<IDialogService, StubDialogService>();
-                            services.AddSingleton<ILoginViewModel, StubLoginViewModel>();
-                            services.AddTransient<IMainWindow, StubMainWindow>();
-                            services.AddTransient<ILoginWindow, StubLoginWindow>();
-                            services.AddTransient<ISetupWizard, StubSetupWizard>();
+                            services.AddSingleton<StubMainWindow>();
+                            services.AddSingleton<IMainWindow>(sp => sp.GetRequiredService<StubMainWindow>());
+                            services.AddSingleton<StubLoginWindow>();
+                            services.AddSingleton<ILoginWindow>(sp => sp.GetRequiredService<StubLoginWindow>());
+                            services.AddSingleton<ISetupWizard, StubSetupWizard>();
                             services.AddSingleton<ILogger<App>>(sp => NullLogger<App>.Instance);
                             services.AddSingleton<ILogger<DatabaseService>>(sp => NullLogger<DatabaseService>.Instance);
                             services.AddSingleton<ILogger<UserService>>(sp => NullLogger<UserService>.Instance);
@@ -69,6 +70,69 @@ namespace InventoryManagementApp.Tests
                     var settings = host.Services.GetRequiredService<ISettingsService>();
                     var setup = settings.GetSettingAsync("SetupComplete").GetAwaiter().GetResult();
                     Assert.Equal("true", setup);
+
+                    app.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
+        public void StartAsync_AssignsOwnerAfterMainWindowShown()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".db");
+                    var host = Host.CreateDefaultBuilder()
+                        .ConfigureAppConfiguration(builder =>
+                        {
+                            builder.AddInMemoryCollection(new Dictionary<string, string>
+                            {
+                                ["Database:Path"] = dbPath
+                            });
+                        })
+                        .ConfigureServices(services =>
+                        {
+                            services.AddSingleton<DatabaseService>(sp => new DatabaseService(dbPath, NullLogger<DatabaseService>.Instance));
+                            services.AddSingleton<IDatabaseService>(sp => sp.GetRequiredService<DatabaseService>());
+                            services.AddSingleton<MigrationRunner>();
+                            services.AddSingleton<IUserContext, ApplicationUserContext>();
+                            services.AddSingleton<IAuthorizationService, FailingAuthorizationService>();
+                            services.AddSingleton<IUserService, UserService>();
+                            services.AddSingleton<ISettingsService, SettingsService>();
+                            services.AddSingleton<IThemeService, StubThemeService>();
+                            services.AddSingleton<IDialogService, StubDialogService>();
+                            services.AddSingleton<StubMainWindow>();
+                            services.AddSingleton<IMainWindow>(sp => sp.GetRequiredService<StubMainWindow>());
+                            services.AddSingleton<StubLoginWindow>();
+                            services.AddSingleton<ILoginWindow>(sp => sp.GetRequiredService<StubLoginWindow>());
+                            services.AddSingleton<ISetupWizard, StubSetupWizard>();
+                            services.AddSingleton<ILogger<App>>(sp => NullLogger<App>.Instance);
+                            services.AddSingleton<ILogger<DatabaseService>>(sp => NullLogger<DatabaseService>.Instance);
+                            services.AddSingleton<ILogger<UserService>>(sp => NullLogger<UserService>.Instance);
+                            services.AddSingleton<ILogger<SettingsService>>(sp => NullLogger<SettingsService>.Instance);
+                            services.AddSingleton<ILogger<MigrationRunner>>(sp => NullLogger<MigrationRunner>.Instance);
+                        })
+                        .Build();
+
+                    var app = new App(host);
+                    app.StartAsync().GetAwaiter().GetResult();
+
+                    var main = host.Services.GetRequiredService<StubMainWindow>();
+                    var login = host.Services.GetRequiredService<StubLoginWindow>();
+                    Assert.True(main.IsShown);
+                    Assert.Same(main, login.Owner);
+                    Assert.True(login.OwnerAssignedAfterMainShown);
 
                     app.Shutdown();
                 }
@@ -121,16 +185,40 @@ namespace InventoryManagementApp.Tests
             }
         }
 
-        private sealed class StubMainWindow : Window, IMainWindow { }
+        private sealed class StubMainWindow : Window, IMainWindow
+        {
+            public bool IsShown { get; private set; }
+
+            public new void Show()
+            {
+                IsShown = true;
+                base.Show();
+            }
+        }
 
         private sealed class StubLoginWindow : Window, ILoginWindow
         {
-            public StubLoginWindow()
+            private readonly StubMainWindow _main;
+
+            public StubLoginWindow(StubMainWindow main)
             {
+                _main = main;
                 ViewModel = new StubLoginViewModel();
             }
 
+            public bool OwnerAssignedAfterMainShown { get; private set; }
+
             public ILoginViewModel ViewModel { get; }
+
+            public new Window Owner
+            {
+                get => base.Owner;
+                set
+                {
+                    OwnerAssignedAfterMainShown = _main.IsShown;
+                    base.Owner = value;
+                }
+            }
 
             public new bool? ShowDialog() => true;
         }

--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -155,8 +155,8 @@ namespace InventoryManagementApp
             PathHelper.Configure(loggerFactory.CreateLogger("PathHelper"));
             var settingsService = Host.Services.GetRequiredService<ISettingsService>();
             SecurityHelper.SettingsService = settingsService;
-            await SecurityHelper.GetIterationsAsync().ConfigureAwait(false);
-            var setupDone = await settingsService.GetSettingAsync("SetupComplete").ConfigureAwait(false);
+            await SecurityHelper.GetIterationsAsync();
+            var setupDone = await settingsService.GetSettingAsync("SetupComplete");
             if (string.IsNullOrWhiteSpace(setupDone))
             {
                 // Bypass authorization during initial setup
@@ -174,14 +174,14 @@ namespace InventoryManagementApp
                     Host.Services.GetService<ILogger<SettingsService>>());
 
                 var wizard = Host.Services.GetRequiredService<ISetupWizard>();
-                var result = await wizard.RunAsync().ConfigureAwait(false);
+                var result = await wizard.RunAsync();
                 if (result == null)
                 {
                     Shutdown();
                     return;
                 }
 
-                var users = await bypassUsers.GetAllUsersAsync(System.Threading.CancellationToken.None).ConfigureAwait(false);
+                var users = await bypassUsers.GetAllUsersAsync(System.Threading.CancellationToken.None);
                 var admin = users.FirstOrDefault(u => u.IsAdmin);
                 if (admin == null)
                 {
@@ -192,18 +192,18 @@ namespace InventoryManagementApp
                         IsAdmin = true,
                         PasswordExpired = true
                     };
-                    await bypassUsers.AddUserAsync(admin).ConfigureAwait(false);
+                    await bypassUsers.AddUserAsync(admin);
                 }
-                await bypassUsers.ChangeUserPasswordAsync(admin.UserID, result.Password).ConfigureAwait(false);
-                await bypassSettings.SaveSettingAsync("ApplicationName", result.ApplicationName).ConfigureAwait(false);
-                await bypassSettings.SaveItemLabelSingularAsync(result.ItemLabelSingular).ConfigureAwait(false);
-                await bypassSettings.SaveItemLabelPluralAsync(result.ItemLabelPlural).ConfigureAwait(false);
-                await bypassSettings.SaveSettingAsync("SetupComplete", "true").ConfigureAwait(false);
+                await bypassUsers.ChangeUserPasswordAsync(admin.UserID, result.Password);
+                await bypassSettings.SaveSettingAsync("ApplicationName", result.ApplicationName);
+                await bypassSettings.SaveItemLabelSingularAsync(result.ItemLabelSingular);
+                await bypassSettings.SaveItemLabelPluralAsync(result.ItemLabelPlural);
+                await bypassSettings.SaveSettingAsync("SetupComplete", "true");
 
                 // Refresh settings service for normal operations
                 settingsService = Host.Services.GetRequiredService<ISettingsService>();
             }
-            await LabelProvider.Instance.InitializeAsync(settingsService).ConfigureAwait(false);
+            await LabelProvider.Instance.InitializeAsync(settingsService);
 
             var main = (Window)Host.Services.GetRequiredService<IMainWindow>();
             Current.MainWindow = main;


### PR DESCRIPTION
## Summary
- Remove `ConfigureAwait(false)` from startup awaits so execution returns to the dispatcher before creating windows
- Add regression test confirming login window gets an owner only after main window is visible

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b39f0510148324ac6c58d8d8a4c2b4