### PR TITLE
Auto-detect subnets for device discovery

### DIFF
--- a/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
+++ b/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
@@ -48,10 +48,33 @@ public class DeviceDiscoveryServiceTests
     }
 
     [Fact]
-    public async Task DiscoverDevices_NoSubnetsConfigured_ReturnsEmpty()
+    public async Task DiscoverDevices_UsesAutoDetectedSubnets()
     {
         var configuration = new ConfigurationBuilder().Build();
-        var service = new DeviceDiscoveryService(configuration);
+
+        IList<string> detected = new List<string> { "192.168.0.0/29" };
+
+        Task<bool> PortChecker(string ip, int port, CancellationToken _)
+        {
+            if (ip == "192.168.0.1" && port == 445) return Task.FromResult(true);
+            if (ip == "192.168.0.2" && port == 21) return Task.FromResult(true);
+            return Task.FromResult(false);
+        }
+
+        var service = new DeviceDiscoveryService(configuration, null, PortChecker, () => detected);
+
+        Assert.True(service.HasConfiguredSubnets);
+        var devices = await service.DiscoverDevicesAsync();
+
+        Assert.Equal(6, devices.Count);
+        Assert.Contains(devices, d => d.Ip == "192.168.0.1" && d.Protocols.Contains(DeviceProtocol.Smb));
+    }
+
+    [Fact]
+    public async Task DiscoverDevices_NoConfigOrDetectedSubnets_ReturnsEmpty()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+        var service = new DeviceDiscoveryService(configuration, null, null, () => new List<string>());
 
         Assert.False(service.HasConfiguredSubnets);
         var devices = await service.DiscoverDevicesAsync();

--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Net.NetworkInformation;
 using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Interfaces;
@@ -25,14 +26,24 @@ namespace InventoryManagementApp.Services.Devices
 
         public DeviceDiscoveryService(IConfiguration configuration,
             ILogger<DeviceDiscoveryService>? logger = null,
-            Func<string, int, CancellationToken, Task<bool>>? portChecker = null)
+            Func<string, int, CancellationToken, Task<bool>>? portChecker = null,
+            Func<IList<string>>? subnetResolver = null)
         {
             _logger = logger ?? NullLogger<DeviceDiscoveryService>.Instance;
             _portChecker = portChecker ?? DefaultPortChecker;
+            subnetResolver ??= GetLocalSubnets;
             _subnets = configuration.GetSection("DeviceDiscovery:Subnets").Get<IList<string>>() ?? new List<string>();
             if (_subnets.Count == 0)
             {
-                _logger.LogWarning("No subnets configured for device discovery.");
+                _subnets = subnetResolver() ?? new List<string>();
+                if (_subnets.Count == 0)
+                {
+                    _logger.LogWarning("No subnets configured or detected for device discovery.");
+                }
+                else
+                {
+                    _logger.LogInformation("Using auto-detected subnets: {Subnets}", string.Join(", ", _subnets));
+                }
             }
             _ftpPort = configuration.GetValue<int?>("DeviceDiscovery:FtpPort") ?? 21;
         }
@@ -130,6 +141,33 @@ namespace InventoryManagementApp.Services.Devices
                     Array.Reverse(bytes);
                 yield return new IPAddress(bytes).ToString();
             }
+        }
+
+        private static IList<string> GetLocalSubnets()
+        {
+            var subnets = new List<string>();
+            foreach (var ni in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                if (ni.OperationalStatus != OperationalStatus.Up || ni.NetworkInterfaceType == NetworkInterfaceType.Loopback)
+                    continue;
+                var ipProps = ni.GetIPProperties();
+                foreach (var ua in ipProps.UnicastAddresses)
+                {
+                    if (ua.Address.AddressFamily != AddressFamily.InterNetwork || ua.IPv4Mask == null)
+                        continue;
+                    var ipBytes = ua.Address.GetAddressBytes();
+                    var maskBytes = ua.IPv4Mask.GetAddressBytes();
+                    var networkBytes = new byte[4];
+                    for (int i = 0; i < 4; i++)
+                        networkBytes[i] = (byte)(ipBytes[i] & maskBytes[i]);
+                    var network = new IPAddress(networkBytes);
+                    int prefix = maskBytes.Sum(b => Convert.ToString(b, 2).Count(c => c == '1'));
+                    var cidr = $"{network}/{prefix}";
+                    if (!subnets.Contains(cidr))
+                        subnets.Add(cidr);
+                }
+            }
+            return subnets;
         }
 
         private static async Task<bool> DefaultPortChecker(string ip, int port, CancellationToken ct)


### PR DESCRIPTION
## Summary
- derive local network subnets when no subnets configured for device discovery
- add tests covering auto-detected and empty subnet scenarios

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b73944d3488324a3e631cd8c372e82