### PR TITLE
Add scanner status navigation command

### DIFF
--- a/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
@@ -42,6 +42,18 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task OpenScannerStatusCommand_IsNotNull()
+        {
+            await RunOnStaThread(() =>
+            {
+                using var db = new DatabaseService(":memory:");
+                using var vm = CreateMainViewModel(db, new DummyItemService(), new DummyDialogService());
+                Assert.NotNull(vm.OpenScannerStatusCommand);
+                return Task.CompletedTask;
+            });
+        }
+
+        [Fact]
         public async Task UpdateUserAsync_UpdatesCurrentUserPhotoAndRaisesEvent()
         {
             await RunOnStaThread(async () =>

--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -61,6 +61,7 @@
                         <TextBlock Text="Diagnostics" Style="{StaticResource CaptionTextBlock}" Margin="6,8,6,2"/>
                         <Button Style="{StaticResource NavButton}" Content="Devices" Command="{Binding OpenDevicesPageCommand}"/>
                         <Button Style="{StaticResource NavButton}" Content="Device Settings" Command="{Binding OpenDeviceSettingsCommand}"/>
+                        <Button Style="{StaticResource NavButton}" Content="Scanner Status" Command="{Binding OpenScannerStatusCommand}"/>
 
                         <Separator/>
 

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -198,6 +198,7 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand OpenPrintLabelWindowCommand { get; }
         public IAsyncRelayCommand OpenDevicesPageCommand { get; }
         public IAsyncRelayCommand OpenDeviceSettingsCommand { get; }
+        public IAsyncRelayCommand OpenScannerStatusCommand { get; }
 
         public MainViewModel(IItemService itemService,
                              IUserService userService,
@@ -559,6 +560,22 @@ namespace InventoryManagementApp.ViewModels
                 {
                     _logger.LogError(ex, "Failed to open device settings page");
                     _dialogService.ShowInfo($"Failed to open device settings page: {ex.Message}", "Device Settings");
+                    throw;
+                }
+            });
+
+            OpenScannerStatusCommand = new AsyncRelayCommand(async () =>
+            {
+                try
+                {
+                    var window = new ScannerStatusWindow(_scannerService, _dialogService, _deviceService, _deviceGroupService, _deviceFileService);
+                    window.Show();
+                    await Task.CompletedTask;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to open scanner status window");
+                    _dialogService.ShowInfo($"Failed to open scanner status window: {ex.Message}", "Scanner Status");
                     throw;
                 }
             });


### PR DESCRIPTION
## Summary
- add Scanner Status side-menu button bound to `OpenScannerStatusCommand`
- implement command in `MainViewModel` to show `ScannerStatusWindow`
- cover presence of command in navigation tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b814b96eb48324870737a880c333c8