### PR TITLE
Use explicit typing for SMB file listing

### DIFF
--- a/InventoryManagementApp/Services/Devices/DeviceFileService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceFileService.cs
@@ -90,10 +90,10 @@ namespace InventoryManagementApp.Services.Devices
 
                     try
                     {
-                        status = fileStore.ListFiles("\\", out var items);
-                        if (status != NTStatus.STATUS_SUCCESS) continue;
+                        status = fileStore.ListFiles("\\", out List<dynamic>? items);
+                        if (status != NTStatus.STATUS_SUCCESS || items == null) continue;
 
-                        foreach (var info in items)
+                        foreach (dynamic info in items)
                         {
                             cancellationToken.ThrowIfCancellationRequested();
                             var name = info.FileName;


### PR DESCRIPTION
## Summary
- explicitly type SMB file listing results to avoid dynamic inference issues

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c24a6d4c8324945dedef21c04a77