### PR TITLE
feat: make discovery timeouts configurable

### DIFF
--- a/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
+++ b/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
@@ -41,6 +41,43 @@ public class DeviceDiscoveryServiceTests
     }
 
     [Fact]
+    public void Constructor_UsesConfiguredTimeouts()
+    {
+        var configDict = new Dictionary<string, string?>
+        {
+            ["DeviceDiscovery:LivenessTimeoutMs"] = "1234",
+            ["DeviceDiscovery:PortProbeTimeoutMs"] = "5678"
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configDict!)
+            .Build();
+
+        var service = new DeviceDiscoveryService(configuration, null, null, () => new List<string>());
+
+        var livenessField = typeof(DeviceDiscoveryService).GetField("_livenessTimeoutMs", BindingFlags.NonPublic | BindingFlags.Instance);
+        var portField = typeof(DeviceDiscoveryService).GetField("_portProbeTimeoutMs", BindingFlags.NonPublic | BindingFlags.Instance);
+        var livenessValue = Assert.IsType<int>(livenessField!.GetValue(service));
+        var portValue = Assert.IsType<int>(portField!.GetValue(service));
+        Assert.Equal(1234, livenessValue);
+        Assert.Equal(5678, portValue);
+    }
+
+    [Fact]
+    public void Constructor_DefaultsTimeouts()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+
+        var service = new DeviceDiscoveryService(configuration, null, null, () => new List<string>());
+
+        var livenessField = typeof(DeviceDiscoveryService).GetField("_livenessTimeoutMs", BindingFlags.NonPublic | BindingFlags.Instance);
+        var portField = typeof(DeviceDiscoveryService).GetField("_portProbeTimeoutMs", BindingFlags.NonPublic | BindingFlags.Instance);
+        var livenessValue = Assert.IsType<int>(livenessField!.GetValue(service));
+        var portValue = Assert.IsType<int>(portField!.GetValue(service));
+        Assert.Equal(400, livenessValue);
+        Assert.Equal(700, portValue);
+    }
+
+    [Fact]
     public async Task DiscoverDevices_FindsProtocolsAndMarksStatus()
     {
         var configDict = new Dictionary<string, string?>

--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -27,6 +27,8 @@ namespace InventoryManagementApp.Services.Devices
         private readonly int[] _ftpPorts;
         private readonly IDictionary<int, DeviceProtocol> _additionalPorts;
         private readonly int _maxConcurrentScans;
+        private readonly int _livenessTimeoutMs;
+        private readonly int _portProbeTimeoutMs;
 
         public bool HasConfiguredSubnets => _subnets.Count > 0;
 
@@ -56,6 +58,8 @@ namespace InventoryManagementApp.Services.Devices
             _ftpPorts = configuration.GetSection("DeviceDiscovery:FtpPorts").Get<int[]>() ?? new[] { 21, 3721 };
             _additionalPorts = configuration.GetSection("DeviceDiscovery:AdditionalPorts").Get<Dictionary<int, DeviceProtocol>>() ?? new Dictionary<int, DeviceProtocol>();
             _maxConcurrentScans = configuration.GetValue<int?>("DeviceDiscovery:MaxConcurrentScans") ?? 128;
+            _livenessTimeoutMs = configuration.GetValue<int?>("DeviceDiscovery:LivenessTimeoutMs") ?? 400;
+            _portProbeTimeoutMs = configuration.GetValue<int?>("DeviceDiscovery:PortProbeTimeoutMs") ?? 700;
         }
 
         public async Task<IReadOnlyList<DiscoveredDevice>> DiscoverDevicesAsync(CancellationToken cancellationToken = default)
@@ -182,14 +186,14 @@ namespace InventoryManagementApp.Services.Devices
             };
         }
 
-        private static async Task<bool> IsAlive(string ip, CancellationToken ct)
+        private async Task<bool> IsAlive(string ip, CancellationToken ct)
         {
             if (await HasArpEntry(ip).ConfigureAwait(false)) return true;
 
             try
             {
                 using var ping = new Ping();
-                var reply = await ping.SendPingAsync(ip, 400).ConfigureAwait(false);
+                var reply = await ping.SendPingAsync(ip, _livenessTimeoutMs).ConfigureAwait(false);
                 if (reply.Status == IPStatus.Success) return true;
             }
             catch { /* ignore */ }
@@ -197,7 +201,7 @@ namespace InventoryManagementApp.Services.Devices
             var ports = new[] { 445, 80, 21, 3721 };
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             var probes = ports
-                .Select(p => SafeTcpProbeAsync(ip, p, 400, cts.Token))
+                .Select(p => SafeTcpProbeAsync(ip, p, _livenessTimeoutMs, cts.Token))
                 .ToList();
 
             while (probes.Count > 0)
@@ -358,8 +362,8 @@ namespace InventoryManagementApp.Services.Devices
             }
         }
 
-        private static Task<bool> DefaultPortChecker(string ip, int port, CancellationToken ct)
-            => SafeTcpProbeAsync(ip, port, timeoutMs: 700, ct);
+        private Task<bool> DefaultPortChecker(string ip, int port, CancellationToken ct)
+            => SafeTcpProbeAsync(ip, port, _portProbeTimeoutMs, ct);
 
         private static Task<bool> QuickTcp(string ip, int port, int timeoutMs, CancellationToken ct)
             => SafeTcpProbeAsync(ip, port, timeoutMs, ct);

--- a/InventoryManagementApp/appsettings.json
+++ b/InventoryManagementApp/appsettings.json
@@ -13,6 +13,8 @@
       "80": "Http",
       "8080": "Http"
     },
-    "MaxConcurrentScans": 128
+    "MaxConcurrentScans": 128,
+    "LivenessTimeoutMs": 400,
+    "PortProbeTimeoutMs": 700
   }
 }


### PR DESCRIPTION
## Summary
- allow configuring liveness and port probe timeouts for device discovery
- wire timeout settings into discovery routines
- cover new settings with unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cf80e3e48324a2c1c891b15f0c6e