### PR TITLE
Use AsyncFtpClient for FTP operations

### DIFF
--- a/InventoryManagementApp/Services/Devices/DeviceFileService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceFileService.cs
@@ -93,11 +93,11 @@ namespace InventoryManagementApp.Services.Devices
         private async Task<IEnumerable<string>> ListFtpFilesAsync(Device device, string? extensionFilter, CancellationToken cancellationToken)
         {
             var results = new List<string>();
-            using var client = new FtpClient(device.Ip, device.Username, device.Password);
+            using var client = new AsyncFtpClient(device.Ip, device.Username, device.Password);
             try
             {
-                await client.ConnectAsync(cancellationToken);
-                var list = await client.GetNameListingAsync("/", cancellationToken);
+                await client.Connect(cancellationToken);
+                var list = await client.GetNameListing("/", cancellationToken);
                 foreach (var item in list)
                 {
                     var name = Path.GetFileName(item);
@@ -114,7 +114,7 @@ namespace InventoryManagementApp.Services.Devices
                 try
                 {
                     if (client.IsConnected)
-                        await client.DisconnectAsync(cancellationToken);
+                        await client.Disconnect(cancellationToken);
                 }
                 catch { }
             }
@@ -128,13 +128,13 @@ namespace InventoryManagementApp.Services.Devices
                 switch (device.Protocol)
                 {
                     case DeviceProtocol.Ftp:
-                        using (var client = new FtpClient(device.Ip, device.Username, device.Password))
+                        using (var client = new AsyncFtpClient(device.Ip, device.Username, device.Password))
                         {
-                            await client.ConnectAsync(cancellationToken);
+                            await client.Connect(cancellationToken);
                             using var ms = new MemoryStream();
-                            await client.DownloadStreamAsync(ms, file, token: cancellationToken);
+                            await client.DownloadStream(ms, file, token: cancellationToken);
                             if (client.IsConnected)
-                                await client.DisconnectAsync(cancellationToken);
+                                await client.Disconnect(cancellationToken);
                             return ms.ToArray();
                         }
                     case DeviceProtocol.Smb:


### PR DESCRIPTION
## Summary
- replace `FtpClient` with `AsyncFtpClient` in `DeviceFileService`
- adjust FTP methods to use `Connect`, `GetNameListing`, `DownloadStream`, and `Disconnect`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b4ace6c483248751975863d1a2fc