### PR TITLE
feat: add label provider for device management app

### DIFF
--- a/DeviceManagementApp/Resources/LabelProvider.cs
+++ b/DeviceManagementApp/Resources/LabelProvider.cs
@@ -1,0 +1,59 @@
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using DeviceManagementApp.Interfaces;
+
+namespace DeviceManagementApp.Resources
+{
+    public class LabelProvider : ObservableObject
+    {
+        public static LabelProvider Instance { get; } = new LabelProvider();
+
+        private LabelProvider() { }
+
+        private string _pageLabel = string.Empty;
+        public string PageLabel
+        {
+            get => _pageLabel;
+            private set => SetProperty(ref _pageLabel, value);
+        }
+
+        private string _tooltipLabel = string.Empty;
+        public string TooltipLabel
+        {
+            get => _tooltipLabel;
+            private set => SetProperty(ref _tooltipLabel, value);
+        }
+
+        private string _itemLabelSingular = "Item";
+        public string ItemLabelSingular
+        {
+            get => _itemLabelSingular;
+            private set => SetProperty(ref _itemLabelSingular, value);
+        }
+
+        private string _itemLabelPlural = "Items";
+        public string ItemLabelPlural
+        {
+            get => _itemLabelPlural;
+            private set => SetProperty(ref _itemLabelPlural, value);
+        }
+
+        public async Task InitializeAsync(ISettingsService settingsService)
+        {
+            var singular = await settingsService.GetItemLabelSingularAsync().ConfigureAwait(false);
+            var plural = await settingsService.GetItemLabelPluralAsync().ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(singular))
+                ItemLabelSingular = singular;
+            if (!string.IsNullOrWhiteSpace(plural))
+                ItemLabelPlural = plural;
+        }
+
+        public void UpdateLabels(string pageLabel, string tooltipLabel, string singular, string plural)
+        {
+            PageLabel = pageLabel;
+            TooltipLabel = tooltipLabel;
+            ItemLabelSingular = singular;
+            ItemLabelPlural = plural;
+        }
+    }
+}

--- a/DeviceManagementApp/Resources/Templates.xaml
+++ b/DeviceManagementApp/Resources/Templates.xaml
@@ -1,7 +1,7 @@
 <!-- Resources/Templates.xaml -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
+                    xmlns:helpers="clr-namespace:DeviceManagementApp.Resources"
                     xmlns:models="clr-namespace:DeviceManagementApp.Models">
     <DataTemplate x:Key="StatCardTemplate">
         <Border Style="{StaticResource Card}">


### PR DESCRIPTION
## Summary
- add LabelProvider to DeviceManagementApp with item, page, and tooltip labels
- reference new LabelProvider from Templates.xaml

## Testing
- `dotnet build DeviceManagementApp/DeviceManagementApp.csproj` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc177dddcc8324b8dd87aad87cdd5c