### PR TITLE
Fix user password creation and validation policy

### DIFF
--- a/InventoryManagementApp/Utilities/Helpers/PasswordValidator.cs
+++ b/InventoryManagementApp/Utilities/Helpers/PasswordValidator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 namespace InventoryManagementApp.Utilities.Helpers
 {
@@ -10,6 +11,30 @@ namespace InventoryManagementApp.Utilities.Helpers
             if (string.IsNullOrWhiteSpace(password))
             {
                 error = "Password cannot be empty.";
+                return false;
+            }
+
+            if (password.Length < 8)
+            {
+                error = "Password must be at least 8 characters long.";
+                return false;
+            }
+
+            if (!password.Any(char.IsUpper))
+            {
+                error = "Password must contain at least one uppercase letter.";
+                return false;
+            }
+
+            if (!password.Any(char.IsLower))
+            {
+                error = "Password must contain at least one lowercase letter.";
+                return false;
+            }
+
+            if (!password.Any(char.IsDigit))
+            {
+                error = "Password must contain at least one digit.";
                 return false;
             }
 

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -276,16 +276,14 @@ namespace InventoryManagementApp.ViewModels
 
             if (string.IsNullOrWhiteSpace(entered))
             {
-                var hash = SecurityHelper.HashPassword(PasswordDefaults.TemporaryPassword, out var salt);
-                newUser.PasswordHash = hash;
-                newUser.PasswordSalt = salt;
+                newUser.PasswordHash = PasswordDefaults.TemporaryPassword;
+                newUser.PasswordSalt = string.Empty;
                 newUser.PasswordExpired = true;
             }
             else
             {
-                var hash = SecurityHelper.HashPassword(entered, out var salt);
-                newUser.PasswordHash = hash;
-                newUser.PasswordSalt = salt;
+                newUser.PasswordHash = entered;
+                newUser.PasswordSalt = string.Empty;
             }
 
             try
@@ -299,9 +297,15 @@ namespace InventoryManagementApp.ViewModels
             {
                 await _dialogService.ShowInfoAsync("You are not authorized to add users.", "Unauthorized");
             }
+            catch (ArgumentException ex)
+            {
+                _logger.LogError(ex, "Failed to add user because the password is invalid");
+                await _dialogService.ShowInfoAsync(ex.Message, "Invalid Password");
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to add user");
+                await _dialogService.ShowInfoAsync($"Failed to add user: {ex.Message}", "Error");
             }
         }
 


### PR DESCRIPTION
### Motivation
- Admin-created users could be saved with a double-hashed password because `UserManagementViewModel` hashed the password before calling `UserService.AddUserAsync`, while `UserService` already expects plaintext and hashes it during persistence.
- `PasswordValidator` only rejected empty passwords even though the existing tests and documented policy require a minimum length plus uppercase, lowercase, and digit checks.

### Description
- Updated `UserManagementViewModel.AddUserAsync` to pass plaintext entered/default passwords into `UserService.AddUserAsync` and let the service remain the single hashing authority.
- Preserved temporary-password expiry behavior for users created without an entered password.
- Added user-facing error dialogs when add-user password validation fails or another add-user error occurs.
- Implemented the password complexity rules already covered by `PasswordValidatorTests`.

### Testing
- Reviewed the branch diff against `master`; only `UserManagementViewModel.cs` and `PasswordValidator.cs` changed.
- Confirmed `PasswordValidator.cs` now satisfies the existing `PasswordValidatorTests` expectations by inspection.
- Attempted to run `.NET` validation, but this environment does not have the .NET SDK installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/scheduled-toolmanagementappv2-2026-06-15)