### PR TITLE
Remove duplicate Templates.xaml inclusion

### DIFF
--- a/DeviceManagementApp/DeviceManagementApp.csproj
+++ b/DeviceManagementApp/DeviceManagementApp.csproj
@@ -39,10 +39,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Generator>MSBuild:Compile</Generator>
     </Resource>
-    <Page Include="Resources\Templates.xaml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">


### PR DESCRIPTION
## Summary
- remove explicit inclusion of Resources/Templates.xaml in project to avoid duplicate build item

## Testing
- `dotnet build DeviceManagementApp/DeviceManagementApp.csproj` *(fails: command not found)*
- `dotnet test DeviceManagementApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1623790c832496f98929e97ddcf2