### PR TITLE
Add dashboard and settings views with device preferences

### DIFF
--- a/DeviceManagementApp.Tests/DashboardViewModelTests.cs
+++ b/DeviceManagementApp.Tests/DashboardViewModelTests.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DeviceManagementApp.Interfaces;
+using DeviceManagementApp.Models;
+using DeviceManagementApp.ViewModels;
+using DeviceManagementApp.Views.Pages;
+using System.Windows.Controls;
+using Xunit;
+
+namespace DeviceManagementApp.Tests
+{
+    public class DashboardViewModelTests
+    {
+        private sealed class StubDeviceService : IDeviceService
+        {
+            public List<Device> Devices { get; } = new();
+            public Task<IEnumerable<Device>> GetDevicesAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult<IEnumerable<Device>>(Devices);
+            public Task<Device?> GetDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
+                => Task.FromResult<Device?>(null);
+            public Task AddOrUpdateDeviceAsync(Device device, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task DeleteDeviceAsync(string ip, int? port, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+        }
+
+        private sealed class DummyNavigationService : INavigationService
+        {
+            public void Navigate(Page page) { }
+        }
+
+        [Fact]
+        public async Task LoadAsync_CalculatesStats()
+        {
+            var service = new StubDeviceService();
+            service.Devices.Add(new Device { AssignedUserId = 1 });
+            service.Devices.Add(new Device { AssignedUserId = null });
+            var nav = new DummyNavigationService();
+            var devicesVm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new StubDeviceService(), new DummyGroupService());
+            var vm = new DashboardViewModel(service, nav, devicesVm);
+
+            await vm.LoadAsync(CancellationToken.None);
+
+            Assert.Contains(vm.StatCards, s => s.Title == "Total Devices" && s.Value == "2");
+            Assert.Contains(vm.StatCards, s => s.Title == "Assigned Devices" && s.Value == "1");
+            Assert.Contains(vm.StatCards, s => s.Title == "Unassigned Devices" && s.Value == "1");
+        }
+
+        private sealed class DummyDiscoveryService : IDeviceDiscoveryService
+        {
+            public Task<IEnumerable<Device>> DiscoverDevicesAsync(IProgress<double>? progress = null, CancellationToken cancellationToken = default)
+                => Task.FromResult<IEnumerable<Device>>(Enumerable.Empty<Device>());
+        }
+        private sealed class DummyFileService : IDeviceFileService
+        {
+            public Task<IEnumerable<string>> ListFilesAsync(Device device, string? extensionFilter = null, CancellationToken cancellationToken = default)
+                => Task.FromResult<IEnumerable<string>>(Enumerable.Empty<string>());
+            public Task<int> DownloadUnseenFilesAsync(Device device, string basePath, CancellationToken cancellationToken = default)
+                => Task.FromResult(0);
+        }
+        private sealed class DummyDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => true;
+        }
+        private sealed class DummyGroupService : IDeviceGroupService
+        {
+            public Task<IEnumerable<DeviceGroup>> GetGroupsAsync(CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<DeviceGroup>>(Enumerable.Empty<DeviceGroup>());
+            public Task<int> CreateGroupAsync(string name, CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task UpdateGroupAsync(DeviceGroup group, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteGroupAsync(int groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task AssignDeviceToGroupAsync(string deviceIp, int? devicePort, int? groupId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int?> GetDeviceGroupIdAsync(string deviceIp, int? devicePort, CancellationToken cancellationToken = default) => Task.FromResult<int?>(null);
+        }
+    }
+}

--- a/DeviceManagementApp.Tests/MainViewModelTests.cs
+++ b/DeviceManagementApp.Tests/MainViewModelTests.cs
@@ -27,7 +27,9 @@ namespace DeviceManagementApp.Tests
                     var app = new Application();
                     var nav = new TestNavigationService();
                     var devicesVm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
-                    var vm = new MainViewModel(nav, devicesVm);
+                    var dashboardVm = new DashboardViewModel(new DummyDeviceService(), nav, devicesVm);
+                    var settingsVm = new SettingsViewModel(new DummySettingsService(), new DummyDialogService());
+                    var vm = new MainViewModel(nav, devicesVm, dashboardVm, settingsVm);
                     vm.OpenDevicesCommand.Execute(null);
                     currentPage = vm.CurrentPage;
                     currentTitle = vm.CurrentPageTitle;
@@ -63,7 +65,9 @@ namespace DeviceManagementApp.Tests
                     {
                         SelectedDevice = new Device()
                     };
-                    var vm = new MainViewModel(nav, devicesVm);
+                    var dashboardVm = new DashboardViewModel(new DummyDeviceService(), nav, devicesVm);
+                    var settingsVm = new SettingsViewModel(new DummySettingsService(), new DummyDialogService());
+                    var vm = new MainViewModel(nav, devicesVm, dashboardVm, settingsVm);
                     devicesVm.ViewDetailsCommand.Execute(null);
                     Application.Current?.Shutdown();
                 }
@@ -78,6 +82,64 @@ namespace DeviceManagementApp.Tests
 
             if (threadEx != null) throw threadEx;
             Assert.True(navigated);
+        }
+
+        [Fact]
+        public void OpenDashboardCommand_NavigatesToDashboardPage()
+        {
+            Exception? threadEx = null;
+            Page? currentPage = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    var nav = new TestNavigationService();
+                    var devicesVm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
+                    var dashboardVm = new DashboardViewModel(new DummyDeviceService(), nav, devicesVm);
+                    var settingsVm = new SettingsViewModel(new DummySettingsService(), new DummyDialogService());
+                    var vm = new MainViewModel(nav, devicesVm, dashboardVm, settingsVm);
+                    vm.OpenDashboardCommand.Execute(null);
+                    currentPage = vm.CurrentPage;
+                    Application.Current?.Shutdown();
+                }
+                catch (Exception ex) { threadEx = ex; }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+            Assert.IsType<DeviceManagementApp.Views.Pages.DashboardPage>(currentPage);
+        }
+
+        [Fact]
+        public void OpenSettingsCommand_NavigatesToSettingsPage()
+        {
+            Exception? threadEx = null;
+            Page? currentPage = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    var nav = new TestNavigationService();
+                    var devicesVm = new DevicesViewModel(new DummyDiscoveryService(), new DummyFileService(), new DummyDialogService(), new DummyDeviceService(), new DummyDeviceGroupService());
+                    var dashboardVm = new DashboardViewModel(new DummyDeviceService(), nav, devicesVm);
+                    var settingsVm = new SettingsViewModel(new DummySettingsService(), new DummyDialogService());
+                    var vm = new MainViewModel(nav, devicesVm, dashboardVm, settingsVm);
+                    vm.OpenSettingsCommand.Execute(null);
+                    currentPage = vm.CurrentPage;
+                    Application.Current?.Shutdown();
+                }
+                catch (Exception ex) { threadEx = ex; }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (threadEx != null) throw threadEx;
+            Assert.IsType<DeviceManagementApp.Views.Pages.SettingsPage>(currentPage);
         }
 
         private sealed class TestNavigationService : INavigationService
@@ -132,6 +194,28 @@ namespace DeviceManagementApp.Tests
                 => Task.CompletedTask;
             public Task<int?> GetDeviceGroupIdAsync(string deviceIp, int? devicePort, CancellationToken cancellationToken = default)
                 => Task.FromResult<int?>(null);
+        }
+
+        private sealed class DummySettingsService : ISettingsService
+        {
+            public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
+            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>());
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default) => Task.FromResult<string?>(null);
+            public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default) => Task.FromResult("Device");
+            public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult("Devices");
+            public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default) => Task.FromResult<IDictionary<ItemDetailField, bool>>(new Dictionary<ItemDetailField, bool>());
+            public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default) => Task.CompletedTask;
         }
     }
 }

--- a/DeviceManagementApp.Tests/SettingsViewModelTests.cs
+++ b/DeviceManagementApp.Tests/SettingsViewModelTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DeviceManagementApp.Interfaces;
+using DeviceManagementApp.Models;
+using DeviceManagementApp.ViewModels;
+using Xunit;
+
+namespace DeviceManagementApp.Tests
+{
+    public class SettingsViewModelTests
+    {
+        private sealed class StubSettingsService : ISettingsService
+        {
+            public string ThemeSaved = string.Empty;
+            public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
+            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
+            { Settings[key] = value; return Task.CompletedTask; }
+            public Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default)
+            { return Task.FromResult(key != null && Settings.TryGetValue(key, out var v) ? v : null); }
+            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default)
+            { return Task.FromResult(new Dictionary<string, string>(Settings)); }
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
+            { foreach (var kv in settings) Settings[kv.Key] = kv.Value; return Task.CompletedTask; }
+            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
+            { Settings.Remove(key); return Task.CompletedTask; }
+            public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default) => Task.FromResult<string?>(_theme);
+            public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default)
+            { ThemeSaved = theme; _theme = theme; return Task.CompletedTask; }
+            public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+            public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default) => Task.FromResult("Device");
+            public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult("Devices");
+            public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult<IDictionary<ItemDetailField, bool>>(new Dictionary<ItemDetailField, bool>());
+            public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
+            { ItemDetailVisibilityChanged?.Invoke(this, visibility); return Task.CompletedTask; }
+            private string? _theme;
+            public Dictionary<string, string> Settings { get; } = new();
+        }
+
+        private sealed class DummyDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => true;
+        }
+
+        [Fact]
+        public async Task Theme_Setter_SavesValue()
+        {
+            var service = new StubSettingsService();
+            var vm = new SettingsViewModel(service, new DummyDialogService());
+            await vm.InitializeAsync();
+            vm.Theme = "Dark";
+            Assert.Equal("Dark", service.ThemeSaved);
+        }
+    }
+}

--- a/DeviceManagementApp/App.xaml.cs
+++ b/DeviceManagementApp/App.xaml.cs
@@ -65,8 +65,12 @@ namespace DeviceManagementApp
                 services.AddSingleton<IDeviceFileService, DeviceFileService>();
                 services.AddSingleton<IDeviceGroupService, DeviceGroupService>();
                 services.AddSingleton<IDeviceDiscoveryService, DeviceDiscoveryService>();
+                services.AddSingleton<IDialogService, DialogService>();
+                services.AddSingleton<ISettingsService, SettingsService>();
                 services.AddSingleton<INavigationService, NavigationService>();
                 services.AddSingleton<DevicesViewModel>();
+                services.AddSingleton<DashboardViewModel>();
+                services.AddSingleton<SettingsViewModel>();
                 services.AddSingleton<IMainViewModel, MainViewModel>();
                 services.AddSingleton<MainWindow>();
             })

--- a/DeviceManagementApp/MainWindow.xaml
+++ b/DeviceManagementApp/MainWindow.xaml
@@ -22,7 +22,9 @@
                 <ScrollViewer Grid.Row="1">
                     <StackPanel Orientation="Vertical" Margin="12,0,12,8">
                         <TextBlock Text="Operations" Style="{StaticResource CaptionTextBlock}" Margin="6,8,6,2"/>
+                        <Button Style="{StaticResource NavButton}" Content="Dashboard" Command="{Binding OpenDashboardCommand}"/>
                         <Button Style="{StaticResource NavButton}" Content="Devices" Command="{Binding OpenDevicesCommand}"/>
+                        <Button Style="{StaticResource NavButton}" Content="Settings" Command="{Binding OpenSettingsCommand}"/>
                         <Separator/>
                         <Button Style="{StaticResource NavButton}" Content="Exit" Command="{Binding ExitCommand}"/>
                     </StackPanel>

--- a/DeviceManagementApp/Models/ItemDetailOption.cs
+++ b/DeviceManagementApp/Models/ItemDetailOption.cs
@@ -1,0 +1,22 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace DeviceManagementApp.Models
+{
+    public class ItemDetailOption : ObservableObject
+    {
+        public ItemDetailOption(ItemDetailField field, bool isVisible)
+        {
+            Field = field;
+            _isVisible = isVisible;
+        }
+
+        public ItemDetailField Field { get; }
+
+        bool _isVisible;
+        public bool IsVisible
+        {
+            get => _isVisible;
+            set => SetProperty(ref _isVisible, value);
+        }
+    }
+}

--- a/DeviceManagementApp/Models/StatCard.cs
+++ b/DeviceManagementApp/Models/StatCard.cs
@@ -1,0 +1,22 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace DeviceManagementApp.Models
+{
+    public class StatCard : ObservableObject
+    {
+        string _title = string.Empty;
+        string _value = string.Empty;
+
+        public string Title
+        {
+            get => _title;
+            set => SetProperty(ref _title, value);
+        }
+
+        public string Value
+        {
+            get => _value;
+            set => SetProperty(ref _value, value);
+        }
+    }
+}

--- a/DeviceManagementApp/Services/DialogService.cs
+++ b/DeviceManagementApp/Services/DialogService.cs
@@ -1,0 +1,14 @@
+using System.Windows;
+using DeviceManagementApp.Interfaces;
+
+namespace DeviceManagementApp.Services
+{
+    public class DialogService : IDialogService
+    {
+        public void ShowInfo(string message, string title)
+            => MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Information);
+
+        public bool ShowConfirmation(string message, string title)
+            => MessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes;
+    }
+}

--- a/DeviceManagementApp/Services/SettingsService.cs
+++ b/DeviceManagementApp/Services/SettingsService.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using DeviceManagementApp.Interfaces;
+using DeviceManagementApp.Models;
+
+namespace DeviceManagementApp.Services
+{
+    public class SettingsService : ISettingsService
+    {
+        readonly DatabaseService _dbService;
+        readonly ILogger<SettingsService> _logger;
+        public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
+
+        const string UpsertSql = @"INSERT INTO Settings (Key, Value) VALUES (@Key, @Value) ON CONFLICT(Key) DO UPDATE SET Value = @Value";
+
+        public SettingsService(DatabaseService dbService, ILogger<SettingsService>? logger = null)
+        {
+            _dbService = dbService;
+            _logger = logger ?? NullLogger<SettingsService>.Instance;
+        }
+
+        public async Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentException("Key cannot be null or empty.", nameof(key));
+            var p = new[] { new SqliteParameter("@Key", key), new SqliteParameter("@Value", value) };
+            using var conn = _dbService.CreateConnection();
+            await SqliteHelper.ExecuteNonQueryAsync(conn, UpsertSql, p, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default)
+        {
+            if (key is null) return null;
+            const string sql = "SELECT Value FROM Settings WHERE Key = @Key";
+            using var conn = _dbService.CreateConnection();
+            var p = new[] { new SqliteParameter("@Key", key) };
+            var result = await SqliteHelper.ExecuteScalarAsync(conn, sql, p, cancellationToken).ConfigureAwait(false);
+            return result?.ToString();
+        }
+
+        public async Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default)
+        {
+            var dict = new Dictionary<string, string>();
+            const string sql = "SELECT Key, Value FROM Settings";
+            using var conn = _dbService.CreateConnection();
+            using var cmd = new SqliteCommand(sql, conn);
+            using var rdr = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await rdr.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var key = rdr["Key"]?.ToString();
+                var value = rdr["Value"]?.ToString();
+                if (key != null && value != null)
+                    dict[key] = value;
+            }
+            return dict;
+        }
+
+        public async Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
+        {
+            foreach (var kv in settings)
+                await SaveSettingAsync(kv.Key, kv.Value, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
+        {
+            const string sql = "DELETE FROM Settings WHERE Key = @Key";
+            using var conn = _dbService.CreateConnection();
+            var p = new[] { new SqliteParameter("@Key", key) };
+            await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken).ConfigureAwait(false);
+        }
+
+        const string ThemeKey = "Theme";
+        const string PasswordIterationsKey = "PasswordIterations";
+        const string AutoLogoutMinutesKey = "AutoLogoutMinutes";
+        const string ItemLabelSingularKey = "ItemLabelSingular";
+        const string ItemLabelPluralKey = "ItemLabelPlural";
+        const string ItemDetailVisibilityKey = "ItemDetailVisibility";
+
+        public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default)
+            => GetSettingAsync(ThemeKey, cancellationToken);
+
+        public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default)
+            => SaveSettingAsync(ThemeKey, theme, cancellationToken);
+
+        public async Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default)
+        {
+            var value = await GetSettingAsync(PasswordIterationsKey, cancellationToken).ConfigureAwait(false);
+            return int.TryParse(value, out var i) && i > 0 ? i : 100_000;
+        }
+
+        public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default)
+            => SaveSettingAsync(PasswordIterationsKey, iterations.ToString(), cancellationToken);
+
+        public async Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default)
+        {
+            var value = await GetSettingAsync(AutoLogoutMinutesKey, cancellationToken).ConfigureAwait(false);
+            return int.TryParse(value, out var i) && i >= 0 ? i : 1;
+        }
+
+        public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default)
+            => SaveSettingAsync(AutoLogoutMinutesKey, minutes.ToString(), cancellationToken);
+
+        public async Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default)
+        {
+            var value = await GetSettingAsync(ItemLabelSingularKey, cancellationToken).ConfigureAwait(false);
+            return string.IsNullOrWhiteSpace(value) ? "Device" : value;
+        }
+
+        public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default)
+            => SaveSettingAsync(ItemLabelSingularKey, label, cancellationToken);
+
+        public async Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default)
+        {
+            var value = await GetSettingAsync(ItemLabelPluralKey, cancellationToken).ConfigureAwait(false);
+            return string.IsNullOrWhiteSpace(value) ? "Devices" : value;
+        }
+
+        public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default)
+            => SaveSettingAsync(ItemLabelPluralKey, label, cancellationToken);
+
+        public async Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default)
+        {
+            var json = await GetSettingAsync(ItemDetailVisibilityKey, cancellationToken).ConfigureAwait(false);
+            Dictionary<ItemDetailField, bool> visibility;
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                try
+                {
+                    var dict = JsonSerializer.Deserialize<Dictionary<string, bool>>(json!) ?? new();
+                    visibility = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, f => dict.TryGetValue(f.ToString(), out var v) ? v : true);
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogError(ex, "Failed to parse item detail visibility settings");
+                    visibility = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true);
+                }
+            }
+            else
+            {
+                visibility = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true);
+                await SaveItemDetailVisibilityAsync(visibility, cancellationToken).ConfigureAwait(false);
+            }
+            return visibility;
+        }
+
+        public async Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
+        {
+            var dict = visibility.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value);
+            var json = JsonSerializer.Serialize(dict);
+            await SaveSettingAsync(ItemDetailVisibilityKey, json, cancellationToken).ConfigureAwait(false);
+            ItemDetailVisibilityChanged?.Invoke(this, new Dictionary<ItemDetailField, bool>(visibility));
+        }
+    }
+}

--- a/DeviceManagementApp/ViewModels/DashboardViewModel.cs
+++ b/DeviceManagementApp/ViewModels/DashboardViewModel.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DeviceManagementApp.Interfaces;
+using DeviceManagementApp.Models;
+using DeviceManagementApp.Views.Pages;
+
+namespace DeviceManagementApp.ViewModels
+{
+    public class DashboardViewModel : ObservableObject
+    {
+        readonly IDeviceService _deviceService;
+        readonly INavigationService _navigationService;
+        readonly DevicesViewModel _devicesViewModel;
+
+        public ObservableCollection<StatCard> StatCards { get; } = new();
+        public ObservableCollection<Device> AssignedDevices { get; } = new();
+        public ObservableCollection<Device> UnassignedDevices { get; } = new();
+
+        public IRelayCommand NewDeviceCommand { get; }
+        public IRelayCommand AssignDeviceCommand { get; }
+        public IRelayCommand AssignDeviceInListCommand { get; }
+
+        public DashboardViewModel(IDeviceService deviceService, INavigationService navigationService, DevicesViewModel devicesViewModel)
+        {
+            _deviceService = deviceService;
+            _navigationService = navigationService;
+            _devicesViewModel = devicesViewModel;
+            NewDeviceCommand = new RelayCommand(OpenDevices);
+            AssignDeviceCommand = new RelayCommand(OpenDevices);
+            AssignDeviceInListCommand = new RelayCommand<Device>(d =>
+            {
+                if (d != null)
+                {
+                    UnassignedDevices.Remove(d);
+                    AssignedDevices.Add(d);
+                }
+            });
+        }
+
+        void OpenDevices()
+        {
+            _navigationService.Navigate(new DevicesPage { DataContext = _devicesViewModel });
+        }
+
+        public async Task LoadAsync(CancellationToken cancellationToken)
+        {
+            StatCards.Clear();
+            AssignedDevices.Clear();
+            UnassignedDevices.Clear();
+            var devices = await _deviceService.GetDevicesAsync(cancellationToken).ConfigureAwait(false);
+            var list = devices.ToList();
+            var assigned = list.Where(d => d.AssignedUserId != null).ToList();
+            foreach (var d in assigned)
+                AssignedDevices.Add(d);
+            var unassigned = list.Where(d => d.AssignedUserId == null).ToList();
+            foreach (var d in unassigned)
+                UnassignedDevices.Add(d);
+            StatCards.Add(new StatCard { Title = "Total Devices", Value = list.Count.ToString() });
+            StatCards.Add(new StatCard { Title = "Assigned Devices", Value = assigned.Count.ToString() });
+            StatCards.Add(new StatCard { Title = "Unassigned Devices", Value = unassigned.Count.ToString() });
+        }
+
+        public IRelayCommand ReturnDeviceCommand => new RelayCommand<Device>(d =>
+        {
+            if (d != null)
+                AssignedDevices.Remove(d);
+        });
+    }
+}

--- a/DeviceManagementApp/ViewModels/MainViewModel.cs
+++ b/DeviceManagementApp/ViewModels/MainViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -13,16 +14,21 @@ namespace DeviceManagementApp.ViewModels
     {
         private readonly INavigationService _navigationService;
         private readonly DevicesViewModel _devicesViewModel;
+        private readonly DashboardViewModel _dashboardViewModel;
+        private readonly SettingsViewModel _settingsViewModel;
 
-        public MainViewModel(INavigationService navigationService, DevicesViewModel devicesViewModel)
+        public MainViewModel(INavigationService navigationService, DevicesViewModel devicesViewModel, DashboardViewModel dashboardViewModel, SettingsViewModel settingsViewModel)
         {
             _navigationService = navigationService;
             _devicesViewModel = devicesViewModel;
+            _dashboardViewModel = dashboardViewModel;
+            _settingsViewModel = settingsViewModel;
             _devicesViewModel.ViewDetailsRequested += DevicesViewModel_ViewDetailsRequested;
 
             WindowTitle = "Device Management";
             OpenDevicesCommand = new RelayCommand(OpenDevices);
             OpenDashboardCommand = new RelayCommand(OpenDashboard);
+            OpenSettingsCommand = new RelayCommand(OpenSettings);
             ExitCommand = new RelayCommand(() => Application.Current.Shutdown());
 
             OpenDashboard();
@@ -46,6 +52,7 @@ namespace DeviceManagementApp.ViewModels
 
         public IRelayCommand OpenDevicesCommand { get; }
         public IRelayCommand OpenDashboardCommand { get; }
+        public IRelayCommand OpenSettingsCommand { get; }
         public IRelayCommand ExitCommand { get; }
 
         private void OpenDevices()
@@ -55,11 +62,20 @@ namespace DeviceManagementApp.ViewModels
             CurrentPageTitle = "Devices";
         }
 
-        private void OpenDashboard()
+        private async void OpenDashboard()
         {
-            var page = new Page { Title = "Dashboard", Content = new TextBlock { Text = "Dashboard" } };
+            var page = new DashboardPage { DataContext = _dashboardViewModel };
             CurrentPage = page;
             CurrentPageTitle = "Dashboard";
+            await _dashboardViewModel.LoadAsync(CancellationToken.None);
+        }
+
+        private async void OpenSettings()
+        {
+            await _settingsViewModel.InitializeAsync();
+            var page = new SettingsPage { DataContext = _settingsViewModel };
+            CurrentPage = page;
+            CurrentPageTitle = "Settings";
         }
 
         private void DevicesViewModel_ViewDetailsRequested(object? sender, Device device)

--- a/DeviceManagementApp/ViewModels/SettingsViewModel.cs
+++ b/DeviceManagementApp/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DeviceManagementApp.Interfaces;
+using DeviceManagementApp.Models;
+using DeviceManagementApp.Resources;
+
+namespace DeviceManagementApp.ViewModels
+{
+    public class SettingsViewModel : ObservableObject
+    {
+        readonly ISettingsService _settingsService;
+        readonly IDialogService _dialogService;
+        bool _bulkUpdating;
+
+        public ObservableCollection<ItemDetailOption> ItemDetailOptions { get; } = new();
+
+        public SettingsViewModel(ISettingsService settingsService, IDialogService dialogService)
+        {
+            _settingsService = settingsService;
+            _dialogService = dialogService;
+            ThemeOptions = new ObservableCollection<string> { "Light", "Dark" };
+            TestDbCommand = new RelayCommand(() =>
+            {
+                var success = TestDbConnection(out var message);
+                _dialogService.ShowInfo(message, "Database Connection");
+            });
+            BrowseCompanyLogoCommand = new RelayCommand(() => _dialogService.ShowInfo("Browsing not implemented.", "Settings"));
+            SaveCompanyLogoCommand = new AsyncRelayCommand(SaveCompanyLogoAsync);
+            SelectAllItemDisplayCommand = new RelayCommand(() =>
+            {
+                _bulkUpdating = true;
+                foreach (var o in ItemDetailOptions) o.IsVisible = true;
+                _bulkUpdating = false;
+                _ = SaveVisibilityAsync();
+            });
+            SelectNoneItemDisplayCommand = new RelayCommand(() =>
+            {
+                _bulkUpdating = true;
+                foreach (var o in ItemDetailOptions) o.IsVisible = false;
+                _bulkUpdating = false;
+                _ = SaveVisibilityAsync();
+            });
+        }
+
+        bool _initialized;
+        public async Task InitializeAsync()
+        {
+            if (_initialized) return;
+            ConnectionString = await _settingsService.GetSettingAsync("ConnectionString").ConfigureAwait(false) ?? string.Empty;
+            ApplicationName = await _settingsService.GetSettingAsync("ApplicationName").ConfigureAwait(false) ?? string.Empty;
+            Theme = await _settingsService.GetThemeAsync().ConfigureAwait(false) ?? ThemeOptions[0];
+            PasswordIterations = await _settingsService.GetPasswordIterationsAsync().ConfigureAwait(false);
+            AutoLogoutMinutes = await _settingsService.GetAutoLogoutMinutesAsync().ConfigureAwait(false);
+            ItemLabelSingular = await _settingsService.GetItemLabelSingularAsync().ConfigureAwait(false);
+            ItemLabelPlural = await _settingsService.GetItemLabelPluralAsync().ConfigureAwait(false);
+            CompanyLogoPath = await _settingsService.GetSettingAsync("CompanyLogoPath").ConfigureAwait(false) ?? string.Empty;
+            var vis = await _settingsService.GetItemDetailVisibilityAsync().ConfigureAwait(false);
+            foreach (var field in Enum.GetValues<ItemDetailField>())
+            {
+                var option = new ItemDetailOption(field, vis.TryGetValue(field, out var v) ? v : true);
+                option.PropertyChanged += ItemDetailOption_PropertyChanged;
+                ItemDetailOptions.Add(option);
+            }
+            _initialized = true;
+        }
+
+        private string _connectionString = string.Empty;
+        public string ConnectionString
+        {
+            get => _connectionString;
+            set => SetProperty(ref _connectionString, value);
+        }
+
+        private string _theme = string.Empty;
+        public string Theme
+        {
+            get => _theme;
+            set
+            {
+                if (SetProperty(ref _theme, value))
+                    _ = _settingsService.SaveThemeAsync(value);
+            }
+        }
+
+        private int _passwordIterations;
+        public int PasswordIterations
+        {
+            get => _passwordIterations;
+            set
+            {
+                if (SetProperty(ref _passwordIterations, value))
+                    _ = _settingsService.SavePasswordIterationsAsync(value);
+            }
+        }
+
+        private int _autoLogoutMinutes;
+        public int AutoLogoutMinutes
+        {
+            get => _autoLogoutMinutes;
+            set
+            {
+                if (SetProperty(ref _autoLogoutMinutes, value))
+                    _ = _settingsService.SaveAutoLogoutMinutesAsync(value);
+            }
+        }
+
+        private string _itemLabelSingular = string.Empty;
+        public string ItemLabelSingular
+        {
+            get => _itemLabelSingular;
+            set
+            {
+                if (SetProperty(ref _itemLabelSingular, value))
+                {
+                    _ = _settingsService.SaveItemLabelSingularAsync(value);
+                    LabelProvider.Instance.UpdateLabels(LabelProvider.Instance.PageLabel, LabelProvider.Instance.TooltipLabel, value, ItemLabelPlural);
+                }
+            }
+        }
+
+        private string _itemLabelPlural = string.Empty;
+        public string ItemLabelPlural
+        {
+            get => _itemLabelPlural;
+            set
+            {
+                if (SetProperty(ref _itemLabelPlural, value))
+                {
+                    _ = _settingsService.SaveItemLabelPluralAsync(value);
+                    LabelProvider.Instance.UpdateLabels(LabelProvider.Instance.PageLabel, LabelProvider.Instance.TooltipLabel, ItemLabelSingular, value);
+                }
+            }
+        }
+
+        private string _companyLogoPath = string.Empty;
+        public string CompanyLogoPath
+        {
+            get => _companyLogoPath;
+            set
+            {
+                if (SetProperty(ref _companyLogoPath, value))
+                    _ = _settingsService.SaveSettingAsync("CompanyLogoPath", value);
+            }
+        }
+
+        private string _applicationName = string.Empty;
+        public string ApplicationName
+        {
+            get => _applicationName;
+            set
+            {
+                if (SetProperty(ref _applicationName, value))
+                    _ = _settingsService.SaveSettingAsync("ApplicationName", value);
+            }
+        }
+
+        void ItemDetailOption_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(ItemDetailOption.IsVisible) && !_bulkUpdating)
+                _ = SaveVisibilityAsync();
+        }
+
+        async Task SaveVisibilityAsync()
+        {
+            var dict = ItemDetailOptions.ToDictionary(o => o.Field, o => o.IsVisible);
+            await _settingsService.SaveItemDetailVisibilityAsync(dict).ConfigureAwait(false);
+        }
+
+        bool TestDbConnection(out string message)
+        {
+            try
+            {
+                using var db = new DatabaseService(ConnectionString);
+                using var conn = db.CreateConnection();
+                message = "Connection successful.";
+                return true;
+            }
+            catch (Exception ex)
+            {
+                message = $"Connection failed: {ex.Message}";
+                return false;
+            }
+        }
+
+        async Task SaveCompanyLogoAsync(CancellationToken token)
+        {
+            if (string.IsNullOrWhiteSpace(CompanyLogoPath))
+            {
+                _dialogService.ShowInfo("Selected logo path is invalid.", "Invalid Path");
+                return;
+            }
+            try
+            {
+                await _settingsService.SaveSettingAsync("CompanyLogoPath", CompanyLogoPath, token).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowInfo($"Failed to save company logo: {ex.Message}", "Error");
+            }
+        }
+
+        public ObservableCollection<string> ThemeOptions { get; }
+        public IRelayCommand TestDbCommand { get; }
+        public IRelayCommand BrowseCompanyLogoCommand { get; }
+        public IAsyncRelayCommand SaveCompanyLogoCommand { get; }
+        public IRelayCommand SelectAllItemDisplayCommand { get; }
+        public IRelayCommand SelectNoneItemDisplayCommand { get; }
+    }
+}

--- a/DeviceManagementApp/Views/Pages/DashboardPage.xaml
+++ b/DeviceManagementApp/Views/Pages/DashboardPage.xaml
@@ -1,0 +1,119 @@
+<!-- Views/DashboardPage.xaml -->
+<Page x:Class="DeviceManagementApp.Views.Pages.DashboardPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <TextBlock Text="Overview" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
+        <ItemsControl Grid.Row="1" ItemsSource="{Binding StatCards}" ItemTemplate="{StaticResource StatCardTemplate}" ItemsPanel="{StaticResource WrapPanelItems}"/>
+        <Grid Grid.Row="2" Margin="0,16,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Border Style="{StaticResource Card}" Grid.Column="0">
+                <StackPanel>
+                    <TextBlock Text="Recent Activity" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
+                    <ListView ItemsSource="{Binding RecentActivity}"
+                              ItemTemplate="{StaticResource ActivityLogItemTemplate}"
+                              VirtualizingPanel.IsVirtualizing="True"
+                              VirtualizingPanel.VirtualizationMode="Recycling"
+                              Style="{StaticResource CardListView}">
+                        <ListView.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel/>
+                            </ItemsPanelTemplate>
+                        </ListView.ItemsPanel>
+                    </ListView>
+                </StackPanel>
+            </Border>
+            <Border Style="{StaticResource Card}" Grid.Column="1">
+                <StackPanel>
+                    <TextBlock Text="Quick Actions" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
+                    <WrapPanel>
+                        <Button Style="{StaticResource PrimaryButton}"
+                                Content="New Device"
+                                Command="{Binding NewDeviceCommand}"
+                                Margin="0,0,8,8"/>
+                        <Button Style="{StaticResource PrimaryButton}"
+                                Content="Assign Device"
+                                Command="{Binding AssignDeviceCommand}"
+                                Margin="0,0,8,8"/>
+                    </WrapPanel>
+                </StackPanel>
+            </Border>
+            <Border Style="{StaticResource Card}" Grid.Column="2">
+                <StackPanel>
+                    <TextBlock Text="Assigned Devices" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
+                    <ListView ItemsSource="{Binding AssignedDevices}"
+                              Style="{StaticResource CardListView}"
+                              VirtualizingPanel.IsVirtualizing="True"
+                              VirtualizingPanel.VirtualizationMode="Recycling">
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal">
+                                    <StackPanel.ToolTip>
+                                        <Image Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"
+                                               MaxWidth="150"
+                                               MaxHeight="150"
+                                               Stretch="Uniform"/>
+                                    </StackPanel.ToolTip>
+                                    <TextBlock Text="{Binding DeviceId}" Margin="0,0,8,0"/>
+                                    <TextBlock Text="{Binding AssignedTo}" Margin="0,0,8,0"/>
+                                    <Button Content="Return"
+                                            Command="{Binding DataContext.ReturnDeviceCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
+                                            CommandParameter="{Binding}"
+                                            Margin="0,0,0,0"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                        <ListView.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel/>
+                            </ItemsPanelTemplate>
+                        </ListView.ItemsPanel>
+                    </ListView>
+                </StackPanel>
+            </Border>
+            <Border Style="{StaticResource Card}" Grid.Column="3">
+                <StackPanel>
+                    <TextBlock Text="Unassigned Devices" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,8"/>
+                    <ListView ItemsSource="{Binding UnassignedDevices}"
+                              Style="{StaticResource CardListView}"
+                              VirtualizingPanel.IsVirtualizing="True"
+                              VirtualizingPanel.VirtualizationMode="Recycling">
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal">
+                                    <StackPanel.ToolTip>
+                                        <Image Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"
+                                               MaxWidth="150"
+                                               MaxHeight="150"
+                                               Stretch="Uniform"/>
+                                    </StackPanel.ToolTip>
+                                    <TextBlock Text="{Binding DeviceId}" Margin="0,0,8,0"/>
+                                    <Button Content="Assign"
+                                            Command="{Binding DataContext.AssignDeviceInListCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
+                                            CommandParameter="{Binding}"
+                                            Margin="0,0,0,0"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                        <ListView.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel/>
+                            </ItemsPanelTemplate>
+                        </ListView.ItemsPanel>
+                    </ListView>
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Grid>
+</Page>

--- a/DeviceManagementApp/Views/Pages/DashboardPage.xaml.cs
+++ b/DeviceManagementApp/Views/Pages/DashboardPage.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace DeviceManagementApp.Views.Pages
+{
+    public partial class DashboardPage : Page
+    {
+        public DashboardPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/DeviceManagementApp/Views/Pages/SettingsPage.xaml
+++ b/DeviceManagementApp/Views/Pages/SettingsPage.xaml
@@ -1,0 +1,122 @@
+<!-- Views/SettingsPage.xaml -->
+<Page x:Class="DeviceManagementApp.Views.Pages.SettingsPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      Background="{DynamicResource BackgroundBrush}">
+
+    <ScrollViewer>
+        <StackPanel Margin="8" Orientation="Vertical">
+            <Border Style="{StaticResource Card}" Padding="12" Margin="0,0,0,8">
+                <StackPanel Orientation="Vertical">
+                    <TextBlock Text="Database" Style="{StaticResource SectionHeader}"/>
+                    <Grid Margin="0,8,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="200"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Connection String"
+                                   Style="{StaticResource LabelTextBlock}"
+                                   VerticalAlignment="Center"/>
+                        <TextBox Grid.Column="1"
+                                 Text="{Binding ConnectionString}"
+                                 Margin="8,0,8,0"/>
+                        <Button Grid.Column="2"
+                                Style="{StaticResource PrimaryButton}"
+                                Content="Test"
+                                Command="{Binding TestDbCommand}"/>
+                    </Grid>
+                </StackPanel>
+            </Border>
+
+            <Border Style="{StaticResource Card}" Padding="12" Margin="0,0,0,8">
+                <StackPanel Orientation="Vertical">
+                    <TextBlock Text="General" Style="{StaticResource SectionHeader}"/>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="200"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <TextBlock Text="Theme" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                        <ComboBox Grid.Column="1" SelectedItem="{Binding Theme}" ItemsSource="{Binding ThemeOptions}" Margin="8,0,0,0" ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
+                        <TextBlock Grid.Row="1" Text="Password Iterations" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding PasswordIterations}" Margin="8,0,0,0" PreviewTextInput="PasswordIterationsBox_PreviewTextInput"/>
+                        <TextBlock Grid.Row="2" Text="Auto-logout (minutes)" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding AutoLogoutMinutes}" Margin="8,0,0,0" PreviewTextInput="AutoLogoutMinutesBox_PreviewTextInput"/>
+                        <TextBlock Grid.Row="3" Text="Device name (singular)" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding ItemLabelSingular}" Margin="8,0,0,0"
+                                 ToolTip="Used for buttons like 'New Device' and 'Assign Device'"/>
+                        <TextBlock Grid.Row="4"
+                                   Text="Device name (plural)"
+                                   Style="{StaticResource LabelTextBlock}"
+                                   VerticalAlignment="Center"/>
+                        <TextBox Grid.Row="4"
+                                 Grid.Column="1"
+                                 Text="{Binding ItemLabelPlural}"
+                                 Margin="8,0,0,0"
+                                 ToolTip="Used for navigation and import/export pages"/>
+                    </Grid>
+                </StackPanel>
+            </Border>
+
+            <Border Style="{StaticResource Card}" Padding="12" Margin="0,0,0,8">
+                <StackPanel Orientation="Vertical">
+                    <TextBlock Text="Device Display" Style="{StaticResource SectionHeader}"/>
+                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                        <Button Style="{StaticResource PrimaryButton}" Content="Select All" Command="{Binding SelectAllItemDisplayCommand}" Margin="0,0,8,0"/>
+                        <Button Style="{StaticResource PrimaryButton}" Content="Select None" Command="{Binding SelectNoneItemDisplayCommand}"/>
+                    </StackPanel>
+                    <ItemsControl ItemsSource="{Binding ItemDetailOptions}" Margin="0,8,0,0">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <CheckBox Content="{Binding Field}" IsChecked="{Binding IsVisible, Mode=TwoWay}"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+
+            <Border Style="{StaticResource Card}" Padding="12">
+                <StackPanel Orientation="Vertical">
+                    <TextBlock Text="Branding" Style="{StaticResource SectionHeader}"/>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="200"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Text="Application Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                        <TextBox Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding ApplicationName}" Margin="8,0,0,8"/>
+
+                        <TextBlock Grid.Row="1" Text="Company Logo" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+
+                        <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal">
+                            <Border Width="64" Height="64" CornerRadius="6" Background="{DynamicResource SurfaceAltBrush}" Margin="8,0,8,0">
+                                <Image Width="64" Height="64"
+                                       Source="{Binding CompanyLogoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=logo}"
+                                       Stretch="Uniform" ClipToBounds="True"/>
+                            </Border>
+                            <TextBlock Text="{Binding CompanyLogoPath}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+                        </StackPanel>
+
+                        <Button Grid.Row="1" Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Change Logo" Command="{Binding BrowseCompanyLogoCommand}" Margin="8,0,8,0"/>
+                        <Button Grid.Row="1" Grid.Column="3" Style="{StaticResource PrimaryButton}" Content="Save Logo" Command="{Binding SaveCompanyLogoCommand}" />
+                    </Grid>
+                </StackPanel>
+            </Border>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/DeviceManagementApp/Views/Pages/SettingsPage.xaml.cs
+++ b/DeviceManagementApp/Views/Pages/SettingsPage.xaml.cs
@@ -1,0 +1,28 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+using TextBox = System.Windows.Controls.TextBox;
+
+namespace DeviceManagementApp.Views.Pages
+{
+    public partial class SettingsPage : Page
+    {
+        public SettingsPage()
+        {
+            InitializeComponent();
+        }
+
+        void PasswordIterationsBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
+        {
+            var textBox = (TextBox)sender;
+            var proposed = textBox.Text.Insert(textBox.SelectionStart, e.Text);
+            e.Handled = !int.TryParse(proposed, out var value) || value <= 0;
+        }
+
+        void AutoLogoutMinutesBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
+        {
+            var textBox = (TextBox)sender;
+            var proposed = textBox.Text.Insert(textBox.SelectionStart, e.Text);
+            e.Handled = !int.TryParse(proposed, out var value) || value < 0;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add device dashboard and settings pages with device terminology
- compute device statistics and persist preferences
- wire up navigation commands and sidebar buttons

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb28dece8832499698b7ecb11e455