### PR TITLE
Defer theme application until resources load

### DIFF
--- a/InventoryManagementApp.Tests/AppStartupTests.cs
+++ b/InventoryManagementApp.Tests/AppStartupTests.cs
@@ -212,6 +212,71 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void StartAsync_AppliesThemeFromSettings()
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".db");
+                    var db = new DatabaseService(dbPath, NullLogger<DatabaseService>.Instance);
+                    var preSettings = new SettingsService(db);
+                    preSettings.SaveSettingAsync("SetupComplete", "true").GetAwaiter().GetResult();
+                    preSettings.SaveThemeAsync("Dark").GetAwaiter().GetResult();
+
+                    var host = Host.CreateDefaultBuilder()
+                        .ConfigureAppConfiguration(builder =>
+                        {
+                            builder.AddInMemoryCollection(new Dictionary<string, string>
+                            {
+                                ["Database:Path"] = dbPath
+                            });
+                        })
+                        .ConfigureServices(services =>
+                        {
+                            services.AddSingleton<DatabaseService>(sp => new DatabaseService(dbPath, NullLogger<DatabaseService>.Instance));
+                            services.AddSingleton<IDatabaseService>(sp => sp.GetRequiredService<DatabaseService>());
+                            services.AddSingleton<MigrationRunner>();
+                            services.AddSingleton<IUserContext, ApplicationUserContext>();
+                            services.AddSingleton<IAuthorizationService, FailingAuthorizationService>();
+                            services.AddSingleton<IUserService, UserService>();
+                            services.AddSingleton<ISettingsService, SettingsService>();
+                            services.AddSingleton<IThemeService, StubThemeService>();
+                            services.AddSingleton<IDialogService, StubDialogService>();
+                            services.AddSingleton<StubMainWindow>();
+                            services.AddSingleton<IMainWindow>(sp => sp.GetRequiredService<StubMainWindow>());
+                            services.AddSingleton<StubLoginWindow>();
+                            services.AddSingleton<ILoginWindow>(sp => sp.GetRequiredService<StubLoginWindow>());
+                            services.AddSingleton<ISetupWizard, StubSetupWizard>();
+                            services.AddSingleton<ILogger<App>>(sp => NullLogger<App>.Instance);
+                            services.AddSingleton<ILogger<DatabaseService>>(sp => NullLogger<DatabaseService>.Instance);
+                            services.AddSingleton<ILogger<UserService>>(sp => NullLogger<UserService>.Instance);
+                            services.AddSingleton<ILogger<SettingsService>>(sp => NullLogger<SettingsService>.Instance);
+                            services.AddSingleton<ILogger<MigrationRunner>>(sp => NullLogger<MigrationRunner>.Instance);
+                        })
+                        .Build();
+
+                    var app = new App(host);
+                    app.StartAsync().GetAwaiter().GetResult();
+
+                    var themeSvc = (StubThemeService)host.Services.GetRequiredService<IThemeService>();
+                    Assert.Equal("Dark", themeSvc.AppliedTheme);
+
+                    app.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+        }
+
+        [Fact]
         public void FirstRun_ShowsMainWindowAfterSetup()
         {
             Exception? threadEx = null;
@@ -280,7 +345,8 @@ namespace InventoryManagementApp.Tests
 
         private sealed class StubThemeService : IThemeService
         {
-            public void ApplyTheme(string? theme) { }
+            public string? AppliedTheme { get; private set; }
+            public void ApplyTheme(string? theme) => AppliedTheme = theme;
         }
 
         private sealed class StubDialogService : IDialogService

--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -45,11 +45,6 @@ namespace InventoryManagementApp
             _logger = Host.Services.GetRequiredService<ILogger<App>>();
             _dialogService = Host.Services.GetRequiredService<IDialogService>();
 
-            var settingsService = Host.Services.GetRequiredService<ISettingsService>();
-            var themeService = Host.Services.GetRequiredService<IThemeService>();
-            var theme = settingsService.GetThemeAsync().GetAwaiter().GetResult();
-            themeService.ApplyTheme(theme);
-
             DispatcherUnhandledException += (s, e) => HandleDispatcherException(e.Exception, e);
             AppDomain.CurrentDomain.UnhandledException += (s, e) =>
                 HandleDomainException(e.ExceptionObject as Exception ?? new Exception("Unknown"), e);
@@ -154,6 +149,10 @@ namespace InventoryManagementApp
             var loggerFactory = Host.Services.GetRequiredService<ILoggerFactory>();
             PathHelper.Configure(loggerFactory.CreateLogger("PathHelper"));
             var settingsService = Host.Services.GetRequiredService<ISettingsService>();
+            var themeService = Host.Services.GetRequiredService<IThemeService>();
+            var theme = await settingsService.GetThemeAsync();
+            themeService.ApplyTheme(theme);
+
             SecurityHelper.SettingsService = settingsService;
             await SecurityHelper.GetIterationsAsync();
             var setupDone = await settingsService.GetSettingAsync("SetupComplete");


### PR DESCRIPTION
## Summary
- Remove synchronous theme retrieval from App constructor
- Apply theme in StartAsync after resources are available
- Add unit test ensuring startup uses stored theme

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b55ddeccc08324aa0cfdbaf9905998