### PR TITLE
Remove obsolete connection argument from EnsureColumn call

### DIFF
--- a/InventoryManagementApp/Services/Core/DatabaseService.cs
+++ b/InventoryManagementApp/Services/Core/DatabaseService.cs
@@ -178,7 +178,7 @@ namespace InventoryManagementApp.Services.Core
                 );";
             using var cmd = new SqliteCommand(sql, conn);
             cmd.ExecuteNonQuery();
-            EnsureColumn(conn, "Items", "DeviceId", "TEXT");
+            EnsureColumn("Items", "DeviceId", "TEXT");
 
             EnsureIndex(conn, "Items", "ItemNumber", true);
             EnsureIndex(conn, "Items", "NameDescription");


### PR DESCRIPTION
## Summary
- drop unused database connection argument when ensuring DeviceId column in Items table

## Testing
- `dotnet test` *(fails: dotnet: command not found)*
- `apt-get update` *(fails: 403 Forbidden [IP: 172.30.0.83 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68b6b483e88c8324b971863a6f131783