### PR TITLE
Remove redundant SqliteHelper compile entry

### DIFF
--- a/DeviceManagementApp/DeviceManagementApp.csproj
+++ b/DeviceManagementApp/DeviceManagementApp.csproj
@@ -53,7 +53,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Services/Core/SqliteHelper.cs" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- remove explicit SqliteHelper compile include from DeviceManagementApp project file

## Testing
- `dotnet test DeviceManagementApp.sln` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bc0f88e1588324b7752243937fe41b