### PR TITLE
Refresh devices page on open

### DIFF
--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -530,9 +530,9 @@ namespace InventoryManagementApp.ViewModels
                 try
                 {
                     var vm = new DevicesViewModel(_deviceDiscoveryService, _deviceFileService, _dialogService);
+                    await vm.RefreshCommand.ExecuteAsync(null);
                     var page = new DevicesPage { DataContext = vm, Title = "Devices" };
                     CurrentPage = page;
-                    await Task.CompletedTask;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary
- Refresh device discovery before navigating to Devices page
- Preserve exception logging and user notification for device page opening

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b793b7b6808324b722c4fbbaa6a998