### PR TITLE
Support device ports in services

### DIFF
--- a/InventoryManagementApp.Tests/DeviceGroupServiceTests.cs
+++ b/InventoryManagementApp.Tests/DeviceGroupServiceTests.cs
@@ -17,8 +17,8 @@ public class DeviceGroupServiceTests
         Assert.Single(groups);
         Assert.Equal("Test Group", groups.First().Name);
 
-        await service.AssignDeviceToGroupAsync("10.0.0.1", groupId);
-        var assigned = await service.GetDeviceGroupIdAsync("10.0.0.1");
+        await service.AssignDeviceToGroupAsync("10.0.0.1", 1234, groupId);
+        var assigned = await service.GetDeviceGroupIdAsync("10.0.0.1", 1234);
         Assert.Equal(groupId, assigned);
     }
 }

--- a/InventoryManagementApp.Tests/DeviceServiceTests.cs
+++ b/InventoryManagementApp.Tests/DeviceServiceTests.cs
@@ -18,14 +18,14 @@ public class DeviceServiceTests
         var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
         await using var db = new DatabaseService(dbPath);
         var service = new DeviceService(db);
-        var device = new Device { Ip = "1.2.3.4", Hostname = "test", Protocol = DeviceProtocol.Ftp, Username = "u", Password = "p", Domain = "d" };
+        var device = new Device { Ip = "1.2.3.4", Port = 21, Hostname = "test", Protocol = DeviceProtocol.Ftp, Username = "u", Password = "p", Domain = "d" };
         await service.AddOrUpdateDeviceAsync(device);
-        var fetched = await service.GetDeviceAsync("1.2.3.4");
+        var fetched = await service.GetDeviceAsync("1.2.3.4", 21);
         Assert.NotNull(fetched);
         Assert.Equal("test", fetched!.Hostname);
         var all = await service.GetDevicesAsync();
         Assert.Single(all);
-        await service.DeleteDeviceAsync("1.2.3.4");
+        await service.DeleteDeviceAsync("1.2.3.4", 21);
         Assert.Empty(await service.GetDevicesAsync());
     }
 

--- a/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
@@ -296,8 +296,8 @@ namespace InventoryManagementApp.Tests
             public Task<IEnumerable<DeviceGroup>> GetGroupsAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<DeviceGroup>>(Array.Empty<DeviceGroup>());
             public Task UpdateGroupAsync(DeviceGroup group, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task AssignDeviceToGroupAsync(string deviceIp, int? groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<int?> GetDeviceGroupIdAsync(string deviceIp, CancellationToken cancellationToken = default) => Task.FromResult<int?>(null);
+            public Task AssignDeviceToGroupAsync(string deviceIp, int? devicePort, int? groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int?> GetDeviceGroupIdAsync(string deviceIp, int? devicePort, CancellationToken cancellationToken = default) => Task.FromResult<int?>(null);
         }
 
         

--- a/InventoryManagementApp.Tests/MainViewModelTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelTests.cs
@@ -513,8 +513,8 @@ namespace InventoryManagementApp.Tests
             public Task<IEnumerable<DeviceGroup>> GetGroupsAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<DeviceGroup>>(Array.Empty<DeviceGroup>());
             public Task UpdateGroupAsync(DeviceGroup group, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task AssignDeviceToGroupAsync(string deviceIp, int? groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<int?> GetDeviceGroupIdAsync(string deviceIp, CancellationToken cancellationToken = default) => Task.FromResult<int?>(null);
+            public Task AssignDeviceToGroupAsync(string deviceIp, int? devicePort, int? groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int?> GetDeviceGroupIdAsync(string deviceIp, int? devicePort, CancellationToken cancellationToken = default) => Task.FromResult<int?>(null);
         }
 
         private sealed class DummyDispatcherTimer : IDispatcherTimer

--- a/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
@@ -23,7 +23,7 @@ public class ScannerStatusViewModelTests
         public TaskCompletionSource<Device> Tcs { get; } = new();
         public Task<IEnumerable<Device>> GetDevicesAsync(CancellationToken cancellationToken = default)
             => Task.FromResult<IEnumerable<Device>>(Array.Empty<Device>());
-        public Task<Device?> GetDeviceAsync(string ip, CancellationToken cancellationToken = default)
+        public Task<Device?> GetDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
             => Task.FromResult<Device?>(null);
         public Task AddOrUpdateDeviceAsync(Device device, CancellationToken cancellationToken = default)
         {
@@ -31,14 +31,14 @@ public class ScannerStatusViewModelTests
             Tcs.TrySetResult(device);
             return Task.CompletedTask;
         }
-        public Task DeleteDeviceAsync(string ip, CancellationToken cancellationToken = default)
+        public Task DeleteDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
     }
 
     private sealed class RecordingDeviceGroupService : IDeviceGroupService
     {
         public List<DeviceGroup> Groups { get; } = new();
-        public TaskCompletionSource<(string ip, int? groupId)> AssignTcs { get; } = new();
+        public TaskCompletionSource<(string ip, int? port, int? groupId)> AssignTcs { get; } = new();
         public TaskCompletionSource<DeviceGroup> UpdateTcs { get; } = new();
         public DeviceGroup? UpdatedGroup { get; private set; }
         public Task<IEnumerable<DeviceGroup>> GetGroupsAsync(CancellationToken cancellationToken = default)
@@ -53,12 +53,12 @@ public class ScannerStatusViewModelTests
         }
         public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
-        public Task AssignDeviceToGroupAsync(string deviceIp, int? groupId, CancellationToken cancellationToken = default)
+        public Task AssignDeviceToGroupAsync(string deviceIp, int? devicePort, int? groupId, CancellationToken cancellationToken = default)
         {
-            AssignTcs.TrySetResult((deviceIp, groupId));
+            AssignTcs.TrySetResult((deviceIp, devicePort, groupId));
             return Task.CompletedTask;
         }
-        public Task<int?> GetDeviceGroupIdAsync(string deviceIp, CancellationToken cancellationToken = default)
+        public Task<int?> GetDeviceGroupIdAsync(string deviceIp, int? devicePort, CancellationToken cancellationToken = default)
             => Task.FromResult<int?>(null);
     }
 
@@ -122,6 +122,7 @@ public class ScannerStatusViewModelTests
         var assignment = await groupService.AssignTcs.Task;
 
         Assert.Equal("1.2.3.4", assignment.ip);
+        Assert.Null(assignment.port);
         Assert.Equal(1, assignment.groupId);
     }
 

--- a/InventoryManagementApp/Interfaces/IDeviceGroupService.cs
+++ b/InventoryManagementApp/Interfaces/IDeviceGroupService.cs
@@ -11,7 +11,7 @@ namespace InventoryManagementApp.Interfaces
         Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default);
         Task UpdateGroupAsync(DeviceGroup group, CancellationToken cancellationToken = default);
         Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default);
-        Task AssignDeviceToGroupAsync(string deviceIp, int? groupId, CancellationToken cancellationToken = default);
-        Task<int?> GetDeviceGroupIdAsync(string deviceIp, CancellationToken cancellationToken = default);
+        Task AssignDeviceToGroupAsync(string deviceIp, int? devicePort, int? groupId, CancellationToken cancellationToken = default);
+        Task<int?> GetDeviceGroupIdAsync(string deviceIp, int? devicePort, CancellationToken cancellationToken = default);
     }
 }

--- a/InventoryManagementApp/Interfaces/IDeviceService.cs
+++ b/InventoryManagementApp/Interfaces/IDeviceService.cs
@@ -8,8 +8,8 @@ namespace InventoryManagementApp.Interfaces
     public interface IDeviceService
     {
         Task<IEnumerable<Device>> GetDevicesAsync(CancellationToken cancellationToken = default);
-        Task<Device?> GetDeviceAsync(string ip, CancellationToken cancellationToken = default);
+        Task<Device?> GetDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default);
         Task AddOrUpdateDeviceAsync(Device device, CancellationToken cancellationToken = default);
-        Task DeleteDeviceAsync(string ip, CancellationToken cancellationToken = default);
+        Task DeleteDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default);
     }
 }

--- a/InventoryManagementApp/Models/Device.cs
+++ b/InventoryManagementApp/Models/Device.cs
@@ -16,6 +16,7 @@ namespace InventoryManagementApp.Models
     public class Device : ObservableObject
     {
         string _ip = string.Empty;
+        int? _port;
         string _hostname = string.Empty;
         string _macAddress = string.Empty;
         DeviceProtocol _protocol;
@@ -34,6 +35,12 @@ namespace InventoryManagementApp.Models
         {
             get => _ip;
             set => SetProperty(ref _ip, value);
+        }
+
+        public int? Port
+        {
+            get => _port;
+            set => SetProperty(ref _port, value);
         }
 
         public string Hostname

--- a/InventoryManagementApp/Services/Core/DatabaseService.cs
+++ b/InventoryManagementApp/Services/Core/DatabaseService.cs
@@ -153,13 +153,15 @@ namespace InventoryManagementApp.Services.Core
                     Value TEXT
                 );
                 CREATE TABLE IF NOT EXISTS Devices (
-                    Ip TEXT PRIMARY KEY,
+                    Ip TEXT NOT NULL,
+                    Port INTEGER,
                     Hostname TEXT,
                     Protocol TEXT,
                     Username TEXT,
                     Password TEXT,
                     Domain TEXT,
                     ItemId INTEGER,
+                    PRIMARY KEY (Ip, Port),
                     FOREIGN KEY (ItemId) REFERENCES Items(ItemID)
                 );
                 CREATE TABLE IF NOT EXISTS DeviceGroups (
@@ -167,8 +169,10 @@ namespace InventoryManagementApp.Services.Core
                     Name TEXT NOT NULL
                 );
                 CREATE TABLE IF NOT EXISTS DeviceGroupAssignments (
-                    DeviceIp TEXT PRIMARY KEY,
+                    DeviceIp TEXT NOT NULL,
+                    DevicePort INTEGER,
                     GroupId INTEGER,
+                    PRIMARY KEY (DeviceIp, DevicePort),
                     FOREIGN KEY (GroupId) REFERENCES DeviceGroups(GroupId)
                 );
                 CREATE TABLE IF NOT EXISTS PulledDeviceFiles (
@@ -179,6 +183,8 @@ namespace InventoryManagementApp.Services.Core
             using var cmd = new SqliteCommand(sql, conn);
             cmd.ExecuteNonQuery();
             EnsureColumn("Items", "DeviceId", "TEXT");
+            EnsureColumn("Devices", "Port", "INTEGER");
+            EnsureColumn("DeviceGroupAssignments", "DevicePort", "INTEGER");
 
             EnsureIndex(conn, "Items", "ItemNumber", true);
             EnsureIndex(conn, "Items", "NameDescription");

--- a/InventoryManagementApp/Services/Devices/DeviceFileService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceFileService.cs
@@ -65,7 +65,12 @@ namespace InventoryManagementApp.Services.Devices
             dynamic client = _smbClientFactory();
             try
             {
-                bool connected = await Task.Run(() => client.Connect(device.Ip, SMBTransportType.DirectTCPTransport), cancellationToken);
+                bool connected = await Task.Run(() =>
+                {
+                    if (device.Port.HasValue)
+                        return client.Connect(device.Ip, device.Port.Value);
+                    return client.Connect(device.Ip, SMBTransportType.DirectTCPTransport);
+                }, cancellationToken);
                 if (!connected) return results;
 
                 NTStatus status = await Task.Run(() => client.Login(device.Domain ?? string.Empty, device.Username ?? string.Empty, device.Password ?? string.Empty), cancellationToken);
@@ -125,6 +130,7 @@ namespace InventoryManagementApp.Services.Devices
         {
             var results = new List<string>();
             using var client = new AsyncFtpClient(device.Ip, device.Username, device.Password);
+            if (device.Port.HasValue) client.Port = device.Port.Value;
             try
             {
                 await client.Connect(cancellationToken);
@@ -161,6 +167,7 @@ namespace InventoryManagementApp.Services.Devices
                     case DeviceProtocol.Ftp:
                         using (var ftpClient = new AsyncFtpClient(device.Ip, device.Username, device.Password))
                         {
+                            if (device.Port.HasValue) ftpClient.Port = device.Port.Value;
                             await ftpClient.Connect(cancellationToken);
                             using var ms = new MemoryStream();
                             await ftpClient.DownloadStream(ms, file, token: cancellationToken);
@@ -172,7 +179,12 @@ namespace InventoryManagementApp.Services.Devices
                         dynamic smbClient = _smbClientFactory();
                         try
                         {
-                            bool connected = await Task.Run(() => smbClient.Connect(device.Ip, SMBTransportType.DirectTCPTransport), cancellationToken);
+                            bool connected = await Task.Run(() =>
+                            {
+                                if (device.Port.HasValue)
+                                    return smbClient.Connect(device.Ip, device.Port.Value);
+                                return smbClient.Connect(device.Ip, SMBTransportType.DirectTCPTransport);
+                            }, cancellationToken);
                             if (!connected) return null;
 
                             NTStatus status = await Task.Run(() => smbClient.Login(device.Domain ?? string.Empty, device.Username ?? string.Empty, device.Password ?? string.Empty), cancellationToken);

--- a/InventoryManagementApp/Services/Devices/DeviceGroupService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceGroupService.cs
@@ -64,30 +64,42 @@ namespace InventoryManagementApp.Services.Devices
             await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task AssignDeviceToGroupAsync(string deviceIp, int? groupId, CancellationToken cancellationToken = default)
+        public async Task AssignDeviceToGroupAsync(string deviceIp, int? devicePort, int? groupId, CancellationToken cancellationToken = default)
         {
             using var conn = _db.CreateConnection();
             using var cmd = conn.CreateCommand();
             if (groupId.HasValue)
             {
-                cmd.CommandText = "INSERT INTO DeviceGroupAssignments (DeviceIp, GroupId) VALUES ($ip, $gid) ON CONFLICT(DeviceIp) DO UPDATE SET GroupId=$gid";
+                cmd.CommandText = "INSERT INTO DeviceGroupAssignments (DeviceIp, DevicePort, GroupId) VALUES ($ip, $port, $gid) ON CONFLICT(DeviceIp, DevicePort) DO UPDATE SET GroupId=$gid";
                 cmd.Parameters.AddWithValue("$ip", deviceIp);
+                if (devicePort.HasValue)
+                    cmd.Parameters.AddWithValue("$port", devicePort.Value);
+                else
+                    cmd.Parameters.AddWithValue("$port", DBNull.Value);
                 cmd.Parameters.AddWithValue("$gid", groupId.Value);
             }
             else
             {
-                cmd.CommandText = "DELETE FROM DeviceGroupAssignments WHERE DeviceIp=$ip";
+                cmd.CommandText = "DELETE FROM DeviceGroupAssignments WHERE DeviceIp=$ip AND IFNULL(DevicePort,-1)=IFNULL($port,-1)";
                 cmd.Parameters.AddWithValue("$ip", deviceIp);
+                if (devicePort.HasValue)
+                    cmd.Parameters.AddWithValue("$port", devicePort.Value);
+                else
+                    cmd.Parameters.AddWithValue("$port", DBNull.Value);
             }
             await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<int?> GetDeviceGroupIdAsync(string deviceIp, CancellationToken cancellationToken = default)
+        public async Task<int?> GetDeviceGroupIdAsync(string deviceIp, int? devicePort, CancellationToken cancellationToken = default)
         {
             using var conn = _db.CreateConnection();
             using var cmd = conn.CreateCommand();
-            cmd.CommandText = "SELECT GroupId FROM DeviceGroupAssignments WHERE DeviceIp=$ip";
+            cmd.CommandText = "SELECT GroupId FROM DeviceGroupAssignments WHERE DeviceIp=$ip AND IFNULL(DevicePort,-1)=IFNULL($port,-1)";
             cmd.Parameters.AddWithValue("$ip", deviceIp);
+            if (devicePort.HasValue)
+                cmd.Parameters.AddWithValue("$port", devicePort.Value);
+            else
+                cmd.Parameters.AddWithValue("$port", DBNull.Value);
             var result = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
             if (result == null || result == DBNull.Value)
                 return null;

--- a/InventoryManagementApp/Services/Devices/DeviceService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceService.cs
@@ -22,8 +22,8 @@ namespace InventoryManagementApp.Services.Devices
         {
             using var conn = _db.CreateConnection();
             using var cmd = conn.CreateCommand();
-            cmd.CommandText = @"SELECT d.Ip, d.Hostname, d.Protocol, d.Username, d.Password, d.Domain, d.ItemId, i.NameDescription
-                               FROM Devices d LEFT JOIN Items i ON i.DeviceId = d.Ip ORDER BY d.Ip";
+            cmd.CommandText = @"SELECT d.Ip, d.Port, d.Hostname, d.Protocol, d.Username, d.Password, d.Domain, d.ItemId, i.NameDescription
+                               FROM Devices d LEFT JOIN Items i ON i.DeviceId = d.Ip ORDER BY d.Ip, d.Port";
             using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
             var devices = new List<Device>();
             while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -31,38 +31,44 @@ namespace InventoryManagementApp.Services.Devices
                 devices.Add(new Device
                 {
                     Ip = reader.GetString(0),
-                    Hostname = reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
-                    Protocol = Enum.TryParse<DeviceProtocol>(reader.IsDBNull(2) ? string.Empty : reader.GetString(2), true, out var p) ? p : DeviceProtocol.Unknown,
-                    Username = reader.IsDBNull(3) ? string.Empty : reader.GetString(3),
-                    Password = reader.IsDBNull(4) ? string.Empty : reader.GetString(4),
-                    Domain = reader.IsDBNull(5) ? string.Empty : reader.GetString(5),
-                    ItemId = reader.IsDBNull(6) ? null : reader.GetInt32(6),
-                    ItemName = reader.IsDBNull(7) ? string.Empty : reader.GetString(7)
+                    Port = reader.IsDBNull(1) ? null : reader.GetInt32(1),
+                    Hostname = reader.IsDBNull(2) ? string.Empty : reader.GetString(2),
+                    Protocol = Enum.TryParse<DeviceProtocol>(reader.IsDBNull(3) ? string.Empty : reader.GetString(3), true, out var p) ? p : DeviceProtocol.Unknown,
+                    Username = reader.IsDBNull(4) ? string.Empty : reader.GetString(4),
+                    Password = reader.IsDBNull(5) ? string.Empty : reader.GetString(5),
+                    Domain = reader.IsDBNull(6) ? string.Empty : reader.GetString(6),
+                    ItemId = reader.IsDBNull(7) ? null : reader.GetInt32(7),
+                    ItemName = reader.IsDBNull(8) ? string.Empty : reader.GetString(8)
                 });
             }
             return devices;
         }
 
-        public async Task<Device?> GetDeviceAsync(string ip, CancellationToken cancellationToken = default)
+        public async Task<Device?> GetDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
         {
             using var conn = _db.CreateConnection();
             using var cmd = conn.CreateCommand();
-            cmd.CommandText = @"SELECT d.Ip, d.Hostname, d.Protocol, d.Username, d.Password, d.Domain, d.ItemId, i.NameDescription
-                               FROM Devices d LEFT JOIN Items i ON i.DeviceId = d.Ip WHERE d.Ip=$ip";
+            cmd.CommandText = @"SELECT d.Ip, d.Port, d.Hostname, d.Protocol, d.Username, d.Password, d.Domain, d.ItemId, i.NameDescription
+                               FROM Devices d LEFT JOIN Items i ON i.DeviceId = d.Ip WHERE d.Ip=$ip AND IFNULL(d.Port,-1)=IFNULL($port,-1)";
             cmd.Parameters.AddWithValue("$ip", ip);
+            if (port.HasValue)
+                cmd.Parameters.AddWithValue("$port", port.Value);
+            else
+                cmd.Parameters.AddWithValue("$port", DBNull.Value);
             using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
             if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
                 return new Device
                 {
                     Ip = reader.GetString(0),
-                    Hostname = reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
-                    Protocol = Enum.TryParse<DeviceProtocol>(reader.IsDBNull(2) ? string.Empty : reader.GetString(2), true, out var p) ? p : DeviceProtocol.Unknown,
-                    Username = reader.IsDBNull(3) ? string.Empty : reader.GetString(3),
-                    Password = reader.IsDBNull(4) ? string.Empty : reader.GetString(4),
-                    Domain = reader.IsDBNull(5) ? string.Empty : reader.GetString(5),
-                    ItemId = reader.IsDBNull(6) ? null : reader.GetInt32(6),
-                    ItemName = reader.IsDBNull(7) ? string.Empty : reader.GetString(7)
+                    Port = reader.IsDBNull(1) ? null : reader.GetInt32(1),
+                    Hostname = reader.IsDBNull(2) ? string.Empty : reader.GetString(2),
+                    Protocol = Enum.TryParse<DeviceProtocol>(reader.IsDBNull(3) ? string.Empty : reader.GetString(3), true, out var p) ? p : DeviceProtocol.Unknown,
+                    Username = reader.IsDBNull(4) ? string.Empty : reader.GetString(4),
+                    Password = reader.IsDBNull(5) ? string.Empty : reader.GetString(5),
+                    Domain = reader.IsDBNull(6) ? string.Empty : reader.GetString(6),
+                    ItemId = reader.IsDBNull(7) ? null : reader.GetInt32(7),
+                    ItemName = reader.IsDBNull(8) ? string.Empty : reader.GetString(8)
                 };
             }
             return null;
@@ -72,9 +78,9 @@ namespace InventoryManagementApp.Services.Devices
         {
             using var conn = _db.CreateConnection();
             using var cmd = conn.CreateCommand();
-            cmd.CommandText = @"INSERT INTO Devices (Ip, Hostname, Protocol, Username, Password, Domain, ItemId)
-                                VALUES ($ip, $hostname, $protocol, $username, $password, $domain, $itemId)
-                                ON CONFLICT(Ip) DO UPDATE SET 
+            cmd.CommandText = @"INSERT INTO Devices (Ip, Port, Hostname, Protocol, Username, Password, Domain, ItemId)
+                                VALUES ($ip, $port, $hostname, $protocol, $username, $password, $domain, $itemId)
+                                ON CONFLICT(Ip, Port) DO UPDATE SET
                                     Hostname=$hostname,
                                     Protocol=$protocol,
                                     Username=$username,
@@ -82,6 +88,10 @@ namespace InventoryManagementApp.Services.Devices
                                     Domain=$domain,
                                     ItemId=$itemId";
             cmd.Parameters.AddWithValue("$ip", device.Ip);
+            if (device.Port.HasValue)
+                cmd.Parameters.AddWithValue("$port", device.Port.Value);
+            else
+                cmd.Parameters.AddWithValue("$port", DBNull.Value);
             cmd.Parameters.AddWithValue("$hostname", (object?)device.Hostname ?? DBNull.Value);
             cmd.Parameters.AddWithValue("$protocol", device.Protocol.ToString());
             cmd.Parameters.AddWithValue("$username", (object?)device.Username ?? DBNull.Value);
@@ -94,12 +104,16 @@ namespace InventoryManagementApp.Services.Devices
             await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task DeleteDeviceAsync(string ip, CancellationToken cancellationToken = default)
+        public async Task DeleteDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
         {
             using var conn = _db.CreateConnection();
             using var cmd = conn.CreateCommand();
-            cmd.CommandText = "DELETE FROM Devices WHERE Ip=$ip";
+            cmd.CommandText = "DELETE FROM Devices WHERE Ip=$ip AND IFNULL(Port,-1)=IFNULL($port,-1)"; 
             cmd.Parameters.AddWithValue("$ip", ip);
+            if (port.HasValue)
+                cmd.Parameters.AddWithValue("$port", port.Value);
+            else
+                cmd.Parameters.AddWithValue("$port", DBNull.Value);
             await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
     }

--- a/InventoryManagementApp/Services/Devices/ScannerService.cs
+++ b/InventoryManagementApp/Services/Devices/ScannerService.cs
@@ -38,6 +38,7 @@ namespace InventoryManagementApp.Services.Devices
                     {
                         Hostname = string.IsNullOrWhiteSpace(d.Hostname) ? $"Device {d.Ip}" : d.Hostname,
                         Ip = d.Ip,
+                        Port = d.Port,
                         Protocol = d.Protocol,
                         Username = d.Username,
                         Password = d.Password,
@@ -69,7 +70,7 @@ namespace InventoryManagementApp.Services.Devices
 
             // Merge statuses for any duplicate IPs
             return devices
-                .GroupBy(d => d.Ip)
+                .GroupBy(d => new { d.Ip, d.Port })
                 .Select(g =>
                 {
                     var device = g.First();

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -689,11 +689,11 @@ namespace InventoryManagementApp.ViewModels
         {
             public Task<IEnumerable<Device>> GetDevicesAsync(CancellationToken cancellationToken = default)
                 => Task.FromResult<IEnumerable<Device>>(Array.Empty<Device>());
-            public Task<Device?> GetDeviceAsync(string ip, CancellationToken cancellationToken = default)
+            public Task<Device?> GetDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
                 => Task.FromResult<Device?>(null);
             public Task AddOrUpdateDeviceAsync(Device device, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
-            public Task DeleteDeviceAsync(string ip, CancellationToken cancellationToken = default)
+            public Task DeleteDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
         }
 
@@ -703,8 +703,8 @@ namespace InventoryManagementApp.ViewModels
             public Task<IEnumerable<DeviceGroup>> GetGroupsAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<DeviceGroup>>(Array.Empty<DeviceGroup>());
             public Task UpdateGroupAsync(DeviceGroup group, CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task AssignDeviceToGroupAsync(string deviceIp, int? groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<int?> GetDeviceGroupIdAsync(string deviceIp, CancellationToken cancellationToken = default) => Task.FromResult<int?>(null);
+            public Task AssignDeviceToGroupAsync(string deviceIp, int? devicePort, int? groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int?> GetDeviceGroupIdAsync(string deviceIp, int? devicePort, CancellationToken cancellationToken = default) => Task.FromResult<int?>(null);
         }
 
         private sealed class DummyDeviceFileService : IDeviceFileService

--- a/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
@@ -135,7 +135,7 @@ namespace InventoryManagementApp.ViewModels
                 Devices.Clear();
                 foreach (var d in devices)
                 {
-                    d.GroupId = await _groupService.GetDeviceGroupIdAsync(d.Ip, cancellationToken);
+                    d.GroupId = await _groupService.GetDeviceGroupIdAsync(d.Ip, d.Port, cancellationToken);
                     if (d.LastSeen.Kind != DateTimeKind.Local)
                     {
                         _logger.LogWarning("Device {Ip} reported LastSeen kind {Kind}; converting to local time", d.Ip, d.LastSeen.Kind);
@@ -160,7 +160,7 @@ namespace InventoryManagementApp.ViewModels
                 if (string.IsNullOrWhiteSpace(ip))
                     return;
 
-                var existing = await _deviceService.GetDeviceAsync(ip);
+                var existing = await _deviceService.GetDeviceAsync(ip, null);
                 if (existing == null)
                 {
                     await _deviceService.AddOrUpdateDeviceAsync(new Device { Ip = ip });
@@ -244,7 +244,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 try
                 {
-                    await _groupService.AssignDeviceToGroupAsync(device.Ip, device.GroupId);
+                    await _groupService.AssignDeviceToGroupAsync(device.Ip, device.Port, device.GroupId);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary
- Add nullable `Port` property to `Device`
- Persist device port and use `(Ip, Port)` as unique key
- Track group assignments by IP and port
- Use device port for SMB/FTP connections

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository access denied)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ef9e8d0883249065a575a33d667e