### PR TITLE
Fix TcpClient ConnectAsync result handling

### DIFF
--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -177,7 +177,7 @@ namespace InventoryManagementApp.Services.Devices
             try
             {
                 client = new TcpClient();
-                connectTask = client.ConnectAsync(ip, port, ct);
+                connectTask = client.ConnectAsync(ip, port, ct).AsTask();
                 await connectTask.WaitAsync(TimeSpan.FromSeconds(1), ct).ConfigureAwait(false);
                 return client.Connected;
             }


### PR DESCRIPTION
## Summary
- ensure DeviceDiscoveryService converts TcpClient.ConnectAsync to a Task

## Testing
- `dotnet build` *(fails: dotnet: command not found)*
- `dotnet test` *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7900eb0c08324979bdfef78b9219d