### PR TITLE
Remove EnumeratorCancellation attribute from device discovery

### DIFF
--- a/InventoryManagementApp/Interfaces/IDeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Interfaces/IDeviceDiscoveryService.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Models;
@@ -11,7 +10,7 @@ namespace InventoryManagementApp.Interfaces
         Task<IReadOnlyList<DiscoveredDevice>> DiscoverDevicesAsync(CancellationToken cancellationToken = default);
 
         IAsyncEnumerable<DiscoveredDevice> DiscoverDevicesAsync(IProgress<double>? progress = null,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Indicates whether any subnets have been configured for device discovery.

--- a/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
+++ b/InventoryManagementApp/Services/Devices/DeviceDiscoveryService.cs
@@ -13,7 +13,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Channels;
-using System.Runtime.CompilerServices;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models;
 using Microsoft.Extensions.Configuration;
@@ -134,7 +133,7 @@ namespace InventoryManagementApp.Services.Devices
         }
 
         public async IAsyncEnumerable<DiscoveredDevice> DiscoverDevicesAsync(IProgress<double>? progress = null,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             if (_subnets.Count == 0)
             {


### PR DESCRIPTION
## Summary
- Drop EnumeratorCancellation attribute from `IDeviceDiscoveryService` interface and implementation
- Remove unused runtime compiler services using directives

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fc970acc83249bb549510a119b12