### PR TITLE
Add item search intelligence pane

### DIFF
--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
@@ -4,7 +4,8 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       x:Class="InventoryManagementApp.Views.Pages.ItemSearchPage"
       Background="{DynamicResource BackgroundBrush}"
-      Loaded="Page_Loaded">
+      Loaded="Page_Loaded"
+      Unloaded="Page_Unloaded">
     <Page.Resources>
         <Style x:Key="StatusTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
             <Setter Property="Text" Value="Available"/>
@@ -214,82 +215,145 @@
 
             <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushAlt}"/>
 
-            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
-                    <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Margin="0" BorderThickness="0,0,0,1">
-                        <DockPanel LastChildFill="True">
-                            <TextBlock Text="Currently Checked Out" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0"/>
-                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
-                                <Button Content="Print" Click="PrintCheckedOut_Click" Margin="0,0,4,0"/>
-                                <Button Content="Details" Command="{Binding ViewDetailsCommand}"/>
-                            </StackPanel>
-                            <TextBlock Text="Visible while searching; double-click to inspect or check back in." Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="10,0,0,0"/>
-                        </DockPanel>
-                    </Border>
-                    <DataGrid x:Name="CheckedOutGrid"
-                              Grid.Row="1"
-                              Style="{StaticResource VirtualizedDataGridStyle}"
-                              ItemsSource="{Binding CheckedOutItems}"
-                              SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
-                              RowHeight="64"
-                              EnableRowVirtualization="True"
-                              MouseDoubleClick="ItemGrid_MouseDoubleClick">
-                        <DataGrid.ContextMenu>
-                            <ContextMenu>
-                                <MenuItem Header="Open Details" Command="{Binding PlacementTarget.DataContext.ViewDetailsCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                                <MenuItem Header="Check In" Command="{Binding PlacementTarget.DataContext.ToggleCheckOutCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                                <Separator/>
-                                <MenuItem Header="Print Checked Out" Click="PrintCheckedOut_Click"/>
-                            </ContextMenu>
-                        </DataGrid.ContextMenu>
-                        <DataGrid.Columns>
-                            <DataGridTemplateColumn Header="Photo" Width="56" IsReadOnly="True">
-                                <DataGridTemplateColumn.CellTemplate>
-                                    <DataTemplate>
-                                        <Image Width="44" Height="44" Stretch="UniformToFill" Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
-                                    </DataTemplate>
-                                </DataGridTemplateColumn.CellTemplate>
-                            </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Checked Out Item" Width="*" IsReadOnly="True">
-                                <DataGridTemplateColumn.CellTemplate>
-                                    <DataTemplate>
-                                        <StackPanel Margin="0,3">
-                                            <TextBlock Text="{Binding Name}" Style="{StaticResource ResultPrimaryText}"/>
-                                            <WrapPanel Margin="0,3,0,0">
-                                                <TextBlock Text="{Binding ItemNumber}" Style="{StaticResource ResultDetailText}"/>
-                                                <TextBlock Text="{Binding Location}" Style="{StaticResource ResultDetailText}"/>
-                                                <TextBlock Text="{Binding CheckedOutBy}" Style="{StaticResource ResultDetailText}"/>
-                                            </WrapPanel>
-                                        </StackPanel>
-                                    </DataTemplate>
-                                </DataGridTemplateColumn.CellTemplate>
-                            </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Out Since" Width="118" IsReadOnly="True">
-                                <DataGridTemplateColumn.CellTemplate>
-                                    <DataTemplate>
-                                        <TextBlock Text="{Binding CheckedOutTime, StringFormat=yyyy-MM-dd HH:mm}" Margin="0,4" TextWrapping="Wrap"/>
-                                    </DataTemplate>
-                                </DataGridTemplateColumn.CellTemplate>
-                            </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Header="Action" Width="76">
-                                <DataGridTemplateColumn.CellTemplate>
-                                    <DataTemplate>
-                                        <Button Content="Check In"
-                                                MinWidth="64"
-                                                Padding="4,0"
-                                                Command="{Binding DataContext.ToggleCheckOutCommand, RelativeSource={RelativeSource AncestorType=Page}}"
-                                                CommandParameter="{Binding}"/>
-                                    </DataTemplate>
-                                </DataGridTemplateColumn.CellTemplate>
-                            </DataGridTemplateColumn>
-                        </DataGrid.Columns>
-                    </DataGrid>
-                </Grid>
-            </Border>
+            <Grid Grid.Column="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="1.35*" MinHeight="190"/>
+                    <RowDefinition Height="4"/>
+                    <RowDefinition Height="*" MinHeight="175"/>
+                </Grid.RowDefinitions>
+
+                <Border Grid.Row="0" Style="{StaticResource Card}" Padding="0">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Margin="0" BorderThickness="0,0,0,1">
+                            <DockPanel LastChildFill="True">
+                                <TextBlock Text="Currently Checked Out" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0"/>
+                                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+                                    <Button Content="Print" Click="PrintCheckedOut_Click" Margin="0,0,4,0"/>
+                                    <Button Content="Details" Command="{Binding ViewDetailsCommand}"/>
+                                </StackPanel>
+                                <TextBlock Text="Visible while searching; double-click to inspect or check back in." Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                            </DockPanel>
+                        </Border>
+                        <DataGrid x:Name="CheckedOutGrid"
+                                  Grid.Row="1"
+                                  Style="{StaticResource VirtualizedDataGridStyle}"
+                                  ItemsSource="{Binding CheckedOutItems}"
+                                  SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
+                                  RowHeight="64"
+                                  EnableRowVirtualization="True"
+                                  MouseDoubleClick="ItemGrid_MouseDoubleClick">
+                            <DataGrid.ContextMenu>
+                                <ContextMenu>
+                                    <MenuItem Header="Open Details" Command="{Binding PlacementTarget.DataContext.ViewDetailsCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                    <MenuItem Header="Check In" Command="{Binding PlacementTarget.DataContext.ToggleCheckOutCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                    <Separator/>
+                                    <MenuItem Header="Print Checked Out" Click="PrintCheckedOut_Click"/>
+                                </ContextMenu>
+                            </DataGrid.ContextMenu>
+                            <DataGrid.Columns>
+                                <DataGridTemplateColumn Header="Photo" Width="56" IsReadOnly="True">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <Image Width="44" Height="44" Stretch="UniformToFill" Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+                                <DataGridTemplateColumn Header="Checked Out Item" Width="*" IsReadOnly="True">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <StackPanel Margin="0,3">
+                                                <TextBlock Text="{Binding Name}" Style="{StaticResource ResultPrimaryText}"/>
+                                                <WrapPanel Margin="0,3,0,0">
+                                                    <TextBlock Text="{Binding ItemNumber}" Style="{StaticResource ResultDetailText}"/>
+                                                    <TextBlock Text="{Binding Location}" Style="{StaticResource ResultDetailText}"/>
+                                                    <TextBlock Text="{Binding CheckedOutBy}" Style="{StaticResource ResultDetailText}"/>
+                                                </WrapPanel>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+                                <DataGridTemplateColumn Header="Out Since" Width="118" IsReadOnly="True">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding CheckedOutTime, StringFormat=yyyy-MM-dd HH:mm}" Margin="0,4" TextWrapping="Wrap"/>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+                                <DataGridTemplateColumn Header="Action" Width="76">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <Button Content="Check In"
+                                                    MinWidth="64"
+                                                    Padding="4,0"
+                                                    Command="{Binding DataContext.ToggleCheckOutCommand, RelativeSource={RelativeSource AncestorType=Page}}"
+                                                    CommandParameter="{Binding}"/>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </Grid>
+                </Border>
+
+                <GridSplitter Grid.Row="1" Height="4" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushAlt}"/>
+
+                <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Margin="0" BorderThickness="0,0,0,1">
+                            <DockPanel LastChildFill="True">
+                                <TextBlock Text="Search Intelligence" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0"/>
+                                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+                                    <Button Content="Repeat" Click="RepeatSelectedSearch_Click" Margin="0,0,4,0"/>
+                                    <Button Content="Open Item" Click="OpenDemandItem_Click"/>
+                                </StackPanel>
+                                <TextBlock x:Name="SearchIntelligenceSummaryText" Text="No search activity yet" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                            </DockPanel>
+                        </Border>
+                        <TabControl Grid.Row="1" Margin="0" Padding="0">
+                            <TabItem Header="Recent Searches">
+                                <DataGrid x:Name="RecentSearchGrid"
+                                          Style="{StaticResource VirtualizedDataGridStyle}"
+                                          AutoGenerateColumns="False"
+                                          IsReadOnly="True"
+                                          RowHeight="26"
+                                          MouseDoubleClick="RecentSearchGrid_MouseDoubleClick">
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="Search" Binding="{Binding Term}" Width="*"/>
+                                        <DataGridTextColumn Header="Brand" Binding="{Binding Category}" Width="82"/>
+                                        <DataGridTextColumn Header="Results" Binding="{Binding ResultCount}" Width="58"/>
+                                        <DataGridTextColumn Header="Unavailable" Binding="{Binding UnavailableCount}" Width="82"/>
+                                        <DataGridTextColumn Header="Last" Binding="{Binding LastSearched, StringFormat={}{0:HH:mm}}" Width="54"/>
+                                    </DataGrid.Columns>
+                                </DataGrid>
+                            </TabItem>
+                            <TabItem Header="Unavailable Demand">
+                                <DataGrid x:Name="UnavailableDemandGrid"
+                                          Style="{StaticResource VirtualizedDataGridStyle}"
+                                          AutoGenerateColumns="False"
+                                          IsReadOnly="True"
+                                          RowHeight="30"
+                                          MouseDoubleClick="UnavailableDemandGrid_MouseDoubleClick">
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="86"/>
+                                        <DataGridTextColumn Header="Item" Binding="{Binding Name}" Width="*"/>
+                                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="84"/>
+                                        <DataGridTextColumn Header="Hits" Binding="{Binding HitCount}" Width="46"/>
+                                        <DataGridTextColumn Header="Terms" Binding="{Binding SearchTerms}" Width="120"/>
+                                    </DataGrid.Columns>
+                                </DataGrid>
+                            </TabItem>
+                        </TabControl>
+                    </Grid>
+                </Border>
+            </Grid>
         </Grid>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
+using System.Windows.Threading;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
 using WpfDataGrid = System.Windows.Controls.DataGrid;
@@ -14,9 +17,19 @@ namespace InventoryManagementApp.Views.Pages
 {
     public partial class ItemSearchPage : Page
     {
+        private readonly ObservableCollection<SearchHistoryEntry> _searchHistory = new();
+        private readonly ObservableCollection<UnavailableDemandEntry> _unavailableDemand = new();
+        private readonly Dictionary<int, UnavailableDemandEntry> _demandByItemId = new();
+        private ItemManagementViewModel? _attachedViewModel;
+        private bool _recordSearchPending;
+        private string _lastSearchSignature = string.Empty;
+
         public ItemSearchPage()
         {
             InitializeComponent();
+            RecentSearchGrid.ItemsSource = _searchHistory;
+            UnavailableDemandGrid.ItemsSource = _unavailableDemand;
+            UpdateSearchIntelligenceSummary();
         }
 
         private async void Page_Loaded(object sender, RoutedEventArgs e)
@@ -24,9 +37,32 @@ namespace InventoryManagementApp.Views.Pages
             UpdateState();
             if (DataContext is ItemManagementViewModel vm)
             {
+                AttachViewModel(vm);
                 vm.SelectedCategory = "All";
                 await vm.SearchCommand.ExecuteAsync(null);
             }
+        }
+
+        private void Page_Unloaded(object sender, RoutedEventArgs e)
+        {
+            DetachViewModel();
+        }
+
+        private void AttachViewModel(ItemManagementViewModel vm)
+        {
+            if (ReferenceEquals(_attachedViewModel, vm))
+                return;
+
+            DetachViewModel();
+            _attachedViewModel = vm;
+            vm.SearchResults.CollectionChanged += SearchResults_CollectionChanged;
+        }
+
+        private void DetachViewModel()
+        {
+            if (_attachedViewModel != null)
+                _attachedViewModel.SearchResults.CollectionChanged -= SearchResults_CollectionChanged;
+            _attachedViewModel = null;
         }
 
         private void UpdateState()
@@ -40,6 +76,147 @@ namespace InventoryManagementApp.Views.Pages
                 return;
 
             vm.SelectedItem = item;
+            if (vm.ViewDetailsCommand.CanExecute(null))
+                vm.ViewDetailsCommand.Execute(null);
+        }
+
+        private void SearchResults_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (_recordSearchPending)
+                return;
+
+            _recordSearchPending = true;
+            Dispatcher.BeginInvoke(new Action(() =>
+            {
+                _recordSearchPending = false;
+                RecordCurrentSearch();
+            }), DispatcherPriority.Background);
+        }
+
+        private void RecordCurrentSearch()
+        {
+            if (_attachedViewModel == null)
+                return;
+
+            var term = (_attachedViewModel.SearchText ?? string.Empty).Trim();
+            if (string.IsNullOrWhiteSpace(term))
+            {
+                UpdateSearchIntelligenceSummary();
+                return;
+            }
+
+            var category = string.IsNullOrWhiteSpace(_attachedViewModel.SelectedCategory)
+                ? "All"
+                : _attachedViewModel.SelectedCategory;
+            var results = _attachedViewModel.SearchResults.ToList();
+            var unavailable = results.Where(IsUnavailable).ToList();
+            var signature = BuildSearchSignature(term, category, results, unavailable);
+            if (string.Equals(signature, _lastSearchSignature, StringComparison.Ordinal))
+                return;
+
+            _lastSearchSignature = signature;
+            UpsertSearchHistory(term, category, results.Count, unavailable.Count);
+            CaptureUnavailableDemand(term, unavailable);
+            UpdateSearchIntelligenceSummary();
+        }
+
+        private static string BuildSearchSignature(string term, string category, IEnumerable<ItemModel> results, IEnumerable<ItemModel> unavailable)
+        {
+            var resultIds = string.Join(",", results.Select(item => item.ItemID).OrderBy(id => id));
+            var unavailableIds = string.Join(",", unavailable.Select(item => item.ItemID).OrderBy(id => id));
+            return $"{term}|{category}|{resultIds}|{unavailableIds}";
+        }
+
+        private void UpsertSearchHistory(string term, string category, int resultCount, int unavailableCount)
+        {
+            var existing = _searchHistory.FirstOrDefault(entry =>
+                string.Equals(entry.Term, term, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(entry.Category, category, StringComparison.OrdinalIgnoreCase));
+
+            if (existing != null)
+                _searchHistory.Remove(existing);
+            else
+                existing = new SearchHistoryEntry();
+
+            existing.Term = term;
+            existing.Category = category;
+            existing.ResultCount = resultCount;
+            existing.UnavailableCount = unavailableCount;
+            existing.LastSearched = DateTime.Now;
+            _searchHistory.Insert(0, existing);
+
+            while (_searchHistory.Count > 10)
+                _searchHistory.RemoveAt(_searchHistory.Count - 1);
+        }
+
+        private void CaptureUnavailableDemand(string term, IEnumerable<ItemModel> unavailableItems)
+        {
+            foreach (var item in unavailableItems.GroupBy(item => item.ItemID).Select(group => group.First()))
+            {
+                if (!_demandByItemId.TryGetValue(item.ItemID, out var entry))
+                {
+                    entry = new UnavailableDemandEntry { Item = item };
+                    _demandByItemId[item.ItemID] = entry;
+                }
+
+                entry.UpdateFrom(item, term);
+            }
+
+            _unavailableDemand.Clear();
+            foreach (var entry in _demandByItemId.Values
+                         .OrderByDescending(entry => entry.HitCount)
+                         .ThenByDescending(entry => entry.LastSearched)
+                         .ThenBy(entry => entry.Name)
+                         .Take(12))
+            {
+                _unavailableDemand.Add(entry);
+            }
+        }
+
+        private void UpdateSearchIntelligenceSummary()
+        {
+            SearchIntelligenceSummaryText.Text = _searchHistory.Count == 0
+                ? "No search activity yet"
+                : $"{_searchHistory.Count} recent searches; {_unavailableDemand.Count} unavailable demand signals";
+        }
+
+        private void RepeatSelectedSearch_Click(object sender, RoutedEventArgs e)
+        {
+            RepeatSearch(RecentSearchGrid.SelectedItem as SearchHistoryEntry);
+        }
+
+        private void RecentSearchGrid_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            RepeatSearch(RecentSearchGrid.SelectedItem as SearchHistoryEntry);
+        }
+
+        private void RepeatSearch(SearchHistoryEntry? entry)
+        {
+            if (entry == null || DataContext is not ItemManagementViewModel vm)
+                return;
+
+            if (vm.Categories.Contains(entry.Category))
+                vm.SelectedCategory = entry.Category;
+            vm.SearchText = entry.Term;
+            _ = vm.SearchCommand.ExecuteAsync(null);
+        }
+
+        private void OpenDemandItem_Click(object sender, RoutedEventArgs e)
+        {
+            OpenDemandItem(UnavailableDemandGrid.SelectedItem as UnavailableDemandEntry);
+        }
+
+        private void UnavailableDemandGrid_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            OpenDemandItem(UnavailableDemandGrid.SelectedItem as UnavailableDemandEntry);
+        }
+
+        private void OpenDemandItem(UnavailableDemandEntry? entry)
+        {
+            if (entry?.Item == null || DataContext is not ItemManagementViewModel vm)
+                return;
+
+            vm.SelectedItem = entry.Item;
             if (vm.ViewDetailsCommand.CanExecute(null))
                 vm.ViewDetailsCommand.Execute(null);
         }
@@ -143,6 +320,11 @@ namespace InventoryManagementApp.Views.Pages
             });
         }
 
+        private static bool IsUnavailable(ItemModel item)
+        {
+            return item.HasNoOnHand || item.HasRentedStock || item.IsCheckedOut;
+        }
+
         private static string GetStatus(ItemModel item)
         {
             if (item.IsIncomplete)
@@ -154,6 +336,40 @@ namespace InventoryManagementApp.Views.Pages
             if (item.HasNoOnHand)
                 return "Unavailable";
             return "Available";
+        }
+
+        public sealed class SearchHistoryEntry
+        {
+            public string Term { get; set; } = string.Empty;
+            public string Category { get; set; } = "All";
+            public int ResultCount { get; set; }
+            public int UnavailableCount { get; set; }
+            public DateTime LastSearched { get; set; }
+        }
+
+        public sealed class UnavailableDemandEntry
+        {
+            private readonly List<string> _terms = new();
+
+            public ItemModel? Item { get; set; }
+            public int HitCount { get; private set; }
+            public DateTime LastSearched { get; private set; }
+            public string ItemNumber => Item?.ItemNumber ?? string.Empty;
+            public string Name => Item?.Name ?? string.Empty;
+            public string Status => Item == null ? string.Empty : GetStatus(Item);
+            public string SearchTerms => string.Join(", ", _terms.Take(3));
+
+            public void UpdateFrom(ItemModel item, string term)
+            {
+                Item = item;
+                HitCount++;
+                LastSearched = DateTime.Now;
+
+                if (!_terms.Any(existing => string.Equals(existing, term, StringComparison.OrdinalIgnoreCase)))
+                    _terms.Insert(0, term);
+                while (_terms.Count > 3)
+                    _terms.RemoveAt(_terms.Count - 1);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds a compact Search Intelligence pane to the desktop item search workflow without leaving the checkout screen.
- Tracks recent item searches in the current session with result counts, unavailable counts, brand filter, and double-click repeat search.
- Tracks unavailable demand signals for searched items that are checked out, rented, or out of stock, with double-click drill-down into item details.
- Keeps the classic split workflow intact: search/results on the left, checked-out items on the right, plus a lower-right intelligence pane for repeated technician/advisor decisions.

## Validation
- Reviewed the focused diff through the GitHub connector.
- GitHub reported no statuses for the branch at PR creation time.
- Local .NET build/tests could not run because this scheduled environment cannot clone the repository directly and does not provide the .NET SDK.