### PR TITLE
Defer login until main window is visible

### DIFF
--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -209,6 +209,9 @@ namespace InventoryManagementApp
             Current.MainWindow = main;
             main.Show();
 
+            // Defer login sequence until the main window is fully shown
+            await main.Dispatcher.InvokeAsync(() => { }, DispatcherPriority.ApplicationIdle);
+
             var login = Host.Services.GetRequiredService<ILoginWindow>();
             login.Owner = main;
             login.WindowStartupLocation = WindowStartupLocation.CenterOwner;


### PR DESCRIPTION
## Summary
- wait for the main window to finish rendering before launching the login dialog

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a0ae317483248a96887500592b07