### PR TITLE
Improve user management failure feedback

### DIFF
--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -442,7 +442,13 @@ namespace InventoryManagementApp.ViewModels
             var newPassword = PasswordDefaults.TemporaryPassword;
             try
             {
-                await _userService.ChangeUserPasswordAsync(user.UserID, newPassword);
+                var changed = await _userService.ChangeUserPasswordAsync(user.UserID, newPassword);
+                if (!changed)
+                {
+                    await _dialogService.ShowInfoAsync("Failed to reset password.", "Error");
+                    return;
+                }
+
                 var refreshed = await _userService.GetUserByIDAsync(user.UserID, CancellationToken.None);
                 if (refreshed != null)
                 {
@@ -459,6 +465,16 @@ namespace InventoryManagementApp.ViewModels
             catch (UnauthorizedAccessException)
             {
                 await _dialogService.ShowInfoAsync("You are not authorized to reset passwords.", "Unauthorized");
+            }
+            catch (ArgumentException ex)
+            {
+                _logger.LogError(ex, "Failed to reset password because the default password is invalid");
+                await _dialogService.ShowInfoAsync(ex.Message, "Invalid Password");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to reset password for user {UserID}", user.UserID);
+                await _dialogService.ShowInfoAsync($"Failed to reset password: {ex.Message}", "Error");
             }
         }
 
@@ -487,6 +503,7 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to delete user {UserID}", user.UserID);
+                await _dialogService.ShowInfoAsync($"Failed to delete user: {ex.Message}", "Error");
             }
         }
 


### PR DESCRIPTION
## Summary
- Show an admin-facing error when a password reset service call returns `false` instead of continuing as if it succeeded.
- Surface invalid default password and unexpected reset failures through the dialog service.
- Surface unexpected delete-user failures through the dialog service instead of only logging them.

## Validation
- Reviewed the diff against `master`; change is limited to `UserManagementViewModel` failure handling.
- Could not run `dotnet test` in this scheduled environment because the .NET SDK is not installed (`dotnet: command not found`).