### PR TITLE
Tighten rentals desktop workflow interactions

### DIFF
--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
@@ -2,7 +2,8 @@
 <Page x:Class="InventoryManagementApp.Views.Pages.ManageRentalsPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      Background="{DynamicResource BackgroundBrush}">
+      Background="{DynamicResource BackgroundBrush}"
+      Focusable="True">
     <Grid Margin="0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -23,6 +24,9 @@
                     <Button Style="{StaticResource PrimaryButton}" Content="Extend" Command="{Binding ExtendCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="History" Command="{Binding OpenHistoryCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Place Request" Command="{Binding PlaceRequestCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Print Rental" Command="{Binding PrintRentalCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Pick Slip" Command="{Binding PrintPickingSlipCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Invoice" Command="{Binding PrintInvoiceCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Print Search" Command="{Binding PrintSearchResultsCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Print Checked Out" Command="{Binding PrintCheckedOutCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Print Requests" Command="{Binding PrintRequestsCommand}" Margin="0,0,4,0"/>
@@ -30,7 +34,7 @@
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
                     <TextBlock Text="Filter" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                    <TextBox Width="150" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,4,0"/>
+                    <TextBox x:Name="SearchTextBox" Width="150" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,4,0"/>
                     <DatePicker SelectedDate="{Binding FilterFrom, UpdateSourceTrigger=PropertyChanged}" Width="125" Margin="0,0,4,0"/>
                     <DatePicker SelectedDate="{Binding FilterTo, UpdateSourceTrigger=PropertyChanged}" Width="125" Margin="0,0,4,0"/>
                     <ComboBox ItemsSource="{Binding StatusOptions}" SelectedItem="{Binding SelectedStatus, UpdateSourceTrigger=PropertyChanged}" Width="110" Margin="0,0,4,0"/>
@@ -76,8 +80,12 @@
                             <MenuItem Header="Extend" Command="{Binding ExtendCommand}"/>
                             <MenuItem Header="Place Request" Command="{Binding PlaceRequestCommand}"/>
                             <MenuItem Header="History" Command="{Binding OpenHistoryCommand}"/>
+                            <Separator/>
                             <MenuItem Header="Print Rental" Command="{Binding PrintRentalCommand}"/>
+                            <MenuItem Header="Print Picking Slip" Command="{Binding PrintPickingSlipCommand}"/>
+                            <MenuItem Header="Print Invoice" Command="{Binding PrintInvoiceCommand}"/>
                             <MenuItem Header="Print Search Results" Command="{Binding PrintSearchResultsCommand}"/>
+                            <Separator/>
                             <MenuItem Header="Delete" Command="{Binding DeleteRentalCommand}"/>
                         </ContextMenu>
                     </DataGrid.ContextMenu>
@@ -133,6 +141,10 @@
                             <MenuItem Header="Extend" Command="{Binding ExtendCommand}"/>
                             <MenuItem Header="Place Request" Command="{Binding PlaceRequestCommand}"/>
                             <MenuItem Header="History" Command="{Binding OpenHistoryCommand}"/>
+                            <Separator/>
+                            <MenuItem Header="Print Rental" Command="{Binding PrintRentalCommand}"/>
+                            <MenuItem Header="Print Picking Slip" Command="{Binding PrintPickingSlipCommand}"/>
+                            <MenuItem Header="Print Invoice" Command="{Binding PrintInvoiceCommand}"/>
                             <MenuItem Header="Print Checked Out" Command="{Binding PrintCheckedOutCommand}"/>
                         </ContextMenu>
                     </DataGrid.ContextMenu>

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
@@ -1,7 +1,10 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
+using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
+using RentalModel = InventoryManagementApp.Models.Domain.Rental;
 
 namespace InventoryManagementApp.Views.Pages
 {
@@ -14,14 +17,19 @@ namespace InventoryManagementApp.Views.Pages
         {
             InitializeComponent();
             Loaded += ManageRentalsPage_Loaded;
+            PreviewKeyDown += ManageRentalsPage_PreviewKeyDown;
         }
 
         private async void ManageRentalsPage_Loaded(object sender, RoutedEventArgs e)
         {
+            Focus();
             if (DataContext is ManageRentalsViewModel vm)
             {
                 await vm.LoadRentalsAsync();
             }
+
+            SearchTextBox.Focus();
+            SearchTextBox.SelectAll();
         }
 
         private void RentalRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
@@ -50,13 +58,135 @@ namespace InventoryManagementApp.Views.Pages
             SelectRowForContextMenu(sender, e);
         }
 
-        private static void SelectRowForContextMenu(object sender, MouseButtonEventArgs e)
+        private void ManageRentalsPage_PreviewKeyDown(object sender, KeyEventArgs e)
         {
-            if (sender is DataGridRow row && !row.IsSelected)
+            if (DataContext is not ManageRentalsViewModel vm)
+                return;
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F)
             {
-                row.IsSelected = true;
+                SearchTextBox.Focus();
+                SearchTextBox.SelectAll();
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P)
+            {
+                vm.PrintSearchResultsCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.P)
+            {
+                vm.PrintCheckedOutCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.R)
+            {
+                vm.PrintRequestsCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.D)
+            {
+                OpenFocusedDetails(vm);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.H && vm.OpenHistoryCommand.CanExecute(null))
+            {
+                vm.OpenHistoryCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.I && vm.CheckInCommand.CanExecute(null))
+            {
+                vm.CheckInCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.E && vm.ExtendCommand.CanExecute(null))
+            {
+                vm.ExtendCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.R && vm.PlaceRequestCommand.CanExecute(null))
+            {
+                vm.PlaceRequestCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter)
+            {
+                OpenFocusedDetails(vm);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Delete && vm.DeleteRentalCommand.CanExecute(null))
+            {
+                vm.DeleteRentalCommand.Execute(null);
                 e.Handled = true;
             }
+        }
+
+        private static void OpenFocusedDetails(ManageRentalsViewModel vm)
+        {
+            if (Keyboard.FocusedElement is DependencyObject focusedElement && FindAncestor<DataGrid>(focusedElement) is DataGrid grid)
+            {
+                if (grid.SelectedItem is Reservation && vm.OpenRequestDetailsCommand.CanExecute(null))
+                {
+                    vm.OpenRequestDetailsCommand.Execute(null);
+                    return;
+                }
+            }
+
+            if (vm.OpenRentalDetailsCommand.CanExecute(null))
+                vm.OpenRentalDetailsCommand.Execute(null);
+            else if (vm.OpenRequestDetailsCommand.CanExecute(null))
+                vm.OpenRequestDetailsCommand.Execute(null);
+        }
+
+        private void SelectRowForContextMenu(object sender, MouseButtonEventArgs e)
+        {
+            var row = sender as DataGridRow ?? FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject);
+            if (row == null)
+                return;
+
+            row.IsSelected = true;
+            row.Focus();
+
+            if (DataContext is ManageRentalsViewModel vm)
+            {
+                if (row.Item is RentalModel rental)
+                    vm.SelectedRental = rental;
+                else if (row.Item is Reservation request)
+                    vm.SelectedRequest = request;
+            }
+        }
+
+        private static T? FindAncestor<T>(DependencyObject? current) where T : DependencyObject
+        {
+            while (current != null)
+            {
+                if (current is T match)
+                    return match;
+
+                current = VisualTreeHelper.GetParent(current);
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds keyboard shortcuts to the rentals workstation for fast advisor/technician actions: focus search, open details, print search results, print checked-out items, print requests, check in, extend, place request, history, and delete.
- Makes rentals/request right-click context menus select the exact row under the pointer before running an action.
- Surfaces existing rental print actions in the toolbar and row context menus, including rental sheet, picking slip, invoice, checked-out list, search results, and requests.

## Why
The rentals page already had the split desktop workflow and durable open requests, but the repeated advisor/technician actions still required too much mouse work and some document actions were hidden behind commands. This keeps the rentals workflow aligned with the item-search desktop station.

## Validation
- Reviewed the focused branch diff against `master`.
- Read the changed files back from the branch to verify bindings, command names, shortcut handlers, and context-menu selection wiring.
- Local .NET build/tests could not run because this scheduled environment does not include the .NET SDK and direct repository cloning is blocked.