### PR TITLE
Enable adding scanner devices from status page

### DIFF
--- a/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.ViewModels;
+using System.Windows.Documents;
+using InventoryManagementApp.ViewModels.Rental;
+using Xunit;
+
+public class ScannerStatusViewModelTests
+{
+    private sealed class StubScannerService : IScannerService
+    {
+        public List<ScannerDevice> Devices { get; } = new();
+        public Task<IEnumerable<ScannerDevice>> GetScannerDevicesAsync(CancellationToken cancellationToken)
+            => Task.FromResult<IEnumerable<ScannerDevice>>(Devices);
+    }
+
+    private sealed class StubSettingsService : ISettingsService
+    {
+        public List<string> IpAddresses { get; private set; } = new();
+        public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
+        public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+        public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
+        public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<IEnumerable<string>> GetScannerIpAddressesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IEnumerable<string>>(IpAddresses);
+        public Task<IEnumerable<string>> SaveScannerIpAddressesAsync(IEnumerable<string>? ipAddresses, CancellationToken cancellationToken = default)
+        {
+            IpAddresses = ipAddresses?.ToList() ?? new List<string>();
+            return Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+        }
+        public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+        public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+        public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+        public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+        public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+        public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IDictionary<ItemDetailField, bool>>(new Dictionary<ItemDetailField, bool>());
+        public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
+        {
+            ItemDetailVisibilityChanged?.Invoke(this, visibility);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StubDialogService : IDialogService
+    {
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => false;
+        public ItemModel? ShowEditItemDialog(ItemModel item) => null;
+        public void ShowItemDetails(ItemModel item) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
+        public CustomerModel? ShowEditCustomerDialog(CustomerModel customer) => null;
+        public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
+        public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+    }
+
+    [Fact]
+    public async Task AddDeviceCommand_SavesIpAndRefreshesDevices()
+    {
+        var scannerService = new StubScannerService();
+        var dialogService = new StubDialogService();
+        var settingsService = new StubSettingsService();
+        var vm = new ScannerStatusViewModel(scannerService, dialogService, settingsService);
+
+        var ip = "192.168.1.10";
+        vm.PromptForIp = () => ip;
+        scannerService.Devices.Add(new ScannerDevice { Name = "Test", Ip = ip, Status = "Online", LastSeen = DateTime.UtcNow });
+
+        await vm.AddDeviceCommand.ExecuteAsync(null);
+
+        Assert.Contains(ip, settingsService.IpAddresses);
+        Assert.Single(vm.Devices);
+        Assert.Equal(ip, vm.Devices[0].Ip);
+    }
+}

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -514,7 +514,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 try
                 {
-                    var vm = new ScannerStatusViewModel(_scannerService, _dialogService);
+                    var vm = new ScannerStatusViewModel(_scannerService, _dialogService, _settingsService);
                     var page = new ScannerStatusPage { DataContext = vm, Title = "Scanner Status" };
                     CurrentPage = page;
                     await Task.CompletedTask;

--- a/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Threading;
@@ -9,6 +10,7 @@ using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualBasic;
 
 namespace InventoryManagementApp.ViewModels
 {
@@ -16,6 +18,7 @@ namespace InventoryManagementApp.ViewModels
     {
         readonly IScannerService _service;
         readonly IDialogService _dialogService;
+        readonly ISettingsService _settingsService;
         readonly ILogger<ScannerStatusViewModel> _logger;
         readonly DispatcherTimer _timer;
 
@@ -36,15 +39,21 @@ namespace InventoryManagementApp.ViewModels
         }
 
         public IAsyncRelayCommand RefreshCommand { get; }
+        public IAsyncRelayCommand AddDeviceCommand { get; }
+
+        public Func<string?> PromptForIp { get; set; } = () =>
+            Interaction.InputBox("Enter scanner IP:", "Add Device", string.Empty);
 
         internal bool IsTimerRunning => _timer.IsEnabled;
 
-        public ScannerStatusViewModel(IScannerService service, IDialogService dialogService, ILogger<ScannerStatusViewModel>? logger = null)
+        public ScannerStatusViewModel(IScannerService service, IDialogService dialogService, ISettingsService settingsService, ILogger<ScannerStatusViewModel>? logger = null)
         {
             _service = service;
             _dialogService = dialogService;
+            _settingsService = settingsService;
             _logger = logger ?? NullLogger<ScannerStatusViewModel>.Instance;
             RefreshCommand = new AsyncRelayCommand(RefreshAsync);
+            AddDeviceCommand = new AsyncRelayCommand(AddDeviceAsync);
             _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
             _timer.Tick += OnTimerTick;
         }
@@ -74,6 +83,34 @@ namespace InventoryManagementApp.ViewModels
             {
                 _logger.LogError(ex, "Failed to refresh scanner devices");
                 await _dialogService.ShowInfoAsync($"Failed to refresh scanner devices: {ex.Message}", "Error");
+            }
+        }
+
+        async Task AddDeviceAsync()
+        {
+            try
+            {
+                var ip = PromptForIp?.Invoke();
+                if (string.IsNullOrWhiteSpace(ip))
+                    return;
+
+                var ips = (await _settingsService.GetScannerIpAddressesAsync()).ToList();
+                if (!ips.Contains(ip))
+                    ips.Add(ip);
+
+                var invalid = await _settingsService.SaveScannerIpAddressesAsync(ips);
+                if (invalid.Any())
+                {
+                    await _dialogService.ShowInfoAsync($"Invalid IP address: {string.Join(", ", invalid)}", "Invalid IP");
+                    return;
+                }
+
+                await RefreshAsync(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to add scanner IP");
+                await _dialogService.ShowInfoAsync($"Failed to add device: {ex.Message}", "Error");
             }
         }
 

--- a/InventoryManagementApp/Views/Pages/ScannerStatusPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ScannerStatusPage.xaml
@@ -16,6 +16,7 @@
             <Border Style="{StaticResource Card}">
                 <StackPanel Orientation="Horizontal">
                     <Button Style="{StaticResource PrimaryButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Add Device" Command="{Binding AddDeviceCommand}" Margin="8,0,0,0"/>
                     <CheckBox Content="Auto Refresh" IsChecked="{Binding AutoRefresh}" Margin="12,6,0,0"/>
                 </StackPanel>
             </Border>

--- a/InventoryManagementApp/Views/Windows/ScannerStatusWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/ScannerStatusWindow.xaml.cs
@@ -9,13 +9,15 @@ namespace InventoryManagementApp.Views.Windows
     {
         private readonly IScannerService _scannerService;
         private readonly IDialogService _dialogService;
+        private readonly ISettingsService _settingsService;
 
-        public ScannerStatusWindow(IScannerService scannerService, IDialogService dialogService)
+        public ScannerStatusWindow(IScannerService scannerService, IDialogService dialogService, ISettingsService settingsService)
         {
             InitializeComponent();
             _scannerService = scannerService;
             _dialogService = dialogService;
-            DataContext = new ScannerStatusViewModel(_scannerService, _dialogService);
+            _settingsService = settingsService;
+            DataContext = new ScannerStatusViewModel(_scannerService, _dialogService, _settingsService);
             this.DisposeDataContextOnUnload();
         }
     }


### PR DESCRIPTION
## Summary
- add **Add Device** button to scanner status page
- support adding scanner IPs via `AddDeviceCommand` and refresh device list
- add unit test validating new IP persistence and display

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b690b695248324a63f40063e865533