### PR TITLE
Propagate MAC addresses through device discovery

### DIFF
--- a/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
+++ b/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
@@ -373,4 +373,19 @@ public class DeviceDiscoveryServiceTests
         var result = await task.ConfigureAwait(false);
         Assert.Equal(string.Empty, result);
     }
+
+    [Fact]
+    public async Task ScanIpAsync_PopulatesMacAddressFromArpTable()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+        Task<bool> PortChecker(string _, int __, CancellationToken ___) => Task.FromResult(false);
+        var service = new DeviceDiscoveryService(configuration, null, PortChecker, () => new List<string>());
+
+        var method = typeof(DeviceDiscoveryService).GetMethod("ScanIpAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var arp = new Dictionary<string, string> { ["192.168.0.1"] = "aa-bb-cc-dd-ee-ff" };
+        var task = (Task<DiscoveredDevice>)method.Invoke(service, new object[] { "192.168.0.1", arp, CancellationToken.None })!;
+        var device = await task.ConfigureAwait(false);
+
+        Assert.Equal("aa-bb-cc-dd-ee-ff", device.MacAddress);
+    }
 }

--- a/InventoryManagementApp.Tests/DevicesPageTests.cs
+++ b/InventoryManagementApp.Tests/DevicesPageTests.cs
@@ -95,7 +95,7 @@ namespace InventoryManagementApp.Tests
                         grid.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
                         grid.Arrange(new Rect(0, 0, grid.DesiredSize.Width, grid.DesiredSize.Height));
                         grid.UpdateLayout();
-                        var textBlock = grid.Columns[2].GetCellContent(grid.Items[0]) as TextBlock;
+                        var textBlock = grid.Columns[3].GetCellContent(grid.Items[0]) as TextBlock;
                         cellText = textBlock?.Text;
                     }
 
@@ -113,6 +113,55 @@ namespace InventoryManagementApp.Tests
 
             if (threadEx != null) throw threadEx;
             Assert.Equal("Smb, Http", cellText);
+        }
+
+        [Fact]
+        public void DevicesPage_DisplaysMacAddress()
+        {
+            Exception? threadEx = null;
+            string? cellText = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary
+                    {
+                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                    });
+
+                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService());
+                    vm.Devices.Add(new Device { Ip = "1.2.3.4", Hostname = "test", MacAddress = "aa-bb", ProtocolsDisplay = "Smb" });
+
+                    var page = new DevicesPage { DataContext = vm };
+                    page.ApplyTemplate();
+                    var grid = FindVisualChild<DataGrid>(page);
+                    grid?.ApplyTemplate();
+                    grid?.UpdateLayout();
+                    if (grid != null)
+                    {
+                        grid.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+                        grid.Arrange(new Rect(0, 0, grid.DesiredSize.Width, grid.DesiredSize.Height));
+                        grid.UpdateLayout();
+                        var textBlock = grid.Columns[1].GetCellContent(grid.Items[0]) as TextBlock;
+                        cellText = textBlock?.Text;
+                    }
+
+                    Application.Current?.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadEx != null) throw threadEx;
+            Assert.Equal("aa-bb", cellText);
         }
 
         private sealed class BindingErrorTraceListener : TraceListener

--- a/InventoryManagementApp.Tests/DevicesViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DevicesViewModelTests.cs
@@ -113,6 +113,28 @@ public class DevicesViewModelTests
     }
 
     [Fact]
+    public async Task RefreshCommand_CopiesMacAddress()
+    {
+        var discovery = new StubDiscoveryService();
+        var fileService = new RecordingDeviceFileService();
+        var dialog = new RecordingDialogService();
+        discovery.Devices.Add(new DiscoveredDevice
+        {
+            Ip = "1.2.3.6",
+            Hostname = "mac",
+            MacAddress = "aa-bb-cc-dd-ee-ff",
+            IsOnline = true,
+            Protocols = new List<DeviceProtocol>()
+        });
+        var vm = new DevicesViewModel(discovery, fileService, dialog);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Single(vm.Devices);
+        Assert.Equal("aa-bb-cc-dd-ee-ff", vm.Devices[0].MacAddress);
+    }
+
+    [Fact]
     public async Task RefreshCommand_ReportsProgressAndAddsDevicesIncrementally()
     {
         var discovery = new StubDiscoveryService();

--- a/InventoryManagementApp/Models/Device.cs
+++ b/InventoryManagementApp/Models/Device.cs
@@ -17,6 +17,7 @@ namespace InventoryManagementApp.Models
     {
         string _ip = string.Empty;
         string _hostname = string.Empty;
+        string _macAddress = string.Empty;
         DeviceProtocol _protocol;
         List<DeviceProtocol> _protocols = new();
         string _protocolsDisplay = string.Empty;
@@ -39,6 +40,12 @@ namespace InventoryManagementApp.Models
         {
             get => _hostname;
             set => SetProperty(ref _hostname, value);
+        }
+
+        public string MacAddress
+        {
+            get => _macAddress;
+            set => SetProperty(ref _macAddress, value);
         }
 
         public DeviceProtocol Protocol

--- a/InventoryManagementApp/Models/DiscoveredDevice.cs
+++ b/InventoryManagementApp/Models/DiscoveredDevice.cs
@@ -6,6 +6,7 @@ namespace InventoryManagementApp.Models
     {
         public string Ip { get; set; } = string.Empty;
         public string Hostname { get; set; } = string.Empty;
+        public string MacAddress { get; set; } = string.Empty;
         public bool IsOnline { get; set; }
         public IList<DeviceProtocol> Protocols { get; set; } = new List<DeviceProtocol>();
     }

--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -200,11 +200,13 @@ namespace InventoryManagementApp.Services.Devices
             }
 
             var hostname = await nameTask.ConfigureAwait(false);
+            var macAddress = arpTable.TryGetValue(ip, out var mac) ? mac : string.Empty;
 
             return new DiscoveredDevice
             {
                 Ip = ip,
                 Hostname = string.IsNullOrWhiteSpace(hostname) ? ip : hostname,
+                MacAddress = macAddress,
                 IsOnline = alive,
                 Protocols = protocols
             };

--- a/InventoryManagementApp/ViewModels/DevicesViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DevicesViewModel.cs
@@ -96,6 +96,7 @@ namespace InventoryManagementApp.ViewModels
                     {
                         Ip = d.Ip,
                         Hostname = d.Hostname,
+                        MacAddress = d.MacAddress,
                         Protocol = d.Protocols.FirstOrDefault(DeviceProtocol.Unknown),
                         Protocols = d.Protocols.ToList(),
                         ProtocolsDisplay = d.Protocols.Count > 0

--- a/InventoryManagementApp/Views/Pages/DevicesPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DevicesPage.xaml
@@ -43,6 +43,7 @@
                           ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="IP" Binding="{Binding Ip}" Width="150"/>
+                        <DataGridTextColumn Header="MAC" Binding="{Binding MacAddress}" Width="150"/>
                         <DataGridTextColumn Header="Hostname" Binding="{Binding Hostname}" Width="*"/>
                         <DataGridTextColumn Header="Protocols" Binding="{Binding ProtocolsDisplay}" Width="150"/>
                         <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="120"/>


### PR DESCRIPTION
## Summary
- capture MAC addresses during device discovery and expose them on models
- display MAC addresses in device list
- add unit tests for MAC propagation and UI display

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7db425db08324a495f3a3414ccae6