### PR TITLE
Add device assignment functionality

### DIFF
--- a/DeviceManagementApp.Tests/DeviceAssignmentServiceTests.cs
+++ b/DeviceManagementApp.Tests/DeviceAssignmentServiceTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using DeviceManagementApp.Models;
+using DeviceManagementApp.Services;
+using Xunit;
+
+public class DeviceAssignmentServiceTests
+{
+    [Fact]
+    public async Task AssignAndReturnDevice()
+    {
+        using var db = new DatabaseService(":memory:");
+        var assignmentService = new DeviceAssignmentService(db);
+        var deviceService = new DeviceService(db);
+
+        await deviceService.AddOrUpdateDeviceAsync(new Device { Ip = "1.2.3.4" });
+
+        var assignment = new DeviceAssignment
+        {
+            DeviceIp = "1.2.3.4",
+            UserId = 1,
+            DepartmentId = 2,
+            AssignedDate = DateTime.UtcNow
+        };
+        await assignmentService.AssignAsync(assignment);
+
+        var current = await assignmentService.GetCurrentAssignmentAsync("1.2.3.4");
+        Assert.NotNull(current);
+        Assert.Equal(1, current!.UserId);
+        Assert.Equal(2, current.DepartmentId);
+
+        var device = await deviceService.GetDeviceAsync("1.2.3.4", null);
+        Assert.NotNull(device);
+        Assert.Equal(1, device!.AssignedUserId);
+        Assert.Equal(2, device.DepartmentId);
+
+        await assignmentService.ReturnAsync("1.2.3.4");
+        current = await assignmentService.GetCurrentAssignmentAsync("1.2.3.4");
+        Assert.Null(current);
+        device = await deviceService.GetDeviceAsync("1.2.3.4", null);
+        Assert.NotNull(device);
+        Assert.Null(device!.AssignedUserId);
+    }
+}

--- a/DeviceManagementApp/Interfaces/IDeviceAssignmentService.cs
+++ b/DeviceManagementApp/Interfaces/IDeviceAssignmentService.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DeviceManagementApp.Models;
+
+namespace DeviceManagementApp.Interfaces
+{
+    public interface IDeviceAssignmentService
+    {
+        Task<DeviceAssignment?> GetCurrentAssignmentAsync(string deviceIp, CancellationToken cancellationToken = default);
+        Task AssignAsync(DeviceAssignment assignment, CancellationToken cancellationToken = default);
+        Task ReturnAsync(string deviceIp, CancellationToken cancellationToken = default);
+    }
+}

--- a/DeviceManagementApp/Models/DeviceAssignment.cs
+++ b/DeviceManagementApp/Models/DeviceAssignment.cs
@@ -1,0 +1,44 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace DeviceManagementApp.Models
+{
+    public class DeviceAssignment : ObservableObject
+    {
+        string _deviceIp = string.Empty;
+        int _userId;
+        DateTime _assignedDate;
+        DateTime? _returnedDate;
+        int? _departmentId;
+
+        public string DeviceIp
+        {
+            get => _deviceIp;
+            set => SetProperty(ref _deviceIp, value);
+        }
+
+        public int UserId
+        {
+            get => _userId;
+            set => SetProperty(ref _userId, value);
+        }
+
+        public DateTime AssignedDate
+        {
+            get => _assignedDate;
+            set => SetProperty(ref _assignedDate, value);
+        }
+
+        public DateTime? ReturnedDate
+        {
+            get => _returnedDate;
+            set => SetProperty(ref _returnedDate, value);
+        }
+
+        public int? DepartmentId
+        {
+            get => _departmentId;
+            set => SetProperty(ref _departmentId, value);
+        }
+    }
+}

--- a/DeviceManagementApp/Services/DatabaseService.cs
+++ b/DeviceManagementApp/Services/DatabaseService.cs
@@ -180,6 +180,15 @@ namespace DeviceManagementApp.Services
                     PRIMARY KEY (DeviceIp, DevicePort),
                     FOREIGN KEY (GroupId) REFERENCES DeviceGroups(GroupId)
                 );
+                CREATE TABLE IF NOT EXISTS DeviceAssignments (
+                    DeviceIp TEXT NOT NULL,
+                    UserId INTEGER NOT NULL,
+                    AssignedDate DATETIME NOT NULL,
+                    ReturnedDate DATETIME,
+                    DepartmentId INTEGER,
+                    PRIMARY KEY (DeviceIp, AssignedDate),
+                    FOREIGN KEY (UserId) REFERENCES Users(UserID)
+                );
                 CREATE TABLE IF NOT EXISTS PulledDeviceFiles (
                     DeviceIp TEXT NOT NULL,
                     Hash TEXT NOT NULL,
@@ -202,6 +211,8 @@ namespace DeviceManagementApp.Services
             EnsureColumn("Devices", "MemoryGb", "INTEGER");
             EnsureColumn("Devices", "StorageGb", "INTEGER");
             EnsureColumn("Devices", "OperatingSystem", "TEXT");
+            EnsureColumn("DeviceAssignments", "ReturnedDate", "DATETIME");
+            EnsureColumn("DeviceAssignments", "DepartmentId", "INTEGER");
 
             EnsureIndex(conn, "Items", "ItemNumber", true);
             EnsureIndex(conn, "Items", "NameDescription");
@@ -218,6 +229,7 @@ namespace DeviceManagementApp.Services
             EnsureIndex(conn, "Devices", "AssignedUserId");
             EnsureIndex(conn, "Devices", "DepartmentId");
             EnsureIndex(conn, "PulledDeviceFiles", "DeviceIp");
+            EnsureIndex(conn, "DeviceAssignments", "DeviceIp");
         }
 
         void MigrateLegacyItemsTable(SqliteConnection conn)

--- a/DeviceManagementApp/Services/DeviceAssignmentService.cs
+++ b/DeviceManagementApp/Services/DeviceAssignmentService.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DeviceManagementApp.Interfaces;
+using DeviceManagementApp.Models;
+using Microsoft.Data.Sqlite;
+
+namespace DeviceManagementApp.Services
+{
+    public class DeviceAssignmentService : IDeviceAssignmentService
+    {
+        readonly DatabaseService _db;
+
+        public DeviceAssignmentService(DatabaseService db)
+        {
+            _db = db;
+        }
+
+        public async Task<DeviceAssignment?> GetCurrentAssignmentAsync(string deviceIp, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"SELECT DeviceIp, UserId, AssignedDate, ReturnedDate, DepartmentId
+                                FROM DeviceAssignments
+                                WHERE DeviceIp=$ip AND ReturnedDate IS NULL
+                                ORDER BY AssignedDate DESC LIMIT 1";
+            cmd.Parameters.AddWithValue("$ip", deviceIp);
+            using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return new DeviceAssignment
+                {
+                    DeviceIp = reader.GetString(0),
+                    UserId = reader.GetInt32(1),
+                    AssignedDate = reader.GetDateTime(2),
+                    ReturnedDate = reader.IsDBNull(3) ? null : reader.GetDateTime(3),
+                    DepartmentId = reader.IsDBNull(4) ? null : reader.GetInt32(4)
+                };
+            }
+            return null;
+        }
+
+        public async Task AssignAsync(DeviceAssignment assignment, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var tran = conn.BeginTransaction();
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.Transaction = tran;
+                cmd.CommandText = @"INSERT INTO DeviceAssignments (DeviceIp, UserId, AssignedDate, DepartmentId)
+                                    VALUES ($ip, $uid, $adate, $dept)";
+                cmd.Parameters.AddWithValue("$ip", assignment.DeviceIp);
+                cmd.Parameters.AddWithValue("$uid", assignment.UserId);
+                cmd.Parameters.AddWithValue("$adate", assignment.AssignedDate);
+                if (assignment.DepartmentId.HasValue)
+                    cmd.Parameters.AddWithValue("$dept", assignment.DepartmentId.Value);
+                else
+                    cmd.Parameters.AddWithValue("$dept", DBNull.Value);
+                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.Transaction = tran;
+                cmd.CommandText = @"UPDATE Devices SET AssignedUserId=$uid, DepartmentId=$dept WHERE Ip=$ip";
+                cmd.Parameters.AddWithValue("$uid", assignment.UserId);
+                if (assignment.DepartmentId.HasValue)
+                    cmd.Parameters.AddWithValue("$dept", assignment.DepartmentId.Value);
+                else
+                    cmd.Parameters.AddWithValue("$dept", DBNull.Value);
+                cmd.Parameters.AddWithValue("$ip", assignment.DeviceIp);
+                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+            await tran.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task ReturnAsync(string deviceIp, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var tran = conn.BeginTransaction();
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.Transaction = tran;
+                cmd.CommandText = @"UPDATE DeviceAssignments SET ReturnedDate=$rdate WHERE DeviceIp=$ip AND ReturnedDate IS NULL";
+                cmd.Parameters.AddWithValue("$ip", deviceIp);
+                cmd.Parameters.AddWithValue("$rdate", DateTime.UtcNow);
+                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.Transaction = tran;
+                cmd.CommandText = @"UPDATE Devices SET AssignedUserId=NULL WHERE Ip=$ip";
+                cmd.Parameters.AddWithValue("$ip", deviceIp);
+                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+            await tran.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/DeviceManagementApp/ViewModels/AssignDeviceViewModel.cs
+++ b/DeviceManagementApp/ViewModels/AssignDeviceViewModel.cs
@@ -1,0 +1,33 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace DeviceManagementApp.ViewModels
+{
+    public class AssignDeviceViewModel : ObservableObject
+    {
+        int _userId;
+        int? _departmentId;
+
+        public int UserId
+        {
+            get => _userId;
+            set => SetProperty(ref _userId, value);
+        }
+
+        public int? DepartmentId
+        {
+            get => _departmentId;
+            set => SetProperty(ref _departmentId, value);
+        }
+
+        public IRelayCommand OkCommand { get; }
+        public IRelayCommand CancelCommand { get; }
+
+        public AssignDeviceViewModel(Action<bool?> close)
+        {
+            OkCommand = new RelayCommand(() => close(true));
+            CancelCommand = new RelayCommand(() => close(false));
+        }
+    }
+}

--- a/DeviceManagementApp/ViewModels/DevicesViewModel.cs
+++ b/DeviceManagementApp/ViewModels/DevicesViewModel.cs
@@ -13,6 +13,7 @@ using CommunityToolkit.Mvvm.Input;
 using DeviceManagementApp.Interfaces;
 using DeviceManagementApp.Models;
 using DeviceManagementApp.Views.Pages;
+using DeviceManagementApp.Views;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualBasic;
@@ -26,6 +27,7 @@ namespace DeviceManagementApp.ViewModels
         private readonly IDialogService _dialogService;
         private readonly IDeviceService _deviceService;
         private readonly IDeviceGroupService _groupService;
+        private readonly IDeviceAssignmentService _assignmentService;
         private readonly IDeviceSoftwareService _softwareService;
         private readonly INavigationService _navigationService;
         private readonly ILogger<DevicesViewModel> _logger;
@@ -61,6 +63,8 @@ namespace DeviceManagementApp.ViewModels
                     PingSelectedDeviceCommand.NotifyCanExecuteChanged();
                     DownloadUnseenFilesCommand.NotifyCanExecuteChanged();
                     ViewDetailsCommand.NotifyCanExecuteChanged();
+                    AssignDeviceCommand.NotifyCanExecuteChanged();
+                    ReturnDeviceCommand.NotifyCanExecuteChanged();
                 }
             }
         }
@@ -73,6 +77,8 @@ namespace DeviceManagementApp.ViewModels
         public IAsyncRelayCommand RenameGroupCommand { get; }
         public IAsyncRelayCommand DeleteGroupCommand { get; }
         public IAsyncRelayCommand DownloadUnseenFilesCommand { get; }
+        public IAsyncRelayCommand AssignDeviceCommand { get; }
+        public IAsyncRelayCommand ReturnDeviceCommand { get; }
         public IRelayCommand ViewDetailsCommand { get; }
 
         private string _sourceFolder = string.Empty;
@@ -123,6 +129,26 @@ namespace DeviceManagementApp.ViewModels
         public Func<string?> PromptForGroupName { get; set; } = () =>
             Interaction.InputBox("Enter group name:", "Add Group", string.Empty);
 
+        public Func<Device, DeviceAssignment?> PromptForAssignment { get; set; } = device =>
+        {
+            var dialog = new AssignDeviceDialog();
+            AssignDeviceViewModel vm = null!;
+            dialog.DataContext = vm = new AssignDeviceViewModel(r => dialog.DialogResult = r)
+            {
+                UserId = device.AssignedUserId ?? 0,
+                DepartmentId = device.DepartmentId
+            };
+            return dialog.ShowDialog() == true
+                ? new DeviceAssignment
+                {
+                    DeviceIp = device.Ip,
+                    UserId = vm.UserId,
+                    DepartmentId = vm.DepartmentId,
+                    AssignedDate = DateTime.UtcNow
+                }
+                : null;
+        };
+
         private DeviceGroup? _selectedGroup;
         public DeviceGroup? SelectedGroup
         {
@@ -170,6 +196,7 @@ namespace DeviceManagementApp.ViewModels
                                  IDialogService dialogService,
                                  IDeviceService deviceService,
                                  IDeviceGroupService groupService,
+                                 IDeviceAssignmentService? assignmentService = null,
                                  IDeviceSoftwareService? softwareService = null,
                                  INavigationService? navigationService = null,
                                  ILogger<DevicesViewModel>? logger = null)
@@ -179,6 +206,7 @@ namespace DeviceManagementApp.ViewModels
             _dialogService = dialogService;
             _deviceService = deviceService;
             _groupService = groupService;
+            _assignmentService = assignmentService ?? NullDeviceAssignmentService.Instance;
             _softwareService = softwareService ?? NullDeviceSoftwareService.Instance;
             _navigationService = navigationService ?? NullNavigationService.Instance;
             _logger = logger ?? NullLogger<DevicesViewModel>.Instance;
@@ -194,6 +222,8 @@ namespace DeviceManagementApp.ViewModels
             RenameGroupCommand = new AsyncRelayCommand(RenameGroupAsync);
             DeleteGroupCommand = new AsyncRelayCommand(DeleteGroupAsync);
             DownloadUnseenFilesCommand = new AsyncRelayCommand(DownloadUnseenFilesAsync, CanDownloadUnseenFiles);
+            AssignDeviceCommand = new AsyncRelayCommand(AssignDeviceAsync, () => SelectedDevice != null);
+            ReturnDeviceCommand = new AsyncRelayCommand(ReturnDeviceAsync, () => SelectedDevice?.AssignedUserId != null);
             ViewDetailsCommand = new RelayCommand(OpenDetails, () => SelectedDevice != null);
         }
 
@@ -241,6 +271,19 @@ namespace DeviceManagementApp.ViewModels
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, "Failed to get group for device {Ip}", device.Ip);
+                    }
+                    try
+                    {
+                        var assignment = await _assignmentService.GetCurrentAssignmentAsync(device.Ip).ConfigureAwait(false);
+                        if (assignment != null)
+                        {
+                            device.AssignedUserId = assignment.UserId;
+                            device.DepartmentId = assignment.DepartmentId;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to get assignment for device {Ip}", device.Ip);
                     }
                     device.PropertyChanged += Device_PropertyChanged;
                     Devices.Add(device);
@@ -425,6 +468,58 @@ namespace DeviceManagementApp.ViewModels
             }
         }
 
+        private async Task AssignDeviceAsync()
+        {
+            if (SelectedDevice is null)
+                return;
+
+            var assignment = PromptForAssignment?.Invoke(SelectedDevice);
+            if (assignment == null)
+                return;
+
+            try
+            {
+                await _assignmentService.AssignAsync(assignment);
+                SelectedDevice.AssignedUserId = assignment.UserId;
+                SelectedDevice.DepartmentId = assignment.DepartmentId;
+                if (!Staff.Any(s => s.Key == assignment.UserId))
+                    Staff.Add(new(assignment.UserId, assignment.UserId.ToString()));
+                if (assignment.DepartmentId.HasValue && !Departments.Any(d => d.Key == assignment.DepartmentId))
+                    Departments.Add(new(assignment.DepartmentId.Value, assignment.DepartmentId.Value.ToString()));
+                DevicesView.Refresh();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to assign device {Ip}", assignment.DeviceIp);
+                await _dialogService.ShowInfoAsync($"Failed to assign device: {ex.Message}", "Devices");
+            }
+
+            ReturnDeviceCommand.NotifyCanExecuteChanged();
+            AssignDeviceCommand.NotifyCanExecuteChanged();
+        }
+
+        private async Task ReturnDeviceAsync()
+        {
+            if (SelectedDevice is null)
+                return;
+
+            try
+            {
+                await _assignmentService.ReturnAsync(SelectedDevice.Ip);
+                SelectedDevice.AssignedUserId = null;
+                SelectedDevice.DepartmentId = null;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to return device {Ip}", SelectedDevice.Ip);
+                await _dialogService.ShowInfoAsync($"Failed to return device: {ex.Message}", "Devices");
+            }
+
+            ReturnDeviceCommand.NotifyCanExecuteChanged();
+            AssignDeviceCommand.NotifyCanExecuteChanged();
+            DevicesView.Refresh();
+        }
+
         async Task LoadInstalledSoftwareAsync(Device device)
         {
             try
@@ -488,6 +583,18 @@ namespace DeviceManagementApp.ViewModels
             if (AssignedUserFilter.HasValue && d.AssignedUserId != AssignedUserFilter)
                 return false;
             return true;
+        }
+
+        class NullDeviceAssignmentService : IDeviceAssignmentService
+        {
+            public static readonly IDeviceAssignmentService Instance = new NullDeviceAssignmentService();
+            NullDeviceAssignmentService() { }
+            public Task<DeviceAssignment?> GetCurrentAssignmentAsync(string deviceIp, CancellationToken cancellationToken = default)
+                => Task.FromResult<DeviceAssignment?>(null);
+            public Task AssignAsync(DeviceAssignment assignment, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task ReturnAsync(string deviceIp, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
         }
 
         class NullDeviceSoftwareService : IDeviceSoftwareService

--- a/DeviceManagementApp/Views/AssignDeviceDialog.xaml
+++ b/DeviceManagementApp/Views/AssignDeviceDialog.xaml
@@ -1,0 +1,20 @@
+<Window x:Class="DeviceManagementApp.Views.AssignDeviceDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Assign Device" ResizeMode="NoResize"
+        SizeToContent="WidthAndHeight" WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="10">
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+            <TextBlock Text="User ID:" Width="80" VerticalAlignment="Center"/>
+            <TextBox Width="150" Text="{Binding UserId, UpdateSourceTrigger=PropertyChanged}"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+            <TextBlock Text="Department:" Width="80" VerticalAlignment="Center"/>
+            <TextBox Width="150" Text="{Binding DepartmentId, UpdateSourceTrigger=PropertyChanged}"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="OK" Width="75" Margin="0,0,8,0" Command="{Binding OkCommand}"/>
+            <Button Content="Cancel" Width="75" Command="{Binding CancelCommand}"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/DeviceManagementApp/Views/AssignDeviceDialog.xaml.cs
+++ b/DeviceManagementApp/Views/AssignDeviceDialog.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace DeviceManagementApp.Views
+{
+    public partial class AssignDeviceDialog : Window
+    {
+        public AssignDeviceDialog()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/DeviceManagementApp/Views/Pages/DevicesPage.xaml
+++ b/DeviceManagementApp/Views/Pages/DevicesPage.xaml
@@ -48,6 +48,14 @@
                                 Content="Delete Group"
                                 Command="{Binding DeleteGroupCommand}"
                                 Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource PrimaryButton}"
+                                Content="Assign"
+                                Command="{Binding AssignDeviceCommand}"
+                                Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource PrimaryButton}"
+                                Content="Return"
+                                Command="{Binding ReturnDeviceCommand}"
+                                Margin="0,0,8,0"/>
                         <ComboBox Width="120"
                                   ItemsSource="{Binding Departments}"
                                   SelectedValue="{Binding DepartmentFilter}"
@@ -113,6 +121,7 @@
                         <DataGridTextColumn Header="Protocols" Binding="{Binding ProtocolsDisplay}" IsReadOnly="True" Width="150"/>
                         <DataGridTextColumn Header="Status" Binding="{Binding Status}" IsReadOnly="True" Width="120"/>
                         <DataGridTextColumn Header="Last Seen" Binding="{Binding LastSeen, StringFormat={}{0:G}}" IsReadOnly="True" Width="180"/>
+                        <DataGridTextColumn Header="Assigned To" Binding="{Binding AssignedUserId}" IsReadOnly="True" Width="120"/>
                     </DataGrid.Columns>
                 </DataGrid>
             </Border>


### PR DESCRIPTION
## Summary
- track device assignments with new model and SQLite table
- add service and commands to assign and return devices
- include dialog UI and unit tests for assignment logic

## Testing
- `dotnet test DeviceManagementApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2017c8a8832482961b5d3804b693