### PR TITLE
Add device detail view with filtering and navigation

### DIFF
--- a/DeviceManagementApp.Tests/DeviceDetailsPageTests.cs
+++ b/DeviceManagementApp.Tests/DeviceDetailsPageTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using DeviceManagementApp.Models;
+using DeviceManagementApp.ViewModels;
+using DeviceManagementApp.Views.Pages;
+using Xunit;
+
+namespace DeviceManagementApp.Tests
+{
+    public class DeviceDetailsPageTests
+    {
+        [Fact]
+        public void DeviceDetailsPage_ShowsHardwareAndSoftware()
+        {
+            Exception? threadEx = null;
+            string? cpuText = null;
+            int softwareCount = 0;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary
+                    {
+                        Source = new Uri("pack://application:,,,/DeviceManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                    });
+
+                    var device = new Device { Ip = "1.2.3.4", Cpu = "Intel", MemoryGb = 16, StorageGb = 512, OperatingSystem = "Windows" };
+                    var software = new[] { new DeviceSoftware { Name = "App", Version = "1.0" } };
+                    var vm = new DeviceDetailsViewModel(device, software);
+                    var page = new DeviceDetailsPage { DataContext = vm };
+                    page.ApplyTemplate();
+                    page.Measure(new System.Windows.Size(double.PositiveInfinity, double.PositiveInfinity));
+                    page.Arrange(new System.Windows.Rect(0, 0, page.DesiredSize.Width, page.DesiredSize.Height));
+                    page.UpdateLayout();
+                    cpuText = FindVisualChildren<TextBlock>(page).FirstOrDefault(t => t.Text == "Intel")?.Text;
+                    var list = FindVisualChild<ListBox>(page);
+                    softwareCount = list?.Items.Count ?? 0;
+
+                    Application.Current?.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadEx != null) throw threadEx;
+            Assert.Equal("Intel", cpuText);
+            Assert.Equal(1, softwareCount);
+        }
+
+        static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+        {
+            int count = VisualTreeHelper.GetChildrenCount(parent);
+            for (int i = 0; i < count; i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                if (child is T typedChild)
+                    return typedChild;
+                var result = FindVisualChild<T>(child);
+                if (result != null)
+                    return result;
+            }
+            return null;
+        }
+
+        static System.Collections.Generic.IEnumerable<T> FindVisualChildren<T>(DependencyObject parent) where T : DependencyObject
+        {
+            int count = VisualTreeHelper.GetChildrenCount(parent);
+            for (int i = 0; i < count; i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                if (child is T typedChild)
+                    yield return typedChild;
+                foreach (var c in FindVisualChildren<T>(child))
+                    yield return c;
+            }
+        }
+    }
+}

--- a/DeviceManagementApp.Tests/DevicesPageTests.cs
+++ b/DeviceManagementApp.Tests/DevicesPageTests.cs
@@ -199,6 +199,51 @@ namespace DeviceManagementApp.Tests
         }
 
         [Fact]
+        public void DevicesPage_FiltersByDepartmentAndStaff()
+        {
+            Exception? threadEx = null;
+            int rowCount = 0;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary
+                    {
+                        Source = new Uri("pack://application:,,,/DeviceManagementApp;component/Resources/Styles.xaml", UriKind.Absolute)
+                    });
+
+                    var vm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
+                    vm.Devices.Add(new Device { Ip = "1", DepartmentId = 1, AssignedUserId = 1, ProtocolsDisplay = "" });
+                    vm.Devices.Add(new Device { Ip = "2", DepartmentId = 2, AssignedUserId = 1, ProtocolsDisplay = "" });
+                    vm.Devices.Add(new Device { Ip = "3", DepartmentId = 1, AssignedUserId = 2, ProtocolsDisplay = "" });
+
+                    var page = new DevicesPage { DataContext = vm };
+                    page.ApplyTemplate();
+                    var grid = FindVisualChild<DataGrid>(page);
+                    vm.DepartmentFilter = 1;
+                    vm.AssignedUserFilter = 1;
+                    grid?.Items.Refresh();
+                    rowCount = grid?.Items.Count ?? 0;
+
+                    Application.Current?.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadEx != null) throw threadEx;
+            Assert.Equal(1, rowCount);
+        }
+
+        [Fact]
         public void DevicesPage_DoesNotHaveSettingsButton()
         {
             Exception? threadEx = null;

--- a/DeviceManagementApp.Tests/DevicesViewModelTests.cs
+++ b/DeviceManagementApp.Tests/DevicesViewModelTests.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
+using System.Windows.Controls;
 using DeviceManagementApp.Interfaces;
 using DeviceManagementApp.Models;
 using DeviceManagementApp.Services;
 using DeviceManagementApp.ViewModels;
+using DeviceManagementApp.Views.Pages;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
@@ -132,6 +134,12 @@ public class DevicesViewModelTests
         }
         public Task DeleteDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
+    }
+
+    private sealed class RecordingNavigationService : INavigationService
+    {
+        public Page? LastPage { get; private set; }
+        public void Navigate(Page page) => LastPage = page;
     }
 
     [Fact]
@@ -575,5 +583,23 @@ public class DevicesViewModelTests
         await vm.DownloadUnseenFilesCommand.ExecuteAsync(null);
 
         Assert.Equal(0, fileService.DownloadCallCount);
+    }
+
+    [Fact]
+    public void ViewDetailsCommand_NavigatesToDetailsPage()
+    {
+        var discovery = new StubDiscoveryService();
+        var fileService = new RecordingDeviceFileService();
+        var dialog = new RecordingDialogService();
+        var nav = new RecordingNavigationService();
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), new RecordingDeviceGroupService(), navigationService: nav);
+        var device = new Device { Ip = "1" };
+        vm.Devices.Add(device);
+        vm.SelectedDevice = device;
+        vm.InstalledSoftware.Add(new DeviceSoftware { Name = "App", Version = "1" });
+
+        vm.ViewDetailsCommand.Execute(null);
+
+        Assert.IsType<DeviceDetailsPage>(nav.LastPage);
     }
 }

--- a/DeviceManagementApp/App.xaml.cs
+++ b/DeviceManagementApp/App.xaml.cs
@@ -10,6 +10,7 @@ using Serilog;
 using Serilog.Events;
 using DeviceManagementApp.Services;
 using DeviceManagementApp.Interfaces;
+using DeviceManagementApp.ViewModels;
 using Application = System.Windows.Application;
 
 namespace DeviceManagementApp
@@ -65,6 +66,8 @@ namespace DeviceManagementApp
                 services.AddSingleton<IDeviceFileService, DeviceFileService>();
                 services.AddSingleton<IDeviceGroupService, DeviceGroupService>();
                 services.AddSingleton<IDeviceDiscoveryService, DeviceDiscoveryService>();
+                services.AddSingleton<INavigationService, NavigationService>();
+                services.AddSingleton<DevicesViewModel>();
             })
             .Build();
 

--- a/DeviceManagementApp/Interfaces/INavigationService.cs
+++ b/DeviceManagementApp/Interfaces/INavigationService.cs
@@ -1,0 +1,9 @@
+using System.Windows.Controls;
+
+namespace DeviceManagementApp.Interfaces
+{
+    public interface INavigationService
+    {
+        void Navigate(Page page);
+    }
+}

--- a/DeviceManagementApp/MainWindow.xaml
+++ b/DeviceManagementApp/MainWindow.xaml
@@ -3,7 +3,5 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="MainWindow" Height="450" Width="800"
         Icon="Assets/CompanyLogo/SDLogo.png">
-    <Grid>
-
-    </Grid>
+    <Frame x:Name="MainFrame" NavigationUIVisibility="Hidden"/>
 </Window>

--- a/DeviceManagementApp/MainWindow.xaml.cs
+++ b/DeviceManagementApp/MainWindow.xaml.cs
@@ -1,4 +1,8 @@
 using System.Windows;
+using Microsoft.Extensions.DependencyInjection;
+using DeviceManagementApp.Interfaces;
+using DeviceManagementApp.ViewModels;
+using DeviceManagementApp.Views.Pages;
 
 namespace DeviceManagementApp
 {
@@ -7,6 +11,17 @@ namespace DeviceManagementApp
         public MainWindow()
         {
             InitializeComponent();
+            Loaded += MainWindow_Loaded;
+        }
+
+        void MainWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            var host = ((App)Application.Current).Host;
+            var nav = host.Services.GetRequiredService<INavigationService>();
+            if (nav is Services.NavigationService ns)
+                ns.Frame = MainFrame;
+            var vm = host.Services.GetRequiredService<DevicesViewModel>();
+            nav.Navigate(new DevicesPage { DataContext = vm });
         }
     }
 }

--- a/DeviceManagementApp/Services/NavigationService.cs
+++ b/DeviceManagementApp/Services/NavigationService.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+using DeviceManagementApp.Interfaces;
+
+namespace DeviceManagementApp.Services
+{
+    public class NavigationService : INavigationService
+    {
+        public Frame? Frame { get; set; }
+
+        public void Navigate(Page page)
+        {
+            Frame?.Navigate(page);
+        }
+    }
+}

--- a/DeviceManagementApp/ViewModels/DeviceDetailsViewModel.cs
+++ b/DeviceManagementApp/ViewModels/DeviceDetailsViewModel.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using DeviceManagementApp.Models;
+
+namespace DeviceManagementApp.ViewModels
+{
+    public class DeviceDetailsViewModel : ObservableObject
+    {
+        public Device Device { get; }
+        public ObservableCollection<DeviceSoftware> InstalledSoftware { get; } = new();
+
+        public DeviceDetailsViewModel(Device device, IEnumerable<DeviceSoftware> software)
+        {
+            Device = device;
+            foreach (var s in software)
+                InstalledSoftware.Add(s);
+        }
+    }
+}

--- a/DeviceManagementApp/ViewModels/DevicesViewModel.cs
+++ b/DeviceManagementApp/ViewModels/DevicesViewModel.cs
@@ -6,10 +6,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Net.NetworkInformation;
+using System.Windows.Controls;
+using System.Windows.Data;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DeviceManagementApp.Interfaces;
 using DeviceManagementApp.Models;
+using DeviceManagementApp.Views.Pages;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualBasic;
@@ -24,12 +27,16 @@ namespace DeviceManagementApp.ViewModels
         private readonly IDeviceService _deviceService;
         private readonly IDeviceGroupService _groupService;
         private readonly IDeviceSoftwareService _softwareService;
+        private readonly INavigationService _navigationService;
         private readonly ILogger<DevicesViewModel> _logger;
 
         public ObservableCollection<Device> Devices { get; } = new();
         public ObservableCollection<string> DeviceFiles { get; } = new();
         public ObservableCollection<DeviceGroup> Groups { get; } = new();
         public ObservableCollection<DeviceSoftware> InstalledSoftware { get; } = new();
+        public ObservableCollection<KeyValuePair<int?, string>> Departments { get; } = new() { new(null, "All Departments") };
+        public ObservableCollection<KeyValuePair<int?, string>> Staff { get; } = new() { new(null, "All Staff") };
+        public ICollectionView DevicesView { get; }
 
         private string _fileExtensionFilter = "*.*";
         public string FileExtensionFilter
@@ -53,6 +60,7 @@ namespace DeviceManagementApp.ViewModels
                     PullAllReportsCommand.NotifyCanExecuteChanged();
                     PingSelectedDeviceCommand.NotifyCanExecuteChanged();
                     DownloadUnseenFilesCommand.NotifyCanExecuteChanged();
+                    ViewDetailsCommand.NotifyCanExecuteChanged();
                 }
             }
         }
@@ -65,6 +73,7 @@ namespace DeviceManagementApp.ViewModels
         public IAsyncRelayCommand RenameGroupCommand { get; }
         public IAsyncRelayCommand DeleteGroupCommand { get; }
         public IAsyncRelayCommand DownloadUnseenFilesCommand { get; }
+        public IRelayCommand ViewDetailsCommand { get; }
 
         private string _sourceFolder = string.Empty;
         public string SourceFolder
@@ -134,12 +143,35 @@ namespace DeviceManagementApp.ViewModels
             set => SetProperty(ref _groupName, value);
         }
 
+        private int? _departmentFilter;
+        public int? DepartmentFilter
+        {
+            get => _departmentFilter;
+            set
+            {
+                if (SetProperty(ref _departmentFilter, value))
+                    DevicesView.Refresh();
+            }
+        }
+
+        private int? _assignedUserFilter;
+        public int? AssignedUserFilter
+        {
+            get => _assignedUserFilter;
+            set
+            {
+                if (SetProperty(ref _assignedUserFilter, value))
+                    DevicesView.Refresh();
+            }
+        }
+
         public DevicesViewModel(IDeviceDiscoveryService discoveryService,
                                  IDeviceFileService fileService,
                                  IDialogService dialogService,
                                  IDeviceService deviceService,
                                  IDeviceGroupService groupService,
                                  IDeviceSoftwareService? softwareService = null,
+                                 INavigationService? navigationService = null,
                                  ILogger<DevicesViewModel>? logger = null)
         {
             _discoveryService = discoveryService;
@@ -148,7 +180,11 @@ namespace DeviceManagementApp.ViewModels
             _deviceService = deviceService;
             _groupService = groupService;
             _softwareService = softwareService ?? NullDeviceSoftwareService.Instance;
+            _navigationService = navigationService ?? NullNavigationService.Instance;
             _logger = logger ?? NullLogger<DevicesViewModel>.Instance;
+
+            DevicesView = CollectionViewSource.GetDefaultView(Devices);
+            DevicesView.Filter = FilterDevice;
 
             RefreshCommand = new AsyncRelayCommand(RefreshAsync, () => !IsDiscovering);
             PullAllReportsCommand = new AsyncRelayCommand(PullAllReportsAsync, CanPullAllReports);
@@ -158,6 +194,7 @@ namespace DeviceManagementApp.ViewModels
             RenameGroupCommand = new AsyncRelayCommand(RenameGroupAsync);
             DeleteGroupCommand = new AsyncRelayCommand(DeleteGroupAsync);
             DownloadUnseenFilesCommand = new AsyncRelayCommand(DownloadUnseenFilesAsync, CanDownloadUnseenFiles);
+            ViewDetailsCommand = new RelayCommand(OpenDetails, () => SelectedDevice != null);
         }
 
         private async Task RefreshAsync()
@@ -170,6 +207,10 @@ namespace DeviceManagementApp.ViewModels
                 foreach (var d in Devices)
                     d.PropertyChanged -= Device_PropertyChanged;
                 Devices.Clear();
+                Departments.Clear();
+                Departments.Add(new(null, "All Departments"));
+                Staff.Clear();
+                Staff.Add(new(null, "All Staff"));
 
                 var groups = await _groupService.GetGroupsAsync();
                 Groups.Clear();
@@ -203,12 +244,17 @@ namespace DeviceManagementApp.ViewModels
                     }
                     device.PropertyChanged += Device_PropertyChanged;
                     Devices.Add(device);
+                    if (device.DepartmentId.HasValue && !Departments.Any(dp => dp.Key == device.DepartmentId))
+                        Departments.Add(new(device.DepartmentId.Value, device.DepartmentId.Value.ToString()));
+                    if (device.AssignedUserId.HasValue && !Staff.Any(s => s.Key == device.AssignedUserId))
+                        Staff.Add(new(device.AssignedUserId.Value, device.AssignedUserId.Value.ToString()));
                 }
 
                 if (Devices.Count == 0 && !_discoveryService.HasConfiguredSubnets)
                 {
                     await _dialogService.ShowInfoAsync("No subnets configured for device discovery.", "Devices");
                 }
+                DevicesView.Refresh();
             }
             catch (Exception ex)
             {
@@ -425,6 +471,25 @@ namespace DeviceManagementApp.ViewModels
             }
         }
 
+        private void OpenDetails()
+        {
+            if (SelectedDevice == null)
+                return;
+            var vm = new DeviceDetailsViewModel(SelectedDevice, InstalledSoftware);
+            _navigationService.Navigate(new DeviceDetailsPage { DataContext = vm });
+        }
+
+        private bool FilterDevice(object obj)
+        {
+            if (obj is not Device d)
+                return false;
+            if (DepartmentFilter.HasValue && d.DepartmentId != DepartmentFilter)
+                return false;
+            if (AssignedUserFilter.HasValue && d.AssignedUserId != AssignedUserFilter)
+                return false;
+            return true;
+        }
+
         class NullDeviceSoftwareService : IDeviceSoftwareService
         {
             public static readonly IDeviceSoftwareService Instance = new NullDeviceSoftwareService();
@@ -435,6 +500,13 @@ namespace DeviceManagementApp.ViewModels
                 => Task.CompletedTask;
             public Task DeleteAsync(string deviceIp, int? devicePort, string name, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
+        }
+
+        class NullNavigationService : INavigationService
+        {
+            public static readonly INavigationService Instance = new NullNavigationService();
+            NullNavigationService() { }
+            public void Navigate(Page page) { }
         }
     }
 }

--- a/DeviceManagementApp/Views/Pages/DeviceDetailsPage.xaml
+++ b/DeviceManagementApp/Views/Pages/DeviceDetailsPage.xaml
@@ -5,10 +5,17 @@
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <TextBlock Text="{Binding SelectedDevice.Ip}" FontWeight="Bold" Margin="0,0,0,8"/>
-        <ListBox Grid.Row="1" ItemsSource="{Binding InstalledSoftware}">
+        <TextBlock Text="{Binding Device.Ip}" FontWeight="Bold" Margin="0,0,0,8"/>
+        <StackPanel Grid.Row="1" Margin="0,0,0,8">
+            <TextBlock Text="{Binding Device.OperatingSystem}"/>
+            <TextBlock Text="{Binding Device.Cpu}"/>
+            <TextBlock Text="{Binding Device.MemoryGb, StringFormat={}{0} GB}"/>
+            <TextBlock Text="{Binding Device.StorageGb, StringFormat={}{0} GB}"/>
+        </StackPanel>
+        <ListBox Grid.Row="2" ItemsSource="{Binding InstalledSoftware}">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal">

--- a/DeviceManagementApp/Views/Pages/DevicesPage.xaml
+++ b/DeviceManagementApp/Views/Pages/DevicesPage.xaml
@@ -26,6 +26,10 @@
                                 Command="{Binding PingSelectedDeviceCommand}"
                                 Margin="0,0,8,0"/>
                         <Button Style="{StaticResource PrimaryButton}"
+                                Content="View Details"
+                                Command="{Binding ViewDetailsCommand}"
+                                Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource PrimaryButton}"
                                 Content="Add Device"
                                 Command="{Binding AddDeviceCommand}"
                                 Margin="0,0,8,0"/>
@@ -44,6 +48,18 @@
                                 Content="Delete Group"
                                 Command="{Binding DeleteGroupCommand}"
                                 Margin="0,0,8,0"/>
+                        <ComboBox Width="120"
+                                  ItemsSource="{Binding Departments}"
+                                  SelectedValue="{Binding DepartmentFilter}"
+                                  DisplayMemberPath="Value"
+                                  SelectedValuePath="Key"
+                                  Margin="0,0,8,0"/>
+                        <ComboBox Width="120"
+                                  ItemsSource="{Binding Staff}"
+                                  SelectedValue="{Binding AssignedUserFilter}"
+                                  DisplayMemberPath="Value"
+                                  SelectedValuePath="Key"
+                                  Margin="0,0,8,0"/>
                         <TextBox Text="{Binding FileExtensionFilter, UpdateSourceTrigger=PropertyChanged}"
                                  Width="120"
                                  Margin="0,0,8,0"/>
@@ -79,7 +95,7 @@
                              Visibility="{Binding IsDiscovering, Converter={StaticResource BoolToVis}}"/>
             </StackPanel>
             <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0" Margin="0,8,0,0">
-                <DataGrid ItemsSource="{Binding Devices}"
+                <DataGrid ItemsSource="{Binding DevicesView}"
                           SelectedItem="{Binding SelectedDevice}"
                           AutoGenerateColumns="False"
                           IsReadOnly="False"


### PR DESCRIPTION
## Summary
- Show device hardware and installed software in new DeviceDetailsPage/ViewModel
- Filter devices by department and assigned staff with navigation to detail view
- Add UI tests for device filtering and detail display

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1de937b88324a723a76ac9bee54b