### PR TITLE
Apply desktop section shell to settings page

### DIFF
--- a/InventoryManagementApp/Resources/DesktopPageShellResources.xaml
+++ b/InventoryManagementApp/Resources/DesktopPageShellResources.xaml
@@ -1,0 +1,39 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style x:Key="DesktopSectionListTabControl" TargetType="TabControl" BasedOn="{StaticResource {x:Type TabControl}}">
+        <Setter Property="TabStripPlacement" Value="Left"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+        <Setter Property="Padding" Value="0"/>
+    </Style>
+
+    <Style x:Key="DesktopSectionListTabItem" TargetType="TabItem" BasedOn="{StaticResource {x:Type TabItem}}">
+        <Setter Property="Width" Value="184"/>
+        <Setter Property="MinHeight" Value="27"/>
+        <Setter Property="Padding" Value="8,3"/>
+        <Setter Property="Margin" Value="0,0,0,2"/>
+        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="FontSize" Value="12"/>
+    </Style>
+
+    <Style x:Key="DesktopContentPane" TargetType="Border" BasedOn="{StaticResource Card}">
+        <Setter Property="Padding" Value="0"/>
+        <Setter Property="Margin" Value="4,0,0,0"/>
+    </Style>
+
+    <Style x:Key="DesktopSectionActionStrip" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="0,0,0,1"/>
+        <Setter Property="Padding" Value="4"/>
+    </Style>
+
+    <Style x:Key="DesktopSettingsForm" TargetType="Grid">
+        <Setter Property="Margin" Value="8"/>
+    </Style>
+
+    <Style x:Key="DesktopSettingsCheckList" TargetType="ItemsControl">
+        <Setter Property="Margin" Value="6,0,0,0"/>
+    </Style>
+</ResourceDictionary>

--- a/InventoryManagementApp/Views/Pages/SettingsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/SettingsPage.xaml
@@ -4,37 +4,58 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       Background="{DynamicResource BackgroundBrush}">
 
-    <ScrollViewer>
-        <StackPanel Margin="0" Orientation="Vertical">
-            <Border Style="{StaticResource Card}" Padding="8" Margin="0,0,0,6">
-                <StackPanel Orientation="Vertical">
-                    <TextBlock Text="Database" Style="{StaticResource SectionHeader}"/>
-                    <Grid Margin="0,6,0,0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="200"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Text="Connection String"
-                                   Style="{StaticResource LabelTextBlock}"
-                                   VerticalAlignment="Center"/>
-                        <TextBox Grid.Column="1"
-                                 Text="{Binding ConnectionString}"
-                                 Margin="6,0,6,0"/>
-                        <Button Grid.Column="2"
-                                Style="{StaticResource PrimaryButton}"
-                                Content="Test"
-                                Command="{Binding TestDbCommand}"/>
-                    </Grid>
-                </StackPanel>
-            </Border>
+    <Grid Margin="0">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
 
-            <Border Style="{StaticResource Card}" Padding="8" Margin="0,0,0,6">
-                <StackPanel Orientation="Vertical">
-                    <TextBlock Text="General" Style="{StaticResource SectionHeader}"/>
-                    <Grid>
+        <Border Style="{StaticResource ToolbarCard}">
+            <DockPanel LastChildFill="False">
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
+                    <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Test DB" Command="{Binding TestDbCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Test Email" Command="{Binding TestEmailCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Save Email" Command="{Binding SaveEmailSettingsCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Save Messaging" Command="{Binding SaveMessagingSettingsCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Save Backup" Command="{Binding SaveBackupSettingsCommand}"/>
+                </StackPanel>
+                <TextBlock DockPanel.Dock="Right"
+                           Text="Settings apply to local workstation behavior and shared service configuration."
+                           Style="{StaticResource CaptionTextBlock}"
+                           VerticalAlignment="Center"/>
+            </DockPanel>
+        </Border>
+
+        <TabControl Grid.Row="1"
+                    Style="{StaticResource DesktopSectionListTabControl}"
+                    ItemContainerStyle="{StaticResource DesktopSectionListTabItem}">
+            <TabItem Header="01 Database">
+                <Border Style="{StaticResource DesktopContentPane}">
+                    <DockPanel>
+                        <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Test" Command="{Binding TestDbCommand}"/>
+                            </StackPanel>
+                        </Border>
+                        <Grid Style="{StaticResource DesktopSettingsForm}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="170"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="Connection String" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                            <TextBox Grid.Column="1" Text="{Binding ConnectionString}" Margin="6,0,0,0"/>
+                        </Grid>
+                    </DockPanel>
+                </Border>
+            </TabItem>
+
+            <TabItem Header="02 General">
+                <Border Style="{StaticResource DesktopContentPane}">
+                    <Grid Style="{StaticResource DesktopSettingsForm}">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="200"/>
+                            <ColumnDefinition Width="170"/>
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
@@ -45,145 +66,108 @@
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
                         <TextBlock Text="Theme" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <ComboBox Grid.Column="1" SelectedItem="{Binding Theme}" ItemsSource="{Binding ThemeOptions}" Margin="6,0,0,0" ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
+                        <ComboBox Grid.Column="1" SelectedItem="{Binding Theme}" ItemsSource="{Binding ThemeOptions}" Margin="6,0,0,4" ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
                         <TextBlock Grid.Row="1" Text="Password Iterations" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding PasswordIterations}" Margin="6,0,0,0" PreviewTextInput="PasswordIterationsBox_PreviewTextInput"/>
+                        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding PasswordIterations}" Margin="6,0,0,4" PreviewTextInput="PasswordIterationsBox_PreviewTextInput"/>
                         <TextBlock Grid.Row="2" Text="Auto-logout (minutes)" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding AutoLogoutMinutes}" Margin="6,0,0,0" PreviewTextInput="AutoLogoutMinutesBox_PreviewTextInput"/>
+                        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding AutoLogoutMinutes}" Margin="6,0,0,4" PreviewTextInput="AutoLogoutMinutesBox_PreviewTextInput"/>
                         <TextBlock Grid.Row="3" Text="Item name (singular)" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding ItemLabelSingular}" Margin="6,0,0,0"
-                                 ToolTip="Used for buttons like 'New Item' and 'Rent Item'"/>
-                        <TextBlock Grid.Row="4"
-                                   Text="Item name (plural)"
-                                   Style="{StaticResource LabelTextBlock}"
-                                   VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="4"
-                                 Grid.Column="1"
-                                 Text="{Binding ItemLabelPlural}"
-                                 Margin="6,0,0,0"
-                                 ToolTip="Used for navigation and import/export pages"/>
+                        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding ItemLabelSingular}" Margin="6,0,0,4"/>
+                        <TextBlock Grid.Row="4" Text="Item name (plural)" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                        <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding ItemLabelPlural}" Margin="6,0,0,0"/>
                     </Grid>
-                </StackPanel>
-            </Border>
+                </Border>
+            </TabItem>
 
-            <Border Style="{StaticResource Card}" Padding="8" Margin="0,0,0,6">
-                <StackPanel Orientation="Vertical">
-                    <TextBlock Text="Item Display" Style="{StaticResource SectionHeader}"/>
-                    <TextBlock Text="Choose which fields appear in search results and management grids." Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,6"/>
-                    <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                        <Button Style="{StaticResource PrimaryButton}" Content="Select All" Command="{Binding SelectAllItemDisplayCommand}" Margin="0,0,8,0"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Select None" Command="{Binding SelectNoneItemDisplayCommand}"/>
-                    </StackPanel>
-                    <ItemsControl ItemsSource="{Binding ItemDetailOptions}" Margin="0,6,0,0">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <CheckBox Content="{Binding Field}" IsChecked="{Binding IsVisible, Mode=TwoWay}"/>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-                </StackPanel>
-            </Border>
+            <TabItem Header="03 Item Display">
+                <Border Style="{StaticResource DesktopContentPane}">
+                    <DockPanel>
+                        <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Bulk Edit" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Select All" Command="{Binding SelectAllItemDisplayCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Select None" Command="{Binding SelectNoneItemDisplayCommand}"/>
+                            </StackPanel>
+                        </Border>
+                        <ScrollViewer>
+                            <ItemsControl ItemsSource="{Binding ItemDetailOptions}" Style="{StaticResource DesktopSettingsCheckList}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <CheckBox Content="{Binding Field}" IsChecked="{Binding IsVisible, Mode=TwoWay}" Margin="0,2,0,0"/>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
+                    </DockPanel>
+                </Border>
+            </TabItem>
 
-            <Border Style="{StaticResource Card}" Padding="8" Margin="0,0,0,6">
-                <StackPanel Orientation="Vertical">
-                    <TextBlock Text="Email Configuration (Rental Reminders)" Style="{StaticResource SectionHeader}"/>
-                    <TextBlock Text="Configure email settings for automated rental reminder emails. Enable on server instance, disable on client instances." 
-                               TextWrapping="Wrap" Margin="0,4,0,6" Opacity="0.7" FontSize="12"/>
-                    
-                    <Grid>
+            <TabItem Header="04 Email">
+                <Border Style="{StaticResource DesktopContentPane}">
+                    <DockPanel>
+                        <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Test Email" Command="{Binding TestEmailCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Save Email Settings" Command="{Binding SaveEmailSettingsCommand}"/>
+                            </StackPanel>
+                        </Border>
+                        <ScrollViewer>
+                            <Grid Style="{StaticResource DesktopSettingsForm}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="170"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <TextBlock Text="Enable Email Reminders" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" IsChecked="{Binding EmailEnabled}" Margin="6,0,0,4"/>
+                                <TextBlock Grid.Row="1" Text="Email Provider" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                                <ComboBox Grid.Row="1" Grid.Column="1" SelectedItem="{Binding SelectedEmailProvider}" ItemsSource="{Binding EmailProviders}" Margin="6,0,0,4" ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
+                                <TextBlock Grid.Row="2" Text="SMTP Host" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                                <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding SmtpHost}" Margin="6,0,0,4"/>
+                                <TextBlock Grid.Row="3" Text="SMTP Port" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                                <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding SmtpPort}" Margin="6,0,0,4"/>
+                                <TextBlock Grid.Row="4" Text="Username" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                                <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding SmtpUsername}" Margin="6,0,0,4"/>
+                                <TextBlock Grid.Row="5" Text="Password" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                                <PasswordBox Grid.Row="5" Grid.Column="1" x:Name="SmtpPasswordBox" Margin="6,0,0,4" PasswordChanged="SmtpPasswordBox_PasswordChanged"/>
+                                <TextBlock Grid.Row="6" Text="From Email" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                                <StackPanel Grid.Row="6" Grid.Column="1" Orientation="Horizontal" Margin="6,0,0,4">
+                                    <ComboBox Width="280" ItemsSource="{Binding FromEmailOptions}" SelectedItem="{Binding SelectedFromEmail}" ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Remove" Command="{Binding RemoveFromEmailCommand}" Margin="6,0,0,0"/>
+                                </StackPanel>
+                                <TextBlock Grid.Row="7" Text="Add Sender Email" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                                <StackPanel Grid.Row="7" Grid.Column="1" Orientation="Horizontal" Margin="6,0,0,4">
+                                    <TextBox Width="280" Text="{Binding NewFromEmail}"/>
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddFromEmailCommand}" Margin="6,0,0,0"/>
+                                </StackPanel>
+                                <TextBlock Grid.Row="8" Text="From Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                                <TextBox Grid.Row="8" Grid.Column="1" Text="{Binding FromName}" Margin="6,0,0,4"/>
+                                <TextBlock Grid.Row="9" Text="Enable SSL/TLS" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Row="9" Grid.Column="1" IsChecked="{Binding EnableSsl}" Margin="6,0,0,0"/>
+                            </Grid>
+                        </ScrollViewer>
+                    </DockPanel>
+                </Border>
+            </TabItem>
+
+            <TabItem Header="05 Branding">
+                <Border Style="{StaticResource DesktopContentPane}">
+                    <Grid Style="{StaticResource DesktopSettingsForm}">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="200"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
-
-                        <TextBlock Text="Enable Email Reminders" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <CheckBox Grid.Column="1" IsChecked="{Binding EmailEnabled}" Margin="6,0,0,6"
-                                  ToolTip="Enable on server instance, disable on client instances"/>
-
-                        <TextBlock Grid.Row="1" Text="Email Provider" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <ComboBox Grid.Row="1" Grid.Column="1" SelectedItem="{Binding SelectedEmailProvider}" 
-                                  ItemsSource="{Binding EmailProviders}" Margin="6,0,0,6" 
-                                  ItemContainerStyle="{StaticResource DropdownItemStyle}"
-                                  ToolTip="Select a provider for auto-configuration or choose Custom"/>
-
-                        <TextBlock Grid.Row="2" Text="SMTP Host" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding SmtpHost}" Margin="6,0,0,6"
-                                 ToolTip="SMTP server address (e.g., smtp.gmail.com)"/>
-
-                        <TextBlock Grid.Row="3" Text="SMTP Port" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding SmtpPort}" Margin="6,0,0,6"
-                                 ToolTip="SMTP port (usually 587 for TLS)"/>
-
-                        <TextBlock Grid.Row="4" Text="Username" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding SmtpUsername}" Margin="6,0,0,6"
-                                 ToolTip="Email account username"/>
-
-                        <TextBlock Grid.Row="5" Text="Password" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <PasswordBox Grid.Row="5" Grid.Column="1" x:Name="SmtpPasswordBox" Margin="6,0,0,6"
-                                     ToolTip="Email account password"
-                                     PasswordChanged="SmtpPasswordBox_PasswordChanged"/>
-
-                        <TextBlock Grid.Row="6" Text="From Email" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <StackPanel Grid.Row="6" Grid.Column="1" Orientation="Horizontal" Margin="6,0,0,6">
-                            <ComboBox Width="280"
-                                      ItemsSource="{Binding FromEmailOptions}"
-                                      SelectedItem="{Binding SelectedFromEmail}"
-                                      ItemContainerStyle="{StaticResource DropdownItemStyle}"
-                                      ToolTip="Select the sender email address"/>
-                            <Button Style="{StaticResource PrimaryButton}"
-                                    Content="Remove"
-                                    Command="{Binding RemoveFromEmailCommand}"
-                                    Margin="6,0,0,0"
-                                    ToolTip="Remove the selected sender email"/>
-                        </StackPanel>
-
-                        <TextBlock Grid.Row="7" Text="Add Sender Email" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <StackPanel Grid.Row="7" Grid.Column="1" Orientation="Horizontal" Margin="6,0,0,6">
-                            <TextBox Width="280"
-                                     Text="{Binding NewFromEmail}"
-                                     ToolTip="Add a sender email address"/>
-                            <Button Style="{StaticResource PrimaryButton}"
-                                    Content="Add"
-                                    Command="{Binding AddFromEmailCommand}"
-                                    Margin="6,0,0,0"/>
-                        </StackPanel>
-
-                        <TextBlock Grid.Row="8" Text="From Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="8" Grid.Column="1" Text="{Binding FromName}" Margin="6,0,0,6"
-                                 ToolTip="Display name for outgoing emails"/>
-
-                        <TextBlock Grid.Row="9" Text="Enable SSL/TLS" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <CheckBox Grid.Row="9" Grid.Column="1" IsChecked="{Binding EnableSsl}" Margin="6,0,0,6"
-                                  ToolTip="Recommended: Keep enabled for secure connection"/>
-                    </Grid>
-
-                    <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                        <Button Style="{StaticResource PrimaryButton}" Content="Test Email" Command="{Binding TestEmailCommand}" Margin="0,0,8,0"
-                                ToolTip="Send a test email to verify configuration"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Save Email Settings" Command="{Binding SaveEmailSettingsCommand}"
-                                ToolTip="Save email configuration (restart required)"/>
-                    </StackPanel>
-                </StackPanel>
-            </Border>
-
-            <Border Style="{StaticResource Card}" Padding="8">
-                <StackPanel Orientation="Vertical">
-                    <TextBlock Text="Branding" Style="{StaticResource SectionHeader}"/>
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="200"/>
+                            <ColumnDefinition Width="170"/>
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="Auto"/>
@@ -192,87 +176,73 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
-
                         <TextBlock Text="Application Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding ApplicationName}" Margin="6,0,0,6"/>
-
+                        <TextBox Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding ApplicationName}" Margin="6,0,0,4"/>
                         <TextBlock Grid.Row="1" Text="Company Logo" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-
-                        <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal">
-                            <Border Width="64" Height="64" CornerRadius="6" Background="{DynamicResource SurfaceAltBrush}" Margin="6,0,6,0">
-                                <Image Width="64" Height="64"
-                                       Source="{Binding CompanyLogoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=logo}"
-                                       Stretch="Uniform" ClipToBounds="True"/>
+                        <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal" Margin="6,0,0,0">
+                            <Border Width="44" Height="44" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Margin="0,0,6,0">
+                                <Image Width="44" Height="44" Source="{Binding CompanyLogoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=logo}" Stretch="Uniform" ClipToBounds="True"/>
                             </Border>
-                            <TextBlock Text="{Binding CompanyLogoPath}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+                            <TextBlock Text="{Binding CompanyLogoPath}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
                         </StackPanel>
-
-                        <Button Grid.Row="1" Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Change Logo" Command="{Binding BrowseCompanyLogoCommand}" Margin="6,0,6,0"/>
-                        <Button Grid.Row="1" Grid.Column="3" Style="{StaticResource PrimaryButton}" Content="Save Logo" Command="{Binding SaveCompanyLogoCommand}" />
+                        <Button Grid.Row="1" Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Change Logo" Command="{Binding BrowseCompanyLogoCommand}" Margin="6,0,4,0"/>
+                        <Button Grid.Row="1" Grid.Column="3" Style="{StaticResource PrimaryButton}" Content="Save Logo" Command="{Binding SaveCompanyLogoCommand}"/>
                     </Grid>
-                </StackPanel>
-            </Border>
+                </Border>
+            </TabItem>
 
-            <Border Style="{StaticResource Card}" Padding="8" Margin="0,6,0,0">
-                <StackPanel Orientation="Vertical">
-                    <TextBlock Text="Messaging (SMS)" Style="{StaticResource SectionHeader}"/>
-                    <Grid Margin="0,6,0,0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="200"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
+            <TabItem Header="06 Messaging">
+                <Border Style="{StaticResource DesktopContentPane}">
+                    <DockPanel>
+                        <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Save Messaging Settings" Command="{Binding SaveMessagingSettingsCommand}"/>
+                            </StackPanel>
+                        </Border>
+                        <Grid Style="{StaticResource DesktopSettingsForm}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="170"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Text="Provider" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                            <ComboBox Grid.Column="1" ItemsSource="{Binding SmsProviders}" SelectedItem="{Binding SelectedSmsProvider}" Margin="6,0,0,4" ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
+                            <TextBlock Grid.Row="1" Text="Sender ID/Number" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding SmsSender}" Margin="6,0,0,4"/>
+                            <TextBlock Grid.Row="2" Text="API Key" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                            <PasswordBox Grid.Row="2" Grid.Column="1" x:Name="SmsApiKeyBox" Margin="6,0,0,0" PasswordChanged="SmsApiKeyBox_PasswordChanged"/>
+                        </Grid>
+                    </DockPanel>
+                </Border>
+            </TabItem>
 
-                        <TextBlock Text="Provider" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <ComboBox Grid.Column="1"
-                                  ItemsSource="{Binding SmsProviders}"
-                                  SelectedItem="{Binding SelectedSmsProvider}"
-                                  Margin="6,0,0,6"
-                                  ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
-
-                        <TextBlock Grid.Row="1" Text="Sender ID/Number" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding SmsSender}" Margin="6,0,0,6"
-                                 ToolTip="Sender ID or phone number used for outgoing SMS"/>
-
-                        <TextBlock Grid.Row="2" Text="API Key" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <PasswordBox Grid.Row="2" Grid.Column="1" x:Name="SmsApiKeyBox" Margin="6,0,0,6"
-                                     ToolTip="API key or token for the SMS provider"
-                                     PasswordChanged="SmsApiKeyBox_PasswordChanged"/>
-                    </Grid>
-
-                    <Button Style="{StaticResource PrimaryButton}"
-                            Content="Save Messaging Settings"
-                            Command="{Binding SaveMessagingSettingsCommand}"
-                            Margin="0,6,0,0"/>
-                </StackPanel>
-            </Border>
-
-            <Border Style="{StaticResource Card}" Padding="8" Margin="0,6,0,0">
-                <StackPanel Orientation="Vertical">
-                    <TextBlock Text="Backups" Style="{StaticResource SectionHeader}"/>
-                    <Grid Margin="0,6,0,0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="200"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-
-                        <TextBlock Text="Backup Folder" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Column="1" Text="{Binding BackupDirectory}" Margin="6,0,6,0"
-                                 ToolTip="Default folder for database backups"/>
-                        <Button Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Browse"
-                                Command="{Binding BrowseBackupDirectoryCommand}" Margin="0,0,8,0"/>
-                        <Button Grid.Column="3" Style="{StaticResource PrimaryButton}" Content="Save"
-                                Command="{Binding SaveBackupSettingsCommand}"/>
-                    </Grid>
-                </StackPanel>
-            </Border>
-        </StackPanel>
-    </ScrollViewer>
+            <TabItem Header="07 Backups">
+                <Border Style="{StaticResource DesktopContentPane}">
+                    <DockPanel>
+                        <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Save" Command="{Binding SaveBackupSettingsCommand}"/>
+                            </StackPanel>
+                        </Border>
+                        <Grid Style="{StaticResource DesktopSettingsForm}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="170"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="Backup Folder" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                            <TextBox Grid.Column="1" Text="{Binding BackupDirectory}" Margin="6,0,4,0"/>
+                            <Button Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Browse" Command="{Binding BrowseBackupDirectoryCommand}"/>
+                        </Grid>
+                    </DockPanel>
+                </Border>
+            </TabItem>
+        </TabControl>
+    </Grid>
 </Page>
-

--- a/InventoryManagementApp/Views/Pages/SettingsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/SettingsPage.xaml
@@ -28,9 +28,8 @@
         </Border>
 
         <TabControl Grid.Row="1"
-                    Style="{StaticResource DesktopSectionListTabControl}"
-                    ItemContainerStyle="{StaticResource DesktopSectionListTabItem}">
-            <TabItem Header="01 Database">
+                    Style="{StaticResource DesktopSectionListTabControl}">
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="01 Database">
                 <Border Style="{StaticResource DesktopContentPane}">
                     <DockPanel>
                         <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
@@ -51,7 +50,7 @@
                 </Border>
             </TabItem>
 
-            <TabItem Header="02 General">
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="02 General">
                 <Border Style="{StaticResource DesktopContentPane}">
                     <Grid Style="{StaticResource DesktopSettingsForm}">
                         <Grid.ColumnDefinitions>
@@ -79,7 +78,7 @@
                 </Border>
             </TabItem>
 
-            <TabItem Header="03 Item Display">
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="03 Item Display">
                 <Border Style="{StaticResource DesktopContentPane}">
                     <DockPanel>
                         <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
@@ -102,7 +101,7 @@
                 </Border>
             </TabItem>
 
-            <TabItem Header="04 Email">
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="04 Email">
                 <Border Style="{StaticResource DesktopContentPane}">
                     <DockPanel>
                         <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
@@ -163,7 +162,7 @@
                 </Border>
             </TabItem>
 
-            <TabItem Header="05 Branding">
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="05 Branding">
                 <Border Style="{StaticResource DesktopContentPane}">
                     <Grid Style="{StaticResource DesktopSettingsForm}">
                         <Grid.ColumnDefinitions>
@@ -191,7 +190,7 @@
                 </Border>
             </TabItem>
 
-            <TabItem Header="06 Messaging">
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="06 Messaging">
                 <Border Style="{StaticResource DesktopContentPane}">
                     <DockPanel>
                         <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
@@ -221,7 +220,7 @@
                 </Border>
             </TabItem>
 
-            <TabItem Header="07 Backups">
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="07 Backups">
                 <Border Style="{StaticResource DesktopContentPane}">
                     <DockPanel>
                         <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">


### PR DESCRIPTION
## Summary
- Adds the missing `DesktopPageShellResources.xaml` dictionary already referenced by `App.xaml` so the desktop shell resources resolve at startup.
- Converts the Settings screen from a long stack of section cards into the shared desktop page pattern: compact top toolbar, numbered left section selector, right-side content pane, and thin section action strips.
- Keeps settings forms dense and aligned with standard WPF-style controls.

## Validation
- Checked the changed XAML locally with Python XML parsing for well-formed markup.
- Not run locally: this scheduled environment does not have the .NET SDK installed and direct repository cloning is blocked.