### PR TITLE
Use async dialog for unobserved task exceptions

### DIFF
--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -280,10 +280,10 @@ namespace InventoryManagementApp
             _dialogService.ShowInfo("An unexpected error occurred. The application may need to close.", "Error");
         }
 
-        internal void HandleTaskException(AggregateException ex, UnobservedTaskExceptionEventArgs? e = null)
+        internal async void HandleTaskException(AggregateException ex, UnobservedTaskExceptionEventArgs? e = null)
         {
             _logger.LogError(ex, "Unobserved task exception");
-            _dialogService.ShowInfo("An unexpected background error occurred.", "Error");
+            await _dialogService.ShowInfoAsync("An unexpected background error occurred.", "Error");
             if (e != null) e.SetObserved();
         }
 


### PR DESCRIPTION
## Summary
- Display unobserved task errors using async dialog API

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7628d43ec8324912943659cfe7f44