### PR TITLE
Add immediate device group selection

### DIFF
--- a/InventoryManagementApp.Tests/DevicesViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DevicesViewModelTests.cs
@@ -99,12 +99,13 @@ public class DevicesViewModelTests
         public TaskCompletionSource<(string ip, int? port, int? groupId)> AssignTcs { get; } = new();
         public TaskCompletionSource<DeviceGroup> UpdateTcs { get; } = new();
         public string? CreatedGroupName { get; private set; }
+        public int NextGroupId { get; set; } = 1;
         public Task<IEnumerable<DeviceGroup>> GetGroupsAsync(CancellationToken cancellationToken = default)
             => Task.FromResult<IEnumerable<DeviceGroup>>(Groups);
         public Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default)
         {
             CreatedGroupName = name;
-            return Task.FromResult(0);
+            return Task.FromResult(NextGroupId);
         }
         public Task UpdateGroupAsync(DeviceGroup group, CancellationToken cancellationToken = default)
         {
@@ -469,7 +470,7 @@ public class DevicesViewModelTests
     }
 
     [Fact]
-    public async Task AddGroupCommand_CreatesGroupAndRefreshes()
+    public async Task AddGroupCommand_AddsGroupToCollection()
     {
         var discovery = new StubDiscoveryService();
         var fileService = new RecordingDeviceFileService();
@@ -481,7 +482,10 @@ public class DevicesViewModelTests
         await vm.AddGroupCommand.ExecuteAsync(null);
 
         Assert.Equal("NewGroup", groupService.CreatedGroupName);
-        Assert.Equal(1, discovery.DiscoverCallCount);
+        Assert.Single(vm.Groups);
+        Assert.Equal("NewGroup", vm.Groups[0].Name);
+        Assert.Equal(1, vm.Groups[0].Id);
+        Assert.Same(vm.Groups[0], vm.SelectedGroup);
     }
 
     [Fact]

--- a/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
@@ -41,10 +41,11 @@ public class ScannerStatusViewModelTests
         public TaskCompletionSource<(string ip, int? port, int? groupId)> AssignTcs { get; } = new();
         public TaskCompletionSource<DeviceGroup> UpdateTcs { get; } = new();
         public DeviceGroup? UpdatedGroup { get; private set; }
+        public int NextGroupId { get; set; } = 1;
         public Task<IEnumerable<DeviceGroup>> GetGroupsAsync(CancellationToken cancellationToken = default)
             => Task.FromResult<IEnumerable<DeviceGroup>>(Groups);
         public Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default)
-            => Task.FromResult(0);
+            => Task.FromResult(NextGroupId);
         public Task UpdateGroupAsync(DeviceGroup group, CancellationToken cancellationToken = default)
         {
             UpdatedGroup = group;
@@ -124,6 +125,25 @@ public class ScannerStatusViewModelTests
         Assert.Equal("1.2.3.4", assignment.ip);
         Assert.Null(assignment.port);
         Assert.Equal(1, assignment.groupId);
+    }
+
+    [Fact]
+    public async Task AddGroupCommand_AddsGroupToCollection()
+    {
+        var scanner = new StubScannerService();
+        var dialog = new StubDialogService();
+        var deviceService = new RecordingDeviceService();
+        var groupService = new RecordingDeviceGroupService();
+        var fileService = new StubDeviceFileService();
+        var vm = new ScannerStatusViewModel(scanner, dialog, deviceService, groupService, fileService);
+        vm.PromptForGroupName = () => "NewGroup";
+
+        await vm.AddGroupCommand.ExecuteAsync(null);
+
+        Assert.Single(vm.Groups);
+        Assert.Equal("NewGroup", vm.Groups[0].Name);
+        Assert.Equal(1, vm.Groups[0].Id);
+        Assert.Same(vm.Groups[0], vm.SelectedGroup);
     }
 
     [Fact]

--- a/InventoryManagementApp/ViewModels/DevicesViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DevicesViewModel.cs
@@ -321,8 +321,10 @@ namespace InventoryManagementApp.ViewModels
                 if (string.IsNullOrWhiteSpace(name))
                     return;
 
-                await _groupService.CreateGroupAsync(name);
-                await RefreshAsync();
+                var id = await _groupService.CreateGroupAsync(name);
+                var group = new DeviceGroup { Id = id, Name = name };
+                Groups.Add(group);
+                SelectedGroup = group;
             }
             catch (Exception ex)
             {

--- a/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ScannerStatusViewModel.cs
@@ -209,8 +209,10 @@ namespace InventoryManagementApp.ViewModels
                 if (string.IsNullOrWhiteSpace(name))
                     return;
 
-                await _groupService.CreateGroupAsync(name);
-                await RefreshAsync(CancellationToken.None);
+                var id = await _groupService.CreateGroupAsync(name);
+                var group = new DeviceGroup { Id = id, Name = name };
+                Groups.Add(group);
+                SelectedGroup = group;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- Update DevicesViewModel and ScannerStatusViewModel to append newly created groups and select them
- Add unit tests for DevicesViewModel and ScannerStatusViewModel confirming Groups contains new group after AddGroupCommand

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b942751ca88324ac36b56f410c560a