### PR TITLE
Split rentals workflow into search and checked-out panes

### DIFF
--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Documents;
@@ -26,6 +27,10 @@ namespace InventoryManagementApp.ViewModels
         private List<RentalModel> _allRentals = new();
 
         public ObservableCollection<RentalModel> Rentals { get; } = new();
+        public ObservableCollection<RentalModel> ActiveRentals { get; } = new();
+
+        public string SearchSummary => $"{Rentals.Count} result{(Rentals.Count == 1 ? string.Empty : "s")} shown";
+        public string CheckedOutSummary => $"{ActiveRentals.Count} tool{(ActiveRentals.Count == 1 ? string.Empty : "s")} currently checked out";
 
         private string _searchText = string.Empty;
         public string SearchText
@@ -85,6 +90,7 @@ namespace InventoryManagementApp.ViewModels
                     CheckInCommand.NotifyCanExecuteChanged();
                     ExtendCommand.NotifyCanExecuteChanged();
                     OpenHistoryCommand.NotifyCanExecuteChanged();
+                    OpenRentalDetailsCommand.NotifyCanExecuteChanged();
                     PrintRentalCommand.NotifyCanExecuteChanged();
                     PrintPickingSlipCommand.NotifyCanExecuteChanged();
                     PrintInvoiceCommand.NotifyCanExecuteChanged();
@@ -105,7 +111,10 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand CheckInCommand { get; }
         public IAsyncRelayCommand ExtendCommand { get; }
         public IAsyncRelayCommand OpenHistoryCommand { get; }
+        public IRelayCommand OpenRentalDetailsCommand { get; }
         public IRelayCommand PrintRentalCommand { get; }
+        public IRelayCommand PrintSearchResultsCommand { get; }
+        public IRelayCommand PrintCheckedOutCommand { get; }
         public IRelayCommand PrintPickingSlipCommand { get; }
         public IRelayCommand PrintInvoiceCommand { get; }
         public IAsyncRelayCommand DeleteRentalCommand { get; }
@@ -118,10 +127,13 @@ namespace InventoryManagementApp.ViewModels
 
             ApplyFilterCommand = new RelayCommand(ApplyFilter);
             ClearFilterCommand = new RelayCommand(ClearFilter);
-            CheckInCommand = new AsyncRelayCommand(CheckInAsync, () => SelectedRental != null);
-            ExtendCommand = new AsyncRelayCommand(ExtendAsync, () => SelectedRental != null);
+            CheckInCommand = new AsyncRelayCommand(CheckInAsync, CanReturnSelectedRental);
+            ExtendCommand = new AsyncRelayCommand(ExtendAsync, CanReturnSelectedRental);
             OpenHistoryCommand = new AsyncRelayCommand(OpenHistoryAsync, () => SelectedRental != null);
+            OpenRentalDetailsCommand = new RelayCommand(OpenRentalDetails, () => SelectedRental != null);
             PrintRentalCommand = new RelayCommand(PrintRental, () => SelectedRental != null);
+            PrintSearchResultsCommand = new RelayCommand(PrintSearchResults);
+            PrintCheckedOutCommand = new RelayCommand(PrintCheckedOut);
             PrintPickingSlipCommand = new RelayCommand(PrintPickingSlip, () => SelectedRental != null);
             PrintInvoiceCommand = new RelayCommand(PrintInvoice, () => SelectedRental != null);
             DeleteRentalCommand = new AsyncRelayCommand(DeleteRentalAsync, () => SelectedRental != null);
@@ -134,7 +146,8 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 _allRentals = await _rentalService.GetAllRentalsAsync();
-                Rentals.ReplaceRange(_allRentals);
+                RefreshActiveRentals();
+                ApplyFilter();
             }
             catch (Exception ex)
             {
@@ -162,6 +175,7 @@ namespace InventoryManagementApp.ViewModels
                 var term = SearchText.Trim();
                 filtered = filtered.Where(r =>
                     (r.ItemNumber?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    (r.ItemName?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
                     (r.CustomerName?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false));
             }
 
@@ -173,6 +187,7 @@ namespace InventoryManagementApp.ViewModels
                 filtered = filtered.Where(r => string.Equals(r.Status, SelectedStatus, StringComparison.OrdinalIgnoreCase));
 
             Rentals.ReplaceRange(filtered);
+            OnPropertyChanged(nameof(SearchSummary));
         }
 
         void ClearFilter()
@@ -182,6 +197,7 @@ namespace InventoryManagementApp.ViewModels
             FilterTo = null;
             SelectedStatus = StatusOptions.First();
             Rentals.ReplaceRange(_allRentals);
+            OnPropertyChanged(nameof(SearchSummary));
         }
 
         async Task CheckInAsync()
@@ -256,10 +272,35 @@ namespace InventoryManagementApp.ViewModels
             {
                 ItemID = SelectedRental.ItemID,
                 ItemNumber = SelectedRental.ItemNumber,
-                Name = SelectedRental.ItemNumber
+                Name = SelectedRental.ItemName
             };
 
             _dialogService.ShowRentalHistory(item, history);
+        }
+
+        void OpenRentalDetails()
+        {
+            if (SelectedRental == null)
+                return;
+
+            var rental = SelectedRental;
+            var details = new StringBuilder();
+            details.AppendLine($"Rental #: {rental.RentalID}");
+            details.AppendLine($"Tool #: {rental.ItemNumber}");
+            details.AppendLine($"Tool: {rental.ItemName}");
+            details.AppendLine($"Status: {rental.Status}");
+            details.AppendLine();
+            details.AppendLine($"Checked out to: {ValueOrNotRecorded(rental.CustomerName)}");
+            details.AppendLine($"Checked out: {FormatDate(rental.RentalDate)}");
+            details.AppendLine($"Due back: {FormatDate(rental.DueDate)}");
+            details.AppendLine($"Returned: {FormatNullableDate(rental.ReturnDate)}");
+            details.AppendLine($"Time out: {DescribeRentalAge(rental)}");
+            details.AppendLine();
+            details.AppendLine(IsRentalActive(rental)
+                ? "Next steps: check in when returned, extend if approved, or open history for prior usage."
+                : "Next steps: open history to inspect prior usage or print this rental record.");
+
+            _dialogService.ShowInfo(details.ToString(), $"Rental Details - {rental.ItemNumber}");
         }
 
         void PrintRental()
@@ -301,6 +342,7 @@ namespace InventoryManagementApp.ViewModels
 
                 AddRow("Rental #:", SelectedRental.RentalID.ToString());
                 AddRow("Item #:", SelectedRental.ItemNumber);
+                AddRow("Item:", SelectedRental.ItemName);
                 AddRow("Customer:", SelectedRental.CustomerName);
                 AddRow("Rental Date:", SelectedRental.RentalDate.ToString("yyyy-MM-dd HH:mm"));
                 AddRow("Due Date:", SelectedRental.DueDate.ToString("yyyy-MM-dd HH:mm"));
@@ -316,6 +358,97 @@ namespace InventoryManagementApp.ViewModels
                 _logger.LogError(ex, "Failed to print rental {RentalID}", SelectedRental?.RentalID);
                 _dialogService.ShowInfo($"Failed to print rental: {ex.Message}", "Error");
             }
+        }
+
+        void PrintSearchResults()
+        {
+            PrintRentalList("Rental Search Results", Rentals, "There are no rental search results to print.");
+        }
+
+        void PrintCheckedOut()
+        {
+            PrintRentalList("Currently Checked Out Tools", ActiveRentals, "There are no checked-out tools to print.");
+        }
+
+        void PrintRentalList(string title, IEnumerable<RentalModel> rentals, string emptyMessage)
+        {
+            var records = rentals.ToList();
+            if (records.Count == 0)
+            {
+                _dialogService.ShowInfo(emptyMessage, title);
+                return;
+            }
+
+            try
+            {
+                var doc = new FlowDocument
+                {
+                    PagePadding = new Thickness(36),
+                    FontFamily = new System.Windows.Media.FontFamily("Calibri"),
+                    FontSize = 11
+                };
+
+                doc.Blocks.Add(new Paragraph(new Bold(new Run(title)))
+                {
+                    FontSize = 20,
+                    TextAlignment = TextAlignment.Center,
+                    Margin = new Thickness(0, 0, 0, 10)
+                });
+
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | {records.Count} record{(records.Count == 1 ? string.Empty : "s")}"))
+                {
+                    FontSize = 10,
+                    Margin = new Thickness(0, 0, 0, 10)
+                });
+
+                var table = new Table { CellSpacing = 0 };
+                table.Columns.Add(new TableColumn { Width = new GridLength(70) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(95) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(160) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(140) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(95) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(95) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(80) });
+
+                var group = new TableRowGroup();
+                table.RowGroups.Add(group);
+                AddPrintRow(group, true, "Rental", "Tool #", "Tool", "Who Has It", "Out", "Due", "Status");
+
+                foreach (var rental in records)
+                {
+                    AddPrintRow(group, false, rental.RentalID.ToString(), rental.ItemNumber, rental.ItemName, rental.CustomerName, rental.RentalDate.ToString("yyyy-MM-dd"), rental.DueDate.ToString("yyyy-MM-dd"), rental.Status ?? string.Empty);
+                }
+
+                doc.Blocks.Add(table);
+                _dialogService.ShowPrintPreview(doc, title, string.Empty);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to print rental list {Title}", title);
+                _dialogService.ShowInfo($"Failed to print rental list: {ex.Message}", "Error");
+            }
+        }
+
+        static void AddPrintRow(TableRowGroup group, bool isHeader, params string[] values)
+        {
+            var row = new TableRow();
+            foreach (var value in values)
+            {
+                var paragraph = new Paragraph(new Run(value ?? string.Empty))
+                {
+                    Margin = new Thickness(3),
+                    FontSize = isHeader ? 10 : 9,
+                    FontWeight = isHeader ? FontWeights.Bold : FontWeights.Normal
+                };
+                var cell = new TableCell(paragraph)
+                {
+                    BorderBrush = System.Windows.Media.Brushes.Gray,
+                    BorderThickness = new Thickness(0.5),
+                    Padding = new Thickness(2)
+                };
+                row.Cells.Add(cell);
+            }
+            group.Rows.Add(row);
         }
 
         void PrintPickingSlip()
@@ -357,9 +490,7 @@ namespace InventoryManagementApp.ViewModels
             if (SelectedRental == null)
                 return;
 
-            var confirmed = await _dialogService.ShowConfirmAsync(
-                "Delete Rental",
-                $"Are you sure you want to delete rental #{SelectedRental.RentalID}?");
+            var confirmed = await _dialogService.ShowConfirmAsync("Delete Rental", $"Are you sure you want to delete rental #{SelectedRental.RentalID}?");
             if (!confirmed)
                 return;
 
@@ -369,8 +500,9 @@ namespace InventoryManagementApp.ViewModels
                 IsLoading = true;
                 await _rentalService.DeleteRentalAsync(rentalToDelete.RentalID);
                 _allRentals.Remove(rentalToDelete);
-                Rentals.Remove(rentalToDelete);
                 SelectedRental = null;
+                RefreshActiveRentals();
+                ApplyFilter();
             }
             catch (UnauthorizedAccessException)
             {
@@ -386,6 +518,43 @@ namespace InventoryManagementApp.ViewModels
                 IsLoading = false;
             }
         }
+
+        void RefreshActiveRentals()
+        {
+            ActiveRentals.ReplaceRange(_allRentals.Where(IsRentalActive));
+            OnPropertyChanged(nameof(CheckedOutSummary));
+        }
+
+        bool CanReturnSelectedRental()
+        {
+            return SelectedRental != null && IsRentalActive(SelectedRental);
+        }
+
+        static bool IsRentalActive(RentalModel rental)
+        {
+            return rental.ReturnDate == null && !string.Equals(rental.Status, "Returned", StringComparison.OrdinalIgnoreCase);
+        }
+
+        static string ValueOrNotRecorded(string? value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? "Not recorded" : value;
+        }
+
+        static string FormatDate(DateTime value)
+        {
+            return value.ToString("yyyy-MM-dd HH:mm");
+        }
+
+        static string FormatNullableDate(DateTime? value)
+        {
+            return value?.ToString("yyyy-MM-dd HH:mm") ?? "Not returned yet";
+        }
+
+        static string DescribeRentalAge(RentalModel rental)
+        {
+            var end = rental.ReturnDate ?? DateTime.Now;
+            var days = Math.Max(0, (end.Date - rental.RentalDate.Date).Days);
+            return days == 1 ? "1 day" : $"{days} days";
+        }
     }
 }
-

--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -26,7 +26,7 @@ namespace InventoryManagementApp.ViewModels
         public ObservableCollection<RentalModel> ActiveRentals { get; } = new();
 
         public string SearchSummary => $"{Rentals.Count} result{(Rentals.Count == 1 ? string.Empty : "s")} shown";
-        public string CheckedOutSummary => $"{ActiveRentals.Count} tool{(ActiveRentals.Count == 1 ? string.Empty : "s")} currently checked out";
+        public string CheckedOutSummary => $"{ActiveRentals.Count} item{(ActiveRentals.Count == 1 ? string.Empty : "s")} currently checked out";
 
         private string _searchText = string.Empty;
         public string SearchText
@@ -280,7 +280,7 @@ namespace InventoryManagementApp.ViewModels
             var rental = SelectedRental;
             var details = new StringBuilder();
             details.AppendLine($"Rental #: {rental.RentalID}");
-            details.AppendLine($"Tool #: {rental.ItemNumber}");
+            details.AppendLine($"Item #: {rental.ItemNumber}");
             details.AppendLine($"Location: {ValueOrNotRecorded(rental.ItemLocation)}");
             details.AppendLine($"Status: {rental.Status}");
             details.AppendLine();
@@ -331,7 +331,7 @@ namespace InventoryManagementApp.ViewModels
 
         void PrintSearchResults() => PrintRentalList("Rental Search Results", Rentals, "There are no rental search results to print.");
 
-        void PrintCheckedOut() => PrintRentalList("Currently Checked Out Tools", ActiveRentals, "There are no checked-out tools to print.");
+        void PrintCheckedOut() => PrintRentalList("Currently Checked Out Items", ActiveRentals, "There are no checked-out items to print.");
 
         void PrintRentalList(string title, IEnumerable<RentalModel> rentals, string emptyMessage)
         {
@@ -362,7 +362,7 @@ namespace InventoryManagementApp.ViewModels
 
                 var group = new TableRowGroup();
                 table.RowGroups.Add(group);
-                AddPrintRow(group, true, "Rental", "Tool #", "Location", "Who Has It", "Out", "Due", "Status");
+                AddPrintRow(group, true, "Rental", "Item #", "Location", "Checked Out To", "Out", "Due", "Status");
 
                 foreach (var rental in records)
                 {

--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -15,10 +15,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace InventoryManagementApp.ViewModels
 {
-    /// <summary>
-    /// View model backing the ManageRentalsPage. Provides filtering and
-    /// commands for common rental operations.
-    /// </summary>
     public class ManageRentalsViewModel : ObservableObject
     {
         private readonly IRentalService _rentalService;
@@ -65,8 +61,7 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        public ObservableCollection<string> StatusOptions { get; } =
-            new ObservableCollection<string> { "All", "Rented", "Returned" };
+        public ObservableCollection<string> StatusOptions { get; } = new() { "All", "Rented", "Returned" };
 
         private string _selectedStatus = "All";
         public string SelectedStatus
@@ -139,7 +134,6 @@ namespace InventoryManagementApp.ViewModels
             DeleteRentalCommand = new AsyncRelayCommand(DeleteRentalAsync, () => SelectedRental != null);
         }
 
-        /// <summary>Loads all rentals from the service.</summary>
         public async Task LoadRentalsAsync()
         {
             IsLoading = true;
@@ -175,7 +169,7 @@ namespace InventoryManagementApp.ViewModels
                 var term = SearchText.Trim();
                 filtered = filtered.Where(r =>
                     (r.ItemNumber?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (r.ItemName?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    (r.ItemLocation?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
                     (r.CustomerName?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false));
             }
 
@@ -272,7 +266,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 ItemID = SelectedRental.ItemID,
                 ItemNumber = SelectedRental.ItemNumber,
-                Name = SelectedRental.ItemName
+                Name = SelectedRental.ItemNumber
             };
 
             _dialogService.ShowRentalHistory(item, history);
@@ -287,10 +281,14 @@ namespace InventoryManagementApp.ViewModels
             var details = new StringBuilder();
             details.AppendLine($"Rental #: {rental.RentalID}");
             details.AppendLine($"Tool #: {rental.ItemNumber}");
-            details.AppendLine($"Tool: {rental.ItemName}");
+            details.AppendLine($"Location: {ValueOrNotRecorded(rental.ItemLocation)}");
             details.AppendLine($"Status: {rental.Status}");
             details.AppendLine();
             details.AppendLine($"Checked out to: {ValueOrNotRecorded(rental.CustomerName)}");
+            details.AppendLine($"Contact: {ValueOrNotRecorded(rental.CustomerContact)}");
+            details.AppendLine($"Phone: {ValueOrNotRecorded(rental.CustomerPhone)}");
+            details.AppendLine($"Email: {ValueOrNotRecorded(rental.CustomerEmail)}");
+            details.AppendLine();
             details.AppendLine($"Checked out: {FormatDate(rental.RentalDate)}");
             details.AppendLine($"Due back: {FormatDate(rental.DueDate)}");
             details.AppendLine($"Returned: {FormatNullableDate(rental.ReturnDate)}");
@@ -309,46 +307,17 @@ namespace InventoryManagementApp.ViewModels
                 return;
             try
             {
-                var doc = new FlowDocument
-                {
-                    PagePadding = new Thickness(40),
-                    FontFamily = new System.Windows.Media.FontFamily("Calibri"),
-                    FontSize = 16
-                };
-
-                doc.Blocks.Add(new Paragraph(new Bold(new Run("Rental Information")))
-                {
-                    FontSize = 22,
-                    TextAlignment = TextAlignment.Center,
-                    Margin = new Thickness(0, 0, 0, 20)
-                });
-
-                var table = new Table();
-                table.Columns.Add(new TableColumn { Width = new GridLength(150) });
-                table.Columns.Add(new TableColumn());
-                var group = new TableRowGroup();
-                table.RowGroups.Add(group);
-
-                void AddRow(string label, string value)
-                {
-                    var row = new TableRow();
-                    row.Cells.Add(new TableCell(new Paragraph(new Run(label))
-                    {
-                        FontWeight = FontWeights.Bold
-                    }));
-                    row.Cells.Add(new TableCell(new Paragraph(new Run(value ?? string.Empty))));
-                    group.Rows.Add(row);
-                }
-
-                AddRow("Rental #:", SelectedRental.RentalID.ToString());
-                AddRow("Item #:", SelectedRental.ItemNumber);
-                AddRow("Item:", SelectedRental.ItemName);
-                AddRow("Customer:", SelectedRental.CustomerName);
-                AddRow("Rental Date:", SelectedRental.RentalDate.ToString("yyyy-MM-dd HH:mm"));
-                AddRow("Due Date:", SelectedRental.DueDate.ToString("yyyy-MM-dd HH:mm"));
-                AddRow("Return Date:", SelectedRental.ReturnDate?.ToString("yyyy-MM-dd HH:mm") ?? "N/A");
-                AddRow("Status:", SelectedRental.Status ?? string.Empty);
-
+                var doc = CreateRentalDocument("Rental Information");
+                var table = CreateKeyValueTable();
+                var group = table.RowGroups[0];
+                AddKeyValueRow(group, "Rental #:", SelectedRental.RentalID.ToString());
+                AddKeyValueRow(group, "Item #:", SelectedRental.ItemNumber);
+                AddKeyValueRow(group, "Location:", SelectedRental.ItemLocation);
+                AddKeyValueRow(group, "Customer:", SelectedRental.CustomerName);
+                AddKeyValueRow(group, "Rental Date:", SelectedRental.RentalDate.ToString("yyyy-MM-dd HH:mm"));
+                AddKeyValueRow(group, "Due Date:", SelectedRental.DueDate.ToString("yyyy-MM-dd HH:mm"));
+                AddKeyValueRow(group, "Return Date:", SelectedRental.ReturnDate?.ToString("yyyy-MM-dd HH:mm") ?? "N/A");
+                AddKeyValueRow(group, "Status:", SelectedRental.Status ?? string.Empty);
                 doc.Blocks.Add(table);
 
                 _dialogService.ShowPrintPreview(doc, $"Rental {SelectedRental.RentalID}", string.Empty);
@@ -360,15 +329,9 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        void PrintSearchResults()
-        {
-            PrintRentalList("Rental Search Results", Rentals, "There are no rental search results to print.");
-        }
+        void PrintSearchResults() => PrintRentalList("Rental Search Results", Rentals, "There are no rental search results to print.");
 
-        void PrintCheckedOut()
-        {
-            PrintRentalList("Currently Checked Out Tools", ActiveRentals, "There are no checked-out tools to print.");
-        }
+        void PrintCheckedOut() => PrintRentalList("Currently Checked Out Tools", ActiveRentals, "There are no checked-out tools to print.");
 
         void PrintRentalList(string title, IEnumerable<RentalModel> rentals, string emptyMessage)
         {
@@ -381,20 +344,7 @@ namespace InventoryManagementApp.ViewModels
 
             try
             {
-                var doc = new FlowDocument
-                {
-                    PagePadding = new Thickness(36),
-                    FontFamily = new System.Windows.Media.FontFamily("Calibri"),
-                    FontSize = 11
-                };
-
-                doc.Blocks.Add(new Paragraph(new Bold(new Run(title)))
-                {
-                    FontSize = 20,
-                    TextAlignment = TextAlignment.Center,
-                    Margin = new Thickness(0, 0, 0, 10)
-                });
-
+                var doc = CreateRentalDocument(title, fontSize: 11);
                 doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | {records.Count} record{(records.Count == 1 ? string.Empty : "s")}"))
                 {
                     FontSize = 10,
@@ -404,7 +354,7 @@ namespace InventoryManagementApp.ViewModels
                 var table = new Table { CellSpacing = 0 };
                 table.Columns.Add(new TableColumn { Width = new GridLength(70) });
                 table.Columns.Add(new TableColumn { Width = new GridLength(95) });
-                table.Columns.Add(new TableColumn { Width = new GridLength(160) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(140) });
                 table.Columns.Add(new TableColumn { Width = new GridLength(140) });
                 table.Columns.Add(new TableColumn { Width = new GridLength(95) });
                 table.Columns.Add(new TableColumn { Width = new GridLength(95) });
@@ -412,11 +362,11 @@ namespace InventoryManagementApp.ViewModels
 
                 var group = new TableRowGroup();
                 table.RowGroups.Add(group);
-                AddPrintRow(group, true, "Rental", "Tool #", "Tool", "Who Has It", "Out", "Due", "Status");
+                AddPrintRow(group, true, "Rental", "Tool #", "Location", "Who Has It", "Out", "Due", "Status");
 
                 foreach (var rental in records)
                 {
-                    AddPrintRow(group, false, rental.RentalID.ToString(), rental.ItemNumber, rental.ItemName, rental.CustomerName, rental.RentalDate.ToString("yyyy-MM-dd"), rental.DueDate.ToString("yyyy-MM-dd"), rental.Status ?? string.Empty);
+                    AddPrintRow(group, false, rental.RentalID.ToString(), rental.ItemNumber, rental.ItemLocation, rental.CustomerName, rental.RentalDate.ToString("yyyy-MM-dd"), rental.DueDate.ToString("yyyy-MM-dd"), rental.Status ?? string.Empty);
                 }
 
                 doc.Blocks.Add(table);
@@ -427,6 +377,42 @@ namespace InventoryManagementApp.ViewModels
                 _logger.LogError(ex, "Failed to print rental list {Title}", title);
                 _dialogService.ShowInfo($"Failed to print rental list: {ex.Message}", "Error");
             }
+        }
+
+        static FlowDocument CreateRentalDocument(string title, double fontSize = 16)
+        {
+            var doc = new FlowDocument
+            {
+                PagePadding = new Thickness(36),
+                FontFamily = new System.Windows.Media.FontFamily("Calibri"),
+                FontSize = fontSize
+            };
+
+            doc.Blocks.Add(new Paragraph(new Bold(new Run(title)))
+            {
+                FontSize = 20,
+                TextAlignment = TextAlignment.Center,
+                Margin = new Thickness(0, 0, 0, 10)
+            });
+
+            return doc;
+        }
+
+        static Table CreateKeyValueTable()
+        {
+            var table = new Table();
+            table.Columns.Add(new TableColumn { Width = new GridLength(150) });
+            table.Columns.Add(new TableColumn());
+            table.RowGroups.Add(new TableRowGroup());
+            return table;
+        }
+
+        static void AddKeyValueRow(TableRowGroup group, string label, string value)
+        {
+            var row = new TableRow();
+            row.Cells.Add(new TableCell(new Paragraph(new Run(label)) { FontWeight = FontWeights.Bold }));
+            row.Cells.Add(new TableCell(new Paragraph(new Run(value ?? string.Empty))));
+            group.Rows.Add(row);
         }
 
         static void AddPrintRow(TableRowGroup group, bool isHeader, params string[] values)
@@ -525,30 +511,18 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(CheckedOutSummary));
         }
 
-        bool CanReturnSelectedRental()
-        {
-            return SelectedRental != null && IsRentalActive(SelectedRental);
-        }
+        bool CanReturnSelectedRental() => SelectedRental != null && IsRentalActive(SelectedRental);
 
         static bool IsRentalActive(RentalModel rental)
         {
             return rental.ReturnDate == null && !string.Equals(rental.Status, "Returned", StringComparison.OrdinalIgnoreCase);
         }
 
-        static string ValueOrNotRecorded(string? value)
-        {
-            return string.IsNullOrWhiteSpace(value) ? "Not recorded" : value;
-        }
+        static string ValueOrNotRecorded(string? value) => string.IsNullOrWhiteSpace(value) ? "Not recorded" : value;
 
-        static string FormatDate(DateTime value)
-        {
-            return value.ToString("yyyy-MM-dd HH:mm");
-        }
+        static string FormatDate(DateTime value) => value.ToString("yyyy-MM-dd HH:mm");
 
-        static string FormatNullableDate(DateTime? value)
-        {
-            return value?.ToString("yyyy-MM-dd HH:mm") ?? "Not returned yet";
-        }
+        static string FormatNullableDate(DateTime? value) => value?.ToString("yyyy-MM-dd HH:mm") ?? "Not returned yet";
 
         static string DescribeRentalAge(RentalModel rental)
         {

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
@@ -42,22 +42,13 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                <Border Background="{DynamicResource SurfaceAltBrush}"
-                        BorderBrush="{DynamicResource BorderBrushAlt}"
-                        BorderThickness="0,0,0,1"
-                        Padding="5,3">
+                <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
                     <DockPanel>
                         <TextBlock Text="01 Search Results" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
                         <TextBlock Text="{Binding SearchSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
                     </DockPanel>
                 </Border>
-                <DataGrid Grid.Row="1"
-                          ItemsSource="{Binding Rentals}"
-                          SelectedItem="{Binding SelectedRental}"
-                          SelectionMode="Single"
-                          IsReadOnly="True"
-                          AutoGenerateColumns="False"
-                          Style="{StaticResource VirtualizedDataGridStyle}">
+                <DataGrid Grid.Row="1" ItemsSource="{Binding Rentals}" SelectedItem="{Binding SelectedRental}" SelectionMode="Single" IsReadOnly="True" AutoGenerateColumns="False" Style="{StaticResource VirtualizedDataGridStyle}">
                     <DataGrid.RowStyle>
                         <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
                             <EventSetter Event="MouseDoubleClick" Handler="RentalRow_MouseDoubleClick"/>
@@ -67,7 +58,7 @@
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Rental" Binding="{Binding RentalID}" Width="70"/>
                         <DataGridTextColumn Header="Tool #" Binding="{Binding ItemNumber}" Width="120"/>
-                        <DataGridTextColumn Header="Tool / Item" Binding="{Binding ItemName}" Width="220"/>
+                        <DataGridTextColumn Header="Location" Binding="{Binding ItemLocation}" Width="180"/>
                         <DataGridTextColumn Header="Who Has It" Binding="{Binding CustomerName}" Width="190"/>
                         <DataGridTextColumn Header="Checked Out" Binding="{Binding RentalDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="145"/>
                         <DataGridTextColumn Header="Due Back" Binding="{Binding DueDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="145"/>
@@ -75,8 +66,7 @@
                         <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="110"/>
                     </DataGrid.Columns>
                     <DataGrid.ContextMenu>
-                        <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
-                                    DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                        <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
                             <MenuItem Header="Open Details" Command="{Binding OpenRentalDetailsCommand}"/>
                             <MenuItem Header="Check In" Command="{Binding CheckInCommand}"/>
                             <MenuItem Header="Extend" Command="{Binding ExtendCommand}"/>
@@ -125,7 +115,7 @@
                     </DataGrid.RowStyle>
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Tool #" Binding="{Binding ItemNumber}" Width="120"/>
-                        <DataGridTextColumn Header="Tool / Item" Binding="{Binding ItemName}" Width="250"/>
+                        <DataGridTextColumn Header="Location" Binding="{Binding ItemLocation}" Width="180"/>
                         <DataGridTextColumn Header="Checked Out To" Binding="{Binding CustomerName}" Width="220"/>
                         <DataGridTextColumn Header="Checked Out" Binding="{Binding RentalDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="150"/>
                         <DataGridTextColumn Header="Due Back" Binding="{Binding DueDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="150"/>

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
@@ -6,6 +6,8 @@
     <Grid Margin="0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="2*"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -14,15 +16,17 @@
             <DockPanel LastChildFill="False">
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
                     <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenRentalDetailsCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Check In" Command="{Binding CheckInCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Extend" Command="{Binding ExtendCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="History" Command="{Binding OpenHistoryCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Print" Command="{Binding PrintRentalCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Print Search" Command="{Binding PrintSearchResultsCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Print Checked Out" Command="{Binding PrintCheckedOutCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Delete" Command="{Binding DeleteRentalCommand}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
                     <TextBlock Text="Filter" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                    <TextBox Width="140" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,4,0"/>
+                    <TextBox Width="150" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,4,0"/>
                     <DatePicker SelectedDate="{Binding FilterFrom, UpdateSourceTrigger=PropertyChanged}" Width="125" Margin="0,0,4,0"/>
                     <DatePicker SelectedDate="{Binding FilterTo, UpdateSourceTrigger=PropertyChanged}" Width="125" Margin="0,0,4,0"/>
                     <ComboBox ItemsSource="{Binding StatusOptions}" SelectedItem="{Binding SelectedStatus, UpdateSourceTrigger=PropertyChanged}" Width="110" Margin="0,0,4,0"/>
@@ -34,38 +38,56 @@
 
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
             <Grid>
-                <DataGrid ItemsSource="{Binding Rentals}"
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Border Background="{DynamicResource SurfaceAltBrush}"
+                        BorderBrush="{DynamicResource BorderBrushAlt}"
+                        BorderThickness="0,0,0,1"
+                        Padding="5,3">
+                    <DockPanel>
+                        <TextBlock Text="01 Search Results" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                        <TextBlock Text="{Binding SearchSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                    </DockPanel>
+                </Border>
+                <DataGrid Grid.Row="1"
+                          ItemsSource="{Binding Rentals}"
                           SelectedItem="{Binding SelectedRental}"
-                          SelectionMode="Extended"
+                          SelectionMode="Single"
                           IsReadOnly="True"
                           AutoGenerateColumns="False"
                           Style="{StaticResource VirtualizedDataGridStyle}">
+                    <DataGrid.RowStyle>
+                        <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                            <EventSetter Event="MouseDoubleClick" Handler="RentalRow_MouseDoubleClick"/>
+                            <EventSetter Event="PreviewMouseRightButtonDown" Handler="RentalRow_PreviewMouseRightButtonDown"/>
+                        </Style>
+                    </DataGrid.RowStyle>
                     <DataGrid.Columns>
-                        <StaticResource ResourceKey="RentalIdColumn"/>
-                        <StaticResource ResourceKey="RentalItemNumberColumn"/>
-                        <StaticResource ResourceKey="RentalItemNameColumn"/>
-                        <StaticResource ResourceKey="RentalCustomerColumn"/>
-                        <StaticResource ResourceKey="RentalOutColumn"/>
-                        <StaticResource ResourceKey="RentalDueColumn"/>
-                        <StaticResource ResourceKey="RentalReturnedColumn"/>
-                        <StaticResource ResourceKey="RentalStatusColumn"/>
+                        <DataGridTextColumn Header="Rental" Binding="{Binding RentalID}" Width="70"/>
+                        <DataGridTextColumn Header="Tool #" Binding="{Binding ItemNumber}" Width="120"/>
+                        <DataGridTextColumn Header="Tool / Item" Binding="{Binding ItemName}" Width="220"/>
+                        <DataGridTextColumn Header="Who Has It" Binding="{Binding CustomerName}" Width="190"/>
+                        <DataGridTextColumn Header="Checked Out" Binding="{Binding RentalDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="145"/>
+                        <DataGridTextColumn Header="Due Back" Binding="{Binding DueDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="145"/>
+                        <DataGridTextColumn Header="Returned" Binding="{Binding ReturnDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="145"/>
+                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="110"/>
                     </DataGrid.Columns>
                     <DataGrid.ContextMenu>
                         <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
                                     DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                            <MenuItem Header="Open Details" Command="{Binding OpenRentalDetailsCommand}"/>
                             <MenuItem Header="Check In" Command="{Binding CheckInCommand}"/>
                             <MenuItem Header="Extend" Command="{Binding ExtendCommand}"/>
                             <MenuItem Header="History" Command="{Binding OpenHistoryCommand}"/>
-                            <MenuItem Header="Print" Command="{Binding PrintRentalCommand}"/>
+                            <MenuItem Header="Print Rental" Command="{Binding PrintRentalCommand}"/>
+                            <MenuItem Header="Print Search Results" Command="{Binding PrintSearchResultsCommand}"/>
                             <MenuItem Header="Delete" Command="{Binding DeleteRentalCommand}"/>
                         </ContextMenu>
                     </DataGrid.ContextMenu>
                 </DataGrid>
-                <TextBlock Text="No rental records"
-                           HorizontalAlignment="Center"
-                           VerticalAlignment="Center"
-                           FontSize="13"
-                           FontWeight="SemiBold">
+                <TextBlock Grid.Row="1" Text="No rental records match this search" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="13" FontWeight="SemiBold">
                     <TextBlock.Style>
                         <Style TargetType="TextBlock">
                             <Setter Property="Visibility" Value="Collapsed"/>
@@ -80,9 +102,60 @@
             </Grid>
         </Border>
 
-        <ProgressBar Grid.Row="2"
-                     IsIndeterminate="True"
-                     Margin="0,4,0,0"
-                     Visibility="{Binding IsLoading, Converter={StaticResource BoolToVis}}"/>
+        <GridSplitter Grid.Row="2" Height="6" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+
+        <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                    <DockPanel>
+                        <TextBlock Text="02 Currently Checked Out" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                        <TextBlock Text="{Binding CheckedOutSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                    </DockPanel>
+                </Border>
+                <DataGrid Grid.Row="1" ItemsSource="{Binding ActiveRentals}" SelectedItem="{Binding SelectedRental}" SelectionMode="Single" IsReadOnly="True" AutoGenerateColumns="False" Style="{StaticResource VirtualizedDataGridStyle}">
+                    <DataGrid.RowStyle>
+                        <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                            <EventSetter Event="MouseDoubleClick" Handler="RentalRow_MouseDoubleClick"/>
+                            <EventSetter Event="PreviewMouseRightButtonDown" Handler="RentalRow_PreviewMouseRightButtonDown"/>
+                        </Style>
+                    </DataGrid.RowStyle>
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Tool #" Binding="{Binding ItemNumber}" Width="120"/>
+                        <DataGridTextColumn Header="Tool / Item" Binding="{Binding ItemName}" Width="250"/>
+                        <DataGridTextColumn Header="Checked Out To" Binding="{Binding CustomerName}" Width="220"/>
+                        <DataGridTextColumn Header="Checked Out" Binding="{Binding RentalDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="150"/>
+                        <DataGridTextColumn Header="Due Back" Binding="{Binding DueDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="150"/>
+                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="110"/>
+                    </DataGrid.Columns>
+                    <DataGrid.ContextMenu>
+                        <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                            <MenuItem Header="Open Details" Command="{Binding OpenRentalDetailsCommand}"/>
+                            <MenuItem Header="Check In" Command="{Binding CheckInCommand}"/>
+                            <MenuItem Header="Extend" Command="{Binding ExtendCommand}"/>
+                            <MenuItem Header="History" Command="{Binding OpenHistoryCommand}"/>
+                            <MenuItem Header="Print Checked Out" Command="{Binding PrintCheckedOutCommand}"/>
+                        </ContextMenu>
+                    </DataGrid.ContextMenu>
+                </DataGrid>
+                <TextBlock Grid.Row="1" Text="No tools are currently checked out" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="13" FontWeight="SemiBold">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding ActiveRentals.Count}" Value="0">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+            </Grid>
+        </Border>
+
+        <ProgressBar Grid.Row="4" IsIndeterminate="True" Margin="0,4,0,0" Visibility="{Binding IsLoading, Converter={StaticResource BoolToVis}}"/>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
@@ -57,9 +57,9 @@
                     </DataGrid.RowStyle>
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Rental" Binding="{Binding RentalID}" Width="70"/>
-                        <DataGridTextColumn Header="Tool #" Binding="{Binding ItemNumber}" Width="120"/>
+                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="120"/>
                         <DataGridTextColumn Header="Location" Binding="{Binding ItemLocation}" Width="180"/>
-                        <DataGridTextColumn Header="Who Has It" Binding="{Binding CustomerName}" Width="190"/>
+                        <DataGridTextColumn Header="Checked Out To" Binding="{Binding CustomerName}" Width="190"/>
                         <DataGridTextColumn Header="Checked Out" Binding="{Binding RentalDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="145"/>
                         <DataGridTextColumn Header="Due Back" Binding="{Binding DueDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="145"/>
                         <DataGridTextColumn Header="Returned" Binding="{Binding ReturnDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="145"/>
@@ -114,7 +114,7 @@
                         </Style>
                     </DataGrid.RowStyle>
                     <DataGrid.Columns>
-                        <DataGridTextColumn Header="Tool #" Binding="{Binding ItemNumber}" Width="120"/>
+                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="120"/>
                         <DataGridTextColumn Header="Location" Binding="{Binding ItemLocation}" Width="180"/>
                         <DataGridTextColumn Header="Checked Out To" Binding="{Binding CustomerName}" Width="220"/>
                         <DataGridTextColumn Header="Checked Out" Binding="{Binding RentalDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="150"/>
@@ -131,7 +131,7 @@
                         </ContextMenu>
                     </DataGrid.ContextMenu>
                 </DataGrid>
-                <TextBlock Grid.Row="1" Text="No tools are currently checked out" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="13" FontWeight="SemiBold">
+                <TextBlock Grid.Row="1" Text="No items are currently checked out" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="13" FontWeight="SemiBold">
                     <TextBlock.Style>
                         <Style TargetType="TextBlock">
                             <Setter Property="Visibility" Value="Collapsed"/>

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
@@ -1,17 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
@@ -32,6 +21,23 @@ namespace InventoryManagementApp.Views.Pages
             if (DataContext is ManageRentalsViewModel vm)
             {
                 await vm.LoadRentalsAsync();
+            }
+        }
+
+        private void RentalRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is ManageRentalsViewModel vm && vm.OpenRentalDetailsCommand.CanExecute(null))
+            {
+                vm.OpenRentalDetailsCommand.Execute(null);
+            }
+        }
+
+        private void RentalRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is DataGridRow row && !row.IsSelected)
+            {
+                row.IsSelected = true;
+                e.Handled = true;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Reworks the rentals screen into a split desktop workflow: filtered rental search results on top and currently checked-out tools below.
- Adds row double-click and context-menu detail paths so a technician or advisor can drill into who has a tool, contact info, checkout date, due-back date, return status, and time out.
- Adds printable search results and printable checked-out tool lists from the same page.
- Keeps check-in and extend actions scoped to active rentals so returned records cannot be checked in or extended accidentally.

## Why it matters
This directly supports the requested old WPF-style technician flow: search a tool, see current checkout state immediately, check it back in when returned, and print either the search result set or the current checked-out list without leaving the page.

## Validation
- Reviewed the diff against current `master` with the GitHub connector.
- Verified the branch is current with `master` and only changes the rentals page, rentals view model, and rentals page code-behind.
- Corrected the implementation to use actual `Rental` fields (`ItemNumber`, `ItemLocation`, customer contact fields, dates, status) instead of non-existent item-name properties.
- Not run locally: this scheduled environment cannot clone the repo directly and does not have the .NET SDK installed.