### PR TITLE
Fix ARP token trimming in device discovery

### DIFF
--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -471,7 +471,7 @@ namespace InventoryManagementApp.Services.Devices
                     if (start >= 0)
                     {
                         var token = span[start..i];
-                        token = token.Trim('(', ')');
+                        token = token.Trim('(').Trim(')');
                         if (ip.Length == 0 && IPAddress.TryParse(token.ToString(), out _))
                         {
                             ip = token.ToString();


### PR DESCRIPTION
## Summary
- fix improper `Trim` overload usage when parsing ARP tokens

## Testing
- `dotnet test` *(fails: command not found; dotnet SDK missing)*
- `apt-get update` *(fails: 403 - repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fc9393948324811d7a7d9ce4d403