### PR TITLE
Optimize device scanning for incremental IP processing

### DIFF
--- a/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
+++ b/InventoryManagementApp.Tests/DeviceDiscoveryServiceTests.cs
@@ -411,4 +411,31 @@ public class DeviceDiscoveryServiceTests
         var result = (bool)method.Invoke(null, parameters)!;
         Assert.False(result);
     }
+
+    [Fact]
+    public async Task DiscoverDevicesAsync_SkipsDuplicateIpAddresses()
+    {
+        var configDict = new Dictionary<string, string?>
+        {
+            ["DeviceDiscovery:Subnets:0"] = "127.0.0.1",
+            ["DeviceDiscovery:Subnets:1"] = "127.0.0.1",
+            ["DeviceDiscovery:FtpPorts:0"] = "21"
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configDict!)
+            .Build();
+
+        var callCount = 0;
+        Task<bool> PortChecker(string ip, int port, CancellationToken _)
+        {
+            Interlocked.Increment(ref callCount);
+            return Task.FromResult(false);
+        }
+
+        var service = new DeviceDiscoveryService(configuration, null, PortChecker);
+
+        await service.DiscoverDevicesAsync();
+
+        Assert.Equal(1, callCount);
+    }
 }

--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -138,12 +138,15 @@ namespace InventoryManagementApp.Services.Devices
                 yield break;
             }
 
-            var ipSequence = _subnets.SelectMany(ExpandAddressPattern).Distinct();
+            var ipSequence = _subnets.SelectMany(ExpandAddressPattern);
             var arpTable = LoadArpTable();
 
             var channel = Channel.CreateUnbounded<DiscoveredDevice>();
             long total = 0;
             long processed = 0;
+
+            var seenIps = new HashSet<string>();
+            var seenLock = new object();
 
             var scanTask = Task.Run(async () =>
             {
@@ -155,6 +158,14 @@ namespace InventoryManagementApp.Services.Devices
                         CancellationToken = cancellationToken
                     }, async (ip, ct) =>
                     {
+                        bool isNew;
+                        lock (seenLock)
+                        {
+                            isNew = seenIps.Add(ip);
+                        }
+                        if (!isNew)
+                            return;
+
                         Interlocked.Increment(ref total);
 
                         var d = await ScanIpAsync(ip, arpTable, ct).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- Start device scans immediately as IPs are generated
- Avoid duplicate scans using thread-safe IP tracking
- Add regression test to ensure duplicate IPs are skipped

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b81a9d9bb08324ab3f9ed6ad417cdf