### PR TITLE
Add report pulling controls with extension filter

### DIFF
--- a/InventoryManagementApp.Tests/DevicesViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DevicesViewModelTests.cs
@@ -98,6 +98,7 @@ public class DevicesViewModelTests
         var fileService = new RecordingDeviceFileService();
         var dialog = new RecordingDialogService();
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", Hostname = "test", IsOnline = true, Protocols = new List<DeviceProtocol>() });
+        fileService.Files.AddRange(new[] { "a.txt", "b.txt" });
         var vm = new DevicesViewModel(discovery, fileService, dialog);
 
         await vm.RefreshCommand.ExecuteAsync(null);
@@ -106,6 +107,8 @@ public class DevicesViewModelTests
         await vm.PullAllReportsCommand.ExecuteAsync(null);
 
         Assert.Equal(".txt", fileService.LastExtensionFilter);
+        Assert.Equal(2, vm.DeviceFiles.Count);
+        Assert.Contains("a.txt", vm.DeviceFiles);
     }
 
     [Fact]

--- a/InventoryManagementApp/Views/Pages/DevicesPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DevicesPage.xaml
@@ -14,7 +14,18 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
             <Border Style="{StaticResource Card}">
-                <Button Style="{StaticResource PrimaryButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <Button Style="{StaticResource PrimaryButton}"
+                            Content="Refresh"
+                            Command="{Binding RefreshCommand}"
+                            Margin="0,0,8,0"/>
+                    <TextBox Text="{Binding FileExtensionFilter, UpdateSourceTrigger=PropertyChanged}"
+                             Width="120"
+                             Margin="0,0,8,0"/>
+                    <Button Style="{StaticResource PrimaryButton}"
+                            Content="Pull Reports"
+                            Command="{Binding PullAllReportsCommand}"/>
+                </StackPanel>
             </Border>
             <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0" Margin="0,8,0,0">
                 <DataGrid ItemsSource="{Binding Devices}"


### PR DESCRIPTION
## Summary
- Add Refresh, filter textbox, and Pull Reports button to devices page
- Extend device view model tests to cover extension filtering

## Testing
- `dotnet test` *(fails: dotnet command not found; unable to install SDK due to unsigned repository)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c8afc6b08324855da7117d07ae99