### PR TITLE
Add theme-aware NavButton brushes and tests

### DIFF
--- a/InventoryManagementApp.Tests/ThemeServiceTests.cs
+++ b/InventoryManagementApp.Tests/ThemeServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Media;
 using InventoryManagementApp.Services;
 using Xunit;
 
@@ -48,6 +49,23 @@ namespace InventoryManagementApp.Tests
                 service.ApplyTheme("Light");
                 Assert.DoesNotContain(app.Resources.MergedDictionaries, d => d.Source?.OriginalString.Contains("Colors.Dark.xaml") == true);
                 Assert.Contains("Colors.Light.xaml", app.Resources.MergedDictionaries[0].Source.OriginalString);
+                app.Shutdown();
+                await Task.CompletedTask;
+            });
+        }
+
+        [Fact]
+        public async Task NavButtonBrushes_UpdateWithTheme()
+        {
+            await RunOnStaThread(async () =>
+            {
+                var app = new Application();
+                var service = new ThemeService();
+                service.ApplyTheme("Dark");
+                var darkHover = (SolidColorBrush)app.Resources["NavButtonHoverBrush"];
+                service.ApplyTheme("Light");
+                var lightHover = (SolidColorBrush)app.Resources["NavButtonHoverBrush"];
+                Assert.NotEqual(darkHover.Color, lightHover.Color);
                 app.Shutdown();
                 await Task.CompletedTask;
             });

--- a/InventoryManagementApp/Resources/Colors.Dark.xaml
+++ b/InventoryManagementApp/Resources/Colors.Dark.xaml
@@ -24,6 +24,12 @@
     <Color x:Key="Col.CardBackground">#1F1F1F</Color>
     <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource Col.CardBackground}"/>
     <SolidColorBrush x:Key="OverlayBrush" Color="#80000000"/>
+    <SolidColorBrush x:Key="NavButtonHoverBrush" Color="#243142"/>
+    <SolidColorBrush x:Key="NavButtonHoverBorderBrush" Color="#3A4B5E"/>
+    <SolidColorBrush x:Key="NavButtonPressedBrush" Color="#1E2936"/>
+    <SolidColorBrush x:Key="NavButtonPressedBorderBrush" Color="#3A4B5E"/>
+    <SolidColorBrush x:Key="NavButtonDisabledBrush" Color="#17202A"/>
+    <SolidColorBrush x:Key="NavButtonDisabledBorderBrush" Color="#232E3A"/>
     <x:Array x:Key="UserInitialsBrushes" Type="SolidColorBrush">
         <SolidColorBrush Color="#FF1ABC9C"/>
         <SolidColorBrush Color="#FF3498DB"/>

--- a/InventoryManagementApp/Resources/Colors.Light.xaml
+++ b/InventoryManagementApp/Resources/Colors.Light.xaml
@@ -24,6 +24,12 @@
     <Color x:Key="Col.CardBackground">#FFFFFF</Color>
     <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource Col.CardBackground}"/>
     <SolidColorBrush x:Key="OverlayBrush" Color="#80000000"/>
+    <SolidColorBrush x:Key="NavButtonHoverBrush" Color="#E0E0E0"/>
+    <SolidColorBrush x:Key="NavButtonHoverBorderBrush" Color="#BBBBBB"/>
+    <SolidColorBrush x:Key="NavButtonPressedBrush" Color="#D5D5D5"/>
+    <SolidColorBrush x:Key="NavButtonPressedBorderBrush" Color="#AAAAAA"/>
+    <SolidColorBrush x:Key="NavButtonDisabledBrush" Color="#F4F4F4"/>
+    <SolidColorBrush x:Key="NavButtonDisabledBorderBrush" Color="#DDDDDD"/>
     <x:Array x:Key="UserInitialsBrushes" Type="SolidColorBrush">
         <SolidColorBrush Color="#FF1ABC9C"/>
         <SolidColorBrush Color="#FF3498DB"/>

--- a/InventoryManagementApp/Resources/Styles.xaml
+++ b/InventoryManagementApp/Resources/Styles.xaml
@@ -235,18 +235,17 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="#243142"/>
-                            <Setter Property="BorderBrush" Value="#3A4B5E"/>
-                            <Setter Property="Foreground" Value="White"/>
+                            <Setter Property="Background" Value="{DynamicResource NavButtonHoverBrush}"/>
+                            <Setter Property="BorderBrush" Value="{DynamicResource NavButtonHoverBorderBrush}"/>
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter Property="Background" Value="#1E2936"/>
-                            <Setter Property="Foreground" Value="White"/>
+                            <Setter Property="Background" Value="{DynamicResource NavButtonPressedBrush}"/>
+                            <Setter Property="BorderBrush" Value="{DynamicResource NavButtonPressedBorderBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Foreground" Value="#6C7A86"/>
-                            <Setter Property="Background" Value="#17202A"/>
-                            <Setter Property="BorderBrush" Value="#232E3A"/>
+                            <Setter Property="Foreground" Value="{DynamicResource ForegroundMutedBrush}"/>
+                            <Setter Property="Background" Value="{DynamicResource NavButtonDisabledBrush}"/>
+                            <Setter Property="BorderBrush" Value="{DynamicResource NavButtonDisabledBorderBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>


### PR DESCRIPTION
## Summary
- define NavButton hover, pressed and disabled brushes (and matching borders) in light and dark themes
- update NavButton style to use DynamicResource for theme-based brushes
- add test verifying NavButton hover brush color changes when switching themes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b55a9c188c832498fa49d4fbfda01f