### PR TITLE
Handle missing subnet configuration in device discovery

### DIFF
--- a/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
+++ b/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
@@ -46,4 +46,16 @@ public class DeviceDiscoveryServiceTests
         Assert.False(offline.IsOnline);
         Assert.Empty(offline.Protocols);
     }
+
+    [Fact]
+    public async Task DiscoverDevices_NoSubnetsConfigured_ReturnsEmpty()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+        var service = new DeviceDiscoveryService(configuration);
+
+        Assert.False(service.HasConfiguredSubnets);
+        var devices = await service.DiscoverDevicesAsync();
+
+        Assert.Empty(devices);
+    }
 }

--- a/InventoryManagementApp.Tests/DevicesViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DevicesViewModelTests.cs
@@ -11,6 +11,7 @@ public class DevicesViewModelTests
     private sealed class StubDiscoveryService : IDeviceDiscoveryService
     {
         public List<DiscoveredDevice> Devices { get; } = new();
+        public bool HasConfiguredSubnets { get; set; } = true;
         public Task<IReadOnlyList<DiscoveredDevice>> DiscoverDevicesAsync(CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<DiscoveredDevice>>(Devices);
     }
@@ -31,9 +32,15 @@ public class DevicesViewModelTests
             => Task.FromResult(0);
     }
 
-    private sealed class StubDialogService : IDialogService
+    private sealed class RecordingDialogService : IDialogService
     {
-        public void ShowInfo(string message, string title) { }
+        public string? LastInfoMessage { get; private set; }
+        public void ShowInfo(string message, string title) => LastInfoMessage = message;
+        public Task ShowInfoAsync(string message, string title)
+        {
+            LastInfoMessage = message;
+            return Task.CompletedTask;
+        }
         public bool ShowConfirmation(string message, string title) => false;
         public ItemModel? ShowEditItemDialog(ItemModel item) => null;
         public void ShowItemDetails(ItemModel item) { }
@@ -53,7 +60,7 @@ public class DevicesViewModelTests
     {
         var discovery = new StubDiscoveryService();
         var fileService = new RecordingDeviceFileService();
-        var dialog = new StubDialogService();
+        var dialog = new RecordingDialogService();
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", Hostname = "test", IsOnline = true, Protocols = new List<DeviceProtocol> { DeviceProtocol.Ftp } });
         var vm = new DevicesViewModel(discovery, fileService, dialog);
 
@@ -69,7 +76,7 @@ public class DevicesViewModelTests
     {
         var discovery = new StubDiscoveryService();
         var fileService = new RecordingDeviceFileService();
-        var dialog = new StubDialogService();
+        var dialog = new RecordingDialogService();
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", Hostname = "test", IsOnline = true, Protocols = new List<DeviceProtocol>() });
         fileService.Files.AddRange(new[] { "a.txt", "b.txt" });
         var vm = new DevicesViewModel(discovery, fileService, dialog);
@@ -89,7 +96,7 @@ public class DevicesViewModelTests
     {
         var discovery = new StubDiscoveryService();
         var fileService = new RecordingDeviceFileService();
-        var dialog = new StubDialogService();
+        var dialog = new RecordingDialogService();
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", Hostname = "test", IsOnline = true, Protocols = new List<DeviceProtocol>() });
         var vm = new DevicesViewModel(discovery, fileService, dialog);
 
@@ -99,5 +106,19 @@ public class DevicesViewModelTests
         await vm.PullAllReportsCommand.ExecuteAsync(null);
 
         Assert.Equal(".txt", fileService.LastExtensionFilter);
+    }
+
+    [Fact]
+    public async Task RefreshCommand_NoSubnets_ShowsWarning()
+    {
+        var discovery = new StubDiscoveryService { HasConfiguredSubnets = false };
+        var fileService = new RecordingDeviceFileService();
+        var dialog = new RecordingDialogService();
+
+        var vm = new DevicesViewModel(discovery, fileService, dialog);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Equal("No subnets configured for device discovery.", dialog.LastInfoMessage);
     }
 }

--- a/InventoryManagementApp/Interfaces/IDeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Interfaces/IDeviceDiscoveryService.cs
@@ -8,5 +8,10 @@ namespace InventoryManagementApp.Interfaces
     public interface IDeviceDiscoveryService
     {
         Task<IReadOnlyList<DiscoveredDevice>> DiscoverDevicesAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Indicates whether any subnets have been configured for device discovery.
+        /// </summary>
+        bool HasConfiguredSubnets { get; }
     }
 }

--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -21,6 +21,8 @@ namespace InventoryManagementApp.Services.Devices
         private readonly IList<string> _subnets;
         private readonly int _ftpPort;
 
+        public bool HasConfiguredSubnets => _subnets.Count > 0;
+
         public DeviceDiscoveryService(IConfiguration configuration,
             ILogger<DeviceDiscoveryService>? logger = null,
             Func<string, int, CancellationToken, Task<bool>>? portChecker = null)
@@ -28,11 +30,21 @@ namespace InventoryManagementApp.Services.Devices
             _logger = logger ?? NullLogger<DeviceDiscoveryService>.Instance;
             _portChecker = portChecker ?? DefaultPortChecker;
             _subnets = configuration.GetSection("DeviceDiscovery:Subnets").Get<IList<string>>() ?? new List<string>();
+            if (_subnets.Count == 0)
+            {
+                _logger.LogWarning("No subnets configured for device discovery.");
+            }
             _ftpPort = configuration.GetValue<int?>("DeviceDiscovery:FtpPort") ?? 21;
         }
 
         public async Task<IReadOnlyList<DiscoveredDevice>> DiscoverDevicesAsync(CancellationToken cancellationToken = default)
         {
+            if (_subnets.Count == 0)
+            {
+                _logger.LogWarning("Device discovery attempted with no configured subnets.");
+                return Array.Empty<DiscoveredDevice>();
+            }
+
             var devices = new ConcurrentBag<DiscoveredDevice>();
             var addresses = _subnets.SelectMany(GetAddresses).Distinct();
 

--- a/InventoryManagementApp/ViewModels/DevicesViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DevicesViewModel.cs
@@ -64,6 +64,12 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 var devices = await _discoveryService.DiscoverDevicesAsync();
+                if (devices.Count == 0 && !_discoveryService.HasConfiguredSubnets)
+                {
+                    await _dialogService.ShowInfoAsync("No subnets configured for device discovery.", "Devices");
+                    return;
+                }
+
                 Devices.Clear();
                 foreach (var d in devices)
                 {


### PR DESCRIPTION
## Summary
- warn when no subnets are configured for device discovery
- surface missing subnet warning in device refresh dialog
- cover missing subnet scenarios in unit tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c4504a9c83249c60abecb7a4d808