### PR TITLE
Add scanner file browsing capability

### DIFF
--- a/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
@@ -19,6 +19,13 @@ public class ScannerStatusViewModelTests
             => Task.FromResult<IEnumerable<ScannerDevice>>(Devices);
     }
 
+    private sealed class StubScannerFileService : IScannerFileService
+    {
+        public List<string> Files { get; } = new();
+        public Task<IEnumerable<string>> ListFilesAsync(string deviceIp, CancellationToken cancellationToken = default)
+            => Task.FromResult<IEnumerable<string>>(Files);
+    }
+
     private sealed class StubScannerGroupService : IScannerGroupService
     {
         public List<ScannerGroup> Groups { get; } = new();
@@ -114,7 +121,8 @@ public class ScannerStatusViewModelTests
         var dialogService = new StubDialogService();
         var settingsService = new StubSettingsService();
         var groupService = new StubScannerGroupService();
-        var vm = new ScannerStatusViewModel(scannerService, dialogService, settingsService, groupService);
+        var fileService = new StubScannerFileService();
+        var vm = new ScannerStatusViewModel(scannerService, dialogService, settingsService, groupService, fileService);
 
         var ip = "192.168.1.10";
         vm.PromptForIp = () => ip;
@@ -125,5 +133,26 @@ public class ScannerStatusViewModelTests
         Assert.Contains(ip, settingsService.IpAddresses);
         Assert.Single(vm.Devices);
         Assert.Equal(ip, vm.Devices[0].Ip);
+    }
+
+    [Fact]
+    public async Task SelectedDevice_LoadsFiles()
+    {
+        var scannerService = new StubScannerService();
+        var dialogService = new StubDialogService();
+        var settingsService = new StubSettingsService();
+        var groupService = new StubScannerGroupService();
+        var fileService = new StubScannerFileService();
+        fileService.Files.AddRange(new[] { "a.txt", "b.txt" });
+        var vm = new ScannerStatusViewModel(scannerService, dialogService, settingsService, groupService, fileService);
+
+        var device = new ScannerDevice { Name = "Test", Ip = "1.2.3.4", Status = "Online", LastSeen = DateTime.UtcNow };
+        vm.Devices.Add(device);
+        vm.SelectedDevice = device;
+
+        await vm.LoadFilesCommand.ExecuteAsync(null);
+
+        Assert.Equal(2, vm.DeviceFiles.Count);
+        Assert.Contains("a.txt", vm.DeviceFiles);
     }
 }

--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -116,6 +116,7 @@ namespace InventoryManagementApp
                 services.AddSingleton<IDialogService, DialogService>();
                 services.AddSingleton<IScannerService, ScannerService>();
                 services.AddSingleton<IScannerGroupService, ScannerGroupService>();
+                services.AddSingleton<IScannerFileService, ScannerFileService>();
                 services.AddSingleton<MemoryBudget>();
                 services.AddTransient<ItemsViewModel>();
                 services.AddSingleton<IMainViewModel, MainViewModel>();

--- a/InventoryManagementApp/Interfaces/IScannerFileService.cs
+++ b/InventoryManagementApp/Interfaces/IScannerFileService.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InventoryManagementApp.Interfaces
+{
+    public interface IScannerFileService
+    {
+        Task<IEnumerable<string>> ListFilesAsync(string deviceIp, CancellationToken cancellationToken = default);
+    }
+}

--- a/InventoryManagementApp/Services/Devices/ScannerFileService.cs
+++ b/InventoryManagementApp/Services/Devices/ScannerFileService.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using InventoryManagementApp.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace InventoryManagementApp.Services.Devices
+{
+    public class ScannerFileService : IScannerFileService
+    {
+        private readonly ILogger<ScannerFileService> _logger;
+
+        public ScannerFileService(ILogger<ScannerFileService>? logger = null)
+        {
+            _logger = logger ?? NullLogger<ScannerFileService>.Instance;
+        }
+
+        public Task<IEnumerable<string>> ListFilesAsync(string deviceIp, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var path = $"\\\\{deviceIp}\\Shared";
+                if (!Directory.Exists(path))
+                    return Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+                var files = Directory.GetFiles(path)
+                                     .Select(Path.GetFileName)!
+                                     .ToArray();
+                return Task.FromResult<IEnumerable<string>>(files);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to list files for device {Ip}", deviceIp);
+                return Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            }
+        }
+    }
+}

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -45,6 +45,7 @@ namespace InventoryManagementApp.ViewModels
         readonly IDialogService _dialogService;
         readonly IScannerService _scannerService;
         readonly IScannerGroupService _scannerGroupService;
+        readonly IScannerFileService _scannerFileService;
         readonly IThemeService _themeService;
         readonly ILogger<MainViewModel> _logger;
         readonly Func<Task<bool>> _showLoginWindow;
@@ -209,7 +210,8 @@ namespace InventoryManagementApp.ViewModels
                              IDispatcherTimer? autoLogoutTimer = null,
                              IScannerService? scannerService = null,
                              IScannerGroupService? scannerGroupService = null,
-                             IDispatcherTimer? globalSearchDebounceTimer = null)
+                             IDispatcherTimer? globalSearchDebounceTimer = null,
+                             IScannerFileService? scannerFileService = null)
         {
             _itemService = itemService;
             _userService = userService;
@@ -222,6 +224,7 @@ namespace InventoryManagementApp.ViewModels
             _dialogService = dialogService;
             _scannerService = scannerService ?? new DummyScannerService();
             _scannerGroupService = scannerGroupService ?? new DummyScannerGroupService();
+            _scannerFileService = scannerFileService ?? new DummyScannerFileService();
             _fileDialogService = fileDialogService;
             _logger = logger ?? NullLogger<MainViewModel>.Instance;
             _showLoginWindow = showLoginWindow ?? new Func<Task<bool>>(async () =>
@@ -518,7 +521,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 try
                 {
-                    var vm = new ScannerStatusViewModel(_scannerService, _dialogService, _settingsService, _scannerGroupService);
+                    var vm = new ScannerStatusViewModel(_scannerService, _dialogService, _settingsService, _scannerGroupService, _scannerFileService);
                     var page = new ScannerStatusPage { DataContext = vm, Title = "Scanner Status" };
                     CurrentPage = page;
                     await Task.CompletedTask;
@@ -682,6 +685,12 @@ namespace InventoryManagementApp.ViewModels
             public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task AssignDeviceToGroupAsync(string deviceIp, int? groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<int?> GetDeviceGroupIdAsync(string deviceIp, CancellationToken cancellationToken = default) => Task.FromResult<int?>(null);
+        }
+
+        private sealed class DummyScannerFileService : IScannerFileService
+        {
+            public Task<IEnumerable<string>> ListFilesAsync(string deviceIp, CancellationToken cancellationToken = default)
+                => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
         }
     }
 }

--- a/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
@@ -21,11 +21,13 @@ namespace InventoryManagementApp.ViewModels
         readonly IDialogService _dialogService;
         readonly ISettingsService _settingsService;
         readonly IScannerGroupService _groupService;
+        readonly IScannerFileService _fileService;
         readonly ILogger<ScannerStatusViewModel> _logger;
         readonly DispatcherTimer _timer;
 
         public ObservableCollection<ScannerDevice> Devices { get; } = new();
         public ObservableCollection<ScannerGroup> Groups { get; } = new();
+        public ObservableCollection<string> DeviceFiles { get; } = new();
 
         bool _autoRefresh;
         public bool AutoRefresh
@@ -44,6 +46,7 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand RefreshCommand { get; }
         public IAsyncRelayCommand AddDeviceCommand { get; }
         public IAsyncRelayCommand AddGroupCommand { get; }
+        public IAsyncRelayCommand LoadFilesCommand { get; }
 
         public Func<string?> PromptForIp { get; set; } = () =>
             Interaction.InputBox("Enter scanner IP:", "Add Device", string.Empty);
@@ -53,16 +56,31 @@ namespace InventoryManagementApp.ViewModels
 
         internal bool IsTimerRunning => _timer.IsEnabled;
 
-        public ScannerStatusViewModel(IScannerService service, IDialogService dialogService, ISettingsService settingsService, IScannerGroupService groupService, ILogger<ScannerStatusViewModel>? logger = null)
+        ScannerDevice? _selectedDevice;
+        public ScannerDevice? SelectedDevice
+        {
+            get => _selectedDevice;
+            set
+            {
+                if (SetProperty(ref _selectedDevice, value))
+                {
+                    LoadFilesCommand.Execute(null);
+                }
+            }
+        }
+
+        public ScannerStatusViewModel(IScannerService service, IDialogService dialogService, ISettingsService settingsService, IScannerGroupService groupService, IScannerFileService fileService, ILogger<ScannerStatusViewModel>? logger = null)
         {
             _service = service;
             _dialogService = dialogService;
             _settingsService = settingsService;
             _groupService = groupService;
+            _fileService = fileService;
             _logger = logger ?? NullLogger<ScannerStatusViewModel>.Instance;
             RefreshCommand = new AsyncRelayCommand(RefreshAsync);
             AddDeviceCommand = new AsyncRelayCommand(AddDeviceAsync);
             AddGroupCommand = new AsyncRelayCommand(AddGroupAsync);
+            LoadFilesCommand = new AsyncRelayCommand(LoadFilesAsync);
             _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
             _timer.Tick += OnTimerTick;
         }
@@ -129,6 +147,23 @@ namespace InventoryManagementApp.ViewModels
             {
                 _logger.LogError(ex, "Failed to add scanner IP");
                 await _dialogService.ShowInfoAsync($"Failed to add device: {ex.Message}", "Error");
+            }
+        }
+
+        async Task LoadFilesAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                DeviceFiles.Clear();
+                if (SelectedDevice is null)
+                    return;
+                var files = await _fileService.ListFilesAsync(SelectedDevice.Ip, cancellationToken);
+                foreach (var f in files)
+                    DeviceFiles.Add(f);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load files for device {Ip}", SelectedDevice?.Ip);
             }
         }
 

--- a/InventoryManagementApp/Views/Pages/ScannerStatusPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ScannerStatusPage.xaml
@@ -23,26 +23,35 @@
             </Border>
 
             <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0" Margin="0,8,0,0">
-                <DataGrid ItemsSource="{Binding Devices}"
-                          AutoGenerateColumns="False"
-                          IsReadOnly="True"
-                          Style="{StaticResource VirtualizedDataGridStyle}"
-                          ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
-                        <DataGridTextColumn Header="IP" Binding="{Binding Ip}" Width="180"/>
-                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="160"/>
-                        <DataGridComboBoxColumn Header="Group"
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="2*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <DataGrid Grid.Column="0"
+                              ItemsSource="{Binding Devices}"
+                              SelectedItem="{Binding SelectedDevice}"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True"
+                              Style="{StaticResource VirtualizedDataGridStyle}"
+                              ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
+                            <DataGridTextColumn Header="IP" Binding="{Binding Ip}" Width="180"/>
+                            <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="160"/>
+                            <DataGridComboBoxColumn Header="Group"
                                                SelectedValueBinding="{Binding GroupId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                SelectedValuePath="Id"
                                                DisplayMemberPath="Name"
                                                ItemsSource="{Binding DataContext.Groups, RelativeSource={RelativeSource AncestorType=Page}}"
                                                Width="200"/>
-                        <DataGridTextColumn Header="Last Seen"
+                            <DataGridTextColumn Header="Last Seen"
                                             Binding="{Binding LastSeen, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat='{}{0:yyyy-MM-dd HH:mm}', TargetNullValue=''}"
                                             Width="220"/>
-                    </DataGrid.Columns>
-                </DataGrid>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <ListBox Grid.Column="1" ItemsSource="{Binding DeviceFiles}" Margin="8,0,0,0"/>
+                </Grid>
             </Border>
         </Grid>
     </DockPanel>

--- a/InventoryManagementApp/Views/Windows/ScannerStatusWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/ScannerStatusWindow.xaml.cs
@@ -11,15 +11,17 @@ namespace InventoryManagementApp.Views.Windows
         private readonly IDialogService _dialogService;
         private readonly ISettingsService _settingsService;
         private readonly IScannerGroupService _groupService;
+        private readonly IScannerFileService _fileService;
 
-        public ScannerStatusWindow(IScannerService scannerService, IDialogService dialogService, ISettingsService settingsService, IScannerGroupService groupService)
+        public ScannerStatusWindow(IScannerService scannerService, IDialogService dialogService, ISettingsService settingsService, IScannerGroupService groupService, IScannerFileService fileService)
         {
             InitializeComponent();
             _scannerService = scannerService;
             _dialogService = dialogService;
             _settingsService = settingsService;
             _groupService = groupService;
-            DataContext = new ScannerStatusViewModel(_scannerService, _dialogService, _settingsService, _groupService);
+            _fileService = fileService;
+            DataContext = new ScannerStatusViewModel(_scannerService, _dialogService, _settingsService, _groupService, _fileService);
             this.DisposeDataContextOnUnload();
         }
     }


### PR DESCRIPTION
## Summary
- add `IScannerFileService` and `ScannerFileService` to enumerate files from scanner shares
- show files of the selected scanner in `ScannerStatusPage`
- expose file loading in `ScannerStatusViewModel` and wire up in DI and tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b696872824832483babbc7ffe73bb4