### PR TITLE
[codex] Improve reports desktop workstation

### DIFF
--- a/InventoryManagementApp/ViewModels/ReportsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ReportsViewModel.cs
@@ -1,10 +1,10 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System;
 using System.Collections.ObjectModel;
-using System.Data;
 using System.Linq;
-using System.Windows.Documents;
 using System.Threading.Tasks;
+using System.Windows.Documents;
 using InventoryManagementApp.Services.Items;
 
 #nullable enable
@@ -16,6 +16,7 @@ namespace InventoryManagementApp.ViewModels
         private readonly ReportService _reportService;
 
         public ObservableCollection<string> ReportTypes { get; }
+        public ObservableCollection<ReportLine> ReportLines { get; } = new();
 
         private string _selectedReport = string.Empty;
         public string SelectedReport
@@ -25,19 +26,81 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _selectedReport, value))
                 {
+                    ReportStatus = string.IsNullOrWhiteSpace(value)
+                        ? "Select a report to begin."
+                        : $"Ready to run {value}.";
                     RunReportCommand.NotifyCanExecuteChanged();
                 }
             }
         }
 
-        private DataTable _reportResults = new();
-        public DataTable ReportResults
+        private ReportLine? _selectedReportLine;
+        public ReportLine? SelectedReportLine
         {
-            get => _reportResults;
-            set => SetProperty(ref _reportResults, value);
+            get => _selectedReportLine;
+            set
+            {
+                if (SetProperty(ref _selectedReportLine, value))
+                    OnPropertyChanged(nameof(SelectedLineDetail));
+            }
         }
 
+        private string _reportTitle = "Reports";
+        public string ReportTitle
+        {
+            get => _reportTitle;
+            set => SetProperty(ref _reportTitle, value);
+        }
+
+        private string _reportSubtitle = "Run operational reports for inventory, rentals, maintenance, reservations, and usage.";
+        public string ReportSubtitle
+        {
+            get => _reportSubtitle;
+            set => SetProperty(ref _reportSubtitle, value);
+        }
+
+        private string _reportSummary = "No report has been run yet.";
+        public string ReportSummary
+        {
+            get => _reportSummary;
+            set => SetProperty(ref _reportSummary, value);
+        }
+
+        private string _reportStatus = "Select a report to begin.";
+        public string ReportStatus
+        {
+            get => _reportStatus;
+            set => SetProperty(ref _reportStatus, value);
+        }
+
+        private bool _isBusy;
+        public bool IsBusy
+        {
+            get => _isBusy;
+            set
+            {
+                if (SetProperty(ref _isBusy, value))
+                    RunReportCommand.NotifyCanExecuteChanged();
+            }
+        }
+
+        private DateTime? _lastRunAt;
+        public DateTime? LastRunAt
+        {
+            get => _lastRunAt;
+            set
+            {
+                if (SetProperty(ref _lastRunAt, value))
+                    OnPropertyChanged(nameof(LastRunText));
+            }
+        }
+
+        public string LastRunText => LastRunAt.HasValue ? LastRunAt.Value.ToString("g") : "Not run";
+        public int ReportLineCount => ReportLines.Count;
+        public string SelectedLineDetail => SelectedReportLine?.Text ?? "Select or double-click a report row to inspect the detail.";
+
         public IAsyncRelayCommand RunReportCommand { get; }
+        public IRelayCommand ClearReportCommand { get; }
 
         public ReportsViewModel(ReportService reportService)
         {
@@ -63,55 +126,174 @@ namespace InventoryManagementApp.ViewModels
             };
 
             RunReportCommand = new AsyncRelayCommand(RunReportAsync, CanRunReport);
+            ClearReportCommand = new RelayCommand(ClearReport, () => ReportLines.Count > 0);
         }
 
-        private bool CanRunReport() => !string.IsNullOrEmpty(SelectedReport);
+        private bool CanRunReport() => !IsBusy && !string.IsNullOrWhiteSpace(SelectedReport);
 
         private async Task RunReportAsync()
         {
-            FlowDocument? doc = SelectedReport switch
-            {
-                "Summary" => await _reportService.GenerateSummaryReport(),
-                "Inventory" => await _reportService.GenerateInventoryReport(),
-                "Activity Log" => await _reportService.GenerateActivityLogReport(),
-                "Customers" => await _reportService.GenerateCustomerReport(),
-                "Users" => await _reportService.GenerateUserReport(),
-                "Active Rentals" => await _reportService.GenerateRentalReport(true),
-                "Full Rental History" => await _reportService.GenerateRentalReport(false),
-                "Most Rented Items" => await _reportService.GenerateRentalFrequencyReport(20),
-                "Maintenance Schedule" => await _reportService.GenerateMaintenanceReport(false),
-                "Overdue Maintenance" => await _reportService.GenerateMaintenanceReport(true),
-                "Calibration Records" => await _reportService.GenerateCalibrationReport(false),
-                "Overdue Calibrations" => await _reportService.GenerateCalibrationReport(true),
-                "Active Reservations" => await _reportService.GenerateReservationReport(true),
-                "All Reservations" => await _reportService.GenerateReservationReport(false),
-                "Active Kits" => await _reportService.GenerateKitReport(),
-                _ => null,
-            };
+            IsBusy = true;
+            ReportStatus = $"Running {SelectedReport}...";
 
-            ReportResults = ConvertToTable(doc);
+            try
+            {
+                FlowDocument? doc = SelectedReport switch
+                {
+                    "Summary" => await _reportService.GenerateSummaryReport(),
+                    "Inventory" => await _reportService.GenerateInventoryReport(),
+                    "Activity Log" => await _reportService.GenerateActivityLogReport(),
+                    "Customers" => await _reportService.GenerateCustomerReport(),
+                    "Users" => await _reportService.GenerateUserReport(),
+                    "Active Rentals" => await _reportService.GenerateRentalReport(true),
+                    "Full Rental History" => await _reportService.GenerateRentalReport(false),
+                    "Most Rented Items" => await _reportService.GenerateRentalFrequencyReport(20),
+                    "Maintenance Schedule" => await _reportService.GenerateMaintenanceReport(false),
+                    "Overdue Maintenance" => await _reportService.GenerateMaintenanceReport(true),
+                    "Calibration Records" => await _reportService.GenerateCalibrationReport(false),
+                    "Overdue Calibrations" => await _reportService.GenerateCalibrationReport(true),
+                    "Active Reservations" => await _reportService.GenerateReservationReport(true),
+                    "All Reservations" => await _reportService.GenerateReservationReport(false),
+                    "Active Kits" => await _reportService.GenerateKitReport(),
+                    _ => null,
+                };
+
+                LoadReport(doc);
+            }
+            catch (Exception ex)
+            {
+                ReportLines.Clear();
+                SelectedReportLine = null;
+                ReportTitle = SelectedReport;
+                ReportSubtitle = "The report could not be generated.";
+                ReportSummary = ex.Message;
+                ReportStatus = "Report failed.";
+                LastRunAt = DateTime.Now;
+                OnPropertyChanged(nameof(ReportLineCount));
+                ClearReportCommand.NotifyCanExecuteChanged();
+            }
+            finally
+            {
+                IsBusy = false;
+            }
         }
 
-        private static DataTable ConvertToTable(FlowDocument? doc)
+        private void LoadReport(FlowDocument? doc)
         {
-            var table = new DataTable();
-            table.Columns.Add("Line");
+            ReportLines.Clear();
+            SelectedReportLine = null;
 
-            if (doc == null)
-                return table;
-
-            var paragraphs = doc.Blocks
+            var lines = doc?.Blocks
                 .OfType<Paragraph>()
-                .Skip(1)
                 .Select(p => new TextRange(p.ContentStart, p.ContentEnd).Text.Trim())
-                .Where(t => !string.IsNullOrWhiteSpace(t));
+                .Where(t => !string.IsNullOrWhiteSpace(t))
+                .ToList() ?? new();
 
-            foreach (var line in paragraphs)
+            ReportTitle = lines.FirstOrDefault() ?? SelectedReport;
+            ReportSubtitle = BuildSubtitle(SelectedReport);
+
+            var detailLines = lines.Skip(1).ToList();
+            for (var i = 0; i < detailLines.Count; i++)
             {
-                table.Rows.Add(line);
+                ReportLines.Add(new ReportLine(i + 1, ClassifyLine(detailLines[i]), detailLines[i], BuildActionHint(detailLines[i])));
             }
 
-            return table;
+            LastRunAt = DateTime.Now;
+            ReportSummary = BuildSummary(detailLines);
+            ReportStatus = $"{SelectedReport} completed with {ReportLines.Count} line(s).";
+            OnPropertyChanged(nameof(ReportLineCount));
+            ClearReportCommand.NotifyCanExecuteChanged();
         }
+
+        private void ClearReport()
+        {
+            ReportLines.Clear();
+            SelectedReportLine = null;
+            ReportTitle = "Reports";
+            ReportSubtitle = "Run operational reports for inventory, rentals, maintenance, reservations, and usage.";
+            ReportSummary = "No report has been run yet.";
+            ReportStatus = "Report cleared.";
+            LastRunAt = null;
+            OnPropertyChanged(nameof(ReportLineCount));
+            ClearReportCommand.NotifyCanExecuteChanged();
+        }
+
+        private static string BuildSubtitle(string reportName)
+        {
+            return reportName switch
+            {
+                "Most Rented Items" => "Usage intelligence for buying more high-demand items.",
+                "Active Rentals" => "Open rental work that may need advisor follow-up.",
+                "Active Reservations" => "Pending holds and requests waiting for availability.",
+                "Overdue Maintenance" => "Items requiring maintenance attention before further checkout.",
+                "Overdue Calibrations" => "Calibrations that should be handled before field use.",
+                "Activity Log" => "Recent inventory activity for operational review.",
+                _ => $"Operational output for {reportName}."
+            };
+        }
+
+        private static string BuildSummary(System.Collections.Generic.IReadOnlyCollection<string> lines)
+        {
+            if (lines.Count == 0)
+                return "The report returned no detail rows.";
+
+            var urgentCount = lines.Count(line => ContainsAny(line, "overdue", "late", "out of stock", "checked out", "rented", "reservation", "maintenance", "calibration"));
+            return urgentCount == 0
+                ? $"{lines.Count} line(s) returned. No obvious overdue, unavailable, or request wording was detected."
+                : $"{lines.Count} line(s) returned. {urgentCount} line(s) mention availability, overdue, request, maintenance, or calibration follow-up.";
+        }
+
+        private static string ClassifyLine(string line)
+        {
+            if (ContainsAny(line, "overdue", "late"))
+                return "Overdue";
+            if (ContainsAny(line, "reservation", "request", "hold"))
+                return "Request";
+            if (ContainsAny(line, "checked out", "rented", "rental"))
+                return "Rental";
+            if (ContainsAny(line, "maintenance", "repair"))
+                return "Maintenance";
+            if (ContainsAny(line, "calibration", "calibrated"))
+                return "Calibration";
+            if (ContainsAny(line, "item", "tool", "inventory", "stock"))
+                return "Inventory";
+            if (ContainsAny(line, "customer", "technician", "advisor", "user"))
+                return "Person";
+            return "Detail";
+        }
+
+        private static string BuildActionHint(string line)
+        {
+            if (ContainsAny(line, "overdue", "late"))
+                return "Open the related rental or item record and follow up.";
+            if (ContainsAny(line, "reservation", "request", "hold"))
+                return "Check availability and contact the waiting user or customer.";
+            if (ContainsAny(line, "maintenance", "repair", "calibration"))
+                return "Review the item before it is rented or checked out again.";
+            if (ContainsAny(line, "checked out", "rented", "rental"))
+                return "Confirm holder, due-back date, and return status.";
+            return "Use the source page to drill into the related record.";
+        }
+
+        private static bool ContainsAny(string text, params string[] terms)
+        {
+            return terms.Any(term => text.Contains(term, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    public sealed class ReportLine
+    {
+        public ReportLine(int number, string category, string text, string actionHint)
+        {
+            Number = number;
+            Category = category;
+            Text = text;
+            ActionHint = actionHint;
+        }
+
+        public int Number { get; }
+        public string Category { get; }
+        public string Text { get; }
+        public string ActionHint { get; }
     }
 }

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml
@@ -7,19 +7,142 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
+
         <Border Style="{StaticResource ToolbarCard}">
-            <StackPanel Orientation="Horizontal">
-                <ComboBox Width="220" ItemsSource="{Binding ReportTypes}" SelectedItem="{Binding SelectedReport}" ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
-                <Button Style="{StaticResource PrimaryButton}" Content="Run" Command="{Binding RunReportCommand}" Margin="6,0,0,0"/>
-            </StackPanel>
+            <DockPanel LastChildFill="False">
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
+                    <TextBlock Text="Report" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <ComboBox Width="230"
+                              ItemsSource="{Binding ReportTypes}"
+                              SelectedItem="{Binding SelectedReport}"
+                              ItemContainerStyle="{StaticResource DropdownItemStyle}"
+                              ToolTip="Choose the report to run"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Run" Command="{Binding RunReportCommand}" Margin="6,0,0,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearReportCommand}" Margin="4,0,0,0"/>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
+                    <Button Style="{StaticResource PrimaryButton}" Content="Print Report" Click="PrintReport_Click" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Copy Row" Click="CopySelectedRow_Click"/>
+                </StackPanel>
+            </DockPanel>
         </Border>
-        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
-            <DataGrid ItemsSource="{Binding ReportResults}"
-                      AutoGenerateColumns="True"
-                      IsReadOnly="True"
-                      Style="{StaticResource VirtualizedDataGridStyle}"
-                      ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}"/>
-        </Border>
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2.7*"/>
+                <ColumnDefinition Width="4"/>
+                <ColumnDefinition Width="1.15*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <Border Grid.ColumnSpan="3" Style="{StaticResource Card}" Padding="6" Margin="0,0,0,4">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel>
+                        <TextBlock Text="{Binding ReportTitle}" Style="{StaticResource PageTitleTextBlock}"/>
+                        <TextBlock Text="{Binding ReportSubtitle}"
+                                   FontSize="11"
+                                   Margin="0,2,0,0"
+                                   TextWrapping="Wrap"
+                                   Foreground="{DynamicResource MutedForegroundBrush}"/>
+                    </StackPanel>
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock Text="Rows:" Style="{StaticResource LabelTextBlock}" Margin="0,0,4,0"/>
+                        <TextBlock Text="{Binding ReportLineCount}" Margin="0,0,12,0"/>
+                        <TextBlock Text="Last Run:" Style="{StaticResource LabelTextBlock}" Margin="0,0,4,0"/>
+                        <TextBlock Text="{Binding LastRunText}"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
+                <DataGrid x:Name="ReportGrid"
+                          ItemsSource="{Binding ReportLines}"
+                          SelectedItem="{Binding SelectedReportLine, Mode=TwoWay}"
+                          IsReadOnly="True"
+                          AutoGenerateColumns="False"
+                          MouseDoubleClick="ReportGrid_MouseDoubleClick"
+                          Style="{StaticResource VirtualizedDataGridStyle}">
+                    <DataGrid.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="Copy Selected Row" Click="CopySelectedRow_Click"/>
+                            <MenuItem Header="Print Report" Click="PrintReport_Click"/>
+                        </ContextMenu>
+                    </DataGrid.ContextMenu>
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="#" Binding="{Binding Number}" Width="50"/>
+                        <DataGridTextColumn Header="Type" Binding="{Binding Category}" Width="110"/>
+                        <DataGridTextColumn Header="Report Detail" Binding="{Binding Text}" Width="*"/>
+                        <DataGridTextColumn Header="Next Action" Binding="{Binding ActionHint}" Width="260"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Border>
+
+            <GridSplitter Grid.Row="1"
+                          Grid.Column="1"
+                          Width="4"
+                          HorizontalAlignment="Stretch"
+                          Background="{DynamicResource BorderBrushAlt}"/>
+
+            <Grid Grid.Row="1" Grid.Column="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <Border Style="{StaticResource Card}" Padding="6" Margin="0,0,0,4">
+                    <StackPanel>
+                        <TextBlock Text="Report Summary" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="{Binding ReportSummary}" TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Border>
+
+                <Border Grid.Row="1" Style="{StaticResource Card}" Padding="6">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <TextBlock Text="Selected Row Detail" Style="{StaticResource SectionHeader}"/>
+                        <TextBox Grid.Row="1"
+                                 Text="{Binding SelectedLineDetail, Mode=OneWay}"
+                                 IsReadOnly="True"
+                                 TextWrapping="Wrap"
+                                 AcceptsReturn="True"
+                                 VerticalScrollBarVisibility="Auto"
+                                 Margin="0,3,0,0"/>
+                    </Grid>
+                </Border>
+
+                <Border Grid.Row="2" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
+                    <StackPanel>
+                        <TextBlock Text="Operator path" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="Double-click a row or use the context menu to copy details for follow-up. Use the source page named by the report type to open the related item, rental, customer, request, maintenance, or calibration record."
+                                   FontSize="11"
+                                   TextWrapping="Wrap"
+                                   Foreground="{DynamicResource MutedForegroundBrush}"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Grid>
+
+        <DockPanel Grid.Row="2" Margin="0,4,0,0">
+            <ProgressBar Width="160"
+                         Height="16"
+                         DockPanel.Dock="Right"
+                         IsIndeterminate="True"
+                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
+            <TextBlock Text="{Binding ReportStatus}" VerticalAlignment="Center"/>
+        </DockPanel>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
@@ -1,4 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
+using InventoryManagementApp.ViewModels;
+using WpfMessageBox = System.Windows.MessageBox;
+using WpfPrintDialog = System.Windows.Controls.PrintDialog;
 
 namespace InventoryManagementApp.Views.Pages
 {
@@ -7,6 +15,107 @@ namespace InventoryManagementApp.Views.Pages
         public ReportsPage()
         {
             InitializeComponent();
+        }
+
+        private void ReportGrid_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            CopySelectedRow_Click(sender, e);
+        }
+
+        private void CopySelectedRow_Click(object sender, RoutedEventArgs e)
+        {
+            if (ReportGrid.SelectedItem is not ReportLine line)
+            {
+                WpfMessageBox.Show("Select a report row first.", "Reports", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            Clipboard.SetText($"{line.Category}: {line.Text}{Environment.NewLine}Next action: {line.ActionHint}");
+        }
+
+        private void PrintReport_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is not ReportsViewModel vm || vm.ReportLines.Count == 0)
+            {
+                WpfMessageBox.Show("Run a report before printing.", "Reports", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var printDialog = new WpfPrintDialog();
+            if (printDialog.ShowDialog() != true)
+                return;
+
+            var document = BuildReportDocument(vm.ReportTitle, vm.ReportSummary, vm.LastRunText, vm.ReportLines.ToList());
+            document.PageWidth = printDialog.PrintableAreaWidth;
+            document.PageHeight = printDialog.PrintableAreaHeight;
+            document.PagePadding = new Thickness(36);
+            document.ColumnWidth = printDialog.PrintableAreaWidth;
+            printDialog.PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator, vm.ReportTitle);
+        }
+
+        private static FlowDocument BuildReportDocument(string title, string summary, string lastRunText, IReadOnlyCollection<ReportLine> lines)
+        {
+            var document = new FlowDocument
+            {
+                FontFamily = new System.Windows.Media.FontFamily("Segoe UI"),
+                FontSize = 11
+            };
+
+            document.Blocks.Add(new Paragraph(new Run(title))
+            {
+                FontSize = 16,
+                FontWeight = FontWeights.SemiBold,
+                Margin = new Thickness(0, 0, 0, 4)
+            });
+            document.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:g} - Last run {lastRunText} - {lines.Count} row(s)"))
+            {
+                FontSize = 10,
+                Margin = new Thickness(0, 0, 0, 4)
+            });
+            document.Blocks.Add(new Paragraph(new Run(summary))
+            {
+                Margin = new Thickness(0, 0, 0, 10)
+            });
+
+            var table = new Table { CellSpacing = 0 };
+            foreach (var width in new[] { 45.0, 95.0, 330.0, 230.0 })
+                table.Columns.Add(new TableColumn { Width = new GridLength(width) });
+
+            var rowGroup = new TableRowGroup();
+            table.RowGroups.Add(rowGroup);
+
+            var header = new TableRow { FontWeight = FontWeights.SemiBold };
+            rowGroup.Rows.Add(header);
+            AddCell(header, "#");
+            AddCell(header, "Type");
+            AddCell(header, "Report Detail");
+            AddCell(header, "Next Action");
+
+            foreach (var line in lines)
+            {
+                var row = new TableRow();
+                rowGroup.Rows.Add(row);
+                AddCell(row, line.Number.ToString());
+                AddCell(row, line.Category);
+                AddCell(row, line.Text);
+                AddCell(row, line.ActionHint);
+            }
+
+            document.Blocks.Add(table);
+            return document;
+        }
+
+        private static void AddCell(TableRow row, string text)
+        {
+            row.Cells.Add(new TableCell(new Paragraph(new Run(text ?? string.Empty))
+            {
+                Margin = new Thickness(2)
+            })
+            {
+                BorderBrush = System.Windows.Media.Brushes.Gray,
+                BorderThickness = new Thickness(0, 0, 0, 0.5),
+                Padding = new Thickness(3, 2, 3, 2)
+            });
         }
     }
 }


### PR DESCRIPTION
## Summary
- Redesign Reports into a compact classic desktop workstation with report metadata, result grid, selected-line detail, summary pane, and status strip.
- Replace passive DataTable output with structured report rows that classify each line and suggest the next operational action.
- Add same-screen print, copy, clear, double-click, and context-menu workflows so report output is actionable without leaving the page.

## Validation
- Parsed `ReportsPage.xaml` as well-formed XML locally.
- Checked the changed files for the banned standalone terms used by the repository guard.
- Could not run local .NET build/tests because this scheduled environment does not include the .NET SDK.