### PR TITLE
[codex] Improve category desktop directory workflow

### DIFF
--- a/InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs
@@ -1,14 +1,16 @@
-﻿// ViewModels/CategoryManagementViewModel.cs
+// ViewModels/CategoryManagementViewModel.cs
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Input;
 using InventoryManagementApp.Services.Categories;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using WpfMessageBox = System.Windows.MessageBox;
 
 namespace InventoryManagementApp.ViewModels
 {
@@ -19,9 +21,11 @@ namespace InventoryManagementApp.ViewModels
         private int _selectedInventoryId;
         private CategoryItem? _selectedCategory;
         private string _categoryName = "";
+        private string _searchText = "";
         private bool _isBusy;
 
         public ObservableCollection<CategoryItem> Categories { get; } = new();
+        public ObservableCollection<CategoryItem> FilteredCategories { get; } = new();
 
         public int SelectedInventoryId
         {
@@ -44,6 +48,11 @@ namespace InventoryManagementApp.ViewModels
                 _selectedCategory = value;
                 OnPropertyChanged();
                 CategoryName = value?.Name ?? "";
+                OnPropertyChanged(nameof(SelectedCategoryTitle));
+                OnPropertyChanged(nameof(SelectedCategorySubtitle));
+                OnPropertyChanged(nameof(SelectedCategoryDetail));
+                OnPropertyChanged(nameof(SelectedCategoryNextAction));
+                OnPropertyChanged(nameof(SelectedCategorySummary));
                 _saveCommand.RaiseCanExecuteChanged();
                 _deleteCommand.RaiseCanExecuteChanged();
             }
@@ -62,21 +71,60 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
+        public string SearchText
+        {
+            get => _searchText;
+            set
+            {
+                if (_searchText == value) return;
+                _searchText = value;
+                OnPropertyChanged();
+                ApplyFilter();
+                _clearSearchCommand.RaiseCanExecuteChanged();
+            }
+        }
+
         public bool IsBusy
         {
             get => _isBusy;
             private set { if (_isBusy == value) return; _isBusy = value; OnPropertyChanged(); }
         }
 
+        public string CategoryResultsSummary => string.IsNullOrWhiteSpace(SearchText)
+            ? $"{FilteredCategories.Count} {(FilteredCategories.Count == 1 ? "category" : "categories")} shown"
+            : $"{FilteredCategories.Count} of {Categories.Count} categor{(FilteredCategories.Count == 1 ? "y" : "ies")} match \"{SearchText.Trim()}\"";
+
+        public string SelectedCategoryTitle => SelectedCategory == null
+            ? "No category selected"
+            : SelectedCategory.Name;
+
+        public string SelectedCategorySubtitle => SelectedCategory == null
+            ? "Select or double-click a category row."
+            : $"Category #{SelectedCategory.CategoryID}";
+
+        public string SelectedCategoryDetail => SelectedCategory == null
+            ? "Choose a category to rename, delete, copy, print, or review before assigning inventory records."
+            : $"Category #{SelectedCategory.CategoryID} is named \"{SelectedCategory.Name}\". Use this directory to keep advisor search filters and inventory setup tidy.";
+
+        public string SelectedCategoryNextAction => SelectedCategory == null
+            ? "Create a category, filter the list, or select a row to continue."
+            : "Natural next step: confirm the name matches how technicians and advisors search, then use inventory item setup to assign matching records.";
+
+        public string SelectedCategorySummary => SelectedCategory == null
+            ? "Select or double-click a category row to view details, copy it, print the directory, rename it, or delete it."
+            : $"Selected: #{SelectedCategory.CategoryID} | {SelectedCategory.Name}";
+
         private readonly AsyncCommand _addCommand;
         private readonly AsyncCommand _saveCommand;
         private readonly AsyncCommand _deleteCommand;
         private readonly AsyncCommand _refreshCommand;
+        private readonly AsyncCommand _clearSearchCommand;
 
         public ICommand AddCommand => _addCommand;
         public ICommand SaveCommand => _saveCommand;
         public ICommand DeleteCommand => _deleteCommand;
         public ICommand RefreshCommand => _refreshCommand;
+        public ICommand ClearSearchCommand => _clearSearchCommand;
 
         public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -88,6 +136,7 @@ namespace InventoryManagementApp.ViewModels
             _saveCommand = new AsyncCommand(SaveAsync, () => SelectedCategory != null && !string.IsNullOrWhiteSpace(CategoryName));
             _deleteCommand = new AsyncCommand(DeleteAsync, () => SelectedCategory != null);
             _refreshCommand = new AsyncCommand(LoadAsync);
+            _clearSearchCommand = new AsyncCommand(ClearSearchAsync, () => !string.IsNullOrWhiteSpace(SearchText));
         }
 
         private async void LoadCategoriesAsync()
@@ -114,16 +163,43 @@ namespace InventoryManagementApp.ViewModels
             IsBusy = true;
             try
             {
+                var selectedId = SelectedCategory?.CategoryID;
                 var list = await _service.GetCategoriesForInventoryAsync(SelectedInventoryId);
                 Categories.Clear();
                 foreach (var c in list) Categories.Add(new CategoryItem { CategoryID = c.CategoryID, Name = c.Name });
-                if (SelectedCategory != null)
-                {
-                    var match = Categories.FirstOrDefault(x => x.CategoryID == SelectedCategory.CategoryID);
-                    SelectedCategory = match;
-                }
+                ApplyFilter(selectedId);
             }
             finally { IsBusy = false; }
+        }
+
+        private void ApplyFilter(int? preferredSelectedId = null)
+        {
+            var search = SearchText.Trim();
+            var currentId = preferredSelectedId ?? SelectedCategory?.CategoryID;
+            var filtered = Categories
+                .Where(c => string.IsNullOrWhiteSpace(search)
+                    || c.Name.Contains(search, StringComparison.OrdinalIgnoreCase)
+                    || c.CategoryID.ToString().Contains(search, StringComparison.OrdinalIgnoreCase))
+                .OrderBy(c => c.Name)
+                .ThenBy(c => c.CategoryID)
+                .ToList();
+
+            FilteredCategories.Clear();
+            foreach (var category in filtered)
+                FilteredCategories.Add(category);
+
+            SelectedCategory = currentId.HasValue
+                ? FilteredCategories.FirstOrDefault(c => c.CategoryID == currentId.Value)
+                : FilteredCategories.FirstOrDefault();
+
+            OnPropertyChanged(nameof(CategoryResultsSummary));
+        }
+
+        private async Task ClearSearchAsync()
+        {
+            SearchText = "";
+            ApplyFilter();
+            await Task.CompletedTask;
         }
 
         private async Task AddAsync()
@@ -139,7 +215,8 @@ namespace InventoryManagementApp.ViewModels
                 return;
             }
             await LoadAsync();
-            SelectedCategory = Categories.FirstOrDefault(x => x.CategoryID == id);
+            SelectedCategory = FilteredCategories.FirstOrDefault(x => x.CategoryID == id)
+                ?? Categories.FirstOrDefault(x => x.CategoryID == id);
         }
 
         private async Task SaveAsync()
@@ -152,20 +229,29 @@ namespace InventoryManagementApp.ViewModels
             {
                 var item = Categories.FirstOrDefault(x => x.CategoryID == SelectedCategory.CategoryID);
                 if (item != null) item.Name = name;
+                ApplyFilter(SelectedCategory.CategoryID);
             }
         }
 
         private async Task DeleteAsync()
         {
             if (SelectedCategory == null) return;
-            var id = SelectedCategory.CategoryID;
+            var category = SelectedCategory;
+            var confirmed = WpfMessageBox.Show(
+                $"Delete category \"{category.Name}\"?",
+                "Delete Category",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Warning) == MessageBoxResult.Yes;
+            if (!confirmed) return;
+
+            var id = category.CategoryID;
             var ok = await _service.DeleteCategoryAsync(id);
             if (ok)
             {
                 var item = Categories.FirstOrDefault(x => x.CategoryID == id);
                 if (item != null) Categories.Remove(item);
                 CategoryName = "";
-                SelectedCategory = null;
+                ApplyFilter();
             }
         }
 

--- a/InventoryManagementApp/Views/Pages/CategoriesPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CategoriesPage.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Views/Pages/CategoriesPage.xaml -->
+<!-- Views/Pages/CategoriesPage.xaml -->
 <Page x:Class="InventoryManagementApp.Views.Pages.CategoriesPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -8,40 +8,177 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <Border Style="{StaticResource ToolbarCard}">
-            <DockPanel LastChildFill="False">
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
-                    <TextBlock Text="Category" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                    <TextBox Width="240"
-                             Margin="0,0,4,0"
-                             Text="{Binding CategoryName, UpdateSourceTrigger=PropertyChanged}"
-                             ToolTip="Category name"/>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="240"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="240"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Grid.Column="0" Text="Category:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                <TextBox Grid.Column="1"
+                         Text="{Binding CategoryName, UpdateSourceTrigger=PropertyChanged}"
+                         ToolTip="Category name"/>
+
+                <TextBlock Grid.Column="2" Text="Find:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="10,0,6,0"/>
+                <TextBox Grid.Column="3"
+                         Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                         ToolTip="Filter categories by ID or name"/>
+
+                <StackPanel Grid.Column="5" Orientation="Horizontal" HorizontalAlignment="Right">
                     <Button Style="{StaticResource PrimaryButton}" Content="New" Command="{Binding AddCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Save" Command="{Binding SaveCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Delete" Command="{Binding DeleteCommand}"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearSearchCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print" Click="PrintCategories_Click"/>
                 </StackPanel>
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
+            </Grid>
+        </Border>
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="1.1*"/>
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                        <DockPanel>
+                            <TextBlock Text="01 Category Directory" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                            <TextBlock Text="{Binding CategoryResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                        </DockPanel>
+                    </Border>
+
+                    <DataGrid x:Name="CategoryGrid"
+                              Grid.Row="1"
+                              ItemsSource="{Binding FilteredCategories}"
+                              SelectedItem="{Binding SelectedCategory, Mode=TwoWay}"
+                              IsReadOnly="True"
+                              AutoGenerateColumns="False"
+                              SelectionMode="Single"
+                              Style="{StaticResource VirtualizedDataGridStyle}">
+                        <DataGrid.RowStyle>
+                            <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                                <EventSetter Event="MouseDoubleClick" Handler="CategoryRow_MouseDoubleClick"/>
+                                <EventSetter Event="PreviewMouseRightButtonDown" Handler="CategoryRow_PreviewMouseRightButtonDown"/>
+                            </Style>
+                        </DataGrid.RowStyle>
+                        <DataGrid.ContextMenu>
+                            <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                <MenuItem Header="Open Category Detail" Click="OpenCategoryDetail_Click"/>
+                                <MenuItem Header="Copy Category" Click="CopyCategory_Click"/>
+                                <Separator/>
+                                <MenuItem Header="Print Current Results" Click="PrintCategories_Click"/>
+                                <MenuItem Header="Refresh" Command="{Binding RefreshCommand}"/>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="ID" Binding="{Binding CategoryID}" Width="90"/>
+                            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+
+                    <TextBlock Grid.Row="1"
+                               Text="No categories match this filter"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"
+                               FontSize="13"
+                               FontWeight="SemiBold">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding FilteredCategories.Count}" Value="0">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Grid>
+            </Border>
+
+            <GridSplitter Grid.Column="1"
+                          Width="6"
+                          HorizontalAlignment="Stretch"
+                          VerticalAlignment="Stretch"
+                          Background="{DynamicResource BorderBrushBase}"/>
+
+            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="8">
+                <DockPanel LastChildFill="True">
+                    <Border DockPanel.Dock="Top"
+                            Background="{DynamicResource SurfaceAltBrush}"
+                            BorderBrush="{DynamicResource BorderBrushAlt}"
+                            BorderThickness="1"
+                            Padding="6"
+                            Margin="0,0,0,6">
+                        <StackPanel>
+                            <TextBlock Text="Category Detail" Style="{StaticResource SectionHeader}"/>
+                            <TextBlock Text="{Binding SelectedCategoryTitle}"
+                                       Style="{StaticResource PageTitleTextBlock}"
+                                       TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding SelectedCategorySubtitle}"
+                                       FontSize="11"
+                                       Margin="0,2,0,0"
+                                       TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+
+                    <StackPanel DockPanel.Dock="Top" Margin="0,0,0,6">
+                        <TextBlock Text="Admin path" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="{Binding SelectedCategoryNextAction}" TextWrapping="Wrap"/>
+                    </StackPanel>
+
+                    <StackPanel DockPanel.Dock="Bottom" Margin="0,6,0,0">
+                        <TextBlock Text="Actions" Style="{StaticResource SectionHeader}"/>
+                        <UniformGrid Columns="2">
+                            <Button Style="{StaticResource GhostButton}"
+                                    Content="Open"
+                                    Click="OpenCategoryDetail_Click"
+                                    Margin="0,0,4,0"/>
+                            <Button Style="{StaticResource GhostButton}"
+                                    Content="Copy"
+                                    Click="CopyCategory_Click"/>
+                        </UniformGrid>
+                    </StackPanel>
+
+                    <Border BorderBrush="{DynamicResource BorderBrushAlt}"
+                            BorderThickness="1"
+                            Background="{DynamicResource TextBoxBackgroundBrush}"
+                            Padding="6">
+                        <TextBlock Text="{Binding SelectedCategoryDetail}"
+                                   TextWrapping="Wrap"/>
+                    </Border>
+                </DockPanel>
+            </Border>
+        </Grid>
+
+        <Border Grid.Row="2" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
+            <DockPanel LastChildFill="True">
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                    <Button Style="{StaticResource PrimaryButton}" Content="Open" Click="OpenCategoryDetail_Click" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Clear Filter" Command="{Binding ClearSearchCommand}"/>
                 </StackPanel>
+                <TextBlock Text="{Binding SelectedCategorySummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0"/>
             </DockPanel>
         </Border>
 
-        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
-            <DataGrid ItemsSource="{Binding Categories}"
-                      SelectedItem="{Binding SelectedCategory, Mode=TwoWay}"
-                      IsReadOnly="True"
-                      AutoGenerateColumns="False"
-                      Style="{StaticResource VirtualizedDataGridStyle}">
-                <DataGrid.Columns>
-                    <DataGridTextColumn Header="ID" Binding="{Binding CategoryID}" Width="90"/>
-                    <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
-                </DataGrid.Columns>
-            </DataGrid>
-        </Border>
-
-        <ProgressBar Grid.Row="2"
+        <ProgressBar Grid.Row="3"
                      IsIndeterminate="True"
                      Margin="0,4,0,0"
                      Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>

--- a/InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs
@@ -1,7 +1,15 @@
-﻿// Views/Pages/CategoriesPage.xaml.cs
+// Views/Pages/CategoriesPage.xaml.cs
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Input;
 using InventoryManagementApp.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
+using WpfMessageBox = System.Windows.MessageBox;
+using WpfPrintDialog = System.Windows.Controls.PrintDialog;
 
 namespace InventoryManagementApp.Views.Pages
 {
@@ -18,6 +26,126 @@ namespace InventoryManagementApp.Views.Pages
                 vm.SelectedInventoryId = inventoryId;
                 await vm.InitializeAsync().ConfigureAwait(false);
             };
+        }
+
+        private void CategoryRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            OpenCategoryDetail_Click(sender, e);
+        }
+
+        private void CategoryRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is DataGridRow row && !row.IsSelected)
+            {
+                row.IsSelected = true;
+                e.Handled = true;
+            }
+        }
+
+        private void OpenCategoryDetail_Click(object sender, RoutedEventArgs e)
+        {
+            if (CategoryGrid.SelectedItem is not CategoryManagementViewModel.CategoryItem category)
+            {
+                WpfMessageBox.Show("Select a category row first.", "Category Detail", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            WpfMessageBox.Show(FormatCategoryDetail(category), $"Category Detail - {category.Name}", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        private void CopyCategory_Click(object sender, RoutedEventArgs e)
+        {
+            if (CategoryGrid.SelectedItem is not CategoryManagementViewModel.CategoryItem category)
+            {
+                WpfMessageBox.Show("Select a category row first.", "Category Detail", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            Clipboard.SetText(FormatCategoryDetail(category));
+        }
+
+        private void PrintCategories_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is not CategoryManagementViewModel vm || vm.FilteredCategories.Count == 0)
+            {
+                WpfMessageBox.Show("There are no categories to print.", "Category Directory", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var printDialog = new WpfPrintDialog();
+            if (printDialog.ShowDialog() != true)
+                return;
+
+            var document = BuildPrintDocument(vm.FilteredCategories.ToList(), vm.CategoryResultsSummary);
+            document.PageWidth = printDialog.PrintableAreaWidth;
+            document.PageHeight = printDialog.PrintableAreaHeight;
+            document.PagePadding = new Thickness(36);
+            document.ColumnWidth = printDialog.PrintableAreaWidth;
+            printDialog.PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator, "Category Directory");
+        }
+
+        private static string FormatCategoryDetail(CategoryManagementViewModel.CategoryItem category)
+        {
+            return $"Category #: {category.CategoryID}{Environment.NewLine}" +
+                   $"Name: {category.Name}{Environment.NewLine}{Environment.NewLine}" +
+                   "Next steps: assign matching inventory items to this category, review search results by category, or rename the category if advisors cannot find it quickly.";
+        }
+
+        private static FlowDocument BuildPrintDocument(IReadOnlyCollection<CategoryManagementViewModel.CategoryItem> categories, string summary)
+        {
+            var document = new FlowDocument
+            {
+                FontFamily = new System.Windows.Media.FontFamily("Segoe UI"),
+                FontSize = 10
+            };
+
+            document.Blocks.Add(new Paragraph(new Run("Category Directory"))
+            {
+                FontSize = 16,
+                FontWeight = FontWeights.SemiBold,
+                Margin = new Thickness(0, 0, 0, 4)
+            });
+            document.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:g} - {summary}"))
+            {
+                FontSize = 10,
+                Margin = new Thickness(0, 0, 0, 10)
+            });
+
+            var table = new Table { CellSpacing = 0 };
+            table.Columns.Add(new TableColumn { Width = new GridLength(90) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(420) });
+
+            var rowGroup = new TableRowGroup();
+            table.RowGroups.Add(rowGroup);
+
+            var header = new TableRow { FontWeight = FontWeights.SemiBold };
+            rowGroup.Rows.Add(header);
+            AddCell(header, "ID");
+            AddCell(header, "Name");
+
+            foreach (var category in categories)
+            {
+                var row = new TableRow();
+                rowGroup.Rows.Add(row);
+                AddCell(row, category.CategoryID.ToString());
+                AddCell(row, category.Name);
+            }
+
+            document.Blocks.Add(table);
+            return document;
+        }
+
+        private static void AddCell(TableRow row, string text)
+        {
+            row.Cells.Add(new TableCell(new Paragraph(new Run(text ?? string.Empty))
+            {
+                Margin = new Thickness(2)
+            })
+            {
+                BorderBrush = System.Windows.Media.Brushes.Gray,
+                BorderThickness = new Thickness(0, 0, 0, 0.5),
+                Padding = new Thickness(3, 2, 3, 2)
+            });
         }
     }
 }


### PR DESCRIPTION
## Summary
- redesign Categories into a compact desktop directory with search, selected-row detail, and a right-side action pane
- add double-click/right-click category drill-down, copy, print-current-results, and print-directory support
- add filtered category collections, result summaries, selected-category guidance, and delete confirmation

## Validation
- Parsed `InventoryManagementApp/Views/Pages/CategoriesPage.xaml` as well-formed XML locally
- Checked changed category files for banned standalone source wording
- Local .NET build/test could not run because the scheduled environment does not have the .NET SDK installed