### PR TITLE
Dispose SMB2Client with try-finally in DeviceFileService

### DIFF
--- a/InventoryManagementApp/Services/Devices/DeviceFileService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceFileService.cs
@@ -53,9 +53,9 @@ namespace InventoryManagementApp.Services.Devices
         private async Task<IEnumerable<string>> ListSmbFilesAsync(Device device, string? extensionFilter, CancellationToken cancellationToken)
         {
             var results = new List<string>();
+            var client = new SMB2Client();
             try
             {
-                using var client = new SMB2Client();
                 var status = await Task.Run(() => client.Connect(device.Ip, SMBTransportType.DirectTCPTransport), cancellationToken);
                 if (status != NTStatus.STATUS_SUCCESS)
                     return results;
@@ -90,12 +90,15 @@ namespace InventoryManagementApp.Services.Devices
                         fileStore.Dispose();
                     }
                 }
-                client.Logoff();
-                client.Disconnect();
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "SMB file listing failed for device {Ip}", device.Ip);
+            }
+            finally
+            {
+                try { client.Logoff(); } catch { }
+                try { client.Disconnect(); } catch { }
             }
             return results;
         }


### PR DESCRIPTION
## Summary
- Instantiate SMB2Client without a using statement and manage it manually
- Wrap SMB operations in a try/finally block, ensuring Logoff and Disconnect are invoked

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b6eb36a08324aee22b77d2007872