### PR TITLE
Improve desktop item detail drilldown

### DIFF
--- a/InventoryManagementApp/ViewModels/ItemDetailsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemDetailsViewModel.cs
@@ -67,9 +67,15 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (ItemModel.IsIncomplete)
                 {
-                    var notes = string.Join(" | ", new[] { ItemModel.MissingComponentsNotes, ItemModel.IssuesNotes }
-                        .WhereText());
-                    return string.IsNullOrWhiteSpace(notes) ? "Marked incomplete" : notes;
+                    var missing = ItemModel.MissingComponentsNotes;
+                    var issues = ItemModel.IssuesNotes;
+                    if (!string.IsNullOrWhiteSpace(missing) && !string.IsNullOrWhiteSpace(issues))
+                        return $"{missing} | {issues}";
+                    if (!string.IsNullOrWhiteSpace(missing))
+                        return missing;
+                    if (!string.IsNullOrWhiteSpace(issues))
+                        return issues;
+                    return "Marked incomplete";
                 }
 
                 if (!string.IsNullOrWhiteSpace(ItemModel.IssuesNotes))
@@ -248,14 +254,6 @@ namespace InventoryManagementApp.ViewModels
             target.MissingComponentsNotes = source.MissingComponentsNotes;
             target.IssuesNotes = source.IssuesNotes;
             target.CheckoutCount = source.CheckoutCount;
-        }
-    }
-
-    internal static class ItemDetailsTextExtensions
-    {
-        public static string[] WhereText(this string[] values)
-        {
-            return Array.FindAll(values, value => !string.IsNullOrWhiteSpace(value));
         }
     }
 }

--- a/InventoryManagementApp/ViewModels/ItemDetailsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemDetailsViewModel.cs
@@ -23,6 +23,73 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand OpenRentalHistoryCommand { get; }
 
         public string CheckOutButtonText => ItemModel.IsCheckedOut ? "Check In" : "Check Out";
+        public string StatusText
+        {
+            get
+            {
+                if (ItemModel.IsIncomplete)
+                    return "Maintenance / Incomplete";
+                if (ItemModel.IsCheckedOut)
+                    return "Checked Out";
+                if (ItemModel.HasRentedStock)
+                    return "Rented";
+                if (ItemModel.HasNoOnHand)
+                    return "Unavailable";
+                return "Available";
+            }
+        }
+
+        public string AvailabilitySummary => ItemModel.IsCheckedOut
+            ? "Not available until it is checked back in."
+            : ItemModel.HasRentedStock
+                ? "Rental stock is currently out with a customer."
+                : ItemModel.HasNoOnHand
+                    ? "No on-hand stock is available at this location."
+                    : "Available for checkout or rental.";
+
+        public string HolderSummary => ItemModel.IsCheckedOut
+            ? string.IsNullOrWhiteSpace(ItemModel.CheckedOutBy) ? "Holder not recorded" : ItemModel.CheckedOutBy
+            : ItemModel.HasRentedStock ? "Customer rental in progress" : "Shelf / available stock";
+
+        public string CheckedOutSinceText => ItemModel.CheckedOutTime?.ToString("yyyy-MM-dd HH:mm") ?? "Not checked out";
+        public string TimeOutText => ItemModel.CheckedOutTime is DateTime checkedOut
+            ? FormatElapsed(DateTime.Now - checkedOut)
+            : "-";
+        public string LastCheckInText => ItemModel.CheckedInTime?.ToString("yyyy-MM-dd HH:mm") ?? "No recent check-in recorded";
+        public string StockSummary => $"On hand {ItemModel.QuantityOnHand} | Rented {ItemModel.RentedQuantity}";
+        public string UsageSummary => ItemModel.CheckoutCount == 1 ? "1 recorded checkout" : $"{ItemModel.CheckoutCount} recorded checkouts";
+        public string UpdatedText => ItemModel.UpdatedAt == default ? "Not recorded" : ItemModel.UpdatedAt.ToString("yyyy-MM-dd HH:mm");
+        public string PurchasedText => ItemModel.PurchasedDate?.ToString("yyyy-MM-dd") ?? "Not recorded";
+        public string PriceText => ItemModel.Price > 0 ? ItemModel.Price.ToString("C") : "Not recorded";
+        public string ConditionSummary
+        {
+            get
+            {
+                if (ItemModel.IsIncomplete)
+                {
+                    var notes = string.Join(" | ", new[] { ItemModel.MissingComponentsNotes, ItemModel.IssuesNotes }
+                        .WhereText());
+                    return string.IsNullOrWhiteSpace(notes) ? "Marked incomplete" : notes;
+                }
+
+                if (!string.IsNullOrWhiteSpace(ItemModel.IssuesNotes))
+                    return ItemModel.IssuesNotes;
+
+                return "No open condition notes";
+            }
+        }
+
+        public string NextActionText
+        {
+            get
+            {
+                if (ItemModel.IsCheckedOut)
+                    return "Check in from this window, then review any waiting rental requests from the rentals page.";
+                if (ItemModel.HasRentedStock || ItemModel.HasNoOnHand)
+                    return "Open rental history or place a request from the rentals workflow if another user needs this item.";
+                return "Check out to a technician, rent to a customer, or open history before handing it out.";
+            }
+        }
 
         public ItemDetailsViewModel(ItemModel item, IItemService itemService, ICustomerService customerService, IRentalService rentalService, IDialogService dialogService, Action onClose)
         {
@@ -63,10 +130,7 @@ namespace InventoryManagementApp.ViewModels
             var refreshed = await _itemService.GetItemByIDAsync(ItemModel.ItemID).ConfigureAwait(false);
             if (refreshed != null)
             {
-                ItemModel.CheckedOutBy = refreshed.CheckedOutBy;
-                ItemModel.CheckedOutTime = refreshed.CheckedOutTime;
-                ItemModel.CheckedInBy = refreshed.CheckedInBy;
-                ItemModel.CheckedInTime = refreshed.CheckedInTime;
+                CopyItem(ItemModel, refreshed);
             }
 
             RefreshState();
@@ -100,6 +164,28 @@ namespace InventoryManagementApp.ViewModels
         void RefreshState()
         {
             OnPropertyChanged(nameof(CheckOutButtonText));
+            OnPropertyChanged(nameof(StatusText));
+            OnPropertyChanged(nameof(AvailabilitySummary));
+            OnPropertyChanged(nameof(HolderSummary));
+            OnPropertyChanged(nameof(CheckedOutSinceText));
+            OnPropertyChanged(nameof(TimeOutText));
+            OnPropertyChanged(nameof(LastCheckInText));
+            OnPropertyChanged(nameof(StockSummary));
+            OnPropertyChanged(nameof(UsageSummary));
+            OnPropertyChanged(nameof(UpdatedText));
+            OnPropertyChanged(nameof(PurchasedText));
+            OnPropertyChanged(nameof(PriceText));
+            OnPropertyChanged(nameof(ConditionSummary));
+            OnPropertyChanged(nameof(NextActionText));
+        }
+
+        static string FormatElapsed(TimeSpan elapsed)
+        {
+            if (elapsed.TotalDays >= 1)
+                return $"{(int)elapsed.TotalDays}d {elapsed.Hours}h";
+            if (elapsed.TotalHours >= 1)
+                return $"{(int)elapsed.TotalHours}h {elapsed.Minutes}m";
+            return $"{Math.Max(0, (int)elapsed.TotalMinutes)}m";
         }
 
         static ItemModel CloneItem(ItemModel source)
@@ -112,6 +198,7 @@ namespace InventoryManagementApp.ViewModels
                 Name = source.Name,
                 Brand = source.Brand,
                 Location = source.Location,
+                Price = source.Price,
                 QuantityOnHand = source.QuantityOnHand,
                 RentedQuantity = source.RentedQuantity,
                 Supplier = source.Supplier,
@@ -125,7 +212,12 @@ namespace InventoryManagementApp.ViewModels
                 CheckedOutTime = source.CheckedOutTime,
                 CheckedInBy = source.CheckedInBy,
                 CheckedInTime = source.CheckedInTime,
-                ImagePath = source.ImagePath
+                ImagePath = source.ImagePath,
+                UpdatedAt = source.UpdatedAt,
+                IsIncomplete = source.IsIncomplete,
+                MissingComponentsNotes = source.MissingComponentsNotes,
+                IssuesNotes = source.IssuesNotes,
+                CheckoutCount = source.CheckoutCount
             };
         }
 
@@ -136,6 +228,7 @@ namespace InventoryManagementApp.ViewModels
             target.Name = source.Name;
             target.Brand = source.Brand;
             target.Location = source.Location;
+            target.Price = source.Price;
             target.QuantityOnHand = source.QuantityOnHand;
             target.RentedQuantity = source.RentedQuantity;
             target.Supplier = source.Supplier;
@@ -150,6 +243,19 @@ namespace InventoryManagementApp.ViewModels
             target.CheckedInBy = source.CheckedInBy;
             target.CheckedInTime = source.CheckedInTime;
             target.ImagePath = source.ImagePath;
+            target.UpdatedAt = source.UpdatedAt;
+            target.IsIncomplete = source.IsIncomplete;
+            target.MissingComponentsNotes = source.MissingComponentsNotes;
+            target.IssuesNotes = source.IssuesNotes;
+            target.CheckoutCount = source.CheckoutCount;
+        }
+    }
+
+    internal static class ItemDetailsTextExtensions
+    {
+        public static string[] WhereText(this string[] values)
+        {
+            return Array.FindAll(values, value => !string.IsNullOrWhiteSpace(value));
         }
     }
 }

--- a/InventoryManagementApp/Views/Windows/ItemDetailsWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ItemDetailsWindow.xaml
@@ -174,9 +174,11 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <TextBlock Grid.Row="0" Text="{Binding ConditionSummary}" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,0,0,6"/>
-                            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource ControlBackgroundBrush}" Padding="6">
-                                <TextBlock Text="{Binding ItemModel.Notes}" TextWrapping="Wrap"/>
-                            </ScrollViewer>
+                            <Border Grid.Row="1" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource ControlBackgroundBrush}" Padding="6">
+                                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                    <TextBlock Text="{Binding ItemModel.Notes}" TextWrapping="Wrap"/>
+                                </ScrollViewer>
+                            </Border>
                             <Grid Grid.Row="2" Margin="0,6,0,0">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="82"/>

--- a/InventoryManagementApp/Views/Windows/ItemDetailsWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ItemDetailsWindow.xaml
@@ -3,64 +3,200 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
-        Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} Details'}" Width="520" Height="420" WindowStartupLocation="CenterOwner"
+        Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} Details'}"
+        Width="760" Height="560" MinWidth="700" MinHeight="500"
+        WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="12">
+    <Window.Resources>
+        <Style x:Key="DetailLabel" TargetType="TextBlock" BasedOn="{StaticResource LabelTextBlock}">
+            <Setter Property="Margin" Value="0,0,8,2"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+        </Style>
+        <Style x:Key="DetailValue" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+            <Setter Property="Margin" Value="0,0,0,2"/>
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+        </Style>
+        <Style x:Key="StatusValue" TargetType="TextBlock" BasedOn="{StaticResource DetailValue}">
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding ItemModel.IsCheckedOut}" Value="True">
+                    <Setter Property="Foreground" Value="{DynamicResource WarningBrush}"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding ItemModel.HasRentedStock}" Value="True">
+                    <Setter Property="Foreground" Value="{DynamicResource WarningBrush}"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding ItemModel.HasNoOnHand}" Value="True">
+                    <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding ItemModel.IsIncomplete}" Value="True">
+                    <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Resources>
+
+    <Grid Margin="8">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/> <!-- Image -->
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
+        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}">
+            <DockPanel LastChildFill="True">
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                    <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Rent Out" Command="{Binding RentOutCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="{Binding CheckOutButtonText}" Command="{Binding ToggleCheckOutCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="History" Command="{Binding OpenRentalHistoryCommand}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="{Binding ItemModel.ItemNumber}" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,10,0"/>
+                    <TextBlock Text="{Binding ItemModel.Name}" Style="{StaticResource HeadingTextBlock}"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="180"/>
+                <ColumnDefinition Width="220"/>
+                <ColumnDefinition Width="4"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-            <Image Grid.Row="0" Grid.ColumnSpan="2" Width="120" Height="120" Margin="0,0,0,8" HorizontalAlignment="Center"
-                   Source="{Binding ItemModel.ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+                <DockPanel LastChildFill="True">
+                    <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                        <TextBlock Text="01 Item" Style="{StaticResource SectionHeader}" Margin="0"/>
+                    </Border>
+                    <StackPanel Margin="8">
+                        <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource ControlBackgroundBrush}" Height="170" Margin="0,0,0,8">
+                            <Image Stretch="Uniform" Margin="4" Source="{Binding ItemModel.ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
+                        </Border>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="76"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Status" Style="{StaticResource DetailLabel}"/>
+                            <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding StatusText}" Style="{StaticResource StatusValue}"/>
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Brand" Style="{StaticResource DetailLabel}"/>
+                            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding ItemModel.Brand}" Style="{StaticResource DetailValue}"/>
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Part #" Style="{StaticResource DetailLabel}"/>
+                            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding ItemModel.PartNumber}" Style="{StaticResource DetailValue}"/>
+                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Location" Style="{StaticResource DetailLabel}"/>
+                            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding ItemModel.Location}" Style="{StaticResource DetailValue}"/>
+                            <TextBlock Grid.Row="4" Grid.Column="0" Text="Supplier" Style="{StaticResource DetailLabel}"/>
+                            <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding ItemModel.Supplier}" Style="{StaticResource DetailValue}"/>
+                            <TextBlock Grid.Row="5" Grid.Column="0" Text="Price" Style="{StaticResource DetailLabel}"/>
+                            <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding PriceText}" Style="{StaticResource DetailValue}"/>
+                            <TextBlock Grid.Row="6" Grid.Column="0" Text="Purchased" Style="{StaticResource DetailLabel}"/>
+                            <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding PurchasedText}" Style="{StaticResource DetailValue}"/>
+                        </Grid>
+                    </StackPanel>
+                </DockPanel>
+            </Border>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} Number'}" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding ItemModel.ItemNumber}" Margin="8,4"/>
+            <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushAlt}"/>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding ItemModel.Name}" Margin="8,4"/>
+            <Grid Grid.Column="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="Brand" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding ItemModel.Brand}" Margin="8,4"/>
+                <Border Grid.Row="0" Style="{StaticResource Card}" Padding="0" Margin="0,0,0,4">
+                    <DockPanel LastChildFill="True">
+                        <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                            <TextBlock Text="02 Availability" Style="{StaticResource SectionHeader}" Margin="0"/>
+                        </Border>
+                        <Grid Margin="8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="128"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="128"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Availability" Style="{StaticResource DetailLabel}"/>
+                            <TextBlock Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding AvailabilitySummary}" Style="{StaticResource DetailValue}" FontWeight="SemiBold"/>
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Current holder" Style="{StaticResource DetailLabel}"/>
+                            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding HolderSummary}" Style="{StaticResource DetailValue}"/>
+                            <TextBlock Grid.Row="1" Grid.Column="2" Text="Stock" Style="{StaticResource DetailLabel}"/>
+                            <TextBlock Grid.Row="1" Grid.Column="3" Text="{Binding StockSummary}" Style="{StaticResource DetailValue}"/>
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Out since" Style="{StaticResource DetailLabel}"/>
+                            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding CheckedOutSinceText}" Style="{StaticResource DetailValue}"/>
+                            <TextBlock Grid.Row="2" Grid.Column="2" Text="Time out" Style="{StaticResource DetailLabel}"/>
+                            <TextBlock Grid.Row="2" Grid.Column="3" Text="{Binding TimeOutText}" Style="{StaticResource DetailValue}"/>
+                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Last check-in" Style="{StaticResource DetailLabel}"/>
+                            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding LastCheckInText}" Style="{StaticResource DetailValue}"/>
+                            <TextBlock Grid.Row="3" Grid.Column="2" Text="Usage" Style="{StaticResource DetailLabel}"/>
+                            <TextBlock Grid.Row="3" Grid.Column="3" Text="{Binding UsageSummary}" Style="{StaticResource DetailValue}"/>
+                        </Grid>
+                    </DockPanel>
+                </Border>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Text="Location" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-            <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding ItemModel.Location}" Margin="8,4"/>
+                <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0" Margin="0,0,0,4">
+                    <DockPanel LastChildFill="True">
+                        <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                            <TextBlock Text="03 Next Actions" Style="{StaticResource SectionHeader}" Margin="0"/>
+                        </Border>
+                        <TextBlock Text="{Binding NextActionText}" Margin="8" TextWrapping="Wrap"/>
+                    </DockPanel>
+                </Border>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Part #" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-            <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding ItemModel.PartNumber}" Margin="8,4"/>
-
-            <TextBlock Grid.Row="6" Grid.Column="0" Text="Supplier" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-            <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding ItemModel.Supplier}" Margin="8,4"/>
-
-            <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Vertical" Margin="0,8,0,0">
-                <TextBlock Text="Notes" Style="{StaticResource LabelTextBlock}"/>
-                <ScrollViewer Height="90" VerticalScrollBarVisibility="Auto">
-                    <TextBlock Text="{Binding ItemModel.Notes}" TextWrapping="Wrap"/>
-                </ScrollViewer>
-            </StackPanel>
+                <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
+                    <DockPanel LastChildFill="True">
+                        <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                            <TextBlock Text="04 Notes / Condition" Style="{StaticResource SectionHeader}" Margin="0"/>
+                        </Border>
+                        <Grid Margin="8">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Text="{Binding ConditionSummary}" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,0,0,6"/>
+                            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource ControlBackgroundBrush}" Padding="6">
+                                <TextBlock Text="{Binding ItemModel.Notes}" TextWrapping="Wrap"/>
+                            </ScrollViewer>
+                            <Grid Grid.Row="2" Margin="0,6,0,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="82"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="82"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Keywords" Style="{StaticResource DetailLabel}"/>
+                                <TextBlock Grid.Column="1" Text="{Binding ItemModel.Keywords}" Style="{StaticResource DetailValue}"/>
+                                <TextBlock Grid.Column="2" Text="Updated" Style="{StaticResource DetailLabel}"/>
+                                <TextBlock Grid.Column="3" Text="{Binding UpdatedText}" Style="{StaticResource DetailValue}"/>
+                            </Grid>
+                        </Grid>
+                    </DockPanel>
+                </Border>
+            </Grid>
         </Grid>
 
-        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
-            <Button Style="{StaticResource GhostButton}" Content="Edit" Command="{Binding EditCommand}" Margin="0,0,8,0"/>
-            <Button Style="{StaticResource GhostButton}" Content="Rent Out" Command="{Binding RentOutCommand}" Margin="0,0,8,0"/>
-            <Button Style="{StaticResource GhostButton}" Content="{Binding CheckOutButtonText}" Command="{Binding ToggleCheckOutCommand}" Margin="0,0,8,0"/>
-            <Button Style="{StaticResource GhostButton}" Content="Rental History" Command="{Binding OpenRentalHistoryCommand}" Margin="0,0,8,0"/>
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+            <Button Style="{StaticResource GhostButton}" Content="Rental History" Command="{Binding OpenRentalHistoryCommand}" Margin="0,0,6,0"/>
             <Button Style="{StaticResource PrimaryButton}" Content="Close" Command="{Binding CloseCommand}"/>
         </StackPanel>
     </Grid>

--- a/InventoryManagementApp/Views/Windows/RentItemPopupWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/RentItemPopupWindow.xaml
@@ -4,43 +4,62 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
         Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Rent {0}'}"
-        Width="800" Height="420"
-        WindowStartupLocation="CenterScreen"
+        Width="760" Height="360" MinWidth="680" MinHeight="320"
+        WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <DockPanel Margin="10">
-        <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="10" CornerRadius="8">
-            <TextBlock Text="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Rent {0}'}" Style="{StaticResource HeadingTextBlock}"/>
+    <DockPanel Margin="8">
+        <Border DockPanel.Dock="Top" Style="{StaticResource ToolbarCard}">
+            <DockPanel LastChildFill="True">
+                <TextBlock Text="Rent Item" Style="{StaticResource PageTitleTextBlock}" DockPanel.Dock="Left" Margin="0,0,12,0"/>
+                <TextBlock Text="Select the customer and due-back date before confirming the rental." Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center"/>
+            </DockPanel>
         </Border>
 
-        <Border Style="{StaticResource Card}" Margin="0,8,0,8">
-            <Grid Margin="4">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="200"/>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
+        <Border Style="{StaticResource Card}" Padding="0" Margin="0,0,0,8">
+            <DockPanel LastChildFill="True">
+                <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                    <TextBlock Text="01 Rental Details" Style="{StaticResource SectionHeader}" Margin="0"/>
+                </Border>
 
-                <TextBlock Grid.Row="0" Grid.Column="0" Text="Customer" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                <ComboBox Grid.Row="0" Grid.Column="1"
-                          ItemsSource="{Binding Customers}"
-                          DisplayMemberPath="Company"
-                          SelectedItem="{Binding SelectedCustomer, Mode=TwoWay}" Margin="8,4"
-                          ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
-                <Button Grid.Row="0" Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Add Customer" Command="{Binding AddCustomerCommand}" Margin="8,4,0,4"/>
+                <Grid Margin="8">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="135"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
 
-                <TextBlock Grid.Row="1" Grid.Column="0" Text="Due Date" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                <DatePicker Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2"
-                            SelectedDate="{Binding SelectedDueDate, Mode=TwoWay}" Margin="8,4"/>
-            </Grid>
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Customer" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                    <ComboBox Grid.Row="0" Grid.Column="1"
+                              ItemsSource="{Binding Customers}"
+                              DisplayMemberPath="Company"
+                              SelectedItem="{Binding SelectedCustomer, Mode=TwoWay}"
+                              Margin="8,3"
+                              MinWidth="320"
+                              ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
+                    <Button Grid.Row="0" Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Add Customer" Command="{Binding AddCustomerCommand}" Margin="8,3,0,3"/>
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Due Back" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                    <DatePicker Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2"
+                                SelectedDate="{Binding SelectedDueDate, Mode=TwoWay}"
+                                Margin="8,3"
+                                Width="160"
+                                HorizontalAlignment="Left"/>
+
+                    <Border Grid.Row="2" Grid.ColumnSpan="3" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="6" Margin="0,10,0,0">
+                        <TextBlock Text="Confirm only after the item has been physically picked or set aside for the customer." TextWrapping="Wrap"/>
+                    </Border>
+                </Grid>
+            </DockPanel>
         </Border>
 
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Style="{StaticResource PrimaryButton}" Content="Cancel" Command="{Binding CancelCommand}"/>
-            <Button Style="{StaticResource PrimaryButton}" Content="Confirm" Command="{Binding CheckOutCommand}" Margin="8,0,0,0"/>
+            <Button Style="{StaticResource GhostButton}" Content="Cancel" Command="{Binding CancelCommand}" Margin="0,0,6,0"/>
+            <Button Style="{StaticResource PrimaryButton}" Content="Confirm Rental" Command="{Binding CheckOutCommand}"/>
         </StackPanel>
     </DockPanel>
 </Window>


### PR DESCRIPTION
## Summary
- Redesigns the item details window into a compact desktop drilldown with a toolbar, photo pane, availability section, next-action guidance, and notes/condition section.
- Adds operational detail state for availability, holder, checked-out time, elapsed time out, stock, usage, purchase/price, updated date, and condition notes.
- Keeps the existing edit, rent, check-in/check-out, history, and close paths available from the detail window.
- Aligns the rent popup with the classic desktop dialog direction using section headers, compact form rows, standard buttons, and no rounded decorative header.
- Fixes item detail refresh fragility by copying price, updated date, incomplete/condition fields, and checkout count after edit/rental/checkout refreshes.

## Validation
- Reviewed the focused branch diff against `master`.
- Checked the banned-word guard term and avoided adding it in changed files.
- Local .NET build/tests could not run because this scheduled environment cannot clone the repository directly and does not provide the .NET SDK.