### PR TITLE
[codex] Improve customer desktop drilldown workflow

### DIFF
--- a/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
@@ -3,7 +3,10 @@ using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Documents;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Utilities.Extensions;
 
@@ -18,6 +21,11 @@ namespace InventoryManagementApp.ViewModels
 
         public ObservableCollection<CustomerModel> Customers { get; } = new();
 
+        public string CustomerResultsSummary => $"{Customers.Count} customer{(Customers.Count == 1 ? string.Empty : "s")} shown";
+        public string SelectedCustomerSummary => SelectedCustomer == null
+            ? "Select or double-click a customer row to view contact details, print a customer sheet, edit, or delete."
+            : $"{ValueOrNotRecorded(SelectedCustomer.Company)} | {ValueOrNotRecorded(SelectedCustomer.Contact)} | {ValueOrNotRecorded(SelectedCustomer.Phone)} | {ValueOrNotRecorded(SelectedCustomer.Email)}";
+
         private CustomerModel? _selectedCustomer;
         public CustomerModel? SelectedCustomer
         {
@@ -29,6 +37,9 @@ namespace InventoryManagementApp.ViewModels
                     ((AsyncRelayCommand)UpdateCustomerCommand).NotifyCanExecuteChanged();
                     ((AsyncRelayCommand)DeleteCustomerCommand).NotifyCanExecuteChanged();
                     ((AsyncRelayCommand)EditCustomerCommand).NotifyCanExecuteChanged();
+                    OpenCustomerDetailsCommand.NotifyCanExecuteChanged();
+                    PrintSelectedCustomerCommand.NotifyCanExecuteChanged();
+                    OnPropertyChanged(nameof(SelectedCustomerSummary));
 
                     if (value != null)
                     {
@@ -75,10 +86,12 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand<CustomerModel> EditCustomerFromRowCommand { get; }
         public IAsyncRelayCommand<CustomerModel> DeleteCustomerFromRowCommand { get; }
         public IAsyncRelayCommand ClearCustomerSearchCommand { get; }
+        public IRelayCommand OpenCustomerDetailsCommand { get; }
+        public IRelayCommand PrintCustomerDirectoryCommand { get; }
+        public IRelayCommand PrintSelectedCustomerCommand { get; }
 
         public CustomerManagementViewModel(ICustomerService customerService, IDialogService dialogService)
         {
-
             _customerService = customerService;
             _dialogService = dialogService;
             AddCustomerCommand = new AsyncRelayCommand(AddCustomerAsync);
@@ -89,13 +102,26 @@ namespace InventoryManagementApp.ViewModels
             EditCustomerFromRowCommand = new AsyncRelayCommand<CustomerModel>(EditCustomerAsync);
             DeleteCustomerFromRowCommand = new AsyncRelayCommand<CustomerModel>(c => DeleteCustomerAsync(c));
             ClearCustomerSearchCommand = new AsyncRelayCommand(ClearCustomerSearchAsync);
+            OpenCustomerDetailsCommand = new RelayCommand(OpenCustomerDetails, () => SelectedCustomer != null);
+            PrintCustomerDirectoryCommand = new RelayCommand(PrintCustomerDirectory);
+            PrintSelectedCustomerCommand = new RelayCommand(PrintSelectedCustomer, () => SelectedCustomer != null);
         }
 
         public async Task LoadCustomersAsync()
         {
             if (_customerService == null) return;
-            var all = await _customerService.GetAllCustomersAsync();
-            Customers.ReplaceRange(all);
+
+            try
+            {
+                var all = await _customerService.GetAllCustomersAsync();
+                Customers.ReplaceRange(all);
+                OnPropertyChanged(nameof(CustomerResultsSummary));
+            }
+            catch (Exception ex)
+            {
+                if (_dialogService != null)
+                    await _dialogService.ShowInfoAsync($"Failed to load customers: {ex.Message}", "Customer Load Failed");
+            }
         }
 
         async Task AddCustomerAsync()
@@ -112,6 +138,10 @@ namespace InventoryManagementApp.ViewModels
             catch (UnauthorizedAccessException)
             {
                 await _dialogService.ShowInfoAsync("You are not authorized to add customers.", "Unauthorized");
+            }
+            catch (Exception ex)
+            {
+                await _dialogService.ShowInfoAsync($"Failed to add customer: {ex.Message}", "Add Customer Failed");
             }
         }
 
@@ -138,24 +168,39 @@ namespace InventoryManagementApp.ViewModels
             {
                 await _dialogService.ShowInfoAsync("You are not authorized to update customers.", "Unauthorized");
             }
+            catch (Exception ex)
+            {
+                await _dialogService.ShowInfoAsync($"Failed to update customer: {ex.Message}", "Update Customer Failed");
+            }
         }
 
         async Task SearchCustomersAsync()
         {
             if (_customerService == null) return;
-            var all = await _customerService.GetAllCustomersAsync();
-            if (!string.IsNullOrWhiteSpace(CustomerSearchTerm))
+
+            try
             {
-                all = all.Where(c =>
-                    (c.Company?.Contains(CustomerSearchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (c.Email?.Contains(CustomerSearchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (c.Contact?.Contains(CustomerSearchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (c.Phone?.Contains(CustomerSearchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (c.Mobile?.Contains(CustomerSearchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (c.Address?.Contains(CustomerSearchTerm, StringComparison.OrdinalIgnoreCase) ?? false))
-                    .ToList();
+                var all = await _customerService.GetAllCustomersAsync();
+                if (!string.IsNullOrWhiteSpace(CustomerSearchTerm))
+                {
+                    var term = CustomerSearchTerm.Trim();
+                    all = all.Where(c =>
+                        (c.Company?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                        (c.Email?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                        (c.Contact?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                        (c.Phone?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                        (c.Mobile?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                        (c.Address?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false))
+                        .ToList();
+                }
+                Customers.ReplaceRange(all);
+                OnPropertyChanged(nameof(CustomerResultsSummary));
             }
-            Customers.ReplaceRange(all);
+            catch (Exception ex)
+            {
+                if (_dialogService != null)
+                    await _dialogService.ShowInfoAsync($"Failed to search customers: {ex.Message}", "Customer Search Failed");
+            }
         }
 
         private void ClearNewCustomerFields()
@@ -180,6 +225,10 @@ namespace InventoryManagementApp.ViewModels
             if (customer == null || _customerService == null || _dialogService == null)
                 return;
 
+            var confirmed = await _dialogService.ShowConfirmAsync("Delete Customer", $"Delete {ValueOrNotRecorded(customer.Company)} from the customer list?");
+            if (!confirmed)
+                return;
+
             try
             {
                 await _customerService.DeleteCustomerAsync(customer.CustomerID);
@@ -189,6 +238,10 @@ namespace InventoryManagementApp.ViewModels
             catch (UnauthorizedAccessException)
             {
                 await _dialogService.ShowInfoAsync("You are not authorized to delete customers.", "Unauthorized");
+            }
+            catch (Exception ex)
+            {
+                await _dialogService.ShowInfoAsync($"Failed to delete customer: {ex.Message}", "Delete Customer Failed");
             }
         }
 
@@ -206,6 +259,166 @@ namespace InventoryManagementApp.ViewModels
             {
                 await _dialogService.ShowInfoAsync("You are not authorized to update customers.", "Unauthorized");
             }
+            catch (Exception ex)
+            {
+                await _dialogService.ShowInfoAsync($"Failed to edit customer: {ex.Message}", "Edit Customer Failed");
+            }
         }
+
+        void OpenCustomerDetails()
+        {
+            if (SelectedCustomer == null || _dialogService == null)
+                return;
+
+            var customer = SelectedCustomer;
+            var details = new StringBuilder();
+            details.AppendLine($"Customer #: {customer.CustomerID}");
+            details.AppendLine($"Company: {ValueOrNotRecorded(customer.Company)}");
+            details.AppendLine($"Primary contact: {ValueOrNotRecorded(customer.Contact)}");
+            details.AppendLine();
+            details.AppendLine($"Phone: {ValueOrNotRecorded(customer.Phone)}");
+            details.AppendLine($"Mobile: {ValueOrNotRecorded(customer.Mobile)}");
+            details.AppendLine($"Email: {ValueOrNotRecorded(customer.Email)}");
+            details.AppendLine();
+            details.AppendLine($"Address: {ValueOrNotRecorded(customer.Address)}");
+            details.AppendLine();
+            details.AppendLine("Next steps: edit the contact, print a customer sheet, then use rentals or requests to review open activity for this customer.");
+
+            _dialogService.ShowInfo(details.ToString(), $"Customer Details - {ValueOrNotRecorded(customer.Company)}");
+        }
+
+        void PrintCustomerDirectory()
+        {
+            if (_dialogService == null)
+                return;
+
+            if (Customers.Count == 0)
+            {
+                _dialogService.ShowInfo("There are no customers to print.", "Customer Directory");
+                return;
+            }
+
+            try
+            {
+                var doc = CreateCustomerDocument("Customer Directory", fontSize: 11);
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | {Customers.Count} customer{(Customers.Count == 1 ? string.Empty : "s")}"))
+                {
+                    FontSize = 10,
+                    Margin = new Thickness(0, 0, 0, 10)
+                });
+
+                var table = new Table { CellSpacing = 0 };
+                table.Columns.Add(new TableColumn { Width = new GridLength(175) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(130) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(105) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(105) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(190) });
+
+                var group = new TableRowGroup();
+                table.RowGroups.Add(group);
+                AddPrintRow(group, true, "Company", "Contact", "Phone", "Mobile", "Email");
+
+                foreach (var customer in Customers)
+                {
+                    AddPrintRow(group, false, customer.Company, customer.Contact, customer.Phone, customer.Mobile, customer.Email);
+                }
+
+                doc.Blocks.Add(table);
+                _dialogService.ShowPrintPreview(doc, "Customer Directory", string.Empty);
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowInfo($"Failed to print customer directory: {ex.Message}", "Print Failed");
+            }
+        }
+
+        void PrintSelectedCustomer()
+        {
+            if (SelectedCustomer == null || _dialogService == null)
+                return;
+
+            try
+            {
+                var customer = SelectedCustomer;
+                var doc = CreateCustomerDocument($"Customer Sheet - {ValueOrNotRecorded(customer.Company)}");
+                var table = CreateKeyValueTable();
+                var group = table.RowGroups[0];
+                AddKeyValueRow(group, "Customer #:", customer.CustomerID.ToString());
+                AddKeyValueRow(group, "Company:", customer.Company);
+                AddKeyValueRow(group, "Primary contact:", customer.Contact);
+                AddKeyValueRow(group, "Phone:", customer.Phone);
+                AddKeyValueRow(group, "Mobile:", customer.Mobile);
+                AddKeyValueRow(group, "Email:", customer.Email);
+                AddKeyValueRow(group, "Address:", customer.Address);
+                AddKeyValueRow(group, "Advisor note:", "Use rentals and requests to review open activity before promising availability or delivery dates.");
+                doc.Blocks.Add(table);
+
+                _dialogService.ShowPrintPreview(doc, $"Customer {customer.CustomerID}", string.Empty);
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowInfo($"Failed to print customer sheet: {ex.Message}", "Print Failed");
+            }
+        }
+
+        static FlowDocument CreateCustomerDocument(string title, double fontSize = 16)
+        {
+            var doc = new FlowDocument
+            {
+                PagePadding = new Thickness(36),
+                FontFamily = new System.Windows.Media.FontFamily("Calibri"),
+                FontSize = fontSize
+            };
+
+            doc.Blocks.Add(new Paragraph(new Bold(new Run(title)))
+            {
+                FontSize = 20,
+                TextAlignment = TextAlignment.Center,
+                Margin = new Thickness(0, 0, 0, 10)
+            });
+
+            return doc;
+        }
+
+        static Table CreateKeyValueTable()
+        {
+            var table = new Table();
+            table.Columns.Add(new TableColumn { Width = new GridLength(150) });
+            table.Columns.Add(new TableColumn());
+            table.RowGroups.Add(new TableRowGroup());
+            return table;
+        }
+
+        static void AddKeyValueRow(TableRowGroup group, string label, string? value)
+        {
+            var row = new TableRow();
+            row.Cells.Add(new TableCell(new Paragraph(new Run(label)) { FontWeight = FontWeights.Bold }));
+            row.Cells.Add(new TableCell(new Paragraph(new Run(ValueOrNotRecorded(value)))));
+            group.Rows.Add(row);
+        }
+
+        static void AddPrintRow(TableRowGroup group, bool isHeader, params string?[] values)
+        {
+            var row = new TableRow();
+            foreach (var value in values)
+            {
+                var paragraph = new Paragraph(new Run(ValueOrNotRecorded(value)))
+                {
+                    Margin = new Thickness(3),
+                    FontSize = isHeader ? 10 : 9,
+                    FontWeight = isHeader ? FontWeights.Bold : FontWeights.Normal
+                };
+                var cell = new TableCell(paragraph)
+                {
+                    BorderBrush = System.Windows.Media.Brushes.Gray,
+                    BorderThickness = new Thickness(0.5),
+                    Padding = new Thickness(2)
+                };
+                row.Cells.Add(cell);
+            }
+            group.Rows.Add(row);
+        }
+
+        static string ValueOrNotRecorded(string? value) => string.IsNullOrWhiteSpace(value) ? "Not recorded" : value;
     }
 }

--- a/InventoryManagementApp/Views/Pages/CustomersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CustomersPage.xaml
@@ -8,13 +8,18 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Border Style="{StaticResource ToolbarCard}">
             <DockPanel LastChildFill="False">
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
                     <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddCustomerCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditCustomerCommand}"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCustomerDetailsCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditCustomerCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Print Customer" Command="{Binding PrintSelectedCustomerCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Print Directory" Command="{Binding PrintCustomerDirectoryCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteCustomerCommand}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
                     <TextBlock Text="Filter" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
@@ -27,24 +32,71 @@
             </DockPanel>
         </Border>
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
-            <DataGrid ItemsSource="{Binding Customers}" SelectedItem="{Binding SelectedCustomer}" IsReadOnly="True" AutoGenerateColumns="False" SelectionMode="Extended" Style="{StaticResource VirtualizedDataGridStyle}">
-                <DataGrid.Columns>
-                    <DataGridTextColumn Header="Company" Binding="{Binding Company}" Width="*"/>
-                    <DataGridTextColumn Header="Contact" Binding="{Binding Contact}" Width="200"/>
-                    <DataGridTextColumn Header="Phone" Binding="{Binding Phone}" Width="150"/>
-                    <DataGridTextColumn Header="Email" Binding="{Binding Email}" Width="220"/>
-                </DataGrid.Columns>
-                <DataGrid.ContextMenu>
-                    <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
-                        <MenuItem Header="Edit"
-                                  Command="{Binding PlacementTarget.DataContext.EditCustomerFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                                  CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                        <MenuItem Header="Delete"
-                                  Command="{Binding PlacementTarget.DataContext.DeleteCustomerFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                                  CommandParameter="{Binding PlacementTarget.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                    </ContextMenu>
-                </DataGrid.ContextMenu>
-            </DataGrid>
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                    <DockPanel>
+                        <TextBlock Text="01 Customer Directory" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                        <TextBlock Text="{Binding CustomerResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                    </DockPanel>
+                </Border>
+                <DataGrid Grid.Row="1"
+                          ItemsSource="{Binding Customers}"
+                          SelectedItem="{Binding SelectedCustomer}"
+                          IsReadOnly="True"
+                          AutoGenerateColumns="False"
+                          SelectionMode="Single"
+                          Style="{StaticResource VirtualizedDataGridStyle}">
+                    <DataGrid.RowStyle>
+                        <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                            <EventSetter Event="MouseDoubleClick" Handler="CustomerRow_MouseDoubleClick"/>
+                            <EventSetter Event="PreviewMouseRightButtonDown" Handler="CustomerRow_PreviewMouseRightButtonDown"/>
+                        </Style>
+                    </DataGrid.RowStyle>
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Company" Binding="{Binding Company}" Width="2*"/>
+                        <DataGridTextColumn Header="Contact" Binding="{Binding Contact}" Width="180"/>
+                        <DataGridTextColumn Header="Phone" Binding="{Binding Phone}" Width="130"/>
+                        <DataGridTextColumn Header="Mobile" Binding="{Binding Mobile}" Width="130"/>
+                        <DataGridTextColumn Header="Email" Binding="{Binding Email}" Width="220"/>
+                        <DataGridTextColumn Header="Address" Binding="{Binding Address}" Width="2*"/>
+                    </DataGrid.Columns>
+                    <DataGrid.ContextMenu>
+                        <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                            <MenuItem Header="Open Details" Command="{Binding OpenCustomerDetailsCommand}"/>
+                            <MenuItem Header="Edit" Command="{Binding EditCustomerCommand}"/>
+                            <MenuItem Header="Print Customer Sheet" Command="{Binding PrintSelectedCustomerCommand}"/>
+                            <Separator/>
+                            <MenuItem Header="Print Directory" Command="{Binding PrintCustomerDirectoryCommand}"/>
+                            <MenuItem Header="Delete" Command="{Binding DeleteCustomerCommand}"/>
+                        </ContextMenu>
+                    </DataGrid.ContextMenu>
+                </DataGrid>
+                <TextBlock Grid.Row="1" Text="No customers match this search" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="13" FontWeight="SemiBold">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Customers.Count}" Value="0">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+            </Grid>
+        </Border>
+        <Border Grid.Row="2" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
+            <DockPanel LastChildFill="True">
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCustomerDetailsCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Clear Search" Command="{Binding ClearCustomerSearchCommand}"/>
+                </StackPanel>
+                <TextBlock Text="{Binding SelectedCustomerSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0"/>
+            </DockPanel>
         </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/CustomersPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CustomersPage.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
@@ -17,6 +18,23 @@ namespace InventoryManagementApp.Views.Pages
             if (DataContext is CustomerManagementViewModel vm)
             {
                 await vm.LoadCustomersAsync();
+            }
+        }
+
+        private void CustomerRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is CustomerManagementViewModel vm && vm.OpenCustomerDetailsCommand.CanExecute(null))
+            {
+                vm.OpenCustomerDetailsCommand.Execute(null);
+            }
+        }
+
+        private void CustomerRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is DataGridRow row && !row.IsSelected)
+            {
+                row.IsSelected = true;
+                e.Handled = true;
             }
         }
     }


### PR DESCRIPTION
## Summary
- redesign the Customers page as a compact classic desktop directory with a section header, footer summary, single-select grid, and actionable context menu
- add customer row double-click/right-click drilldown behavior so customer records no longer feel like a dead-end list
- add customer detail, customer sheet printing, directory printing, delete confirmation, and broader error feedback around customer load/search/add/update/edit/delete flows

## Why
Advisors handling rentals by phone need customer contact details, printable customer sheets, and quick next actions from the same dense business-app screen. This keeps the customer workflow aligned with the recent item/rental/detail window desktop direction.

## Validation
- compared the branch against `master` and confirmed only the intended customer view/viewmodel/code-behind files changed
- verified `IDialogService` supports the confirmation and print-preview methods used here
- no GitHub commit statuses were reported for this branch before PR creation
- local .NET build/tests could not run because this scheduled environment does not include the .NET SDK and direct clone remains blocked