### PR TITLE
Add EnumeratorCancellation support to device discovery

### DIFF
--- a/DeviceManagementApp/Services/DeviceDiscoveryService.cs
+++ b/DeviceManagementApp/Services/DeviceDiscoveryService.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Text;
 using System.Threading;
@@ -133,7 +134,7 @@ namespace DeviceManagementApp.Services
         }
 
         public async IAsyncEnumerable<DiscoveredDevice> DiscoverDevicesAsync(IProgress<double>? progress = null,
-            CancellationToken cancellationToken = default)
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             if (_subnets.Count == 0)
             {


### PR DESCRIPTION
## Summary
- allow DeviceDiscoveryService to honor cancellation when enumerating by applying `[EnumeratorCancellation]`

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0aa61f548324a2725abb8e578655