### PR TITLE
Add company logo selection during initial setup

### DIFF
--- a/InventoryManagementApp.Tests/AppStartupTests.cs
+++ b/InventoryManagementApp.Tests/AppStartupTests.cs
@@ -85,6 +85,70 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void FirstRun_SavesCompanyLogoPath()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".db");
+                    var host = Host.CreateDefaultBuilder()
+                        .ConfigureAppConfiguration(builder =>
+                        {
+                            builder.AddInMemoryCollection(new Dictionary<string, string>
+                            {
+                                ["Database:Path"] = dbPath
+                            });
+                        })
+                        .ConfigureServices(services =>
+                        {
+                            services.AddSingleton<DatabaseService>(sp => new DatabaseService(dbPath, NullLogger<DatabaseService>.Instance));
+                            services.AddSingleton<IDatabaseService>(sp => sp.GetRequiredService<DatabaseService>());
+                            services.AddSingleton<MigrationRunner>();
+                            services.AddSingleton<IUserContext, ApplicationUserContext>();
+                            services.AddSingleton<IAuthorizationService, FailingAuthorizationService>();
+                            services.AddSingleton<IUserService, UserService>();
+                            services.AddSingleton<ISettingsService, SettingsService>();
+                            services.AddSingleton<IThemeService, StubThemeService>();
+                            services.AddSingleton<IDialogService, StubDialogService>();
+                            services.AddSingleton<StubMainWindow>();
+                            services.AddSingleton<IMainWindow>(sp => sp.GetRequiredService<StubMainWindow>());
+                            services.AddSingleton<StubLoginWindow>();
+                            services.AddSingleton<ILoginWindow>(sp => sp.GetRequiredService<StubLoginWindow>());
+                            services.AddSingleton<ISetupWizard, StubSetupWizard>();
+                            services.AddSingleton<ILogger<App>>(sp => NullLogger<App>.Instance);
+                            services.AddSingleton<ILogger<DatabaseService>>(sp => NullLogger<DatabaseService>.Instance);
+                            services.AddSingleton<ILogger<UserService>>(sp => NullLogger<UserService>.Instance);
+                            services.AddSingleton<ILogger<SettingsService>>(sp => NullLogger<SettingsService>.Instance);
+                            services.AddSingleton<ILogger<MigrationRunner>>(sp => NullLogger<MigrationRunner>.Instance);
+                        })
+                        .Build();
+
+                    var app = new App(host);
+                    app.StartAsync().GetAwaiter().GetResult();
+
+                    var settings = host.Services.GetRequiredService<ISettingsService>();
+                    var saved = settings.GetSettingAsync("CompanyLogoPath").GetAwaiter().GetResult();
+                    var stub = (StubSetupWizard)host.Services.GetRequiredService<ISetupWizard>();
+                    var expected = Path.Combine("Assets", "CompanyLogo", Path.GetFileName(stub.LogoPath));
+                    Assert.Equal(expected, saved);
+                    Assert.True(File.Exists(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, saved)));
+
+                    app.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
         public void StartAsync_AssignsOwnerAfterMainWindowShown()
         {
             Exception? threadEx = null;
@@ -225,8 +289,10 @@ namespace InventoryManagementApp.Tests
 
         private sealed class StubSetupWizard : ISetupWizard
         {
+            public string LogoPath { get; } = Path.GetTempFileName();
+
             public Task<SetupWizardResult?> RunAsync() =>
-                Task.FromResult<SetupWizardResult?>(new SetupWizardResult("password", false, "App", "Item", "Items"));
+                Task.FromResult<SetupWizardResult?>(new SetupWizardResult("password", "App", "Item", "Items", LogoPath));
         }
     }
 }

--- a/InventoryManagementApp.Tests/SetupWizardViewModelTests.cs
+++ b/InventoryManagementApp.Tests/SetupWizardViewModelTests.cs
@@ -1,4 +1,5 @@
 using InventoryManagementApp.ViewModels;
+using InventoryManagementApp.Interfaces;
 using Xunit;
 
 public class SetupWizardViewModelTests
@@ -6,9 +7,16 @@ public class SetupWizardViewModelTests
     [Fact]
     public void Defaults_AreCorrect()
     {
-        var vm = new SetupWizardViewModel(() => { }, () => { });
+        var vm = new SetupWizardViewModel(new DummyFileDialogService(), () => { }, () => { });
         Assert.Equal(string.Empty, vm.ApplicationName);
         Assert.Equal("Item", vm.ItemLabelSingular);
         Assert.Equal("Items", vm.ItemLabelPlural);
+        Assert.Equal(string.Empty, vm.CompanyLogoPath);
+    }
+
+    private sealed class DummyFileDialogService : IFileDialogService
+    {
+        public string? OpenFile(string filter) => null;
+        public string? SaveFile(string filter) => null;
     }
 }

--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -198,6 +198,38 @@ namespace InventoryManagementApp
                 await bypassSettings.SaveSettingAsync("ApplicationName", result.ApplicationName);
                 await bypassSettings.SaveItemLabelSingularAsync(result.ItemLabelSingular);
                 await bypassSettings.SaveItemLabelPluralAsync(result.ItemLabelPlural);
+
+                if (!string.IsNullOrWhiteSpace(result.CompanyLogoPath))
+                {
+                    try
+                    {
+                        var baseDir = Path.GetFullPath(AppDomain.CurrentDomain.BaseDirectory);
+                        var fullInputPath = Path.GetFullPath(result.CompanyLogoPath);
+                        if (File.Exists(fullInputPath))
+                        {
+                            string relativePath;
+                            if (!fullInputPath.StartsWith(baseDir, StringComparison.OrdinalIgnoreCase))
+                            {
+                                var assetsDir = Path.Combine(baseDir, "Assets", "CompanyLogo");
+                                Directory.CreateDirectory(assetsDir);
+                                var destPath = Path.Combine(assetsDir, Path.GetFileName(fullInputPath));
+                                File.Copy(fullInputPath, destPath, true);
+                                relativePath = Path.GetRelativePath(baseDir, destPath);
+                            }
+                            else
+                            {
+                                relativePath = Path.GetRelativePath(baseDir, fullInputPath);
+                            }
+
+                            await bypassSettings.SaveSettingAsync("CompanyLogoPath", relativePath);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to save company logo path.");
+                    }
+                }
+
                 await bypassSettings.SaveSettingAsync("SetupComplete", "true");
 
                 // Refresh settings service for normal operations

--- a/InventoryManagementApp/Interfaces/ISetupWizard.cs
+++ b/InventoryManagementApp/Interfaces/ISetupWizard.cs
@@ -11,5 +11,6 @@ namespace InventoryManagementApp.Interfaces
         string Password,
         string ApplicationName,
         string ItemLabelSingular,
-        string ItemLabelPlural);
+        string ItemLabelPlural,
+        string CompanyLogoPath);
 }

--- a/InventoryManagementApp/ViewModels/SetupWizardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/SetupWizardViewModel.cs
@@ -1,9 +1,13 @@
 using System;
+using CommunityToolkit.Mvvm.Input;
+using InventoryManagementApp.Interfaces;
 
 namespace InventoryManagementApp.ViewModels
 {
     public class SetupWizardViewModel : ChangePasswordViewModel
     {
+        readonly IFileDialogService _fileDialog;
+
         string _applicationName = string.Empty;
         public string ApplicationName
         {
@@ -25,9 +29,27 @@ namespace InventoryManagementApp.ViewModels
             set => SetProperty(ref _itemLabelPlural, value);
         }
 
-        public SetupWizardViewModel(Action onSave, Action onCancel)
+        string _companyLogoPath = string.Empty;
+        public string CompanyLogoPath
+        {
+            get => _companyLogoPath;
+            set => SetProperty(ref _companyLogoPath, value);
+        }
+
+        public IRelayCommand BrowseCompanyLogoCommand { get; }
+
+        public SetupWizardViewModel(IFileDialogService fileDialog, Action onSave, Action onCancel)
             : base(onSave, onCancel)
         {
+            _fileDialog = fileDialog;
+            BrowseCompanyLogoCommand = new RelayCommand(BrowseCompanyLogo);
+        }
+
+        void BrowseCompanyLogo()
+        {
+            var path = _fileDialog.OpenFile("Image Files|*.png;*.jpg;*.jpeg;*.bmp");
+            if (!string.IsNullOrWhiteSpace(path))
+                CompanyLogoPath = path;
         }
     }
 }

--- a/InventoryManagementApp/Views/Windows/SetupWizardWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/SetupWizardWindow.xaml
@@ -20,6 +20,8 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0" Text="Application Name" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
         <TextBox Grid.Row="1" Width="200" Text="{Binding ApplicationName}" HorizontalAlignment="Center"/>
@@ -27,12 +29,20 @@
         <TextBox Grid.Row="3" Width="200" Text="{Binding ItemLabelSingular}" HorizontalAlignment="Center"/>
         <TextBlock Grid.Row="4" Text="Item Label Plural" Margin="0,10,0,0" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
         <TextBox Grid.Row="5" Width="200" Text="{Binding ItemLabelPlural}" HorizontalAlignment="Center"/>
-        <TextBlock Grid.Row="6" Text="Admin Password" Margin="0,10,0,0" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
-        <PasswordBox Grid.Row="7" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
-        <TextBlock Grid.Row="8" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
-        <PasswordBox Grid.Row="9" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
-        <TextBlock Grid.Row="10" Text="{Binding ValidationMessage}" Margin="0,10,0,0" Style="{StaticResource ErrorTextBlock}" HorizontalAlignment="Center"/>
-        <controls:DialogButtonBar Grid.Row="11"
+        <TextBlock Grid.Row="6" Text="Company Logo" Margin="0,10,0,0" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
+        <StackPanel Grid.Row="7" Orientation="Horizontal" HorizontalAlignment="Center">
+            <Border Width="64" Height="64" CornerRadius="6" Background="{StaticResource SurfaceAltBrush}" Margin="0,0,8,0">
+                <Image Width="64" Height="64" Source="{Binding CompanyLogoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=logo}" Stretch="UniformToFill" ClipToBounds="True"/>
+            </Border>
+            <TextBlock Text="{Binding CompanyLogoPath}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" Width="140" Margin="0,0,8,0"/>
+            <Button Content="Browse" Command="{Binding BrowseCompanyLogoCommand}" Style="{StaticResource PrimaryButton}"/>
+        </StackPanel>
+        <TextBlock Grid.Row="8" Text="Admin Password" Margin="0,10,0,0" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
+        <PasswordBox Grid.Row="9" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
+        <TextBlock Grid.Row="10" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
+        <PasswordBox Grid.Row="11" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
+        <TextBlock Grid.Row="12" Text="{Binding ValidationMessage}" Margin="0,10,0,0" Style="{StaticResource ErrorTextBlock}" HorizontalAlignment="Center"/>
+        <controls:DialogButtonBar Grid.Row="13"
                                   LeftButtonText="Cancel"
                                   LeftCommand="{Binding CancelCommand}"
                                   RightButtonText="OK"

--- a/InventoryManagementApp/Views/Windows/SetupWizardWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/SetupWizardWindow.xaml.cs
@@ -13,10 +13,10 @@ namespace InventoryManagementApp.Views.Windows
         bool _disposed;
         readonly SetupWizardViewModel _viewModel;
 
-        public SetupWizardWindow()
+        public SetupWizardWindow(IFileDialogService fileDialogService)
         {
             InitializeComponent();
-            _viewModel = new SetupWizardViewModel(() => DialogResult = true, () => DialogResult = false);
+            _viewModel = new SetupWizardViewModel(fileDialogService, () => DialogResult = true, () => DialogResult = false);
             DataContext = _viewModel;
             this.DisposeDataContextOnUnload();
         }
@@ -34,7 +34,8 @@ namespace InventoryManagementApp.Views.Windows
                     _viewModel.NewPassword,
                     _viewModel.ApplicationName,
                     _viewModel.ItemLabelSingular,
-                    _viewModel.ItemLabelPlural)
+                    _viewModel.ItemLabelPlural,
+                    _viewModel.CompanyLogoPath)
                 : null;
             return Task.FromResult(result);
         }


### PR DESCRIPTION
## Summary
- allow setup wizard to choose a company logo path
- copy selected logo into Assets and persist relative path on first run
- cover setup wizard defaults and startup logo persistence in tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4153b03e08324b490be31ae35378e