### PR TITLE
Compile Templates.xaml as Page to enable x:Shared

### DIFF
--- a/DeviceManagementApp/DeviceManagementApp.csproj
+++ b/DeviceManagementApp/DeviceManagementApp.csproj
@@ -39,10 +39,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Generator>MSBuild:Compile</Generator>
     </Resource>
-    <Resource Include="Resources\Templates.xaml">
+    <Page Include="Resources\Templates.xaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Generator>MSBuild:Compile</Generator>
-    </Resource>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">


### PR DESCRIPTION
## Summary
- compile `Resources/Templates.xaml` as a WPF Page instead of a Resource so the resource dictionary is compiled and supports `x:Shared`

## Testing
- `dotnet build DeviceManagementApp/DeviceManagementApp.csproj` *(fails: command not found: dotnet)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bc14db92588324a27daeae61908595