### PR TITLE
Configure device discovery subnet

### DIFF
--- a/InventoryManagementApp/appsettings.json
+++ b/InventoryManagementApp/appsettings.json
@@ -6,7 +6,7 @@
     "Directory": "Logs"
   },
   "DeviceDiscovery": {
-    "Subnets": [],
+    "Subnets": [ "192.168.1.0/24" ],
     "FtpPort": 21
   }
 }


### PR DESCRIPTION
## Summary
- configure DeviceDiscovery Subnets to search 192.168.1.0/24

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b79469aba08324881dd89efe08f8d9