### PR TITLE
Isolate device configuration from inventory settings

### DIFF
--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -238,7 +238,7 @@ namespace InventoryManagementApp.ViewModels
             _deviceService = deviceService ?? new DummyDeviceService();
             _deviceGroupService = deviceGroupService ?? new DummyDeviceGroupService();
             _deviceFileService = deviceFileService ?? new DummyDeviceFileService();
-            var defaultConfig = new ConfigurationBuilder().AddJsonFile("appsettings.json", optional: true).Build();
+            var defaultConfig = new ConfigurationBuilder().Build();
             _deviceDiscoveryService = deviceDiscoveryService ?? new DeviceDiscoveryService(defaultConfig, null, null, null, _settingsService);
             _fileDialogService = fileDialogService;
             _logger = logger ?? NullLogger<MainViewModel>.Instance;
@@ -553,7 +553,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 try
                 {
-                    var config = new ConfigurationBuilder().AddJsonFile("appsettings.json", optional: true).Build();
+                    var config = new ConfigurationBuilder().Build();
                     var vm = new DeviceSettingsViewModel(_settingsService, config, (DeviceManagementApp.Interfaces.IDialogService)_dialogService);
                     await vm.InitializeAsync().ConfigureAwait(false);
                     var page = new DeviceManagementApp.Views.Pages.DeviceSettingsPage { DataContext = vm, Title = "Device Settings" };

--- a/InventoryManagementApp/appsettings.json
+++ b/InventoryManagementApp/appsettings.json
@@ -4,17 +4,5 @@
   },
   "Logging": {
     "Directory": "Logs"
-  },
-  "DeviceDiscovery": {
-    "Subnets": [ "192.168.2.0/24" ],
-    "FtpPorts": [21, 3721],
-    "AdditionalPorts": {
-      "5555": "Adb",
-      "80": "Http",
-      "8080": "Http"
-    },
-    "MaxConcurrentScans": 128,
-    "LivenessTimeoutMs": 400,
-    "PortProbeTimeoutMs": 700
   }
 }


### PR DESCRIPTION
## Summary
- Remove device discovery configuration from InventoryManagementApp's settings file.
- Use empty configuration for inventory device features, letting DeviceManagementApp own device discovery settings.

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b973cd9470832481b95557e59f964c