### PR TITLE
Target test project for Windows build

### DIFF
--- a/DeviceManagementApp.Tests/DeviceManagementApp.Tests.csproj
+++ b/DeviceManagementApp.Tests/DeviceManagementApp.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- target DeviceManagementApp.Tests at `net8.0-windows`
- keep WPF support enabled in test project

## Testing
- `dotnet test DeviceManagementApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0a8a9aa883248c933aec3a59756e