### PR TITLE
Rename scanner status to device status

### DIFF
--- a/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelNavigationTests.cs
@@ -42,13 +42,13 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public async Task OpenScannerStatusCommand_IsNotNull()
+        public async Task OpenDeviceStatusCommand_IsNotNull()
         {
             await RunOnStaThread(() =>
             {
                 using var db = new DatabaseService(":memory:");
                 using var vm = CreateMainViewModel(db, new DummyItemService(), new DummyDialogService());
-                Assert.NotNull(vm.OpenScannerStatusCommand);
+                Assert.NotNull(vm.OpenDeviceStatusCommand);
                 return Task.CompletedTask;
             });
         }

--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -61,7 +61,7 @@
                         <TextBlock Text="Devices" Style="{StaticResource CaptionTextBlock}" Margin="6,8,6,2"/>
                         <Button Style="{StaticResource NavButton}" Content="Manage Devices" Command="{Binding OpenDevicesPageCommand}"/>
                         <Button Style="{StaticResource NavButton}" Content="Device Settings" Command="{Binding OpenDeviceSettingsCommand}"/>
-                        <Button Style="{StaticResource NavButton}" Content="Scanner Status" Command="{Binding OpenScannerStatusCommand}"/>
+                        <Button Style="{StaticResource NavButton}" Content="Device Status" Command="{Binding OpenDeviceStatusCommand}"/>
 
                         <Separator/>
 

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -198,7 +198,7 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand OpenPrintLabelWindowCommand { get; }
         public IAsyncRelayCommand OpenDevicesPageCommand { get; }
         public IAsyncRelayCommand OpenDeviceSettingsCommand { get; }
-        public IAsyncRelayCommand OpenScannerStatusCommand { get; }
+        public IAsyncRelayCommand OpenDeviceStatusCommand { get; }
 
         public MainViewModel(IItemService itemService,
                              IUserService userService,
@@ -564,7 +564,7 @@ namespace InventoryManagementApp.ViewModels
                 }
             });
 
-            OpenScannerStatusCommand = new AsyncRelayCommand(async () =>
+            OpenDeviceStatusCommand = new AsyncRelayCommand(async () =>
             {
                 try
                 {
@@ -574,8 +574,8 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Failed to open scanner status window");
-                    _dialogService.ShowInfo($"Failed to open scanner status window: {ex.Message}", "Scanner Status");
+                    _logger.LogError(ex, "Failed to open device status window");
+                    _dialogService.ShowInfo($"Failed to open device status window: {ex.Message}", "Device Status");
                     throw;
                 }
             });

--- a/InventoryManagementApp/Views/Windows/ScannerStatusWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ScannerStatusWindow.xaml
@@ -2,13 +2,13 @@
 <Window x:Class="InventoryManagementApp.Views.Windows.ScannerStatusWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Scanner Status"
+        Title="Device Status"
         Width="900" Height="560"
         WindowStartupLocation="CenterScreen"
         Background="{DynamicResource BackgroundBrush}">
     <DockPanel Margin="10">
         <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="10" CornerRadius="8">
-            <TextBlock Text="Scanner Status" Style="{StaticResource HeadingTextBlock}"/>
+            <TextBlock Text="Device Status" Style="{StaticResource HeadingTextBlock}"/>
         </Border>
         <Grid>
             <Grid.RowDefinitions>


### PR DESCRIPTION
## Summary
- rename Scanner Status navigation to Device Status
- update window titles and viewmodel command
- adjust navigation test for new command name

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b93ccad28c8324ac370618085f369d