### PR TITLE
Add same-screen rental request workflow

### DIFF
--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -432,7 +432,7 @@ namespace InventoryManagementApp.ViewModels
 
             try
             {
-                var doc = CreateRentalDocument("Pending Tool Requests", fontSize: 11);
+                var doc = CreateRentalDocument("Open Requests", fontSize: 11);
                 doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | {requests.Count} request{(requests.Count == 1 ? string.Empty : "s")}"))
                 {
                     FontSize = 10,
@@ -457,7 +457,7 @@ namespace InventoryManagementApp.ViewModels
                 }
 
                 doc.Blocks.Add(table);
-                _dialogService.ShowPrintPreview(doc, "Pending Tool Requests", string.Empty);
+                _dialogService.ShowPrintPreview(doc, "Open Requests", string.Empty);
             }
             catch (Exception ex)
             {

--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Documents;
 using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Utilities.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -24,9 +25,11 @@ namespace InventoryManagementApp.ViewModels
 
         public ObservableCollection<RentalModel> Rentals { get; } = new();
         public ObservableCollection<RentalModel> ActiveRentals { get; } = new();
+        public ObservableCollection<Reservation> PendingRequests { get; } = new();
 
         public string SearchSummary => $"{Rentals.Count} result{(Rentals.Count == 1 ? string.Empty : "s")} shown";
         public string CheckedOutSummary => $"{ActiveRentals.Count} item{(ActiveRentals.Count == 1 ? string.Empty : "s")} currently checked out";
+        public string RequestSummary => $"{PendingRequests.Count} pending request{(PendingRequests.Count == 1 ? string.Empty : "s")}";
 
         private string _searchText = string.Empty;
         public string SearchText
@@ -86,10 +89,24 @@ namespace InventoryManagementApp.ViewModels
                     ExtendCommand.NotifyCanExecuteChanged();
                     OpenHistoryCommand.NotifyCanExecuteChanged();
                     OpenRentalDetailsCommand.NotifyCanExecuteChanged();
+                    PlaceRequestCommand.NotifyCanExecuteChanged();
                     PrintRentalCommand.NotifyCanExecuteChanged();
                     PrintPickingSlipCommand.NotifyCanExecuteChanged();
                     PrintInvoiceCommand.NotifyCanExecuteChanged();
                     DeleteRentalCommand.NotifyCanExecuteChanged();
+                }
+            }
+        }
+
+        private Reservation? _selectedRequest;
+        public Reservation? SelectedRequest
+        {
+            get => _selectedRequest;
+            set
+            {
+                if (SetProperty(ref _selectedRequest, value))
+                {
+                    OpenRequestDetailsCommand.NotifyCanExecuteChanged();
                 }
             }
         }
@@ -107,9 +124,12 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand ExtendCommand { get; }
         public IAsyncRelayCommand OpenHistoryCommand { get; }
         public IRelayCommand OpenRentalDetailsCommand { get; }
+        public IAsyncRelayCommand PlaceRequestCommand { get; }
+        public IRelayCommand OpenRequestDetailsCommand { get; }
         public IRelayCommand PrintRentalCommand { get; }
         public IRelayCommand PrintSearchResultsCommand { get; }
         public IRelayCommand PrintCheckedOutCommand { get; }
+        public IRelayCommand PrintRequestsCommand { get; }
         public IRelayCommand PrintPickingSlipCommand { get; }
         public IRelayCommand PrintInvoiceCommand { get; }
         public IAsyncRelayCommand DeleteRentalCommand { get; }
@@ -126,9 +146,12 @@ namespace InventoryManagementApp.ViewModels
             ExtendCommand = new AsyncRelayCommand(ExtendAsync, CanReturnSelectedRental);
             OpenHistoryCommand = new AsyncRelayCommand(OpenHistoryAsync, () => SelectedRental != null);
             OpenRentalDetailsCommand = new RelayCommand(OpenRentalDetails, () => SelectedRental != null);
+            PlaceRequestCommand = new AsyncRelayCommand(PlaceRequestAsync, CanPlaceRequestForSelectedRental);
+            OpenRequestDetailsCommand = new RelayCommand(OpenRequestDetails, () => SelectedRequest != null);
             PrintRentalCommand = new RelayCommand(PrintRental, () => SelectedRental != null);
             PrintSearchResultsCommand = new RelayCommand(PrintSearchResults);
             PrintCheckedOutCommand = new RelayCommand(PrintCheckedOut);
+            PrintRequestsCommand = new RelayCommand(PrintRequests);
             PrintPickingSlipCommand = new RelayCommand(PrintPickingSlip, () => SelectedRental != null);
             PrintInvoiceCommand = new RelayCommand(PrintInvoice, () => SelectedRental != null);
             DeleteRentalCommand = new AsyncRelayCommand(DeleteRentalAsync, () => SelectedRental != null);
@@ -283,6 +306,7 @@ namespace InventoryManagementApp.ViewModels
             details.AppendLine($"Item #: {rental.ItemNumber}");
             details.AppendLine($"Location: {ValueOrNotRecorded(rental.ItemLocation)}");
             details.AppendLine($"Status: {rental.Status}");
+            details.AppendLine($"Pending requests: {PendingRequests.Count(r => r.ItemID == rental.ItemID && r.IsActive)}");
             details.AppendLine();
             details.AppendLine($"Checked out to: {ValueOrNotRecorded(rental.CustomerName)}");
             details.AppendLine($"Contact: {ValueOrNotRecorded(rental.CustomerContact)}");
@@ -295,10 +319,73 @@ namespace InventoryManagementApp.ViewModels
             details.AppendLine($"Time out: {DescribeRentalAge(rental)}");
             details.AppendLine();
             details.AppendLine(IsRentalActive(rental)
-                ? "Next steps: check in when returned, extend if approved, or open history for prior usage."
+                ? "Next steps: check in when returned, extend if approved, place a request for the next customer, or open history for prior usage."
                 : "Next steps: open history to inspect prior usage or print this rental record.");
 
             _dialogService.ShowInfo(details.ToString(), $"Rental Details - {rental.ItemNumber}");
+        }
+
+        async Task PlaceRequestAsync()
+        {
+            if (SelectedRental == null)
+                return;
+
+            var rental = SelectedRental;
+            var reservation = new Reservation
+            {
+                ItemID = rental.ItemID,
+                CustomerID = 0,
+                ItemNumber = rental.ItemNumber,
+                ItemName = rental.ItemNumber,
+                CustomerName = string.Empty,
+                ReservationDate = DateTime.Now,
+                StartDate = rental.DueDate.Date,
+                EndDate = rental.DueDate.Date.AddDays(7),
+                Quantity = 1,
+                Status = "Pending",
+                Notes = $"Requested from rental screen while rental #{rental.RentalID} is out to {ValueOrNotRecorded(rental.CustomerName)}. Due back {rental.DueDate:yyyy-MM-dd}."
+            };
+
+            try
+            {
+                var accepted = await _dialogService.ShowReservationEditDialogAsync(reservation, isNew: true);
+                if (!accepted)
+                    return;
+
+                PendingRequests.Add(reservation);
+                SelectedRequest = reservation;
+                OnPropertyChanged(nameof(RequestSummary));
+                await _dialogService.ShowInfoAsync("Request captured on this rental screen. It will stay visible in the pending request queue until the page is reloaded or a reservation service is wired in.", "Request Captured");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to place request for rental {RentalID}", rental.RentalID);
+                await _dialogService.ShowInfoAsync($"Failed to place request: {ex.Message}", "Error");
+            }
+        }
+
+        void OpenRequestDetails()
+        {
+            if (SelectedRequest == null)
+                return;
+
+            var request = SelectedRequest;
+            var details = new StringBuilder();
+            details.AppendLine($"Item #: {ValueOrNotRecorded(request.ItemNumber)}");
+            details.AppendLine($"Item: {ValueOrNotRecorded(request.ItemName)}");
+            details.AppendLine($"Customer: {ValueOrNotRecorded(request.CustomerName)}");
+            details.AppendLine($"Status: {ValueOrNotRecorded(request.Status)}");
+            details.AppendLine($"Quantity: {request.Quantity}");
+            details.AppendLine();
+            details.AppendLine($"Requested: {FormatDate(request.ReservationDate)}");
+            details.AppendLine($"Needed from: {FormatDate(request.StartDate)}");
+            details.AppendLine($"Needed until: {FormatDate(request.EndDate)}");
+            details.AppendLine();
+            details.AppendLine($"Notes: {ValueOrNotRecorded(request.Notes)}");
+            details.AppendLine();
+            details.AppendLine("Next steps: contact the current holder, monitor check-in, then convert this request into the durable reservation workflow when availability opens.");
+
+            _dialogService.ShowInfo(details.ToString(), $"Request Details - {request.ItemNumber}");
         }
 
         void PrintRental()
@@ -318,6 +405,7 @@ namespace InventoryManagementApp.ViewModels
                 AddKeyValueRow(group, "Due Date:", SelectedRental.DueDate.ToString("yyyy-MM-dd HH:mm"));
                 AddKeyValueRow(group, "Return Date:", SelectedRental.ReturnDate?.ToString("yyyy-MM-dd HH:mm") ?? "N/A");
                 AddKeyValueRow(group, "Status:", SelectedRental.Status ?? string.Empty);
+                AddKeyValueRow(group, "Pending Requests:", PendingRequests.Count(r => r.ItemID == SelectedRental.ItemID && r.IsActive).ToString());
                 doc.Blocks.Add(table);
 
                 _dialogService.ShowPrintPreview(doc, $"Rental {SelectedRental.RentalID}", string.Empty);
@@ -332,6 +420,51 @@ namespace InventoryManagementApp.ViewModels
         void PrintSearchResults() => PrintRentalList("Rental Search Results", Rentals, "There are no rental search results to print.");
 
         void PrintCheckedOut() => PrintRentalList("Currently Checked Out Items", ActiveRentals, "There are no checked-out items to print.");
+
+        void PrintRequests()
+        {
+            var requests = PendingRequests.ToList();
+            if (requests.Count == 0)
+            {
+                _dialogService.ShowInfo("There are no pending requests to print.", "Pending Requests");
+                return;
+            }
+
+            try
+            {
+                var doc = CreateRentalDocument("Pending Tool Requests", fontSize: 11);
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | {requests.Count} request{(requests.Count == 1 ? string.Empty : "s")}"))
+                {
+                    FontSize = 10,
+                    Margin = new Thickness(0, 0, 0, 10)
+                });
+
+                var table = new Table { CellSpacing = 0 };
+                table.Columns.Add(new TableColumn { Width = new GridLength(100) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(150) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(150) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(95) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(95) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(90) });
+
+                var group = new TableRowGroup();
+                table.RowGroups.Add(group);
+                AddPrintRow(group, true, "Item #", "Item", "Customer", "Needed", "Until", "Status");
+
+                foreach (var request in requests)
+                {
+                    AddPrintRow(group, false, request.ItemNumber, request.ItemName, request.CustomerName, request.StartDate.ToString("yyyy-MM-dd"), request.EndDate.ToString("yyyy-MM-dd"), request.Status);
+                }
+
+                doc.Blocks.Add(table);
+                _dialogService.ShowPrintPreview(doc, "Pending Tool Requests", string.Empty);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to print pending requests");
+                _dialogService.ShowInfo($"Failed to print pending requests: {ex.Message}", "Error");
+            }
+        }
 
         void PrintRentalList(string title, IEnumerable<RentalModel> rentals, string emptyMessage)
         {
@@ -512,6 +645,8 @@ namespace InventoryManagementApp.ViewModels
         }
 
         bool CanReturnSelectedRental() => SelectedRental != null && IsRentalActive(SelectedRental);
+
+        bool CanPlaceRequestForSelectedRental() => SelectedRental != null && IsRentalActive(SelectedRental);
 
         static bool IsRentalActive(RentalModel rental)
         {

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Views/ManageRentalsPage.xaml -->
+<!-- Views/ManageRentalsPage.xaml -->
 <Page x:Class="InventoryManagementApp.Views.Pages.ManageRentalsPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -8,7 +8,9 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="2*"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
+            <RowDefinition Height="1.1*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="0.9*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
@@ -20,8 +22,10 @@
                     <Button Style="{StaticResource PrimaryButton}" Content="Check In" Command="{Binding CheckInCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Extend" Command="{Binding ExtendCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="History" Command="{Binding OpenHistoryCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Place Request" Command="{Binding PlaceRequestCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Print Search" Command="{Binding PrintSearchResultsCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Print Checked Out" Command="{Binding PrintCheckedOutCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Print Requests" Command="{Binding PrintRequestsCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Delete" Command="{Binding DeleteRentalCommand}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
@@ -70,6 +74,7 @@
                             <MenuItem Header="Open Details" Command="{Binding OpenRentalDetailsCommand}"/>
                             <MenuItem Header="Check In" Command="{Binding CheckInCommand}"/>
                             <MenuItem Header="Extend" Command="{Binding ExtendCommand}"/>
+                            <MenuItem Header="Place Request" Command="{Binding PlaceRequestCommand}"/>
                             <MenuItem Header="History" Command="{Binding OpenHistoryCommand}"/>
                             <MenuItem Header="Print Rental" Command="{Binding PrintRentalCommand}"/>
                             <MenuItem Header="Print Search Results" Command="{Binding PrintSearchResultsCommand}"/>
@@ -126,6 +131,7 @@
                             <MenuItem Header="Open Details" Command="{Binding OpenRentalDetailsCommand}"/>
                             <MenuItem Header="Check In" Command="{Binding CheckInCommand}"/>
                             <MenuItem Header="Extend" Command="{Binding ExtendCommand}"/>
+                            <MenuItem Header="Place Request" Command="{Binding PlaceRequestCommand}"/>
                             <MenuItem Header="History" Command="{Binding OpenHistoryCommand}"/>
                             <MenuItem Header="Print Checked Out" Command="{Binding PrintCheckedOutCommand}"/>
                         </ContextMenu>
@@ -146,6 +152,63 @@
             </Grid>
         </Border>
 
-        <ProgressBar Grid.Row="4" IsIndeterminate="True" Margin="0,4,0,0" Visibility="{Binding IsLoading, Converter={StaticResource BoolToVis}}"/>
+        <GridSplitter Grid.Row="4" Height="6" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+
+        <Border Grid.Row="5" Style="{StaticResource Card}" Padding="0">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                    <DockPanel>
+                        <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
+                            <TextBlock Text="03 Pending Requests" Style="{StaticResource SectionHeader}" Margin="0"/>
+                            <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenRequestDetailsCommand}" Margin="8,0,4,0"/>
+                            <Button Style="{StaticResource PrimaryButton}" Content="Print" Command="{Binding PrintRequestsCommand}"/>
+                        </StackPanel>
+                        <TextBlock Text="{Binding RequestSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                    </DockPanel>
+                </Border>
+                <DataGrid Grid.Row="1" ItemsSource="{Binding PendingRequests}" SelectedItem="{Binding SelectedRequest}" SelectionMode="Single" IsReadOnly="True" AutoGenerateColumns="False" Style="{StaticResource VirtualizedDataGridStyle}">
+                    <DataGrid.RowStyle>
+                        <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                            <EventSetter Event="MouseDoubleClick" Handler="RequestRow_MouseDoubleClick"/>
+                            <EventSetter Event="PreviewMouseRightButtonDown" Handler="RequestRow_PreviewMouseRightButtonDown"/>
+                        </Style>
+                    </DataGrid.RowStyle>
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="120"/>
+                        <DataGridTextColumn Header="Item" Binding="{Binding ItemName}" Width="180"/>
+                        <DataGridTextColumn Header="Customer" Binding="{Binding CustomerName}" Width="220"/>
+                        <DataGridTextColumn Header="Requested" Binding="{Binding ReservationDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="145"/>
+                        <DataGridTextColumn Header="Needed From" Binding="{Binding StartDate, StringFormat={}{0:yyyy-MM-dd}}" Width="120"/>
+                        <DataGridTextColumn Header="Needed Until" Binding="{Binding EndDate, StringFormat={}{0:yyyy-MM-dd}}" Width="120"/>
+                        <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="110"/>
+                        <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" Width="*"/>
+                    </DataGrid.Columns>
+                    <DataGrid.ContextMenu>
+                        <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                            <MenuItem Header="Open Request Details" Command="{Binding OpenRequestDetailsCommand}"/>
+                            <MenuItem Header="Print Requests" Command="{Binding PrintRequestsCommand}"/>
+                        </ContextMenu>
+                    </DataGrid.ContextMenu>
+                </DataGrid>
+                <TextBlock Grid.Row="1" Text="No pending requests captured in this session" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="13" FontWeight="SemiBold">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding PendingRequests.Count}" Value="0">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+            </Grid>
+        </Border>
+
+        <ProgressBar Grid.Row="6" IsIndeterminate="True" Margin="0,4,0,0" Visibility="{Binding IsLoading, Converter={StaticResource BoolToVis}}"/>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using InventoryManagementApp.ViewModels;
@@ -33,6 +33,24 @@ namespace InventoryManagementApp.Views.Pages
         }
 
         private void RentalRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            SelectRowForContextMenu(sender, e);
+        }
+
+        private void RequestRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is ManageRentalsViewModel vm && vm.OpenRequestDetailsCommand.CanExecute(null))
+            {
+                vm.OpenRequestDetailsCommand.Execute(null);
+            }
+        }
+
+        private void RequestRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            SelectRowForContextMenu(sender, e);
+        }
+
+        private static void SelectRowForContextMenu(object sender, MouseButtonEventArgs e)
         {
             if (sender is DataGridRow row && !row.IsSelected)
             {


### PR DESCRIPTION
## Summary
- Adds a pending request queue to the rentals desktop workflow so advisors can place a request from an unavailable active rental without leaving the page.
- Prefills the existing reservation dialog from the selected rental, including item, due-back timing, current holder context, and notes.
- Adds request details, printing, double-click drill-down, and right-click actions consistent with the classic desktop grid workflow.

## Validation
- Diff reviewed via GitHub connector.
- Local .NET build/tests were not run because the scheduled environment does not provide the .NET SDK.