### PR TITLE
Add printable item search intelligence report

### DIFF
--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml
@@ -311,8 +311,10 @@
                             <DockPanel LastChildFill="True">
                                 <TextBlock Text="Search Intelligence" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0"/>
                                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
-                                    <Button Content="Repeat" Click="RepeatSelectedSearch_Click" Margin="0,0,4,0"/>
-                                    <Button Content="Open Item" Click="OpenDemandItem_Click"/>
+                                    <Button Content="Repeat" Click="RepeatSelectedSearch_Click" ToolTip="Run the selected recent search again" Margin="0,0,4,0"/>
+                                    <Button Content="Open" Click="OpenDemandItem_Click" ToolTip="Open the selected unavailable item" Margin="0,0,4,0"/>
+                                    <Button Content="Print" Click="PrintSearchIntelligence_Click" ToolTip="Print recent searches and unavailable demand" Margin="0,0,4,0"/>
+                                    <Button Content="Clear" Click="ClearSearchIntelligence_Click" ToolTip="Clear this session's search intelligence"/>
                                 </StackPanel>
                                 <TextBlock x:Name="SearchIntelligenceSummaryText" Text="No search activity yet" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="10,0,0,0"/>
                             </DockPanel>
@@ -325,6 +327,14 @@
                                           IsReadOnly="True"
                                           RowHeight="26"
                                           MouseDoubleClick="RecentSearchGrid_MouseDoubleClick">
+                                    <DataGrid.ContextMenu>
+                                        <ContextMenu>
+                                            <MenuItem Header="Repeat Search" Click="RepeatSelectedSearch_Click"/>
+                                            <MenuItem Header="Print Intelligence Report" Click="PrintSearchIntelligence_Click"/>
+                                            <Separator/>
+                                            <MenuItem Header="Clear Session Intelligence" Click="ClearSearchIntelligence_Click"/>
+                                        </ContextMenu>
+                                    </DataGrid.ContextMenu>
                                     <DataGrid.Columns>
                                         <DataGridTextColumn Header="Search" Binding="{Binding Term}" Width="*"/>
                                         <DataGridTextColumn Header="Brand" Binding="{Binding Category}" Width="82"/>
@@ -339,13 +349,24 @@
                                           Style="{StaticResource VirtualizedDataGridStyle}"
                                           AutoGenerateColumns="False"
                                           IsReadOnly="True"
-                                          RowHeight="30"
+                                          RowHeight="32"
                                           MouseDoubleClick="UnavailableDemandGrid_MouseDoubleClick">
+                                    <DataGrid.ContextMenu>
+                                        <ContextMenu>
+                                            <MenuItem Header="Open Item Details" Click="OpenDemandItem_Click"/>
+                                            <MenuItem Header="Print Intelligence Report" Click="PrintSearchIntelligence_Click"/>
+                                            <Separator/>
+                                            <MenuItem Header="Clear Session Intelligence" Click="ClearSearchIntelligence_Click"/>
+                                        </ContextMenu>
+                                    </DataGrid.ContextMenu>
                                     <DataGrid.Columns>
-                                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="86"/>
-                                        <DataGridTextColumn Header="Item" Binding="{Binding Name}" Width="*"/>
-                                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="84"/>
-                                        <DataGridTextColumn Header="Hits" Binding="{Binding HitCount}" Width="46"/>
+                                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="76"/>
+                                        <DataGridTextColumn Header="Item" Binding="{Binding Name}" Width="1.4*"/>
+                                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="82"/>
+                                        <DataGridTextColumn Header="Hits" Binding="{Binding HitCount}" Width="42"/>
+                                        <DataGridTextColumn Header="Holder" Binding="{Binding Holder}" Width="86"/>
+                                        <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="78"/>
+                                        <DataGridTextColumn Header="Last" Binding="{Binding LastSearched, StringFormat={}{0:HH:mm}}" Width="50"/>
                                         <DataGridTextColumn Header="Terms" Binding="{Binding SearchTerms}" Width="120"/>
                                     </DataGrid.Columns>
                                 </DataGrid>

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
@@ -221,6 +221,38 @@ namespace InventoryManagementApp.Views.Pages
                 vm.ViewDetailsCommand.Execute(null);
         }
 
+        private void ClearSearchIntelligence_Click(object sender, RoutedEventArgs e)
+        {
+            if (_searchHistory.Count == 0 && _unavailableDemand.Count == 0)
+                return;
+
+            _searchHistory.Clear();
+            _unavailableDemand.Clear();
+            _demandByItemId.Clear();
+            _lastSearchSignature = string.Empty;
+            UpdateSearchIntelligenceSummary();
+        }
+
+        private void PrintSearchIntelligence_Click(object sender, RoutedEventArgs e)
+        {
+            if (_searchHistory.Count == 0 && _unavailableDemand.Count == 0)
+            {
+                WpfMessageBox.Show("There is no search intelligence to print yet.", "Print", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var printDialog = new WpfPrintDialog();
+            if (printDialog.ShowDialog() != true)
+                return;
+
+            var document = BuildSearchIntelligenceDocument(_searchHistory.ToList(), _unavailableDemand.ToList());
+            document.PageWidth = printDialog.PrintableAreaWidth;
+            document.PageHeight = printDialog.PrintableAreaHeight;
+            document.PagePadding = new Thickness(36);
+            document.ColumnWidth = printDialog.PrintableAreaWidth;
+            printDialog.PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator, "Item Search Intelligence");
+        }
+
         private void PrintSearchResults_Click(object sender, RoutedEventArgs e)
         {
             if (DataContext is ItemManagementViewModel vm)
@@ -307,6 +339,108 @@ namespace InventoryManagementApp.Views.Pages
             return document;
         }
 
+        private static FlowDocument BuildSearchIntelligenceDocument(
+            IReadOnlyCollection<SearchHistoryEntry> searches,
+            IReadOnlyCollection<UnavailableDemandEntry> demand)
+        {
+            var document = new FlowDocument
+            {
+                FontFamily = new System.Windows.Media.FontFamily("Segoe UI"),
+                FontSize = 11
+            };
+
+            document.Blocks.Add(new Paragraph(new Run("Item Search Intelligence"))
+            {
+                FontSize = 16,
+                FontWeight = FontWeights.SemiBold,
+                Margin = new Thickness(0, 0, 0, 4)
+            });
+            document.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:g} - {searches.Count} recent search(es), {demand.Count} unavailable demand signal(s)"))
+            {
+                FontSize = 10,
+                Margin = new Thickness(0, 0, 0, 10)
+            });
+
+            if (searches.Count > 0)
+            {
+                AddSectionTitle(document, "Recent Searches");
+                var searchTable = new Table { CellSpacing = 0 };
+                foreach (var width in new[] { 210.0, 90.0, 70.0, 90.0, 90.0 })
+                    searchTable.Columns.Add(new TableColumn { Width = new GridLength(width) });
+
+                var rowGroup = new TableRowGroup();
+                searchTable.RowGroups.Add(rowGroup);
+                var header = new TableRow { FontWeight = FontWeights.SemiBold };
+                rowGroup.Rows.Add(header);
+                AddCell(header, "Search");
+                AddCell(header, "Brand");
+                AddCell(header, "Results");
+                AddCell(header, "Unavailable");
+                AddCell(header, "Last Search");
+
+                foreach (var entry in searches)
+                {
+                    var row = new TableRow();
+                    rowGroup.Rows.Add(row);
+                    AddCell(row, entry.Term);
+                    AddCell(row, entry.Category);
+                    AddCell(row, entry.ResultCount.ToString());
+                    AddCell(row, entry.UnavailableCount.ToString());
+                    AddCell(row, entry.LastSearched.ToString("g"));
+                }
+
+                document.Blocks.Add(searchTable);
+            }
+
+            if (demand.Count > 0)
+            {
+                AddSectionTitle(document, "Unavailable Demand");
+                var demandTable = new Table { CellSpacing = 0 };
+                foreach (var width in new[] { 75.0, 150.0, 85.0, 45.0, 90.0, 80.0, 90.0, 120.0 })
+                    demandTable.Columns.Add(new TableColumn { Width = new GridLength(width) });
+
+                var rowGroup = new TableRowGroup();
+                demandTable.RowGroups.Add(rowGroup);
+                var header = new TableRow { FontWeight = FontWeights.SemiBold };
+                rowGroup.Rows.Add(header);
+                AddCell(header, "Item #");
+                AddCell(header, "Item");
+                AddCell(header, "Status");
+                AddCell(header, "Hits");
+                AddCell(header, "Holder");
+                AddCell(header, "Location");
+                AddCell(header, "Last Search");
+                AddCell(header, "Terms");
+
+                foreach (var entry in demand)
+                {
+                    var row = new TableRow();
+                    rowGroup.Rows.Add(row);
+                    AddCell(row, entry.ItemNumber);
+                    AddCell(row, entry.Name);
+                    AddCell(row, entry.Status);
+                    AddCell(row, entry.HitCount.ToString());
+                    AddCell(row, entry.Holder);
+                    AddCell(row, entry.Location);
+                    AddCell(row, entry.LastSearched.ToString("g"));
+                    AddCell(row, entry.SearchTerms);
+                }
+
+                document.Blocks.Add(demandTable);
+            }
+
+            return document;
+        }
+
+        private static void AddSectionTitle(FlowDocument document, string title)
+        {
+            document.Blocks.Add(new Paragraph(new Run(title))
+            {
+                FontWeight = FontWeights.SemiBold,
+                Margin = new Thickness(0, 10, 0, 4)
+            });
+        }
+
         private static void AddCell(TableRow row, string text)
         {
             row.Cells.Add(new TableCell(new Paragraph(new Run(text ?? string.Empty))
@@ -357,6 +491,8 @@ namespace InventoryManagementApp.Views.Pages
             public string ItemNumber => Item?.ItemNumber ?? string.Empty;
             public string Name => Item?.Name ?? string.Empty;
             public string Status => Item == null ? string.Empty : GetStatus(Item);
+            public string Holder => Item?.CheckedOutBy ?? string.Empty;
+            public string Location => Item?.Location ?? string.Empty;
             public string SearchTerms => string.Join(", ", _terms.Take(3));
 
             public void UpdateFrom(ItemModel item, string term)


### PR DESCRIPTION
## Summary
- Adds compact Print and Clear actions to the item search Search Intelligence pane.
- Adds right-click actions for repeating searches, opening unavailable-demand items, printing the intelligence report, and clearing session intelligence.
- Expands unavailable-demand rows with holder, location, and last-search information so advisors/admins can see what is being repeatedly searched while unavailable.
- Adds a printable Item Search Intelligence report covering recent searches and unavailable-demand signals.

## Validation
- Reviewed the focused branch diff against `master`.
- Verified the changed XAML/code-behind file contents through the GitHub connector.
- Local .NET build/tests could not run because this scheduled environment does not have the .NET SDK installed.