### PR TITLE
Fix converter namespace for DeviceManagementApp

### DIFF
--- a/DeviceManagementApp/Resources/Converters.xaml
+++ b/DeviceManagementApp/Resources/Converters.xaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:conv="clr-namespace:DeviceManagementApp.Utilities.Converters">
+                    xmlns:conv="clr-namespace:DeviceManagementApp.Utilities.Converters;assembly=DeviceManagementApp">
     <conv:NullToDefaultImageConverter x:Key="NullToDefaultImageConverter"/>
     <conv:BooleanToAdminConverter x:Key="BooleanToAdminConverter"/>
     <conv:DateTimeMinToEmptyStringConverter x:Key="DateTimeMinToEmptyStringConverter"/>


### PR DESCRIPTION
## Summary
- specify DeviceManagementApp assembly in converter resource dictionary

## Testing
- `dotnet clean DeviceManagementApp/DeviceManagementApp.csproj` *(fails: command not found)*
- `dotnet build DeviceManagementApp/DeviceManagementApp.csproj` *(fails: command not found)*
- `dotnet run --project DeviceManagementApp/DeviceManagementApp.csproj` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc107f707c8324a30ab35fc90caf6a