### PR TITLE
refactor: centralize button color resources

### DIFF
--- a/InventoryManagementApp/Resources/Colors.Dark.xaml
+++ b/InventoryManagementApp/Resources/Colors.Dark.xaml
@@ -31,6 +31,10 @@
     <SolidColorBrush x:Key="NavButtonPressedBorderBrush" Color="#3A4B5E"/>
     <SolidColorBrush x:Key="NavButtonDisabledBrush" Color="#17202A"/>
     <SolidColorBrush x:Key="NavButtonDisabledBorderBrush" Color="#232E3A"/>
+    <SolidColorBrush x:Key="BtnBg" Color="#2A2E37"/>
+    <SolidColorBrush x:Key="BtnBgHover" Color="#353A45"/>
+    <SolidColorBrush x:Key="BtnBorder" Color="#444A57"/>
+    <SolidColorBrush x:Key="BtnFg" Color="#FFFFFF"/>
     <x:Array x:Key="UserInitialsBrushes" Type="SolidColorBrush">
         <SolidColorBrush Color="#FF1ABC9C"/>
         <SolidColorBrush Color="#FF3498DB"/>

--- a/InventoryManagementApp/Resources/Colors.Light.xaml
+++ b/InventoryManagementApp/Resources/Colors.Light.xaml
@@ -31,6 +31,10 @@
     <SolidColorBrush x:Key="NavButtonPressedBorderBrush" Color="#AAAAAA"/>
     <SolidColorBrush x:Key="NavButtonDisabledBrush" Color="#F4F4F4"/>
     <SolidColorBrush x:Key="NavButtonDisabledBorderBrush" Color="#DDDDDD"/>
+    <SolidColorBrush x:Key="BtnBg" Color="#E0E0E0"/>
+    <SolidColorBrush x:Key="BtnBgHover" Color="#D5D5D5"/>
+    <SolidColorBrush x:Key="BtnBorder" Color="#BBBBBB"/>
+    <SolidColorBrush x:Key="BtnFg" Color="#1A1A1A"/>
     <x:Array x:Key="UserInitialsBrushes" Type="SolidColorBrush">
         <SolidColorBrush Color="#FF1ABC9C"/>
         <SolidColorBrush Color="#FF3498DB"/>

--- a/InventoryManagementApp/Resources/Styles.xaml
+++ b/InventoryManagementApp/Resources/Styles.xaml
@@ -365,15 +365,10 @@
             </Trigger>
         </Style.Triggers>
     </Style>
-    <SolidColorBrush x:Key="BtnBg" Color="#2A2E37"/>
-    <SolidColorBrush x:Key="BtnBgHover" Color="#353A45"/>
-    <SolidColorBrush x:Key="BtnBorder" Color="#444A57"/>
-    <SolidColorBrush x:Key="BtnFg" Color="#FFFFFF"/>
-
     <Style TargetType="Button">
-        <Setter Property="Foreground" Value="{StaticResource BtnFg}"/>
-        <Setter Property="Background" Value="{StaticResource BtnBg}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource BtnBorder}"/>
+        <Setter Property="Foreground" Value="{DynamicResource BtnFg}"/>
+        <Setter Property="Background" Value="{DynamicResource BtnBg}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BtnBorder}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Padding" Value="10,6"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
@@ -391,11 +386,11 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="{StaticResource BtnBgHover}"/>
-                            <Setter Property="Foreground" Value="White"/>
+                            <Setter Property="Background" Value="{DynamicResource BtnBgHover}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource BtnFg}"/>
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter Property="Foreground" Value="White"/>
+                            <Setter Property="Foreground" Value="{DynamicResource BtnFg}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.6"/>


### PR DESCRIPTION
## Summary
- move button brush definitions to theme-specific color dictionaries
- reference button colors via `DynamicResource` to follow active theme
- audit buttons to remove hard-coded colors

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b55b7a95988324b7c08d36fd8f6030