### PR TITLE
Add scanner group management

### DIFF
--- a/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
@@ -66,7 +66,8 @@ namespace InventoryManagementApp.Tests
                     NullLogger<MainViewModel>.Instance,
                     () => Task.FromResult(true),
                     new DummyDispatcherTimer(),
-                    new DummyScannerService());
+                    new DummyScannerService(),
+                    new DummyScannerGroupService());
 
                 var um = vm.UserManagement;
                 um.Users.Add(currentUser);
@@ -104,7 +105,8 @@ namespace InventoryManagementApp.Tests
                 NullLogger<MainViewModel>.Instance,
                 () => Task.FromResult(true),
                 new DummyDispatcherTimer(),
-                new DummyScannerService());
+                new DummyScannerService(),
+                new DummyScannerGroupService());
         }
 
         static Task RunOnStaThread(Func<Task> action)
@@ -284,6 +286,16 @@ namespace InventoryManagementApp.Tests
         private sealed class DummyScannerService : IScannerService
         {
             public Task<IEnumerable<ScannerDevice>> GetScannerDevicesAsync(CancellationToken cancellationToken) => Task.FromResult<IEnumerable<ScannerDevice>>(Array.Empty<ScannerDevice>());
+        }
+
+        private sealed class DummyScannerGroupService : IScannerGroupService
+        {
+            public Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task<IEnumerable<ScannerGroup>> GetGroupsAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<ScannerGroup>>(Array.Empty<ScannerGroup>());
+            public Task UpdateGroupAsync(ScannerGroup group, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task AssignDeviceToGroupAsync(string deviceIp, int? groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int?> GetDeviceGroupIdAsync(string deviceIp, CancellationToken cancellationToken = default) => Task.FromResult<int?>(null);
         }
     }
 }

--- a/InventoryManagementApp.Tests/MainViewModelTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelTests.cs
@@ -49,6 +49,7 @@ namespace InventoryManagementApp.Tests
                     () => Task.FromResult(true),
                     new DummyDispatcherTimer(),
                     new DummyScannerService(),
+                    new DummyScannerGroupService(),
                     debounceTimer);
 
                 var field = typeof(MainViewModel).GetField("<GlobalSearchCommand>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -91,6 +92,7 @@ namespace InventoryManagementApp.Tests
                     () => Task.FromResult(true),
                     new DummyDispatcherTimer(),
                     new DummyScannerService(),
+                    new DummyScannerGroupService(),
                     globalDebounceTimer);
 
                 var itemManagement = new ItemManagementViewModel(
@@ -154,6 +156,7 @@ namespace InventoryManagementApp.Tests
                     () => Task.FromResult(true),
                     new DummyDispatcherTimer(),
                     new DummyScannerService(),
+                    new DummyScannerGroupService(),
                     debounceTimer);
 
                 vm.Dispose();
@@ -189,6 +192,7 @@ namespace InventoryManagementApp.Tests
                     () => Task.FromResult(true),
                     new DummyDispatcherTimer(),
                     new DummyScannerService(),
+                    new DummyScannerGroupService(),
                     debounceTimer);
 
                 var openDashboardField = typeof(MainViewModel).GetField("<OpenDashboardCommand>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -226,6 +230,7 @@ namespace InventoryManagementApp.Tests
                     () => Task.FromResult(true),
                     new DummyDispatcherTimer(),
                     new DummyScannerService(),
+                    new DummyScannerGroupService(),
                     debounceTimer);
 
                 var openDashboardField = typeof(MainViewModel).GetField("<OpenDashboardCommand>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -291,6 +296,7 @@ namespace InventoryManagementApp.Tests
                         () => Task.FromResult(true),
                         new DummyDispatcherTimer(),
                         new DummyScannerService(),
+                        new DummyScannerGroupService(),
                         new DummyDispatcherTimer());
 
                     Assert.NotNull(vm.CurrentUserInitialsBrush);
@@ -495,6 +501,16 @@ namespace InventoryManagementApp.Tests
         private sealed class DummyScannerService : IScannerService
         {
             public Task<IEnumerable<ScannerDevice>> GetScannerDevicesAsync(CancellationToken cancellationToken) => Task.FromResult<IEnumerable<ScannerDevice>>(Array.Empty<ScannerDevice>());
+        }
+
+        private sealed class DummyScannerGroupService : IScannerGroupService
+        {
+            public Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task<IEnumerable<ScannerGroup>> GetGroupsAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<ScannerGroup>>(Array.Empty<ScannerGroup>());
+            public Task UpdateGroupAsync(ScannerGroup group, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task AssignDeviceToGroupAsync(string deviceIp, int? groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int?> GetDeviceGroupIdAsync(string deviceIp, CancellationToken cancellationToken = default) => Task.FromResult<int?>(null);
         }
 
         private sealed class DummyDispatcherTimer : IDispatcherTimer

--- a/InventoryManagementApp.Tests/ScannerGroupServiceTests.cs
+++ b/InventoryManagementApp.Tests/ScannerGroupServiceTests.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using System.Threading.Tasks;
+using InventoryManagementApp.Services.Core;
+using InventoryManagementApp.Services.Devices;
+using Xunit;
+
+public class ScannerGroupServiceTests
+{
+    [Fact]
+    public async Task CreateGroupAndAssignDevice()
+    {
+        using var db = new DatabaseService(":memory:");
+        var service = new ScannerGroupService(db);
+
+        var groupId = await service.CreateGroupAsync("Test Group");
+        var groups = await service.GetGroupsAsync();
+        Assert.Single(groups);
+        Assert.Equal("Test Group", groups.First().Name);
+
+        await service.AssignDeviceToGroupAsync("10.0.0.1", groupId);
+        var assigned = await service.GetDeviceGroupIdAsync("10.0.0.1");
+        Assert.Equal(groupId, assigned);
+    }
+}
+

--- a/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
@@ -19,6 +19,42 @@ public class ScannerStatusViewModelTests
             => Task.FromResult<IEnumerable<ScannerDevice>>(Devices);
     }
 
+    private sealed class StubScannerGroupService : IScannerGroupService
+    {
+        public List<ScannerGroup> Groups { get; } = new();
+        public Dictionary<string, int?> DeviceGroups { get; } = new();
+        public Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default)
+        {
+            var id = Groups.Count + 1;
+            Groups.Add(new ScannerGroup { Id = id, Name = name });
+            return Task.FromResult(id);
+        }
+        public Task<IEnumerable<ScannerGroup>> GetGroupsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IEnumerable<ScannerGroup>>(Groups);
+        public Task UpdateGroupAsync(ScannerGroup group, CancellationToken cancellationToken = default)
+        {
+            var existing = Groups.FirstOrDefault(g => g.Id == group.Id);
+            if (existing != null) existing.Name = group.Name;
+            return Task.CompletedTask;
+        }
+        public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default)
+        {
+            Groups.RemoveAll(g => g.Id == groupId);
+            return Task.CompletedTask;
+        }
+        public Task AssignDeviceToGroupAsync(string deviceIp, int? groupId, CancellationToken cancellationToken = default)
+        {
+            if (groupId == null) DeviceGroups.Remove(deviceIp);
+            else DeviceGroups[deviceIp] = groupId;
+            return Task.CompletedTask;
+        }
+        public Task<int?> GetDeviceGroupIdAsync(string deviceIp, CancellationToken cancellationToken = default)
+        {
+            DeviceGroups.TryGetValue(deviceIp, out var gid);
+            return Task.FromResult<int?>(gid);
+        }
+    }
+
     private sealed class StubSettingsService : ISettingsService
     {
         public List<string> IpAddresses { get; private set; } = new();
@@ -77,7 +113,8 @@ public class ScannerStatusViewModelTests
         var scannerService = new StubScannerService();
         var dialogService = new StubDialogService();
         var settingsService = new StubSettingsService();
-        var vm = new ScannerStatusViewModel(scannerService, dialogService, settingsService);
+        var groupService = new StubScannerGroupService();
+        var vm = new ScannerStatusViewModel(scannerService, dialogService, settingsService, groupService);
 
         var ip = "192.168.1.10";
         vm.PromptForIp = () => ip;

--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -115,6 +115,7 @@ namespace InventoryManagementApp
                 services.AddSingleton<IThemeService, ThemeService>();
                 services.AddSingleton<IDialogService, DialogService>();
                 services.AddSingleton<IScannerService, ScannerService>();
+                services.AddSingleton<IScannerGroupService, ScannerGroupService>();
                 services.AddSingleton<MemoryBudget>();
                 services.AddTransient<ItemsViewModel>();
                 services.AddSingleton<IMainViewModel, MainViewModel>();

--- a/InventoryManagementApp/Interfaces/IScannerGroupService.cs
+++ b/InventoryManagementApp/Interfaces/IScannerGroupService.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using InventoryManagementApp.Models;
+
+namespace InventoryManagementApp.Interfaces
+{
+    public interface IScannerGroupService
+    {
+        Task<IEnumerable<ScannerGroup>> GetGroupsAsync(CancellationToken cancellationToken = default);
+        Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default);
+        Task UpdateGroupAsync(ScannerGroup group, CancellationToken cancellationToken = default);
+        Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default);
+        Task AssignDeviceToGroupAsync(string deviceIp, int? groupId, CancellationToken cancellationToken = default);
+        Task<int?> GetDeviceGroupIdAsync(string deviceIp, CancellationToken cancellationToken = default);
+    }
+}

--- a/InventoryManagementApp/Models/ScannerDevice.cs
+++ b/InventoryManagementApp/Models/ScannerDevice.cs
@@ -9,6 +9,7 @@ namespace InventoryManagementApp.Models
         string _ip = string.Empty;
         string _status = string.Empty;
         DateTime _lastSeen;
+        int? _groupId;
 
         public string Name
         {
@@ -32,6 +33,12 @@ namespace InventoryManagementApp.Models
         {
             get => _lastSeen;
             set => SetProperty(ref _lastSeen, value);
+        }
+
+        public int? GroupId
+        {
+            get => _groupId;
+            set => SetProperty(ref _groupId, value);
         }
     }
 }

--- a/InventoryManagementApp/Models/ScannerGroup.cs
+++ b/InventoryManagementApp/Models/ScannerGroup.cs
@@ -1,0 +1,22 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace InventoryManagementApp.Models
+{
+    public class ScannerGroup : ObservableObject
+    {
+        int _id;
+        string _name = string.Empty;
+
+        public int Id
+        {
+            get => _id;
+            set => SetProperty(ref _id, value);
+        }
+
+        public string Name
+        {
+            get => _name;
+            set => SetProperty(ref _name, value);
+        }
+    }
+}

--- a/InventoryManagementApp/Services/Core/DatabaseService.cs
+++ b/InventoryManagementApp/Services/Core/DatabaseService.cs
@@ -149,6 +149,15 @@ namespace InventoryManagementApp.Services.Core
                 CREATE TABLE IF NOT EXISTS Settings (
                     Key TEXT PRIMARY KEY,
                     Value TEXT
+                );
+                CREATE TABLE IF NOT EXISTS ScannerGroups (
+                    GroupId INTEGER PRIMARY KEY AUTOINCREMENT,
+                    Name TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS ScannerDeviceGroups (
+                    DeviceIp TEXT PRIMARY KEY,
+                    GroupId INTEGER,
+                    FOREIGN KEY (GroupId) REFERENCES ScannerGroups(GroupId)
                 );";
             using var cmd = new SqliteCommand(sql, conn);
             cmd.ExecuteNonQuery();

--- a/InventoryManagementApp/Services/Devices/ScannerGroupService.cs
+++ b/InventoryManagementApp/Services/Devices/ScannerGroupService.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.Services.Core;
+using Microsoft.Data.Sqlite;
+
+namespace InventoryManagementApp.Services.Devices
+{
+    public class ScannerGroupService : IScannerGroupService
+    {
+        readonly DatabaseService _db;
+
+        public ScannerGroupService(DatabaseService db)
+        {
+            _db = db;
+        }
+
+        public async Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "INSERT INTO ScannerGroups (Name) VALUES ($name); SELECT last_insert_rowid();";
+            cmd.Parameters.AddWithValue("$name", name);
+            var result = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            return (int)(long)result!;
+        }
+
+        public async Task<IEnumerable<ScannerGroup>> GetGroupsAsync(CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT GroupId, Name FROM ScannerGroups ORDER BY Name";
+            using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            var groups = new List<ScannerGroup>();
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                groups.Add(new ScannerGroup
+                {
+                    Id = reader.GetInt32(0),
+                    Name = reader.GetString(1)
+                });
+            }
+            return groups;
+        }
+
+        public async Task UpdateGroupAsync(ScannerGroup group, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "UPDATE ScannerGroups SET Name=$name WHERE GroupId=$id";
+            cmd.Parameters.AddWithValue("$name", group.Name);
+            cmd.Parameters.AddWithValue("$id", group.Id);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "DELETE FROM ScannerGroups WHERE GroupId=$id";
+            cmd.Parameters.AddWithValue("$id", groupId);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task AssignDeviceToGroupAsync(string deviceIp, int? groupId, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            if (groupId.HasValue)
+            {
+                cmd.CommandText = "INSERT INTO ScannerDeviceGroups (DeviceIp, GroupId) VALUES ($ip, $gid) ON CONFLICT(DeviceIp) DO UPDATE SET GroupId=$gid";
+                cmd.Parameters.AddWithValue("$ip", deviceIp);
+                cmd.Parameters.AddWithValue("$gid", groupId.Value);
+            }
+            else
+            {
+                cmd.CommandText = "DELETE FROM ScannerDeviceGroups WHERE DeviceIp=$ip";
+                cmd.Parameters.AddWithValue("$ip", deviceIp);
+            }
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<int?> GetDeviceGroupIdAsync(string deviceIp, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT GroupId FROM ScannerDeviceGroups WHERE DeviceIp=$ip";
+            cmd.Parameters.AddWithValue("$ip", deviceIp);
+            var result = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            if (result == null || result == DBNull.Value)
+                return null;
+            return (int)(long)result;
+        }
+    }
+}

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -11,6 +11,7 @@ using System.Windows;
 using System.Windows.Controls;
 using Forms = System.Windows.Forms;
 using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Models;
 using InventoryManagementApp.Services;
 using InventoryManagementApp.Services.Rentals;
 using InventoryManagementApp.Services.Items;
@@ -43,6 +44,7 @@ namespace InventoryManagementApp.ViewModels
         readonly IFileDialogService _fileDialogService;
         readonly IDialogService _dialogService;
         readonly IScannerService _scannerService;
+        readonly IScannerGroupService _scannerGroupService;
         readonly IThemeService _themeService;
         readonly ILogger<MainViewModel> _logger;
         readonly Func<Task<bool>> _showLoginWindow;
@@ -206,6 +208,7 @@ namespace InventoryManagementApp.ViewModels
                              Func<Task<bool>>? showLoginWindow = null,
                              IDispatcherTimer? autoLogoutTimer = null,
                              IScannerService? scannerService = null,
+                             IScannerGroupService? scannerGroupService = null,
                              IDispatcherTimer? globalSearchDebounceTimer = null)
         {
             _itemService = itemService;
@@ -218,6 +221,7 @@ namespace InventoryManagementApp.ViewModels
             _themeService = themeService;
             _dialogService = dialogService;
             _scannerService = scannerService ?? new DummyScannerService();
+            _scannerGroupService = scannerGroupService ?? new DummyScannerGroupService();
             _fileDialogService = fileDialogService;
             _logger = logger ?? NullLogger<MainViewModel>.Instance;
             _showLoginWindow = showLoginWindow ?? new Func<Task<bool>>(async () =>
@@ -514,7 +518,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 try
                 {
-                    var vm = new ScannerStatusViewModel(_scannerService, _dialogService, _settingsService);
+                    var vm = new ScannerStatusViewModel(_scannerService, _dialogService, _settingsService, _scannerGroupService);
                     var page = new ScannerStatusPage { DataContext = vm, Title = "Scanner Status" };
                     CurrentPage = page;
                     await Task.CompletedTask;
@@ -668,6 +672,16 @@ namespace InventoryManagementApp.ViewModels
         {
             public Task<IEnumerable<Models.ScannerDevice>> GetScannerDevicesAsync(CancellationToken cancellationToken)
                 => Task.FromResult<IEnumerable<Models.ScannerDevice>>(Array.Empty<Models.ScannerDevice>());
+        }
+
+        private sealed class DummyScannerGroupService : IScannerGroupService
+        {
+            public Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task<IEnumerable<ScannerGroup>> GetGroupsAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<ScannerGroup>>(Array.Empty<ScannerGroup>());
+            public Task UpdateGroupAsync(ScannerGroup group, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task AssignDeviceToGroupAsync(string deviceIp, int? groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int?> GetDeviceGroupIdAsync(string deviceIp, CancellationToken cancellationToken = default) => Task.FromResult<int?>(null);
         }
     }
 }

--- a/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
@@ -11,6 +11,7 @@ using InventoryManagementApp.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualBasic;
+using System.ComponentModel;
 
 namespace InventoryManagementApp.ViewModels
 {
@@ -19,10 +20,12 @@ namespace InventoryManagementApp.ViewModels
         readonly IScannerService _service;
         readonly IDialogService _dialogService;
         readonly ISettingsService _settingsService;
+        readonly IScannerGroupService _groupService;
         readonly ILogger<ScannerStatusViewModel> _logger;
         readonly DispatcherTimer _timer;
 
         public ObservableCollection<ScannerDevice> Devices { get; } = new();
+        public ObservableCollection<ScannerGroup> Groups { get; } = new();
 
         bool _autoRefresh;
         public bool AutoRefresh
@@ -40,20 +43,26 @@ namespace InventoryManagementApp.ViewModels
 
         public IAsyncRelayCommand RefreshCommand { get; }
         public IAsyncRelayCommand AddDeviceCommand { get; }
+        public IAsyncRelayCommand AddGroupCommand { get; }
 
         public Func<string?> PromptForIp { get; set; } = () =>
             Interaction.InputBox("Enter scanner IP:", "Add Device", string.Empty);
 
+        public Func<string?> PromptForGroupName { get; set; } = () =>
+            Interaction.InputBox("Enter group name:", "Add Group", string.Empty);
+
         internal bool IsTimerRunning => _timer.IsEnabled;
 
-        public ScannerStatusViewModel(IScannerService service, IDialogService dialogService, ISettingsService settingsService, ILogger<ScannerStatusViewModel>? logger = null)
+        public ScannerStatusViewModel(IScannerService service, IDialogService dialogService, ISettingsService settingsService, IScannerGroupService groupService, ILogger<ScannerStatusViewModel>? logger = null)
         {
             _service = service;
             _dialogService = dialogService;
             _settingsService = settingsService;
+            _groupService = groupService;
             _logger = logger ?? NullLogger<ScannerStatusViewModel>.Instance;
             RefreshCommand = new AsyncRelayCommand(RefreshAsync);
             AddDeviceCommand = new AsyncRelayCommand(AddDeviceAsync);
+            AddGroupCommand = new AsyncRelayCommand(AddGroupAsync);
             _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
             _timer.Tick += OnTimerTick;
         }
@@ -67,15 +76,24 @@ namespace InventoryManagementApp.ViewModels
         {
             try
             {
+                var groups = await _groupService.GetGroupsAsync(cancellationToken);
+                Groups.Clear();
+                foreach (var g in groups)
+                    Groups.Add(g);
+
                 var devices = await _service.GetScannerDevicesAsync(cancellationToken);
+                foreach (var d in Devices)
+                    d.PropertyChanged -= Device_PropertyChanged;
                 Devices.Clear();
                 foreach (var d in devices)
                 {
+                    d.GroupId = await _groupService.GetDeviceGroupIdAsync(d.Ip, cancellationToken);
                     if (d.LastSeen.Kind != DateTimeKind.Local)
                     {
                         _logger.LogWarning("Device {Ip} reported LastSeen kind {Kind}; converting to local time", d.Ip, d.LastSeen.Kind);
                         d.LastSeen = d.LastSeen.ToLocalTime();
                     }
+                    d.PropertyChanged += Device_PropertyChanged;
                     Devices.Add(d);
                 }
             }
@@ -114,10 +132,45 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
+        async Task AddGroupAsync()
+        {
+            try
+            {
+                var name = PromptForGroupName?.Invoke();
+                if (string.IsNullOrWhiteSpace(name))
+                    return;
+
+                await _groupService.CreateGroupAsync(name);
+                await RefreshAsync(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to add scanner group");
+                await _dialogService.ShowInfoAsync($"Failed to add group: {ex.Message}", "Error");
+            }
+        }
+
+        async void Device_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(ScannerDevice.GroupId) && sender is ScannerDevice device)
+            {
+                try
+                {
+                    await _groupService.AssignDeviceToGroupAsync(device.Ip, device.GroupId);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to assign device {Ip} to group {Group}", device.Ip, device.GroupId);
+                }
+            }
+        }
+
         public void Dispose()
         {
             _timer.Tick -= OnTimerTick;
             _timer.Stop();
+            foreach (var d in Devices)
+                d.PropertyChanged -= Device_PropertyChanged;
         }
     }
 }

--- a/InventoryManagementApp/Views/Pages/ScannerStatusPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ScannerStatusPage.xaml
@@ -17,6 +17,7 @@
                 <StackPanel Orientation="Horizontal">
                     <Button Style="{StaticResource PrimaryButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Add Device" Command="{Binding AddDeviceCommand}" Margin="8,0,0,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Add Group" Command="{Binding AddGroupCommand}" Margin="8,0,0,0"/>
                     <CheckBox Content="Auto Refresh" IsChecked="{Binding AutoRefresh}" Margin="12,6,0,0"/>
                 </StackPanel>
             </Border>
@@ -31,6 +32,12 @@
                         <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
                         <DataGridTextColumn Header="IP" Binding="{Binding Ip}" Width="180"/>
                         <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="160"/>
+                        <DataGridComboBoxColumn Header="Group"
+                                               SelectedValueBinding="{Binding GroupId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                               SelectedValuePath="Id"
+                                               DisplayMemberPath="Name"
+                                               ItemsSource="{Binding DataContext.Groups, RelativeSource={RelativeSource AncestorType=Page}}"
+                                               Width="200"/>
                         <DataGridTextColumn Header="Last Seen"
                                             Binding="{Binding LastSeen, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat='{}{0:yyyy-MM-dd HH:mm}', TargetNullValue=''}"
                                             Width="220"/>

--- a/InventoryManagementApp/Views/Windows/ScannerStatusWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/ScannerStatusWindow.xaml.cs
@@ -10,14 +10,16 @@ namespace InventoryManagementApp.Views.Windows
         private readonly IScannerService _scannerService;
         private readonly IDialogService _dialogService;
         private readonly ISettingsService _settingsService;
+        private readonly IScannerGroupService _groupService;
 
-        public ScannerStatusWindow(IScannerService scannerService, IDialogService dialogService, ISettingsService settingsService)
+        public ScannerStatusWindow(IScannerService scannerService, IDialogService dialogService, ISettingsService settingsService, IScannerGroupService groupService)
         {
             InitializeComponent();
             _scannerService = scannerService;
             _dialogService = dialogService;
             _settingsService = settingsService;
-            DataContext = new ScannerStatusViewModel(_scannerService, _dialogService, _settingsService);
+            _groupService = groupService;
+            DataContext = new ScannerStatusViewModel(_scannerService, _dialogService, _settingsService, _groupService);
             this.DisposeDataContextOnUnload();
         }
     }


### PR DESCRIPTION
## Summary
- add scanner group model and database tables
- CRUD service and UI for assigning scanners to groups
- tests for group creation and device assignment

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b69482070483249cf012ebb59d63af