### PR TITLE
refactor: remove device code from main view model

### DIFF
--- a/DeviceManagementApp.Tests/MainViewModelNavigationTests.cs
+++ b/DeviceManagementApp.Tests/MainViewModelNavigationTests.cs
@@ -4,8 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Reflection;
 using InventoryManagementApp.Data;
-using DeviceManagementApp.Interfaces;
-using DeviceManagementApp.Models;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Models;
@@ -44,18 +42,6 @@ namespace DeviceManagementApp.Tests
         }
 
         [Fact]
-        public async Task OpenDeviceStatusCommand_IsNotNull()
-        {
-            await RunOnStaThread(() =>
-            {
-                using var db = new DatabaseService(":memory:");
-                using var vm = CreateMainViewModel(db, new DummyItemService(), new DummyDialogService());
-                Assert.NotNull(vm.OpenDeviceStatusCommand);
-                return Task.CompletedTask;
-            });
-        }
-
-        [Fact]
         public async Task UpdateUserAsync_UpdatesCurrentUserPhotoAndRaisesEvent()
         {
             await RunOnStaThread(async () =>
@@ -79,11 +65,7 @@ namespace DeviceManagementApp.Tests
                     new DummyDialogService(),
                     NullLogger<MainViewModel>.Instance,
                     () => Task.FromResult(true),
-                    new DummyDispatcherTimer(),
-                    new DummyScannerService(),
-                    null,
-                    new DummyDeviceGroupService(),
-                    );
+                    new DummyDispatcherTimer());
 
                 var um = vm.UserManagement;
                 um.Users.Add(currentUser);
@@ -120,11 +102,7 @@ namespace DeviceManagementApp.Tests
                 dialogService,
                 NullLogger<MainViewModel>.Instance,
                 () => Task.FromResult(true),
-                new DummyDispatcherTimer(),
-                new DummyScannerService(),
-                null,
-                new DummyDeviceGroupService(),
-                );
+                new DummyDispatcherTimer());
         }
 
         static Task RunOnStaThread(Func<Task> action)
@@ -299,21 +277,5 @@ namespace DeviceManagementApp.Tests
             public void Stop() => IsEnabled = false;
         }
 
-        private sealed class DummyScannerService : IScannerService
-        {
-            public Task<IEnumerable<Device>> GetDevicesAsync(CancellationToken cancellationToken) => Task.FromResult<IEnumerable<Device>>(Array.Empty<Device>());
-        }
-
-        private sealed class DummyDeviceGroupService : IDeviceGroupService
-        {
-            public Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default) => Task.FromResult(0);
-            public Task<IEnumerable<DeviceGroup>> GetGroupsAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<DeviceGroup>>(Array.Empty<DeviceGroup>());
-            public Task UpdateGroupAsync(DeviceGroup group, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task AssignDeviceToGroupAsync(string deviceIp, int? devicePort, int? groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<int?> GetDeviceGroupIdAsync(string deviceIp, int? devicePort, CancellationToken cancellationToken = default) => Task.FromResult<int?>(null);
-        }
-
-        
     }
 }

--- a/DeviceManagementApp.Tests/MainViewModelTests.cs
+++ b/DeviceManagementApp.Tests/MainViewModelTests.cs
@@ -9,8 +9,6 @@ using System.Windows;
 using System.Windows.Media;
 using CommunityToolkit.Mvvm.Input;
 using InventoryManagementApp.Data;
-using DeviceManagementApp.Interfaces;
-using DeviceManagementApp.Models;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models;
 using InventoryManagementApp.Models.Domain;
@@ -50,9 +48,6 @@ namespace DeviceManagementApp.Tests
                     NullLogger<MainViewModel>.Instance,
                     () => Task.FromResult(true),
                     new DummyDispatcherTimer(),
-                    new DummyScannerService(),
-                    null,
-                    new DummyDeviceGroupService(),
                     debounceTimer);
 
                 var field = typeof(MainViewModel).GetField("<GlobalSearchCommand>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -93,10 +88,7 @@ namespace DeviceManagementApp.Tests
                     new DummyDialogService(),
                     NullLogger<MainViewModel>.Instance,
                     () => Task.FromResult(true),
-                new DummyDispatcherTimer(),
-                new DummyScannerService(),
-                null,
-                new DummyDeviceGroupService(),
+                    new DummyDispatcherTimer(),
                     globalDebounceTimer);
 
                 var itemManagement = new ItemManagementViewModel(
@@ -159,10 +151,7 @@ namespace DeviceManagementApp.Tests
                     NullLogger<MainViewModel>.Instance,
                     () => Task.FromResult(true),
                 new DummyDispatcherTimer(),
-                new DummyScannerService(),
-                null,
-                new DummyDeviceGroupService(),
-                    debounceTimer);
+                debounceTimer);
 
                 vm.Dispose();
 
@@ -196,10 +185,7 @@ namespace DeviceManagementApp.Tests
                     NullLogger<MainViewModel>.Instance,
                     () => Task.FromResult(true),
                 new DummyDispatcherTimer(),
-                new DummyScannerService(),
-                null,
-                new DummyDeviceGroupService(),
-                    debounceTimer);
+                debounceTimer);
 
                 var openDashboardField = typeof(MainViewModel).GetField("<OpenDashboardCommand>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
                 openDashboardField!.SetValue(vm, new AsyncRelayCommand(() => Task.CompletedTask));
@@ -235,10 +221,7 @@ namespace DeviceManagementApp.Tests
                     NullLogger<MainViewModel>.Instance,
                     () => Task.FromResult(true),
                 new DummyDispatcherTimer(),
-                new DummyScannerService(),
-                null,
-                new DummyDeviceGroupService(),
-                    debounceTimer);
+                debounceTimer);
 
                 var openDashboardField = typeof(MainViewModel).GetField("<OpenDashboardCommand>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
                 openDashboardField!.SetValue(vm, new AsyncRelayCommand(() => Task.CompletedTask));
@@ -302,9 +285,6 @@ namespace DeviceManagementApp.Tests
                         NullLogger<MainViewModel>.Instance,
                         () => Task.FromResult(true),
                     new DummyDispatcherTimer(),
-                    new DummyScannerService(),
-                    null,
-                    new DummyDeviceGroupService(),
                         new DummyDispatcherTimer());
 
                     Assert.NotNull(vm.CurrentUserInitialsBrush);
@@ -502,21 +482,6 @@ namespace DeviceManagementApp.Tests
             public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }
-        }
-
-        private sealed class DummyScannerService : IScannerService
-        {
-            public Task<IEnumerable<Device>> GetDevicesAsync(CancellationToken cancellationToken) => Task.FromResult<IEnumerable<Device>>(Array.Empty<Device>());
-        }
-
-        private sealed class DummyDeviceGroupService : IDeviceGroupService
-        {
-            public Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default) => Task.FromResult(0);
-            public Task<IEnumerable<DeviceGroup>> GetGroupsAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<DeviceGroup>>(Array.Empty<DeviceGroup>());
-            public Task UpdateGroupAsync(DeviceGroup group, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task AssignDeviceToGroupAsync(string deviceIp, int? devicePort, int? groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task<int?> GetDeviceGroupIdAsync(string deviceIp, int? devicePort, CancellationToken cancellationToken = default) => Task.FromResult<int?>(null);
         }
 
         private sealed class DummyDispatcherTimer : IDispatcherTimer

--- a/DeviceManagementApp.Tests/MainWindowSideMenuTests.cs
+++ b/DeviceManagementApp.Tests/MainWindowSideMenuTests.cs
@@ -23,5 +23,14 @@ namespace DeviceManagementApp.Tests
             Assert.DoesNotContain("Content=\"Device Settings\"", xaml);
             Assert.DoesNotContain("OpenDeviceSettingsCommand", xaml);
         }
+
+        [Fact]
+        public void SideMenu_DoesNotContainDeviceStatusButton()
+        {
+            var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "InventoryManagementApp", "MainWindow.xaml"));
+            var xaml = File.ReadAllText(path);
+            Assert.DoesNotContain("Content=\"Device Status\"", xaml);
+            Assert.DoesNotContain("OpenDeviceStatusCommand", xaml);
+        }
     }
 }

--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -58,11 +58,6 @@
 
                         <Separator/>
 
-                        <TextBlock Text="Devices" Style="{StaticResource CaptionTextBlock}" Margin="6,8,6,2"/>
-                        <Button Style="{StaticResource NavButton}" Content="Device Status" Command="{Binding OpenDeviceStatusCommand}"/>
-
-                        <Separator/>
-
                         <TextBlock Text="Insights" Style="{StaticResource CaptionTextBlock}" Margin="6,8,6,2"/>
                         <Button Style="{StaticResource NavButton}" Content="Reports" Command="{Binding OpenReportsCommand}"/>
                         <Button Style="{StaticResource NavButton}" Content="Activity Logs" Command="{Binding OpenActivityLogsCommand}"/>

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -1,7 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
@@ -17,7 +16,6 @@ using InventoryManagementApp.Services.Rentals;
 using InventoryManagementApp.Services.Items;
 using InventoryManagementApp.Services.Users;
 using InventoryManagementApp.Views.Pages;
-using InventoryManagementApp.Views.Windows;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using InventoryManagementApp.Utilities.IO;
@@ -27,7 +25,6 @@ using InventoryManagementApp.Utilities;
 using InventoryManagementApp.Utilities.Helpers;
 using Application = System.Windows.Application;
 using MediaBrush = System.Windows.Media.Brush;
-using MediaBrushes = System.Windows.Media.Brushes;
 
 namespace InventoryManagementApp.ViewModels
 {


### PR DESCRIPTION
## Summary
- remove unused device-related directives from `MainViewModel`
- strip device status UI and commands from main window
- update tests to align with removal and assert absence of device features

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba35ae61a48324b413ce53bc1beee8