### PR TITLE
Enable renaming device groups in scanner status

### DIFF
--- a/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
@@ -39,12 +39,18 @@ public class ScannerStatusViewModelTests
     {
         public List<DeviceGroup> Groups { get; } = new();
         public TaskCompletionSource<(string ip, int? groupId)> AssignTcs { get; } = new();
+        public TaskCompletionSource<DeviceGroup> UpdateTcs { get; } = new();
+        public DeviceGroup? UpdatedGroup { get; private set; }
         public Task<IEnumerable<DeviceGroup>> GetGroupsAsync(CancellationToken cancellationToken = default)
             => Task.FromResult<IEnumerable<DeviceGroup>>(Groups);
         public Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default)
             => Task.FromResult(0);
         public Task UpdateGroupAsync(DeviceGroup group, CancellationToken cancellationToken = default)
-            => Task.CompletedTask;
+        {
+            UpdatedGroup = group;
+            UpdateTcs.TrySetResult(group);
+            return Task.CompletedTask;
+        }
         public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
         public Task AssignDeviceToGroupAsync(string deviceIp, int? groupId, CancellationToken cancellationToken = default)
@@ -117,5 +123,26 @@ public class ScannerStatusViewModelTests
 
         Assert.Equal("1.2.3.4", assignment.ip);
         Assert.Equal(1, assignment.groupId);
+    }
+
+    [Fact]
+    public async Task RenamingGroup_UpdatesService()
+    {
+        var scanner = new StubScannerService();
+        var dialog = new StubDialogService();
+        var deviceService = new RecordingDeviceService();
+        var groupService = new RecordingDeviceGroupService();
+        groupService.Groups.Add(new DeviceGroup { Id = 1, Name = "Old" });
+        var fileService = new StubDeviceFileService();
+        var vm = new ScannerStatusViewModel(scanner, dialog, deviceService, groupService, fileService);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+        vm.SelectedGroup = vm.Groups[0];
+        vm.GroupName = "New";
+        await vm.RenameGroupCommand.ExecuteAsync(null);
+        var updated = await groupService.UpdateTcs.Task;
+
+        Assert.Equal(1, updated.Id);
+        Assert.Equal("New", updated.Name);
     }
 }

--- a/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
@@ -30,6 +30,26 @@ namespace InventoryManagementApp.ViewModels
         public ObservableCollection<DeviceGroup> Groups { get; } = new();
         public ObservableCollection<string> DeviceFiles { get; } = new();
 
+        DeviceGroup? _selectedGroup;
+        public DeviceGroup? SelectedGroup
+        {
+            get => _selectedGroup;
+            set
+            {
+                if (SetProperty(ref _selectedGroup, value))
+                {
+                    GroupName = value?.Name ?? string.Empty;
+                }
+            }
+        }
+
+        string _groupName = string.Empty;
+        public string GroupName
+        {
+            get => _groupName;
+            set => SetProperty(ref _groupName, value);
+        }
+
         private string _fileExtensionFilter = "*.*";
         public string FileExtensionFilter
         {
@@ -54,6 +74,7 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand RefreshCommand { get; }
         public IAsyncRelayCommand AddDeviceCommand { get; }
         public IAsyncRelayCommand AddGroupCommand { get; }
+        public IAsyncRelayCommand RenameGroupCommand { get; }
         public IAsyncRelayCommand LoadFilesCommand { get; }
 
         public Func<string?> PromptForIp { get; set; } = () =>
@@ -88,6 +109,7 @@ namespace InventoryManagementApp.ViewModels
             RefreshCommand = new AsyncRelayCommand(RefreshAsync);
             AddDeviceCommand = new AsyncRelayCommand(AddDeviceAsync);
             AddGroupCommand = new AsyncRelayCommand(AddGroupAsync);
+            RenameGroupCommand = new AsyncRelayCommand(RenameGroupAsync);
             LoadFilesCommand = new AsyncRelayCommand(LoadFilesAsync);
             _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
             _timer.Tick += OnTimerTick;
@@ -192,6 +214,24 @@ namespace InventoryManagementApp.ViewModels
             {
                 _logger.LogError(ex, "Failed to add scanner group");
                 await _dialogService.ShowInfoAsync($"Failed to add group: {ex.Message}", "Error");
+            }
+        }
+
+        async Task RenameGroupAsync()
+        {
+            if (SelectedGroup is null || string.IsNullOrWhiteSpace(GroupName))
+                return;
+
+            try
+            {
+                SelectedGroup.Name = GroupName;
+                await _groupService.UpdateGroupAsync(SelectedGroup);
+                await RefreshAsync(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to rename group {GroupId}", SelectedGroup.Id);
+                await _dialogService.ShowInfoAsync($"Failed to rename group: {ex.Message}", "Error");
             }
         }
 

--- a/InventoryManagementApp/Views/Windows/ScannerStatusWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ScannerStatusWindow.xaml
@@ -20,6 +20,15 @@
                 <StackPanel Orientation="Horizontal">
                     <Button Style="{StaticResource PrimaryButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
                     <CheckBox Content="Auto Refresh" IsChecked="{Binding AutoRefresh}" Margin="12,6,0,0"/>
+                    <ComboBox ItemsSource="{Binding Groups}"
+                              SelectedItem="{Binding SelectedGroup}"
+                              DisplayMemberPath="Name"
+                              Width="150"
+                              Margin="12,0,0,0"/>
+                    <TextBox Text="{Binding GroupName, UpdateSourceTrigger=PropertyChanged}"
+                             Width="150"
+                             Margin="12,0,0,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Rename" Command="{Binding RenameGroupCommand}" Margin="12,0,0,0"/>
                 </StackPanel>
             </Border>
 


### PR DESCRIPTION
## Summary
- allow selecting and renaming device groups in Scanner Status window
- add `RenameGroupCommand` to `ScannerStatusViewModel` to persist group name changes
- cover group renaming with unit tests

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b74fd6a5288324964403a4beaf155f