### PR TITLE
Redesign item search into desktop checkout workflow

### DIFF
--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -32,6 +32,10 @@ namespace InventoryManagementApp.ViewModels
 
         public ObservableCollection<ItemModel> Items { get; } = new();
         public ObservableCollection<ItemModel> SearchResults { get; } = new();
+        public ObservableCollection<ItemModel> CheckedOutItems { get; } = new();
+
+        public string SearchResultsSummary => SearchResults.Count == 1 ? "1 result" : $"{SearchResults.Count} results";
+        public string CheckedOutSummary => CheckedOutItems.Count == 1 ? "1 checked out" : $"{CheckedOutItems.Count} checked out";
 
         /// <summary>
         /// List of available item categories derived from distinct brands
@@ -156,6 +160,10 @@ namespace InventoryManagementApp.ViewModels
             // instances.
             Items.CollectionChanged -= Items_CollectionChanged;
             Items.CollectionChanged += Items_CollectionChanged;
+            SearchResults.CollectionChanged -= SearchResults_CollectionChanged;
+            SearchResults.CollectionChanged += SearchResults_CollectionChanged;
+            CheckedOutItems.CollectionChanged -= CheckedOutItems_CollectionChanged;
+            CheckedOutItems.CollectionChanged += CheckedOutItems_CollectionChanged;
         }
 
         Dictionary<ItemDetailField, bool> _visibleFields = new();
@@ -269,6 +277,7 @@ namespace InventoryManagementApp.ViewModels
                 Items.ReplaceRange(list);
                 SearchResults.ReplaceRange(list);
                 LoadCategories(Items);
+                RefreshCheckedOutItems();
             }
             finally
             {
@@ -324,6 +333,7 @@ namespace InventoryManagementApp.ViewModels
                 Items.ReplaceRange(list);
                 SearchResults.ReplaceRange(list);
                 LoadCategories(list, suppressSearch: true);
+                RefreshCheckedOutItems();
             }
             else
             {
@@ -557,6 +567,8 @@ namespace InventoryManagementApp.ViewModels
                     item.CheckedInBy = refreshed.CheckedInBy;
                     item.CheckedInTime = refreshed.CheckedInTime;
                 }
+
+                RefreshCheckedOutItems();
             }
             catch (OperationCanceledException)
             {
@@ -596,12 +608,32 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
+        void RefreshCheckedOutItems()
+        {
+            var checkedOutItems = Items.Where(t => t.IsCheckedOut)
+                                       .OrderByDescending(t => t.CheckedOutTime ?? DateTime.MinValue)
+                                       .ThenBy(t => t.Name)
+                                       .ToList();
+            CheckedOutItems.ReplaceRange(checkedOutItems);
+        }
+
         void Items_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             if (_suppressItemsChanged)
                 return;
 
             LoadCategories(Items);
+            RefreshCheckedOutItems();
+        }
+
+        void SearchResults_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            OnPropertyChanged(nameof(SearchResultsSummary));
+        }
+
+        void CheckedOutItems_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            OnPropertyChanged(nameof(CheckedOutSummary));
         }
 
         /// <inheritdoc />
@@ -625,6 +657,8 @@ namespace InventoryManagementApp.ViewModels
             cts?.Dispose();
 
             Items.CollectionChanged -= Items_CollectionChanged;
+            SearchResults.CollectionChanged -= SearchResults_CollectionChanged;
+            CheckedOutItems.CollectionChanged -= CheckedOutItems_CollectionChanged;
             _settingsService.ItemDetailVisibilityChanged -= OnItemDetailVisibilityChanged;
             _settingsService.ItemCardSizeChanged -= OnItemCardSizeChanged;
         }

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
@@ -11,6 +11,10 @@
             <Setter Property="FontWeight" Value="SemiBold"/>
             <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}"/>
             <Style.Triggers>
+                <DataTrigger Binding="{Binding HasNoOnHand}" Value="True">
+                    <Setter Property="Text" Value="Unavailable"/>
+                    <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}"/>
+                </DataTrigger>
                 <DataTrigger Binding="{Binding HasRentedStock}" Value="True">
                     <Setter Property="Text" Value="Rented"/>
                     <Setter Property="Foreground" Value="{DynamicResource WarningBrush}"/>
@@ -18,10 +22,6 @@
                 <DataTrigger Binding="{Binding IsCheckedOut}" Value="True">
                     <Setter Property="Text" Value="Checked Out"/>
                     <Setter Property="Foreground" Value="{DynamicResource WarningBrush}"/>
-                </DataTrigger>
-                <DataTrigger Binding="{Binding HasNoOnHand}" Value="True">
-                    <Setter Property="Text" Value="Unavailable"/>
-                    <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}"/>
                 </DataTrigger>
                 <DataTrigger Binding="{Binding IsIncomplete}" Value="True">
                     <Setter Property="Text" Value="Incomplete"/>

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
@@ -5,21 +5,177 @@
       x:Class="InventoryManagementApp.Views.Pages.ItemSearchPage"
       Background="{DynamicResource BackgroundBrush}"
       Loaded="Page_Loaded">
-    <Grid Margin="0">
-        <Border Style="{StaticResource Card}" Padding="8">
-            <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-                <ItemsControl ItemsSource="{Binding SearchResults}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <WrapPanel Orientation="Horizontal"/>
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <StaticResource ResourceKey="ItemCardTemplate"/>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </ScrollViewer>
+    <Page.Resources>
+        <Style x:Key="StatusTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+            <Setter Property="Text" Value="Available"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding HasRentedStock}" Value="True">
+                    <Setter Property="Text" Value="Rented"/>
+                    <Setter Property="Foreground" Value="{DynamicResource WarningBrush}"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding IsCheckedOut}" Value="True">
+                    <Setter Property="Text" Value="Checked Out"/>
+                    <Setter Property="Foreground" Value="{DynamicResource WarningBrush}"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding HasNoOnHand}" Value="True">
+                    <Setter Property="Text" Value="Unavailable"/>
+                    <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding IsIncomplete}" Value="True">
+                    <Setter Property="Text" Value="Incomplete"/>
+                    <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+    </Page.Resources>
+
+    <Grid Margin="4">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="320"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="180"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="0" Text="Find tool" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                <TextBox Grid.Column="1"
+                         Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                         ToolTip="Search by name, item number, part number, brand, location, or keyword"/>
+                <TextBlock Grid.Column="2" Text="Brand" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="10,0,6,0"/>
+                <ComboBox Grid.Column="3" ItemsSource="{Binding Categories}" SelectedItem="{Binding SelectedCategory}"/>
+                <StackPanel Grid.Column="4" Orientation="Horizontal" VerticalAlignment="Center" Margin="10,0,0,0">
+                    <TextBlock Text="{Binding SearchResultsSummary}" Style="{StaticResource CaptionTextBlock}" Margin="0,0,12,0"/>
+                    <TextBlock Text="{Binding CheckedOutSummary}" Style="{StaticResource CaptionTextBlock}"/>
+                </StackPanel>
+                <StackPanel Grid.Column="5" Orientation="Horizontal">
+                    <Button Content="Print Results" Click="PrintSearchResults_Click" Margin="0,0,4,0"/>
+                    <Button Content="Print Checked Out" Click="PrintCheckedOut_Click"/>
+                </StackPanel>
+            </Grid>
         </Border>
 
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" MinWidth="520"/>
+                <ColumnDefinition Width="4"/>
+                <ColumnDefinition Width="*" MinWidth="340"/>
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Margin="0" BorderThickness="0,0,0,1">
+                        <DockPanel LastChildFill="True">
+                            <TextBlock Text="Search Results" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0"/>
+                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+                                <Button Content="Details" Command="{Binding ViewDetailsCommand}" Margin="0,0,4,0"/>
+                                <Button Content="Rent Out" Command="{Binding OpenRentalsCommand}" Margin="0,0,4,0"/>
+                                <Button Content="Check Out / In" Command="{Binding ToggleCheckOutCommand}" CommandParameter="{Binding SelectedItem}"/>
+                            </StackPanel>
+                            <TextBlock Text="Double-click a row for full details." Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                        </DockPanel>
+                    </Border>
+                    <DataGrid x:Name="ResultsGrid"
+                              Grid.Row="1"
+                              Style="{StaticResource VirtualizedDataGridStyle}"
+                              ItemsSource="{Binding SearchResults}"
+                              SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
+                              MouseDoubleClick="ItemGrid_MouseDoubleClick">
+                        <DataGrid.ContextMenu>
+                            <ContextMenu>
+                                <MenuItem Header="Open Details" Command="{Binding PlacementTarget.DataContext.ViewDetailsCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                <MenuItem Header="Rent Out" Command="{Binding PlacementTarget.DataContext.OpenRentalsCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                <MenuItem Header="Check Out / In" Command="{Binding PlacementTarget.DataContext.ToggleCheckOutCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                <Separator/>
+                                <MenuItem Header="Print Results" Click="PrintSearchResults_Click"/>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                        <DataGrid.Columns>
+                            <DataGridTemplateColumn Header="Status" Width="95">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Style="{StaticResource StatusTextBlock}"/>
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                            <DataGridTextColumn Header="Tool #" Binding="{Binding ItemNumber}" Width="90"/>
+                            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
+                            <DataGridTextColumn Header="Brand" Binding="{Binding Brand}" Width="110"/>
+                            <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="120"/>
+                            <DataGridTextColumn Header="On Hand" Binding="{Binding QuantityOnHand}" Width="70"/>
+                            <DataGridTextColumn Header="Rented" Binding="{Binding RentedQuantity}" Width="60"/>
+                            <DataGridTextColumn Header="Holder" Binding="{Binding CheckedOutBy}" Width="120"/>
+                            <DataGridTextColumn Header="Out Since" Binding="{Binding CheckedOutTime, StringFormat=yyyy-MM-dd HH:mm}" Width="120"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </Grid>
+            </Border>
+
+            <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushAlt}"/>
+
+            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Margin="0" BorderThickness="0,0,0,1">
+                        <DockPanel LastChildFill="True">
+                            <TextBlock Text="Currently Checked Out" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0"/>
+                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+                                <Button Content="Print" Click="PrintCheckedOut_Click" Margin="0,0,4,0"/>
+                                <Button Content="Details" Command="{Binding ViewDetailsCommand}"/>
+                            </StackPanel>
+                            <TextBlock Text="Visible while searching; double-click to inspect or check back in." Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                        </DockPanel>
+                    </Border>
+                    <DataGrid x:Name="CheckedOutGrid"
+                              Grid.Row="1"
+                              Style="{StaticResource VirtualizedDataGridStyle}"
+                              ItemsSource="{Binding CheckedOutItems}"
+                              SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
+                              MouseDoubleClick="ItemGrid_MouseDoubleClick">
+                        <DataGrid.ContextMenu>
+                            <ContextMenu>
+                                <MenuItem Header="Open Details" Command="{Binding PlacementTarget.DataContext.ViewDetailsCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                <MenuItem Header="Check In" Command="{Binding PlacementTarget.DataContext.ToggleCheckOutCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                <Separator/>
+                                <MenuItem Header="Print Checked Out" Click="PrintCheckedOut_Click"/>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Tool #" Binding="{Binding ItemNumber}" Width="82"/>
+                            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
+                            <DataGridTextColumn Header="Holder" Binding="{Binding CheckedOutBy}" Width="105"/>
+                            <DataGridTextColumn Header="Out Since" Binding="{Binding CheckedOutTime, StringFormat=yyyy-MM-dd HH:mm}" Width="116"/>
+                            <DataGridTemplateColumn Header="Action" Width="76">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <Button Content="Check In"
+                                                MinWidth="64"
+                                                Padding="4,0"
+                                                Command="{Binding DataContext.ToggleCheckOutCommand, RelativeSource={RelativeSource AncestorType=Page}}"
+                                                CommandParameter="{Binding}"/>
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </Grid>
+            </Border>
+        </Grid>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
@@ -47,7 +47,7 @@
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0" Text="Find tool" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                <TextBlock Grid.Column="0" Text="Find item" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
                 <TextBox Grid.Column="1"
                          Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
                          ToolTip="Search by name, item number, part number, brand, location, or keyword"/>
@@ -111,7 +111,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Header="Tool #" Binding="{Binding ItemNumber}" Width="90"/>
+                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="90"/>
                             <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
                             <DataGridTextColumn Header="Brand" Binding="{Binding Brand}" Width="110"/>
                             <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="120"/>
@@ -157,7 +157,7 @@
                             </ContextMenu>
                         </DataGrid.ContextMenu>
                         <DataGrid.Columns>
-                            <DataGridTextColumn Header="Tool #" Binding="{Binding ItemNumber}" Width="82"/>
+                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="82"/>
                             <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
                             <DataGridTextColumn Header="Holder" Binding="{Binding CheckedOutBy}" Width="105"/>
                             <DataGridTextColumn Header="Out Since" Binding="{Binding CheckedOutTime, StringFormat=yyyy-MM-dd HH:mm}" Width="116"/>

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
@@ -144,12 +144,12 @@ namespace InventoryManagementApp.Views.Pages
         {
             if (item.IsIncomplete)
                 return "Incomplete";
-            if (item.HasNoOnHand)
-                return "Unavailable";
             if (item.IsCheckedOut)
                 return "Checked Out";
             if (item.HasRentedStock)
                 return "Rented";
+            if (item.HasNoOnHand)
+                return "Unavailable";
             return "Available";
         }
     }

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
@@ -6,6 +6,9 @@ using System.Windows.Controls;
 using System.Windows.Documents;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
+using WpfDataGrid = System.Windows.Controls.DataGrid;
+using WpfMessageBox = System.Windows.MessageBox;
+using WpfPrintDialog = System.Windows.Controls.PrintDialog;
 
 namespace InventoryManagementApp.Views.Pages
 {
@@ -33,7 +36,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void ItemGrid_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
-            if (DataContext is not ItemManagementViewModel vm || sender is not DataGrid grid || grid.SelectedItem is not ItemModel item)
+            if (DataContext is not ItemManagementViewModel vm || sender is not WpfDataGrid grid || grid.SelectedItem is not ItemModel item)
                 return;
 
             vm.SelectedItem = item;
@@ -58,11 +61,11 @@ namespace InventoryManagementApp.Views.Pages
             var itemList = items.ToList();
             if (itemList.Count == 0)
             {
-                MessageBox.Show("There are no rows to print.", "Print", MessageBoxButton.OK, MessageBoxImage.Information);
+                WpfMessageBox.Show("There are no rows to print.", "Print", MessageBoxButton.OK, MessageBoxImage.Information);
                 return;
             }
 
-            var printDialog = new PrintDialog();
+            var printDialog = new WpfPrintDialog();
             if (printDialog.ShowDialog() != true)
                 return;
 

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
@@ -1,5 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
+using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
@@ -24,6 +29,128 @@ namespace InventoryManagementApp.Views.Pages
         private void UpdateState()
         {
             VisualStateManager.GoToState(this, "Wide", true);
+        }
+
+        private void ItemGrid_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if (DataContext is not ItemManagementViewModel vm || sender is not DataGrid grid || grid.SelectedItem is not ItemModel item)
+                return;
+
+            vm.SelectedItem = item;
+            if (vm.ViewDetailsCommand.CanExecute(null))
+                vm.ViewDetailsCommand.Execute(null);
+        }
+
+        private void PrintSearchResults_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ItemManagementViewModel vm)
+                PrintItems("Tool Search Results", vm.SearchResults);
+        }
+
+        private void PrintCheckedOut_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ItemManagementViewModel vm)
+                PrintItems("Currently Checked Out Tools", vm.CheckedOutItems);
+        }
+
+        private void PrintItems(string title, IEnumerable<ItemModel> items)
+        {
+            var itemList = items.ToList();
+            if (itemList.Count == 0)
+            {
+                MessageBox.Show("There are no rows to print.", "Print", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var printDialog = new PrintDialog();
+            if (printDialog.ShowDialog() != true)
+                return;
+
+            var document = BuildPrintDocument(title, itemList);
+            document.PageWidth = printDialog.PrintableAreaWidth;
+            document.PageHeight = printDialog.PrintableAreaHeight;
+            document.PagePadding = new Thickness(36);
+            document.ColumnWidth = printDialog.PrintableAreaWidth;
+            printDialog.PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator, title);
+        }
+
+        private static FlowDocument BuildPrintDocument(string title, IReadOnlyCollection<ItemModel> items)
+        {
+            var document = new FlowDocument
+            {
+                FontFamily = new System.Windows.Media.FontFamily("Segoe UI"),
+                FontSize = 11
+            };
+
+            document.Blocks.Add(new Paragraph(new Run(title))
+            {
+                FontSize = 16,
+                FontWeight = FontWeights.SemiBold,
+                Margin = new Thickness(0, 0, 0, 4)
+            });
+            document.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:g} - {items.Count} row(s)"))
+            {
+                FontSize = 10,
+                Margin = new Thickness(0, 0, 0, 10)
+            });
+
+            var table = new Table { CellSpacing = 0 };
+            foreach (var width in new[] { 80.0, 180.0, 90.0, 80.0, 70.0, 110.0, 110.0 })
+                table.Columns.Add(new TableColumn { Width = new GridLength(width) });
+
+            var rowGroup = new TableRowGroup();
+            table.RowGroups.Add(rowGroup);
+            var header = new TableRow { FontWeight = FontWeights.SemiBold };
+            rowGroup.Rows.Add(header);
+            AddCell(header, "Tool #");
+            AddCell(header, "Name");
+            AddCell(header, "Status");
+            AddCell(header, "Location");
+            AddCell(header, "On Hand");
+            AddCell(header, "Holder");
+            AddCell(header, "Out Since");
+
+            foreach (var item in items)
+            {
+                var row = new TableRow();
+                rowGroup.Rows.Add(row);
+                AddCell(row, item.ItemNumber);
+                AddCell(row, item.Name);
+                AddCell(row, GetStatus(item));
+                AddCell(row, item.Location);
+                AddCell(row, item.QuantityOnHand.ToString());
+                AddCell(row, item.CheckedOutBy);
+                AddCell(row, item.CheckedOutTime?.ToString("g") ?? string.Empty);
+            }
+
+            document.Blocks.Add(table);
+            return document;
+        }
+
+        private static void AddCell(TableRow row, string text)
+        {
+            row.Cells.Add(new TableCell(new Paragraph(new Run(text ?? string.Empty))
+            {
+                Margin = new Thickness(2)
+            })
+            {
+                BorderBrush = System.Windows.Media.Brushes.Gray,
+                BorderThickness = new Thickness(0, 0, 0, 0.5),
+                Padding = new Thickness(3, 2, 3, 2)
+            });
+        }
+
+        private static string GetStatus(ItemModel item)
+        {
+            if (item.IsIncomplete)
+                return "Incomplete";
+            if (item.HasNoOnHand)
+                return "Unavailable";
+            if (item.IsCheckedOut)
+                return "Checked Out";
+            if (item.HasRentedStock)
+                return "Rented";
+            return "Available";
         }
     }
 }

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
@@ -44,13 +44,13 @@ namespace InventoryManagementApp.Views.Pages
         private void PrintSearchResults_Click(object sender, RoutedEventArgs e)
         {
             if (DataContext is ItemManagementViewModel vm)
-                PrintItems("Tool Search Results", vm.SearchResults);
+                PrintItems("Item Search Results", vm.SearchResults);
         }
 
         private void PrintCheckedOut_Click(object sender, RoutedEventArgs e)
         {
             if (DataContext is ItemManagementViewModel vm)
-                PrintItems("Currently Checked Out Tools", vm.CheckedOutItems);
+                PrintItems("Currently Checked Out Items", vm.CheckedOutItems);
         }
 
         private void PrintItems(string title, IEnumerable<ItemModel> items)
@@ -102,7 +102,7 @@ namespace InventoryManagementApp.Views.Pages
             table.RowGroups.Add(rowGroup);
             var header = new TableRow { FontWeight = FontWeights.SemiBold };
             rowGroup.Rows.Add(header);
-            AddCell(header, "Tool #");
+            AddCell(header, "Item #");
             AddCell(header, "Name");
             AddCell(header, "Status");
             AddCell(header, "Location");


### PR DESCRIPTION
## Summary
- Replaces the item search card wrap with a dense classic desktop split view: search/results on the left and currently checked-out items on the right.
- Adds direct row drill-down, right-click actions, visible availability/checkout/rental status, and same-screen check-in/check-out actions.
- Adds print flows for search results and currently checked-out items.
- Tracks checked-out items and compact result/check-out summaries in `ItemManagementViewModel` so the workflow stays synchronized after refreshes and check-in/check-out actions.

## Validation
- Reviewed branch diff through the GitHub connector.
- Confirmed model aliasing supports the page code-behind `ItemModel` references.
- Local clone/build was blocked by the scheduled environment network restrictions, so WPF build/test validation should run in GitHub Actions.