### PR TITLE
feat: configure max device discovery concurrency

### DIFF
--- a/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
+++ b/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Models;
@@ -9,6 +10,36 @@ using Xunit;
 
 public class DeviceDiscoveryServiceTests
 {
+    [Fact]
+    public void Constructor_UsesConfiguredMaxConcurrentScans()
+    {
+        var configDict = new Dictionary<string, string?>
+        {
+            ["DeviceDiscovery:MaxConcurrentScans"] = "42"
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configDict!)
+            .Build();
+
+        var service = new DeviceDiscoveryService(configuration, null, null, () => new List<string>());
+
+        var field = typeof(DeviceDiscoveryService).GetField("_maxConcurrentScans", BindingFlags.NonPublic | BindingFlags.Instance);
+        var value = Assert.IsType<int>(field!.GetValue(service));
+        Assert.Equal(42, value);
+    }
+
+    [Fact]
+    public void Constructor_DefaultsMaxConcurrentScansTo128()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+
+        var service = new DeviceDiscoveryService(configuration, null, null, () => new List<string>());
+
+        var field = typeof(DeviceDiscoveryService).GetField("_maxConcurrentScans", BindingFlags.NonPublic | BindingFlags.Instance);
+        var value = Assert.IsType<int>(field!.GetValue(service));
+        Assert.Equal(128, value);
+    }
+
     [Fact]
     public async Task DiscoverDevices_FindsProtocolsAndMarksStatus()
     {

--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -26,6 +26,7 @@ namespace InventoryManagementApp.Services.Devices
         private readonly IList<string> _subnets;
         private readonly int[] _ftpPorts;
         private readonly IDictionary<int, DeviceProtocol> _additionalPorts;
+        private readonly int _maxConcurrentScans;
 
         public bool HasConfiguredSubnets => _subnets.Count > 0;
 
@@ -54,6 +55,7 @@ namespace InventoryManagementApp.Services.Devices
 
             _ftpPorts = configuration.GetSection("DeviceDiscovery:FtpPorts").Get<int[]>() ?? new[] { 21, 3721 };
             _additionalPorts = configuration.GetSection("DeviceDiscovery:AdditionalPorts").Get<Dictionary<int, DeviceProtocol>>() ?? new Dictionary<int, DeviceProtocol>();
+            _maxConcurrentScans = configuration.GetValue<int?>("DeviceDiscovery:MaxConcurrentScans") ?? 128;
         }
 
         public async Task<IReadOnlyList<DiscoveredDevice>> DiscoverDevicesAsync(CancellationToken cancellationToken = default)
@@ -82,7 +84,7 @@ namespace InventoryManagementApp.Services.Devices
             var channel = Channel.CreateUnbounded<DiscoveredDevice>();
             int processed = 0;
 
-            using var semaphore = new SemaphoreSlim(128);
+            using var semaphore = new SemaphoreSlim(_maxConcurrentScans);
             var tasks = addresses.Select(async ip =>
             {
                 await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);

--- a/InventoryManagementApp/appsettings.json
+++ b/InventoryManagementApp/appsettings.json
@@ -12,6 +12,7 @@
       "5555": "Adb",
       "80": "Http",
       "8080": "Http"
-    }
+    },
+    "MaxConcurrentScans": 128
   }
 }


### PR DESCRIPTION
## Summary
- add DeviceDiscovery:MaxConcurrentScans setting
- make DeviceDiscoveryService use configurable scan concurrency
- test max concurrent scan configuration

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ceb5d2648324910387ebfdcf241d