### PR TITLE
Fix SMB file download attribute ambiguity

### DIFF
--- a/InventoryManagementApp/Services/Devices/DeviceFileService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceFileService.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using SMBLibrary;
 using SMBLibrary.Client;
+using SMBFileAttributes = SMBLibrary.FileAttributes;
 
 namespace InventoryManagementApp.Services.Devices
 {
@@ -194,7 +195,7 @@ namespace InventoryManagementApp.Services.Devices
                                 {
                                     cancellationToken.ThrowIfCancellationRequested();
                                     object fileInfo;
-                                    status = fileStore.CreateFile(out object handle, file, AccessMask.GENERIC_READ, FileAttributes.Normal, ShareAccess.Read, CreateDisposition.FILE_OPEN, CreateOptions.FILE_NON_DIRECTORY_FILE, out fileInfo);
+                                    status = fileStore.CreateFile(out object handle, file, AccessMask.GENERIC_READ, SMBFileAttributes.Normal, ShareAccess.Read, CreateDisposition.FILE_OPEN, CreateOptions.FILE_NON_DIRECTORY_FILE, out fileInfo);
                                     if (status != NTStatus.STATUS_SUCCESS) continue;
                                     try
                                     {


### PR DESCRIPTION
## Summary
- use SMBLibrary FileAttributes explicitly via alias to avoid ambiguity when creating files during SMB downloads

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c0c96a588324844a27995ecbaaaf