### PR TITLE
Add device assignment management

### DIFF
--- a/DeviceManagementApp.Tests/DeviceAssignmentServiceTests.cs
+++ b/DeviceManagementApp.Tests/DeviceAssignmentServiceTests.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+using DeviceManagementApp.Models;
+using DeviceManagementApp.Services;
+using Xunit;
+
+public class DeviceAssignmentServiceTests
+{
+    [Fact]
+    public async Task AssignAndReturnDevice()
+    {
+        using var db = new DatabaseService(":memory:");
+        var service = new DeviceAssignmentService(db);
+
+        var assignment = new DeviceAssignment
+        {
+            DeviceIp = "10.0.0.1",
+            UserId = 42,
+            DepartmentId = 7,
+            AssignedDate = DateTime.UtcNow
+        };
+
+        await service.AssignDeviceAsync(assignment);
+        var current = await service.GetCurrentAssignmentAsync("10.0.0.1");
+        Assert.NotNull(current);
+        Assert.Equal(42, current!.UserId);
+
+        await service.ReturnDeviceAsync("10.0.0.1");
+        current = await service.GetCurrentAssignmentAsync("10.0.0.1");
+        Assert.Null(current);
+    }
+}

--- a/DeviceManagementApp/App.xaml.cs
+++ b/DeviceManagementApp/App.xaml.cs
@@ -64,6 +64,7 @@ namespace DeviceManagementApp
                 services.AddSingleton<IDeviceService, DeviceService>();
                 services.AddSingleton<IDeviceFileService, DeviceFileService>();
                 services.AddSingleton<IDeviceGroupService, DeviceGroupService>();
+                services.AddSingleton<IDeviceAssignmentService, DeviceAssignmentService>();
                 services.AddSingleton<IDeviceDiscoveryService, DeviceDiscoveryService>();
             })
             .Build();

--- a/DeviceManagementApp/Interfaces/IDeviceAssignmentService.cs
+++ b/DeviceManagementApp/Interfaces/IDeviceAssignmentService.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DeviceManagementApp.Models;
+
+namespace DeviceManagementApp.Interfaces
+{
+    public interface IDeviceAssignmentService
+    {
+        Task<DeviceAssignment?> GetCurrentAssignmentAsync(string deviceIp, CancellationToken cancellationToken = default);
+        Task<int> AssignDeviceAsync(DeviceAssignment assignment, CancellationToken cancellationToken = default);
+        Task ReturnDeviceAsync(string deviceIp, CancellationToken cancellationToken = default);
+    }
+}

--- a/DeviceManagementApp/Models/Device.cs
+++ b/DeviceManagementApp/Models/Device.cs
@@ -30,6 +30,7 @@ namespace DeviceManagementApp.Models
         int? _groupId;
         int? _itemId;
         string _itemName = string.Empty;
+        string _assignedTo = string.Empty;
 
         public string Ip
         {
@@ -119,6 +120,12 @@ namespace DeviceManagementApp.Models
         {
             get => _itemName;
             set => SetProperty(ref _itemName, value);
+        }
+
+        public string AssignedTo
+        {
+            get => _assignedTo;
+            set => SetProperty(ref _assignedTo, value);
         }
     }
 }

--- a/DeviceManagementApp/Models/DeviceAssignment.cs
+++ b/DeviceManagementApp/Models/DeviceAssignment.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace DeviceManagementApp.Models
+{
+    public class DeviceAssignment
+    {
+        public int AssignmentId { get; set; }
+        public string DeviceIp { get; set; } = string.Empty;
+        public int UserId { get; set; }
+        public DateTime AssignedDate { get; set; }
+        public DateTime? ReturnedDate { get; set; }
+        public int? DepartmentId { get; set; }
+    }
+}

--- a/DeviceManagementApp/Services/DatabaseService.cs
+++ b/DeviceManagementApp/Services/DatabaseService.cs
@@ -173,6 +173,14 @@ namespace DeviceManagementApp.Services
                     PRIMARY KEY (DeviceIp, DevicePort),
                     FOREIGN KEY (GroupId) REFERENCES DeviceGroups(GroupId)
                 );
+                CREATE TABLE IF NOT EXISTS DeviceAssignments (
+                    AssignmentId INTEGER PRIMARY KEY AUTOINCREMENT,
+                    DeviceIp TEXT NOT NULL,
+                    UserId INTEGER NOT NULL,
+                    AssignedDate DATETIME NOT NULL,
+                    ReturnedDate DATETIME,
+                    DepartmentId INTEGER
+                );
                 CREATE TABLE IF NOT EXISTS PulledDeviceFiles (
                     DeviceIp TEXT NOT NULL,
                     Hash TEXT NOT NULL,
@@ -196,6 +204,7 @@ namespace DeviceManagementApp.Services
             EnsureIndex(conn, "Rentals", new[] { "ItemID", "CustomerID" });
             EnsureIndex(conn, "Devices", "ItemId");
             EnsureIndex(conn, "PulledDeviceFiles", "DeviceIp");
+            EnsureIndex(conn, "DeviceAssignments", "DeviceIp");
         }
 
         void MigrateLegacyItemsTable(SqliteConnection conn)

--- a/DeviceManagementApp/Services/DeviceAssignmentService.cs
+++ b/DeviceManagementApp/Services/DeviceAssignmentService.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DeviceManagementApp.Interfaces;
+using DeviceManagementApp.Models;
+using Microsoft.Data.Sqlite;
+
+namespace DeviceManagementApp.Services
+{
+    public class DeviceAssignmentService : IDeviceAssignmentService
+    {
+        readonly DatabaseService _db;
+
+        public DeviceAssignmentService(DatabaseService db)
+        {
+            _db = db;
+        }
+
+        public async Task<int> AssignDeviceAsync(DeviceAssignment assignment, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"INSERT INTO DeviceAssignments (DeviceIp, UserId, AssignedDate, DepartmentId)
+                                VALUES ($ip, $userId, $assigned, $dept); SELECT last_insert_rowid();";
+            cmd.Parameters.AddWithValue("$ip", assignment.DeviceIp);
+            cmd.Parameters.AddWithValue("$userId", assignment.UserId);
+            cmd.Parameters.AddWithValue("$assigned", assignment.AssignedDate);
+            if (assignment.DepartmentId.HasValue)
+                cmd.Parameters.AddWithValue("$dept", assignment.DepartmentId.Value);
+            else
+                cmd.Parameters.AddWithValue("$dept", DBNull.Value);
+            var result = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            return (int)(long)result!;
+        }
+
+        public async Task<DeviceAssignment?> GetCurrentAssignmentAsync(string deviceIp, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"SELECT AssignmentId, DeviceIp, UserId, AssignedDate, ReturnedDate, DepartmentId
+                                FROM DeviceAssignments
+                                WHERE DeviceIp=$ip AND ReturnedDate IS NULL ORDER BY AssignedDate DESC LIMIT 1";
+            cmd.Parameters.AddWithValue("$ip", deviceIp);
+            using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return new DeviceAssignment
+                {
+                    AssignmentId = reader.GetInt32(0),
+                    DeviceIp = reader.GetString(1),
+                    UserId = reader.GetInt32(2),
+                    AssignedDate = reader.GetDateTime(3),
+                    ReturnedDate = reader.IsDBNull(4) ? null : reader.GetDateTime(4),
+                    DepartmentId = reader.IsDBNull(5) ? null : reader.GetInt32(5)
+                };
+            }
+            return null;
+        }
+
+        public async Task ReturnDeviceAsync(string deviceIp, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "UPDATE DeviceAssignments SET ReturnedDate=$ret WHERE DeviceIp=$ip AND ReturnedDate IS NULL";
+            cmd.Parameters.AddWithValue("$ret", DateTime.UtcNow);
+            cmd.Parameters.AddWithValue("$ip", deviceIp);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/DeviceManagementApp/Services/DeviceService.cs
+++ b/DeviceManagementApp/Services/DeviceService.cs
@@ -22,8 +22,12 @@ namespace DeviceManagementApp.Services
         {
             using var conn = _db.CreateConnection();
             using var cmd = conn.CreateCommand();
-            cmd.CommandText = @"SELECT d.Ip, d.Port, d.Hostname, d.Protocol, d.Username, d.Password, d.Domain, d.ItemId, i.NameDescription
-                               FROM Devices d LEFT JOIN Items i ON i.ItemID = d.ItemId ORDER BY d.Ip, d.Port";
+            cmd.CommandText = @"SELECT d.Ip, d.Port, d.Hostname, d.Protocol, d.Username, d.Password, d.Domain, d.ItemId, i.NameDescription, IFNULL(u.UserName, '')
+                               FROM Devices d 
+                               LEFT JOIN Items i ON i.ItemID = d.ItemId 
+                               LEFT JOIN DeviceAssignments da ON da.DeviceIp = d.Ip AND da.ReturnedDate IS NULL
+                               LEFT JOIN Users u ON u.UserID = da.UserId
+                               ORDER BY d.Ip, d.Port";
             using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
             var devices = new List<Device>();
             while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -38,7 +42,8 @@ namespace DeviceManagementApp.Services
                     Password = reader.IsDBNull(5) ? string.Empty : reader.GetString(5),
                     Domain = reader.IsDBNull(6) ? string.Empty : reader.GetString(6),
                     ItemId = reader.IsDBNull(7) ? null : reader.GetInt32(7),
-                    ItemName = reader.IsDBNull(8) ? string.Empty : reader.GetString(8)
+                    ItemName = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
+                    AssignedTo = reader.IsDBNull(9) ? string.Empty : reader.GetString(9)
                 });
             }
             return devices;
@@ -48,8 +53,11 @@ namespace DeviceManagementApp.Services
         {
             using var conn = _db.CreateConnection();
             using var cmd = conn.CreateCommand();
-            cmd.CommandText = @"SELECT d.Ip, d.Port, d.Hostname, d.Protocol, d.Username, d.Password, d.Domain, d.ItemId, i.NameDescription
-                               FROM Devices d LEFT JOIN Items i ON i.ItemID = d.ItemId WHERE d.Ip=$ip AND IFNULL(d.Port,-1)=IFNULL($port,-1)";
+            cmd.CommandText = @"SELECT d.Ip, d.Port, d.Hostname, d.Protocol, d.Username, d.Password, d.Domain, d.ItemId, i.NameDescription, IFNULL(u.UserName,'')
+                               FROM Devices d LEFT JOIN Items i ON i.ItemID = d.ItemId
+                               LEFT JOIN DeviceAssignments da ON da.DeviceIp = d.Ip AND da.ReturnedDate IS NULL
+                               LEFT JOIN Users u ON u.UserID = da.UserId
+                               WHERE d.Ip=$ip AND IFNULL(d.Port,-1)=IFNULL($port,-1)";
             cmd.Parameters.AddWithValue("$ip", ip);
             if (port.HasValue)
                 cmd.Parameters.AddWithValue("$port", port.Value);
@@ -68,7 +76,8 @@ namespace DeviceManagementApp.Services
                     Password = reader.IsDBNull(5) ? string.Empty : reader.GetString(5),
                     Domain = reader.IsDBNull(6) ? string.Empty : reader.GetString(6),
                     ItemId = reader.IsDBNull(7) ? null : reader.GetInt32(7),
-                    ItemName = reader.IsDBNull(8) ? string.Empty : reader.GetString(8)
+                    ItemName = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
+                    AssignedTo = reader.IsDBNull(9) ? string.Empty : reader.GetString(9)
                 };
             }
             return null;

--- a/DeviceManagementApp/ViewModels/AssignDeviceDialogViewModel.cs
+++ b/DeviceManagementApp/ViewModels/AssignDeviceDialogViewModel.cs
@@ -1,0 +1,22 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace DeviceManagementApp.ViewModels
+{
+    public class AssignDeviceDialogViewModel : ObservableObject
+    {
+        int _userId;
+        int? _departmentId;
+
+        public int UserId
+        {
+            get => _userId;
+            set => SetProperty(ref _userId, value);
+        }
+
+        public int? DepartmentId
+        {
+            get => _departmentId;
+            set => SetProperty(ref _departmentId, value);
+        }
+    }
+}

--- a/DeviceManagementApp/ViewModels/DevicesViewModel.cs
+++ b/DeviceManagementApp/ViewModels/DevicesViewModel.cs
@@ -22,6 +22,7 @@ namespace DeviceManagementApp.ViewModels
         private readonly IDialogService _dialogService;
         private readonly IDeviceService _deviceService;
         private readonly IDeviceGroupService _groupService;
+        private readonly IDeviceAssignmentService _assignmentService;
         private readonly ILogger<DevicesViewModel> _logger;
 
         public ObservableCollection<Device> Devices { get; } = new();
@@ -47,6 +48,8 @@ namespace DeviceManagementApp.ViewModels
                     PullAllReportsCommand.NotifyCanExecuteChanged();
                     PingSelectedDeviceCommand.NotifyCanExecuteChanged();
                     DownloadUnseenFilesCommand.NotifyCanExecuteChanged();
+                    AssignDeviceCommand.NotifyCanExecuteChanged();
+                    ReturnDeviceCommand.NotifyCanExecuteChanged();
                 }
             }
         }
@@ -59,6 +62,8 @@ namespace DeviceManagementApp.ViewModels
         public IAsyncRelayCommand RenameGroupCommand { get; }
         public IAsyncRelayCommand DeleteGroupCommand { get; }
         public IAsyncRelayCommand DownloadUnseenFilesCommand { get; }
+        public IAsyncRelayCommand AssignDeviceCommand { get; }
+        public IAsyncRelayCommand ReturnDeviceCommand { get; }
 
         private string _sourceFolder = string.Empty;
         public string SourceFolder
@@ -133,6 +138,7 @@ namespace DeviceManagementApp.ViewModels
                                  IDialogService dialogService,
                                  IDeviceService deviceService,
                                  IDeviceGroupService groupService,
+                                 IDeviceAssignmentService assignmentService,
                                  ILogger<DevicesViewModel>? logger = null)
         {
             _discoveryService = discoveryService;
@@ -140,6 +146,7 @@ namespace DeviceManagementApp.ViewModels
             _dialogService = dialogService;
             _deviceService = deviceService;
             _groupService = groupService;
+            _assignmentService = assignmentService;
             _logger = logger ?? NullLogger<DevicesViewModel>.Instance;
 
             RefreshCommand = new AsyncRelayCommand(RefreshAsync, () => !IsDiscovering);
@@ -150,6 +157,42 @@ namespace DeviceManagementApp.ViewModels
             RenameGroupCommand = new AsyncRelayCommand(RenameGroupAsync);
             DeleteGroupCommand = new AsyncRelayCommand(DeleteGroupAsync);
             DownloadUnseenFilesCommand = new AsyncRelayCommand(DownloadUnseenFilesAsync, CanDownloadUnseenFiles);
+            AssignDeviceCommand = new AsyncRelayCommand(AssignDeviceAsync, () => SelectedDevice != null);
+            ReturnDeviceCommand = new AsyncRelayCommand(ReturnDeviceAsync, () => SelectedDevice != null);
+        }
+
+        public Func<DeviceAssignment?> PromptForAssignment { get; set; } = () =>
+        {
+            var dlg = new Views.AssignDeviceDialog();
+            if (dlg.ShowDialog() == true && dlg.DataContext is AssignDeviceDialogViewModel vm)
+            {
+                return new DeviceAssignment
+                {
+                    UserId = vm.UserId,
+                    DepartmentId = vm.DepartmentId,
+                    AssignedDate = DateTime.UtcNow
+                };
+            }
+            return null;
+        };
+
+        private async Task AssignDeviceAsync()
+        {
+            if (SelectedDevice == null) return;
+            var assignment = PromptForAssignment?.Invoke();
+            if (assignment == null) return;
+            assignment.DeviceIp = SelectedDevice.Ip;
+            await _assignmentService.AssignDeviceAsync(assignment);
+            var refreshed = await _deviceService.GetDeviceAsync(SelectedDevice.Ip, SelectedDevice.Port);
+            if (refreshed != null)
+                SelectedDevice.AssignedTo = refreshed.AssignedTo;
+        }
+
+        private async Task ReturnDeviceAsync()
+        {
+            if (SelectedDevice == null) return;
+            await _assignmentService.ReturnDeviceAsync(SelectedDevice.Ip);
+            SelectedDevice.AssignedTo = string.Empty;
         }
 
         private async Task RefreshAsync()

--- a/DeviceManagementApp/Views/AssignDeviceDialog.xaml
+++ b/DeviceManagementApp/Views/AssignDeviceDialog.xaml
@@ -1,0 +1,15 @@
+<Window x:Class="DeviceManagementApp.Views.AssignDeviceDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Assign Device" Height="200" Width="300">
+    <StackPanel Margin="10">
+        <TextBlock Text="User ID"/>
+        <TextBox Text="{Binding UserId, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Text="Department ID" Margin="0,10,0,0"/>
+        <TextBox Text="{Binding DepartmentId, UpdateSourceTrigger=PropertyChanged}"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" IsDefault="True" Width="80" Margin="0,0,5,0" Click="Ok_Click"/>
+            <Button Content="Cancel" IsCancel="True" Width="80"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/DeviceManagementApp/Views/AssignDeviceDialog.xaml.cs
+++ b/DeviceManagementApp/Views/AssignDeviceDialog.xaml.cs
@@ -1,0 +1,16 @@
+using System.Windows;
+using DeviceManagementApp.ViewModels;
+
+namespace DeviceManagementApp.Views
+{
+    public partial class AssignDeviceDialog : Window
+    {
+        public AssignDeviceDialog()
+        {
+            InitializeComponent();
+            DataContext = new AssignDeviceDialogViewModel();
+        }
+
+        void Ok_Click(object sender, RoutedEventArgs e) => DialogResult = true;
+    }
+}

--- a/DeviceManagementApp/Views/Pages/DevicesPage.xaml
+++ b/DeviceManagementApp/Views/Pages/DevicesPage.xaml
@@ -29,6 +29,14 @@
                                 Content="Add Device"
                                 Command="{Binding AddDeviceCommand}"
                                 Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource PrimaryButton}"
+                                Content="Assign"
+                                Command="{Binding AssignDeviceCommand}"
+                                Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource PrimaryButton}"
+                                Content="Return"
+                                Command="{Binding ReturnDeviceCommand}"
+                                Margin="0,0,8,0"/>
                         <Button x:Name="AddGroupButton"
                                 Style="{StaticResource PrimaryButton}"
                                 Content="Add Group"
@@ -94,6 +102,7 @@
                                                  SelectedValuePath="Id"
                                                  DisplayMemberPath="Name"
                                                  ItemsSource="{Binding Groups}" Width="150"/>
+                        <DataGridTextColumn Header="Assignee" Binding="{Binding AssignedTo}" IsReadOnly="True" Width="150"/>
                         <DataGridTextColumn Header="Protocols" Binding="{Binding ProtocolsDisplay}" IsReadOnly="True" Width="150"/>
                         <DataGridTextColumn Header="Status" Binding="{Binding Status}" IsReadOnly="True" Width="120"/>
                         <DataGridTextColumn Header="Last Seen" Binding="{Binding LastSeen, StringFormat={}{0:G}}" IsReadOnly="True" Width="180"/>


### PR DESCRIPTION
## Summary
- add device assignment model, service and database table
- support assigning and returning devices with UI dialog and commands
- show current assignee in device list

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1ad329b083249586075308a08b74