### PR TITLE
Add manual device addition command to device view

### DIFF
--- a/InventoryManagementApp.Tests/DevicesPageTests.cs
+++ b/InventoryManagementApp.Tests/DevicesPageTests.cs
@@ -42,7 +42,7 @@ namespace InventoryManagementApp.Tests
                     PresentationTraceSources.DataBindingSource.Listeners.Add(listener);
                     PresentationTraceSources.DataBindingSource.Switch.Level = SourceLevels.Error;
 
-                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService())
+                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService())
                     {
                         SelectedDevice = new Device()
                     };
@@ -82,7 +82,7 @@ namespace InventoryManagementApp.Tests
                         Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
                     });
 
-                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService());
+                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService());
                     vm.Devices.Add(new Device { Ip = "1.2.3.4", Hostname = "test", ProtocolsDisplay = "Smb, Http" });
 
                     var page = new DevicesPage { DataContext = vm };
@@ -131,7 +131,7 @@ namespace InventoryManagementApp.Tests
                         Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
                     });
 
-                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService());
+                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService());
                     vm.Devices.Add(new Device { Ip = "1.2.3.4", Hostname = "test", MacAddress = "aa-bb", ProtocolsDisplay = "Smb" });
 
                     var page = new DevicesPage { DataContext = vm };
@@ -204,6 +204,18 @@ namespace InventoryManagementApp.Tests
             public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }
+        }
+
+        private sealed class DummyDeviceService : IDeviceService
+        {
+            public Task<IEnumerable<Device>> GetDevicesAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult<IEnumerable<Device>>(Array.Empty<Device>());
+            public Task<Device?> GetDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
+                => Task.FromResult<Device?>(null);
+            public Task AddOrUpdateDeviceAsync(Device device, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task DeleteDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
         }
 
         private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject

--- a/InventoryManagementApp.Tests/DevicesViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DevicesViewModelTests.cs
@@ -17,12 +17,18 @@ public class DevicesViewModelTests
         public List<DiscoveredDevice> Devices { get; } = new();
         public bool HasConfiguredSubnets { get; set; } = true;
 
+        public int DiscoverCallCount { get; private set; }
+
         public Task<IReadOnlyList<DiscoveredDevice>> DiscoverDevicesAsync(CancellationToken cancellationToken = default)
-            => Task.FromResult<IReadOnlyList<DiscoveredDevice>>(Devices);
+        {
+            DiscoverCallCount++;
+            return Task.FromResult<IReadOnlyList<DiscoveredDevice>>(Devices);
+        }
 
         public async IAsyncEnumerable<DiscoveredDevice> DiscoverDevicesAsync(IProgress<double>? progress = null,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
+            DiscoverCallCount++;
             var total = Devices.Count;
             int processed = 0;
             foreach (var d in Devices)
@@ -74,6 +80,22 @@ public class DevicesViewModelTests
         public void ShowPrintLabelDialog() { }
     }
 
+    private sealed class RecordingDeviceService : IDeviceService
+    {
+        public Device? LastDevice { get; private set; }
+        public Task<IEnumerable<Device>> GetDevicesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IEnumerable<Device>>(Array.Empty<Device>());
+        public Task<Device?> GetDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
+            => Task.FromResult<Device?>(null);
+        public Task AddOrUpdateDeviceAsync(Device device, CancellationToken cancellationToken = default)
+        {
+            LastDevice = device;
+            return Task.CompletedTask;
+        }
+        public Task DeleteDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
     [Fact]
     public async Task RefreshCommand_LoadsDevices()
     {
@@ -81,7 +103,7 @@ public class DevicesViewModelTests
         var fileService = new RecordingDeviceFileService();
         var dialog = new RecordingDialogService();
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", Hostname = "test", IsOnline = true, Protocols = new List<DeviceProtocol> { DeviceProtocol.Ftp } });
-        var vm = new DevicesViewModel(discovery, fileService, dialog);
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
 
         await vm.RefreshCommand.ExecuteAsync(null);
 
@@ -104,7 +126,7 @@ public class DevicesViewModelTests
             IsOnline = true,
             Protocols = new List<DeviceProtocol> { DeviceProtocol.Smb, DeviceProtocol.Http }
         });
-        var vm = new DevicesViewModel(discovery, fileService, dialog);
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
 
         await vm.RefreshCommand.ExecuteAsync(null);
 
@@ -126,7 +148,7 @@ public class DevicesViewModelTests
             IsOnline = true,
             Protocols = new List<DeviceProtocol>()
         });
-        var vm = new DevicesViewModel(discovery, fileService, dialog);
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
 
         await vm.RefreshCommand.ExecuteAsync(null);
 
@@ -142,7 +164,7 @@ public class DevicesViewModelTests
         var dialog = new RecordingDialogService();
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.1.1.1", Hostname = "a", IsOnline = true, Protocols = new List<DeviceProtocol>() });
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.1.1.2", Hostname = "b", IsOnline = true, Protocols = new List<DeviceProtocol>() });
-        var vm = new DevicesViewModel(discovery, fileService, dialog);
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
 
         var task = vm.RefreshCommand.ExecuteAsync(null);
         await Task.Delay(15);
@@ -164,7 +186,7 @@ public class DevicesViewModelTests
         var fileService = new RecordingDeviceFileService();
         var dialog = new RecordingDialogService();
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.1.1.1", Hostname = "a", IsOnline = true, Protocols = new List<DeviceProtocol>() });
-        var vm = new DevicesViewModel(discovery, fileService, dialog);
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
 
         Assert.True(vm.RefreshCommand.CanExecute(null));
 
@@ -187,7 +209,7 @@ public class DevicesViewModelTests
         var dialog = new RecordingDialogService();
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", Hostname = "test", IsOnline = true, Protocols = new List<DeviceProtocol>() });
         fileService.Files.AddRange(new[] { "a.txt", "b.txt" });
-        var vm = new DevicesViewModel(discovery, fileService, dialog);
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
 
         await vm.RefreshCommand.ExecuteAsync(null);
         vm.SelectedDevice = vm.Devices[0];
@@ -207,7 +229,7 @@ public class DevicesViewModelTests
         var dialog = new RecordingDialogService();
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", Hostname = "test", IsOnline = true, Protocols = new List<DeviceProtocol>() });
         fileService.Files.AddRange(new[] { "a.txt", "b.txt" });
-        var vm = new DevicesViewModel(discovery, fileService, dialog);
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
 
         await vm.RefreshCommand.ExecuteAsync(null);
         vm.SelectedDevice = vm.Devices[0];
@@ -228,7 +250,7 @@ public class DevicesViewModelTests
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.1.1.1", Hostname = "a", IsOnline = true, Protocols = new List<DeviceProtocol>() });
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.1.1.2", Hostname = "b", IsOnline = true, Protocols = new List<DeviceProtocol>() });
         fileService.Files.Add("a.txt");
-        var vm = new DevicesViewModel(discovery, fileService, dialog);
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
 
         await vm.RefreshCommand.ExecuteAsync(null);
         vm.SelectedDevice = vm.Devices[0];
@@ -247,7 +269,7 @@ public class DevicesViewModelTests
         var fileService = new RecordingDeviceFileService();
         var dialog = new RecordingDialogService();
 
-        var vm = new DevicesViewModel(discovery, fileService, dialog);
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
 
         await vm.RefreshCommand.ExecuteAsync(null);
 
@@ -272,7 +294,7 @@ public class DevicesViewModelTests
             var discovery = new DeviceDiscoveryService(config);
             var fileService = new RecordingDeviceFileService();
             var dialog = new RecordingDialogService();
-            var vm = new DevicesViewModel(discovery, fileService, dialog);
+            var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
 
             await vm.RefreshCommand.ExecuteAsync(null);
 
@@ -286,5 +308,22 @@ public class DevicesViewModelTests
         {
             TaskScheduler.UnobservedTaskException -= Handler;
         }
+    }
+
+    [Fact]
+    public async Task AddDeviceCommand_AddsDeviceAndRefreshes()
+    {
+        var discovery = new StubDiscoveryService();
+        var fileService = new RecordingDeviceFileService();
+        var dialog = new RecordingDialogService();
+        var deviceService = new RecordingDeviceService();
+        var vm = new DevicesViewModel(discovery, fileService, dialog, deviceService);
+        vm.PromptForIpPort = () => "1.2.3.4:1234";
+
+        await vm.AddDeviceCommand.ExecuteAsync(null);
+
+        Assert.Equal("1.2.3.4", deviceService.LastDevice?.Ip);
+        Assert.Equal(1234, deviceService.LastDevice?.Port);
+        Assert.Equal(1, discovery.DiscoverCallCount);
     }
 }

--- a/InventoryManagementApp/ViewModels/DevicesViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DevicesViewModel.cs
@@ -9,6 +9,7 @@ using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualBasic;
 
 namespace InventoryManagementApp.ViewModels
 {
@@ -17,6 +18,7 @@ namespace InventoryManagementApp.ViewModels
         private readonly IDeviceDiscoveryService _discoveryService;
         private readonly IDeviceFileService _fileService;
         private readonly IDialogService _dialogService;
+        private readonly IDeviceService _deviceService;
         private readonly ILogger<DevicesViewModel> _logger;
 
         public ObservableCollection<Device> Devices { get; } = new();
@@ -45,6 +47,7 @@ namespace InventoryManagementApp.ViewModels
 
         public IAsyncRelayCommand RefreshCommand { get; }
         public IAsyncRelayCommand PullAllReportsCommand { get; }
+        public IAsyncRelayCommand AddDeviceCommand { get; }
 
         private double _discoveryProgress;
         public double DiscoveryProgress
@@ -66,18 +69,24 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
+        public Func<string?> PromptForIpPort { get; set; } = () =>
+            Interaction.InputBox("Enter device IP:port:", "Add Device", string.Empty);
+
         public DevicesViewModel(IDeviceDiscoveryService discoveryService,
                                  IDeviceFileService fileService,
                                  IDialogService dialogService,
+                                 IDeviceService deviceService,
                                  ILogger<DevicesViewModel>? logger = null)
         {
             _discoveryService = discoveryService;
             _fileService = fileService;
             _dialogService = dialogService;
+            _deviceService = deviceService;
             _logger = logger ?? NullLogger<DevicesViewModel>.Instance;
 
             RefreshCommand = new AsyncRelayCommand(RefreshAsync, () => !IsDiscovering);
             PullAllReportsCommand = new AsyncRelayCommand(PullAllReportsAsync, CanPullAllReports);
+            AddDeviceCommand = new AsyncRelayCommand(AddDeviceAsync);
         }
 
         private async Task RefreshAsync()
@@ -139,6 +148,31 @@ namespace InventoryManagementApp.ViewModels
             {
                 _logger.LogError(ex, "Failed to load files for {Ip}", SelectedDevice.Ip);
                 await _dialogService.ShowInfoAsync($"Failed to pull reports: {ex.Message}", "Devices");
+            }
+        }
+
+        private async Task AddDeviceAsync()
+        {
+            try
+            {
+                var input = PromptForIpPort?.Invoke();
+                if (string.IsNullOrWhiteSpace(input))
+                    return;
+
+                string ip;
+                int? port = null;
+                var parts = input.Split(':');
+                ip = parts[0];
+                if (parts.Length > 1 && int.TryParse(parts[1], out var parsedPort))
+                    port = parsedPort;
+
+                await _deviceService.AddOrUpdateDeviceAsync(new Device { Ip = ip, Port = port });
+                await RefreshAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to add device");
+                await _dialogService.ShowInfoAsync($"Failed to add device: {ex.Message}", "Devices");
             }
         }
     }

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -529,7 +529,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 try
                 {
-                    var vm = new DevicesViewModel(_deviceDiscoveryService, _deviceFileService, _dialogService);
+                    var vm = new DevicesViewModel(_deviceDiscoveryService, _deviceFileService, _dialogService, _deviceService);
                     var page = new DevicesPage { DataContext = vm, Title = "Devices" };
                     CurrentPage = page;
                     await Task.CompletedTask;

--- a/InventoryManagementApp/Views/Pages/DevicesPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DevicesPage.xaml
@@ -20,6 +20,10 @@
                                 Content="Refresh"
                                 Command="{Binding RefreshCommand}"
                                 Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource PrimaryButton}"
+                                Content="Add Device"
+                                Command="{Binding AddDeviceCommand}"
+                                Margin="0,0,8,0"/>
                         <TextBox Text="{Binding FileExtensionFilter, UpdateSourceTrigger=PropertyChanged}"
                                  Width="120"
                                  Margin="0,0,8,0"/>


### PR DESCRIPTION
## Summary
- allow adding devices manually via `AddDeviceCommand` with IP:port prompt
- inject `IDeviceService` for persistence and refresh list after adding
- expose Add Device button on Devices page and update tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f1b178608324a1f98a7d4ebea5ed