### PR TITLE
Refactor SMB file listing connection handling

### DIFF
--- a/InventoryManagementApp/Services/Devices/DeviceFileService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceFileService.cs
@@ -56,23 +56,28 @@ namespace InventoryManagementApp.Services.Devices
             try
             {
                 using var client = new SMB2Client();
-                var status = await Task.Run(() => client.Connect(device.Ip, SMBTransportType.DirectTCPTransport), cancellationToken);
+                var connected = await Task.Run(() => client.Connect(device.Ip, SMBTransportType.DirectTCPTransport), cancellationToken);
+                if (!connected)
+                    return results;
+
+                NTStatus status = await Task.Run(() => client.Login(device.Domain, device.Username, device.Password), cancellationToken);
                 if (status != NTStatus.STATUS_SUCCESS)
                     return results;
-                status = await Task.Run(() => client.Login(device.Domain, device.Username, device.Password), cancellationToken);
-                if (status != NTStatus.STATUS_SUCCESS)
-                    return results;
+
                 status = client.ListShares(out var shares);
                 if (status != NTStatus.STATUS_SUCCESS)
                     return results;
+
                 foreach (var share in shares)
                 {
                     string shareName = share is string s ? s : (string)((dynamic)share).ShareName;
                     if (string.Equals(shareName, "IPC$", StringComparison.OrdinalIgnoreCase))
                         continue;
+
                     status = client.TreeConnect(shareName, out var fileStore);
                     if (status != NTStatus.STATUS_SUCCESS)
                         continue;
+
                     try
                     {
                         var files = fileStore.ListFiles("\\") as IEnumerable<dynamic>;


### PR DESCRIPTION
## Summary
- ensure SMB connection success is captured as a boolean before proceeding
- use NTStatus for login, share listing, and tree connect operations
- clean up file store after listing files

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b6f1d91c8324b1215a50f716ad01