### PR TITLE
feat: support additional device ports

### DIFF
--- a/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
+++ b/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
@@ -80,6 +80,42 @@ public class DeviceDiscoveryServiceTests
     }
 
     [Fact]
+    public async Task DiscoverDevices_FindsAdditionalPorts()
+    {
+        var configDict = new Dictionary<string, string?>
+        {
+            ["DeviceDiscovery:Subnets:0"] = "192.168.0.0/29",
+            ["DeviceDiscovery:AdditionalPorts:5555"] = "Adb",
+            ["DeviceDiscovery:AdditionalPorts:80"] = "Http",
+            ["DeviceDiscovery:AdditionalPorts:8080"] = "Http"
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configDict!)
+            .Build();
+
+        Task<bool> PortChecker(string ip, int port, CancellationToken _)
+        {
+            if (ip == "192.168.0.2" && port == 5555) return Task.FromResult(true);
+            if (ip == "192.168.0.3" && port == 80) return Task.FromResult(true);
+            if (ip == "192.168.0.4" && port == 8080) return Task.FromResult(true);
+            return Task.FromResult(false);
+        }
+
+        var service = new DeviceDiscoveryService(configuration, null, PortChecker);
+
+        var devices = (await service.DiscoverDevicesAsync()).ToList();
+
+        var adb = devices.First(d => d.Ip == "192.168.0.2");
+        Assert.Contains(DeviceProtocol.Adb, adb.Protocols);
+
+        var http1 = devices.First(d => d.Ip == "192.168.0.3");
+        Assert.Contains(DeviceProtocol.Http, http1.Protocols);
+
+        var http2 = devices.First(d => d.Ip == "192.168.0.4");
+        Assert.Contains(DeviceProtocol.Http, http2.Protocols);
+    }
+
+    [Fact]
     public async Task DiscoverDevices_UsesAutoDetectedSubnets()
     {
         var configDict = new Dictionary<string, string?>

--- a/InventoryManagementApp/Models/Device.cs
+++ b/InventoryManagementApp/Models/Device.cs
@@ -7,7 +7,9 @@ namespace InventoryManagementApp.Models
     {
         Unknown,
         Smb,
-        Ftp
+        Ftp,
+        Adb,
+        Http
     }
 
     public class Device : ObservableObject

--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -25,6 +25,7 @@ namespace InventoryManagementApp.Services.Devices
         private readonly Func<string, int, CancellationToken, Task<bool>> _portChecker;
         private readonly IList<string> _subnets;
         private readonly int[] _ftpPorts;
+        private readonly IDictionary<int, DeviceProtocol> _additionalPorts;
 
         public bool HasConfiguredSubnets => _subnets.Count > 0;
 
@@ -52,6 +53,7 @@ namespace InventoryManagementApp.Services.Devices
             }
 
             _ftpPorts = configuration.GetSection("DeviceDiscovery:FtpPorts").Get<int[]>() ?? new[] { 21, 3721 };
+            _additionalPorts = configuration.GetSection("DeviceDiscovery:AdditionalPorts").Get<Dictionary<int, DeviceProtocol>>() ?? new Dictionary<int, DeviceProtocol>();
         }
 
         public async Task<IReadOnlyList<DiscoveredDevice>> DiscoverDevicesAsync(CancellationToken cancellationToken = default)
@@ -136,6 +138,24 @@ namespace InventoryManagementApp.Services.Devices
                     catch (Exception ex)
                     {
                         _logger.LogDebug(ex, "Error checking FTP port {Port} on {Ip}", port, ip);
+                    }
+                }
+
+                foreach (var kvp in _additionalPorts)
+                {
+                    if (protocols.Contains(kvp.Value))
+                        continue;
+
+                    try
+                    {
+                        if (await _portChecker(ip, kvp.Key, ct).ConfigureAwait(false))
+                        {
+                            protocols.Add(kvp.Value);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogDebug(ex, "Error checking port {Port} on {Ip}", kvp.Key, ip);
                     }
                 }
             }

--- a/InventoryManagementApp/appsettings.json
+++ b/InventoryManagementApp/appsettings.json
@@ -7,6 +7,11 @@
   },
   "DeviceDiscovery": {
     "Subnets": [ "192.168.1.0/24" ],
-    "FtpPorts": [21, 3721]
+    "FtpPorts": [21, 3721],
+    "AdditionalPorts": {
+      "5555": "Adb",
+      "80": "Http",
+      "8080": "Http"
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,30 @@ These options enable using the app for tracking AV gear, sports equipment, or an
 ## Configuration
 The application reads configuration from `appsettings.json`. By default, the SQLite database is stored in `inventory.db` within the application's base directory. This path can be changed by updating the `Database:Path` setting.
 
+### Device Discovery
+`DeviceDiscovery` settings control how the network scanner looks for devices. Besides `Subnets` and `FtpPorts`, you can add an
+`AdditionalPorts` section mapping TCP ports to protocols. When any of these ports respond, the corresponding `DeviceProtocol`
+is added to the discovered device.
+
+Example:
+
+```json
+{
+  "DeviceDiscovery": {
+    "Subnets": [ "192.168.1.0/24" ],
+    "FtpPorts": [21, 3721],
+    "AdditionalPorts": {
+      "5555": "Adb",
+      "80": "Http",
+      "8080": "Http"
+    }
+  }
+}
+```
+
+This configuration detects Android Debug Bridge on port `5555` and HTTP services on ports `80` or `8080`.
+
+
 ## Device File Service
 `IDeviceFileService` connects to network devices over SMB or FTP to list and download files.
 


### PR DESCRIPTION
## Summary
- allow configuring extra discovery ports and protocols
- detect ADB and HTTP ports during device scanning
- document adding custom ports

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ac92802c8324aa5327fabf7b1909