### PR TITLE
Set auto logout default to one minute

### DIFF
--- a/InventoryManagementApp.Tests/SettingsServiceTests.cs
+++ b/InventoryManagementApp.Tests/SettingsServiceTests.cs
@@ -31,4 +31,16 @@ public class SettingsServiceTests
 
         Assert.Equal("Dark", value);
     }
+
+    [Fact]
+    public async Task GetAutoLogoutMinutesAsync_ReturnsDefaultOfOne()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var db = new DatabaseService(dbPath);
+        var service = new SettingsService(db);
+
+        var value = await service.GetAutoLogoutMinutesAsync();
+
+        Assert.Equal(1, value);
+    }
 }

--- a/InventoryManagementApp/Services/Settings/SettingsService.cs
+++ b/InventoryManagementApp/Services/Settings/SettingsService.cs
@@ -301,7 +301,7 @@ namespace InventoryManagementApp.Services.Settings
         public async Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default)
         {
             var value = await GetSettingAsync(AutoLogoutMinutesKey, cancellationToken).ConfigureAwait(false);
-            return int.TryParse(value, out var i) && i >= 0 ? i : 0;
+            return int.TryParse(value, out var i) && i >= 0 ? i : 1;
         }
 
         public async Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- default auto logout to one minute when no setting present
- add unit test verifying new default

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b55c65f3d88324bfd35bf35fc6be85