### PR TITLE
Add asset management and assignment features

### DIFF
--- a/DeviceManagementApp.Tests/AssetAssignmentServiceTests.cs
+++ b/DeviceManagementApp.Tests/AssetAssignmentServiceTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using DeviceManagementApp.Models;
+using DeviceManagementApp.Services;
+using Xunit;
+
+public class AssetAssignmentServiceTests
+{
+    [Fact]
+    public async Task AssignAndReturnAsset()
+    {
+        using var db = new DatabaseService(":memory:");
+        var assetService = new AssetService(db);
+        var assignmentService = new AssetAssignmentService(db);
+
+        var asset = new Asset { Name = "Phone" };
+        await assetService.AddOrUpdateAssetAsync(asset);
+
+        var assignment = new AssetAssignment
+        {
+            AssetId = asset.AssetId,
+            UserId = 1,
+            DepartmentId = 2,
+            AssignedDate = DateTime.UtcNow
+        };
+        await assignmentService.AssignAsync(assignment);
+
+        var current = await assignmentService.GetCurrentAssignmentAsync(asset.AssetId);
+        Assert.NotNull(current);
+        Assert.Equal(1, current!.UserId);
+        Assert.Equal(2, current.DepartmentId);
+
+        var loaded = await assetService.GetAssetAsync(asset.AssetId);
+        Assert.NotNull(loaded);
+        Assert.Equal(1, loaded!.AssignedUserId);
+
+        await assignmentService.ReturnAsync(asset.AssetId);
+        current = await assignmentService.GetCurrentAssignmentAsync(asset.AssetId);
+        Assert.Null(current);
+        loaded = await assetService.GetAssetAsync(asset.AssetId);
+        Assert.NotNull(loaded);
+        Assert.Null(loaded!.AssignedUserId);
+    }
+}

--- a/DeviceManagementApp.Tests/AssetServiceTests.cs
+++ b/DeviceManagementApp.Tests/AssetServiceTests.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+using DeviceManagementApp.Models;
+using DeviceManagementApp.Services;
+using Xunit;
+
+public class AssetServiceTests
+{
+    [Fact]
+    public async Task AddUpdateAndDeleteAsset()
+    {
+        using var db = new DatabaseService(":memory:");
+        var service = new AssetService(db);
+
+        var asset = new Asset { Name = "Laptop", SerialNumber = "ABC123" };
+        await service.AddOrUpdateAssetAsync(asset);
+        Assert.True(asset.AssetId > 0);
+
+        var loaded = await service.GetAssetAsync(asset.AssetId);
+        Assert.NotNull(loaded);
+        Assert.Equal("Laptop", loaded!.Name);
+
+        asset.Name = "Desktop";
+        await service.AddOrUpdateAssetAsync(asset);
+        loaded = await service.GetAssetAsync(asset.AssetId);
+        Assert.Equal("Desktop", loaded!.Name);
+
+        await service.DeleteAssetAsync(asset.AssetId);
+        loaded = await service.GetAssetAsync(asset.AssetId);
+        Assert.Null(loaded);
+    }
+}

--- a/DeviceManagementApp/App.xaml.cs
+++ b/DeviceManagementApp/App.xaml.cs
@@ -64,6 +64,8 @@ namespace DeviceManagementApp
                 services.AddSingleton<IDatabaseService>(sp => sp.GetRequiredService<DatabaseService>());
                 services.AddSingleton<IDatabaseBackupService>(sp => sp.GetRequiredService<DatabaseService>());
                 services.AddSingleton<IDeviceService, DeviceService>();
+                services.AddSingleton<IAssetService, AssetService>();
+                services.AddSingleton<IAssetAssignmentService, AssetAssignmentService>();
                 services.AddSingleton<IDeviceFileService, DeviceFileService>();
                 services.AddSingleton<IDeviceGroupService, DeviceGroupService>();
                 services.AddSingleton<IStaffService, StaffService>();
@@ -74,6 +76,7 @@ namespace DeviceManagementApp
                 services.AddSingleton<ISettingsService, SettingsService>();
                 services.AddSingleton<INavigationService, NavigationService>();
                 services.AddSingleton<DevicesViewModel>();
+                services.AddSingleton<AssetsViewModel>();
                 services.AddSingleton<DashboardViewModel>();
                 services.AddSingleton<SettingsViewModel>();
                 services.AddSingleton<StaffManagementViewModel>();

--- a/DeviceManagementApp/Interfaces/IAssetAssignmentService.cs
+++ b/DeviceManagementApp/Interfaces/IAssetAssignmentService.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DeviceManagementApp.Models;
+
+namespace DeviceManagementApp.Interfaces
+{
+    public interface IAssetAssignmentService
+    {
+        Task<AssetAssignment?> GetCurrentAssignmentAsync(int assetId, CancellationToken cancellationToken = default);
+        Task AssignAsync(AssetAssignment assignment, CancellationToken cancellationToken = default);
+        Task ReturnAsync(int assetId, CancellationToken cancellationToken = default);
+    }
+}

--- a/DeviceManagementApp/Interfaces/IAssetService.cs
+++ b/DeviceManagementApp/Interfaces/IAssetService.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DeviceManagementApp.Models;
+
+namespace DeviceManagementApp.Interfaces
+{
+    public interface IAssetService
+    {
+        Task<IEnumerable<Asset>> GetAssetsAsync(CancellationToken cancellationToken = default);
+        Task<Asset?> GetAssetAsync(int assetId, CancellationToken cancellationToken = default);
+        Task AddOrUpdateAssetAsync(Asset asset, CancellationToken cancellationToken = default);
+        Task DeleteAssetAsync(int assetId, CancellationToken cancellationToken = default);
+    }
+}

--- a/DeviceManagementApp/MainWindow.xaml
+++ b/DeviceManagementApp/MainWindow.xaml
@@ -24,7 +24,9 @@
                         <TextBlock Text="Operations" Style="{StaticResource CaptionTextBlock}" Margin="6,8,6,2"/>
                         <Button Style="{StaticResource NavButton}" Content="Dashboard" Command="{Binding OpenDashboardCommand}"/>
                         <Button Style="{StaticResource NavButton}" Content="Devices" Command="{Binding OpenDevicesCommand}"/>
+                        <Button Style="{StaticResource NavButton}" Content="Assets" Command="{Binding OpenAssetsCommand}"/>
                         <Button Style="{StaticResource NavButton}" Content="Staff" Command="{Binding OpenStaffCommand}"/>
+                        
                         <Button Style="{StaticResource NavButton}" Content="Settings" Command="{Binding OpenSettingsCommand}"/>
                         <Separator/>
                         <Button Style="{StaticResource NavButton}" Content="Exit" Command="{Binding ExitCommand}"/>

--- a/DeviceManagementApp/Models/Asset.cs
+++ b/DeviceManagementApp/Models/Asset.cs
@@ -1,0 +1,44 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace DeviceManagementApp.Models
+{
+    public class Asset : ObservableObject
+    {
+        int _assetId;
+        string _name = string.Empty;
+        string _serialNumber = string.Empty;
+        int? _assignedUserId;
+        int? _departmentId;
+
+        public int AssetId
+        {
+            get => _assetId;
+            set => SetProperty(ref _assetId, value);
+        }
+
+        public string Name
+        {
+            get => _name;
+            set => SetProperty(ref _name, value);
+        }
+
+        public string SerialNumber
+        {
+            get => _serialNumber;
+            set => SetProperty(ref _serialNumber, value);
+        }
+
+        public int? AssignedUserId
+        {
+            get => _assignedUserId;
+            set => SetProperty(ref _assignedUserId, value);
+        }
+
+        public int? DepartmentId
+        {
+            get => _departmentId;
+            set => SetProperty(ref _departmentId, value);
+        }
+    }
+}

--- a/DeviceManagementApp/Models/AssetAssignment.cs
+++ b/DeviceManagementApp/Models/AssetAssignment.cs
@@ -1,0 +1,44 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace DeviceManagementApp.Models
+{
+    public class AssetAssignment : ObservableObject
+    {
+        int _assetId;
+        int _userId;
+        DateTime _assignedDate;
+        DateTime? _returnedDate;
+        int? _departmentId;
+
+        public int AssetId
+        {
+            get => _assetId;
+            set => SetProperty(ref _assetId, value);
+        }
+
+        public int UserId
+        {
+            get => _userId;
+            set => SetProperty(ref _userId, value);
+        }
+
+        public DateTime AssignedDate
+        {
+            get => _assignedDate;
+            set => SetProperty(ref _assignedDate, value);
+        }
+
+        public DateTime? ReturnedDate
+        {
+            get => _returnedDate;
+            set => SetProperty(ref _returnedDate, value);
+        }
+
+        public int? DepartmentId
+        {
+            get => _departmentId;
+            set => SetProperty(ref _departmentId, value);
+        }
+    }
+}

--- a/DeviceManagementApp/Services/AssetAssignmentService.cs
+++ b/DeviceManagementApp/Services/AssetAssignmentService.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DeviceManagementApp.Interfaces;
+using DeviceManagementApp.Models;
+using Microsoft.Data.Sqlite;
+
+namespace DeviceManagementApp.Services
+{
+    public class AssetAssignmentService : IAssetAssignmentService
+    {
+        readonly DatabaseService _db;
+
+        public AssetAssignmentService(DatabaseService db)
+        {
+            _db = db;
+        }
+
+        public async Task<AssetAssignment?> GetCurrentAssignmentAsync(int assetId, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"SELECT AssetId, UserId, AssignedDate, ReturnedDate, DepartmentId
+                                FROM AssetAssignments
+                                WHERE AssetId=$id AND ReturnedDate IS NULL
+                                ORDER BY AssignedDate DESC LIMIT 1";
+            cmd.Parameters.AddWithValue("$id", assetId);
+            using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return new AssetAssignment
+                {
+                    AssetId = reader.GetInt32(0),
+                    UserId = reader.GetInt32(1),
+                    AssignedDate = reader.GetDateTime(2),
+                    ReturnedDate = reader.IsDBNull(3) ? null : reader.GetDateTime(3),
+                    DepartmentId = reader.IsDBNull(4) ? null : reader.GetInt32(4)
+                };
+            }
+            return null;
+        }
+
+        public async Task AssignAsync(AssetAssignment assignment, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var tran = conn.BeginTransaction();
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.Transaction = tran;
+                cmd.CommandText = @"INSERT INTO AssetAssignments (AssetId, UserId, AssignedDate, DepartmentId)
+                                    VALUES ($id, $uid, $adate, $dept)";
+                cmd.Parameters.AddWithValue("$id", assignment.AssetId);
+                cmd.Parameters.AddWithValue("$uid", assignment.UserId);
+                cmd.Parameters.AddWithValue("$adate", assignment.AssignedDate);
+                if (assignment.DepartmentId.HasValue)
+                    cmd.Parameters.AddWithValue("$dept", assignment.DepartmentId.Value);
+                else
+                    cmd.Parameters.AddWithValue("$dept", DBNull.Value);
+                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.Transaction = tran;
+                cmd.CommandText = @"UPDATE Assets SET AssignedUserId=$uid, DepartmentId=$dept WHERE AssetId=$id";
+                cmd.Parameters.AddWithValue("$uid", assignment.UserId);
+                if (assignment.DepartmentId.HasValue)
+                    cmd.Parameters.AddWithValue("$dept", assignment.DepartmentId.Value);
+                else
+                    cmd.Parameters.AddWithValue("$dept", DBNull.Value);
+                cmd.Parameters.AddWithValue("$id", assignment.AssetId);
+                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+            await tran.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task ReturnAsync(int assetId, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var tran = conn.BeginTransaction();
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.Transaction = tran;
+                cmd.CommandText = @"UPDATE AssetAssignments SET ReturnedDate=$rdate WHERE AssetId=$id AND ReturnedDate IS NULL";
+                cmd.Parameters.AddWithValue("$id", assetId);
+                cmd.Parameters.AddWithValue("$rdate", DateTime.UtcNow);
+                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.Transaction = tran;
+                cmd.CommandText = @"UPDATE Assets SET AssignedUserId=NULL, DepartmentId=NULL WHERE AssetId=$id";
+                cmd.Parameters.AddWithValue("$id", assetId);
+                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+            await tran.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/DeviceManagementApp/Services/AssetService.cs
+++ b/DeviceManagementApp/Services/AssetService.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DeviceManagementApp.Interfaces;
+using DeviceManagementApp.Models;
+using Microsoft.Data.Sqlite;
+
+namespace DeviceManagementApp.Services
+{
+    public class AssetService : IAssetService
+    {
+        readonly DatabaseService _db;
+
+        public AssetService(DatabaseService db)
+        {
+            _db = db;
+        }
+
+        public async Task<IEnumerable<Asset>> GetAssetsAsync(CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"SELECT AssetId, Name, SerialNumber, AssignedUserId, DepartmentId FROM Assets ORDER BY Name";
+            using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            var assets = new List<Asset>();
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                assets.Add(new Asset
+                {
+                    AssetId = reader.GetInt32(0),
+                    Name = reader.GetString(1),
+                    SerialNumber = reader.IsDBNull(2) ? string.Empty : reader.GetString(2),
+                    AssignedUserId = reader.IsDBNull(3) ? null : reader.GetInt32(3),
+                    DepartmentId = reader.IsDBNull(4) ? null : reader.GetInt32(4)
+                });
+            }
+            return assets;
+        }
+
+        public async Task<Asset?> GetAssetAsync(int assetId, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"SELECT AssetId, Name, SerialNumber, AssignedUserId, DepartmentId FROM Assets WHERE AssetId=$id";
+            cmd.Parameters.AddWithValue("$id", assetId);
+            using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return new Asset
+                {
+                    AssetId = reader.GetInt32(0),
+                    Name = reader.GetString(1),
+                    SerialNumber = reader.IsDBNull(2) ? string.Empty : reader.GetString(2),
+                    AssignedUserId = reader.IsDBNull(3) ? null : reader.GetInt32(3),
+                    DepartmentId = reader.IsDBNull(4) ? null : reader.GetInt32(4)
+                };
+            }
+            return null;
+        }
+
+        public async Task AddOrUpdateAssetAsync(Asset asset, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"INSERT INTO Assets (AssetId, Name, SerialNumber, AssignedUserId, DepartmentId)
+                                VALUES ($id, $name, $serial, $user, $dept)
+                                ON CONFLICT(AssetId) DO UPDATE SET
+                                    Name=$name,
+                                    SerialNumber=$serial,
+                                    AssignedUserId=$user,
+                                    DepartmentId=$dept";
+            if (asset.AssetId > 0)
+                cmd.Parameters.AddWithValue("$id", asset.AssetId);
+            else
+                cmd.Parameters.AddWithValue("$id", DBNull.Value);
+            cmd.Parameters.AddWithValue("$name", asset.Name);
+            cmd.Parameters.AddWithValue("$serial", (object?)asset.SerialNumber ?? DBNull.Value);
+            if (asset.AssignedUserId.HasValue)
+                cmd.Parameters.AddWithValue("$user", asset.AssignedUserId.Value);
+            else
+                cmd.Parameters.AddWithValue("$user", DBNull.Value);
+            if (asset.DepartmentId.HasValue)
+                cmd.Parameters.AddWithValue("$dept", asset.DepartmentId.Value);
+            else
+                cmd.Parameters.AddWithValue("$dept", DBNull.Value);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            if (asset.AssetId == 0)
+                asset.AssetId = (int)conn.LastInsertRowId;
+        }
+
+        public async Task DeleteAssetAsync(int assetId, CancellationToken cancellationToken = default)
+        {
+            using var conn = _db.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "DELETE FROM Assets WHERE AssetId=$id";
+            cmd.Parameters.AddWithValue("$id", assetId);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/DeviceManagementApp/Services/DatabaseService.cs
+++ b/DeviceManagementApp/Services/DatabaseService.cs
@@ -207,7 +207,25 @@ namespace DeviceManagementApp.Services
                     Name TEXT NOT NULL,
                     Version TEXT,
                     PRIMARY KEY (DeviceIp, DevicePort, Name)
-                );";
+                );
+                CREATE TABLE IF NOT EXISTS Assets (
+                    AssetId INTEGER PRIMARY KEY AUTOINCREMENT,
+                    Name TEXT NOT NULL,
+                    SerialNumber TEXT,
+                    AssignedUserId INTEGER,
+                    DepartmentId INTEGER,
+                    FOREIGN KEY (AssignedUserId) REFERENCES Users(UserID)
+                );
+                CREATE TABLE IF NOT EXISTS AssetAssignments (
+                    AssetId INTEGER NOT NULL,
+                    UserId INTEGER NOT NULL,
+                    AssignedDate DATETIME NOT NULL,
+                    ReturnedDate DATETIME,
+                    DepartmentId INTEGER,
+                    PRIMARY KEY (AssetId, AssignedDate),
+                    FOREIGN KEY (UserId) REFERENCES Users(UserID),
+                    FOREIGN KEY (AssetId) REFERENCES Assets(AssetId)
+                );"
             using var cmd = new SqliteCommand(sql, conn);
             cmd.ExecuteNonQuery();
             EnsureColumn("Devices", "Port", "INTEGER");
@@ -218,6 +236,11 @@ namespace DeviceManagementApp.Services
             EnsureColumn("Devices", "MemoryGb", "INTEGER");
             EnsureColumn("Devices", "StorageGb", "INTEGER");
             EnsureColumn("Devices", "OperatingSystem", "TEXT");
+            EnsureColumn("Assets", "SerialNumber", "TEXT");
+            EnsureColumn("Assets", "AssignedUserId", "INTEGER");
+            EnsureColumn("Assets", "DepartmentId", "INTEGER");
+            EnsureColumn("AssetAssignments", "ReturnedDate", "DATETIME");
+            EnsureColumn("AssetAssignments", "DepartmentId", "INTEGER");
             EnsureColumn("DeviceAssignments", "ReturnedDate", "DATETIME");
             EnsureColumn("DeviceAssignments", "DepartmentId", "INTEGER");
 
@@ -232,6 +255,9 @@ namespace DeviceManagementApp.Services
             EnsureIndex(conn, "Users", "UserName", true);
             EnsureIndex(conn, "Customers", "Contact");
             EnsureIndex(conn, "Rentals", new[] { "ItemID", "CustomerID" });
+            EnsureIndex(conn, "Assets", "Name");
+            EnsureIndex(conn, "Assets", "AssignedUserId");
+            EnsureIndex(conn, "AssetAssignments", "AssetId");
             EnsureIndex(conn, "Devices", "ItemId");
             EnsureIndex(conn, "Devices", "AssignedUserId");
             EnsureIndex(conn, "Devices", "DepartmentId");

--- a/DeviceManagementApp/ViewModels/AssetsViewModel.cs
+++ b/DeviceManagementApp/ViewModels/AssetsViewModel.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Windows.Data;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DeviceManagementApp.Interfaces;
+using DeviceManagementApp.Models;
+
+namespace DeviceManagementApp.ViewModels
+{
+    public class AssetsViewModel : ObservableObject
+    {
+        readonly IAssetService _assetService;
+        readonly IAssetAssignmentService _assignmentService;
+        readonly IDialogService _dialogService;
+        readonly IStaffService _staffService;
+
+        public ObservableCollection<Asset> Assets { get; } = new();
+        public ObservableCollection<KeyValuePair<int?, string>> Staff { get; } = new() { new(null, "All Staff") };
+
+        public ICollectionView AssetsView { get; }
+
+        private Asset? _selectedAsset;
+        public Asset? SelectedAsset
+        {
+            get => _selectedAsset;
+            set
+            {
+                if (SetProperty(ref _selectedAsset, value))
+                {
+                    DeleteAssetCommand.NotifyCanExecuteChanged();
+                    AssignAssetCommand.NotifyCanExecuteChanged();
+                    ReturnAssetCommand.NotifyCanExecuteChanged();
+                }
+            }
+        }
+
+
+        private int? _assignedUserFilter;
+        public int? AssignedUserFilter
+        {
+            get => _assignedUserFilter;
+            set { SetProperty(ref _assignedUserFilter, value); AssetsView.Refresh(); }
+        }
+
+        public IAsyncRelayCommand RefreshCommand { get; }
+        public IAsyncRelayCommand AddAssetCommand { get; }
+        public IAsyncRelayCommand DeleteAssetCommand { get; }
+        public IAsyncRelayCommand AssignAssetCommand { get; }
+        public IAsyncRelayCommand ReturnAssetCommand { get; }
+
+        public AssetsViewModel(IAssetService assetService, IAssetAssignmentService assignmentService, IDialogService dialogService, IStaffService staffService)
+        {
+            _assetService = assetService;
+            _assignmentService = assignmentService;
+            _dialogService = dialogService;
+            _staffService = staffService;
+            AssetsView = CollectionViewSource.GetDefaultView(Assets);
+            AssetsView.Filter = FilterAsset;
+            RefreshCommand = new AsyncRelayCommand(LoadAssetsAsync);
+            AddAssetCommand = new AsyncRelayCommand(AddAssetAsync);
+            DeleteAssetCommand = new AsyncRelayCommand(DeleteAssetAsync, () => SelectedAsset != null);
+            AssignAssetCommand = new AsyncRelayCommand(AssignAssetAsync, () => SelectedAsset != null);
+            ReturnAssetCommand = new AsyncRelayCommand(ReturnAssetAsync, () => SelectedAsset != null && SelectedAsset.AssignedUserId != null);
+        }
+
+        async Task LoadAssetsAsync()
+        {
+            Assets.Clear();
+            foreach (var d in await _assetService.GetAssetsAsync())
+                Assets.Add(d);
+            Staff.Clear();
+            Staff.Add(new(null, "All Staff"));
+            foreach (var s in await _staffService.GetStaffAsync())
+                Staff.Add(new(s.StaffId, s.Name));
+        }
+
+        async Task AddAssetAsync()
+        {
+            var asset = new Asset { Name = "New Asset" };
+            await _assetService.AddOrUpdateAssetAsync(asset);
+            Assets.Add(asset);
+        }
+
+        async Task DeleteAssetAsync()
+        {
+            if (SelectedAsset == null) return;
+            await _assetService.DeleteAssetAsync(SelectedAsset.AssetId);
+            Assets.Remove(SelectedAsset);
+        }
+
+        async Task AssignAssetAsync()
+        {
+            if (SelectedAsset == null || SelectedAsset.AssignedUserId == null) return;
+            var assignment = new AssetAssignment
+            {
+                AssetId = SelectedAsset.AssetId,
+                UserId = SelectedAsset.AssignedUserId.Value,
+                AssignedDate = DateTime.UtcNow,
+                DepartmentId = SelectedAsset.DepartmentId
+            };
+            await _assignmentService.AssignAsync(assignment);
+            ReturnAssetCommand.NotifyCanExecuteChanged();
+        }
+
+        async Task ReturnAssetAsync()
+        {
+            if (SelectedAsset == null) return;
+            await _assignmentService.ReturnAsync(SelectedAsset.AssetId);
+            SelectedAsset.AssignedUserId = null;
+            SelectedAsset.DepartmentId = null;
+            ReturnAssetCommand.NotifyCanExecuteChanged();
+            AssignAssetCommand.NotifyCanExecuteChanged();
+            AssetsView.Refresh();
+        }
+
+        bool FilterAsset(object obj)
+        {
+            if (obj is not Asset a) return false;
+            if (AssignedUserFilter.HasValue && a.AssignedUserId != AssignedUserFilter) return false;
+            return true;
+        }
+    }
+}

--- a/DeviceManagementApp/ViewModels/DashboardViewModel.cs
+++ b/DeviceManagementApp/ViewModels/DashboardViewModel.cs
@@ -16,6 +16,7 @@ namespace DeviceManagementApp.ViewModels
         readonly IDeviceService _deviceService;
         readonly INavigationService _navigationService;
         readonly DevicesViewModel _devicesViewModel;
+        readonly IAssetService _assetService;
 
         public ObservableCollection<StatCard> StatCards { get; } = new();
         public ObservableCollection<Device> AssignedDevices { get; } = new();
@@ -25,11 +26,12 @@ namespace DeviceManagementApp.ViewModels
         public IRelayCommand AssignDeviceCommand { get; }
         public IRelayCommand AssignDeviceInListCommand { get; }
 
-        public DashboardViewModel(IDeviceService deviceService, INavigationService navigationService, DevicesViewModel devicesViewModel)
+        public DashboardViewModel(IDeviceService deviceService, INavigationService navigationService, DevicesViewModel devicesViewModel, IAssetService assetService)
         {
             _deviceService = deviceService;
             _navigationService = navigationService;
             _devicesViewModel = devicesViewModel;
+            _assetService = assetService;
             NewDeviceCommand = new RelayCommand(OpenDevices);
             AssignDeviceCommand = new RelayCommand(OpenDevices);
             AssignDeviceInListCommand = new RelayCommand<Device>(d =>
@@ -63,6 +65,14 @@ namespace DeviceManagementApp.ViewModels
             StatCards.Add(new StatCard { Title = "Total Devices", Value = list.Count.ToString() });
             StatCards.Add(new StatCard { Title = "Assigned Devices", Value = assigned.Count.ToString() });
             StatCards.Add(new StatCard { Title = "Unassigned Devices", Value = unassigned.Count.ToString() });
+
+            var assets = await _assetService.GetAssetsAsync(cancellationToken).ConfigureAwait(false);
+            var assetList = assets.ToList();
+            var assignedAssets = assetList.Where(a => a.AssignedUserId != null).ToList();
+            var unassignedAssets = assetList.Where(a => a.AssignedUserId == null).ToList();
+            StatCards.Add(new StatCard { Title = "Total Assets", Value = assetList.Count.ToString() });
+            StatCards.Add(new StatCard { Title = "Assigned Assets", Value = assignedAssets.Count.ToString() });
+            StatCards.Add(new StatCard { Title = "Unassigned Assets", Value = unassignedAssets.Count.ToString() });
         }
 
         public IRelayCommand ReturnDeviceCommand => new RelayCommand<Device>(d =>

--- a/DeviceManagementApp/ViewModels/MainViewModel.cs
+++ b/DeviceManagementApp/ViewModels/MainViewModel.cs
@@ -18,14 +18,16 @@ namespace DeviceManagementApp.ViewModels
         private readonly DashboardViewModel _dashboardViewModel;
         private readonly SettingsViewModel _settingsViewModel;
         private readonly StaffManagementViewModel _staffManagementViewModel;
+        private readonly AssetsViewModel _assetsViewModel;
 
-        public MainViewModel(INavigationService navigationService, DevicesViewModel devicesViewModel, DashboardViewModel dashboardViewModel, SettingsViewModel settingsViewModel, StaffManagementViewModel staffManagementViewModel)
+        public MainViewModel(INavigationService navigationService, DevicesViewModel devicesViewModel, DashboardViewModel dashboardViewModel, SettingsViewModel settingsViewModel, StaffManagementViewModel staffManagementViewModel, AssetsViewModel assetsViewModel)
         {
             _navigationService = navigationService;
             _devicesViewModel = devicesViewModel;
             _dashboardViewModel = dashboardViewModel;
             _settingsViewModel = settingsViewModel;
             _staffManagementViewModel = staffManagementViewModel;
+            _assetsViewModel = assetsViewModel;
             _devicesViewModel.ViewDetailsRequested += DevicesViewModel_ViewDetailsRequested;
 
             WindowTitle = "Device Management";
@@ -55,10 +57,18 @@ namespace DeviceManagementApp.ViewModels
         public string WindowTitle { get; }
 
         public IRelayCommand OpenDevicesCommand { get; }
+        public IRelayCommand OpenAssetsCommand { get; }
         public IRelayCommand OpenDashboardCommand { get; }
         public IRelayCommand OpenSettingsCommand { get; }
         public IRelayCommand OpenStaffCommand { get; }
         public IRelayCommand ExitCommand { get; }
+
+        private void OpenAssets()
+        {
+            var page = new AssetsPage { DataContext = _assetsViewModel };
+            CurrentPage = page;
+            CurrentPageTitle = "Assets";
+        }
 
         private void OpenDevices()
         {

--- a/DeviceManagementApp/Views/Pages/AssetsPage.xaml
+++ b/DeviceManagementApp/Views/Pages/AssetsPage.xaml
@@ -1,0 +1,22 @@
+<Page x:Class="DeviceManagementApp.Views.Pages.AssetsPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      Title="Assets">
+    <DockPanel>
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,8">
+            <Button Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,0,8,0"/>
+            <Button Content="Add" Command="{Binding AddAssetCommand}" Margin="0,0,8,0"/>
+            <Button Content="Delete" Command="{Binding DeleteAssetCommand}" Margin="0,0,8,0"/>
+            <Button Content="Assign" Command="{Binding AssignAssetCommand}" Margin="0,0,8,0"/>
+            <Button Content="Return" Command="{Binding ReturnAssetCommand}"/>
+        </StackPanel>
+        <DataGrid ItemsSource="{Binding AssetsView}" SelectedItem="{Binding SelectedAsset}" AutoGenerateColumns="False">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
+                <DataGridTextColumn Header="Serial" Binding="{Binding SerialNumber}" Width="*"/>
+                <DataGridTextColumn Header="Assigned User" Binding="{Binding AssignedUserId}" Width="*"/>
+                <DataGridTextColumn Header="Department" Binding="{Binding DepartmentId}" Width="*"/>
+            </DataGrid.Columns>
+        </DataGrid>
+    </DockPanel>
+</Page>

--- a/DeviceManagementApp/Views/Pages/AssetsPage.xaml.cs
+++ b/DeviceManagementApp/Views/Pages/AssetsPage.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace DeviceManagementApp.Views.Pages
+{
+    public partial class AssetsPage : Page
+    {
+        public AssetsPage()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- define Asset and AssetAssignment models and database tables
- add asset services, view model, and UI page with navigation
- track asset assignments in dashboard statistics

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden during package retrieval)*

------
https://chatgpt.com/codex/tasks/task_e_68be6854344c832494d98f3fce74c6c8