### PR TITLE
Enable device renaming and group editing in scanner status

### DIFF
--- a/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Documents;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.ViewModels;
+using Xunit;
+
+public class ScannerStatusViewModelTests
+{
+    private sealed class StubScannerService : IScannerService
+    {
+        public List<Device> Devices { get; } = new();
+        public Task<IEnumerable<Device>> GetDevicesAsync(CancellationToken cancellationToken)
+            => Task.FromResult<IEnumerable<Device>>(Devices);
+    }
+
+    private sealed class RecordingDeviceService : IDeviceService
+    {
+        public Device? LastDevice { get; private set; }
+        public TaskCompletionSource<Device> Tcs { get; } = new();
+        public Task<IEnumerable<Device>> GetDevicesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IEnumerable<Device>>(Array.Empty<Device>());
+        public Task<Device?> GetDeviceAsync(string ip, CancellationToken cancellationToken = default)
+            => Task.FromResult<Device?>(null);
+        public Task AddOrUpdateDeviceAsync(Device device, CancellationToken cancellationToken = default)
+        {
+            LastDevice = device;
+            Tcs.TrySetResult(device);
+            return Task.CompletedTask;
+        }
+        public Task DeleteDeviceAsync(string ip, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class RecordingDeviceGroupService : IDeviceGroupService
+    {
+        public List<DeviceGroup> Groups { get; } = new();
+        public TaskCompletionSource<(string ip, int? groupId)> AssignTcs { get; } = new();
+        public Task<IEnumerable<DeviceGroup>> GetGroupsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IEnumerable<DeviceGroup>>(Groups);
+        public Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default)
+            => Task.FromResult(0);
+        public Task UpdateGroupAsync(DeviceGroup group, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+        public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+        public Task AssignDeviceToGroupAsync(string deviceIp, int? groupId, CancellationToken cancellationToken = default)
+        {
+            AssignTcs.TrySetResult((deviceIp, groupId));
+            return Task.CompletedTask;
+        }
+        public Task<int?> GetDeviceGroupIdAsync(string deviceIp, CancellationToken cancellationToken = default)
+            => Task.FromResult<int?>(null);
+    }
+
+    private sealed class StubDeviceFileService : IDeviceFileService
+    {
+        public Task<IEnumerable<string>> ListFilesAsync(Device device, string? extensionFilter = null, CancellationToken cancellationToken = default)
+            => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+        public Task<int> DownloadUnseenFilesAsync(Device device, string basePath, CancellationToken cancellationToken = default)
+            => Task.FromResult(0);
+    }
+
+    private sealed class StubDialogService : IDialogService
+    {
+        public void ShowInfo(string message, string title) { }
+        public bool ShowConfirmation(string message, string title) => false;
+        public ItemModel? ShowEditItemDialog(ItemModel item) => null;
+        public void ShowItemDetails(ItemModel item) { }
+        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
+        public CustomerModel? ShowAddCustomerDialog() => null;
+        public CustomerModel? ShowEditCustomerDialog(CustomerModel customer) => null;
+        public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+        public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
+        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
+        public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+        public void ShowPrintPreview(FlowDocument document, string title, string description) { }
+        public void ShowPrintLabelDialog() { }
+    }
+
+    [Fact]
+    public async Task ChangingHostname_PersistsDevice()
+    {
+        var scanner = new StubScannerService();
+        scanner.Devices.Add(new Device { Ip = "1.2.3.4", Hostname = "old" });
+        var dialog = new StubDialogService();
+        var deviceService = new RecordingDeviceService();
+        var groupService = new RecordingDeviceGroupService();
+        var fileService = new StubDeviceFileService();
+        var vm = new ScannerStatusViewModel(scanner, dialog, deviceService, groupService, fileService);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+        vm.Devices[0].Hostname = "new";
+        await deviceService.Tcs.Task;
+
+        Assert.Equal("new", deviceService.LastDevice?.Hostname);
+    }
+
+    [Fact]
+    public async Task ChangingGroup_AssignsDevice()
+    {
+        var scanner = new StubScannerService();
+        scanner.Devices.Add(new Device { Ip = "1.2.3.4" });
+        var dialog = new StubDialogService();
+        var deviceService = new RecordingDeviceService();
+        var groupService = new RecordingDeviceGroupService();
+        groupService.Groups.Add(new DeviceGroup { Id = 1, Name = "G1" });
+        var fileService = new StubDeviceFileService();
+        var vm = new ScannerStatusViewModel(scanner, dialog, deviceService, groupService, fileService);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+        vm.Devices[0].GroupId = 1;
+        var assignment = await groupService.AssignTcs.Task;
+
+        Assert.Equal("1.2.3.4", assignment.ip);
+        Assert.Equal(1, assignment.groupId);
+    }
+}

--- a/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
@@ -197,7 +197,10 @@ namespace InventoryManagementApp.ViewModels
 
         async void Device_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(Device.GroupId) && sender is Device device)
+            if (sender is not Device device)
+                return;
+
+            if (e.PropertyName == nameof(Device.GroupId))
             {
                 try
                 {
@@ -206,6 +209,17 @@ namespace InventoryManagementApp.ViewModels
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to assign device {Ip} to group {Group}", device.Ip, device.GroupId);
+                }
+            }
+            else if (e.PropertyName == nameof(Device.Hostname))
+            {
+                try
+                {
+                    await _deviceService.AddOrUpdateDeviceAsync(device);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to update device {Ip}", device.Ip);
                 }
             }
         }

--- a/InventoryManagementApp/Views/Windows/ScannerStatusWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ScannerStatusWindow.xaml
@@ -26,17 +26,26 @@
             <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0" Margin="0,8,0,0">
                 <DataGrid ItemsSource="{Binding Devices}"
                           AutoGenerateColumns="False"
-                          IsReadOnly="True"
+                          IsReadOnly="False"
                           Style="{StaticResource VirtualizedDataGridStyle}"
                           ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
                     <DataGrid.Columns>
-                        <DataGridTextColumn Header="Device" Binding="{Binding Hostname}" Width="*"/>
-                        <DataGridTextColumn Header="Item" Binding="{Binding ItemName}" Width="*"/>
-                        <DataGridTextColumn Header="IP" Binding="{Binding Ip}" Width="180"/>
-                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="160"/>
+                        <DataGridTextColumn Header="Device"
+                                            Binding="{Binding Hostname, UpdateSourceTrigger=PropertyChanged}"
+                                            Width="*"
+                                            IsReadOnly="False"/>
+                        <DataGridComboBoxColumn Header="Group"
+                                                ItemsSource="{Binding DataContext.Groups, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                                DisplayMemberPath="Name"
+                                                SelectedValuePath="Id"
+                                                SelectedValueBinding="{Binding GroupId, UpdateSourceTrigger=PropertyChanged}"
+                                                Width="150"/>
+                        <DataGridTextColumn Header="Item" Binding="{Binding ItemName}" Width="*" IsReadOnly="True"/>
+                        <DataGridTextColumn Header="IP" Binding="{Binding Ip}" Width="180" IsReadOnly="True"/>
+                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="160" IsReadOnly="True"/>
                         <DataGridTextColumn Header="Last Seen"
                                             Binding="{Binding LastSeen, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}"
-                                            Width="220"/>
+                                            Width="220" IsReadOnly="True"/>
                     </DataGrid.Columns>
                 </DataGrid>
             </Border>


### PR DESCRIPTION
## Summary
- Allow editing scanner hostnames directly from the status grid and choose groups via a combo box
- Persist hostname edits using `DeviceService.AddOrUpdateDeviceAsync` and continue assigning groups through `DeviceGroupService.AssignDeviceToGroupAsync`
- Add unit tests covering device renaming and group assignment behavior

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update && apt-get install -y dotnet-sdk-8.0` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b73afc2d588324997c5a30d7e45b65