### PR TITLE
Handle hosts without FTP/SMB as Unknown

### DIFF
--- a/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
+++ b/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
@@ -127,4 +127,26 @@ public class DeviceDiscoveryServiceTests
 
         Assert.Empty(devices);
     }
+
+    [Fact]
+    public async Task DiscoverDevices_PingResponsiveHostWithoutPorts_ReturnsUnknown()
+    {
+        var configDict = new Dictionary<string, string?>
+        {
+            ["DeviceDiscovery:Subnets:0"] = "127.0.0.1"
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configDict!)
+            .Build();
+
+        Task<bool> PortChecker(string ip, int port, CancellationToken _) => Task.FromResult(false);
+
+        var service = new DeviceDiscoveryService(configuration, null, PortChecker);
+
+        var devices = await service.DiscoverDevicesAsync();
+
+        var device = Assert.Single(devices);
+        Assert.True(device.IsOnline);
+        Assert.Contains(DeviceProtocol.Unknown, device.Protocols);
+    }
 }

--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -140,13 +140,18 @@ namespace InventoryManagementApp.Services.Devices
                 }
             }
 
+            if (alive && protocols.Count == 0)
+            {
+                protocols.Add(DeviceProtocol.Unknown);
+            }
+
             var hostname = await ResolveName(ip, ct).ConfigureAwait(false);
 
             return new DiscoveredDevice
             {
                 Ip = ip,
                 Hostname = string.IsNullOrWhiteSpace(hostname) ? ip : hostname,
-                IsOnline = alive && protocols.Count > 0,
+                IsOnline = alive,
                 Protocols = protocols
             };
         }

--- a/InventoryManagementApp/ViewModels/DevicesViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DevicesViewModel.cs
@@ -89,7 +89,7 @@ namespace InventoryManagementApp.ViewModels
                     {
                         Ip = d.Ip,
                         Hostname = d.Hostname,
-                        Protocol = d.Protocols.FirstOrDefault(),
+                        Protocol = d.Protocols.FirstOrDefault(DeviceProtocol.Unknown),
                         Status = d.IsOnline ? "Online" : "Offline"
                     });
                 }


### PR DESCRIPTION
## Summary
- Treat ping-responsive devices with no open FTP/SMB ports as online with Unknown protocol
- Preserve unknown protocol devices in device list
- Test: ensure pingable host with no FTP/SMB ports returns Unknown

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden from repository)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ab7561b08324979122273f2b506b