### PR TITLE
Use named cancellation token in device discovery

### DIFF
--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -339,13 +339,13 @@ namespace InventoryManagementApp.Services.Devices
             {
                 SendUdpDiscoveryAsync(
                     new IPEndPoint(IPAddress.Parse("224.0.0.251"), 5353),
-                    MdnsQuery, results, joinMulticast: true, ct),
+                    MdnsQuery, results, joinMulticast: true, ct: ct),
                 SendUdpDiscoveryAsync(
                     new IPEndPoint(IPAddress.Parse("239.255.255.250"), 1900),
-                    SsdpQuery, results, joinMulticast: true, ct),
+                    SsdpQuery, results, joinMulticast: true, ct: ct),
                 SendUdpDiscoveryAsync(
                     new IPEndPoint(IPAddress.Broadcast, 137),
-                    NbnsQuery, results, broadcast: true, ct)
+                    NbnsQuery, results, broadcast: true, ct: ct)
             };
 
             try { await Task.WhenAll(tasks).ConfigureAwait(false); } catch { }


### PR DESCRIPTION
## Summary
- Ensure SendUdpDiscoveryAsync calls use a named cancellation token

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.0.3 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68b8fa4b07148324bcac37d8ed00330d