### PR TITLE
refactor: extract device views and viewmodels

### DIFF
--- a/DeviceManagementApp/DeviceManagementApp.csproj
+++ b/DeviceManagementApp/DeviceManagementApp.csproj
@@ -7,6 +7,7 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.8" />

--- a/DeviceManagementApp/Interfaces/IDialogService.cs
+++ b/DeviceManagementApp/Interfaces/IDialogService.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace DeviceManagementApp.Interfaces
+{
+    public interface IDialogService
+    {
+        void ShowInfo(string message, string title);
+        Task ShowInfoAsync(string message, string title) =>
+            Application.Current?.Dispatcher?.InvokeAsync(() => ShowInfo(message, title)).Task
+            ?? Task.CompletedTask;
+        bool ShowConfirmation(string message, string title);
+        Task<bool> ShowConfirmationAsync(string message, string title) =>
+            Application.Current?.Dispatcher?.InvokeAsync(() => ShowConfirmation(message, title)).Task
+            ?? Task.FromResult(false);
+    }
+}

--- a/DeviceManagementApp/Interfaces/IScannerService.cs
+++ b/DeviceManagementApp/Interfaces/IScannerService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DeviceManagementApp.Models;
+
+namespace DeviceManagementApp.Interfaces
+{
+    public interface IScannerService
+    {
+        Task<IEnumerable<Device>> GetDevicesAsync(CancellationToken cancellationToken);
+    }
+}

--- a/DeviceManagementApp/Models/ItemDetailField.cs
+++ b/DeviceManagementApp/Models/ItemDetailField.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace DeviceManagementApp.Models
+{
+    public enum ItemDetailField
+    {
+        Image,
+        Name,
+        ItemNumber,
+        PartNumber,
+        Brand,
+        QuantityOnHand,
+        Location,
+        Price,
+        Notes
+    }
+}

--- a/DeviceManagementApp/Utilities/Extensions/FrameworkElementExtensions.cs
+++ b/DeviceManagementApp/Utilities/Extensions/FrameworkElementExtensions.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Windows;
+
+namespace DeviceManagementApp.Utilities.Extensions
+{
+    /// <summary>
+    /// Helper methods for view cleanup.
+    /// </summary>
+    public static class FrameworkElementExtensions
+    {
+        /// <summary>
+        /// Disposes the current or previous <see cref="FrameworkElement.DataContext"/>
+        /// when the element is unloaded or its data context changes.
+        /// </summary>
+        /// <param name="element">Element to monitor.</param>
+        public static void DisposeDataContextOnUnload(this FrameworkElement element)
+        {
+            if (element is null) return;
+
+            element.DataContextChanged += OnDataContextChanged;
+
+            if (element is Window window)
+                window.Closed += OnUnloaded;
+            else
+                element.Unloaded += OnUnloadedHandler;
+        }
+
+        static void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.OldValue is IDisposable disposable)
+                disposable.Dispose();
+        }
+
+        static readonly RoutedEventHandler OnUnloadedHandler = OnUnloaded;
+
+        static void OnUnloaded(object? sender, EventArgs e)
+        {
+            if (sender is FrameworkElement fe)
+            {
+                if (fe.DataContext is IDisposable disposable)
+                    disposable.Dispose();
+
+                fe.DataContextChanged -= OnDataContextChanged;
+
+                if (sender is Window window)
+                    window.Closed -= OnUnloaded;
+                else
+                    fe.Unloaded -= OnUnloadedHandler;
+            }
+        }
+    }
+}
+

--- a/DeviceManagementApp/ViewModels/DeviceSettingsViewModel.cs
+++ b/DeviceManagementApp/ViewModels/DeviceSettingsViewModel.cs
@@ -1,6 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using InventoryManagementApp.Interfaces;
+using DeviceManagementApp.Interfaces;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -8,9 +8,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using InventoryManagementApp.Models;
+using DeviceManagementApp.Models;
 
-namespace InventoryManagementApp.ViewModels
+namespace DeviceManagementApp.ViewModels
 {
     public class DeviceSettingsViewModel : ObservableObject
     {

--- a/DeviceManagementApp/ViewModels/DevicesViewModel.cs
+++ b/DeviceManagementApp/ViewModels/DevicesViewModel.cs
@@ -9,12 +9,11 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DeviceManagementApp.Interfaces;
 using DeviceManagementApp.Models;
-using InventoryManagementApp.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualBasic;
 
-namespace InventoryManagementApp.ViewModels
+namespace DeviceManagementApp.ViewModels
 {
     public class DevicesViewModel : ObservableObject
     {

--- a/DeviceManagementApp/ViewModels/ScannerStatusViewModel.cs
+++ b/DeviceManagementApp/ViewModels/ScannerStatusViewModel.cs
@@ -9,13 +9,12 @@ using System.Threading.Tasks;
 using System.Windows.Threading;
 using DeviceManagementApp.Interfaces;
 using DeviceManagementApp.Models;
-using InventoryManagementApp.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualBasic;
 using System.ComponentModel;
 
-namespace InventoryManagementApp.ViewModels
+namespace DeviceManagementApp.ViewModels
 {
     public class ScannerStatusViewModel : ObservableObject, IDisposable
     {

--- a/DeviceManagementApp/Views/Pages/DeviceSettingsPage.xaml
+++ b/DeviceManagementApp/Views/Pages/DeviceSettingsPage.xaml
@@ -1,0 +1,25 @@
+<!-- Views/Pages/DeviceSettingsPage.xaml -->
+<Page x:Class="DeviceManagementApp.Views.Pages.DeviceSettingsPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      Title="Device Settings"
+      Background="{DynamicResource BackgroundBrush}">
+    <ScrollViewer>
+        <StackPanel Margin="10">
+            <TextBlock Text="Device Discovery Settings" Style="{StaticResource HeadingTextBlock}" Margin="0,0,0,8"/>
+            <TextBlock Text="Subnets (comma-separated)"/>
+            <TextBox Text="{Binding Subnets, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBlock Text="FTP Ports (comma-separated)"/>
+            <TextBox Text="{Binding FtpPorts, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBlock Text="Additional Ports (port:Protocol, comma-separated)"/>
+            <TextBox Text="{Binding AdditionalPorts, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBlock Text="Max Concurrent Scans"/>
+            <TextBox Text="{Binding MaxConcurrentScans, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBlock Text="Liveness Timeout (ms)"/>
+            <TextBox Text="{Binding LivenessTimeoutMs, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <TextBlock Text="Port Probe Timeout (ms)"/>
+            <TextBox Text="{Binding PortProbeTimeoutMs, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <Button Content="Save" Style="{StaticResource PrimaryButton}" Command="{Binding SaveCommand}" Width="100"/>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/DeviceManagementApp/Views/Pages/DeviceSettingsPage.xaml.cs
+++ b/DeviceManagementApp/Views/Pages/DeviceSettingsPage.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace DeviceManagementApp.Views.Pages
+{
+    public partial class DeviceSettingsPage : Page
+    {
+        public DeviceSettingsPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/DeviceManagementApp/Views/Pages/DevicesPage.xaml
+++ b/DeviceManagementApp/Views/Pages/DevicesPage.xaml
@@ -1,0 +1,133 @@
+<!-- Views/DevicesPage.xaml -->
+<Page x:Class="DeviceManagementApp.Views.Pages.DevicesPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      Background="{DynamicResource BackgroundBrush}" Title="Devices">
+    <DockPanel Margin="10">
+        <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="10" CornerRadius="8">
+            <TextBlock Text="Devices" Style="{StaticResource HeadingTextBlock}"/>
+        </Border>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="2*"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <StackPanel>
+                <Border Style="{StaticResource Card}">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <Button Style="{StaticResource PrimaryButton}"
+                                Content="Refresh"
+                                Command="{Binding RefreshCommand}"
+                                Margin="0,0,8,0"/>
+                        <Button x:Name="PingButton"
+                                Style="{StaticResource PrimaryButton}"
+                                Content="Ping"
+                                Command="{Binding PingSelectedDeviceCommand}"
+                                Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource PrimaryButton}"
+                                Content="Add Device"
+                                Command="{Binding AddDeviceCommand}"
+                                Margin="0,0,8,0"/>
+                        <Button x:Name="AddGroupButton"
+                                Style="{StaticResource PrimaryButton}"
+                                Content="Add Group"
+                                Command="{Binding AddGroupCommand}"
+                                Margin="0,0,8,0"/>
+                        <Button x:Name="RenameGroupButton"
+                                Style="{StaticResource PrimaryButton}"
+                                Content="Rename Group"
+                                Command="{Binding RenameGroupCommand}"
+                                Margin="0,0,8,0"/>
+                        <Button x:Name="DeleteGroupButton"
+                                Style="{StaticResource PrimaryButton}"
+                                Content="Delete Group"
+                                Command="{Binding DeleteGroupCommand}"
+                                Margin="0,0,8,0"/>
+                        <Button x:Name="DeviceSettingsButton"
+                                Style="{StaticResource PrimaryButton}"
+                                Content="Device Settings"
+                                Command="{Binding DataContext.OpenDeviceSettingsCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                Margin="0,0,8,0"/>
+                        <TextBox Text="{Binding FileExtensionFilter, UpdateSourceTrigger=PropertyChanged}"
+                                 Width="120"
+                                 Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource PrimaryButton}"
+                                Content="Pull Reports"
+                                Command="{Binding PullAllReportsCommand}"
+                                Margin="0,0,8,0"/>
+                        <TextBox Text="{Binding SourceFolder, UpdateSourceTrigger=PropertyChanged}"
+                                 Width="120"
+                                 Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource PrimaryButton}"
+                                Content="Browse Source"
+                                Click="BrowseSourceFolder"
+                                Margin="0,0,8,0"/>
+                        <TextBox Text="{Binding DestinationFolder, UpdateSourceTrigger=PropertyChanged}"
+                                 Width="120"
+                                 Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource PrimaryButton}"
+                                Content="Browse Dest"
+                                Click="BrowseDestinationFolder"
+                                Margin="0,0,8,0"/>
+                        <Button x:Name="DownloadButton"
+                                Style="{StaticResource PrimaryButton}"
+                                Content="Download Files"
+                                ToolTip="Downloads unseen files from the configured source to the configured destination."
+                                Command="{Binding DownloadUnseenFilesCommand}"/>
+                    </StackPanel>
+                </Border>
+                <ProgressBar Margin="0,8,0,0"
+                             Height="20"
+                             Minimum="0" Maximum="1"
+                             Value="{Binding DiscoveryProgress, Mode=OneWay}"
+                             Visibility="{Binding IsDiscovering, Converter={StaticResource BoolToVis}}"/>
+            </StackPanel>
+            <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0" Margin="0,8,0,0">
+                <DataGrid ItemsSource="{Binding Devices}"
+                          SelectedItem="{Binding SelectedDevice}"
+                          AutoGenerateColumns="False"
+                          IsReadOnly="False"
+                          Style="{StaticResource VirtualizedDataGridStyle}"
+                          ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="IP" Binding="{Binding Ip}" IsReadOnly="True" Width="150"/>
+                        <DataGridTextColumn Header="MAC" Binding="{Binding MacAddress}" IsReadOnly="True" Width="150"/>
+                        <DataGridTextColumn Header="Hostname" Binding="{Binding Hostname, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                        <DataGridComboBoxColumn Header="Group"
+                                                 SelectedValueBinding="{Binding GroupId, UpdateSourceTrigger=PropertyChanged}"
+                                                 SelectedValuePath="Id"
+                                                 DisplayMemberPath="Name"
+                                                 ItemsSource="{Binding Groups}" Width="150"/>
+                        <DataGridTextColumn Header="Protocols" Binding="{Binding ProtocolsDisplay}" IsReadOnly="True" Width="150"/>
+                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" IsReadOnly="True" Width="120"/>
+                        <DataGridTextColumn Header="Last Seen" Binding="{Binding LastSeen, StringFormat={}{0:G}}" IsReadOnly="True" Width="180"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Border>
+            <Border Grid.Row="2" Style="{StaticResource Card}" Margin="0,8,0,0">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="2*"/>
+                        <ColumnDefinition Width="3*"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Margin="8">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                            <TextBlock Text="Username:" Width="70" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding SelectedDevice.Username, UpdateSourceTrigger=PropertyChanged}" Width="150"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                            <TextBlock Text="Password:" Width="70" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding SelectedDevice.Password, UpdateSourceTrigger=PropertyChanged}" Width="150"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                            <TextBlock Text="Domain:" Width="70" VerticalAlignment="Center"/>
+                            <TextBox Text="{Binding SelectedDevice.Domain, UpdateSourceTrigger=PropertyChanged}" Width="150"/>
+                        </StackPanel>
+                    </StackPanel>
+                    <ListBox Grid.Column="1" ItemsSource="{Binding DeviceFiles}" Margin="8"/>
+                </Grid>
+            </Border>
+        </Grid>
+    </DockPanel>
+</Page>

--- a/DeviceManagementApp/Views/Pages/DevicesPage.xaml.cs
+++ b/DeviceManagementApp/Views/Pages/DevicesPage.xaml.cs
@@ -3,7 +3,7 @@ using System.Windows;
 using Forms = System.Windows.Forms;
 using DeviceManagementApp.ViewModels;
 
-namespace InventoryManagementApp.Views.Pages
+namespace DeviceManagementApp.Views.Pages
 {
     public partial class DevicesPage : Page
     {

--- a/DeviceManagementApp/Views/Windows/ScannerStatusWindow.xaml
+++ b/DeviceManagementApp/Views/Windows/ScannerStatusWindow.xaml
@@ -1,0 +1,63 @@
+﻿<!-- Views/ScannerStatusWindow.xaml -->
+<Window x:Class="DeviceManagementApp.Views.Windows.ScannerStatusWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Device Status"
+        Width="900" Height="560"
+        WindowStartupLocation="CenterScreen"
+        Background="{DynamicResource BackgroundBrush}">
+    <DockPanel Margin="10">
+        <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="10" CornerRadius="8">
+            <TextBlock Text="Device Status" Style="{StaticResource HeadingTextBlock}"/>
+        </Border>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <Border Style="{StaticResource Card}">
+                <StackPanel Orientation="Horizontal">
+                    <Button Style="{StaticResource PrimaryButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
+                    <CheckBox Content="Auto Refresh" IsChecked="{Binding AutoRefresh}" Margin="12,6,0,0"/>
+                    <ComboBox ItemsSource="{Binding Groups}"
+                              SelectedItem="{Binding SelectedGroup}"
+                              DisplayMemberPath="Name"
+                              Width="150"
+                              Margin="12,0,0,0"/>
+                    <TextBox Text="{Binding GroupName, UpdateSourceTrigger=PropertyChanged}"
+                             Width="150"
+                             Margin="12,0,0,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Rename" Command="{Binding RenameGroupCommand}" Margin="12,0,0,0"/>
+                </StackPanel>
+            </Border>
+
+            <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0" Margin="0,8,0,0">
+                <DataGrid ItemsSource="{Binding Devices}"
+                          AutoGenerateColumns="False"
+                          IsReadOnly="False"
+                          Style="{StaticResource VirtualizedDataGridStyle}"
+                          ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Device"
+                                            Binding="{Binding Hostname, UpdateSourceTrigger=PropertyChanged}"
+                                            Width="*"
+                                            IsReadOnly="False"/>
+                        <DataGridComboBoxColumn Header="Group"
+                                                ItemsSource="{Binding DataContext.Groups, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                                DisplayMemberPath="Name"
+                                                SelectedValuePath="Id"
+                                                SelectedValueBinding="{Binding GroupId, UpdateSourceTrigger=PropertyChanged}"
+                                                Width="150"/>
+                        <DataGridTextColumn Header="Item" Binding="{Binding ItemName}" Width="*" IsReadOnly="True"/>
+                        <DataGridTextColumn Header="IP" Binding="{Binding Ip}" Width="180" IsReadOnly="True"/>
+                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="160" IsReadOnly="True"/>
+                        <DataGridTextColumn Header="Last Seen"
+                                            Binding="{Binding LastSeen, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}"
+                                            Width="220" IsReadOnly="True"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Border>
+        </Grid>
+    </DockPanel>
+</Window>

--- a/DeviceManagementApp/Views/Windows/ScannerStatusWindow.xaml.cs
+++ b/DeviceManagementApp/Views/Windows/ScannerStatusWindow.xaml.cs
@@ -1,9 +1,9 @@
 using System.Windows;
 using DeviceManagementApp.Interfaces;
 using DeviceManagementApp.ViewModels;
-using InventoryManagementApp.Utilities.Extensions;
+using DeviceManagementApp.Utilities.Extensions;
 
-namespace InventoryManagementApp.Views.Windows
+namespace DeviceManagementApp.Views.Windows
 {
     public partial class ScannerStatusWindow : Window
     {

--- a/InventoryManagementApp.Tests/DeviceSettingsViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DeviceSettingsViewModelTests.cs
@@ -2,11 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using InventoryManagementApp.Interfaces;
-using InventoryManagementApp.ViewModels;
+using DeviceManagementApp.Interfaces;
+using DeviceManagementApp.ViewModels;
+using DeviceManagementApp.Models;
 using Microsoft.Extensions.Configuration;
 using Xunit;
-using InventoryManagementApp.Models;
 
 namespace InventoryManagementApp.Tests
 {
@@ -46,17 +46,6 @@ namespace InventoryManagementApp.Tests
         {
             public void ShowInfo(string message, string title) { }
             public bool ShowConfirmation(string message, string title) => false;
-            public InventoryManagementApp.Models.ItemModel? ShowEditItemDialog(InventoryManagementApp.Models.ItemModel item) => null;
-            public void ShowItemDetails(InventoryManagementApp.Models.ItemModel item) { }
-            public (InventoryManagementApp.Models.CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(InventoryManagementApp.Models.ItemModel item, IEnumerable<InventoryManagementApp.Models.CustomerModel> customers) => null;
-            public InventoryManagementApp.Models.CustomerModel? ShowAddCustomerDialog() => null;
-            public InventoryManagementApp.Models.CustomerModel? ShowEditCustomerDialog(InventoryManagementApp.Models.CustomerModel customer) => null;
-            public void ShowRentalsFilter(InventoryManagementApp.ViewModels.ManageRentalsViewModel viewModel) { }
-            public void ShowRentalHistory(InventoryManagementApp.Models.ItemModel item, IEnumerable<InventoryManagementApp.Models.RentalModel> history) { }
-            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
-            public Func<InventoryManagementApp.Models.ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
-            public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
-            public void ShowPrintLabelDialog() { }
         }
 
         [Fact]

--- a/InventoryManagementApp.Tests/DevicesPageTests.cs
+++ b/InventoryManagementApp.Tests/DevicesPageTests.cs
@@ -10,14 +10,13 @@ using System.Windows.Controls;
 using System.Windows.Media;
 using DeviceManagementApp.Interfaces;
 using DeviceManagementApp.Models;
-using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models;
 using InventoryManagementApp.Models.Domain;
 using ItemModel = InventoryManagementApp.Models.Domain.ItemModel;
 using CustomerModel = InventoryManagementApp.Models.Domain.Customer;
 using RentalModel = InventoryManagementApp.Models.Domain.Rental;
-using InventoryManagementApp.ViewModels;
-using InventoryManagementApp.Views.Pages;
+using DeviceManagementApp.ViewModels;
+using DeviceManagementApp.Views.Pages;
 using Xunit;
 
 namespace InventoryManagementApp.Tests
@@ -37,7 +36,7 @@ namespace InventoryManagementApp.Tests
                     var app = new Application();
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary
                     {
-                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                        Source = new Uri("pack://application:,,,/DeviceManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
                     });
 
                     var listener = new BindingErrorTraceListener(errors);
@@ -81,7 +80,7 @@ namespace InventoryManagementApp.Tests
                     var app = new Application();
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary
                     {
-                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                        Source = new Uri("pack://application:,,,/DeviceManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
                     });
 
                     var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
@@ -130,7 +129,7 @@ namespace InventoryManagementApp.Tests
                     var app = new Application();
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary
                     {
-                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                        Source = new Uri("pack://application:,,,/DeviceManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
                     });
 
                     var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
@@ -168,7 +167,7 @@ namespace InventoryManagementApp.Tests
                     var app = new Application();
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary
                     {
-                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                        Source = new Uri("pack://application:,,,/DeviceManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
                     });
 
                     var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
@@ -217,7 +216,7 @@ namespace InventoryManagementApp.Tests
                     var app = new Application();
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary
                     {
-                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                        Source = new Uri("pack://application:,,,/DeviceManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
                     });
 
                     var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
@@ -255,7 +254,7 @@ namespace InventoryManagementApp.Tests
                     var app = new Application();
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary
                     {
-                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                        Source = new Uri("pack://application:,,,/DeviceManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
                     });
 
                     var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
@@ -293,7 +292,7 @@ namespace InventoryManagementApp.Tests
                     var app = new Application();
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary
                     {
-                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                        Source = new Uri("pack://application:,,,/DeviceManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
                     });
 
                     var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
@@ -331,7 +330,7 @@ namespace InventoryManagementApp.Tests
                     var app = new Application();
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary
                     {
-                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                        Source = new Uri("pack://application:,,,/DeviceManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
                     });
 
                     var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
@@ -369,7 +368,7 @@ namespace InventoryManagementApp.Tests
                     var app = new Application();
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary
                     {
-                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                        Source = new Uri("pack://application:,,,/DeviceManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
                     });
 
                     var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
@@ -407,7 +406,7 @@ namespace InventoryManagementApp.Tests
                     var app = new Application();
                     app.Resources.MergedDictionaries.Add(new ResourceDictionary
                     {
-                        Source = new Uri("pack://application:,,,/InventoryManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                        Source = new Uri("pack://application:,,,/DeviceManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
                     });
 
                     var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
@@ -461,17 +460,6 @@ namespace InventoryManagementApp.Tests
         {
             public void ShowInfo(string message, string title) { }
             public bool ShowConfirmation(string message, string title) => true;
-            public ItemModel? ShowEditItemDialog(ItemModel item) => null;
-            public void ShowItemDetails(ItemModel item) { }
-            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
-            public CustomerModel? ShowAddCustomerDialog() => null;
-            public CustomerModel? ShowEditCustomerDialog(CustomerModel customer) => null;
-            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
-            public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
-            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
-            public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
-            public void ShowPrintPreview(FlowDocument document, string title, string description) { }
-            public void ShowPrintLabelDialog() { }
         }
 
         private sealed class DummyDeviceService : IDeviceService

--- a/InventoryManagementApp.Tests/DevicesViewModelTests.cs
+++ b/InventoryManagementApp.Tests/DevicesViewModelTests.cs
@@ -5,9 +5,8 @@ using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
 using DeviceManagementApp.Interfaces;
 using DeviceManagementApp.Models;
-using InventoryManagementApp.Interfaces;
 using DeviceManagementApp.Services;
-using InventoryManagementApp.ViewModels;
+using DeviceManagementApp.ViewModels;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
@@ -81,17 +80,6 @@ public class DevicesViewModelTests
             ConfirmationCallCount++;
             return ConfirmationResult;
         }
-        public ItemModel? ShowEditItemDialog(ItemModel item) => null;
-        public void ShowItemDetails(ItemModel item) { }
-        public (CustomerModel customer, System.DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
-        public CustomerModel? ShowAddCustomerDialog() => null;
-        public CustomerModel? ShowEditCustomerDialog(CustomerModel customer) => null;
-        public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
-        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
-        public System.Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
-        public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
-        public void ShowPrintLabelDialog() { }
     }
 
     private sealed class RecordingDeviceGroupService : IDeviceGroupService

--- a/InventoryManagementApp.Tests/InventoryManagementApp.Tests.csproj
+++ b/InventoryManagementApp.Tests/InventoryManagementApp.Tests.csproj
@@ -11,5 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../InventoryManagementApp/InventoryManagementApp.csproj" />
+    <ProjectReference Include="../DeviceManagementApp/DeviceManagementApp.csproj" />
   </ItemGroup>
 </Project>

--- a/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ScannerStatusViewModelTests.cs
@@ -5,9 +5,7 @@ using System.Threading.Tasks;
 using System.Windows.Documents;
 using DeviceManagementApp.Interfaces;
 using DeviceManagementApp.Models;
-using InventoryManagementApp.Interfaces;
-using InventoryManagementApp.Models;
-using InventoryManagementApp.ViewModels;
+using DeviceManagementApp.ViewModels;
 using Xunit;
 
 public class ScannerStatusViewModelTests
@@ -77,17 +75,6 @@ public class ScannerStatusViewModelTests
     {
         public void ShowInfo(string message, string title) { }
         public bool ShowConfirmation(string message, string title) => false;
-        public ItemModel? ShowEditItemDialog(ItemModel item) => null;
-        public void ShowItemDetails(ItemModel item) { }
-        public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
-        public CustomerModel? ShowAddCustomerDialog() => null;
-        public CustomerModel? ShowEditCustomerDialog(CustomerModel customer) => null;
-        public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
-        public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
-        public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
-        public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
-        public void ShowPrintPreview(FlowDocument document, string title, string description) { }
-        public void ShowPrintLabelDialog() { }
     }
 
     [Fact]

--- a/InventoryManagementApp/Services/DialogService.cs
+++ b/InventoryManagementApp/Services/DialogService.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace InventoryManagementApp.Services
 {
-    public class DialogService : IDialogService
+    public class DialogService : InventoryManagementApp.Interfaces.IDialogService, DeviceManagementApp.Interfaces.IDialogService
     {
         readonly IServiceProvider _serviceProvider;
         readonly ILogger<DialogService> _logger;

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -32,6 +32,9 @@ using MediaBrush = System.Windows.Media.Brush;
 using MediaBrushes = System.Windows.Media.Brushes;
 using DeviceManagementApp.Services;
 using Microsoft.Extensions.Configuration;
+using DeviceManagementApp.ViewModels;
+using DeviceManagementApp.Views.Pages;
+using DeviceManagementApp.Views.Windows;
 
 namespace InventoryManagementApp.ViewModels
 {
@@ -533,8 +536,8 @@ namespace InventoryManagementApp.ViewModels
             {
                 try
                 {
-                    var vm = new DevicesViewModel(_deviceDiscoveryService, _deviceFileService, _dialogService, _deviceService, _deviceGroupService);
-                    var page = new DevicesPage { DataContext = vm, Title = "Devices" };
+                    var vm = new DevicesViewModel(_deviceDiscoveryService, _deviceFileService, (DeviceManagementApp.Interfaces.IDialogService)_dialogService, _deviceService, _deviceGroupService);
+                    var page = new DeviceManagementApp.Views.Pages.DevicesPage { DataContext = vm, Title = "Devices" };
                     CurrentPage = page;
                     await Task.CompletedTask;
                 }
@@ -551,9 +554,9 @@ namespace InventoryManagementApp.ViewModels
                 try
                 {
                     var config = new ConfigurationBuilder().AddJsonFile("appsettings.json", optional: true).Build();
-                    var vm = new DeviceSettingsViewModel(_settingsService, config, _dialogService);
+                    var vm = new DeviceSettingsViewModel(_settingsService, config, (DeviceManagementApp.Interfaces.IDialogService)_dialogService);
                     await vm.InitializeAsync().ConfigureAwait(false);
-                    var page = new DeviceSettingsPage { DataContext = vm, Title = "Device Settings" };
+                    var page = new DeviceManagementApp.Views.Pages.DeviceSettingsPage { DataContext = vm, Title = "Device Settings" };
                     CurrentPage = page;
                     await Task.CompletedTask;
                 }
@@ -569,7 +572,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 try
                 {
-                    var window = new ScannerStatusWindow(_scannerService, _dialogService, _deviceService, _deviceGroupService, _deviceFileService);
+                    var window = new DeviceManagementApp.Views.Windows.ScannerStatusWindow(_scannerService, (DeviceManagementApp.Interfaces.IDialogService)_dialogService, _deviceService, _deviceGroupService, _deviceFileService);
                     window.Show();
                     await Task.CompletedTask;
                 }


### PR DESCRIPTION
## Summary
- move device-related viewmodels into DeviceManagementApp and add dialog/scan interfaces
- copy device pages and scanner window into DeviceManagementApp with corrected namespaces
- update main view model and tests to reference new project

## Testing
- `dotnet test -c Release` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b95b956ccc8324b221d00194fc1a84