### PR TITLE
Handle cancellable port connect and add unreachable host test

### DIFF
--- a/InventoryManagementApp.Tests/DevicesViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DevicesViewModelTests.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models;
+using InventoryManagementApp.Services.Devices;
 using InventoryManagementApp.ViewModels;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 public class DevicesViewModelTests
@@ -123,5 +126,39 @@ public class DevicesViewModelTests
         await vm.RefreshCommand.ExecuteAsync(null);
 
         Assert.Equal("No subnets configured for device discovery.", dialog.LastInfoMessage);
+    }
+
+    [Fact]
+    public async Task RefreshCommand_UnreachableHosts_NoUnobservedExceptions()
+    {
+        bool unobserved = false;
+        void Handler(object? sender, UnobservedTaskExceptionEventArgs e) => unobserved = true;
+        TaskScheduler.UnobservedTaskException += Handler;
+        try
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["DeviceDiscovery:Subnets:0"] = "203.0.113.0/30"
+                })
+                .Build();
+
+            var discovery = new DeviceDiscoveryService(config);
+            var fileService = new RecordingDeviceFileService();
+            var dialog = new RecordingDialogService();
+            var vm = new DevicesViewModel(discovery, fileService, dialog);
+
+            await vm.RefreshCommand.ExecuteAsync(null);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            Assert.False(unobserved);
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= Handler;
+        }
     }
 }

--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -172,20 +172,36 @@ namespace InventoryManagementApp.Services.Devices
 
         private static async Task<bool> DefaultPortChecker(string ip, int port, CancellationToken ct)
         {
+            TcpClient? client = null;
+            Task? connectTask = null;
             try
             {
-                using var client = new TcpClient();
-                var connectTask = client.ConnectAsync(ip, port);
-                var timeout = Task.Delay(1000, ct);
-                var completed = await Task.WhenAny(connectTask, timeout).ConfigureAwait(false);
-                if (completed == connectTask)
+                client = new TcpClient();
+                connectTask = client.ConnectAsync(ip, port, ct);
+                await connectTask.WaitAsync(TimeSpan.FromSeconds(1), ct).ConfigureAwait(false);
+                return client.Connected;
+            }
+            catch (TimeoutException)
+            {
+                if (connectTask != null)
                 {
-                    await connectTask.ConfigureAwait(false);
-                    return client.Connected;
+                    try
+                    {
+                        client?.Dispose();
+                        await connectTask.ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        // Swallow exceptions from the abandoned connect task
+                    }
                 }
             }
             catch
             {
+            }
+            finally
+            {
+                client?.Dispose();
             }
             return false;
         }


### PR DESCRIPTION
## Summary
- ensure TCP port checks honor cancellation and dispose/await timed-out connections
- add test to confirm scanning unreachable hosts doesn't trigger unobserved exceptions

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 and unsigned)*

------
https://chatgpt.com/codex/tasks/task_e_68b76cd1f9a08324bbca464a46a67cc5