### PR TITLE
Improve rental history desktop drilldown

### DIFF
--- a/InventoryManagementApp/Resources/Templates.xaml
+++ b/InventoryManagementApp/Resources/Templates.xaml
@@ -93,7 +93,7 @@
     <!-- Shared rental DataGrid columns -->
     <DataGridTextColumn x:Key="RentalIdColumn" Header="Rental #" Binding="{Binding RentalID}" Width="90" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalItemNumberColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} #'}" Binding="{Binding ItemNumber}" Width="115" x:Shared="False"/>
-    <DataGridTextColumn x:Key="RentalItemNameColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}" Binding="{Binding ItemName}" Width="*" x:Shared="False"/>
+    <DataGridTextColumn x:Key="RentalItemNameColumn" Header="Location" Binding="{Binding ItemLocation}" Width="160" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalCustomerColumn" Header="Customer" Binding="{Binding CustomerName}" Width="200" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalOutColumn" Header="Out" Binding="{Binding RentalDate, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat=\{0:yyyy-MM-dd HH:mm\}, TargetNullValue=''}" Width="150" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalDueColumn" Header="Due" Binding="{Binding DueDate, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat=\{0:yyyy-MM-dd HH:mm\}, TargetNullValue=''}" Width="150" x:Shared="False"/>

--- a/InventoryManagementApp/Resources/Templates.xaml
+++ b/InventoryManagementApp/Resources/Templates.xaml
@@ -91,12 +91,12 @@
     </DataTemplate>
 
     <!-- Shared rental DataGrid columns -->
-    <DataGridTextColumn x:Key="RentalIdColumn" Header="Rental #" Binding="{Binding RentalId}" Width="100" x:Shared="False"/>
+    <DataGridTextColumn x:Key="RentalIdColumn" Header="Rental #" Binding="{Binding RentalID}" Width="90" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalItemNumberColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} #'}" Binding="{Binding ItemNumber}" Width="115" x:Shared="False"/>
-    <DataGridTextColumn x:Key="RentalItemNameColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}" Binding="{Binding Name}" Width="*" x:Shared="False"/>
+    <DataGridTextColumn x:Key="RentalItemNameColumn" Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}" Binding="{Binding ItemName}" Width="*" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalCustomerColumn" Header="Customer" Binding="{Binding CustomerName}" Width="200" x:Shared="False"/>
-    <DataGridTextColumn x:Key="RentalOutColumn" Header="Out" Binding="{Binding DateOut, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat=\{0:yyyy-MM-dd HH:mm\}, TargetNullValue=''}" Width="150" x:Shared="False"/>
+    <DataGridTextColumn x:Key="RentalOutColumn" Header="Out" Binding="{Binding RentalDate, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat=\{0:yyyy-MM-dd HH:mm\}, TargetNullValue=''}" Width="150" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalDueColumn" Header="Due" Binding="{Binding DueDate, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat=\{0:yyyy-MM-dd HH:mm\}, TargetNullValue=''}" Width="150" x:Shared="False"/>
-    <DataGridTextColumn x:Key="RentalReturnedColumn" Header="Returned" Binding="{Binding DateReturned, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat=\{0:yyyy-MM-dd HH:mm\}, TargetNullValue=''}" Width="150" x:Shared="False"/>
+    <DataGridTextColumn x:Key="RentalReturnedColumn" Header="Returned" Binding="{Binding ReturnDate, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat=\{0:yyyy-MM-dd HH:mm\}, TargetNullValue=''}" Width="150" x:Shared="False"/>
     <DataGridTextColumn x:Key="RentalStatusColumn" Header="Status" Binding="{Binding Status}" Width="120" x:Shared="False"/>
 </ResourceDictionary>

--- a/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
+++ b/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
@@ -47,7 +47,10 @@ namespace InventoryManagementApp.ViewModels.Rental
             set
             {
                 if (SetProperty(ref _selectedEntry, value))
+                {
                     OnPropertyChanged(nameof(SelectedEntrySummary));
+                    OpenDetailsCommand.NotifyCanExecuteChanged();
+                }
             }
         }
 

--- a/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
+++ b/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows;
-using Microsoft.Win32;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Utilities.Extensions;
 using Microsoft.Extensions.Logging;
@@ -24,6 +23,15 @@ namespace InventoryManagementApp.ViewModels.Rental
 
         public ObservableCollection<RentalModel> History { get; }
         public string ItemDisplayName { get; }
+        public string WindowSummary => _allHistory.Count == 1
+            ? "1 rental record loaded"
+            : $"{_allHistory.Count} rental records loaded";
+        public string ResultsSummary => History.Count == _allHistory.Count
+            ? WindowSummary
+            : $"{History.Count} of {_allHistory.Count} records shown";
+        public string SelectedEntrySummary => SelectedEntry == null
+            ? "Select a rental row to see holder, dates, and status. Double-click any row for details."
+            : $"Rental #{SelectedEntry.RentalID} | {SelectedEntry.ItemNumber} | {SelectedEntry.CustomerName} | {SelectedEntry.Status}";
 
         private string _searchText = string.Empty;
         public string SearchText
@@ -36,10 +44,16 @@ namespace InventoryManagementApp.ViewModels.Rental
         public RentalModel? SelectedEntry
         {
             get => _selectedEntry;
-            set => SetProperty(ref _selectedEntry, value);
+            set
+            {
+                if (SetProperty(ref _selectedEntry, value))
+                    OnPropertyChanged(nameof(SelectedEntrySummary));
+            }
         }
 
         public IRelayCommand SearchCommand { get; }
+        public IRelayCommand ClearSearchCommand { get; }
+        public IRelayCommand OpenDetailsCommand { get; }
         public IRelayCommand ExportCsvCommand { get; }
         public IRelayCommand CloseCommand { get; }
 
@@ -55,6 +69,8 @@ namespace InventoryManagementApp.ViewModels.Rental
             _dialogService = dialogService;
 
             SearchCommand = new RelayCommand(ExecuteSearch);
+            ClearSearchCommand = new RelayCommand(ClearSearch);
+            OpenDetailsCommand = new RelayCommand(OpenDetails, () => SelectedEntry != null);
             ExportCsvCommand = new RelayCommand(ExportCsv);
             CloseCommand = new RelayCommand(CloseWindow);
         }
@@ -68,11 +84,40 @@ namespace InventoryManagementApp.ViewModels.Rental
                 results = _allHistory.Where(r =>
                     r.RentalID.ToString().Contains(term, StringComparison.OrdinalIgnoreCase) ||
                     (r.ItemNumber?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    (r.ItemLocation?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
                     (r.CustomerName?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
                     (r.Status?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false));
             }
 
             History.ReplaceRange(results);
+            OnPropertyChanged(nameof(ResultsSummary));
+        }
+
+        void ClearSearch()
+        {
+            SearchText = string.Empty;
+            History.ReplaceRange(_allHistory);
+            OnPropertyChanged(nameof(ResultsSummary));
+        }
+
+        void OpenDetails()
+        {
+            if (SelectedEntry == null)
+                return;
+
+            var returned = SelectedEntry.ReturnDate?.ToString("yyyy-MM-dd HH:mm") ?? "Not returned";
+            var details = new StringBuilder()
+                .AppendLine($"Rental #: {SelectedEntry.RentalID}")
+                .AppendLine($"Item #: {SelectedEntry.ItemNumber}")
+                .AppendLine($"Location: {SelectedEntry.ItemLocation}")
+                .AppendLine($"Customer: {SelectedEntry.CustomerName}")
+                .AppendLine($"Checked out: {SelectedEntry.RentalDate:yyyy-MM-dd HH:mm}")
+                .AppendLine($"Due back: {SelectedEntry.DueDate:yyyy-MM-dd HH:mm}")
+                .AppendLine($"Returned: {returned}")
+                .AppendLine($"Status: {SelectedEntry.Status}")
+                .ToString();
+
+            _dialogService.ShowInfo(details, "Rental History Details");
         }
 
         void ExportCsv()
@@ -100,12 +145,13 @@ namespace InventoryManagementApp.ViewModels.Rental
             path ??= Path.Combine(Environment.CurrentDirectory, "rental_history.csv");
 
             var sb = new StringBuilder();
-            sb.AppendLine("RentalID,ItemNumber,CustomerName,RentalDate,DueDate,ReturnDate,Status");
+            sb.AppendLine("RentalID,ItemNumber,ItemLocation,CustomerName,RentalDate,DueDate,ReturnDate,Status");
             foreach (var r in History)
             {
                 sb.AppendLine(string.Join(',',
                     r.RentalID,
                     Escape(r.ItemNumber),
+                    Escape(r.ItemLocation),
                     Escape(r.CustomerName),
                     r.RentalDate.ToString("o"),
                     r.DueDate.ToString("o"),
@@ -124,8 +170,16 @@ namespace InventoryManagementApp.ViewModels.Rental
             }
         }
 
-        static string Escape(string? value) =>
-            value?.Replace("\"", "\"\"") ?? string.Empty;
+        static string Escape(string? value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return string.Empty;
+
+            var escaped = value.Replace("\"", "\"\"");
+            return escaped.IndexOfAny(new[] { ',', '"', '\r', '\n' }) >= 0
+                ? $"\"{escaped}\""
+                : escaped;
+        }
 
         void CloseWindow()
         {

--- a/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
+++ b/InventoryManagementApp/ViewModels/RentalHistoryViewModel.cs
@@ -12,6 +12,7 @@ using InventoryManagementApp.Utilities.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using InventoryManagementApp.Interfaces;
+using RentalModel = InventoryManagementApp.Models.Domain.Rental;
 
 namespace InventoryManagementApp.ViewModels.Rental
 {

--- a/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml
@@ -4,42 +4,102 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:pages="clr-namespace:InventoryManagementApp.Views.Pages"
         Title="Rental History"
-        Width="1100" Height="640"
-        WindowStartupLocation="CenterScreen"
+        Width="1120" Height="640" MinWidth="900" MinHeight="520"
+        WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <DockPanel Margin="10">
-        <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="10" CornerRadius="8">
-            <DockPanel>
-                <TextBlock Text="Rental History" Style="{StaticResource HeadingTextBlock}" DockPanel.Dock="Left"/>
-                <pages:SearchBar DockPanel.Dock="Right"
-                                   Width="340"
-                                   Text="{Binding SearchText}"
-                                   SearchCommand="{Binding SearchCommand}"/>
+    <DockPanel Margin="8">
+        <Border DockPanel.Dock="Top" Style="{StaticResource ToolbarCard}">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="280"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="340"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                    <TextBlock Text="Rental History" Style="{StaticResource PageTitleTextBlock}"/>
+                    <TextBlock Text="{Binding ItemDisplayName}" Style="{StaticResource CaptionTextBlock}"/>
+                </StackPanel>
+                <TextBlock Grid.Column="1" Text="Find" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="8,0,6,0"/>
+                <pages:SearchBar Grid.Column="2"
+                                 Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                                 SearchCommand="{Binding SearchCommand}"
+                                 SearchLabel=""/>
+                <TextBlock Grid.Column="3" Text="{Binding ResultsSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="10,0,0,0"/>
+                <StackPanel Grid.Column="4" Orientation="Horizontal" VerticalAlignment="Center">
+                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenDetailsCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearSearchCommand}"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <Border DockPanel.Dock="Bottom" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
+            <DockPanel LastChildFill="True">
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                    <Button Style="{StaticResource PrimaryButton}" Width="92" Content="Export CSV" Command="{Binding ExportCsvCommand}" Margin="0,0,6,0"/>
+                    <Button Style="{StaticResource GhostButton}" Width="92" Content="Close" Command="{Binding CloseCommand}"/>
+                </StackPanel>
+                <TextBlock Text="{Binding SelectedEntrySummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0"/>
             </DockPanel>
         </Border>
 
-        <Border Style="{StaticResource Card}" Padding="0" Margin="0,8,0,8">
-            <DataGrid ItemsSource="{Binding History}"
-                      SelectedItem="{Binding SelectedEntry}"
-                      IsReadOnly="True"
-                      AutoGenerateColumns="False"
-                      Style="{StaticResource VirtualizedDataGridStyle}">
-                <DataGrid.Columns>
-                    <StaticResource ResourceKey="RentalIdColumn"/>
-                    <StaticResource ResourceKey="RentalItemNumberColumn"/>
-                    <StaticResource ResourceKey="RentalItemNameColumn"/>
-                    <StaticResource ResourceKey="RentalCustomerColumn"/>
-                    <StaticResource ResourceKey="RentalOutColumn"/>
-                    <StaticResource ResourceKey="RentalDueColumn"/>
-                    <StaticResource ResourceKey="RentalReturnedColumn"/>
-                    <StaticResource ResourceKey="RentalStatusColumn"/>
-                </DataGrid.Columns>
-            </DataGrid>
+        <Border Style="{StaticResource Card}" Padding="0">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Border Grid.Row="0" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                    <DockPanel>
+                        <TextBlock Text="01 Rental Records" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                        <TextBlock Text="Double-click or right-click a row for rental details." Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                    </DockPanel>
+                </Border>
+                <DataGrid Grid.Row="1"
+                          ItemsSource="{Binding History}"
+                          SelectedItem="{Binding SelectedEntry}"
+                          IsReadOnly="True"
+                          AutoGenerateColumns="False"
+                          Style="{StaticResource VirtualizedDataGridStyle}">
+                    <DataGrid.RowStyle>
+                        <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                            <EventSetter Event="MouseDoubleClick" Handler="HistoryRow_MouseDoubleClick"/>
+                            <EventSetter Event="PreviewMouseRightButtonDown" Handler="HistoryRow_PreviewMouseRightButtonDown"/>
+                        </Style>
+                    </DataGrid.RowStyle>
+                    <DataGrid.Columns>
+                        <StaticResource ResourceKey="RentalIdColumn"/>
+                        <StaticResource ResourceKey="RentalItemNumberColumn"/>
+                        <DataGridTextColumn Header="Location" Binding="{Binding ItemLocation}" Width="160"/>
+                        <StaticResource ResourceKey="RentalCustomerColumn"/>
+                        <StaticResource ResourceKey="RentalOutColumn"/>
+                        <StaticResource ResourceKey="RentalDueColumn"/>
+                        <StaticResource ResourceKey="RentalReturnedColumn"/>
+                        <StaticResource ResourceKey="RentalStatusColumn"/>
+                    </DataGrid.Columns>
+                    <DataGrid.ContextMenu>
+                        <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                            <MenuItem Header="Open Details" Command="{Binding OpenDetailsCommand}"/>
+                            <Separator/>
+                            <MenuItem Header="Export Current View" Command="{Binding ExportCsvCommand}"/>
+                            <MenuItem Header="Clear Search" Command="{Binding ClearSearchCommand}"/>
+                        </ContextMenu>
+                    </DataGrid.ContextMenu>
+                </DataGrid>
+                <TextBlock Grid.Row="1" Text="No rental history records match this search" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="13" FontWeight="SemiBold">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding History.Count}" Value="0">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+            </Grid>
         </Border>
-
-        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Style="{StaticResource PrimaryButton}" Width="92" Content="Export CSV" Command="{Binding ExportCsvCommand}"/>
-            <Button Style="{StaticResource GhostButton}" Width="92" Content="Close" Command="{Binding CloseCommand}" Margin="8,0,0,0"/>
-        </StackPanel>
     </DockPanel>
 </Window>

--- a/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/RentalHistoryWindow.xaml.cs
@@ -1,4 +1,6 @@
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
 using InventoryManagementApp.ViewModels.Rental;
 using InventoryManagementApp.Utilities.Extensions;
 
@@ -15,6 +17,23 @@ namespace InventoryManagementApp.Views.Windows
         public RentalHistoryWindow(RentalHistoryViewModel viewModel) : this()
         {
             DataContext = viewModel;
+        }
+
+        private void HistoryRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is RentalHistoryViewModel vm && vm.OpenDetailsCommand.CanExecute(null))
+            {
+                vm.OpenDetailsCommand.Execute(null);
+            }
+        }
+
+        private void HistoryRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is DataGridRow row && !row.IsSelected)
+            {
+                row.IsSelected = true;
+                e.Handled = true;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Redesigns the rental history window into the compact classic desktop layout with a top search/action strip, dense records grid, bottom selected-row status strip, and standard export/close actions.
- Makes rental history rows double-clickable and right-clickable for details so the dialog is no longer a dead-end table.
- Adds rental-history summaries, clear-search support, selected-row detail messaging, and safer CSV quoting for exported reports.
- Fixes shared rental grid column bindings to use the actual rental model fields used by the current rentals workflow.

## Validation
- Reviewed the changed files by reading them back from the branch through the GitHub connector.
- Checked the rental model/property usage against `ManageRentalsViewModel` and the `Rental` domain model.
- Local build/tests could not run because this scheduled environment cannot clone GitHub directly and does not provide the .NET SDK.