### PR TITLE
Add extension filter support for device file listing

### DIFF
--- a/InventoryManagementApp.Tests/DevicesViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DevicesViewModelTests.cs
@@ -15,11 +15,17 @@ public class DevicesViewModelTests
             => Task.FromResult<IReadOnlyList<DiscoveredDevice>>(Devices);
     }
 
-    private sealed class StubDeviceFileService : IDeviceFileService
+    private sealed class RecordingDeviceFileService : IDeviceFileService
     {
         public List<string> Files { get; } = new();
+        public Device? LastDevice { get; private set; }
+        public string? LastExtensionFilter { get; private set; }
         public Task<IEnumerable<string>> ListFilesAsync(Device device, string? extensionFilter = null, CancellationToken cancellationToken = default)
-            => Task.FromResult<IEnumerable<string>>(Files);
+        {
+            LastDevice = device;
+            LastExtensionFilter = extensionFilter;
+            return Task.FromResult<IEnumerable<string>>(Files);
+        }
     }
 
     private sealed class StubDialogService : IDialogService
@@ -43,7 +49,7 @@ public class DevicesViewModelTests
     public async Task RefreshCommand_LoadsDevices()
     {
         var discovery = new StubDiscoveryService();
-        var fileService = new StubDeviceFileService();
+        var fileService = new RecordingDeviceFileService();
         var dialog = new StubDialogService();
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", Hostname = "test", IsOnline = true, Protocols = new List<DeviceProtocol> { DeviceProtocol.Ftp } });
         var vm = new DevicesViewModel(discovery, fileService, dialog);
@@ -59,7 +65,7 @@ public class DevicesViewModelTests
     public async Task PullAllReportsCommand_LoadsFiles()
     {
         var discovery = new StubDiscoveryService();
-        var fileService = new StubDeviceFileService();
+        var fileService = new RecordingDeviceFileService();
         var dialog = new StubDialogService();
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", Hostname = "test", IsOnline = true, Protocols = new List<DeviceProtocol>() });
         fileService.Files.AddRange(new[] { "a.txt", "b.txt" });
@@ -71,5 +77,24 @@ public class DevicesViewModelTests
 
         Assert.Equal(2, vm.DeviceFiles.Count);
         Assert.Contains("a.txt", vm.DeviceFiles);
+        Assert.Same(vm.SelectedDevice, fileService.LastDevice);
+        Assert.Null(fileService.LastExtensionFilter);
+    }
+
+    [Fact]
+    public async Task PullAllReportsCommand_UsesExtensionFilter()
+    {
+        var discovery = new StubDiscoveryService();
+        var fileService = new RecordingDeviceFileService();
+        var dialog = new StubDialogService();
+        discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", Hostname = "test", IsOnline = true, Protocols = new List<DeviceProtocol>() });
+        var vm = new DevicesViewModel(discovery, fileService, dialog);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+        vm.SelectedDevice = vm.Devices[0];
+        vm.FileExtensionFilter = ".txt";
+        await vm.PullAllReportsCommand.ExecuteAsync(null);
+
+        Assert.Equal(".txt", fileService.LastExtensionFilter);
     }
 }

--- a/InventoryManagementApp/ViewModels/DevicesViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DevicesViewModel.cs
@@ -22,6 +22,13 @@ namespace InventoryManagementApp.ViewModels
         public ObservableCollection<Device> Devices { get; } = new();
         public ObservableCollection<string> DeviceFiles { get; } = new();
 
+        private string _fileExtensionFilter = "*.*";
+        public string FileExtensionFilter
+        {
+            get => _fileExtensionFilter;
+            set => SetProperty(ref _fileExtensionFilter, value);
+        }
+
         private Device? _selectedDevice;
         public Device? SelectedDevice
         {
@@ -84,7 +91,8 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 DeviceFiles.Clear();
-                var files = await _fileService.ListFilesAsync(SelectedDevice, null, CancellationToken.None);
+                var filter = FileExtensionFilter == "*.*" ? null : FileExtensionFilter;
+                var files = await _fileService.ListFilesAsync(SelectedDevice, filter, CancellationToken.None);
                 foreach (var f in files)
                     DeviceFiles.Add(f);
             }

--- a/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
@@ -31,6 +31,13 @@ namespace InventoryManagementApp.ViewModels
         public ObservableCollection<string> DeviceFiles { get; } = new();
         public ObservableCollection<ScannerFileRule> Rules { get; } = new();
 
+        private string _fileExtensionFilter = "*.*";
+        public string FileExtensionFilter
+        {
+            get => _fileExtensionFilter;
+            set => SetProperty(ref _fileExtensionFilter, value);
+        }
+
         bool _autoRefresh;
         public bool AutoRefresh
         {
@@ -162,7 +169,8 @@ namespace InventoryManagementApp.ViewModels
                 DeviceFiles.Clear();
                 if (SelectedDevice is null)
                     return;
-                var files = await _fileService.ListFilesAsync(SelectedDevice, null, cancellationToken);
+                var filter = FileExtensionFilter == "*.*" ? null : FileExtensionFilter;
+                var files = await _fileService.ListFilesAsync(SelectedDevice, filter, cancellationToken);
                 foreach (var f in files)
                     DeviceFiles.Add(f);
             }


### PR DESCRIPTION
## Summary
- expose extension filter on device and scanner status view models
- pass selected device and filter to IDeviceFileService.ListFilesAsync
- expand unit tests for file filtering behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ae045844832494ae2aa660d0aee4