### PR TITLE
Add dialog-based notifications for DeviceManagementApp

### DIFF
--- a/DeviceManagementApp.Tests/DialogViewModelTests.cs
+++ b/DeviceManagementApp.Tests/DialogViewModelTests.cs
@@ -1,0 +1,35 @@
+using DeviceManagementApp.ViewModels;
+using Xunit;
+
+namespace DeviceManagementApp.Tests
+{
+    public class DialogViewModelTests
+    {
+        [Fact]
+        public void InfoDialog_OkCommand_InvokesClose()
+        {
+            bool closed = false;
+            var vm = new InfoDialogViewModel("Test", () => closed = true);
+            vm.OkCommand.Execute(null);
+            Assert.True(closed);
+        }
+
+        [Fact]
+        public void ConfirmDialog_OkCommand_SendsTrue()
+        {
+            bool? result = null;
+            var vm = new ConfirmDialogViewModel("Test", r => result = r);
+            vm.OkCommand.Execute(null);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ConfirmDialog_CancelCommand_SendsFalse()
+        {
+            bool? result = null;
+            var vm = new ConfirmDialogViewModel("Test", r => result = r);
+            vm.CancelCommand.Execute(null);
+            Assert.False(result);
+        }
+    }
+}

--- a/DeviceManagementApp/App.xaml.cs
+++ b/DeviceManagementApp/App.xaml.cs
@@ -11,6 +11,7 @@ using Serilog.Events;
 using DeviceManagementApp.Services;
 using DeviceManagementApp.Interfaces;
 using DeviceManagementApp.ViewModels;
+using DeviceManagementApp.Views.Windows;
 
 namespace DeviceManagementApp
 {
@@ -65,6 +66,8 @@ namespace DeviceManagementApp
                 services.AddSingleton<IDeviceFileService, DeviceFileService>();
                 services.AddSingleton<IDeviceGroupService, DeviceGroupService>();
                 services.AddSingleton<IDeviceDiscoveryService, DeviceDiscoveryService>();
+                services.AddTransient<Func<string, InfoDialogWindow>>(sp => message => new InfoDialogWindow(message));
+                services.AddTransient<Func<string, ConfirmDialogWindow>>(sp => message => new ConfirmDialogWindow(message));
                 services.AddSingleton<IDialogService, DialogService>();
                 services.AddSingleton<ISettingsService, SettingsService>();
                 services.AddSingleton<INavigationService, NavigationService>();

--- a/DeviceManagementApp/Services/DialogService.cs
+++ b/DeviceManagementApp/Services/DialogService.cs
@@ -1,14 +1,44 @@
+using System;
 using System.Windows;
 using DeviceManagementApp.Interfaces;
+using DeviceManagementApp.Views.Windows;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DeviceManagementApp.Services
 {
     public class DialogService : IDialogService
     {
+        private readonly Func<string, InfoDialogWindow> _infoFactory;
+        private readonly Func<string, ConfirmDialogWindow> _confirmFactory;
+        private readonly ILogger<DialogService> _logger;
+
+        public DialogService(
+            Func<string, InfoDialogWindow> infoFactory,
+            Func<string, ConfirmDialogWindow> confirmFactory,
+            ILogger<DialogService>? logger = null)
+        {
+            _infoFactory = infoFactory;
+            _confirmFactory = confirmFactory;
+            _logger = logger ?? NullLogger<DialogService>.Instance;
+        }
+
         public void ShowInfo(string message, string title)
-            => MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Information);
+        {
+            var dialog = _infoFactory(message);
+            dialog.Title = title;
+            try { dialog.Owner = Application.Current?.MainWindow; }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for InfoDialogWindow"); }
+            dialog.ShowDialog();
+        }
 
         public bool ShowConfirmation(string message, string title)
-            => MessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes;
+        {
+            var dialog = _confirmFactory(message);
+            dialog.Title = title;
+            try { dialog.Owner = Application.Current?.MainWindow; }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to set owner for ConfirmDialogWindow"); }
+            return dialog.ShowDialog() == true;
+        }
     }
 }

--- a/DeviceManagementApp/ViewModels/ConfirmDialogViewModel.cs
+++ b/DeviceManagementApp/ViewModels/ConfirmDialogViewModel.cs
@@ -1,0 +1,20 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System;
+
+namespace DeviceManagementApp.ViewModels
+{
+    public class ConfirmDialogViewModel : ObservableObject
+    {
+        public string Message { get; }
+        public IRelayCommand OkCommand { get; }
+        public IRelayCommand CancelCommand { get; }
+
+        public ConfirmDialogViewModel(string message, Action<bool?> close)
+        {
+            Message = message;
+            OkCommand = new RelayCommand(() => close(true));
+            CancelCommand = new RelayCommand(() => close(false));
+        }
+    }
+}

--- a/DeviceManagementApp/ViewModels/InfoDialogViewModel.cs
+++ b/DeviceManagementApp/ViewModels/InfoDialogViewModel.cs
@@ -1,0 +1,18 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System;
+
+namespace DeviceManagementApp.ViewModels
+{
+    public class InfoDialogViewModel : ObservableObject
+    {
+        public string Message { get; }
+        public IRelayCommand OkCommand { get; }
+
+        public InfoDialogViewModel(string message, Action close)
+        {
+            Message = message;
+            OkCommand = new RelayCommand(close);
+        }
+    }
+}

--- a/DeviceManagementApp/Views/Controls/DialogButtonBar.xaml
+++ b/DeviceManagementApp/Views/Controls/DialogButtonBar.xaml
@@ -1,0 +1,15 @@
+<UserControl x:Class="DeviceManagementApp.Controls.DialogButtonBar"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+        <Button Style="{StaticResource PrimaryButton}"
+                Content="{Binding LeftButtonText, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                Command="{Binding LeftCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                IsCancel="True"/>
+        <Button Style="{StaticResource PrimaryButton}"
+                Content="{Binding RightButtonText, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                Command="{Binding RightCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                Margin="8,0,0,0"
+                IsDefault="True"/>
+    </StackPanel>
+</UserControl>

--- a/DeviceManagementApp/Views/Controls/DialogButtonBar.xaml.cs
+++ b/DeviceManagementApp/Views/Controls/DialogButtonBar.xaml.cs
@@ -1,0 +1,45 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace DeviceManagementApp.Controls
+{
+    public partial class DialogButtonBar : System.Windows.Controls.UserControl
+    {
+        public DialogButtonBar()
+        {
+            InitializeComponent();
+        }
+
+        public string LeftButtonText
+        {
+            get => (string)GetValue(LeftButtonTextProperty);
+            set => SetValue(LeftButtonTextProperty, value);
+        }
+        public static readonly DependencyProperty LeftButtonTextProperty =
+            DependencyProperty.Register(nameof(LeftButtonText), typeof(string), typeof(DialogButtonBar), new PropertyMetadata("Cancel"));
+
+        public string RightButtonText
+        {
+            get => (string)GetValue(RightButtonTextProperty);
+            set => SetValue(RightButtonTextProperty, value);
+        }
+        public static readonly DependencyProperty RightButtonTextProperty =
+            DependencyProperty.Register(nameof(RightButtonText), typeof(string), typeof(DialogButtonBar), new PropertyMetadata("OK"));
+
+        public ICommand? LeftCommand
+        {
+            get => (ICommand?)GetValue(LeftCommandProperty);
+            set => SetValue(LeftCommandProperty, value);
+        }
+        public static readonly DependencyProperty LeftCommandProperty =
+            DependencyProperty.Register(nameof(LeftCommand), typeof(ICommand), typeof(DialogButtonBar));
+
+        public ICommand? RightCommand
+        {
+            get => (ICommand?)GetValue(RightCommandProperty);
+            set => SetValue(RightCommandProperty, value);
+        }
+        public static readonly DependencyProperty RightCommandProperty =
+            DependencyProperty.Register(nameof(RightCommand), typeof(ICommand), typeof(DialogButtonBar));
+    }
+}

--- a/DeviceManagementApp/Views/Windows/ConfirmDialogWindow.xaml
+++ b/DeviceManagementApp/Views/Windows/ConfirmDialogWindow.xaml
@@ -1,0 +1,24 @@
+<!-- Views/Windows/ConfirmDialogWindow.xaml -->
+<Window x:Class="DeviceManagementApp.Views.Windows.ConfirmDialogWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:DeviceManagementApp.Controls"
+        Title="Confirm"
+        Width="480" Height="220"
+        WindowStartupLocation="CenterScreen"
+        Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="14">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Border Style="{StaticResource Card}">
+            <TextBlock Text="{Binding Message}" Style="{StaticResource DialogMessageTextBlock}"/>
+        </Border>
+        <controls:DialogButtonBar Grid.Row="1"
+                                  LeftButtonText="No"
+                                  LeftCommand="{Binding CancelCommand}"
+                                  RightButtonText="Yes"
+                                  RightCommand="{Binding OkCommand}"/>
+    </Grid>
+</Window>

--- a/DeviceManagementApp/Views/Windows/ConfirmDialogWindow.xaml.cs
+++ b/DeviceManagementApp/Views/Windows/ConfirmDialogWindow.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows;
+using DeviceManagementApp.ViewModels;
+using DeviceManagementApp.Utilities.Extensions;
+
+namespace DeviceManagementApp.Views.Windows
+{
+    public partial class ConfirmDialogWindow : Window
+    {
+        public ConfirmDialogWindow(string message)
+        {
+            InitializeComponent();
+            DataContext = new ConfirmDialogViewModel(message, result => DialogResult = result);
+            this.DisposeDataContextOnUnload();
+        }
+
+        public ConfirmDialogWindow() : this(string.Empty) { }
+    }
+}

--- a/DeviceManagementApp/Views/Windows/InfoDialogWindow.xaml
+++ b/DeviceManagementApp/Views/Windows/InfoDialogWindow.xaml
@@ -1,0 +1,21 @@
+<!-- Views/Windows/InfoDialogWindow.xaml -->
+<Window x:Class="DeviceManagementApp.Views.Windows.InfoDialogWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Information"
+        Width="480" Height="220"
+        WindowStartupLocation="CenterScreen"
+        Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="14">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Border Style="{StaticResource Card}">
+            <TextBlock Text="{Binding Message}" Style="{StaticResource DialogMessageTextBlock}"/>
+        </Border>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Style="{StaticResource PrimaryButton}" Content="OK" Command="{Binding OkCommand}"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/DeviceManagementApp/Views/Windows/InfoDialogWindow.xaml.cs
+++ b/DeviceManagementApp/Views/Windows/InfoDialogWindow.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows;
+using DeviceManagementApp.ViewModels;
+using DeviceManagementApp.Utilities.Extensions;
+
+namespace DeviceManagementApp.Views.Windows
+{
+    public partial class InfoDialogWindow : Window
+    {
+        public InfoDialogWindow(string message)
+        {
+            InitializeComponent();
+            DataContext = new InfoDialogViewModel(message, () => DialogResult = true);
+            this.DisposeDataContextOnUnload();
+        }
+
+        public InfoDialogWindow() : this(string.Empty) { }
+    }
+}


### PR DESCRIPTION
## Summary
- add InfoDialogWindow and ConfirmDialogWindow with shared DialogButtonBar control
- implement InfoDialogViewModel and ConfirmDialogViewModel
- wire up dialog factories and services via dependency injection
- replace MessageBox usage with MVVM-friendly dialogs and add unit tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bd08b8a0a083248fdb0179cac8f48e