### PR TITLE
Scan multiple FTP ports during device discovery

### DIFF
--- a/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
+++ b/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
@@ -15,7 +15,8 @@ public class DeviceDiscoveryServiceTests
         var configDict = new Dictionary<string, string?>
         {
             ["DeviceDiscovery:Subnets:0"] = "192.168.0.0/29",
-            ["DeviceDiscovery:FtpPort"] = "2121"
+            ["DeviceDiscovery:FtpPorts:0"] = "21",
+            ["DeviceDiscovery:FtpPorts:1"] = "2121"
         };
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(configDict!)
@@ -45,6 +46,37 @@ public class DeviceDiscoveryServiceTests
         var offline = devices.First(d => d.Ip == "192.168.0.3");
         Assert.False(offline.IsOnline);
         Assert.Empty(offline.Protocols);
+    }
+
+    [Fact]
+    public async Task DiscoverDevices_FindsFtpOnDifferentPorts()
+    {
+        var configDict = new Dictionary<string, string?>
+        {
+            ["DeviceDiscovery:Subnets:0"] = "192.168.0.0/29",
+            ["DeviceDiscovery:FtpPorts:0"] = "21",
+            ["DeviceDiscovery:FtpPorts:1"] = "2121"
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configDict!)
+            .Build();
+
+        Task<bool> PortChecker(string ip, int port, CancellationToken _)
+        {
+            if (ip == "192.168.0.2" && port == 21) return Task.FromResult(true);
+            if (ip == "192.168.0.3" && port == 2121) return Task.FromResult(true);
+            return Task.FromResult(false);
+        }
+
+        var service = new DeviceDiscoveryService(configuration, null, PortChecker);
+
+        var devices = (await service.DiscoverDevicesAsync()).ToList();
+
+        var ftp1 = devices.First(d => d.Ip == "192.168.0.2");
+        Assert.Contains(DeviceProtocol.Ftp, ftp1.Protocols);
+
+        var ftp2 = devices.First(d => d.Ip == "192.168.0.3");
+        Assert.Contains(DeviceProtocol.Ftp, ftp2.Protocols);
     }
 
     [Fact]

--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -20,7 +20,7 @@ namespace InventoryManagementApp.Services.Devices
         private readonly ILogger<DeviceDiscoveryService> _logger;
         private readonly Func<string, int, CancellationToken, Task<bool>> _portChecker;
         private readonly IList<string> _subnets;
-        private readonly int _ftpPort;
+        private readonly IList<int> _ftpPorts;
 
         public bool HasConfiguredSubnets => _subnets.Count > 0;
 
@@ -45,7 +45,9 @@ namespace InventoryManagementApp.Services.Devices
                     _logger.LogInformation("Using auto-detected subnets: {Subnets}", string.Join(", ", _subnets));
                 }
             }
-            _ftpPort = configuration.GetValue<int?>("DeviceDiscovery:FtpPort") ?? 21;
+            _ftpPorts = configuration.GetSection("DeviceDiscovery:FtpPorts").Get<IList<int>>() ?? new List<int> { 21 };
+            if (_ftpPorts.Count == 0)
+                _ftpPorts.Add(21);
         }
 
         public async Task<IReadOnlyList<DiscoveredDevice>> DiscoverDevicesAsync(CancellationToken cancellationToken = default)
@@ -86,8 +88,14 @@ namespace InventoryManagementApp.Services.Devices
             {
                 if (await _portChecker(ip, 445, ct).ConfigureAwait(false))
                     protocols.Add(DeviceProtocol.Smb);
-                if (await _portChecker(ip, _ftpPort, ct).ConfigureAwait(false))
-                    protocols.Add(DeviceProtocol.Ftp);
+                foreach (var ftpPort in _ftpPorts)
+                {
+                    if (await _portChecker(ip, ftpPort, ct).ConfigureAwait(false))
+                    {
+                        protocols.Add(DeviceProtocol.Ftp);
+                        break;
+                    }
+                }
             }
             catch (Exception ex)
             {

--- a/InventoryManagementApp/appsettings.json
+++ b/InventoryManagementApp/appsettings.json
@@ -7,6 +7,6 @@
   },
   "DeviceDiscovery": {
     "Subnets": [ "192.168.1.0/24" ],
-    "FtpPort": 21
+    "FtpPorts": [21, 3721]
   }
 }


### PR DESCRIPTION
## Summary
- allow configuration of multiple FTP ports via `DeviceDiscovery:FtpPorts`
- scan all configured FTP ports when discovering devices
- add unit tests for multi-port FTP discovery

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden when attempting to install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b79b7693188324a7f9d2e3e27c2f8d