### PR TITLE
Add ComboBox popup background brush for consistent theming

### DIFF
--- a/InventoryManagementApp/Resources/Colors.Dark.xaml
+++ b/InventoryManagementApp/Resources/Colors.Dark.xaml
@@ -24,6 +24,7 @@
     <Color x:Key="Col.CardBackground">#1F1F1F</Color>
     <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource Col.CardBackground}"/>
     <SolidColorBrush x:Key="TextBoxBackgroundBrush" Color="#141C24"/>
+    <SolidColorBrush x:Key="ComboBoxPopupBackgroundBrush" Color="{StaticResource Col.SurfaceAlt}"/>
     <SolidColorBrush x:Key="OverlayBrush" Color="#80000000"/>
     <SolidColorBrush x:Key="NavButtonHoverBrush" Color="#243142"/>
     <SolidColorBrush x:Key="NavButtonHoverBorderBrush" Color="#3A4B5E"/>

--- a/InventoryManagementApp/Resources/Colors.Light.xaml
+++ b/InventoryManagementApp/Resources/Colors.Light.xaml
@@ -24,6 +24,7 @@
     <Color x:Key="Col.CardBackground">#FFFFFF</Color>
     <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource Col.CardBackground}"/>
     <SolidColorBrush x:Key="TextBoxBackgroundBrush" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="ComboBoxPopupBackgroundBrush" Color="{StaticResource Col.SurfaceAlt}"/>
     <SolidColorBrush x:Key="OverlayBrush" Color="#80000000"/>
     <SolidColorBrush x:Key="NavButtonHoverBrush" Color="#E0E0E0"/>
     <SolidColorBrush x:Key="NavButtonHoverBorderBrush" Color="#BBBBBB"/>

--- a/InventoryManagementApp/Resources/Styles.xaml
+++ b/InventoryManagementApp/Resources/Styles.xaml
@@ -178,9 +178,9 @@
                         AllowsTransparency="True"
                         Focusable="False"
                         PopupAnimation="Slide">
-                            <Border 
-                            Background="#1B2430" 
-                            BorderBrush="{DynamicResource BorderBrushAlt}" 
+                            <Border
+                            Background="{DynamicResource ComboBoxPopupBackgroundBrush}"
+                            BorderBrush="{DynamicResource BorderBrushAlt}"
                             BorderThickness="1"
                             CornerRadius="4">
                                 <ScrollViewer>


### PR DESCRIPTION
## Summary
- define `ComboBoxPopupBackgroundBrush` in both light and dark color dictionaries
- use `ComboBoxPopupBackgroundBrush` for ComboBox popup border background
- verify popup foreground/background contrast for light and dark themes

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b55b824e048324b09aa9e84205d1e8