### PR TITLE
Track device specs and assignments

### DIFF
--- a/DeviceManagementApp.Tests/DeviceServiceTests.cs
+++ b/DeviceManagementApp.Tests/DeviceServiceTests.cs
@@ -13,11 +13,32 @@ public class DeviceServiceTests
         var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
         await using var db = new DatabaseService(dbPath);
         var service = new DeviceService(db);
-        var device = new Device { Ip = "1.2.3.4", Port = 21, Hostname = "test", Protocol = DeviceProtocol.Ftp, Username = "u", Password = "p", Domain = "d" };
+        var device = new Device
+        {
+            Ip = "1.2.3.4",
+            Port = 21,
+            Hostname = "test",
+            Protocol = DeviceProtocol.Ftp,
+            Username = "u",
+            Password = "p",
+            Domain = "d",
+            AssignedUserId = 1,
+            DepartmentId = 2,
+            Cpu = "i5",
+            MemoryGb = 8,
+            StorageGb = 256,
+            OperatingSystem = "Windows"
+        };
         await service.AddOrUpdateDeviceAsync(device);
         var fetched = await service.GetDeviceAsync("1.2.3.4", 21);
         Assert.NotNull(fetched);
         Assert.Equal("test", fetched!.Hostname);
+        Assert.Equal(1, fetched.AssignedUserId);
+        Assert.Equal(2, fetched.DepartmentId);
+        Assert.Equal("i5", fetched.Cpu);
+        Assert.Equal(8, fetched.MemoryGb);
+        Assert.Equal(256, fetched.StorageGb);
+        Assert.Equal("Windows", fetched.OperatingSystem);
         var all = await service.GetDevicesAsync();
         Assert.Single(all);
         await service.DeleteDeviceAsync("1.2.3.4", 21);

--- a/DeviceManagementApp/Models/Device.cs
+++ b/DeviceManagementApp/Models/Device.cs
@@ -30,6 +30,12 @@ namespace DeviceManagementApp.Models
         int? _groupId;
         int? _itemId;
         string _itemName = string.Empty;
+        int? _assignedUserId;
+        int? _departmentId;
+        string _cpu = string.Empty;
+        int? _memoryGb;
+        int? _storageGb;
+        string _operatingSystem = string.Empty;
 
         public string Ip
         {
@@ -119,6 +125,42 @@ namespace DeviceManagementApp.Models
         {
             get => _itemName;
             set => SetProperty(ref _itemName, value);
+        }
+
+        public int? AssignedUserId
+        {
+            get => _assignedUserId;
+            set => SetProperty(ref _assignedUserId, value);
+        }
+
+        public int? DepartmentId
+        {
+            get => _departmentId;
+            set => SetProperty(ref _departmentId, value);
+        }
+
+        public string Cpu
+        {
+            get => _cpu;
+            set => SetProperty(ref _cpu, value);
+        }
+
+        public int? MemoryGb
+        {
+            get => _memoryGb;
+            set => SetProperty(ref _memoryGb, value);
+        }
+
+        public int? StorageGb
+        {
+            get => _storageGb;
+            set => SetProperty(ref _storageGb, value);
+        }
+
+        public string OperatingSystem
+        {
+            get => _operatingSystem;
+            set => SetProperty(ref _operatingSystem, value);
         }
     }
 }

--- a/DeviceManagementApp/Services/DatabaseService.cs
+++ b/DeviceManagementApp/Services/DatabaseService.cs
@@ -159,8 +159,15 @@ namespace DeviceManagementApp.Services
                     Password TEXT,
                     Domain TEXT,
                     ItemId INTEGER,
+                    AssignedUserId INTEGER,
+                    DepartmentId INTEGER,
+                    Cpu TEXT,
+                    MemoryGb INTEGER,
+                    StorageGb INTEGER,
+                    OperatingSystem TEXT,
                     PRIMARY KEY (Ip, Port),
-                    FOREIGN KEY (ItemId) REFERENCES Items(ItemID)
+                    FOREIGN KEY (ItemId) REFERENCES Items(ItemID),
+                    FOREIGN KEY (AssignedUserId) REFERENCES Users(UserID)
                 );
                 CREATE TABLE IF NOT EXISTS DeviceGroups (
                     GroupId INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -182,6 +189,12 @@ namespace DeviceManagementApp.Services
             cmd.ExecuteNonQuery();
             EnsureColumn("Devices", "Port", "INTEGER");
             EnsureColumn("DeviceGroupAssignments", "DevicePort", "INTEGER");
+            EnsureColumn("Devices", "AssignedUserId", "INTEGER");
+            EnsureColumn("Devices", "DepartmentId", "INTEGER");
+            EnsureColumn("Devices", "Cpu", "TEXT");
+            EnsureColumn("Devices", "MemoryGb", "INTEGER");
+            EnsureColumn("Devices", "StorageGb", "INTEGER");
+            EnsureColumn("Devices", "OperatingSystem", "TEXT");
 
             EnsureIndex(conn, "Items", "ItemNumber", true);
             EnsureIndex(conn, "Items", "NameDescription");
@@ -195,6 +208,8 @@ namespace DeviceManagementApp.Services
             EnsureIndex(conn, "Customers", "Contact");
             EnsureIndex(conn, "Rentals", new[] { "ItemID", "CustomerID" });
             EnsureIndex(conn, "Devices", "ItemId");
+            EnsureIndex(conn, "Devices", "AssignedUserId");
+            EnsureIndex(conn, "Devices", "DepartmentId");
             EnsureIndex(conn, "PulledDeviceFiles", "DeviceIp");
         }
 

--- a/DeviceManagementApp/Services/DeviceService.cs
+++ b/DeviceManagementApp/Services/DeviceService.cs
@@ -22,7 +22,8 @@ namespace DeviceManagementApp.Services
         {
             using var conn = _db.CreateConnection();
             using var cmd = conn.CreateCommand();
-            cmd.CommandText = @"SELECT d.Ip, d.Port, d.Hostname, d.Protocol, d.Username, d.Password, d.Domain, d.ItemId, i.NameDescription
+            cmd.CommandText = @"SELECT d.Ip, d.Port, d.Hostname, d.Protocol, d.Username, d.Password, d.Domain, d.ItemId, i.NameDescription,
+                                        d.AssignedUserId, d.DepartmentId, d.Cpu, d.MemoryGb, d.StorageGb, d.OperatingSystem
                                FROM Devices d LEFT JOIN Items i ON i.ItemID = d.ItemId ORDER BY d.Ip, d.Port";
             using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
             var devices = new List<Device>();
@@ -38,7 +39,13 @@ namespace DeviceManagementApp.Services
                     Password = reader.IsDBNull(5) ? string.Empty : reader.GetString(5),
                     Domain = reader.IsDBNull(6) ? string.Empty : reader.GetString(6),
                     ItemId = reader.IsDBNull(7) ? null : reader.GetInt32(7),
-                    ItemName = reader.IsDBNull(8) ? string.Empty : reader.GetString(8)
+                    ItemName = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
+                    AssignedUserId = reader.IsDBNull(9) ? null : reader.GetInt32(9),
+                    DepartmentId = reader.IsDBNull(10) ? null : reader.GetInt32(10),
+                    Cpu = reader.IsDBNull(11) ? string.Empty : reader.GetString(11),
+                    MemoryGb = reader.IsDBNull(12) ? null : reader.GetInt32(12),
+                    StorageGb = reader.IsDBNull(13) ? null : reader.GetInt32(13),
+                    OperatingSystem = reader.IsDBNull(14) ? string.Empty : reader.GetString(14)
                 });
             }
             return devices;
@@ -48,7 +55,8 @@ namespace DeviceManagementApp.Services
         {
             using var conn = _db.CreateConnection();
             using var cmd = conn.CreateCommand();
-            cmd.CommandText = @"SELECT d.Ip, d.Port, d.Hostname, d.Protocol, d.Username, d.Password, d.Domain, d.ItemId, i.NameDescription
+            cmd.CommandText = @"SELECT d.Ip, d.Port, d.Hostname, d.Protocol, d.Username, d.Password, d.Domain, d.ItemId, i.NameDescription,
+                                        d.AssignedUserId, d.DepartmentId, d.Cpu, d.MemoryGb, d.StorageGb, d.OperatingSystem
                                FROM Devices d LEFT JOIN Items i ON i.ItemID = d.ItemId WHERE d.Ip=$ip AND IFNULL(d.Port,-1)=IFNULL($port,-1)";
             cmd.Parameters.AddWithValue("$ip", ip);
             if (port.HasValue)
@@ -68,7 +76,13 @@ namespace DeviceManagementApp.Services
                     Password = reader.IsDBNull(5) ? string.Empty : reader.GetString(5),
                     Domain = reader.IsDBNull(6) ? string.Empty : reader.GetString(6),
                     ItemId = reader.IsDBNull(7) ? null : reader.GetInt32(7),
-                    ItemName = reader.IsDBNull(8) ? string.Empty : reader.GetString(8)
+                    ItemName = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
+                    AssignedUserId = reader.IsDBNull(9) ? null : reader.GetInt32(9),
+                    DepartmentId = reader.IsDBNull(10) ? null : reader.GetInt32(10),
+                    Cpu = reader.IsDBNull(11) ? string.Empty : reader.GetString(11),
+                    MemoryGb = reader.IsDBNull(12) ? null : reader.GetInt32(12),
+                    StorageGb = reader.IsDBNull(13) ? null : reader.GetInt32(13),
+                    OperatingSystem = reader.IsDBNull(14) ? string.Empty : reader.GetString(14)
                 };
             }
             return null;
@@ -78,15 +92,21 @@ namespace DeviceManagementApp.Services
         {
             using var conn = _db.CreateConnection();
             using var cmd = conn.CreateCommand();
-            cmd.CommandText = @"INSERT INTO Devices (Ip, Port, Hostname, Protocol, Username, Password, Domain, ItemId)
-                                VALUES ($ip, $port, $hostname, $protocol, $username, $password, $domain, $itemId)
+            cmd.CommandText = @"INSERT INTO Devices (Ip, Port, Hostname, Protocol, Username, Password, Domain, ItemId, AssignedUserId, DepartmentId, Cpu, MemoryGb, StorageGb, OperatingSystem)
+                                VALUES ($ip, $port, $hostname, $protocol, $username, $password, $domain, $itemId, $assignedUserId, $departmentId, $cpu, $memoryGb, $storageGb, $operatingSystem)
                                 ON CONFLICT(Ip, Port) DO UPDATE SET
                                     Hostname=$hostname,
                                     Protocol=$protocol,
                                     Username=$username,
                                     Password=$password,
                                     Domain=$domain,
-                                    ItemId=$itemId";
+                                    ItemId=$itemId,
+                                    AssignedUserId=$assignedUserId,
+                                    DepartmentId=$departmentId,
+                                    Cpu=$cpu,
+                                    MemoryGb=$memoryGb,
+                                    StorageGb=$storageGb,
+                                    OperatingSystem=$operatingSystem";
             cmd.Parameters.AddWithValue("$ip", device.Ip);
             if (device.Port.HasValue)
                 cmd.Parameters.AddWithValue("$port", device.Port.Value);
@@ -101,6 +121,24 @@ namespace DeviceManagementApp.Services
                 cmd.Parameters.AddWithValue("$itemId", device.ItemId.Value);
             else
                 cmd.Parameters.AddWithValue("$itemId", DBNull.Value);
+            if (device.AssignedUserId.HasValue)
+                cmd.Parameters.AddWithValue("$assignedUserId", device.AssignedUserId.Value);
+            else
+                cmd.Parameters.AddWithValue("$assignedUserId", DBNull.Value);
+            if (device.DepartmentId.HasValue)
+                cmd.Parameters.AddWithValue("$departmentId", device.DepartmentId.Value);
+            else
+                cmd.Parameters.AddWithValue("$departmentId", DBNull.Value);
+            cmd.Parameters.AddWithValue("$cpu", (object?)device.Cpu ?? DBNull.Value);
+            if (device.MemoryGb.HasValue)
+                cmd.Parameters.AddWithValue("$memoryGb", device.MemoryGb.Value);
+            else
+                cmd.Parameters.AddWithValue("$memoryGb", DBNull.Value);
+            if (device.StorageGb.HasValue)
+                cmd.Parameters.AddWithValue("$storageGb", device.StorageGb.Value);
+            else
+                cmd.Parameters.AddWithValue("$storageGb", DBNull.Value);
+            cmd.Parameters.AddWithValue("$operatingSystem", (object?)device.OperatingSystem ?? DBNull.Value);
             await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
## Summary
- expand `Device` model with CPU, memory, storage, OS, department, and assigned user fields
- read and persist new device specs in `DeviceService`
- create and index new columns in `Devices` table via `DatabaseService`
- extend unit test to verify new fields are stored and retrieved

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository ... 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1abca7a48324a9c03d4013d45a95