### PR TITLE
Centralize device navigation logic in MainViewModel

### DIFF
--- a/DeviceManagementApp.Tests/DevicesViewModelTests.cs
+++ b/DeviceManagementApp.Tests/DevicesViewModelTests.cs
@@ -3,12 +3,10 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
-using System.Windows.Controls;
 using DeviceManagementApp.Interfaces;
 using DeviceManagementApp.Models;
 using DeviceManagementApp.Services;
 using DeviceManagementApp.ViewModels;
-using DeviceManagementApp.Views.Pages;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
@@ -134,13 +132,6 @@ public class DevicesViewModelTests
         }
         public Task DeleteDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
-    }
-
-    private sealed class RecordingNavigationService : INavigationService
-    {
-        public Page? LastPage { get; private set; }
-        public void Navigate(Page page) => LastPage = page;
-    }
 
     [Fact]
     public async Task RefreshCommand_LoadsDevices()
@@ -586,20 +577,18 @@ public class DevicesViewModelTests
     }
 
     [Fact]
-    public void ViewDetailsCommand_NavigatesToDetailsPage()
+    public void ViewDetailsCommand_RaisesEvent()
     {
         var discovery = new StubDiscoveryService();
         var fileService = new RecordingDeviceFileService();
         var dialog = new RecordingDialogService();
-        var nav = new RecordingNavigationService();
-        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), new RecordingDeviceGroupService(), navigationService: nav);
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), new RecordingDeviceGroupService());
         var device = new Device { Ip = "1" };
         vm.Devices.Add(device);
         vm.SelectedDevice = device;
-        vm.InstalledSoftware.Add(new DeviceSoftware { Name = "App", Version = "1" });
-
+        Device? requested = null;
+        vm.ViewDetailsRequested += (s, d) => requested = d;
         vm.ViewDetailsCommand.Execute(null);
-
-        Assert.IsType<DeviceDetailsPage>(nav.LastPage);
+        Assert.Same(device, requested);
     }
 }

--- a/DeviceManagementApp.Tests/MainViewModelTests.cs
+++ b/DeviceManagementApp.Tests/MainViewModelTests.cs
@@ -2,6 +2,10 @@ using System;
 using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DeviceManagementApp.Interfaces;
+using DeviceManagementApp.Models;
 using DeviceManagementApp.ViewModels;
 using Xunit;
 
@@ -10,10 +14,9 @@ namespace DeviceManagementApp.Tests
     public class MainViewModelTests
     {
         [Fact]
-        public void Constructor_SetsInitialDevicesPage()
+        public void OpenDevicesCommand_NavigatesToDevicesPage()
         {
             Exception? threadEx = null;
-            Page? expectedPage = null;
             Page? currentPage = null;
             string? currentTitle = null;
 
@@ -22,8 +25,10 @@ namespace DeviceManagementApp.Tests
                 try
                 {
                     var app = new Application();
-                    expectedPage = new Page();
-                    var vm = new MainViewModel(expectedPage);
+                    var nav = new TestNavigationService();
+                    var devicesVm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
+                    var vm = new MainViewModel(nav, devicesVm);
+                    vm.OpenDevicesCommand.Execute(null);
                     currentPage = vm.CurrentPage;
                     currentTitle = vm.CurrentPageTitle;
                     Application.Current?.Shutdown();
@@ -38,8 +43,95 @@ namespace DeviceManagementApp.Tests
             thread.Join();
 
             if (threadEx != null) throw threadEx;
-            Assert.Same(expectedPage, currentPage);
+            Assert.IsType<DeviceManagementApp.Views.Pages.DevicesPage>(currentPage);
             Assert.Equal("Devices", currentTitle);
+        }
+
+        [Fact]
+        public void DevicesViewModel_ViewDetailsRequested_Navigates()
+        {
+            Exception? threadEx = null;
+            bool navigated = false;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    var nav = new TestNavigationService { OnNavigate = p => navigated = p is DeviceManagementApp.Views.Pages.DeviceDetailsPage };
+                    var devicesVm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService())
+                    {
+                        SelectedDevice = new Device()
+                    };
+                    var vm = new MainViewModel(nav, devicesVm);
+                    devicesVm.ViewDetailsCommand.Execute(null);
+                    Application.Current?.Shutdown();
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadEx != null) throw threadEx;
+            Assert.True(navigated);
+        }
+
+        private sealed class TestNavigationService : INavigationService
+        {
+            public Action<Page>? OnNavigate { get; set; }
+            public void Navigate(Page page) => OnNavigate?.Invoke(page);
+        }
+
+        private sealed class DummyDiscoveryService : IDeviceDiscoveryService
+        {
+            public Task<IEnumerable<Device>> DiscoverDevicesAsync(IProgress<double>? progress = null, CancellationToken cancellationToken = default)
+                => Task.FromResult<IEnumerable<Device>>(Array.Empty<Device>());
+        }
+
+        private sealed class DummyFileService : IDeviceFileService
+        {
+            public Task<IEnumerable<string>> ListFilesAsync(Device device, string? extensionFilter = null, CancellationToken cancellationToken = default)
+                => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            public Task<int> DownloadUnseenFilesAsync(Device device, string basePath, CancellationToken cancellationToken = default)
+                => Task.FromResult(0);
+        }
+
+        private sealed class DummyDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => true;
+        }
+
+        private sealed class DummyDeviceService : IDeviceService
+        {
+            public Task<IEnumerable<Device>> GetDevicesAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult<IEnumerable<Device>>(Array.Empty<Device>());
+            public Task<Device?> GetDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
+                => Task.FromResult<Device?>(null);
+            public Task AddOrUpdateDeviceAsync(Device device, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task DeleteDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+        }
+
+        private sealed class DummyDeviceGroupService : IDeviceGroupService
+        {
+            public Task<IEnumerable<DeviceGroup>> GetGroupsAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult<IEnumerable<DeviceGroup>>(Array.Empty<DeviceGroup>());
+            public Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default)
+                => Task.FromResult(0);
+            public Task UpdateGroupAsync(DeviceGroup group, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task AssignDeviceToGroupAsync(string deviceIp, int? devicePort, int? groupId, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task<int?> GetDeviceGroupIdAsync(string deviceIp, int? devicePort, CancellationToken cancellationToken = default)
+                => Task.FromResult<int?>(null);
         }
     }
 }

--- a/DeviceManagementApp/App.xaml.cs
+++ b/DeviceManagementApp/App.xaml.cs
@@ -11,7 +11,6 @@ using Serilog.Events;
 using DeviceManagementApp.Services;
 using DeviceManagementApp.Interfaces;
 using DeviceManagementApp.ViewModels;
-using DeviceManagementApp.Views.Pages;
 
 namespace DeviceManagementApp
 {
@@ -68,7 +67,6 @@ namespace DeviceManagementApp
                 services.AddSingleton<IDeviceDiscoveryService, DeviceDiscoveryService>();
                 services.AddSingleton<INavigationService, NavigationService>();
                 services.AddSingleton<DevicesViewModel>();
-                services.AddSingleton<DevicesPage>(sp => new DevicesPage { DataContext = sp.GetRequiredService<DevicesViewModel>() });
                 services.AddSingleton<IMainViewModel, MainViewModel>();
                 services.AddSingleton<MainWindow>();
             })

--- a/DeviceManagementApp/Interfaces/IMainViewModel.cs
+++ b/DeviceManagementApp/Interfaces/IMainViewModel.cs
@@ -1,14 +1,7 @@
-using System.Windows.Controls;
-using CommunityToolkit.Mvvm.Input;
-
 namespace DeviceManagementApp.Interfaces
 {
-    public interface IMainViewModel
-    {
-        Page? CurrentPage { get; }
-        string CurrentPageTitle { get; }
-        string WindowTitle { get; }
-        IRelayCommand OpenDevicesCommand { get; }
-        IRelayCommand ExitCommand { get; }
-    }
+    /// <summary>
+    /// Marker interface for the main view model.
+    /// </summary>
+    public interface IMainViewModel { }
 }

--- a/DeviceManagementApp/ViewModels/DevicesViewModel.cs
+++ b/DeviceManagementApp/ViewModels/DevicesViewModel.cs
@@ -6,14 +6,11 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Net.NetworkInformation;
-using System.Windows.Controls;
 using System.Windows.Data;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DeviceManagementApp.Interfaces;
 using DeviceManagementApp.Models;
-using DeviceManagementApp.Views.Pages;
-using DeviceManagementApp.Views;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualBasic;
@@ -29,7 +26,6 @@ namespace DeviceManagementApp.ViewModels
         private readonly IDeviceGroupService _groupService;
         private readonly IDeviceAssignmentService _assignmentService;
         private readonly IDeviceSoftwareService _softwareService;
-        private readonly INavigationService _navigationService;
         private readonly ILogger<DevicesViewModel> _logger;
 
         public ObservableCollection<Device> Devices { get; } = new();
@@ -38,6 +34,8 @@ namespace DeviceManagementApp.ViewModels
         public ObservableCollection<DeviceSoftware> InstalledSoftware { get; } = new();
         public ObservableCollection<KeyValuePair<int?, string>> Departments { get; } = new() { new(null, "All Departments") };
         public ObservableCollection<KeyValuePair<int?, string>> Staff { get; } = new() { new(null, "All Staff") };
+
+        public event EventHandler<Device>? ViewDetailsRequested;
         public ICollectionView DevicesView { get; }
 
         private string _fileExtensionFilter = "*.*";
@@ -198,7 +196,6 @@ namespace DeviceManagementApp.ViewModels
                                  IDeviceGroupService groupService,
                                  IDeviceAssignmentService? assignmentService = null,
                                  IDeviceSoftwareService? softwareService = null,
-                                 INavigationService? navigationService = null,
                                  ILogger<DevicesViewModel>? logger = null)
         {
             _discoveryService = discoveryService;
@@ -208,7 +205,6 @@ namespace DeviceManagementApp.ViewModels
             _groupService = groupService;
             _assignmentService = assignmentService ?? NullDeviceAssignmentService.Instance;
             _softwareService = softwareService ?? NullDeviceSoftwareService.Instance;
-            _navigationService = navigationService ?? NullNavigationService.Instance;
             _logger = logger ?? NullLogger<DevicesViewModel>.Instance;
 
             DevicesView = CollectionViewSource.GetDefaultView(Devices);
@@ -224,7 +220,7 @@ namespace DeviceManagementApp.ViewModels
             DownloadUnseenFilesCommand = new AsyncRelayCommand(DownloadUnseenFilesAsync, CanDownloadUnseenFiles);
             AssignDeviceCommand = new AsyncRelayCommand(AssignDeviceAsync, () => SelectedDevice != null);
             ReturnDeviceCommand = new AsyncRelayCommand(ReturnDeviceAsync, () => SelectedDevice?.AssignedUserId != null);
-            ViewDetailsCommand = new RelayCommand(OpenDetails, () => SelectedDevice != null);
+            ViewDetailsCommand = new RelayCommand(OnViewDetails, () => SelectedDevice != null);
         }
 
         private async Task RefreshAsync()
@@ -566,12 +562,11 @@ namespace DeviceManagementApp.ViewModels
             }
         }
 
-        private void OpenDetails()
+        private void OnViewDetails()
         {
             if (SelectedDevice == null)
                 return;
-            var vm = new DeviceDetailsViewModel(SelectedDevice, InstalledSoftware);
-            _navigationService.Navigate(new DeviceDetailsPage { DataContext = vm });
+            ViewDetailsRequested?.Invoke(this, SelectedDevice);
         }
 
         private bool FilterDevice(object obj)
@@ -609,11 +604,5 @@ namespace DeviceManagementApp.ViewModels
                 => Task.CompletedTask;
         }
 
-        class NullNavigationService : INavigationService
-        {
-            public static readonly INavigationService Instance = new NullNavigationService();
-            NullNavigationService() { }
-            public void Navigate(Page page) { }
-        }
     }
 }

--- a/DeviceManagementApp/ViewModels/MainViewModel.cs
+++ b/DeviceManagementApp/ViewModels/MainViewModel.cs
@@ -1,22 +1,31 @@
+using System;
 using System.Windows;
 using System.Windows.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DeviceManagementApp.Interfaces;
+using DeviceManagementApp.Models;
+using DeviceManagementApp.Views.Pages;
 
 namespace DeviceManagementApp.ViewModels
 {
     public class MainViewModel : ObservableObject, IMainViewModel
     {
-        private readonly Page _devicesPage;
+        private readonly INavigationService _navigationService;
+        private readonly DevicesViewModel _devicesViewModel;
 
-        public MainViewModel(Page devicesPage)
+        public MainViewModel(INavigationService navigationService, DevicesViewModel devicesViewModel)
         {
-            _devicesPage = devicesPage;
-            OpenDevicesCommand = new RelayCommand(OpenDevices);
-            ExitCommand = new RelayCommand(() => Application.Current.Shutdown());
+            _navigationService = navigationService;
+            _devicesViewModel = devicesViewModel;
+            _devicesViewModel.ViewDetailsRequested += DevicesViewModel_ViewDetailsRequested;
+
             WindowTitle = "Device Management";
-            OpenDevices();
+            OpenDevicesCommand = new RelayCommand(OpenDevices);
+            OpenDashboardCommand = new RelayCommand(OpenDashboard);
+            ExitCommand = new RelayCommand(() => Application.Current.Shutdown());
+
+            OpenDashboard();
         }
 
         private Page? _currentPage;
@@ -36,12 +45,27 @@ namespace DeviceManagementApp.ViewModels
         public string WindowTitle { get; }
 
         public IRelayCommand OpenDevicesCommand { get; }
+        public IRelayCommand OpenDashboardCommand { get; }
         public IRelayCommand ExitCommand { get; }
 
         private void OpenDevices()
         {
-            CurrentPage = _devicesPage;
+            var page = new DevicesPage { DataContext = _devicesViewModel };
+            CurrentPage = page;
             CurrentPageTitle = "Devices";
+        }
+
+        private void OpenDashboard()
+        {
+            var page = new Page { Title = "Dashboard", Content = new TextBlock { Text = "Dashboard" } };
+            CurrentPage = page;
+            CurrentPageTitle = "Dashboard";
+        }
+
+        private void DevicesViewModel_ViewDetailsRequested(object? sender, Device device)
+        {
+            var vm = new DeviceDetailsViewModel(device, _devicesViewModel.InstalledSoftware);
+            _navigationService.Navigate(new DeviceDetailsPage { DataContext = vm });
         }
     }
 }


### PR DESCRIPTION
## Summary
- Introduced marker `IMainViewModel` and reworked `MainViewModel` to manage dashboard and device navigation
- Moved device detail navigation from `DevicesViewModel` to `MainViewModel` using `INavigationService`
- Updated services and tests to reflect centralized navigation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcaf05a6188324b5a2d008301a8fd0