### PR TITLE
Remove extraneous project reference from DeviceManagementApp tests

### DIFF
--- a/DeviceManagementApp.Tests/DeviceManagementApp.Tests.csproj
+++ b/DeviceManagementApp.Tests/DeviceManagementApp.Tests.csproj
@@ -11,6 +11,5 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../DeviceManagementApp/DeviceManagementApp.csproj" />
-    <ProjectReference Include="../InventoryManagementApp/InventoryManagementApp.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- remove InventoryManagementApp project reference from test project so tests depend only on DeviceManagementApp

## Testing
- `dotnet build DeviceManagementApp.Tests/DeviceManagementApp.Tests.csproj -t:Rebuild` *(fails: command not found: dotnet)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0a94f59c8324a9cfd7f1a4a95644