### PR TITLE
feat: refresh theme palettes

### DIFF
--- a/DeviceManagementApp/Resources/Colors.Dark.xaml
+++ b/DeviceManagementApp/Resources/Colors.Dark.xaml
@@ -1,11 +1,11 @@
 <!-- Resources/Colors.Dark.xaml -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Color x:Key="Col.Background">#0F141A</Color>
-    <Color x:Key="Col.Surface">#111820</Color>
-    <Color x:Key="Col.SurfaceAlt">#1B2430</Color>
-    <Color x:Key="Col.Border">#1E2A36</Color>
-    <Color x:Key="Col.BorderAlt">#2A3542</Color>
+    <Color x:Key="Col.Background">#121212</Color>
+    <Color x:Key="Col.Surface">#1E1E1E</Color>
+    <Color x:Key="Col.SurfaceAlt">#292929</Color>
+    <Color x:Key="Col.Border">#373737</Color>
+    <Color x:Key="Col.BorderAlt">#444444</Color>
     <Color x:Key="Col.Fg">#E6F0F5</Color>
     <Color x:Key="Col.FgMuted">#93A4B3</Color>
     <Color x:Key="Col.Success">#2ECC71</Color>
@@ -19,8 +19,10 @@
     <SolidColorBrush x:Key="ForegroundMutedBrush" Color="{StaticResource Col.FgMuted}"/>
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource Col.Success}"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource Col.Error}"/>
-    <Color x:Key="Col.Accent">gray</Color>
+    <Color x:Key="Col.Accent">#FF7043</Color>
     <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource Col.Accent}"/>
+    <Color x:Key="Col.OnAccent">#FFFFFF</Color>
+    <SolidColorBrush x:Key="OnAccentForegroundBrush" Color="{StaticResource Col.OnAccent}"/>
     <Color x:Key="Col.CardBackground">#1F1F1F</Color>
     <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource Col.CardBackground}"/>
     <SolidColorBrush x:Key="TextBoxBackgroundBrush" Color="#141C24"/>
@@ -36,9 +38,9 @@
     <SolidColorBrush x:Key="BtnBgHover" Color="#353A45"/>
     <SolidColorBrush x:Key="BtnBorder" Color="#444A57"/>
     <SolidColorBrush x:Key="BtnFg" Color="#FFFFFF"/>
-    <SolidColorBrush x:Key="FocusVisualStrokeBrush" Color="#5FA8FF"/>
+    <SolidColorBrush x:Key="FocusVisualStrokeBrush" Color="{StaticResource Col.Accent}"/>
     <SolidColorBrush x:Key="ItemHoverBrush" Color="#2D3C4E"/>
-    <SolidColorBrush x:Key="ItemSelectedBrush" Color="#1E90FF"/>
+    <SolidColorBrush x:Key="ItemSelectedBrush" Color="{StaticResource Col.Accent}"/>
     <SolidColorBrush x:Key="DisabledForegroundBrush" Color="#6C7A86"/>
     <SolidColorBrush x:Key="DisabledBackgroundBrush" Color="#1A1A1A"/>
     <SolidColorBrush x:Key="DataGridRowBackgroundBrush" Color="#121A22"/>

--- a/DeviceManagementApp/Resources/Colors.Light.xaml
+++ b/DeviceManagementApp/Resources/Colors.Light.xaml
@@ -1,11 +1,11 @@
 <!-- Resources/Colors.Light.xaml -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Color x:Key="Col.Background">#FFFFFF</Color>
-    <Color x:Key="Col.Surface">#F5F5F5</Color>
-    <Color x:Key="Col.SurfaceAlt">#EEEEEE</Color>
-    <Color x:Key="Col.Border">#DDDDDD</Color>
-    <Color x:Key="Col.BorderAlt">#CCCCCC</Color>
+    <Color x:Key="Col.Background">#FAF9F6</Color>
+    <Color x:Key="Col.Surface">#FFFFFF</Color>
+    <Color x:Key="Col.SurfaceAlt">#F0F0F0</Color>
+    <Color x:Key="Col.Border">#E0E0E0</Color>
+    <Color x:Key="Col.BorderAlt">#D0D0D0</Color>
     <Color x:Key="Col.Fg">#1A1A1A</Color>
     <Color x:Key="Col.FgMuted">#555555</Color>
     <Color x:Key="Col.Success">#2ECC71</Color>
@@ -19,8 +19,10 @@
     <SolidColorBrush x:Key="ForegroundMutedBrush" Color="{StaticResource Col.FgMuted}"/>
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource Col.Success}"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource Col.Error}"/>
-    <Color x:Key="Col.Accent">#0078D4</Color>
+    <Color x:Key="Col.Accent">#FF5722</Color>
     <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource Col.Accent}"/>
+    <Color x:Key="Col.OnAccent">#FFFFFF</Color>
+    <SolidColorBrush x:Key="OnAccentForegroundBrush" Color="{StaticResource Col.OnAccent}"/>
     <Color x:Key="Col.CardBackground">#FFFFFF</Color>
     <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource Col.CardBackground}"/>
     <SolidColorBrush x:Key="TextBoxBackgroundBrush" Color="#FFFFFF"/>
@@ -36,9 +38,9 @@
     <SolidColorBrush x:Key="BtnBgHover" Color="#D5D5D5"/>
     <SolidColorBrush x:Key="BtnBorder" Color="#BBBBBB"/>
     <SolidColorBrush x:Key="BtnFg" Color="#1A1A1A"/>
-    <SolidColorBrush x:Key="FocusVisualStrokeBrush" Color="#5FA8FF"/>
+    <SolidColorBrush x:Key="FocusVisualStrokeBrush" Color="{StaticResource Col.Accent}"/>
     <SolidColorBrush x:Key="ItemHoverBrush" Color="#E0E0E0"/>
-    <SolidColorBrush x:Key="ItemSelectedBrush" Color="#0078D4"/>
+    <SolidColorBrush x:Key="ItemSelectedBrush" Color="{StaticResource Col.Accent}"/>
     <SolidColorBrush x:Key="DisabledForegroundBrush" Color="#999999"/>
     <SolidColorBrush x:Key="DisabledBackgroundBrush" Color="#F4F4F4"/>
     <SolidColorBrush x:Key="DataGridRowBackgroundBrush" Color="#FFFFFF"/>

--- a/DeviceManagementApp/Resources/Styles.xaml
+++ b/DeviceManagementApp/Resources/Styles.xaml
@@ -95,11 +95,11 @@
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
             </Trigger>
             <Trigger Property="IsSelected" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
                 <Setter Property="FontWeight" Value="SemiBold"/>
             </Trigger>
         </Style.Triggers>
@@ -112,11 +112,11 @@
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
             </Trigger>
             <Trigger Property="IsSelected" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
                 <Setter Property="FontWeight" Value="SemiBold"/>
             </Trigger>
         </Style.Triggers>
@@ -315,11 +315,11 @@
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
             </Trigger>
             <Trigger Property="IsSelected" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -356,11 +356,11 @@
         <Style.Triggers>
             <Trigger Property="IsHighlighted" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
             </Trigger>
             <Trigger Property="IsChecked" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
                 <Setter Property="FontWeight" Value="SemiBold"/>
             </Trigger>
         </Style.Triggers>

--- a/InventoryManagementApp/Resources/Colors.Dark.xaml
+++ b/InventoryManagementApp/Resources/Colors.Dark.xaml
@@ -1,11 +1,11 @@
 <!-- Resources/Colors.Dark.xaml -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Color x:Key="Col.Background">#0F141A</Color>
-    <Color x:Key="Col.Surface">#111820</Color>
-    <Color x:Key="Col.SurfaceAlt">#1B2430</Color>
-    <Color x:Key="Col.Border">#1E2A36</Color>
-    <Color x:Key="Col.BorderAlt">#2A3542</Color>
+    <Color x:Key="Col.Background">#121212</Color>
+    <Color x:Key="Col.Surface">#1E1E1E</Color>
+    <Color x:Key="Col.SurfaceAlt">#292929</Color>
+    <Color x:Key="Col.Border">#373737</Color>
+    <Color x:Key="Col.BorderAlt">#444444</Color>
     <Color x:Key="Col.Fg">#E6F0F5</Color>
     <Color x:Key="Col.FgMuted">#93A4B3</Color>
     <Color x:Key="Col.Success">#2ECC71</Color>
@@ -19,8 +19,10 @@
     <SolidColorBrush x:Key="ForegroundMutedBrush" Color="{StaticResource Col.FgMuted}"/>
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource Col.Success}"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource Col.Error}"/>
-    <Color x:Key="Col.Accent">gray</Color>
+    <Color x:Key="Col.Accent">#FF7043</Color>
     <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource Col.Accent}"/>
+    <Color x:Key="Col.OnAccent">#FFFFFF</Color>
+    <SolidColorBrush x:Key="OnAccentForegroundBrush" Color="{StaticResource Col.OnAccent}"/>
     <Color x:Key="Col.CardBackground">#1F1F1F</Color>
     <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource Col.CardBackground}"/>
     <SolidColorBrush x:Key="TextBoxBackgroundBrush" Color="#141C24"/>
@@ -36,9 +38,9 @@
     <SolidColorBrush x:Key="BtnBgHover" Color="#353A45"/>
     <SolidColorBrush x:Key="BtnBorder" Color="#444A57"/>
     <SolidColorBrush x:Key="BtnFg" Color="#FFFFFF"/>
-    <SolidColorBrush x:Key="FocusVisualStrokeBrush" Color="#5FA8FF"/>
+    <SolidColorBrush x:Key="FocusVisualStrokeBrush" Color="{StaticResource Col.Accent}"/>
     <SolidColorBrush x:Key="ItemHoverBrush" Color="#2D3C4E"/>
-    <SolidColorBrush x:Key="ItemSelectedBrush" Color="#1E90FF"/>
+    <SolidColorBrush x:Key="ItemSelectedBrush" Color="{StaticResource Col.Accent}"/>
     <SolidColorBrush x:Key="DisabledForegroundBrush" Color="#6C7A86"/>
     <SolidColorBrush x:Key="DisabledBackgroundBrush" Color="#1A1A1A"/>
     <SolidColorBrush x:Key="DataGridRowBackgroundBrush" Color="#121A22"/>

--- a/InventoryManagementApp/Resources/Colors.Light.xaml
+++ b/InventoryManagementApp/Resources/Colors.Light.xaml
@@ -1,11 +1,11 @@
 <!-- Resources/Colors.Light.xaml -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Color x:Key="Col.Background">#FFFFFF</Color>
-    <Color x:Key="Col.Surface">#F5F5F5</Color>
-    <Color x:Key="Col.SurfaceAlt">#EEEEEE</Color>
-    <Color x:Key="Col.Border">#DDDDDD</Color>
-    <Color x:Key="Col.BorderAlt">#CCCCCC</Color>
+    <Color x:Key="Col.Background">#FAF9F6</Color>
+    <Color x:Key="Col.Surface">#FFFFFF</Color>
+    <Color x:Key="Col.SurfaceAlt">#F0F0F0</Color>
+    <Color x:Key="Col.Border">#E0E0E0</Color>
+    <Color x:Key="Col.BorderAlt">#D0D0D0</Color>
     <Color x:Key="Col.Fg">#1A1A1A</Color>
     <Color x:Key="Col.FgMuted">#555555</Color>
     <Color x:Key="Col.Success">#2ECC71</Color>
@@ -19,8 +19,10 @@
     <SolidColorBrush x:Key="ForegroundMutedBrush" Color="{StaticResource Col.FgMuted}"/>
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource Col.Success}"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource Col.Error}"/>
-    <Color x:Key="Col.Accent">#0078D4</Color>
+    <Color x:Key="Col.Accent">#FF5722</Color>
     <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource Col.Accent}"/>
+    <Color x:Key="Col.OnAccent">#FFFFFF</Color>
+    <SolidColorBrush x:Key="OnAccentForegroundBrush" Color="{StaticResource Col.OnAccent}"/>
     <Color x:Key="Col.CardBackground">#FFFFFF</Color>
     <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource Col.CardBackground}"/>
     <SolidColorBrush x:Key="TextBoxBackgroundBrush" Color="#FFFFFF"/>
@@ -36,9 +38,9 @@
     <SolidColorBrush x:Key="BtnBgHover" Color="#D5D5D5"/>
     <SolidColorBrush x:Key="BtnBorder" Color="#BBBBBB"/>
     <SolidColorBrush x:Key="BtnFg" Color="#1A1A1A"/>
-    <SolidColorBrush x:Key="FocusVisualStrokeBrush" Color="#5FA8FF"/>
+    <SolidColorBrush x:Key="FocusVisualStrokeBrush" Color="{StaticResource Col.Accent}"/>
     <SolidColorBrush x:Key="ItemHoverBrush" Color="#E0E0E0"/>
-    <SolidColorBrush x:Key="ItemSelectedBrush" Color="#0078D4"/>
+    <SolidColorBrush x:Key="ItemSelectedBrush" Color="{StaticResource Col.Accent}"/>
     <SolidColorBrush x:Key="DisabledForegroundBrush" Color="#999999"/>
     <SolidColorBrush x:Key="DisabledBackgroundBrush" Color="#F4F4F4"/>
     <SolidColorBrush x:Key="DataGridRowBackgroundBrush" Color="#FFFFFF"/>

--- a/InventoryManagementApp/Resources/Styles.xaml
+++ b/InventoryManagementApp/Resources/Styles.xaml
@@ -95,11 +95,11 @@
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
             </Trigger>
             <Trigger Property="IsSelected" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
                 <Setter Property="FontWeight" Value="SemiBold"/>
             </Trigger>
         </Style.Triggers>
@@ -112,11 +112,11 @@
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
             </Trigger>
             <Trigger Property="IsSelected" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
                 <Setter Property="FontWeight" Value="SemiBold"/>
             </Trigger>
         </Style.Triggers>
@@ -315,11 +315,11 @@
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
             </Trigger>
             <Trigger Property="IsSelected" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -356,11 +356,11 @@
         <Style.Triggers>
             <Trigger Property="IsHighlighted" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
             </Trigger>
             <Trigger Property="IsChecked" Value="True">
                 <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
-                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
                 <Setter Property="FontWeight" Value="SemiBold"/>
             </Trigger>
         </Style.Triggers>


### PR DESCRIPTION
## Summary
- introduce orange-accent theme with revised surface colors for light and dark modes
- centralize accent usage via OnAccentForegroundBrush and style updates

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden when attempting to install .NET SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf814fe94832480713d54212fe63a