### PR TITLE
Support multiple FTP ports for device discovery

### DIFF
--- a/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
+++ b/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
@@ -82,7 +82,14 @@ public class DeviceDiscoveryServiceTests
     [Fact]
     public async Task DiscoverDevices_UsesAutoDetectedSubnets()
     {
-        var configuration = new ConfigurationBuilder().Build();
+        var configDict = new Dictionary<string, string?>
+        {
+            ["DeviceDiscovery:FtpPorts:0"] = "21",
+            ["DeviceDiscovery:FtpPorts:1"] = "2121"
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configDict!)
+            .Build();
 
         IList<string> detected = new List<string> { "192.168.0.0/29" };
 
@@ -105,7 +112,14 @@ public class DeviceDiscoveryServiceTests
     [Fact]
     public async Task DiscoverDevices_NoConfigOrDetectedSubnets_ReturnsEmpty()
     {
-        var configuration = new ConfigurationBuilder().Build();
+        var configDict = new Dictionary<string, string?>
+        {
+            ["DeviceDiscovery:FtpPorts:0"] = "21",
+            ["DeviceDiscovery:FtpPorts:1"] = "2121"
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configDict!)
+            .Build();
         var service = new DeviceDiscoveryService(configuration, null, null, () => new List<string>());
 
         Assert.False(service.HasConfiguredSubnets);

--- a/InventoryManagementApp/appsettings.json
+++ b/InventoryManagementApp/appsettings.json
@@ -7,6 +7,6 @@
   },
   "DeviceDiscovery": {
     "Subnets": [ "192.168.1.0/24" ],
-    "FtpPort": 21
+    "FtpPorts": [21, 3721]
   }
 }


### PR DESCRIPTION
## Summary
- Configure DeviceDiscovery to use `FtpPorts` array in app settings
- Update DeviceDiscoveryService tests to configure FTP port arrays

## Testing
- `dotnet test` *(fails: command not found)*
- `./scripts/check-banned-words.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b7a20be8b08324b03f707f35cf9cd8