### PR TITLE
Set light theme as default

### DIFF
--- a/InventoryManagementApp.Tests/AppStartupTests.cs
+++ b/InventoryManagementApp.Tests/AppStartupTests.cs
@@ -261,7 +261,7 @@ namespace InventoryManagementApp.Tests
                     app.StartAsync().GetAwaiter().GetResult();
 
                     var themeSvc = (StubThemeService)host.Services.GetRequiredService<IThemeService>();
-                    Assert.Equal("Dark", themeSvc.AppliedTheme);
+                    Assert.Equal("Light", themeSvc.AppliedTheme);
 
                     app.Shutdown();
                 }

--- a/InventoryManagementApp.Tests/ThemeServiceTests.cs
+++ b/InventoryManagementApp.Tests/ThemeServiceTests.cs
@@ -39,6 +39,20 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task ApplyTheme_DefaultsToLightWhenThemeIsNull()
+        {
+            await RunOnStaThread(async () =>
+            {
+                var app = new Application();
+                var service = new ThemeService();
+                service.ApplyTheme(null);
+                Assert.Contains("Colors.Light.xaml", app.Resources.MergedDictionaries[0].Source.OriginalString);
+                app.Shutdown();
+                await Task.CompletedTask;
+            });
+        }
+
+        [Fact]
         public async Task ApplyTheme_ReplacesExistingDictionary()
         {
             await RunOnStaThread(async () =>

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -7,7 +7,7 @@
             <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <!-- Theme dictionary added at runtime -->
-                <ResourceDictionary Source="Resources/Colors.Dark.xaml"/>
+                <ResourceDictionary Source="Resources/Colors.Light.xaml"/>
                 <ResourceDictionary Source="Resources/Styles.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
                 <ResourceDictionary Source="Resources/Templates.xaml"/>

--- a/InventoryManagementApp/Services/ThemeService.cs
+++ b/InventoryManagementApp/Services/ThemeService.cs
@@ -16,7 +16,7 @@ namespace InventoryManagementApp.Services
             if (app == null) return;
 
             var dictionaries = app.Resources.MergedDictionaries;
-            var dict = string.Equals(theme, "Light", StringComparison.OrdinalIgnoreCase) ? _light : _dark;
+            var dict = string.Equals(theme, "Dark", StringComparison.OrdinalIgnoreCase) ? _dark : _light;
 
             // Remove any existing theme dictionaries
             for (int i = dictionaries.Count - 1; i >= 0; i--)


### PR DESCRIPTION
## Summary
- default to light theme resources
- ensure ThemeService defaults to light theme
- adjust tests for light default and add coverage

## Testing
- `./scripts/check-banned-words.sh`
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b7937aac04832494bd858c3fb9ec79