### PR TITLE
feat(devices): add device settings page

### DIFF
--- a/InventoryManagementApp.Tests/DeviceSettingsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DeviceSettingsViewModelTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.ViewModels;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+using InventoryManagementApp.Models;
+
+namespace InventoryManagementApp.Tests
+{
+    public class DeviceSettingsViewModelTests
+    {
+        private sealed class StubSettingsService : ISettingsService
+        {
+            private readonly Dictionary<string, string> _settings = new();
+            public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
+            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
+            { _settings[key] = value; return Task.CompletedTask; }
+            public Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default)
+            { return Task.FromResult(key != null && _settings.TryGetValue(key, out var v) ? v : null); }
+            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default)
+            { return Task.FromResult(new Dictionary<string, string>(_settings)); }
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
+            { foreach (var kv in settings) _settings[kv.Key] = kv.Value; return Task.CompletedTask; }
+            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
+            { _settings.Remove(key); return Task.CompletedTask; }
+            public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult<IDictionary<ItemDetailField, bool>>(new Dictionary<ItemDetailField, bool>());
+            public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
+            { ItemDetailVisibilityChanged?.Invoke(this, visibility); return Task.CompletedTask; }
+        }
+
+        private sealed class DummyDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => false;
+            public InventoryManagementApp.Models.ItemModel? ShowEditItemDialog(InventoryManagementApp.Models.ItemModel item) => null;
+            public void ShowItemDetails(InventoryManagementApp.Models.ItemModel item) { }
+            public (InventoryManagementApp.Models.CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(InventoryManagementApp.Models.ItemModel item, IEnumerable<InventoryManagementApp.Models.CustomerModel> customers) => null;
+            public InventoryManagementApp.Models.CustomerModel? ShowAddCustomerDialog() => null;
+            public InventoryManagementApp.Models.CustomerModel? ShowEditCustomerDialog(InventoryManagementApp.Models.CustomerModel customer) => null;
+            public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(InventoryManagementApp.Models.ItemModel item, IEnumerable<InventoryManagementApp.Models.RentalModel> history) { }
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
+            public Func<InventoryManagementApp.Models.ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+        }
+
+        [Fact]
+        public async Task SaveCommand_PersistsSettings()
+        {
+            var settings = new StubSettingsService();
+            var config = new ConfigurationBuilder().Build();
+            var vm = new DeviceSettingsViewModel(settings, config, new DummyDialogService());
+            vm.Subnets = "10.0.0.0/24";
+            vm.FtpPorts = "21";
+            vm.AdditionalPorts = "5555:Adb";
+            vm.MaxConcurrentScans = 5;
+            vm.LivenessTimeoutMs = 100;
+            vm.PortProbeTimeoutMs = 200;
+            await vm.SaveCommand.ExecuteAsync(null);
+            var all = await settings.GetAllSettingsAsync();
+            Assert.Equal("10.0.0.0/24", all["DeviceDiscovery_Subnets"]);
+            Assert.Equal("21", all["DeviceDiscovery_FtpPorts"]);
+            Assert.Equal("5555:Adb", all["DeviceDiscovery_AdditionalPorts"]);
+            Assert.Equal("5", all["DeviceDiscovery_MaxConcurrentScans"]);
+            Assert.Equal("100", all["DeviceDiscovery_LivenessTimeoutMs"]);
+            Assert.Equal("200", all["DeviceDiscovery_PortProbeTimeoutMs"]);
+        }
+    }
+}

--- a/InventoryManagementApp.Tests/DevicesPageTests.cs
+++ b/InventoryManagementApp.Tests/DevicesPageTests.cs
@@ -164,6 +164,44 @@ namespace InventoryManagementApp.Tests
             Assert.Equal("aa-bb", cellText);
         }
 
+        [Fact]
+        public void DevicesPage_HasSettingsButton()
+        {
+            Exception? threadEx = null;
+            Button? settingsButton = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary
+                    {
+                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                    });
+
+                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
+                    var page = new DevicesPage { DataContext = vm };
+                    page.ApplyTemplate();
+                    settingsButton = (Button)page.FindName("DeviceSettingsButton");
+
+                    Application.Current?.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadEx != null) throw threadEx;
+            Assert.NotNull(settingsButton);
+            Assert.Equal("Device Settings", settingsButton!.Content);
+        }
+
         private sealed class BindingErrorTraceListener : TraceListener
         {
             private readonly List<string> _errors;

--- a/InventoryManagementApp.Tests/MainWindowSideMenuTests.cs
+++ b/InventoryManagementApp.Tests/MainWindowSideMenuTests.cs
@@ -14,5 +14,14 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("Content=\"Print Preview\"", xaml);
             Assert.DoesNotContain("OpenPrintPreviewWindowCommand", xaml);
         }
+
+        [Fact]
+        public void SideMenu_ContainsDeviceSettingsButton()
+        {
+            var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "InventoryManagementApp", "MainWindow.xaml"));
+            var xaml = File.ReadAllText(path);
+            Assert.Contains("Content=\"Device Settings\"", xaml);
+            Assert.Contains("OpenDeviceSettingsCommand", xaml);
+        }
     }
 }

--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -120,7 +120,13 @@ namespace InventoryManagementApp
                 services.AddSingleton<IDialogService, DialogService>();
                 services.AddSingleton<IDeviceService, DeviceService>();
                 services.AddSingleton<IScannerService, ScannerService>();
-                services.AddSingleton<IDeviceDiscoveryService, DeviceDiscoveryService>();
+                services.AddSingleton<IDeviceDiscoveryService>(sp =>
+                    new DeviceDiscoveryService(
+                        sp.GetRequiredService<IConfiguration>(),
+                        sp.GetRequiredService<ILogger<DeviceDiscoveryService>>(),
+                        null,
+                        null,
+                        sp.GetRequiredService<ISettingsService>()));
                 services.AddSingleton<IDeviceGroupService, DeviceGroupService>();
                 services.AddSingleton<IDeviceFileService, DeviceFileService>();
                 services.AddSingleton<MemoryBudget>();

--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -60,6 +60,7 @@
 
                         <TextBlock Text="Diagnostics" Style="{StaticResource CaptionTextBlock}" Margin="6,8,6,2"/>
                         <Button Style="{StaticResource NavButton}" Content="Devices" Command="{Binding OpenDevicesPageCommand}"/>
+                        <Button Style="{StaticResource NavButton}" Content="Device Settings" Command="{Binding OpenDeviceSettingsCommand}"/>
 
                         <Separator/>
 

--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -43,13 +43,20 @@ namespace InventoryManagementApp.Services.Devices
         public DeviceDiscoveryService(IConfiguration configuration,
             ILogger<DeviceDiscoveryService>? logger = null,
             Func<string, int, CancellationToken, Task<bool>>? portChecker = null,
-            Func<IList<string>>? subnetResolver = null)
+            Func<IList<string>>? subnetResolver = null,
+            ISettingsService? settingsService = null)
         {
             _logger = logger ?? NullLogger<DeviceDiscoveryService>.Instance;
             _portChecker = portChecker ?? DefaultPortChecker;
             subnetResolver ??= GetLocalSubnets;
 
             _subnets = configuration.GetSection("DeviceDiscovery:Subnets").Get<IList<string>>() ?? new List<string>();
+            if (settingsService != null)
+            {
+                var subnetsOverride = settingsService.GetSettingAsync("DeviceDiscovery_Subnets").GetAwaiter().GetResult();
+                if (!string.IsNullOrWhiteSpace(subnetsOverride))
+                    _subnets = subnetsOverride.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToList();
+            }
             if (_subnets.Count == 0)
             {
                 _subnets = subnetResolver() ?? new List<string>();
@@ -64,10 +71,50 @@ namespace InventoryManagementApp.Services.Devices
             }
 
             _ftpPorts = configuration.GetSection("DeviceDiscovery:FtpPorts").Get<int[]>() ?? new[] { 21, 3721 };
+            if (settingsService != null)
+            {
+                var ftpOverride = settingsService.GetSettingAsync("DeviceDiscovery_FtpPorts").GetAwaiter().GetResult();
+                if (!string.IsNullOrWhiteSpace(ftpOverride))
+                    _ftpPorts = ftpOverride.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                        .Select(p => int.TryParse(p, out var v) ? v : 0).Where(v => v > 0).ToArray();
+            }
             _additionalPorts = configuration.GetSection("DeviceDiscovery:AdditionalPorts").Get<Dictionary<int, DeviceProtocol>>() ?? new Dictionary<int, DeviceProtocol>();
+            if (settingsService != null)
+            {
+                var addOverride = settingsService.GetSettingAsync("DeviceDiscovery_AdditionalPorts").GetAwaiter().GetResult();
+                if (!string.IsNullOrWhiteSpace(addOverride))
+                {
+                    _additionalPorts = new Dictionary<int, DeviceProtocol>();
+                    foreach (var part in addOverride.Split(',', StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        var kv = part.Split(':');
+                        if (kv.Length == 2 && int.TryParse(kv[0], out var port)
+                            && Enum.TryParse<DeviceProtocol>(kv[1], true, out var proto))
+                            _additionalPorts[port] = proto;
+                    }
+                }
+            }
             _maxConcurrentScans = configuration.GetValue<int?>("DeviceDiscovery:MaxConcurrentScans") ?? 128;
+            if (settingsService != null)
+            {
+                var val = settingsService.GetSettingAsync("DeviceDiscovery_MaxConcurrentScans").GetAwaiter().GetResult();
+                if (int.TryParse(val, out var mcs))
+                    _maxConcurrentScans = mcs;
+            }
             _livenessTimeoutMs = configuration.GetValue<int?>("DeviceDiscovery:LivenessTimeoutMs") ?? 400;
+            if (settingsService != null)
+            {
+                var val = settingsService.GetSettingAsync("DeviceDiscovery_LivenessTimeoutMs").GetAwaiter().GetResult();
+                if (int.TryParse(val, out var lt))
+                    _livenessTimeoutMs = lt;
+            }
             _portProbeTimeoutMs = configuration.GetValue<int?>("DeviceDiscovery:PortProbeTimeoutMs") ?? 700;
+            if (settingsService != null)
+            {
+                var val = settingsService.GetSettingAsync("DeviceDiscovery_PortProbeTimeoutMs").GetAwaiter().GetResult();
+                if (int.TryParse(val, out var pt))
+                    _portProbeTimeoutMs = pt;
+            }
         }
 
         public async Task<IReadOnlyList<DiscoveredDevice>> DiscoverDevicesAsync(CancellationToken cancellationToken = default)

--- a/InventoryManagementApp/ViewModels/DeviceSettingsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DeviceSettingsViewModel.cs
@@ -1,0 +1,106 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using InventoryManagementApp.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using InventoryManagementApp.Models;
+
+namespace InventoryManagementApp.ViewModels
+{
+    public class DeviceSettingsViewModel : ObservableObject
+    {
+        private readonly ISettingsService _settingsService;
+        private readonly IConfiguration _configuration;
+        private readonly IDialogService _dialogService;
+        private readonly ILogger<DeviceSettingsViewModel> _logger;
+
+        public DeviceSettingsViewModel(ISettingsService settingsService, IConfiguration configuration, IDialogService dialogService, ILogger<DeviceSettingsViewModel>? logger = null)
+        {
+            _settingsService = settingsService;
+            _configuration = configuration;
+            _dialogService = dialogService;
+            _logger = logger ?? NullLogger<DeviceSettingsViewModel>.Instance;
+            SaveCommand = new AsyncRelayCommand(SaveAsync);
+        }
+
+        public IAsyncRelayCommand SaveCommand { get; }
+
+        private string _subnets = string.Empty;
+        public string Subnets { get => _subnets; set => SetProperty(ref _subnets, value); }
+
+        private string _ftpPorts = string.Empty;
+        public string FtpPorts { get => _ftpPorts; set => SetProperty(ref _ftpPorts, value); }
+
+        private string _additionalPorts = string.Empty;
+        public string AdditionalPorts { get => _additionalPorts; set => SetProperty(ref _additionalPorts, value); }
+
+        private int _maxConcurrentScans;
+        public int MaxConcurrentScans { get => _maxConcurrentScans; set => SetProperty(ref _maxConcurrentScans, value); }
+
+        private int _livenessTimeoutMs;
+        public int LivenessTimeoutMs { get => _livenessTimeoutMs; set => SetProperty(ref _livenessTimeoutMs, value); }
+
+        private int _portProbeTimeoutMs;
+        public int PortProbeTimeoutMs { get => _portProbeTimeoutMs; set => SetProperty(ref _portProbeTimeoutMs, value); }
+
+        bool _initialized;
+        public async Task InitializeAsync()
+        {
+            if (_initialized) return;
+            _subnets = await _settingsService.GetSettingAsync("DeviceDiscovery_Subnets").ConfigureAwait(false)
+                       ?? string.Join(", ", _configuration.GetSection("DeviceDiscovery:Subnets").Get<string[]>() ?? Array.Empty<string>());
+            _ftpPorts = await _settingsService.GetSettingAsync("DeviceDiscovery_FtpPorts").ConfigureAwait(false)
+                       ?? string.Join(", ", _configuration.GetSection("DeviceDiscovery:FtpPorts").Get<int[]>() ?? Array.Empty<int>());
+            _additionalPorts = await _settingsService.GetSettingAsync("DeviceDiscovery_AdditionalPorts").ConfigureAwait(false)
+                       ?? string.Join(", ", (_configuration.GetSection("DeviceDiscovery:AdditionalPorts").Get<Dictionary<int, DeviceProtocol>>() ?? new()).Select(kv => $"{kv.Key}:{kv.Value}"));
+            if (int.TryParse(await _settingsService.GetSettingAsync("DeviceDiscovery_MaxConcurrentScans").ConfigureAwait(false), out var mcs))
+                _maxConcurrentScans = mcs;
+            else
+                _maxConcurrentScans = _configuration.GetValue<int?>("DeviceDiscovery:MaxConcurrentScans") ?? 128;
+            if (int.TryParse(await _settingsService.GetSettingAsync("DeviceDiscovery_LivenessTimeoutMs").ConfigureAwait(false), out var lt))
+                _livenessTimeoutMs = lt;
+            else
+                _livenessTimeoutMs = _configuration.GetValue<int?>("DeviceDiscovery:LivenessTimeoutMs") ?? 400;
+            if (int.TryParse(await _settingsService.GetSettingAsync("DeviceDiscovery_PortProbeTimeoutMs").ConfigureAwait(false), out var ppt))
+                _portProbeTimeoutMs = ppt;
+            else
+                _portProbeTimeoutMs = _configuration.GetValue<int?>("DeviceDiscovery:PortProbeTimeoutMs") ?? 700;
+            OnPropertyChanged(nameof(Subnets));
+            OnPropertyChanged(nameof(FtpPorts));
+            OnPropertyChanged(nameof(AdditionalPorts));
+            OnPropertyChanged(nameof(MaxConcurrentScans));
+            OnPropertyChanged(nameof(LivenessTimeoutMs));
+            OnPropertyChanged(nameof(PortProbeTimeoutMs));
+            _initialized = true;
+        }
+
+        async Task SaveAsync()
+        {
+            try
+            {
+                await _settingsService.SaveSettingAsync("DeviceDiscovery_Subnets", _subnets).ConfigureAwait(false);
+                await _settingsService.SaveSettingAsync("DeviceDiscovery_FtpPorts", _ftpPorts).ConfigureAwait(false);
+                await _settingsService.SaveSettingAsync("DeviceDiscovery_AdditionalPorts", _additionalPorts).ConfigureAwait(false);
+                await _settingsService.SaveSettingAsync("DeviceDiscovery_MaxConcurrentScans", _maxConcurrentScans.ToString()).ConfigureAwait(false);
+                await _settingsService.SaveSettingAsync("DeviceDiscovery_LivenessTimeoutMs", _livenessTimeoutMs.ToString()).ConfigureAwait(false);
+                await _settingsService.SaveSettingAsync("DeviceDiscovery_PortProbeTimeoutMs", _portProbeTimeoutMs.ToString()).ConfigureAwait(false);
+                _dialogService.ShowInfo("Device settings saved.", "Device Settings");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogWarning(ex, "Unauthorized to change settings.");
+                _dialogService.ShowInfo("You are not authorized to change settings.", "Unauthorized");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save device settings.");
+                _dialogService.ShowInfo($"Failed to save settings: {ex.Message}", "Device Settings");
+            }
+        }
+    }
+}

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -197,6 +197,7 @@ namespace InventoryManagementApp.ViewModels
 
         public IAsyncRelayCommand OpenPrintLabelWindowCommand { get; }
         public IAsyncRelayCommand OpenDevicesPageCommand { get; }
+        public IAsyncRelayCommand OpenDeviceSettingsCommand { get; }
 
         public MainViewModel(IItemService itemService,
                              IUserService userService,
@@ -232,7 +233,8 @@ namespace InventoryManagementApp.ViewModels
             _deviceService = deviceService ?? new DummyDeviceService();
             _deviceGroupService = deviceGroupService ?? new DummyDeviceGroupService();
             _deviceFileService = deviceFileService ?? new DummyDeviceFileService();
-            _deviceDiscoveryService = deviceDiscoveryService ?? new DeviceDiscoveryService(new ConfigurationBuilder().Build());
+            var defaultConfig = new ConfigurationBuilder().AddJsonFile("appsettings.json", optional: true).Build();
+            _deviceDiscoveryService = deviceDiscoveryService ?? new DeviceDiscoveryService(defaultConfig, null, null, null, _settingsService);
             _fileDialogService = fileDialogService;
             _logger = logger ?? NullLogger<MainViewModel>.Instance;
             _showLoginWindow = showLoginWindow ?? new Func<Task<bool>>(async () =>
@@ -538,6 +540,25 @@ namespace InventoryManagementApp.ViewModels
                 {
                     _logger.LogError(ex, "Failed to open devices page");
                     _dialogService.ShowInfo($"Failed to open devices page: {ex.Message}", "Devices");
+                    throw;
+                }
+            });
+
+            OpenDeviceSettingsCommand = new AsyncRelayCommand(async () =>
+            {
+                try
+                {
+                    var config = new ConfigurationBuilder().AddJsonFile("appsettings.json", optional: true).Build();
+                    var vm = new DeviceSettingsViewModel(_settingsService, config, _dialogService);
+                    await vm.InitializeAsync().ConfigureAwait(false);
+                    var page = new DeviceSettingsPage { DataContext = vm, Title = "Device Settings" };
+                    CurrentPage = page;
+                    await Task.CompletedTask;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to open device settings page");
+                    _dialogService.ShowInfo($"Failed to open device settings page: {ex.Message}", "Device Settings");
                     throw;
                 }
             });

--- a/InventoryManagementApp/Views/Pages/DeviceSettingsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DeviceSettingsPage.xaml
@@ -1,0 +1,25 @@
+<!-- Views/Pages/DeviceSettingsPage.xaml -->
+<Page x:Class="InventoryManagementApp.Views.Pages.DeviceSettingsPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      Title="Device Settings"
+      Background="{DynamicResource BackgroundBrush}">
+    <ScrollViewer>
+        <StackPanel Margin="10">
+            <TextBlock Text="Device Discovery Settings" Style="{StaticResource HeadingTextBlock}" Margin="0,0,0,8"/>
+            <TextBlock Text="Subnets (comma-separated)"/>
+            <TextBox Text="{Binding Subnets, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBlock Text="FTP Ports (comma-separated)"/>
+            <TextBox Text="{Binding FtpPorts, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBlock Text="Additional Ports (port:Protocol, comma-separated)"/>
+            <TextBox Text="{Binding AdditionalPorts, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBlock Text="Max Concurrent Scans"/>
+            <TextBox Text="{Binding MaxConcurrentScans, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBlock Text="Liveness Timeout (ms)"/>
+            <TextBox Text="{Binding LivenessTimeoutMs, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBlock Text="Port Probe Timeout (ms)"/>
+            <TextBox Text="{Binding PortProbeTimeoutMs, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <Button Content="Save" Style="{StaticResource PrimaryButton}" Command="{Binding SaveCommand}" Width="100"/>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/InventoryManagementApp/Views/Pages/DeviceSettingsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/DeviceSettingsPage.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace InventoryManagementApp.Views.Pages
+{
+    public partial class DeviceSettingsPage : Page
+    {
+        public DeviceSettingsPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/InventoryManagementApp/Views/Pages/DevicesPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DevicesPage.xaml
@@ -24,6 +24,11 @@
                                 Content="Add Device"
                                 Command="{Binding AddDeviceCommand}"
                                 Margin="0,0,8,0"/>
+                        <Button x:Name="DeviceSettingsButton"
+                                Style="{StaticResource PrimaryButton}"
+                                Content="Device Settings"
+                                Command="{Binding DataContext.OpenDeviceSettingsCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                Margin="0,0,8,0"/>
                         <TextBox Text="{Binding FileExtensionFilter, UpdateSourceTrigger=PropertyChanged}"
                                  Width="120"
                                  Margin="0,0,8,0"/>


### PR DESCRIPTION
## Summary
- add Device Settings nav button under Diagnostics and on Devices page
- create DeviceSettingsPage and ViewModel for device discovery options
- allow DeviceDiscoveryService to read overrides from settings service

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b808e06dd08324bca800957cd52071