### PR TITLE
Parallelize device protocol checks and cancel extra FTP probes

### DIFF
--- a/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
+++ b/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
@@ -185,4 +185,40 @@ public class DeviceDiscoveryServiceTests
         Assert.True(device.IsOnline);
         Assert.Contains(DeviceProtocol.Unknown, device.Protocols);
     }
+
+    [Fact]
+    public async Task ScanIpAsync_CancelsRemainingFtpChecksAfterFirstSuccess()
+    {
+        var configDict = new Dictionary<string, string?>
+        {
+            ["DeviceDiscovery:Subnets:0"] = "192.168.0.1",
+            ["DeviceDiscovery:FtpPorts:0"] = "21",
+            ["DeviceDiscovery:FtpPorts:1"] = "2121"
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configDict!)
+            .Build();
+
+        var secondCancelled = false;
+        Task<bool> PortChecker(string ip, int port, CancellationToken token)
+        {
+            if (port == 21)
+                return Task.FromResult(true);
+            if (port == 2121)
+            {
+                var tcs = new TaskCompletionSource<bool>();
+                token.Register(() => { secondCancelled = true; tcs.TrySetCanceled(token); });
+                return tcs.Task;
+            }
+            return Task.FromResult(false);
+        }
+
+        var service = new DeviceDiscoveryService(configuration, null, PortChecker);
+
+        var devices = await service.DiscoverDevicesAsync();
+
+        var device = Assert.Single(devices);
+        Assert.Contains(DeviceProtocol.Ftp, device.Protocols);
+        Assert.True(secondCancelled);
+    }
 }

--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -115,47 +115,51 @@ namespace InventoryManagementApp.Services.Devices
 
             if (alive)
             {
-                try
+                async Task<DeviceProtocol?> CheckPortAsync(int port, DeviceProtocol protocol, CancellationToken token)
                 {
-                    if (await _portChecker(ip, 445, ct).ConfigureAwait(false))
-                        protocols.Add(DeviceProtocol.Smb);
+                    try
+                    {
+                        if (await _portChecker(ip, port, token).ConfigureAwait(false))
+                            return protocol;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // ignore cancellation
+                    }
+                    catch (Exception ex)
+                    {
+                        if (protocol == DeviceProtocol.Smb)
+                            _logger.LogDebug(ex, "Error checking SMB on {Ip}", ip);
+                        else if (protocol == DeviceProtocol.Ftp)
+                            _logger.LogDebug(ex, "Error checking FTP port {Port} on {Ip}", port, ip);
+                        else
+                            _logger.LogDebug(ex, "Error checking port {Port} on {Ip}", port, ip);
+                    }
+                    return null;
                 }
-                catch (Exception ex)
+
+                using var ftpCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                var tasks = new List<Task<DeviceProtocol?>>
                 {
-                    _logger.LogDebug(ex, "Error checking SMB on {Ip}", ip);
-                }
+                    CheckPortAsync(445, DeviceProtocol.Smb, ct)
+                };
 
                 foreach (var port in _ftpPorts)
-                {
-                    try
-                    {
-                        if (await _portChecker(ip, port, ct).ConfigureAwait(false))
-                        {
-                            protocols.Add(DeviceProtocol.Ftp);
-                            break;
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogDebug(ex, "Error checking FTP port {Port} on {Ip}", port, ip);
-                    }
-                }
+                    tasks.Add(CheckPortAsync(port, DeviceProtocol.Ftp, ftpCts.Token));
 
                 foreach (var kvp in _additionalPorts)
-                {
-                    if (protocols.Contains(kvp.Value))
-                        continue;
+                    tasks.Add(CheckPortAsync(kvp.Key, kvp.Value, ct));
 
-                    try
+                while (tasks.Count > 0)
+                {
+                    var completed = await Task.WhenAny(tasks).ConfigureAwait(false);
+                    tasks.Remove(completed);
+                    var proto = await completed.ConfigureAwait(false);
+                    if (proto.HasValue && !protocols.Contains(proto.Value))
                     {
-                        if (await _portChecker(ip, kvp.Key, ct).ConfigureAwait(false))
-                        {
-                            protocols.Add(kvp.Value);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogDebug(ex, "Error checking port {Port} on {Ip}", kvp.Key, ip);
+                        protocols.Add(proto.Value);
+                        if (proto.Value == DeviceProtocol.Ftp)
+                            ftpCts.Cancel();
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Scan each IP's SMB, FTP, and configured ports in parallel
- Cancel outstanding FTP port checks once one port responds
- Add unit test to ensure FTP checks are cancelled after first success

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cbe491bc832498565ff51d60cadb