### PR TITLE
Remove obsolete device tables

### DIFF
--- a/InventoryManagementApp.Tests/MigrationRunnerTests.cs
+++ b/InventoryManagementApp.Tests/MigrationRunnerTests.cs
@@ -21,7 +21,7 @@ public class MigrationRunnerTests
             {
                 cmd.CommandText = "SELECT IFNULL(MAX(Version),0) FROM SchemaInfo;";
                 var version = Convert.ToInt32(cmd.ExecuteScalar());
-                Assert.Equal(1, version);
+                Assert.Equal(2, version);
             }
 
             using (var pragma = new SqliteCommand("PRAGMA table_info(Items);", conn))
@@ -37,6 +37,11 @@ public class MigrationRunnerTests
                     }
                 }
                 Assert.True(found);
+            }
+
+            using (var check = new SqliteCommand("SELECT name FROM sqlite_master WHERE type='table' AND name='Devices';", conn))
+            {
+                Assert.Null(check.ExecuteScalar());
             }
         }
         finally

--- a/InventoryManagementApp/Services/Core/DatabaseService.cs
+++ b/InventoryManagementApp/Services/Core/DatabaseService.cs
@@ -151,40 +151,10 @@ namespace InventoryManagementApp.Services.Core
                 CREATE TABLE IF NOT EXISTS Settings (
                     Key TEXT PRIMARY KEY,
                     Value TEXT
-                );
-                CREATE TABLE IF NOT EXISTS Devices (
-                    Ip TEXT NOT NULL,
-                    Port INTEGER,
-                    Hostname TEXT,
-                    Protocol TEXT,
-                    Username TEXT,
-                    Password TEXT,
-                    Domain TEXT,
-                    ItemId INTEGER,
-                    PRIMARY KEY (Ip, Port),
-                    FOREIGN KEY (ItemId) REFERENCES Items(ItemID)
-                );
-                CREATE TABLE IF NOT EXISTS DeviceGroups (
-                    GroupId INTEGER PRIMARY KEY AUTOINCREMENT,
-                    Name TEXT NOT NULL
-                );
-                CREATE TABLE IF NOT EXISTS DeviceGroupAssignments (
-                    DeviceIp TEXT NOT NULL,
-                    DevicePort INTEGER,
-                    GroupId INTEGER,
-                    PRIMARY KEY (DeviceIp, DevicePort),
-                    FOREIGN KEY (GroupId) REFERENCES DeviceGroups(GroupId)
-                );
-                CREATE TABLE IF NOT EXISTS PulledDeviceFiles (
-                    DeviceIp TEXT NOT NULL,
-                    Hash TEXT NOT NULL,
-                    PRIMARY KEY (DeviceIp, Hash)
                 );";
             using var cmd = new SqliteCommand(sql, conn);
             cmd.ExecuteNonQuery();
             EnsureColumn("Items", "DeviceId", "TEXT");
-            EnsureColumn("Devices", "Port", "INTEGER");
-            EnsureColumn("DeviceGroupAssignments", "DevicePort", "INTEGER");
 
             EnsureIndex(conn, "Items", "ItemNumber", true);
             EnsureIndex(conn, "Items", "NameDescription");
@@ -198,8 +168,6 @@ namespace InventoryManagementApp.Services.Core
             EnsureIndex(conn, "Users", "UserName", true);
             EnsureIndex(conn, "Customers", "Contact");
             EnsureIndex(conn, "Rentals", new[] { "ItemID", "CustomerID" });
-            EnsureIndex(conn, "Devices", "ItemId");
-            EnsureIndex(conn, "PulledDeviceFiles", "DeviceIp");
         }
 
         void MigrateLegacyItemsTable(SqliteConnection conn)

--- a/InventoryManagementApp/Services/Core/MigrationRunner.cs
+++ b/InventoryManagementApp/Services/Core/MigrationRunner.cs
@@ -43,6 +43,14 @@ namespace InventoryManagementApp.Services.Core
                 ApplyV1(conn);
                 using var insert = new SqliteCommand("INSERT INTO SchemaInfo (Version) VALUES (1);", conn);
                 insert.ExecuteNonQuery();
+                currentVersion = 1;
+            }
+
+            if (currentVersion < 2)
+            {
+                ApplyV2(conn);
+                using var insert = new SqliteCommand("INSERT INTO SchemaInfo (Version) VALUES (2);", conn);
+                insert.ExecuteNonQuery();
             }
         }
 
@@ -80,6 +88,17 @@ namespace InventoryManagementApp.Services.Core
             _db.EnsureColumn("Users", "IsActive", "INTEGER", "1");
             _db.EnsureColumn("Users", "CreatedAt", "DATETIME");
             _db.EnsureColumn("Users", "PasswordExpired", "INTEGER", "0");
+        }
+
+        void ApplyV2(SqliteConnection conn)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"
+                DROP TABLE IF EXISTS Devices;
+                DROP TABLE IF EXISTS DeviceGroups;
+                DROP TABLE IF EXISTS DeviceGroupAssignments;
+                DROP TABLE IF EXISTS PulledDeviceFiles;";
+            cmd.ExecuteNonQuery();
         }
     }
 }


### PR DESCRIPTION
## Summary
- stop creating legacy device tables in the inventory database
- migrate existing databases by dropping device-related tables
- update migration tests for new schema version

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68babbe101b88324bcd66f6ac3b9cca6