### PR TITLE
Display device last seen timestamp

### DIFF
--- a/InventoryManagementApp.Tests/DevicesPageTests.cs
+++ b/InventoryManagementApp.Tests/DevicesPageTests.cs
@@ -116,6 +116,44 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void DevicesPage_HasLastSeenColumn()
+        {
+            Exception? threadEx = null;
+            bool hasColumn = false;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary
+                    {
+                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                    });
+
+                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
+                    var page = new DevicesPage { DataContext = vm };
+                    page.ApplyTemplate();
+                    var grid = FindVisualChild<DataGrid>(page);
+                    hasColumn = grid?.Columns.Any(c => c.Header?.ToString() == "Last Seen") ?? false;
+
+                    Application.Current?.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadEx != null) throw threadEx;
+            Assert.True(hasColumn);
+        }
+
+        [Fact]
         public void DevicesPage_DisplaysMacAddress()
         {
             Exception? threadEx = null;

--- a/InventoryManagementApp/ViewModels/DevicesViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DevicesViewModel.cs
@@ -155,7 +155,8 @@ namespace InventoryManagementApp.ViewModels
                         ProtocolsDisplay = d.Protocols.Count > 0
                             ? string.Join(", ", d.Protocols)
                             : DeviceProtocol.Unknown.ToString(),
-                        Status = d.IsOnline ? "Online" : "Offline"
+                        Status = d.IsOnline ? "Online" : "Offline",
+                        LastSeen = d.IsOnline ? DateTime.UtcNow : default
                     };
                     try
                     {

--- a/InventoryManagementApp/Views/Pages/DevicesPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DevicesPage.xaml
@@ -66,6 +66,7 @@
                                                  ItemsSource="{Binding Groups}" Width="150"/>
                         <DataGridTextColumn Header="Protocols" Binding="{Binding ProtocolsDisplay}" IsReadOnly="True" Width="150"/>
                         <DataGridTextColumn Header="Status" Binding="{Binding Status}" IsReadOnly="True" Width="120"/>
+                        <DataGridTextColumn Header="Last Seen" Binding="{Binding LastSeen, StringFormat={}{0:G}}" IsReadOnly="True" Width="180"/>
                     </DataGrid.Columns>
                 </DataGrid>
             </Border>


### PR DESCRIPTION
## Summary
- Show last seen information in Devices page grid
- Populate device LastSeen from discovery results
- Test for presence of Last Seen column

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b82146086883249710efb8f7d0d3b6