### PR TITLE
Display multiple device protocols

### DIFF
--- a/InventoryManagementApp.Tests/DevicesPageTests.cs
+++ b/InventoryManagementApp.Tests/DevicesPageTests.cs
@@ -6,6 +6,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Documents;
+using System.Windows.Controls;
+using System.Windows.Media;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models;
 using InventoryManagementApp.Models.Domain;
@@ -64,6 +66,55 @@ namespace InventoryManagementApp.Tests
             Assert.Empty(errors);
         }
 
+        [Fact]
+        public void DevicesPage_DisplaysProtocols()
+        {
+            Exception? threadEx = null;
+            string? cellText = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary
+                    {
+                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                    });
+
+                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService());
+                    vm.Devices.Add(new Device { Ip = "1.2.3.4", Hostname = "test", ProtocolsDisplay = "Smb, Http" });
+
+                    var page = new DevicesPage { DataContext = vm };
+                    page.ApplyTemplate();
+                    var grid = FindVisualChild<DataGrid>(page);
+                    grid?.ApplyTemplate();
+                    grid?.UpdateLayout();
+                    if (grid != null)
+                    {
+                        grid.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+                        grid.Arrange(new Rect(0, 0, grid.DesiredSize.Width, grid.DesiredSize.Height));
+                        grid.UpdateLayout();
+                        var textBlock = grid.Columns[2].GetCellContent(grid.Items[0]) as TextBlock;
+                        cellText = textBlock?.Text;
+                    }
+
+                    Application.Current?.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadEx != null) throw threadEx;
+            Assert.Equal("Smb, Http", cellText);
+        }
+
         private sealed class BindingErrorTraceListener : TraceListener
         {
             private readonly List<string> _errors;
@@ -104,6 +155,21 @@ namespace InventoryManagementApp.Tests
             public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }
+        }
+
+        private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+        {
+            int count = VisualTreeHelper.GetChildrenCount(parent);
+            for (int i = 0; i < count; i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                if (child is T typedChild)
+                    return typedChild;
+                var result = FindVisualChild<T>(child);
+                if (result != null)
+                    return result;
+            }
+            return null;
         }
     }
 }

--- a/InventoryManagementApp.Tests/DevicesViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DevicesViewModelTests.cs
@@ -88,6 +88,28 @@ public class DevicesViewModelTests
         Assert.Single(vm.Devices);
         Assert.Equal("1.2.3.4", vm.Devices[0].Ip);
         Assert.Equal("Online", vm.Devices[0].Status);
+        Assert.Equal("Ftp", vm.Devices[0].ProtocolsDisplay);
+    }
+
+    [Fact]
+    public async Task RefreshCommand_AggregatesMultipleProtocols()
+    {
+        var discovery = new StubDiscoveryService();
+        var fileService = new RecordingDeviceFileService();
+        var dialog = new RecordingDialogService();
+        discovery.Devices.Add(new DiscoveredDevice
+        {
+            Ip = "1.2.3.5",
+            Hostname = "multi",
+            IsOnline = true,
+            Protocols = new List<DeviceProtocol> { DeviceProtocol.Smb, DeviceProtocol.Http }
+        });
+        var vm = new DevicesViewModel(discovery, fileService, dialog);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Single(vm.Devices);
+        Assert.Equal("Smb, Http", vm.Devices[0].ProtocolsDisplay);
     }
 
     [Fact]

--- a/InventoryManagementApp/Models/Device.cs
+++ b/InventoryManagementApp/Models/Device.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace InventoryManagementApp.Models
@@ -17,6 +18,8 @@ namespace InventoryManagementApp.Models
         string _ip = string.Empty;
         string _hostname = string.Empty;
         DeviceProtocol _protocol;
+        List<DeviceProtocol> _protocols = new();
+        string _protocolsDisplay = string.Empty;
         string _status = string.Empty;
         DateTime _lastSeen;
         string _username = string.Empty;
@@ -42,6 +45,18 @@ namespace InventoryManagementApp.Models
         {
             get => _protocol;
             set => SetProperty(ref _protocol, value);
+        }
+
+        public IList<DeviceProtocol> Protocols
+        {
+            get => _protocols;
+            set => SetProperty(ref _protocols, (List<DeviceProtocol>)value);
+        }
+
+        public string ProtocolsDisplay
+        {
+            get => _protocolsDisplay;
+            set => SetProperty(ref _protocolsDisplay, value);
         }
 
         public string Status

--- a/InventoryManagementApp/ViewModels/DevicesViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DevicesViewModel.cs
@@ -97,6 +97,10 @@ namespace InventoryManagementApp.ViewModels
                         Ip = d.Ip,
                         Hostname = d.Hostname,
                         Protocol = d.Protocols.FirstOrDefault(DeviceProtocol.Unknown),
+                        Protocols = d.Protocols.ToList(),
+                        ProtocolsDisplay = d.Protocols.Count > 0
+                            ? string.Join(", ", d.Protocols)
+                            : DeviceProtocol.Unknown.ToString(),
                         Status = d.IsOnline ? "Online" : "Offline"
                     });
                 }

--- a/InventoryManagementApp/Views/Pages/DevicesPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DevicesPage.xaml
@@ -44,7 +44,7 @@
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="IP" Binding="{Binding Ip}" Width="150"/>
                         <DataGridTextColumn Header="Hostname" Binding="{Binding Hostname}" Width="*"/>
-                        <DataGridTextColumn Header="Protocol" Binding="{Binding Protocol}" Width="120"/>
+                        <DataGridTextColumn Header="Protocols" Binding="{Binding ProtocolsDisplay}" Width="150"/>
                         <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="120"/>
                     </DataGrid.Columns>
                 </DataGrid>


### PR DESCRIPTION
## Summary
- collect all device protocols and expose formatted string via `ProtocolsDisplay`
- show protocols column in Devices page
- test multi-protocol aggregation and display

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d8a31fd08324989b597ec29edd0f