### PR TITLE
Refactor Clear button style in SearchBar

### DIFF
--- a/Shared/Controls/SearchBar.xaml
+++ b/Shared/Controls/SearchBar.xaml
@@ -14,12 +14,11 @@
                 Content="{Binding SearchLabel, ElementName=Root}"
                 Command="{Binding SearchCommand, ElementName=Root}"
                 Margin="8,0,0,0"/>
-        <Button Style="{StaticResource PrimaryButton}"
-                Content="Clear"
+        <Button Content="Clear"
                 Command="{Binding ClearCommand, ElementName=Root}"
                 Margin="8,0,0,0">
             <Button.Style>
-                <Style TargetType="Button">
+                <Style TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
                     <Setter Property="Visibility" Value="Visible"/>
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding ClearCommand, ElementName=Root}" Value="{x:Null}">


### PR DESCRIPTION
## Summary
- Remove direct style on Clear button in SearchBar and base its style on PrimaryButton resource

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68be72caf3f48324ab27e6f028b4f4f3