### PR TITLE
Add staff selection for device assignment

### DIFF
--- a/DeviceManagementApp.Tests/DevicesViewModelTests.cs
+++ b/DeviceManagementApp.Tests/DevicesViewModelTests.cs
@@ -591,4 +591,33 @@ public class DevicesViewModelTests
         vm.ViewDetailsCommand.Execute(null);
         Assert.Same(device, requested);
     }
+
+    [Fact]
+    public async Task AssignDeviceAsync_AddsStaffNameToFilter()
+    {
+        var discovery = new StubDiscoveryService();
+        var fileService = new RecordingDeviceFileService();
+        var dialog = new RecordingDialogService();
+        var groupService = new RecordingDeviceGroupService();
+        var staffService = new StubStaffService();
+        var vm = new DevicesViewModel(discovery, fileService, dialog, new RecordingDeviceService(), groupService, null, null, staffService);
+        vm.StaffMembers.Add(new Staff { StaffId = 1, Name = "Alice" });
+        vm.SelectedDevice = new Device { Ip = "1" };
+        vm.Devices.Add(vm.SelectedDevice);
+        vm.PromptForAssignment = _ => new DeviceAssignment { DeviceIp = "1", UserId = 1, AssignedDate = DateTime.UtcNow };
+        await vm.AssignDeviceCommand.ExecuteAsync(null);
+        Assert.Contains(vm.Staff, kv => kv.Key == 1 && kv.Value == "Alice");
+    }
+
+    private sealed class StubStaffService : IStaffService
+    {
+        public Task<IReadOnlyList<Staff>> GetStaffAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<Staff>>(Array.Empty<Staff>());
+        public Task<int> AddStaffAsync(Staff staff, CancellationToken cancellationToken = default)
+            => Task.FromResult(0);
+        public Task UpdateStaffAsync(Staff staff, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+        public Task DeleteStaffAsync(int staffId, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
 }

--- a/DeviceManagementApp/ViewModels/AssignDeviceViewModel.cs
+++ b/DeviceManagementApp/ViewModels/AssignDeviceViewModel.cs
@@ -1,18 +1,24 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using DeviceManagementApp.Models;
 
 namespace DeviceManagementApp.ViewModels
 {
     public class AssignDeviceViewModel : ObservableObject
     {
-        int _userId;
+        Staff? _selectedStaff;
         int? _departmentId;
 
-        public int UserId
+        public ObservableCollection<Staff> Staff { get; } = new();
+
+        public Staff? SelectedStaff
         {
-            get => _userId;
-            set => SetProperty(ref _userId, value);
+            get => _selectedStaff;
+            set => SetProperty(ref _selectedStaff, value);
         }
 
         public int? DepartmentId
@@ -24,8 +30,12 @@ namespace DeviceManagementApp.ViewModels
         public IRelayCommand OkCommand { get; }
         public IRelayCommand CancelCommand { get; }
 
-        public AssignDeviceViewModel(Action<bool?> close)
+        public AssignDeviceViewModel(Action<bool?> close, IEnumerable<Staff> staff, int? selectedStaffId = null)
         {
+            foreach (var s in staff)
+                Staff.Add(s);
+            if (selectedStaffId.HasValue)
+                SelectedStaff = Staff.FirstOrDefault(s => s.StaffId == selectedStaffId.Value);
             OkCommand = new RelayCommand(() => close(true));
             CancelCommand = new RelayCommand(() => close(false));
         }

--- a/DeviceManagementApp/ViewModels/DevicesViewModel.cs
+++ b/DeviceManagementApp/ViewModels/DevicesViewModel.cs
@@ -27,6 +27,7 @@ namespace DeviceManagementApp.ViewModels
         private readonly IDeviceGroupService _groupService;
         private readonly IDeviceAssignmentService _assignmentService;
         private readonly IDeviceSoftwareService _softwareService;
+        private readonly IStaffService _staffService;
         private readonly ILogger<DevicesViewModel> _logger;
 
         public ObservableCollection<Device> Devices { get; } = new();
@@ -35,6 +36,7 @@ namespace DeviceManagementApp.ViewModels
         public ObservableCollection<DeviceSoftware> InstalledSoftware { get; } = new();
         public ObservableCollection<KeyValuePair<int?, string>> Departments { get; } = new() { new(null, "All Departments") };
         public ObservableCollection<KeyValuePair<int?, string>> Staff { get; } = new() { new(null, "All Staff") };
+        public ObservableCollection<Staff> StaffMembers { get; } = new();
 
         public event EventHandler<Device>? ViewDetailsRequested;
         public ICollectionView DevicesView { get; }
@@ -132,16 +134,15 @@ namespace DeviceManagementApp.ViewModels
         {
             var dialog = new AssignDeviceDialog();
             AssignDeviceViewModel vm = null!;
-            dialog.DataContext = vm = new AssignDeviceViewModel(r => dialog.DialogResult = r)
+            dialog.DataContext = vm = new AssignDeviceViewModel(r => dialog.DialogResult = r, StaffMembers, device.AssignedUserId)
             {
-                UserId = device.AssignedUserId ?? 0,
                 DepartmentId = device.DepartmentId
             };
-            return dialog.ShowDialog() == true
+            return dialog.ShowDialog() == true && vm.SelectedStaff != null
                 ? new DeviceAssignment
                 {
                     DeviceIp = device.Ip,
-                    UserId = vm.UserId,
+                    UserId = vm.SelectedStaff.StaffId,
                     DepartmentId = vm.DepartmentId,
                     AssignedDate = DateTime.UtcNow
                 }
@@ -197,6 +198,7 @@ namespace DeviceManagementApp.ViewModels
                                  IDeviceGroupService groupService,
                                  IDeviceAssignmentService? assignmentService = null,
                                  IDeviceSoftwareService? softwareService = null,
+                                 IStaffService? staffService = null,
                                  ILogger<DevicesViewModel>? logger = null)
         {
             _discoveryService = discoveryService;
@@ -206,6 +208,7 @@ namespace DeviceManagementApp.ViewModels
             _groupService = groupService;
             _assignmentService = assignmentService ?? NullDeviceAssignmentService.Instance;
             _softwareService = softwareService ?? NullDeviceSoftwareService.Instance;
+            _staffService = staffService ?? NullStaffService.Instance;
             _logger = logger ?? NullLogger<DevicesViewModel>.Instance;
 
             DevicesView = CollectionViewSource.GetDefaultView(Devices);
@@ -238,6 +241,13 @@ namespace DeviceManagementApp.ViewModels
                 Departments.Add(new(null, "All Departments"));
                 Staff.Clear();
                 Staff.Add(new(null, "All Staff"));
+                StaffMembers.Clear();
+                var staff = await _staffService.GetStaffAsync().ConfigureAwait(false);
+                foreach (var s in staff)
+                {
+                    StaffMembers.Add(s);
+                    Staff.Add(new(s.StaffId, s.Name));
+                }
 
                 var groups = await _groupService.GetGroupsAsync();
                 Groups.Clear();
@@ -287,7 +297,11 @@ namespace DeviceManagementApp.ViewModels
                     if (device.DepartmentId.HasValue && !Departments.Any(dp => dp.Key == device.DepartmentId))
                         Departments.Add(new(device.DepartmentId.Value, device.DepartmentId.Value.ToString()));
                     if (device.AssignedUserId.HasValue && !Staff.Any(s => s.Key == device.AssignedUserId))
-                        Staff.Add(new(device.AssignedUserId.Value, device.AssignedUserId.Value.ToString()));
+                    {
+                        var name = StaffMembers.FirstOrDefault(s => s.StaffId == device.AssignedUserId)?.Name
+                                   ?? device.AssignedUserId.Value.ToString();
+                        Staff.Add(new(device.AssignedUserId.Value, name));
+                    }
                 }
 
                 if (Devices.Count == 0 && !_discoveryService.HasConfiguredSubnets)
@@ -479,8 +493,10 @@ namespace DeviceManagementApp.ViewModels
                 await _assignmentService.AssignAsync(assignment);
                 SelectedDevice.AssignedUserId = assignment.UserId;
                 SelectedDevice.DepartmentId = assignment.DepartmentId;
+                var name = StaffMembers.FirstOrDefault(s => s.StaffId == assignment.UserId)?.Name
+                           ?? assignment.UserId.ToString();
                 if (!Staff.Any(s => s.Key == assignment.UserId))
-                    Staff.Add(new(assignment.UserId, assignment.UserId.ToString()));
+                    Staff.Add(new(assignment.UserId, name));
                 if (assignment.DepartmentId.HasValue && !Departments.Any(d => d.Key == assignment.DepartmentId))
                     Departments.Add(new(assignment.DepartmentId.Value, assignment.DepartmentId.Value.ToString()));
                 DevicesView.Refresh();
@@ -602,6 +618,20 @@ namespace DeviceManagementApp.ViewModels
             public Task AddOrUpdateAsync(DeviceSoftware software, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
             public Task DeleteAsync(string deviceIp, int? devicePort, string name, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+        }
+
+        class NullStaffService : IStaffService
+        {
+            public static readonly IStaffService Instance = new NullStaffService();
+            NullStaffService() { }
+            public Task<IReadOnlyList<Staff>> GetStaffAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult<IReadOnlyList<Staff>>(Array.Empty<Staff>());
+            public Task<int> AddStaffAsync(Staff staff, CancellationToken cancellationToken = default)
+                => Task.FromResult(0);
+            public Task UpdateStaffAsync(Staff staff, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+            public Task DeleteStaffAsync(int staffId, CancellationToken cancellationToken = default)
                 => Task.CompletedTask;
         }
 

--- a/DeviceManagementApp/Views/AssignDeviceDialog.xaml
+++ b/DeviceManagementApp/Views/AssignDeviceDialog.xaml
@@ -5,8 +5,11 @@
         SizeToContent="WidthAndHeight" WindowStartupLocation="CenterOwner">
     <StackPanel Margin="10">
         <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-            <TextBlock Text="User ID:" Width="80" VerticalAlignment="Center"/>
-            <TextBox Width="150" Text="{Binding UserId, UpdateSourceTrigger=PropertyChanged}"/>
+            <TextBlock Text="Staff:" Width="80" VerticalAlignment="Center"/>
+            <ComboBox Width="150"
+                      ItemsSource="{Binding Staff}"
+                      DisplayMemberPath="Name"
+                      SelectedItem="{Binding SelectedStaff}"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
             <TextBlock Text="Department:" Width="80" VerticalAlignment="Center"/>


### PR DESCRIPTION
## Summary
- Replace device assignment user ID entry with a staff ComboBox
- Load and expose staff list in DevicesViewModel for assignments and filters
- Store staff names in filters when assigning devices

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bde8dc20f4832497628628afbf580b