### PR TITLE
Use staff service for device assignments

### DIFF
--- a/DeviceManagementApp.Tests/DevicesViewModelTests.cs
+++ b/DeviceManagementApp.Tests/DevicesViewModelTests.cs
@@ -82,6 +82,13 @@ public class DevicesViewModelTests
         }
     }
 
+    private sealed class StubStaffService : IStaffService
+    {
+        public List<KeyValuePair<int, string>> Staff { get; } = new();
+        public Task<IEnumerable<KeyValuePair<int, string>>> GetStaffAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IEnumerable<KeyValuePair<int, string>>>(Staff);
+    }
+
     private sealed class RecordingDeviceGroupService : IDeviceGroupService
     {
         public List<DeviceGroup> Groups { get; } = new();
@@ -148,6 +155,23 @@ public class DevicesViewModelTests
         Assert.Equal("1.2.3.4", vm.Devices[0].Ip);
         Assert.Equal("Online", vm.Devices[0].Status);
         Assert.Equal("Ftp", vm.Devices[0].ProtocolsDisplay);
+    }
+
+    [Fact]
+    public async Task RefreshCommand_LoadsStaffFromService()
+    {
+        var discovery = new StubDiscoveryService();
+        var fileService = new RecordingDeviceFileService();
+        var dialog = new RecordingDialogService();
+        var staffService = new StubStaffService();
+        staffService.Staff.Add(new(1, "Alice"));
+        staffService.Staff.Add(new(2, "Bob"));
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), new RecordingDeviceGroupService(), staffService: staffService);
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Contains(vm.Staff, s => s.Key == 1 && s.Value == "Alice");
+        Assert.Contains(vm.Staff, s => s.Key == 2 && s.Value == "Bob");
     }
 
     [Fact]

--- a/DeviceManagementApp/App.xaml.cs
+++ b/DeviceManagementApp/App.xaml.cs
@@ -67,6 +67,7 @@ namespace DeviceManagementApp
                 services.AddSingleton<IDeviceFileService, DeviceFileService>();
                 services.AddSingleton<IDeviceGroupService, DeviceGroupService>();
                 services.AddSingleton<IDeviceDiscoveryService, DeviceDiscoveryService>();
+                services.AddSingleton<IStaffService, StaffService>();
                 services.AddTransient<Func<string, InfoDialogWindow>>(sp => message => new InfoDialogWindow(message));
                 services.AddTransient<Func<string, ConfirmDialogWindow>>(sp => message => new ConfirmDialogWindow(message));
                 services.AddSingleton<IDialogService, DialogService>();

--- a/DeviceManagementApp/Interfaces/IStaffService.cs
+++ b/DeviceManagementApp/Interfaces/IStaffService.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DeviceManagementApp.Interfaces
+{
+    public interface IStaffService
+    {
+        Task<IEnumerable<KeyValuePair<int, string>>> GetStaffAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/DeviceManagementApp/Services/StaffService.cs
+++ b/DeviceManagementApp/Services/StaffService.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DeviceManagementApp.Interfaces;
+
+namespace DeviceManagementApp.Services
+{
+    public class StaffService : IStaffService
+    {
+        private readonly DatabaseService _db;
+
+        public StaffService(DatabaseService db)
+        {
+            _db = db;
+        }
+
+        public async Task<IEnumerable<KeyValuePair<int, string>>> GetStaffAsync(CancellationToken cancellationToken = default)
+        {
+            var staff = new List<KeyValuePair<int, string>>();
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT UserID, UserName FROM Users ORDER BY UserName";
+            using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var id = reader.GetInt32(0);
+                var name = reader.IsDBNull(1) ? id.ToString() : reader.GetString(1);
+                staff.Add(new KeyValuePair<int, string>(id, name));
+            }
+            return staff;
+        }
+    }
+}

--- a/DeviceManagementApp/ViewModels/AssignDeviceViewModel.cs
+++ b/DeviceManagementApp/ViewModels/AssignDeviceViewModel.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -8,6 +10,8 @@ namespace DeviceManagementApp.ViewModels
     {
         int _userId;
         int? _departmentId;
+
+        public ObservableCollection<KeyValuePair<int, string>> Staff { get; } = new();
 
         public int UserId
         {

--- a/DeviceManagementApp/ViewModels/DevicesViewModel.cs
+++ b/DeviceManagementApp/ViewModels/DevicesViewModel.cs
@@ -27,6 +27,7 @@ namespace DeviceManagementApp.ViewModels
         private readonly IDeviceGroupService _groupService;
         private readonly IDeviceAssignmentService _assignmentService;
         private readonly IDeviceSoftwareService _softwareService;
+        private readonly IStaffService _staffService;
         private readonly ILogger<DevicesViewModel> _logger;
 
         public ObservableCollection<Device> Devices { get; } = new();
@@ -128,25 +129,7 @@ namespace DeviceManagementApp.ViewModels
         public Func<string?> PromptForGroupName { get; set; } = () =>
             Interaction.InputBox("Enter group name:", "Add Group", string.Empty);
 
-        public Func<Device, DeviceAssignment?> PromptForAssignment { get; set; } = device =>
-        {
-            var dialog = new AssignDeviceDialog();
-            AssignDeviceViewModel vm = null!;
-            dialog.DataContext = vm = new AssignDeviceViewModel(r => dialog.DialogResult = r)
-            {
-                UserId = device.AssignedUserId ?? 0,
-                DepartmentId = device.DepartmentId
-            };
-            return dialog.ShowDialog() == true
-                ? new DeviceAssignment
-                {
-                    DeviceIp = device.Ip,
-                    UserId = vm.UserId,
-                    DepartmentId = vm.DepartmentId,
-                    AssignedDate = DateTime.UtcNow
-                }
-                : null;
-        };
+        public Func<Device, DeviceAssignment?> PromptForAssignment { get; set; }
 
         private DeviceGroup? _selectedGroup;
         public DeviceGroup? SelectedGroup
@@ -197,6 +180,7 @@ namespace DeviceManagementApp.ViewModels
                                  IDeviceGroupService groupService,
                                  IDeviceAssignmentService? assignmentService = null,
                                  IDeviceSoftwareService? softwareService = null,
+                                 IStaffService? staffService = null,
                                  ILogger<DevicesViewModel>? logger = null)
         {
             _discoveryService = discoveryService;
@@ -206,6 +190,7 @@ namespace DeviceManagementApp.ViewModels
             _groupService = groupService;
             _assignmentService = assignmentService ?? NullDeviceAssignmentService.Instance;
             _softwareService = softwareService ?? NullDeviceSoftwareService.Instance;
+            _staffService = staffService ?? NullStaffService.Instance;
             _logger = logger ?? NullLogger<DevicesViewModel>.Instance;
 
             DevicesView = CollectionViewSource.GetDefaultView(Devices);
@@ -222,6 +207,29 @@ namespace DeviceManagementApp.ViewModels
             AssignDeviceCommand = new AsyncRelayCommand(AssignDeviceAsync, () => SelectedDevice != null);
             ReturnDeviceCommand = new AsyncRelayCommand(ReturnDeviceAsync, () => SelectedDevice?.AssignedUserId != null);
             ViewDetailsCommand = new RelayCommand(OnViewDetails, () => SelectedDevice != null);
+
+            PromptForAssignment = device =>
+            {
+                var dialog = new AssignDeviceDialog();
+                AssignDeviceViewModel vm = null!;
+                dialog.DataContext = vm = new AssignDeviceViewModel(r => dialog.DialogResult = r)
+                {
+                    UserId = device.AssignedUserId ?? 0,
+                    DepartmentId = device.DepartmentId
+                };
+                vm.Staff.Clear();
+                foreach (var s in Staff.Where(s => s.Key.HasValue))
+                    vm.Staff.Add(new KeyValuePair<int, string>(s.Key!.Value, s.Value));
+                return dialog.ShowDialog() == true
+                    ? new DeviceAssignment
+                    {
+                        DeviceIp = device.Ip,
+                        UserId = vm.UserId,
+                        DepartmentId = vm.DepartmentId,
+                        AssignedDate = DateTime.UtcNow
+                    }
+                    : null;
+            };
         }
 
         private async Task RefreshAsync()
@@ -238,6 +246,9 @@ namespace DeviceManagementApp.ViewModels
                 Departments.Add(new(null, "All Departments"));
                 Staff.Clear();
                 Staff.Add(new(null, "All Staff"));
+                var staffList = (await _staffService.GetStaffAsync()).ToList();
+                foreach (var s in staffList)
+                    Staff.Add(new(s.Key, s.Value));
 
                 var groups = await _groupService.GetGroupsAsync();
                 Groups.Clear();
@@ -287,7 +298,11 @@ namespace DeviceManagementApp.ViewModels
                     if (device.DepartmentId.HasValue && !Departments.Any(dp => dp.Key == device.DepartmentId))
                         Departments.Add(new(device.DepartmentId.Value, device.DepartmentId.Value.ToString()));
                     if (device.AssignedUserId.HasValue && !Staff.Any(s => s.Key == device.AssignedUserId))
-                        Staff.Add(new(device.AssignedUserId.Value, device.AssignedUserId.Value.ToString()));
+                    {
+                        var name = staffList.FirstOrDefault(s => s.Key == device.AssignedUserId.Value).Value
+                                   ?? device.AssignedUserId.Value.ToString();
+                        Staff.Add(new(device.AssignedUserId.Value, name));
+                    }
                 }
 
                 if (Devices.Count == 0 && !_discoveryService.HasConfiguredSubnets)
@@ -479,8 +494,9 @@ namespace DeviceManagementApp.ViewModels
                 await _assignmentService.AssignAsync(assignment);
                 SelectedDevice.AssignedUserId = assignment.UserId;
                 SelectedDevice.DepartmentId = assignment.DepartmentId;
+                var staffName = Staff.FirstOrDefault(s => s.Key == assignment.UserId).Value ?? assignment.UserId.ToString();
                 if (!Staff.Any(s => s.Key == assignment.UserId))
-                    Staff.Add(new(assignment.UserId, assignment.UserId.ToString()));
+                    Staff.Add(new(assignment.UserId, staffName));
                 if (assignment.DepartmentId.HasValue && !Departments.Any(d => d.Key == assignment.DepartmentId))
                     Departments.Add(new(assignment.DepartmentId.Value, assignment.DepartmentId.Value.ToString()));
                 DevicesView.Refresh();
@@ -603,6 +619,14 @@ namespace DeviceManagementApp.ViewModels
                 => Task.CompletedTask;
             public Task DeleteAsync(string deviceIp, int? devicePort, string name, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
+        }
+
+        class NullStaffService : IStaffService
+        {
+            public static readonly IStaffService Instance = new NullStaffService();
+            NullStaffService() { }
+            public Task<IEnumerable<KeyValuePair<int, string>>> GetStaffAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult<IEnumerable<KeyValuePair<int, string>>>(Array.Empty<KeyValuePair<int, string>>());
         }
 
     }

--- a/DeviceManagementApp/Views/AssignDeviceDialog.xaml
+++ b/DeviceManagementApp/Views/AssignDeviceDialog.xaml
@@ -5,8 +5,12 @@
         SizeToContent="WidthAndHeight" WindowStartupLocation="CenterOwner">
     <StackPanel Margin="10">
         <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-            <TextBlock Text="User ID:" Width="80" VerticalAlignment="Center"/>
-            <TextBox Width="150" Text="{Binding UserId, UpdateSourceTrigger=PropertyChanged}"/>
+            <TextBlock Text="Staff:" Width="80" VerticalAlignment="Center"/>
+            <ComboBox Width="150"
+                      ItemsSource="{Binding Staff}"
+                      SelectedValue="{Binding UserId, UpdateSourceTrigger=PropertyChanged}"
+                      DisplayMemberPath="Value"
+                      SelectedValuePath="Key"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
             <TextBlock Text="Department:" Width="80" VerticalAlignment="Center"/>


### PR DESCRIPTION
## Summary
- Replace manual user ID entry with a staff selector in the assignment dialog
- Load and expose staff via new StaffService and integrate into device assignment flow
- Register StaffService and cover staff loading with unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6cab39248324a10b9ba794530e0b