### PR TITLE
Disable Refresh during discovery

### DIFF
--- a/InventoryManagementApp.Tests/DevicesViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DevicesViewModelTests.cs
@@ -114,6 +114,28 @@ public class DevicesViewModelTests
     }
 
     [Fact]
+    public async Task RefreshCommand_DisabledDuringDiscovery()
+    {
+        var discovery = new StubDiscoveryService();
+        var fileService = new RecordingDeviceFileService();
+        var dialog = new RecordingDialogService();
+        discovery.Devices.Add(new DiscoveredDevice { Ip = "1.1.1.1", Hostname = "a", IsOnline = true, Protocols = new List<DeviceProtocol>() });
+        var vm = new DevicesViewModel(discovery, fileService, dialog);
+
+        Assert.True(vm.RefreshCommand.CanExecute(null));
+
+        var task = vm.RefreshCommand.ExecuteAsync(null);
+        while (!vm.IsDiscovering)
+            await Task.Delay(1);
+
+        Assert.False(vm.RefreshCommand.CanExecute(null));
+
+        await task;
+
+        Assert.True(vm.RefreshCommand.CanExecute(null));
+    }
+
+    [Fact]
     public async Task PullAllReportsCommand_LoadsFiles()
     {
         var discovery = new StubDiscoveryService();

--- a/InventoryManagementApp/ViewModels/DevicesViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DevicesViewModel.cs
@@ -57,7 +57,13 @@ namespace InventoryManagementApp.ViewModels
         public bool IsDiscovering
         {
             get => _isDiscovering;
-            private set => SetProperty(ref _isDiscovering, value);
+            private set
+            {
+                if (SetProperty(ref _isDiscovering, value))
+                {
+                    RefreshCommand.NotifyCanExecuteChanged();
+                }
+            }
         }
 
         public DevicesViewModel(IDeviceDiscoveryService discoveryService,
@@ -70,7 +76,7 @@ namespace InventoryManagementApp.ViewModels
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<DevicesViewModel>.Instance;
 
-            RefreshCommand = new AsyncRelayCommand(RefreshAsync);
+            RefreshCommand = new AsyncRelayCommand(RefreshAsync, () => !IsDiscovering);
             PullAllReportsCommand = new AsyncRelayCommand(PullAllReportsAsync, CanPullAllReports);
         }
 


### PR DESCRIPTION
## Summary
- Prevent Refresh while device discovery is in progress by tying command availability to IsDiscovering
- Notify command availability changes when discovery state updates
- Add unit test ensuring RefreshCommand is disabled during discovery

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b7c5f95ccc8324823acaa63fcef768