### PR TITLE
refactor: streamline SMB status checks

### DIFF
--- a/InventoryManagementApp/Services/Devices/DeviceFileService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceFileService.cs
@@ -74,7 +74,7 @@ namespace InventoryManagementApp.Services.Devices
                 if (status != NTStatus.STATUS_SUCCESS) return results;
 
                 status = client.ListShares(out var shares);
-                if (status != NTStatus.STATUS_SUCCESS || shares == null) return results;
+                if (status != NTStatus.STATUS_SUCCESS) return results;
 
                 foreach (var shareObj in shares)
                 {
@@ -93,12 +93,12 @@ namespace InventoryManagementApp.Services.Devices
                     if (string.Equals(shareName, "IPC$", StringComparison.OrdinalIgnoreCase)) continue;
 
                     status = client.TreeConnect(shareName, out var fileStore);
-                    if (status != NTStatus.STATUS_SUCCESS || fileStore == null) continue;
+                    if (status != NTStatus.STATUS_SUCCESS) continue;
 
                     try
                     {
                         status = fileStore.ListFiles("\\", out var items);
-                        if (status != NTStatus.STATUS_SUCCESS || items == null) continue;
+                        if (status != NTStatus.STATUS_SUCCESS) continue;
 
                         foreach (var info in items)
                         {


### PR DESCRIPTION
## Summary
- remove redundant null checks when querying SMB shares, tree connections, and files
- rely solely on `status != NTStatus.STATUS_SUCCESS` for SMB operations

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ba8491d883249da4da73d17d00f8