### PR TITLE
[codex] Improve maintenance and calibration desktop workflows

### DIFF
--- a/InventoryManagementApp/ViewModels/CalibrationManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CalibrationManagementViewModel.cs
@@ -3,7 +3,10 @@ using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Documents;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Services.Calibration;
 using InventoryManagementApp.Interfaces;
@@ -18,6 +21,11 @@ namespace InventoryManagementApp.ViewModels
         public ObservableCollection<CalibrationRecord> CalibrationRecords { get; }
         public ObservableCollection<CalibrationRecord> FilteredCalibrationRecords { get; }
 
+        public string CalibrationResultsSummary => $"{FilteredCalibrationRecords.Count} of {CalibrationRecords.Count} calibration record{(CalibrationRecords.Count == 1 ? string.Empty : "s")} shown";
+        public string SelectedRecordSummary => SelectedRecord == null
+            ? "Select or double-click a calibration row to view certificate details, print the record, edit, or delete."
+            : $"{ValueOrNotRecorded(SelectedRecord.ItemNumber)} | {ValueOrNotRecorded(SelectedRecord.ItemName)} | {SelectedRecord.StatusDisplay} | due {SelectedRecord.NextCalibrationDue:yyyy-MM-dd}";
+
         private CalibrationRecord? _selectedRecord;
         public CalibrationRecord? SelectedRecord
         {
@@ -28,6 +36,9 @@ namespace InventoryManagementApp.ViewModels
                 {
                     EditCalibrationCommand.NotifyCanExecuteChanged();
                     DeleteCalibrationCommand.NotifyCanExecuteChanged();
+                    OpenCalibrationDetailsCommand.NotifyCanExecuteChanged();
+                    PrintSelectedCalibrationCommand.NotifyCanExecuteChanged();
+                    OnPropertyChanged(nameof(SelectedRecordSummary));
                 }
             }
         }
@@ -65,6 +76,9 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand EditCalibrationCommand { get; }
         public IAsyncRelayCommand DeleteCalibrationCommand { get; }
         public IAsyncRelayCommand RefreshCommand { get; }
+        public IRelayCommand OpenCalibrationDetailsCommand { get; }
+        public IRelayCommand PrintCalibrationListCommand { get; }
+        public IRelayCommand PrintSelectedCalibrationCommand { get; }
 
         public CalibrationManagementViewModel(
             CalibrationService calibrationService,
@@ -88,6 +102,9 @@ namespace InventoryManagementApp.ViewModels
             EditCalibrationCommand = new AsyncRelayCommand(EditCalibrationAsync, CanEditOrDelete);
             DeleteCalibrationCommand = new AsyncRelayCommand(DeleteCalibrationAsync, CanEditOrDelete);
             RefreshCommand = new AsyncRelayCommand(LoadCalibrationAsync);
+            OpenCalibrationDetailsCommand = new RelayCommand(OpenCalibrationDetails, CanEditOrDelete);
+            PrintCalibrationListCommand = new RelayCommand(PrintCalibrationList);
+            PrintSelectedCalibrationCommand = new RelayCommand(PrintSelectedCalibration, CanEditOrDelete);
         }
 
         private async Task LoadCalibrationAsync()
@@ -165,6 +182,7 @@ namespace InventoryManagementApp.ViewModels
                     await _calibrationService.UpdateCalibrationRecordAsync(clone);
                     var index = CalibrationRecords.IndexOf(SelectedRecord);
                     if (index >= 0) CalibrationRecords[index] = clone;
+                    SelectedRecord = clone;
                     ApplyFilter();
                     await _dialogService.ShowInfoAsync("Success", "Calibration record updated successfully");
                 }
@@ -181,7 +199,7 @@ namespace InventoryManagementApp.ViewModels
 
             var confirmed = await _dialogService.ShowConfirmAsync(
                 "Delete Calibration Record",
-                $"Are you sure you want to delete this calibration record?");
+                $"Delete calibration certificate {ValueOrNotRecorded(SelectedRecord.CertificateNumber)} for {ValueOrNotRecorded(SelectedRecord.ItemName)}?");
 
             if (confirmed)
             {
@@ -189,6 +207,7 @@ namespace InventoryManagementApp.ViewModels
                 {
                     await _calibrationService.DeleteCalibrationRecordAsync(SelectedRecord.CalibrationID);
                     CalibrationRecords.Remove(SelectedRecord);
+                    SelectedRecord = null;
                     ApplyFilter();
                     await _dialogService.ShowInfoAsync("Success", "Calibration record deleted successfully");
                 }
@@ -227,8 +246,171 @@ namespace InventoryManagementApp.ViewModels
             {
                 FilteredCalibrationRecords.Add(record);
             }
+
+            OnPropertyChanged(nameof(CalibrationResultsSummary));
+        }
+
+        private void OpenCalibrationDetails()
+        {
+            if (SelectedRecord == null) return;
+
+            var record = SelectedRecord;
+            var details = new StringBuilder();
+            details.AppendLine($"Calibration #: {record.CalibrationID}");
+            details.AppendLine($"Item: {ValueOrNotRecorded(record.ItemNumber)} - {ValueOrNotRecorded(record.ItemName)}");
+            details.AppendLine($"Status: {record.StatusDisplay}");
+            details.AppendLine();
+            details.AppendLine($"Calibrated: {record.CalibrationDate:yyyy-MM-dd}");
+            details.AppendLine($"Next due: {record.NextCalibrationDue:yyyy-MM-dd}");
+            details.AppendLine($"Calibrated by: {ValueOrNotRecorded(record.CalibratedBy)}");
+            details.AppendLine($"Certificate: {ValueOrNotRecorded(record.CertificateNumber)}");
+            details.AppendLine($"Standard: {ValueOrNotRecorded(record.Standard)}");
+            details.AppendLine($"Result: {ValueOrNotRecorded(record.Result)}");
+            details.AppendLine($"Cost: {record.Cost:C}");
+            details.AppendLine();
+            details.AppendLine($"Notes: {ValueOrNotRecorded(record.Notes)}");
+            details.AppendLine();
+            details.AppendLine(record.IsOverdue
+                ? "Next action: treat this item as blocked until calibration is renewed or the record is updated."
+                : "Next action: print the certificate sheet, edit certificate details, or review due-soon work from this page.");
+
+            _dialogService.ShowInfo(details.ToString(), $"Calibration Details - {ValueOrNotRecorded(record.ItemNumber)}");
+        }
+
+        private void PrintCalibrationList()
+        {
+            if (FilteredCalibrationRecords.Count == 0)
+            {
+                _dialogService.ShowInfo("There are no calibration records to print.", "Calibration Report");
+                return;
+            }
+
+            try
+            {
+                var doc = CreateCalibrationDocument("Calibration Due Report", fontSize: 11);
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | {CalibrationResultsSummary}"))
+                {
+                    FontSize = 10,
+                    Margin = new Thickness(0, 0, 0, 10)
+                });
+
+                var table = new Table { CellSpacing = 0 };
+                table.Columns.Add(new TableColumn { Width = new GridLength(90) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(150) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(90) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(90) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(105) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(105) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(80) });
+
+                var group = new TableRowGroup();
+                table.RowGroups.Add(group);
+                AddPrintRow(group, true, "Item #", "Name", "Calibrated", "Next Due", "By", "Certificate", "Status");
+                foreach (var record in FilteredCalibrationRecords)
+                {
+                    AddPrintRow(group, false, record.ItemNumber, record.ItemName, record.CalibrationDate.ToString("yyyy-MM-dd"), record.NextCalibrationDue.ToString("yyyy-MM-dd"), record.CalibratedBy, record.CertificateNumber, record.StatusDisplay);
+                }
+
+                doc.Blocks.Add(table);
+                _dialogService.ShowPrintPreview(doc, "Calibration Due Report", string.Empty);
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowInfo($"Failed to print calibration report: {ex.Message}", "Print Failed");
+            }
+        }
+
+        private void PrintSelectedCalibration()
+        {
+            if (SelectedRecord == null) return;
+
+            try
+            {
+                var record = SelectedRecord;
+                var doc = CreateCalibrationDocument($"Calibration Certificate - {ValueOrNotRecorded(record.ItemNumber)}");
+                var table = CreateKeyValueTable();
+                var group = table.RowGroups[0];
+                AddKeyValueRow(group, "Calibration #:", record.CalibrationID.ToString());
+                AddKeyValueRow(group, "Item:", $"{ValueOrNotRecorded(record.ItemNumber)} - {ValueOrNotRecorded(record.ItemName)}");
+                AddKeyValueRow(group, "Status:", record.StatusDisplay);
+                AddKeyValueRow(group, "Calibrated:", record.CalibrationDate.ToString("yyyy-MM-dd"));
+                AddKeyValueRow(group, "Next due:", record.NextCalibrationDue.ToString("yyyy-MM-dd"));
+                AddKeyValueRow(group, "Calibrated by:", record.CalibratedBy);
+                AddKeyValueRow(group, "Certificate:", record.CertificateNumber);
+                AddKeyValueRow(group, "Standard:", record.Standard);
+                AddKeyValueRow(group, "Result:", record.Result);
+                AddKeyValueRow(group, "Cost:", record.Cost.ToString("C"));
+                AddKeyValueRow(group, "Notes:", record.Notes);
+                doc.Blocks.Add(table);
+
+                _dialogService.ShowPrintPreview(doc, $"Calibration {record.CalibrationID}", string.Empty);
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowInfo($"Failed to print calibration record: {ex.Message}", "Print Failed");
+            }
         }
 
         private bool CanEditOrDelete() => SelectedRecord != null;
+
+        private static FlowDocument CreateCalibrationDocument(string title, double fontSize = 16)
+        {
+            var doc = new FlowDocument
+            {
+                PagePadding = new Thickness(36),
+                FontFamily = new System.Windows.Media.FontFamily("Calibri"),
+                FontSize = fontSize
+            };
+
+            doc.Blocks.Add(new Paragraph(new Bold(new Run(title)))
+            {
+                FontSize = 20,
+                TextAlignment = TextAlignment.Center,
+                Margin = new Thickness(0, 0, 0, 10)
+            });
+
+            return doc;
+        }
+
+        private static Table CreateKeyValueTable()
+        {
+            var table = new Table();
+            table.Columns.Add(new TableColumn { Width = new GridLength(150) });
+            table.Columns.Add(new TableColumn());
+            table.RowGroups.Add(new TableRowGroup());
+            return table;
+        }
+
+        private static void AddKeyValueRow(TableRowGroup group, string label, string? value)
+        {
+            var row = new TableRow();
+            row.Cells.Add(new TableCell(new Paragraph(new Run(label)) { FontWeight = FontWeights.Bold }));
+            row.Cells.Add(new TableCell(new Paragraph(new Run(ValueOrNotRecorded(value)))));
+            group.Rows.Add(row);
+        }
+
+        private static void AddPrintRow(TableRowGroup group, bool isHeader, params string?[] values)
+        {
+            var row = new TableRow();
+            foreach (var value in values)
+            {
+                var paragraph = new Paragraph(new Run(ValueOrNotRecorded(value)))
+                {
+                    Margin = new Thickness(3),
+                    FontSize = isHeader ? 10 : 9,
+                    FontWeight = isHeader ? FontWeights.Bold : FontWeights.Normal
+                };
+                var cell = new TableCell(paragraph)
+                {
+                    BorderBrush = System.Windows.Media.Brushes.Gray,
+                    BorderThickness = new Thickness(0.5),
+                    Padding = new Thickness(2)
+                };
+                row.Cells.Add(cell);
+            }
+            group.Rows.Add(row);
+        }
+
+        private static string ValueOrNotRecorded(string? value) => string.IsNullOrWhiteSpace(value) ? "Not recorded" : value;
     }
 }

--- a/InventoryManagementApp/ViewModels/MaintenanceManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MaintenanceManagementViewModel.cs
@@ -3,7 +3,10 @@ using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Documents;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Services.Maintenance;
 using InventoryManagementApp.Interfaces;
@@ -18,6 +21,11 @@ namespace InventoryManagementApp.ViewModels
         public ObservableCollection<MaintenanceRecord> MaintenanceRecords { get; }
         public ObservableCollection<MaintenanceRecord> FilteredMaintenanceRecords { get; }
 
+        public string MaintenanceResultsSummary => $"{FilteredMaintenanceRecords.Count} of {MaintenanceRecords.Count} maintenance record{(MaintenanceRecords.Count == 1 ? string.Empty : "s")} shown";
+        public string SelectedRecordSummary => SelectedRecord == null
+            ? "Select or double-click a maintenance row to view details, complete work, print the record, edit, or delete."
+            : $"{ValueOrNotRecorded(SelectedRecord.ItemNumber)} | {ValueOrNotRecorded(SelectedRecord.ItemName)} | {SelectedRecord.StatusDisplay} | scheduled {SelectedRecord.ScheduledDate:yyyy-MM-dd}";
+
         private MaintenanceRecord? _selectedRecord;
         public MaintenanceRecord? SelectedRecord
         {
@@ -29,6 +37,9 @@ namespace InventoryManagementApp.ViewModels
                     EditMaintenanceCommand.NotifyCanExecuteChanged();
                     DeleteMaintenanceCommand.NotifyCanExecuteChanged();
                     CompleteMaintenanceCommand.NotifyCanExecuteChanged();
+                    OpenMaintenanceDetailsCommand.NotifyCanExecuteChanged();
+                    PrintSelectedMaintenanceCommand.NotifyCanExecuteChanged();
+                    OnPropertyChanged(nameof(SelectedRecordSummary));
                 }
             }
         }
@@ -67,6 +78,9 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand DeleteMaintenanceCommand { get; }
         public IAsyncRelayCommand CompleteMaintenanceCommand { get; }
         public IAsyncRelayCommand RefreshCommand { get; }
+        public IRelayCommand OpenMaintenanceDetailsCommand { get; }
+        public IRelayCommand PrintMaintenanceListCommand { get; }
+        public IRelayCommand PrintSelectedMaintenanceCommand { get; }
 
         public MaintenanceManagementViewModel(
             MaintenanceService maintenanceService,
@@ -92,6 +106,9 @@ namespace InventoryManagementApp.ViewModels
             DeleteMaintenanceCommand = new AsyncRelayCommand(DeleteMaintenanceAsync, CanEditOrDelete);
             CompleteMaintenanceCommand = new AsyncRelayCommand(CompleteMaintenanceAsync, CanComplete);
             RefreshCommand = new AsyncRelayCommand(LoadMaintenanceAsync);
+            OpenMaintenanceDetailsCommand = new RelayCommand(OpenMaintenanceDetails, CanEditOrDelete);
+            PrintMaintenanceListCommand = new RelayCommand(PrintMaintenanceList);
+            PrintSelectedMaintenanceCommand = new RelayCommand(PrintSelectedMaintenance, CanEditOrDelete);
         }
 
         private async Task LoadMaintenanceAsync()
@@ -169,6 +186,7 @@ namespace InventoryManagementApp.ViewModels
                     await _maintenanceService.UpdateMaintenanceRecordAsync(clone);
                     var index = MaintenanceRecords.IndexOf(SelectedRecord);
                     if (index >= 0) MaintenanceRecords[index] = clone;
+                    SelectedRecord = clone;
                     ApplyFilter();
                     await _dialogService.ShowInfoAsync("Success", "Maintenance record updated successfully");
                 }
@@ -185,7 +203,7 @@ namespace InventoryManagementApp.ViewModels
 
             var confirmed = await _dialogService.ShowConfirmAsync(
                 "Delete Maintenance Record",
-                $"Are you sure you want to delete this maintenance record?");
+                $"Delete maintenance for {ValueOrNotRecorded(SelectedRecord.ItemName)} scheduled {SelectedRecord.ScheduledDate:yyyy-MM-dd}?");
 
             if (confirmed)
             {
@@ -193,6 +211,7 @@ namespace InventoryManagementApp.ViewModels
                 {
                     await _maintenanceService.DeleteMaintenanceRecordAsync(SelectedRecord.MaintenanceID);
                     MaintenanceRecords.Remove(SelectedRecord);
+                    SelectedRecord = null;
                     ApplyFilter();
                     await _dialogService.ShowInfoAsync("Success", "Maintenance record deleted successfully");
                 }
@@ -226,6 +245,9 @@ namespace InventoryManagementApp.ViewModels
                     EditMaintenanceCommand.NotifyCanExecuteChanged();
                     DeleteMaintenanceCommand.NotifyCanExecuteChanged();
                     CompleteMaintenanceCommand.NotifyCanExecuteChanged();
+                    OpenMaintenanceDetailsCommand.NotifyCanExecuteChanged();
+                    PrintSelectedMaintenanceCommand.NotifyCanExecuteChanged();
+                    OnPropertyChanged(nameof(SelectedRecordSummary));
                     await _dialogService.ShowInfoAsync("Success", "Maintenance marked as completed");
                 }
                 catch (Exception ex)
@@ -264,10 +286,173 @@ namespace InventoryManagementApp.ViewModels
             {
                 FilteredMaintenanceRecords.Add(record);
             }
+
+            OnPropertyChanged(nameof(MaintenanceResultsSummary));
+        }
+
+        private void OpenMaintenanceDetails()
+        {
+            if (SelectedRecord == null) return;
+
+            var record = SelectedRecord;
+            var details = new StringBuilder();
+            details.AppendLine($"Maintenance #: {record.MaintenanceID}");
+            details.AppendLine($"Item: {ValueOrNotRecorded(record.ItemNumber)} - {ValueOrNotRecorded(record.ItemName)}");
+            details.AppendLine($"Type: {ValueOrNotRecorded(record.MaintenanceType)}");
+            details.AppendLine($"Status: {record.StatusDisplay}");
+            details.AppendLine();
+            details.AppendLine($"Scheduled: {record.ScheduledDate:yyyy-MM-dd}");
+            details.AppendLine($"Completed: {FormatDate(record.CompletedDate)}");
+            details.AppendLine($"Performed by: {ValueOrNotRecorded(record.PerformedBy)}");
+            details.AppendLine($"Cost: {record.Cost:C}");
+            details.AppendLine();
+            details.AppendLine($"Description: {ValueOrNotRecorded(record.Description)}");
+            details.AppendLine($"Notes: {ValueOrNotRecorded(record.Notes)}");
+            details.AppendLine();
+            details.AppendLine(record.IsOverdue
+                ? "Next action: complete or reschedule this overdue maintenance before the item is issued again."
+                : "Next action: review work notes, complete scheduled work, or print this record for the bench file.");
+
+            _dialogService.ShowInfo(details.ToString(), $"Maintenance Details - {ValueOrNotRecorded(record.ItemNumber)}");
+        }
+
+        private void PrintMaintenanceList()
+        {
+            if (FilteredMaintenanceRecords.Count == 0)
+            {
+                _dialogService.ShowInfo("There are no maintenance records to print.", "Maintenance Report");
+                return;
+            }
+
+            try
+            {
+                var doc = CreateMaintenanceDocument("Maintenance Schedule", fontSize: 11);
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | {MaintenanceResultsSummary}"))
+                {
+                    FontSize = 10,
+                    Margin = new Thickness(0, 0, 0, 10)
+                });
+
+                var table = new Table { CellSpacing = 0 };
+                table.Columns.Add(new TableColumn { Width = new GridLength(90) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(150) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(85) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(90) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(85) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(110) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(90) });
+
+                var group = new TableRowGroup();
+                table.RowGroups.Add(group);
+                AddPrintRow(group, true, "Item #", "Name", "Type", "Scheduled", "Status", "Performed By", "Completed");
+                foreach (var record in FilteredMaintenanceRecords)
+                {
+                    AddPrintRow(group, false, record.ItemNumber, record.ItemName, record.MaintenanceType, record.ScheduledDate.ToString("yyyy-MM-dd"), record.StatusDisplay, record.PerformedBy, FormatDate(record.CompletedDate));
+                }
+
+                doc.Blocks.Add(table);
+                _dialogService.ShowPrintPreview(doc, "Maintenance Schedule", string.Empty);
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowInfo($"Failed to print maintenance report: {ex.Message}", "Print Failed");
+            }
+        }
+
+        private void PrintSelectedMaintenance()
+        {
+            if (SelectedRecord == null) return;
+
+            try
+            {
+                var record = SelectedRecord;
+                var doc = CreateMaintenanceDocument($"Maintenance Record - {ValueOrNotRecorded(record.ItemNumber)}");
+                var table = CreateKeyValueTable();
+                var group = table.RowGroups[0];
+                AddKeyValueRow(group, "Maintenance #:", record.MaintenanceID.ToString());
+                AddKeyValueRow(group, "Item:", $"{ValueOrNotRecorded(record.ItemNumber)} - {ValueOrNotRecorded(record.ItemName)}");
+                AddKeyValueRow(group, "Type:", record.MaintenanceType);
+                AddKeyValueRow(group, "Status:", record.StatusDisplay);
+                AddKeyValueRow(group, "Scheduled:", record.ScheduledDate.ToString("yyyy-MM-dd"));
+                AddKeyValueRow(group, "Completed:", FormatDate(record.CompletedDate));
+                AddKeyValueRow(group, "Performed by:", record.PerformedBy);
+                AddKeyValueRow(group, "Cost:", record.Cost.ToString("C"));
+                AddKeyValueRow(group, "Description:", record.Description);
+                AddKeyValueRow(group, "Notes:", record.Notes);
+                doc.Blocks.Add(table);
+
+                _dialogService.ShowPrintPreview(doc, $"Maintenance {record.MaintenanceID}", string.Empty);
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowInfo($"Failed to print maintenance record: {ex.Message}", "Print Failed");
+            }
         }
 
         private bool CanEditOrDelete() => SelectedRecord != null;
 
         private bool CanComplete() => SelectedRecord != null && SelectedRecord.Status == "Scheduled";
+
+        private static FlowDocument CreateMaintenanceDocument(string title, double fontSize = 16)
+        {
+            var doc = new FlowDocument
+            {
+                PagePadding = new Thickness(36),
+                FontFamily = new System.Windows.Media.FontFamily("Calibri"),
+                FontSize = fontSize
+            };
+
+            doc.Blocks.Add(new Paragraph(new Bold(new Run(title)))
+            {
+                FontSize = 20,
+                TextAlignment = TextAlignment.Center,
+                Margin = new Thickness(0, 0, 0, 10)
+            });
+
+            return doc;
+        }
+
+        private static Table CreateKeyValueTable()
+        {
+            var table = new Table();
+            table.Columns.Add(new TableColumn { Width = new GridLength(150) });
+            table.Columns.Add(new TableColumn());
+            table.RowGroups.Add(new TableRowGroup());
+            return table;
+        }
+
+        private static void AddKeyValueRow(TableRowGroup group, string label, string? value)
+        {
+            var row = new TableRow();
+            row.Cells.Add(new TableCell(new Paragraph(new Run(label)) { FontWeight = FontWeights.Bold }));
+            row.Cells.Add(new TableCell(new Paragraph(new Run(ValueOrNotRecorded(value)))));
+            group.Rows.Add(row);
+        }
+
+        private static void AddPrintRow(TableRowGroup group, bool isHeader, params string?[] values)
+        {
+            var row = new TableRow();
+            foreach (var value in values)
+            {
+                var paragraph = new Paragraph(new Run(ValueOrNotRecorded(value)))
+                {
+                    Margin = new Thickness(3),
+                    FontSize = isHeader ? 10 : 9,
+                    FontWeight = isHeader ? FontWeights.Bold : FontWeights.Normal
+                };
+                var cell = new TableCell(paragraph)
+                {
+                    BorderBrush = System.Windows.Media.Brushes.Gray,
+                    BorderThickness = new Thickness(0.5),
+                    Padding = new Thickness(2)
+                };
+                row.Cells.Add(cell);
+            }
+            group.Rows.Add(row);
+        }
+
+        private static string FormatDate(DateTime? value) => value?.ToString("yyyy-MM-dd") ?? "Not recorded";
+
+        private static string ValueOrNotRecorded(string? value) => string.IsNullOrWhiteSpace(value) ? "Not recorded" : value;
     }
 }

--- a/InventoryManagementApp/Views/Pages/CalibrationPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CalibrationPage.xaml
@@ -6,6 +6,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <Border Style="{StaticResource ToolbarCard}">
@@ -13,45 +14,73 @@
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
                     <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddCalibrationCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCalibrationDetailsCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditCalibrationCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Delete" Command="{Binding DeleteCalibrationCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Print Record" Command="{Binding PrintSelectedCalibrationCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Print Due" Command="{Binding PrintCalibrationListCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteCalibrationCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
                     <TextBlock Text="Filter" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                    <TextBox Width="160" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,4,0"/>
-                    <ComboBox Width="140" ItemsSource="{Binding FilterOptions}" SelectedItem="{Binding SelectedFilter}"/>
+                    <TextBox Width="180" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,4,0"/>
+                    <ComboBox Width="150" ItemsSource="{Binding FilterOptions}" SelectedItem="{Binding SelectedFilter}"/>
                 </StackPanel>
             </DockPanel>
         </Border>
 
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
             <Grid>
-                <DataGrid ItemsSource="{Binding FilteredCalibrationRecords}"
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                    <DockPanel>
+                        <TextBlock Text="01 Calibration Register" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                        <TextBlock Text="{Binding CalibrationResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                    </DockPanel>
+                </Border>
+                <DataGrid Grid.Row="1"
+                          ItemsSource="{Binding FilteredCalibrationRecords}"
                           SelectedItem="{Binding SelectedRecord}"
-                          SelectionMode="Extended"
+                          SelectionMode="Single"
                           AutoGenerateColumns="False"
                           IsReadOnly="True"
                           Style="{StaticResource VirtualizedDataGridStyle}">
+                    <DataGrid.RowStyle>
+                        <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                            <EventSetter Event="MouseDoubleClick" Handler="CalibrationRow_MouseDoubleClick"/>
+                            <EventSetter Event="PreviewMouseRightButtonDown" Handler="CalibrationRow_PreviewMouseRightButtonDown"/>
+                        </Style>
+                    </DataGrid.RowStyle>
                     <DataGrid.Columns>
-                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="120"/>
-                        <DataGridTextColumn Header="Name" Binding="{Binding ItemName}" Width="220"/>
-                        <DataGridTextColumn Header="Calibrated" Binding="{Binding CalibrationDate, StringFormat={}{0:yyyy-MM-dd}}" Width="120"/>
-                        <DataGridTextColumn Header="Next Due" Binding="{Binding NextCalibrationDue, StringFormat={}{0:yyyy-MM-dd}}" Width="120"/>
-                        <DataGridTextColumn Header="Calibrated By" Binding="{Binding CalibratedBy}" Width="150"/>
-                        <DataGridTextColumn Header="Certificate" Binding="{Binding CertificateNumber}" Width="150"/>
-                        <DataGridTextColumn Header="Result" Binding="{Binding Result}" Width="110"/>
+                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="115"/>
+                        <DataGridTextColumn Header="Name" Binding="{Binding ItemName}" Width="2*"/>
+                        <DataGridTextColumn Header="Calibrated" Binding="{Binding CalibrationDate, StringFormat={}{0:yyyy-MM-dd}}" Width="115"/>
+                        <DataGridTextColumn Header="Next Due" Binding="{Binding NextCalibrationDue, StringFormat={}{0:yyyy-MM-dd}}" Width="115"/>
+                        <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="105"/>
+                        <DataGridTextColumn Header="Calibrated By" Binding="{Binding CalibratedBy}" Width="140"/>
+                        <DataGridTextColumn Header="Certificate" Binding="{Binding CertificateNumber}" Width="145"/>
+                        <DataGridTextColumn Header="Result" Binding="{Binding Result}" Width="95"/>
+                        <DataGridTextColumn Header="Standard" Binding="{Binding Standard}" Width="140"/>
+                        <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" Width="2*"/>
                     </DataGrid.Columns>
                     <DataGrid.ContextMenu>
                         <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
                                     DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                            <MenuItem Header="Add" Command="{Binding AddCalibrationCommand}"/>
+                            <MenuItem Header="Open Details" Command="{Binding OpenCalibrationDetailsCommand}"/>
                             <MenuItem Header="Edit" Command="{Binding EditCalibrationCommand}"/>
+                            <Separator/>
+                            <MenuItem Header="Print Record" Command="{Binding PrintSelectedCalibrationCommand}"/>
+                            <MenuItem Header="Print Due Report" Command="{Binding PrintCalibrationListCommand}"/>
+                            <Separator/>
                             <MenuItem Header="Delete" Command="{Binding DeleteCalibrationCommand}"/>
                         </ContextMenu>
                     </DataGrid.ContextMenu>
                 </DataGrid>
-                <TextBlock Text="No calibration records"
+                <TextBlock Grid.Row="1"
+                           Text="No calibration records"
                            HorizontalAlignment="Center"
                            VerticalAlignment="Center"
                            FontSize="13"
@@ -68,6 +97,15 @@
                     </TextBlock.Style>
                 </TextBlock>
             </Grid>
+        </Border>
+        <Border Grid.Row="2" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
+            <DockPanel LastChildFill="True">
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCalibrationDetailsCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print Due" Command="{Binding PrintCalibrationListCommand}"/>
+                </StackPanel>
+                <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0"/>
+            </DockPanel>
         </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
@@ -17,6 +18,23 @@ namespace InventoryManagementApp.Views.Pages
             if (DataContext is CalibrationManagementViewModel vm)
             {
                 await vm.LoadCalibrationCommand.ExecuteAsync(null);
+            }
+        }
+
+        private void CalibrationRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is CalibrationManagementViewModel vm && vm.OpenCalibrationDetailsCommand.CanExecute(null))
+            {
+                vm.OpenCalibrationDetailsCommand.Execute(null);
+            }
+        }
+
+        private void CalibrationRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is DataGridRow row && !row.IsSelected)
+            {
+                row.IsSelected = true;
+                e.Handled = true;
             }
         }
     }

--- a/InventoryManagementApp/Views/Pages/MaintenancePage.xaml
+++ b/InventoryManagementApp/Views/Pages/MaintenancePage.xaml
@@ -6,6 +6,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <Border Style="{StaticResource ToolbarCard}">
@@ -13,48 +14,74 @@
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
                     <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddMaintenanceCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenMaintenanceDetailsCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditMaintenanceCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Delete" Command="{Binding DeleteMaintenanceCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Complete" Command="{Binding CompleteMaintenanceCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Print Record" Command="{Binding PrintSelectedMaintenanceCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Print Schedule" Command="{Binding PrintMaintenanceListCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteMaintenanceCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
                     <TextBlock Text="Filter" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                    <TextBox Width="160" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,4,0"/>
-                    <ComboBox Width="140" ItemsSource="{Binding FilterOptions}" SelectedItem="{Binding SelectedFilter}"/>
+                    <TextBox Width="180" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,4,0"/>
+                    <ComboBox Width="150" ItemsSource="{Binding FilterOptions}" SelectedItem="{Binding SelectedFilter}"/>
                 </StackPanel>
             </DockPanel>
         </Border>
 
         <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
             <Grid>
-                <DataGrid ItemsSource="{Binding FilteredMaintenanceRecords}"
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                    <DockPanel>
+                        <TextBlock Text="01 Maintenance Workbench" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                        <TextBlock Text="{Binding MaintenanceResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                    </DockPanel>
+                </Border>
+                <DataGrid Grid.Row="1"
+                          ItemsSource="{Binding FilteredMaintenanceRecords}"
                           SelectedItem="{Binding SelectedRecord}"
-                          SelectionMode="Extended"
+                          SelectionMode="Single"
                           AutoGenerateColumns="False"
                           IsReadOnly="True"
                           Style="{StaticResource VirtualizedDataGridStyle}">
+                    <DataGrid.RowStyle>
+                        <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                            <EventSetter Event="MouseDoubleClick" Handler="MaintenanceRow_MouseDoubleClick"/>
+                            <EventSetter Event="PreviewMouseRightButtonDown" Handler="MaintenanceRow_PreviewMouseRightButtonDown"/>
+                        </Style>
+                    </DataGrid.RowStyle>
                     <DataGrid.Columns>
-                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="120"/>
-                        <DataGridTextColumn Header="Name" Binding="{Binding ItemName}" Width="220"/>
+                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="115"/>
+                        <DataGridTextColumn Header="Name" Binding="{Binding ItemName}" Width="2*"/>
                         <DataGridTextColumn Header="Type" Binding="{Binding MaintenanceType}" Width="120"/>
-                        <DataGridTextColumn Header="Scheduled" Binding="{Binding ScheduledDate, StringFormat={}{0:yyyy-MM-dd}}" Width="120"/>
-                        <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="110"/>
-                        <DataGridTextColumn Header="Performed By" Binding="{Binding PerformedBy}" Width="150"/>
-                        <DataGridTextColumn Header="Completed" Binding="{Binding CompletedDate, StringFormat={}{0:yyyy-MM-dd}}" Width="120"/>
+                        <DataGridTextColumn Header="Scheduled" Binding="{Binding ScheduledDate, StringFormat={}{0:yyyy-MM-dd}}" Width="115"/>
+                        <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="105"/>
+                        <DataGridTextColumn Header="Performed By" Binding="{Binding PerformedBy}" Width="145"/>
+                        <DataGridTextColumn Header="Completed" Binding="{Binding CompletedDate, StringFormat={}{0:yyyy-MM-dd}}" Width="115"/>
                         <DataGridTextColumn Header="Cost" Binding="{Binding Cost, StringFormat={}{0:C}}" Width="90"/>
+                        <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" Width="2*"/>
                     </DataGrid.Columns>
                     <DataGrid.ContextMenu>
                         <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
                                     DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                            <MenuItem Header="Add" Command="{Binding AddMaintenanceCommand}"/>
+                            <MenuItem Header="Open Details" Command="{Binding OpenMaintenanceDetailsCommand}"/>
                             <MenuItem Header="Edit" Command="{Binding EditMaintenanceCommand}"/>
-                            <MenuItem Header="Delete" Command="{Binding DeleteMaintenanceCommand}"/>
                             <MenuItem Header="Complete" Command="{Binding CompleteMaintenanceCommand}"/>
+                            <Separator/>
+                            <MenuItem Header="Print Record" Command="{Binding PrintSelectedMaintenanceCommand}"/>
+                            <MenuItem Header="Print Schedule" Command="{Binding PrintMaintenanceListCommand}"/>
+                            <Separator/>
+                            <MenuItem Header="Delete" Command="{Binding DeleteMaintenanceCommand}"/>
                         </ContextMenu>
                     </DataGrid.ContextMenu>
                 </DataGrid>
-                <TextBlock Text="No maintenance records"
+                <TextBlock Grid.Row="1"
+                           Text="No maintenance records"
                            HorizontalAlignment="Center"
                            VerticalAlignment="Center"
                            FontSize="13"
@@ -71,6 +98,15 @@
                     </TextBlock.Style>
                 </TextBlock>
             </Grid>
+        </Border>
+        <Border Grid.Row="2" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
+            <DockPanel LastChildFill="True">
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenMaintenanceDetailsCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print Schedule" Command="{Binding PrintMaintenanceListCommand}"/>
+                </StackPanel>
+                <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0"/>
+            </DockPanel>
         </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/MaintenancePage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/MaintenancePage.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
@@ -17,6 +18,23 @@ namespace InventoryManagementApp.Views.Pages
             if (DataContext is MaintenanceManagementViewModel vm)
             {
                 await vm.LoadMaintenanceCommand.ExecuteAsync(null);
+            }
+        }
+
+        private void MaintenanceRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is MaintenanceManagementViewModel vm && vm.OpenMaintenanceDetailsCommand.CanExecute(null))
+            {
+                vm.OpenMaintenanceDetailsCommand.Execute(null);
+            }
+        }
+
+        private void MaintenanceRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is DataGridRow row && !row.IsSelected)
+            {
+                row.IsSelected = true;
+                e.Handled = true;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Converts maintenance and calibration from passive record grids into compact classic desktop workbenches with section headers, selected-row footers, single-row selection, and dense action toolbars.
- Adds double-click and right-click row drilldown for maintenance and calibration records so users can open deeper details without leaving the page.
- Adds printable maintenance schedule, maintenance record, calibration due report, and calibration record flows through the existing print-preview service.
- Adds clearer delete confirmations and selected-record summaries to support technician/admin decisions from the same page.

## Why
The item, rental, customer, and history workflows had already moved toward the polished early WPF desktop direction. Maintenance and calibration were still dead-end grids, which made it harder for technicians/admins to answer the natural next questions: what item is affected, what is due, what is overdue, who performed the work, and what can be printed for the bench or certificate file.

## Validation
- Compared the branch against `master` and confirmed only maintenance/calibration view and viewmodel files changed.
- Read the changed branch files back through the GitHub connector to verify command names, row handlers, bindings, and context-menu wiring.
- Local .NET build/tests could not run because direct checkout is blocked in this scheduled environment and the .NET SDK is not available locally.