### PR TITLE
Add scanner file rule monitoring and UI

### DIFF
--- a/InventoryManagementApp.Tests/ScannerRuleServiceTests.cs
+++ b/InventoryManagementApp.Tests/ScannerRuleServiceTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.Services.Core;
+using InventoryManagementApp.Services.Devices;
+using Xunit;
+
+public class ScannerRuleServiceTests
+{
+    static DatabaseService CreateDb(string path)
+        => new DatabaseService(path);
+
+    [Fact]
+    public async Task AddRule_Persists()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        using var db = CreateDb(dbPath);
+        var service = new ScannerRuleService(db);
+        var rule = new ScannerFileRule { DeviceId = "dev1", SourcePath = Path.GetTempPath(), DestinationPath = Path.GetTempPath(), Pattern = "*.txt" };
+        var id = await service.AddRuleAsync(rule);
+        var rules = await service.GetRulesAsync("dev1");
+        Assert.Single(rules);
+        Assert.Equal(id, rules.First().Id);
+    }
+
+    [Fact]
+    public async Task CreatedFile_TriggersCopy()
+    {
+        var source = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var dest = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(source);
+        Directory.CreateDirectory(dest);
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        using var db = CreateDb(dbPath);
+        var service = new ScannerRuleService(db);
+        var rule = new ScannerFileRule { DeviceId = "dev1", SourcePath = source, DestinationPath = dest, Pattern = "*.txt" };
+        await service.AddRuleAsync(rule);
+        var file = Path.Combine(source, "test.txt");
+        await File.WriteAllTextAsync(file, "hello");
+        var copied = false;
+        for (int i = 0; i < 20; i++)
+        {
+            await Task.Delay(100);
+            if (File.Exists(Path.Combine(dest, "test.txt")))
+            {
+                copied = true;
+                break;
+            }
+        }
+        Assert.True(copied);
+    }
+}

--- a/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
@@ -26,6 +26,24 @@ public class ScannerStatusViewModelTests
             => Task.FromResult<IEnumerable<string>>(Files);
     }
 
+    private sealed class StubScannerRuleService : IScannerRuleService
+    {
+        public List<ScannerFileRule> Rules { get; } = new();
+        public Task<int> AddRuleAsync(ScannerFileRule rule, CancellationToken cancellationToken = default)
+        {
+            rule.Id = Rules.Count + 1;
+            Rules.Add(rule);
+            return Task.FromResult(rule.Id);
+        }
+        public Task<IEnumerable<ScannerFileRule>> GetRulesAsync(string deviceId, CancellationToken cancellationToken = default)
+            => Task.FromResult<IEnumerable<ScannerFileRule>>(Rules.Where(r => r.DeviceId == deviceId).ToList());
+        public Task DeleteRuleAsync(int ruleId, CancellationToken cancellationToken = default)
+        {
+            Rules.RemoveAll(r => r.Id == ruleId);
+            return Task.CompletedTask;
+        }
+    }
+
     private sealed class StubScannerGroupService : IScannerGroupService
     {
         public List<ScannerGroup> Groups { get; } = new();
@@ -122,7 +140,8 @@ public class ScannerStatusViewModelTests
         var settingsService = new StubSettingsService();
         var groupService = new StubScannerGroupService();
         var fileService = new StubScannerFileService();
-        var vm = new ScannerStatusViewModel(scannerService, dialogService, settingsService, groupService, fileService);
+        var ruleService = new StubScannerRuleService();
+        var vm = new ScannerStatusViewModel(scannerService, dialogService, settingsService, groupService, fileService, ruleService);
 
         var ip = "192.168.1.10";
         vm.PromptForIp = () => ip;
@@ -143,8 +162,9 @@ public class ScannerStatusViewModelTests
         var settingsService = new StubSettingsService();
         var groupService = new StubScannerGroupService();
         var fileService = new StubScannerFileService();
+        var ruleService = new StubScannerRuleService();
         fileService.Files.AddRange(new[] { "a.txt", "b.txt" });
-        var vm = new ScannerStatusViewModel(scannerService, dialogService, settingsService, groupService, fileService);
+        var vm = new ScannerStatusViewModel(scannerService, dialogService, settingsService, groupService, fileService, ruleService);
 
         var device = new ScannerDevice { Name = "Test", Ip = "1.2.3.4", Status = "Online", LastSeen = DateTime.UtcNow };
         vm.Devices.Add(device);

--- a/InventoryManagementApp/Interfaces/IScannerRuleService.cs
+++ b/InventoryManagementApp/Interfaces/IScannerRuleService.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using InventoryManagementApp.Models;
+
+namespace InventoryManagementApp.Interfaces
+{
+    public interface IScannerRuleService
+    {
+        Task<int> AddRuleAsync(ScannerFileRule rule, CancellationToken cancellationToken = default);
+        Task<IEnumerable<ScannerFileRule>> GetRulesAsync(string deviceId, CancellationToken cancellationToken = default);
+        Task DeleteRuleAsync(int ruleId, CancellationToken cancellationToken = default);
+    }
+}

--- a/InventoryManagementApp/Models/ScannerFileRule.cs
+++ b/InventoryManagementApp/Models/ScannerFileRule.cs
@@ -1,0 +1,43 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace InventoryManagementApp.Models
+{
+    public class ScannerFileRule : ObservableObject
+    {
+        int _id;
+        string _deviceId = string.Empty;
+        string _sourcePath = string.Empty;
+        string _destinationPath = string.Empty;
+        string _pattern = string.Empty;
+
+        public int Id
+        {
+            get => _id;
+            set => SetProperty(ref _id, value);
+        }
+
+        public string DeviceId
+        {
+            get => _deviceId;
+            set => SetProperty(ref _deviceId, value);
+        }
+
+        public string SourcePath
+        {
+            get => _sourcePath;
+            set => SetProperty(ref _sourcePath, value);
+        }
+
+        public string DestinationPath
+        {
+            get => _destinationPath;
+            set => SetProperty(ref _destinationPath, value);
+        }
+
+        public string Pattern
+        {
+            get => _pattern;
+            set => SetProperty(ref _pattern, value);
+        }
+    }
+}

--- a/InventoryManagementApp/Services/Core/DatabaseService.cs
+++ b/InventoryManagementApp/Services/Core/DatabaseService.cs
@@ -158,6 +158,13 @@ namespace InventoryManagementApp.Services.Core
                     DeviceIp TEXT PRIMARY KEY,
                     GroupId INTEGER,
                     FOREIGN KEY (GroupId) REFERENCES ScannerGroups(GroupId)
+                );
+                CREATE TABLE IF NOT EXISTS ScannerFileRules (
+                    RuleId INTEGER PRIMARY KEY AUTOINCREMENT,
+                    DeviceId TEXT NOT NULL,
+                    SourcePath TEXT NOT NULL,
+                    DestinationPath TEXT NOT NULL,
+                    Pattern TEXT NOT NULL
                 );";
             using var cmd = new SqliteCommand(sql, conn);
             cmd.ExecuteNonQuery();
@@ -173,6 +180,7 @@ namespace InventoryManagementApp.Services.Core
             EnsureIndex(conn, "Users", "UserName", true);
             EnsureIndex(conn, "Customers", "Contact");
             EnsureIndex(conn, "Rentals", new[] { "ItemID", "CustomerID" });
+            EnsureIndex(conn, "ScannerFileRules", "DeviceId");
         }
 
         void MigrateLegacyItemsTable(SqliteConnection conn)

--- a/InventoryManagementApp/Services/Devices/ScannerRuleService.cs
+++ b/InventoryManagementApp/Services/Devices/ScannerRuleService.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.Services.Core;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace InventoryManagementApp.Services.Devices
+{
+    public class ScannerRuleService : IScannerRuleService, IDisposable
+    {
+        readonly DatabaseService _db;
+        readonly ILogger<ScannerRuleService> _logger;
+        readonly Dictionary<int, FileSystemWatcher> _watchers = new();
+        bool _disposed;
+
+        public ScannerRuleService(DatabaseService db, ILogger<ScannerRuleService>? logger = null)
+        {
+            _db = db;
+            _logger = logger ?? NullLogger<ScannerRuleService>.Instance;
+        }
+
+        public async Task<int> AddRuleAsync(ScannerFileRule rule, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "INSERT INTO ScannerFileRules (DeviceId, SourcePath, DestinationPath, Pattern) VALUES ($device,$src,$dest,$pat); SELECT last_insert_rowid();";
+            cmd.Parameters.AddWithValue("$device", rule.DeviceId);
+            cmd.Parameters.AddWithValue("$src", rule.SourcePath);
+            cmd.Parameters.AddWithValue("$dest", rule.DestinationPath);
+            cmd.Parameters.AddWithValue("$pat", rule.Pattern);
+            var idObj = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            rule.Id = (int)(long)idObj!;
+            StartWatcher(rule);
+            return rule.Id;
+        }
+
+        public async Task<IEnumerable<ScannerFileRule>> GetRulesAsync(string deviceId, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT RuleId, DeviceId, SourcePath, DestinationPath, Pattern FROM ScannerFileRules WHERE DeviceId=$device";
+            cmd.Parameters.AddWithValue("$device", deviceId);
+            using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            var rules = new List<ScannerFileRule>();
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                rules.Add(new ScannerFileRule
+                {
+                    Id = reader.GetInt32(0),
+                    DeviceId = reader.GetString(1),
+                    SourcePath = reader.GetString(2),
+                    DestinationPath = reader.GetString(3),
+                    Pattern = reader.GetString(4)
+                });
+            }
+            return rules;
+        }
+
+        public async Task DeleteRuleAsync(int ruleId, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "DELETE FROM ScannerFileRules WHERE RuleId=$id";
+            cmd.Parameters.AddWithValue("$id", ruleId);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            if (_watchers.TryGetValue(ruleId, out var watcher))
+            {
+                watcher.Dispose();
+                _watchers.Remove(ruleId);
+            }
+        }
+
+        void StartWatcher(ScannerFileRule rule)
+        {
+            try
+            {
+                if (!Directory.Exists(rule.SourcePath)) Directory.CreateDirectory(rule.SourcePath);
+                if (!Directory.Exists(rule.DestinationPath)) Directory.CreateDirectory(rule.DestinationPath);
+                var watcher = new FileSystemWatcher(rule.SourcePath, rule.Pattern)
+                {
+                    EnableRaisingEvents = true
+                };
+                watcher.Created += (s, e) => CopyFileWithRetry(e.FullPath, rule.DestinationPath);
+                _watchers[rule.Id] = watcher;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to start watcher for rule {RuleId}", rule.Id);
+            }
+        }
+
+        void CopyFileWithRetry(string source, string destDir)
+        {
+            Task.Run(() =>
+            {
+                var dest = Path.Combine(destDir, Path.GetFileName(source));
+                for (int i = 0; i < 10; i++)
+                {
+                    try
+                    {
+                        File.Copy(source, dest, true);
+                        return;
+                    }
+                    catch (IOException)
+                    {
+                        Thread.Sleep(100);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to copy file {File}", source);
+                        return;
+                    }
+                }
+            });
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            foreach (var w in _watchers.Values)
+                w.Dispose();
+            _watchers.Clear();
+            _disposed = true;
+        }
+    }
+}

--- a/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
@@ -22,12 +22,14 @@ namespace InventoryManagementApp.ViewModels
         readonly ISettingsService _settingsService;
         readonly IScannerGroupService _groupService;
         readonly IScannerFileService _fileService;
+        readonly IScannerRuleService _ruleService;
         readonly ILogger<ScannerStatusViewModel> _logger;
         readonly DispatcherTimer _timer;
 
         public ObservableCollection<ScannerDevice> Devices { get; } = new();
         public ObservableCollection<ScannerGroup> Groups { get; } = new();
         public ObservableCollection<string> DeviceFiles { get; } = new();
+        public ObservableCollection<ScannerFileRule> Rules { get; } = new();
 
         bool _autoRefresh;
         public bool AutoRefresh
@@ -47,6 +49,9 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand AddDeviceCommand { get; }
         public IAsyncRelayCommand AddGroupCommand { get; }
         public IAsyncRelayCommand LoadFilesCommand { get; }
+        public IAsyncRelayCommand LoadRulesCommand { get; }
+        public IAsyncRelayCommand AddRuleCommand { get; }
+        public IAsyncRelayCommand<int> DeleteRuleCommand { get; }
 
         public Func<string?> PromptForIp { get; set; } = () =>
             Interaction.InputBox("Enter scanner IP:", "Add Device", string.Empty);
@@ -65,22 +70,27 @@ namespace InventoryManagementApp.ViewModels
                 if (SetProperty(ref _selectedDevice, value))
                 {
                     LoadFilesCommand.Execute(null);
+                    LoadRulesCommand.Execute(null);
                 }
             }
         }
 
-        public ScannerStatusViewModel(IScannerService service, IDialogService dialogService, ISettingsService settingsService, IScannerGroupService groupService, IScannerFileService fileService, ILogger<ScannerStatusViewModel>? logger = null)
+        public ScannerStatusViewModel(IScannerService service, IDialogService dialogService, ISettingsService settingsService, IScannerGroupService groupService, IScannerFileService fileService, IScannerRuleService ruleService, ILogger<ScannerStatusViewModel>? logger = null)
         {
             _service = service;
             _dialogService = dialogService;
             _settingsService = settingsService;
             _groupService = groupService;
             _fileService = fileService;
+            _ruleService = ruleService;
             _logger = logger ?? NullLogger<ScannerStatusViewModel>.Instance;
             RefreshCommand = new AsyncRelayCommand(RefreshAsync);
             AddDeviceCommand = new AsyncRelayCommand(AddDeviceAsync);
             AddGroupCommand = new AsyncRelayCommand(AddGroupAsync);
             LoadFilesCommand = new AsyncRelayCommand(LoadFilesAsync);
+            LoadRulesCommand = new AsyncRelayCommand(LoadRulesAsync);
+            AddRuleCommand = new AsyncRelayCommand(AddRuleAsync);
+            DeleteRuleCommand = new AsyncRelayCommand<int>(DeleteRuleAsync);
             _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
             _timer.Tick += OnTimerTick;
         }
@@ -164,6 +174,67 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load files for device {Ip}", SelectedDevice?.Ip);
+            }
+        }
+
+        async Task LoadRulesAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                Rules.Clear();
+                if (SelectedDevice is null)
+                    return;
+                var rules = await _ruleService.GetRulesAsync(SelectedDevice.Ip, cancellationToken);
+                foreach (var r in rules)
+                    Rules.Add(r);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load rules for device {Ip}", SelectedDevice?.Ip);
+            }
+        }
+
+        async Task AddRuleAsync()
+        {
+            try
+            {
+                if (SelectedDevice is null)
+                    return;
+                var source = Interaction.InputBox("Enter source folder:", "Add Rule", string.Empty);
+                if (string.IsNullOrWhiteSpace(source)) return;
+                var dest = Interaction.InputBox("Enter destination folder:", "Add Rule", string.Empty);
+                if (string.IsNullOrWhiteSpace(dest)) return;
+                var pattern = Interaction.InputBox("Enter file pattern:", "Add Rule", "*.*");
+                if (string.IsNullOrWhiteSpace(pattern)) return;
+                var rule = new ScannerFileRule
+                {
+                    DeviceId = SelectedDevice.Ip,
+                    SourcePath = source,
+                    DestinationPath = dest,
+                    Pattern = pattern
+                };
+                await _ruleService.AddRuleAsync(rule);
+                await LoadRulesAsync(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to add rule");
+                await _dialogService.ShowInfoAsync($"Failed to add rule: {ex.Message}", "Error");
+            }
+        }
+
+        async Task DeleteRuleAsync(int ruleId)
+        {
+            try
+            {
+                await _ruleService.DeleteRuleAsync(ruleId);
+                var existing = Rules.FirstOrDefault(r => r.Id == ruleId);
+                if (existing != null)
+                    Rules.Remove(existing);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to delete rule {RuleId}", ruleId);
             }
         }
 

--- a/InventoryManagementApp/Views/Pages/ScannerStatusPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ScannerStatusPage.xaml
@@ -50,7 +50,33 @@
                                             Width="220"/>
                         </DataGrid.Columns>
                     </DataGrid>
-                    <ListBox Grid.Column="1" ItemsSource="{Binding DeviceFiles}" Margin="8,0,0,0"/>
+                    <Grid Grid.Column="1" Margin="8,0,0,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="2*"/>
+                        </Grid.RowDefinitions>
+                        <Button Grid.Row="0" Style="{StaticResource PrimaryButton}" Content="Add Rule" Command="{Binding AddRuleCommand}"/>
+                        <ListBox Grid.Row="1" ItemsSource="{Binding DeviceFiles}" Margin="0,4,0,4"/>
+                        <DataGrid Grid.Row="2"
+                                  ItemsSource="{Binding Rules}"
+                                  AutoGenerateColumns="False"
+                                  IsReadOnly="True"
+                                  Style="{StaticResource VirtualizedDataGridStyle}">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Source" Binding="{Binding SourcePath}" Width="*"/>
+                                <DataGridTextColumn Header="Destination" Binding="{Binding DestinationPath}" Width="*"/>
+                                <DataGridTextColumn Header="Pattern" Binding="{Binding Pattern}" Width="*"/>
+                                <DataGridTemplateColumn Width="80">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <Button Content="Delete" Command="{Binding DataContext.DeleteRuleCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}" CommandParameter="{Binding Id}"/>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </Grid>
                 </Grid>
             </Border>
         </Grid>


### PR DESCRIPTION
## Summary
- add ScannerFileRule model and SQLite table
- implement ScannerRuleService to persist rules and copy files
- extend scanner status view model and page to manage rules
- test rule persistence and file copy triggers

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6982e675c8324bce461bbb49c2162