### PR TITLE
Fix ListLogger contract and add System namespace to DeviceDiscovery tests

### DIFF
--- a/DeviceManagementApp.Tests/DeviceDiscoveryServiceTests.cs
+++ b/DeviceManagementApp.Tests/DeviceDiscoveryServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -15,9 +16,10 @@ public class DeviceDiscoveryServiceTests
     {
         public List<(LogLevel Level, string Message)> Logs { get; } = new();
 
-        public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
         public bool IsEnabled(LogLevel logLevel) => true;
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) where TState : notnull
             => Logs.Add((logLevel, formatter(state, exception)));
 
         private sealed class NullScope : IDisposable


### PR DESCRIPTION
## Summary
- add missing `System` namespace to DeviceDiscoveryServiceTests
- align `ListLogger<T>` with `ILogger<T>` by adding `notnull` constraints on generic methods

## Testing
- `dotnet test` *(fails: command not found - missing .NET SDK)*
- `apt-get update` *(fails: 403 Forbidden repository access)*

------
https://chatgpt.com/codex/tasks/task_e_68bc14d897a883248634dd90c4837684