### PR TITLE
Enable device group editing and unique device folders

### DIFF
--- a/InventoryManagementApp.Tests/DeviceFileServicePullTests.cs
+++ b/InventoryManagementApp.Tests/DeviceFileServicePullTests.cs
@@ -44,4 +44,20 @@ public class DeviceFileServicePullTests
         var storedDir = Path.Combine(local, "Devices", device.Ip);
         Assert.True(File.Exists(Path.Combine(storedDir, "a.txt")));
     }
+
+    [Fact]
+    public async Task DownloadUnseenFiles_IncludesPortInFolderName()
+    {
+        var remote = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(remote);
+        await File.WriteAllTextAsync(Path.Combine(remote, "a.txt"), "hello");
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        using var db = new DatabaseService(dbPath);
+        var service = new TestDeviceFileService(db, remote);
+        var device = new Device { Ip = "dev1", Port = 1234 };
+        var local = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        await service.DownloadUnseenFilesAsync(device, local);
+        var storedDir = Path.Combine(local, "Devices", "dev1_1234");
+        Assert.True(Directory.Exists(storedDir));
+    }
 }

--- a/InventoryManagementApp.Tests/DevicesPageTests.cs
+++ b/InventoryManagementApp.Tests/DevicesPageTests.cs
@@ -42,7 +42,7 @@ namespace InventoryManagementApp.Tests
                     PresentationTraceSources.DataBindingSource.Listeners.Add(listener);
                     PresentationTraceSources.DataBindingSource.Switch.Level = SourceLevels.Error;
 
-                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService())
+                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService())
                     {
                         SelectedDevice = new Device()
                     };
@@ -82,7 +82,7 @@ namespace InventoryManagementApp.Tests
                         Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
                     });
 
-                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService());
+                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
                     vm.Devices.Add(new Device { Ip = "1.2.3.4", Hostname = "test", ProtocolsDisplay = "Smb, Http" });
 
                     var page = new DevicesPage { DataContext = vm };
@@ -95,7 +95,7 @@ namespace InventoryManagementApp.Tests
                         grid.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
                         grid.Arrange(new Rect(0, 0, grid.DesiredSize.Width, grid.DesiredSize.Height));
                         grid.UpdateLayout();
-                        var textBlock = grid.Columns[3].GetCellContent(grid.Items[0]) as TextBlock;
+                        var textBlock = grid.Columns[4].GetCellContent(grid.Items[0]) as TextBlock;
                         cellText = textBlock?.Text;
                     }
 
@@ -131,7 +131,7 @@ namespace InventoryManagementApp.Tests
                         Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
                     });
 
-                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService());
+                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
                     vm.Devices.Add(new Device { Ip = "1.2.3.4", Hostname = "test", MacAddress = "aa-bb", ProtocolsDisplay = "Smb" });
 
                     var page = new DevicesPage { DataContext = vm };
@@ -216,6 +216,22 @@ namespace InventoryManagementApp.Tests
                 => Task.CompletedTask;
             public Task DeleteDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
+        }
+
+        private sealed class DummyDeviceGroupService : IDeviceGroupService
+        {
+            public Task<IEnumerable<DeviceGroup>> GetGroupsAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult<IEnumerable<DeviceGroup>>(Array.Empty<DeviceGroup>());
+            public Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default)
+                => Task.FromResult(0);
+            public Task UpdateGroupAsync(DeviceGroup group, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task AssignDeviceToGroupAsync(string deviceIp, int? devicePort, int? groupId, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task<int?> GetDeviceGroupIdAsync(string deviceIp, int? devicePort, CancellationToken cancellationToken = default)
+                => Task.FromResult<int?>(null);
         }
 
         private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject

--- a/InventoryManagementApp.Tests/DevicesViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DevicesViewModelTests.cs
@@ -80,6 +80,35 @@ public class DevicesViewModelTests
         public void ShowPrintLabelDialog() { }
     }
 
+    private sealed class RecordingDeviceGroupService : IDeviceGroupService
+    {
+        public List<DeviceGroup> Groups { get; } = new();
+        public TaskCompletionSource<(string ip, int? port, int? groupId)> AssignTcs { get; } = new();
+        public TaskCompletionSource<DeviceGroup> UpdateTcs { get; } = new();
+        public string? CreatedGroupName { get; private set; }
+        public Task<IEnumerable<DeviceGroup>> GetGroupsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IEnumerable<DeviceGroup>>(Groups);
+        public Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default)
+        {
+            CreatedGroupName = name;
+            return Task.FromResult(0);
+        }
+        public Task UpdateGroupAsync(DeviceGroup group, CancellationToken cancellationToken = default)
+        {
+            UpdateTcs.TrySetResult(group);
+            return Task.CompletedTask;
+        }
+        public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+        public Task AssignDeviceToGroupAsync(string deviceIp, int? devicePort, int? groupId, CancellationToken cancellationToken = default)
+        {
+            AssignTcs.TrySetResult((deviceIp, devicePort, groupId));
+            return Task.CompletedTask;
+        }
+        public Task<int?> GetDeviceGroupIdAsync(string deviceIp, int? devicePort, CancellationToken cancellationToken = default)
+            => Task.FromResult<int?>(null);
+    }
+
     private sealed class RecordingDeviceService : IDeviceService
     {
         public Device? LastDevice { get; private set; }
@@ -103,7 +132,7 @@ public class DevicesViewModelTests
         var fileService = new RecordingDeviceFileService();
         var dialog = new RecordingDialogService();
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", Hostname = "test", IsOnline = true, Protocols = new List<DeviceProtocol> { DeviceProtocol.Ftp } });
-        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), new RecordingDeviceGroupService());
 
         await vm.RefreshCommand.ExecuteAsync(null);
 
@@ -126,7 +155,7 @@ public class DevicesViewModelTests
             IsOnline = true,
             Protocols = new List<DeviceProtocol> { DeviceProtocol.Smb, DeviceProtocol.Http }
         });
-        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), new RecordingDeviceGroupService());
 
         await vm.RefreshCommand.ExecuteAsync(null);
 
@@ -148,7 +177,7 @@ public class DevicesViewModelTests
             IsOnline = true,
             Protocols = new List<DeviceProtocol>()
         });
-        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), new RecordingDeviceGroupService());
 
         await vm.RefreshCommand.ExecuteAsync(null);
 
@@ -164,7 +193,7 @@ public class DevicesViewModelTests
         var dialog = new RecordingDialogService();
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.1.1.1", Hostname = "a", IsOnline = true, Protocols = new List<DeviceProtocol>() });
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.1.1.2", Hostname = "b", IsOnline = true, Protocols = new List<DeviceProtocol>() });
-        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), new RecordingDeviceGroupService());
 
         var task = vm.RefreshCommand.ExecuteAsync(null);
         await Task.Delay(15);
@@ -186,7 +215,7 @@ public class DevicesViewModelTests
         var fileService = new RecordingDeviceFileService();
         var dialog = new RecordingDialogService();
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.1.1.1", Hostname = "a", IsOnline = true, Protocols = new List<DeviceProtocol>() });
-        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), new RecordingDeviceGroupService());
 
         Assert.True(vm.RefreshCommand.CanExecute(null));
 
@@ -209,7 +238,7 @@ public class DevicesViewModelTests
         var dialog = new RecordingDialogService();
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", Hostname = "test", IsOnline = true, Protocols = new List<DeviceProtocol>() });
         fileService.Files.AddRange(new[] { "a.txt", "b.txt" });
-        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), new RecordingDeviceGroupService());
 
         await vm.RefreshCommand.ExecuteAsync(null);
         vm.SelectedDevice = vm.Devices[0];
@@ -229,7 +258,7 @@ public class DevicesViewModelTests
         var dialog = new RecordingDialogService();
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", Hostname = "test", IsOnline = true, Protocols = new List<DeviceProtocol>() });
         fileService.Files.AddRange(new[] { "a.txt", "b.txt" });
-        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), new RecordingDeviceGroupService());
 
         await vm.RefreshCommand.ExecuteAsync(null);
         vm.SelectedDevice = vm.Devices[0];
@@ -250,7 +279,7 @@ public class DevicesViewModelTests
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.1.1.1", Hostname = "a", IsOnline = true, Protocols = new List<DeviceProtocol>() });
         discovery.Devices.Add(new DiscoveredDevice { Ip = "1.1.1.2", Hostname = "b", IsOnline = true, Protocols = new List<DeviceProtocol>() });
         fileService.Files.Add("a.txt");
-        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), new RecordingDeviceGroupService());
 
         await vm.RefreshCommand.ExecuteAsync(null);
         vm.SelectedDevice = vm.Devices[0];
@@ -269,7 +298,7 @@ public class DevicesViewModelTests
         var fileService = new RecordingDeviceFileService();
         var dialog = new RecordingDialogService();
 
-        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), new RecordingDeviceGroupService());
 
         await vm.RefreshCommand.ExecuteAsync(null);
 
@@ -294,7 +323,7 @@ public class DevicesViewModelTests
             var discovery = new DeviceDiscoveryService(config);
             var fileService = new RecordingDeviceFileService();
             var dialog = new RecordingDialogService();
-            var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService());
+            var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), new RecordingDeviceGroupService());
 
             await vm.RefreshCommand.ExecuteAsync(null);
 
@@ -317,7 +346,7 @@ public class DevicesViewModelTests
         var fileService = new RecordingDeviceFileService();
         var dialog = new RecordingDialogService();
         var deviceService = new RecordingDeviceService();
-        var vm = new DevicesViewModel(discovery, fileService, dialog, deviceService);
+        var vm = new DevicesViewModel(discovery, fileService, dialog, deviceService, new RecordingDeviceGroupService());
         vm.PromptForIpPort = () => "1.2.3.4:1234";
 
         await vm.AddDeviceCommand.ExecuteAsync(null);
@@ -325,5 +354,80 @@ public class DevicesViewModelTests
         Assert.Equal("1.2.3.4", deviceService.LastDevice?.Ip);
         Assert.Equal(1234, deviceService.LastDevice?.Port);
         Assert.Equal(1, discovery.DiscoverCallCount);
+    }
+
+    [Fact]
+    public async Task ChangingHostname_PersistsDevice()
+    {
+        var discovery = new StubDiscoveryService();
+        discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", Hostname = "old", IsOnline = true, Protocols = new List<DeviceProtocol>() });
+        var fileService = new RecordingDeviceFileService();
+        var dialog = new RecordingDialogService();
+        var deviceService = new RecordingDeviceService();
+        var groupService = new RecordingDeviceGroupService();
+        var vm = new DevicesViewModel(discovery, fileService, dialog, deviceService, groupService);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+        vm.Devices[0].Hostname = "new";
+        await deviceService.Tcs.Task;
+
+        Assert.Equal("new", deviceService.LastDevice?.Hostname);
+    }
+
+    [Fact]
+    public async Task ChangingGroup_AssignsDevice()
+    {
+        var discovery = new StubDiscoveryService();
+        discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", IsOnline = true, Protocols = new List<DeviceProtocol>() });
+        var fileService = new RecordingDeviceFileService();
+        var dialog = new RecordingDialogService();
+        var deviceService = new RecordingDeviceService();
+        var groupService = new RecordingDeviceGroupService();
+        groupService.Groups.Add(new DeviceGroup { Id = 1, Name = "G1" });
+        var vm = new DevicesViewModel(discovery, fileService, dialog, deviceService, groupService);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+        vm.Devices[0].GroupId = 1;
+        var assignment = await groupService.AssignTcs.Task;
+
+        Assert.Equal("1.2.3.4", assignment.ip);
+        Assert.Null(assignment.port);
+        Assert.Equal(1, assignment.groupId);
+    }
+
+    [Fact]
+    public async Task AddGroupCommand_CreatesGroupAndRefreshes()
+    {
+        var discovery = new StubDiscoveryService();
+        var fileService = new RecordingDeviceFileService();
+        var dialog = new RecordingDialogService();
+        var groupService = new RecordingDeviceGroupService();
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), groupService);
+        vm.PromptForGroupName = () => "NewGroup";
+
+        await vm.AddGroupCommand.ExecuteAsync(null);
+
+        Assert.Equal("NewGroup", groupService.CreatedGroupName);
+        Assert.Equal(1, discovery.DiscoverCallCount);
+    }
+
+    [Fact]
+    public async Task RenameGroupCommand_UpdatesService()
+    {
+        var discovery = new StubDiscoveryService();
+        var fileService = new RecordingDeviceFileService();
+        var dialog = new RecordingDialogService();
+        var groupService = new RecordingDeviceGroupService();
+        groupService.Groups.Add(new DeviceGroup { Id = 1, Name = "Old" });
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), groupService);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+        vm.SelectedGroup = vm.Groups[0];
+        vm.GroupName = "New";
+        await vm.RenameGroupCommand.ExecuteAsync(null);
+        var updated = await groupService.UpdateTcs.Task;
+
+        Assert.Equal(1, updated.Id);
+        Assert.Equal("New", updated.Name);
     }
 }

--- a/InventoryManagementApp/Services/Devices/DeviceFileService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceFileService.cs
@@ -248,6 +248,8 @@ namespace InventoryManagementApp.Services.Devices
         public async Task<int> DownloadUnseenFilesAsync(Device device, string basePath, CancellationToken cancellationToken = default)
         {
             var deviceDirName = string.IsNullOrWhiteSpace(device.Hostname) ? device.Ip : device.Hostname;
+            if (device.Port.HasValue)
+                deviceDirName += $"_{device.Port.Value}";
             var deviceDir = Path.Combine(basePath, "Devices", deviceDirName);
             Directory.CreateDirectory(deviceDir);
             var files = await ListFilesAsync(device, null, cancellationToken);

--- a/InventoryManagementApp/ViewModels/DevicesViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DevicesViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,10 +20,12 @@ namespace InventoryManagementApp.ViewModels
         private readonly IDeviceFileService _fileService;
         private readonly IDialogService _dialogService;
         private readonly IDeviceService _deviceService;
+        private readonly IDeviceGroupService _groupService;
         private readonly ILogger<DevicesViewModel> _logger;
 
         public ObservableCollection<Device> Devices { get; } = new();
         public ObservableCollection<string> DeviceFiles { get; } = new();
+        public ObservableCollection<DeviceGroup> Groups { get; } = new();
 
         private string _fileExtensionFilter = "*.*";
         public string FileExtensionFilter
@@ -48,6 +51,8 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand RefreshCommand { get; }
         public IAsyncRelayCommand PullAllReportsCommand { get; }
         public IAsyncRelayCommand AddDeviceCommand { get; }
+        public IAsyncRelayCommand AddGroupCommand { get; }
+        public IAsyncRelayCommand RenameGroupCommand { get; }
 
         private double _discoveryProgress;
         public double DiscoveryProgress
@@ -72,21 +77,48 @@ namespace InventoryManagementApp.ViewModels
         public Func<string?> PromptForIpPort { get; set; } = () =>
             Interaction.InputBox("Enter device IP:port:", "Add Device", string.Empty);
 
+        public Func<string?> PromptForGroupName { get; set; } = () =>
+            Interaction.InputBox("Enter group name:", "Add Group", string.Empty);
+
+        private DeviceGroup? _selectedGroup;
+        public DeviceGroup? SelectedGroup
+        {
+            get => _selectedGroup;
+            set
+            {
+                if (SetProperty(ref _selectedGroup, value))
+                {
+                    GroupName = value?.Name ?? string.Empty;
+                }
+            }
+        }
+
+        private string _groupName = string.Empty;
+        public string GroupName
+        {
+            get => _groupName;
+            set => SetProperty(ref _groupName, value);
+        }
+
         public DevicesViewModel(IDeviceDiscoveryService discoveryService,
                                  IDeviceFileService fileService,
                                  IDialogService dialogService,
                                  IDeviceService deviceService,
+                                 IDeviceGroupService groupService,
                                  ILogger<DevicesViewModel>? logger = null)
         {
             _discoveryService = discoveryService;
             _fileService = fileService;
             _dialogService = dialogService;
             _deviceService = deviceService;
+            _groupService = groupService;
             _logger = logger ?? NullLogger<DevicesViewModel>.Instance;
 
             RefreshCommand = new AsyncRelayCommand(RefreshAsync, () => !IsDiscovering);
             PullAllReportsCommand = new AsyncRelayCommand(PullAllReportsAsync, CanPullAllReports);
             AddDeviceCommand = new AsyncRelayCommand(AddDeviceAsync);
+            AddGroupCommand = new AsyncRelayCommand(AddGroupAsync);
+            RenameGroupCommand = new AsyncRelayCommand(RenameGroupAsync);
         }
 
         private async Task RefreshAsync()
@@ -95,13 +127,21 @@ namespace InventoryManagementApp.ViewModels
             {
                 IsDiscovering = true;
                 DiscoveryProgress = 0;
+
+                foreach (var d in Devices)
+                    d.PropertyChanged -= Device_PropertyChanged;
                 Devices.Clear();
+
+                var groups = await _groupService.GetGroupsAsync();
+                Groups.Clear();
+                foreach (var g in groups)
+                    Groups.Add(g);
 
                 var progress = new Progress<double>(p => DiscoveryProgress = p);
 
                 await foreach (var d in _discoveryService.DiscoverDevicesAsync(progress))
                 {
-                    Devices.Add(new Device
+                    var device = new Device
                     {
                         Ip = d.Ip,
                         Hostname = d.Hostname,
@@ -112,7 +152,17 @@ namespace InventoryManagementApp.ViewModels
                             ? string.Join(", ", d.Protocols)
                             : DeviceProtocol.Unknown.ToString(),
                         Status = d.IsOnline ? "Online" : "Offline"
-                    });
+                    };
+                    try
+                    {
+                        device.GroupId = await _groupService.GetDeviceGroupIdAsync(device.Ip, device.Port);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to get group for device {Ip}", device.Ip);
+                    }
+                    device.PropertyChanged += Device_PropertyChanged;
+                    Devices.Add(device);
                 }
 
                 if (Devices.Count == 0 && !_discoveryService.HasConfiguredSubnets)
@@ -173,6 +223,71 @@ namespace InventoryManagementApp.ViewModels
             {
                 _logger.LogError(ex, "Failed to add device");
                 await _dialogService.ShowInfoAsync($"Failed to add device: {ex.Message}", "Devices");
+            }
+        }
+
+        private async Task AddGroupAsync()
+        {
+            try
+            {
+                var name = PromptForGroupName?.Invoke();
+                if (string.IsNullOrWhiteSpace(name))
+                    return;
+
+                await _groupService.CreateGroupAsync(name);
+                await RefreshAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to add device group");
+                await _dialogService.ShowInfoAsync($"Failed to add group: {ex.Message}", "Devices");
+            }
+        }
+
+        private async Task RenameGroupAsync()
+        {
+            if (SelectedGroup is null || string.IsNullOrWhiteSpace(GroupName))
+                return;
+
+            try
+            {
+                SelectedGroup.Name = GroupName;
+                await _groupService.UpdateGroupAsync(SelectedGroup);
+                await RefreshAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to rename group {GroupId}", SelectedGroup.Id);
+                await _dialogService.ShowInfoAsync($"Failed to rename group: {ex.Message}", "Devices");
+            }
+        }
+
+        async void Device_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (sender is not Device device)
+                return;
+
+            if (e.PropertyName == nameof(Device.Hostname))
+            {
+                try
+                {
+                    await _deviceService.AddOrUpdateDeviceAsync(device);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to update device {Ip}", device.Ip);
+                }
+            }
+            else if (e.PropertyName == nameof(Device.GroupId))
+            {
+                try
+                {
+                    await _groupService.AssignDeviceToGroupAsync(device.Ip, device.Port, device.GroupId);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to assign device {Ip} to group {Group}", device.Ip, device.GroupId);
+                }
             }
         }
     }

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -529,7 +529,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 try
                 {
-                    var vm = new DevicesViewModel(_deviceDiscoveryService, _deviceFileService, _dialogService, _deviceService);
+                    var vm = new DevicesViewModel(_deviceDiscoveryService, _deviceFileService, _dialogService, _deviceService, _deviceGroupService);
                     var page = new DevicesPage { DataContext = vm, Title = "Devices" };
                     CurrentPage = page;
                     await Task.CompletedTask;

--- a/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
@@ -185,6 +185,8 @@ namespace InventoryManagementApp.ViewModels
                 var filter = FileExtensionFilter == "*.*" ? null : FileExtensionFilter;
                 await _fileService.DownloadUnseenFilesAsync(SelectedDevice, AppContext.BaseDirectory, cancellationToken);
                 var deviceDirName = string.IsNullOrWhiteSpace(SelectedDevice.Hostname) ? SelectedDevice.Ip : SelectedDevice.Hostname;
+                if (SelectedDevice.Port.HasValue)
+                    deviceDirName += $"_{SelectedDevice.Port.Value}";
                 var deviceDir = Path.Combine(AppContext.BaseDirectory, "Devices", deviceDirName);
                 if (Directory.Exists(deviceDir))
                 {

--- a/InventoryManagementApp/Views/Pages/DevicesPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DevicesPage.xaml
@@ -42,15 +42,20 @@
                 <DataGrid ItemsSource="{Binding Devices}"
                           SelectedItem="{Binding SelectedDevice}"
                           AutoGenerateColumns="False"
-                          IsReadOnly="True"
+                          IsReadOnly="False"
                           Style="{StaticResource VirtualizedDataGridStyle}"
                           ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
                     <DataGrid.Columns>
-                        <DataGridTextColumn Header="IP" Binding="{Binding Ip}" Width="150"/>
-                        <DataGridTextColumn Header="MAC" Binding="{Binding MacAddress}" Width="150"/>
-                        <DataGridTextColumn Header="Hostname" Binding="{Binding Hostname}" Width="*"/>
-                        <DataGridTextColumn Header="Protocols" Binding="{Binding ProtocolsDisplay}" Width="150"/>
-                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="120"/>
+                        <DataGridTextColumn Header="IP" Binding="{Binding Ip}" IsReadOnly="True" Width="150"/>
+                        <DataGridTextColumn Header="MAC" Binding="{Binding MacAddress}" IsReadOnly="True" Width="150"/>
+                        <DataGridTextColumn Header="Hostname" Binding="{Binding Hostname, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                        <DataGridComboBoxColumn Header="Group"
+                                                 SelectedValueBinding="{Binding GroupId, UpdateSourceTrigger=PropertyChanged}"
+                                                 SelectedValuePath="Id"
+                                                 DisplayMemberPath="Name"
+                                                 ItemsSource="{Binding Groups}" Width="150"/>
+                        <DataGridTextColumn Header="Protocols" Binding="{Binding ProtocolsDisplay}" IsReadOnly="True" Width="150"/>
+                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" IsReadOnly="True" Width="120"/>
                     </DataGrid.Columns>
                 </DataGrid>
             </Border>


### PR DESCRIPTION
## Summary
- Allow editing device hostnames and groups with persistence to services
- Surface device groups in UI and support creating or renaming groups
- Store downloaded device files in folders that include the port number

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f2c1376c8324b8f980f2a586aa17