### PR TITLE
Add ping command and button for devices

### DIFF
--- a/InventoryManagementApp.Tests/DevicesPageTests.cs
+++ b/InventoryManagementApp.Tests/DevicesPageTests.cs
@@ -202,6 +202,44 @@ namespace InventoryManagementApp.Tests
             Assert.Equal("Device Settings", settingsButton!.Content);
         }
 
+        [Fact]
+        public void DevicesPage_HasPingButton()
+        {
+            Exception? threadEx = null;
+            Button? pingButton = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary
+                    {
+                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                    });
+
+                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
+                    var page = new DevicesPage { DataContext = vm };
+                    page.ApplyTemplate();
+                    pingButton = (Button)page.FindName("PingButton");
+
+                    Application.Current?.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadEx != null) throw threadEx;
+            Assert.NotNull(pingButton);
+            Assert.Equal("Ping", pingButton!.Content);
+        }
+
         private sealed class BindingErrorTraceListener : TraceListener
         {
             private readonly List<string> _errors;

--- a/InventoryManagementApp/ViewModels/DevicesViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DevicesViewModel.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Net.NetworkInformation;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using InventoryManagementApp.Interfaces;
@@ -44,12 +45,14 @@ namespace InventoryManagementApp.ViewModels
                 {
                     DeviceFiles.Clear();
                     PullAllReportsCommand.NotifyCanExecuteChanged();
+                    PingSelectedDeviceCommand.NotifyCanExecuteChanged();
                 }
             }
         }
 
         public IAsyncRelayCommand RefreshCommand { get; }
         public IAsyncRelayCommand PullAllReportsCommand { get; }
+        public IAsyncRelayCommand PingSelectedDeviceCommand { get; }
         public IAsyncRelayCommand AddDeviceCommand { get; }
         public IAsyncRelayCommand AddGroupCommand { get; }
         public IAsyncRelayCommand RenameGroupCommand { get; }
@@ -116,6 +119,7 @@ namespace InventoryManagementApp.ViewModels
 
             RefreshCommand = new AsyncRelayCommand(RefreshAsync, () => !IsDiscovering);
             PullAllReportsCommand = new AsyncRelayCommand(PullAllReportsAsync, CanPullAllReports);
+            PingSelectedDeviceCommand = new AsyncRelayCommand(PingSelectedDeviceAsync, () => SelectedDevice != null);
             AddDeviceCommand = new AsyncRelayCommand(AddDeviceAsync);
             AddGroupCommand = new AsyncRelayCommand(AddGroupAsync);
             RenameGroupCommand = new AsyncRelayCommand(RenameGroupAsync);
@@ -199,6 +203,38 @@ namespace InventoryManagementApp.ViewModels
                 _logger.LogError(ex, "Failed to load files for {Ip}", SelectedDevice.Ip);
                 await _dialogService.ShowInfoAsync($"Failed to pull reports: {ex.Message}", "Devices");
             }
+        }
+
+        private async Task PingSelectedDeviceAsync()
+        {
+            if (SelectedDevice == null) return;
+            try
+            {
+                var success = await SafePingAsync(SelectedDevice.Ip, 1000, CancellationToken.None);
+                SelectedDevice.Status = success ? "Online" : "Offline";
+                if (success)
+                    SelectedDevice.LastSeen = DateTime.UtcNow;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to ping device {Ip}", SelectedDevice.Ip);
+            }
+        }
+
+        private static async Task<bool> SafePingAsync(string ip, int timeoutMs, CancellationToken ct)
+        {
+            using var ping = new Ping();
+            try
+            {
+                var pingTask = ping.SendPingAsync(ip, timeoutMs);
+                var completed = await Task.WhenAny(pingTask, Task.Delay(Timeout.InfiniteTimeSpan, ct)).ConfigureAwait(false);
+                if (completed != pingTask)
+                    return false;
+                var reply = await pingTask.ConfigureAwait(false);
+                return reply.Status == IPStatus.Success;
+            }
+            catch (OperationCanceledException) { return false; }
+            catch { return false; }
         }
 
         private async Task AddDeviceAsync()

--- a/InventoryManagementApp/Views/Pages/DevicesPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DevicesPage.xaml
@@ -20,6 +20,11 @@
                                 Content="Refresh"
                                 Command="{Binding RefreshCommand}"
                                 Margin="0,0,8,0"/>
+                        <Button x:Name="PingButton"
+                                Style="{StaticResource PrimaryButton}"
+                                Content="Ping"
+                                Command="{Binding PingSelectedDeviceCommand}"
+                                Margin="0,0,8,0"/>
                         <Button Style="{StaticResource PrimaryButton}"
                                 Content="Add Device"
                                 Command="{Binding AddDeviceCommand}"


### PR DESCRIPTION
## Summary
- allow pinging of selected device via new command and UI button
- add unit test ensuring ping button is present

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8187987ec83248d0734185009fb23