### PR TITLE
feat: add configurable download paths

### DIFF
--- a/InventoryManagementApp.Tests/DevicesPageTests.cs
+++ b/InventoryManagementApp.Tests/DevicesPageTests.cs
@@ -392,6 +392,44 @@ namespace InventoryManagementApp.Tests
             Assert.Equal("Ping", pingButton!.Content);
         }
 
+        [Fact]
+        public void DevicesPage_HasDownloadButton()
+        {
+            Exception? threadEx = null;
+            Button? downloadButton = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary
+                    {
+                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                    });
+
+                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
+                    var page = new DevicesPage { DataContext = vm };
+                    page.ApplyTemplate();
+                    downloadButton = (Button)page.FindName("DownloadButton");
+
+                    Application.Current?.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadEx != null) throw threadEx;
+            Assert.NotNull(downloadButton);
+            Assert.Equal("Download Files", downloadButton!.Content);
+        }
+
         private sealed class BindingErrorTraceListener : TraceListener
         {
             private readonly List<string> _errors;

--- a/InventoryManagementApp.Tests/DevicesViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DevicesViewModelTests.cs
@@ -46,6 +46,8 @@ public class DevicesViewModelTests
         public List<string> Files { get; } = new();
         public Device? LastDevice { get; private set; }
         public string? LastExtensionFilter { get; private set; }
+        public string? LastBasePath { get; private set; }
+        public int DownloadCallCount { get; private set; }
         public Task<IEnumerable<string>> ListFilesAsync(Device device, string? extensionFilter = null, CancellationToken cancellationToken = default)
         {
             LastDevice = device;
@@ -54,7 +56,12 @@ public class DevicesViewModelTests
         }
 
         public Task<int> DownloadUnseenFilesAsync(Device device, string basePath, CancellationToken cancellationToken = default)
-            => Task.FromResult(0);
+        {
+            LastDevice = device;
+            LastBasePath = basePath;
+            DownloadCallCount++;
+            return Task.FromResult(0);
+        }
     }
 
     private sealed class RecordingDialogService : IDialogService
@@ -505,5 +512,46 @@ public class DevicesViewModelTests
 
         Assert.Equal(1, groupService.DeletedGroupId);
         Assert.Equal(1, discovery.DiscoverCallCount);
+    }
+
+    [Fact]
+    public async Task DownloadUnseenFilesCommand_UsesConfiguredPaths()
+    {
+        var discovery = new StubDiscoveryService();
+        discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", IsOnline = true, Protocols = new List<DeviceProtocol>() });
+        var fileService = new RecordingDeviceFileService();
+        var dialog = new RecordingDialogService();
+        var groupService = new RecordingDeviceGroupService();
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), groupService);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+        vm.SourceFolder = "C:/src";
+        vm.DestinationFolder = "C:/dest";
+        vm.SelectedDevice = vm.Devices[0];
+
+        await vm.DownloadUnseenFilesCommand.ExecuteAsync(null);
+
+        Assert.Equal("C:/dest", fileService.LastBasePath);
+        Assert.Equal(vm.SelectedDevice, fileService.LastDevice);
+    }
+
+    [Fact]
+    public async Task DownloadUnseenFilesCommand_DoesNotRunIfSetupIncomplete()
+    {
+        var discovery = new StubDiscoveryService();
+        discovery.Devices.Add(new DiscoveredDevice { Ip = "1.2.3.4", IsOnline = true, Protocols = new List<DeviceProtocol>() });
+        var fileService = new RecordingDeviceFileService();
+        var dialog = new RecordingDialogService();
+        var groupService = new RecordingDeviceGroupService();
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), groupService);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+        vm.SelectedDevice = vm.Devices[0];
+        vm.SourceFolder = string.Empty;
+        vm.DestinationFolder = "C:/dest";
+
+        await vm.DownloadUnseenFilesCommand.ExecuteAsync(null);
+
+        Assert.Equal(0, fileService.DownloadCallCount);
     }
 }

--- a/InventoryManagementApp/ViewModels/DevicesViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DevicesViewModel.cs
@@ -46,6 +46,7 @@ namespace InventoryManagementApp.ViewModels
                     DeviceFiles.Clear();
                     PullAllReportsCommand.NotifyCanExecuteChanged();
                     PingSelectedDeviceCommand.NotifyCanExecuteChanged();
+                    DownloadUnseenFilesCommand.NotifyCanExecuteChanged();
                 }
             }
         }
@@ -57,6 +58,29 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand AddGroupCommand { get; }
         public IAsyncRelayCommand RenameGroupCommand { get; }
         public IAsyncRelayCommand DeleteGroupCommand { get; }
+        public IAsyncRelayCommand DownloadUnseenFilesCommand { get; }
+
+        private string _sourceFolder = string.Empty;
+        public string SourceFolder
+        {
+            get => _sourceFolder;
+            set
+            {
+                if (SetProperty(ref _sourceFolder, value))
+                    DownloadUnseenFilesCommand.NotifyCanExecuteChanged();
+            }
+        }
+
+        private string _destinationFolder = string.Empty;
+        public string DestinationFolder
+        {
+            get => _destinationFolder;
+            set
+            {
+                if (SetProperty(ref _destinationFolder, value))
+                    DownloadUnseenFilesCommand.NotifyCanExecuteChanged();
+            }
+        }
 
         private double _discoveryProgress;
         public double DiscoveryProgress
@@ -125,6 +149,7 @@ namespace InventoryManagementApp.ViewModels
             AddGroupCommand = new AsyncRelayCommand(AddGroupAsync);
             RenameGroupCommand = new AsyncRelayCommand(RenameGroupAsync);
             DeleteGroupCommand = new AsyncRelayCommand(DeleteGroupAsync);
+            DownloadUnseenFilesCommand = new AsyncRelayCommand(DownloadUnseenFilesAsync, CanDownloadUnseenFiles);
         }
 
         private async Task RefreshAsync()
@@ -205,6 +230,25 @@ namespace InventoryManagementApp.ViewModels
             {
                 _logger.LogError(ex, "Failed to load files for {Ip}", SelectedDevice.Ip);
                 await _dialogService.ShowInfoAsync($"Failed to pull reports: {ex.Message}", "Devices");
+            }
+        }
+
+        private bool CanDownloadUnseenFiles()
+            => SelectedDevice != null
+               && !string.IsNullOrWhiteSpace(SourceFolder)
+               && !string.IsNullOrWhiteSpace(DestinationFolder);
+
+        private async Task DownloadUnseenFilesAsync()
+        {
+            if (SelectedDevice == null) return;
+            try
+            {
+                await _fileService.DownloadUnseenFilesAsync(SelectedDevice, DestinationFolder, CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to download files for {Ip}", SelectedDevice.Ip);
+                await _dialogService.ShowInfoAsync($"Failed to download files: {ex.Message}", "Devices");
             }
         }
 

--- a/InventoryManagementApp/Views/Pages/DevicesPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DevicesPage.xaml
@@ -54,7 +54,26 @@
                                  Margin="0,0,8,0"/>
                         <Button Style="{StaticResource PrimaryButton}"
                                 Content="Pull Reports"
-                                Command="{Binding PullAllReportsCommand}"/>
+                                Command="{Binding PullAllReportsCommand}"
+                                Margin="0,0,8,0"/>
+                        <TextBox Text="{Binding SourceFolder, UpdateSourceTrigger=PropertyChanged}"
+                                 Width="120"
+                                 Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource PrimaryButton}"
+                                Content="Browse Source"
+                                Click="BrowseSourceFolder"
+                                Margin="0,0,8,0"/>
+                        <TextBox Text="{Binding DestinationFolder, UpdateSourceTrigger=PropertyChanged}"
+                                 Width="120"
+                                 Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource PrimaryButton}"
+                                Content="Browse Dest"
+                                Click="BrowseDestinationFolder"
+                                Margin="0,0,8,0"/>
+                        <Button x:Name="DownloadButton"
+                                Style="{StaticResource PrimaryButton}"
+                                Content="Download Files"
+                                Command="{Binding DownloadUnseenFilesCommand}"/>
                     </StackPanel>
                 </Border>
                 <ProgressBar Margin="0,8,0,0"

--- a/InventoryManagementApp/Views/Pages/DevicesPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/DevicesPage.xaml.cs
@@ -1,4 +1,7 @@
 using System.Windows.Controls;
+using System.Windows;
+using Forms = System.Windows.Forms;
+using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
 {
@@ -7,6 +10,20 @@ namespace InventoryManagementApp.Views.Pages
         public DevicesPage()
         {
             InitializeComponent();
+        }
+
+        void BrowseSourceFolder(object sender, RoutedEventArgs e)
+        {
+            using var dlg = new Forms.FolderBrowserDialog();
+            if (dlg.ShowDialog() == Forms.DialogResult.OK && DataContext is DevicesViewModel vm)
+                vm.SourceFolder = dlg.SelectedPath;
+        }
+
+        void BrowseDestinationFolder(object sender, RoutedEventArgs e)
+        {
+            using var dlg = new Forms.FolderBrowserDialog();
+            if (dlg.ShowDialog() == Forms.DialogResult.OK && DataContext is DevicesViewModel vm)
+                vm.DestinationFolder = dlg.SelectedPath;
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow users to choose source and destination folders on Devices page
- persist selected folders in DevicesViewModel and use them for downloads
- test that download command validates paths and handles UI elements

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b896a7dc3483249472437df35a6899