### PR TITLE
Add configurable device discovery service

### DIFF
--- a/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
+++ b/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.Services.Devices;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+public class DeviceDiscoveryServiceTests
+{
+    [Fact]
+    public async Task DiscoverDevices_FindsProtocolsAndMarksStatus()
+    {
+        var configDict = new Dictionary<string, string?>
+        {
+            ["DeviceDiscovery:Subnets:0"] = "192.168.0.0/29",
+            ["DeviceDiscovery:FtpPort"] = "2121"
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configDict!)
+            .Build();
+
+        Task<bool> PortChecker(string ip, int port, CancellationToken _)
+        {
+            if (ip == "192.168.0.1" && port == 445) return Task.FromResult(true);
+            if (ip == "192.168.0.2" && port == 2121) return Task.FromResult(true);
+            return Task.FromResult(false);
+        }
+
+        var service = new DeviceDiscoveryService(configuration, null, PortChecker);
+
+        var devices = (await service.DiscoverDevicesAsync()).ToList();
+
+        Assert.Equal(6, devices.Count);
+
+        var smb = devices.First(d => d.Ip == "192.168.0.1");
+        Assert.True(smb.IsOnline);
+        Assert.Contains(DeviceProtocol.Smb, smb.Protocols);
+
+        var ftp = devices.First(d => d.Ip == "192.168.0.2");
+        Assert.True(ftp.IsOnline);
+        Assert.Contains(DeviceProtocol.Ftp, ftp.Protocols);
+
+        var offline = devices.First(d => d.Ip == "192.168.0.3");
+        Assert.False(offline.IsOnline);
+        Assert.Empty(offline.Protocols);
+    }
+}

--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -115,6 +115,7 @@ namespace InventoryManagementApp
                 services.AddSingleton<IThemeService, ThemeService>();
                 services.AddSingleton<IDialogService, DialogService>();
                 services.AddSingleton<IScannerService, ScannerService>();
+                services.AddSingleton<IDeviceDiscoveryService, DeviceDiscoveryService>();
                 services.AddSingleton<IDeviceGroupService, DeviceGroupService>();
                 services.AddSingleton<IScannerFileService, ScannerFileService>();
                 services.AddSingleton<IScannerRuleService, ScannerRuleService>();

--- a/InventoryManagementApp/Interfaces/IDeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Interfaces/IDeviceDiscoveryService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using InventoryManagementApp.Models;
+
+namespace InventoryManagementApp.Interfaces
+{
+    public interface IDeviceDiscoveryService
+    {
+        Task<IReadOnlyList<DiscoveredDevice>> DiscoverDevicesAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/InventoryManagementApp/Models/DiscoveredDevice.cs
+++ b/InventoryManagementApp/Models/DiscoveredDevice.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace InventoryManagementApp.Models
+{
+    public class DiscoveredDevice
+    {
+        public string Ip { get; set; } = string.Empty;
+        public string Hostname { get; set; } = string.Empty;
+        public bool IsOnline { get; set; }
+        public IList<DeviceProtocol> Protocols { get; set; } = new List<DeviceProtocol>();
+    }
+}

--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace InventoryManagementApp.Services.Devices
+{
+    public class DeviceDiscoveryService : IDeviceDiscoveryService
+    {
+        private readonly ILogger<DeviceDiscoveryService> _logger;
+        private readonly Func<string, int, CancellationToken, Task<bool>> _portChecker;
+        private readonly IList<string> _subnets;
+        private readonly int _ftpPort;
+
+        public DeviceDiscoveryService(IConfiguration configuration,
+            ILogger<DeviceDiscoveryService>? logger = null,
+            Func<string, int, CancellationToken, Task<bool>>? portChecker = null)
+        {
+            _logger = logger ?? NullLogger<DeviceDiscoveryService>.Instance;
+            _portChecker = portChecker ?? DefaultPortChecker;
+            _subnets = configuration.GetSection("DeviceDiscovery:Subnets").Get<IList<string>>() ?? new List<string>();
+            _ftpPort = configuration.GetValue<int?>("DeviceDiscovery:FtpPort") ?? 21;
+        }
+
+        public async Task<IReadOnlyList<DiscoveredDevice>> DiscoverDevicesAsync(CancellationToken cancellationToken = default)
+        {
+            var devices = new ConcurrentBag<DiscoveredDevice>();
+            var addresses = _subnets.SelectMany(GetAddresses).Distinct();
+
+            using var semaphore = new SemaphoreSlim(20);
+
+            var tasks = addresses.Select(async ip =>
+            {
+                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    var device = await ScanIpAsync(ip, cancellationToken).ConfigureAwait(false);
+                    devices.Add(device);
+                }
+                finally
+                {
+                    semaphore.Release();
+                }
+            });
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+            return devices.OrderBy(d => d.Ip).ToList();
+        }
+
+        private async Task<DiscoveredDevice> ScanIpAsync(string ip, CancellationToken ct)
+        {
+            var protocols = new List<DeviceProtocol>();
+            try
+            {
+                if (await _portChecker(ip, 445, ct).ConfigureAwait(false))
+                    protocols.Add(DeviceProtocol.Smb);
+                if (await _portChecker(ip, _ftpPort, ct).ConfigureAwait(false))
+                    protocols.Add(DeviceProtocol.Ftp);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error checking ports for {Ip}", ip);
+            }
+
+            string hostname;
+            try
+            {
+                var entry = await Dns.GetHostEntryAsync(ip).ConfigureAwait(false);
+                hostname = entry.HostName;
+            }
+            catch
+            {
+                hostname = ip;
+            }
+
+            return new DiscoveredDevice
+            {
+                Ip = ip,
+                Hostname = hostname,
+                IsOnline = protocols.Count > 0,
+                Protocols = protocols
+            };
+        }
+
+        private static IEnumerable<string> GetAddresses(string cidr)
+        {
+            if (string.IsNullOrWhiteSpace(cidr))
+                yield break;
+            var parts = cidr.Split('/');
+            if (parts.Length != 2)
+                yield break;
+            if (!IPAddress.TryParse(parts[0], out var baseAddress))
+                yield break;
+            if (!int.TryParse(parts[1], out var prefix))
+                yield break;
+            var baseBytes = baseAddress.GetAddressBytes();
+            if (baseBytes.Length != 4)
+                yield break;
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(baseBytes);
+            uint baseUint = BitConverter.ToUInt32(baseBytes, 0);
+            uint mask = prefix == 0 ? 0u : uint.MaxValue << (32 - prefix);
+            uint network = baseUint & mask;
+            uint broadcast = network | ~mask;
+            for (uint ip = network + 1; ip < broadcast; ip++)
+            {
+                var bytes = BitConverter.GetBytes(ip);
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(bytes);
+                yield return new IPAddress(bytes).ToString();
+            }
+        }
+
+        private static async Task<bool> DefaultPortChecker(string ip, int port, CancellationToken ct)
+        {
+            try
+            {
+                using var client = new TcpClient();
+                var connectTask = client.ConnectAsync(ip, port);
+                var timeout = Task.Delay(1000, ct);
+                var completed = await Task.WhenAny(connectTask, timeout).ConfigureAwait(false);
+                if (completed == connectTask)
+                {
+                    await connectTask.ConfigureAwait(false);
+                    return client.Connected;
+                }
+            }
+            catch
+            {
+            }
+            return false;
+        }
+    }
+}

--- a/InventoryManagementApp/appsettings.json
+++ b/InventoryManagementApp/appsettings.json
@@ -4,5 +4,9 @@
   },
   "Logging": {
     "Directory": "Logs"
+  },
+  "DeviceDiscovery": {
+    "Subnets": [],
+    "FtpPort": 21
   }
 }


### PR DESCRIPTION
## Summary
- add `DeviceDiscoveryService` to scan configured subnets for SMB and FTP
- expose results via new `IDeviceDiscoveryService` and `DiscoveredDevice` model
- wire service into application DI and settings

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository access 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b69e7988e083248c295f27c7cf53b5