### PR TITLE
Upgrade dashboard desktop operations board

### DIFF
--- a/InventoryManagementApp/ViewModels/DashboardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DashboardViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Data;
@@ -34,6 +35,11 @@ namespace InventoryManagementApp.ViewModels
         readonly IRelayCommand _openRentalsCommand;
         readonly IRelayCommand _openImportExportCommand;
         readonly ILogger<DashboardViewModel> _logger;
+        ItemModel? _selectedCommonlyUsedItem;
+        ItemModel? _selectedCheckedOutItem;
+        ItemModel? _selectedIncompleteItem;
+        RentalModel? _selectedRental;
+        ActivityLog? _selectedActivity;
 
         public ObservableCollection<StatCard> StatCards { get; } = new();
         public ObservableCollection<ActivityLog> RecentActivity { get; } = new();
@@ -42,12 +48,77 @@ namespace InventoryManagementApp.ViewModels
         public ObservableCollection<ItemModel> CommonlyUsedItems { get; } = new();
         public ObservableCollection<ItemModel> IncompleteItems { get; } = new();
 
+        public ItemModel? SelectedCommonlyUsedItem
+        {
+            get => _selectedCommonlyUsedItem;
+            set
+            {
+                if (SetProperty(ref _selectedCommonlyUsedItem, value))
+                    UpdateSelectedRecordSummary();
+            }
+        }
+
+        public ItemModel? SelectedCheckedOutItem
+        {
+            get => _selectedCheckedOutItem;
+            set
+            {
+                if (SetProperty(ref _selectedCheckedOutItem, value))
+                    UpdateSelectedRecordSummary();
+            }
+        }
+
+        public ItemModel? SelectedIncompleteItem
+        {
+            get => _selectedIncompleteItem;
+            set
+            {
+                if (SetProperty(ref _selectedIncompleteItem, value))
+                    UpdateSelectedRecordSummary();
+            }
+        }
+
+        public RentalModel? SelectedRental
+        {
+            get => _selectedRental;
+            set
+            {
+                if (SetProperty(ref _selectedRental, value))
+                    UpdateSelectedRecordSummary();
+            }
+        }
+
+        public ActivityLog? SelectedActivity
+        {
+            get => _selectedActivity;
+            set
+            {
+                if (SetProperty(ref _selectedActivity, value))
+                    UpdateSelectedRecordSummary();
+            }
+        }
+
+        public string OperationsSummary =>
+            $"{CheckedOutItems.Count} checked out | {RentedItems.Count} active rentals | {IncompleteItems.Count} with issues | {RecentActivity.Count} recent activity rows";
+
+        public string SelectedRecordSummary { get; private set; } = "Select or double-click a row to open the related workflow.";
+
         public IRelayCommand NewItemCommand { get; }
+        public IRelayCommand OpenItemsCommand { get; }
         public IRelayCommand OpenRentalsCommand { get; }
         public IRelayCommand OpenImportExportCommand { get; }
+        public IRelayCommand OpenSelectedCommonItemCommand { get; }
+        public IRelayCommand OpenSelectedCheckedOutItemCommand { get; }
+        public IRelayCommand OpenSelectedIncompleteItemCommand { get; }
+        public IRelayCommand OpenSelectedRentalCommand { get; }
+        public IRelayCommand OpenActivityDestinationCommand { get; }
         public IAsyncRelayCommand PrintCheckedOutItemsCommand { get; }
+        public IAsyncRelayCommand PrintDashboardSnapshotCommand { get; }
         public IAsyncRelayCommand<ItemModel> CheckInItemCommand { get; }
         public IAsyncRelayCommand<RentalModel> ReturnRentalCommand { get; }
+        public IAsyncRelayCommand ToggleSelectedCommonItemCommand { get; }
+        public IAsyncRelayCommand CheckInSelectedItemCommand { get; }
+        public IAsyncRelayCommand ReturnSelectedRentalCommand { get; }
 
         public DashboardViewModel(IItemService itemService,
                                   IRentalService rentalService,
@@ -77,27 +148,22 @@ namespace InventoryManagementApp.ViewModels
             _openImportExportCommand = openImportExportCommand ?? throw new ArgumentNullException(nameof(openImportExportCommand));
             _logger = logger ?? NullLogger<DashboardViewModel>.Instance;
 
-            NewItemCommand = new RelayCommand(() =>
-            {
-                try { _openManageItemsCommand.Execute(null); }
-                catch (Exception ex) { _logger.LogError(ex, "Failed to open manage {ItemLabelPlural} page", LabelProvider.Instance.ItemLabelPlural.ToLower()); }
-            });
-
-            OpenRentalsCommand = new RelayCommand(() =>
-            {
-                try { _openRentalsCommand.Execute(null); }
-                catch (Exception ex) { _logger.LogError(ex, "Failed to open rentals page"); }
-            });
-
-            OpenImportExportCommand = new RelayCommand(() =>
-            {
-                try { _openImportExportCommand.Execute(null); }
-                catch (Exception ex) { _logger.LogError(ex, "Failed to open import/export page"); }
-            });
-
+            NewItemCommand = new RelayCommand(OpenItemsWorkflow);
+            OpenItemsCommand = new RelayCommand(OpenItemsWorkflow);
+            OpenRentalsCommand = new RelayCommand(OpenRentalsWorkflow);
+            OpenImportExportCommand = new RelayCommand(OpenImportExportWorkflow);
+            OpenSelectedCommonItemCommand = new RelayCommand(OpenItemsWorkflow);
+            OpenSelectedCheckedOutItemCommand = new RelayCommand(OpenItemsWorkflow);
+            OpenSelectedIncompleteItemCommand = new RelayCommand(OpenItemsWorkflow);
+            OpenSelectedRentalCommand = new RelayCommand(OpenRentalsWorkflow);
+            OpenActivityDestinationCommand = new RelayCommand(OpenActivityDestination);
             PrintCheckedOutItemsCommand = new AsyncRelayCommand(PrintCheckedOutItemsAsync);
+            PrintDashboardSnapshotCommand = new AsyncRelayCommand(PrintDashboardSnapshotAsync);
             CheckInItemCommand = new AsyncRelayCommand<ItemModel>(CheckInItemAsync);
             ReturnRentalCommand = new AsyncRelayCommand<RentalModel>(ReturnRentalAsync);
+            ToggleSelectedCommonItemCommand = new AsyncRelayCommand(ToggleSelectedCommonItemAsync);
+            CheckInSelectedItemCommand = new AsyncRelayCommand(CheckInSelectedItemAsync);
+            ReturnSelectedRentalCommand = new AsyncRelayCommand(ReturnSelectedRentalAsync);
         }
 
         public Task LoadAsync(CancellationToken cancellationToken)
@@ -115,7 +181,6 @@ namespace InventoryManagementApp.ViewModels
             {
                 StatCards.Clear();
                 
-                // Load stats in parallel
                 var itemCount = await _itemService.CountItemsAsync(new ItemFilter(null), cancellationToken).ConfigureAwait(false);
                 var rentalCount = await _rentalService.CountActiveRentalsAsync().ConfigureAwait(false);
                 var customerCount = await _customerService.CountCustomersAsync(cancellationToken).ConfigureAwait(false);
@@ -156,7 +221,6 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (OperationCanceledException)
             {
-                // Swallow cancellations quietly.
             }
             catch (Exception ex)
             {
@@ -177,10 +241,10 @@ namespace InventoryManagementApp.ViewModels
                 }
                 foreach (var log in result.Value)
                     RecentActivity.Add(log);
+                OnPropertyChanged(nameof(OperationsSummary));
             }
             catch (OperationCanceledException)
             {
-                // Swallow cancellations quietly.
             }
             catch (Exception ex)
             {
@@ -196,6 +260,7 @@ namespace InventoryManagementApp.ViewModels
                 var items = await _itemService.GetCheckedOutItemsAsync(token).ConfigureAwait(false);
                 foreach (var item in items)
                     CheckedOutItems.Add(item);
+                OnPropertyChanged(nameof(OperationsSummary));
             }
             catch (OperationCanceledException)
             {
@@ -215,6 +280,7 @@ namespace InventoryManagementApp.ViewModels
                 var rentals = await _rentalService.GetActiveRentalsAsync().ConfigureAwait(false);
                 foreach (var rental in rentals)
                     RentedItems.Add(rental);
+                OnPropertyChanged(nameof(OperationsSummary));
             }
             catch (OperationCanceledException)
             {
@@ -232,7 +298,12 @@ namespace InventoryManagementApp.ViewModels
             {
                 var result = await _itemService.ToggleItemCheckOutStatusAsync(item.ItemID, token).ConfigureAwait(false);
                 if (result)
+                {
                     CheckedOutItems.Remove(item);
+                    item.IsCheckedOut = !item.IsCheckedOut;
+                    OnPropertyChanged(nameof(OperationsSummary));
+                    UpdateSelectedRecordSummary();
+                }
             }
             catch (OperationCanceledException)
             {
@@ -250,6 +321,8 @@ namespace InventoryManagementApp.ViewModels
             {
                 await _rentalService.ReturnItemAsync(rental.RentalID, DateTime.Today).ConfigureAwait(false);
                 RentedItems.Remove(rental);
+                OnPropertyChanged(nameof(OperationsSummary));
+                UpdateSelectedRecordSummary();
             }
             catch (OperationCanceledException)
             {
@@ -286,6 +359,7 @@ namespace InventoryManagementApp.ViewModels
                 var items = await _itemService.GetIncompleteItemsAsync(token).ConfigureAwait(false);
                 foreach (var item in items)
                     IncompleteItems.Add(item);
+                OnPropertyChanged(nameof(OperationsSummary));
             }
             catch (OperationCanceledException)
             {
@@ -294,6 +368,74 @@ namespace InventoryManagementApp.ViewModels
             {
                 _logger.LogError(ex, "Failed to load incomplete items");
             }
+        }
+
+        private async Task ToggleSelectedCommonItemAsync()
+        {
+            if (SelectedCommonlyUsedItem != null)
+                await CheckInItemAsync(SelectedCommonlyUsedItem, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private async Task CheckInSelectedItemAsync()
+        {
+            if (SelectedCheckedOutItem != null)
+                await CheckInItemAsync(SelectedCheckedOutItem, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private async Task ReturnSelectedRentalAsync()
+        {
+            if (SelectedRental != null)
+                await ReturnRentalAsync(SelectedRental, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private void OpenItemsWorkflow()
+        {
+            try { _openManageItemsCommand.Execute(null); }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to open manage {ItemLabelPlural} page", LabelProvider.Instance.ItemLabelPlural.ToLower()); }
+        }
+
+        private void OpenRentalsWorkflow()
+        {
+            try { _openRentalsCommand.Execute(null); }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to open rentals page"); }
+        }
+
+        private void OpenImportExportWorkflow()
+        {
+            try { _openImportExportCommand.Execute(null); }
+            catch (Exception ex) { _logger.LogError(ex, "Failed to open import/export page"); }
+        }
+
+        private void OpenActivityDestination()
+        {
+            var action = SelectedActivity?.Action ?? string.Empty;
+            if (action.Contains("rental", StringComparison.OrdinalIgnoreCase) || action.Contains("return", StringComparison.OrdinalIgnoreCase))
+                OpenRentalsWorkflow();
+            else
+                OpenItemsWorkflow();
+        }
+
+        private void UpdateSelectedRecordSummary()
+        {
+            SelectedRecordSummary = SelectedCommonlyUsedItem != null
+                ? DescribeItem("Common item", SelectedCommonlyUsedItem)
+                : SelectedCheckedOutItem != null
+                    ? DescribeItem("Checked out", SelectedCheckedOutItem)
+                    : SelectedIncompleteItem != null
+                        ? DescribeItem("Issue", SelectedIncompleteItem)
+                        : SelectedRental != null
+                            ? $"Rental: {SelectedRental.ItemNumber} for {SelectedRental.CustomerName} | due {SelectedRental.DueDate:yyyy-MM-dd}"
+                            : SelectedActivity != null
+                                ? $"Activity: {SelectedActivity.Timestamp:yyyy-MM-dd HH:mm} | {SelectedActivity.UserName} | {SelectedActivity.Action}"
+                                : "Select or double-click a row to open the related workflow.";
+            OnPropertyChanged(nameof(SelectedRecordSummary));
+        }
+
+        private static string DescribeItem(string prefix, ItemModel item)
+        {
+            var status = item.IsCheckedOut ? "checked out" : "available";
+            var issue = item.IsIncomplete ? " | issue noted" : string.Empty;
+            return $"{prefix}: {item.ItemNumber} - {item.Name} | {item.Location} | {status}{issue}";
         }
 
         private async Task PrintCheckedOutItemsAsync()
@@ -317,7 +459,49 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
+        private async Task PrintDashboardSnapshotAsync()
+        {
+            try
+            {
+                var currentUser = await _userService.GetCurrentUserAsync().ConfigureAwait(false);
+                var userName = currentUser?.UserName ?? "Unknown";
+                var doc = GenerateDashboardSnapshotDocument(userName);
+
+                var printDialog = new System.Windows.Controls.PrintDialog();
+                if (printDialog.ShowDialog() == true)
+                {
+                    var paginator = ((System.Windows.Documents.IDocumentPaginatorSource)doc).DocumentPaginator;
+                    printDialog.PrintDocument(paginator, $"Dashboard Snapshot - {DateTime.Now:yyyy-MM-dd HH:mm}");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to print dashboard snapshot");
+            }
+        }
+
         private System.Windows.Documents.FlowDocument GenerateCheckedOutItemsDocument(string userName)
+        {
+            var doc = CreatePrintDocument("Checked Out Items", userName);
+            AddItemTable(doc, CheckedOutItems, "Checked-out inventory", includeHolder: true);
+            AddTotal(doc, $"Total Items: {CheckedOutItems.Count}");
+            return doc;
+        }
+
+        private System.Windows.Documents.FlowDocument GenerateDashboardSnapshotDocument(string userName)
+        {
+            var doc = CreatePrintDocument("Dashboard Operations Snapshot", userName);
+
+            AddSummaryParagraph(doc, OperationsSummary);
+            AddItemTable(doc, CommonlyUsedItems.Take(10), "Commonly used items", includeUsage: true);
+            AddItemTable(doc, CheckedOutItems.Take(25), "Checked-out items", includeHolder: true);
+            AddRentalTable(doc, RentedItems.Take(25), "Active rentals");
+            AddItemTable(doc, IncompleteItems.Take(15), "Items with issues", includeNotes: true);
+
+            return doc;
+        }
+
+        private System.Windows.Documents.FlowDocument CreatePrintDocument(string title, string userName)
         {
             var doc = new System.Windows.Documents.FlowDocument
             {
@@ -326,7 +510,7 @@ namespace InventoryManagementApp.ViewModels
                 FontSize = 12
             };
 
-            doc.Blocks.Add(new System.Windows.Documents.Paragraph(new System.Windows.Documents.Bold(new System.Windows.Documents.Run("Checked Out Items")))
+            doc.Blocks.Add(new System.Windows.Documents.Paragraph(new System.Windows.Documents.Bold(new System.Windows.Documents.Run(title)))
             {
                 FontSize = 20,
                 TextAlignment = System.Windows.TextAlignment.Center,
@@ -345,54 +529,121 @@ namespace InventoryManagementApp.ViewModels
                 Margin = new System.Windows.Thickness(0, 0, 0, 20)
             });
 
-            var table = new System.Windows.Documents.Table();
-            table.CellSpacing = 0;
-            table.BorderBrush = System.Windows.Media.Brushes.Black;
-            table.BorderThickness = new System.Windows.Thickness(1);
+            return doc;
+        }
 
-            table.Columns.Add(new System.Windows.Documents.TableColumn { Width = new System.Windows.GridLength(120) });
-            table.Columns.Add(new System.Windows.Documents.TableColumn { Width = new System.Windows.GridLength(200) });
-            table.Columns.Add(new System.Windows.Documents.TableColumn { Width = new System.Windows.GridLength(100) });
-            table.Columns.Add(new System.Windows.Documents.TableColumn { Width = new System.Windows.GridLength(120) });
+        private static void AddSummaryParagraph(System.Windows.Documents.FlowDocument doc, string summary)
+        {
+            doc.Blocks.Add(new System.Windows.Documents.Paragraph(new System.Windows.Documents.Run(summary))
+            {
+                FontSize = 12,
+                FontWeight = System.Windows.FontWeights.Bold,
+                Margin = new System.Windows.Thickness(0, 0, 0, 12)
+            });
+        }
 
-            var headerGroup = new System.Windows.Documents.TableRowGroup();
-            var headerRow = new System.Windows.Documents.TableRow();
-            headerRow.Background = System.Windows.Media.Brushes.LightGray;
-            
-            AddTableCell(headerRow, "Item Number", true);
+        private void AddItemTable(System.Windows.Documents.FlowDocument doc, IEnumerable<ItemModel> items, string title, bool includeHolder = false, bool includeUsage = false, bool includeNotes = false)
+        {
+            var itemList = items.ToList();
+            AddSectionTitle(doc, title);
+
+            var table = CreateTable(4);
+            var headerRow = CreateHeaderRow();
+            AddTableCell(headerRow, "Item #", true);
             AddTableCell(headerRow, "Name", true);
-            AddTableCell(headerRow, "Location", true);
-            AddTableCell(headerRow, "Checked Out", true);
-            headerGroup.Rows.Add(headerRow);
-            table.RowGroups.Add(headerGroup);
+            AddTableCell(headerRow, includeHolder ? "Holder" : includeUsage ? "Use" : "Location", true);
+            AddTableCell(headerRow, includeNotes ? "Notes" : "Status", true);
+            table.RowGroups[0].Rows.Add(headerRow);
 
-            var dataGroup = new System.Windows.Documents.TableRowGroup();
-            foreach (var item in CheckedOutItems)
+            foreach (var item in itemList)
             {
                 var row = new System.Windows.Documents.TableRow();
                 AddTableCell(row, item.ItemNumber);
                 AddTableCell(row, item.Name);
-                AddTableCell(row, item.Location);
-                AddTableCell(row, item.CheckedOutTime?.ToString("yyyy-MM-dd HH:mm") ?? "");
-                dataGroup.Rows.Add(row);
+                AddTableCell(row, includeHolder ? item.CheckedOutBy : includeUsage ? item.CheckoutCount.ToString() : item.Location);
+                AddTableCell(row, includeNotes ? item.MissingComponentsNotes : (item.IsCheckedOut ? "Checked out" : "Available"));
+                table.RowGroups[1].Rows.Add(row);
             }
-            table.RowGroups.Add(dataGroup);
 
             doc.Blocks.Add(table);
+            AddTotal(doc, $"Rows: {itemList.Count}");
+        }
 
-            doc.Blocks.Add(new System.Windows.Documents.Paragraph(new System.Windows.Documents.Run($"\nTotal Items: {CheckedOutItems.Count}"))
+        private void AddRentalTable(System.Windows.Documents.FlowDocument doc, IEnumerable<RentalModel> rentals, string title)
+        {
+            var rentalList = rentals.ToList();
+            AddSectionTitle(doc, title);
+
+            var table = CreateTable(4);
+            var headerRow = CreateHeaderRow();
+            AddTableCell(headerRow, "Item #", true);
+            AddTableCell(headerRow, "Customer", true);
+            AddTableCell(headerRow, "Start", true);
+            AddTableCell(headerRow, "Due", true);
+            table.RowGroups[0].Rows.Add(headerRow);
+
+            foreach (var rental in rentalList)
+            {
+                var row = new System.Windows.Documents.TableRow();
+                AddTableCell(row, rental.ItemNumber);
+                AddTableCell(row, rental.CustomerName);
+                AddTableCell(row, rental.RentalDate.ToString("yyyy-MM-dd"));
+                AddTableCell(row, rental.DueDate.ToString("yyyy-MM-dd"));
+                table.RowGroups[1].Rows.Add(row);
+            }
+
+            doc.Blocks.Add(table);
+            AddTotal(doc, $"Rows: {rentalList.Count}");
+        }
+
+        private static void AddSectionTitle(System.Windows.Documents.FlowDocument doc, string title)
+        {
+            doc.Blocks.Add(new System.Windows.Documents.Paragraph(new System.Windows.Documents.Bold(new System.Windows.Documents.Run(title)))
+            {
+                FontSize = 14,
+                Margin = new System.Windows.Thickness(0, 12, 0, 6)
+            });
+        }
+
+        private static System.Windows.Documents.Table CreateTable(int columnCount)
+        {
+            var table = new System.Windows.Documents.Table
+            {
+                CellSpacing = 0,
+                BorderBrush = System.Windows.Media.Brushes.Black,
+                BorderThickness = new System.Windows.Thickness(1),
+                Margin = new System.Windows.Thickness(0, 0, 0, 6)
+            };
+
+            for (var i = 0; i < columnCount; i++)
+                table.Columns.Add(new System.Windows.Documents.TableColumn { Width = new System.Windows.GridLength(1, System.Windows.GridUnitType.Star) });
+
+            table.RowGroups.Add(new System.Windows.Documents.TableRowGroup());
+            table.RowGroups.Add(new System.Windows.Documents.TableRowGroup());
+            return table;
+        }
+
+        private static System.Windows.Documents.TableRow CreateHeaderRow()
+        {
+            return new System.Windows.Documents.TableRow
+            {
+                Background = System.Windows.Media.Brushes.LightGray
+            };
+        }
+
+        private static void AddTotal(System.Windows.Documents.FlowDocument doc, string text)
+        {
+            doc.Blocks.Add(new System.Windows.Documents.Paragraph(new System.Windows.Documents.Run(text))
             {
                 FontSize = 12,
                 FontWeight = System.Windows.FontWeights.Bold,
-                Margin = new System.Windows.Thickness(0, 20, 0, 0)
+                Margin = new System.Windows.Thickness(0, 4, 0, 8)
             });
-
-            return doc;
         }
 
-        private void AddTableCell(System.Windows.Documents.TableRow row, string text, bool isHeader = false)
+        private void AddTableCell(System.Windows.Documents.TableRow row, string? text, bool isHeader = false)
         {
-            var cell = new System.Windows.Documents.TableCell(new System.Windows.Documents.Paragraph(new System.Windows.Documents.Run(text)))
+            var cell = new System.Windows.Documents.TableCell(new System.Windows.Documents.Paragraph(new System.Windows.Documents.Run(text ?? string.Empty)))
             {
                 BorderBrush = System.Windows.Media.Brushes.Black,
                 BorderThickness = new System.Windows.Thickness(1),

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml
@@ -2,28 +2,25 @@
 <Page x:Class="InventoryManagementApp.Views.Pages.DashboardPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
-      Background="{DynamicResource BackgroundBrush}">
+      xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
+      Background="{DynamicResource BackgroundBrush}"
+      Focusable="True">
     <Grid Margin="0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0" Style="{StaticResource ToolbarCard}">
             <DockPanel LastChildFill="False">
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
-                    <Button Style="{StaticResource PrimaryButton}"
-                            Content="New Item"
-                            Command="{Binding NewItemCommand}"
-                            Margin="0,0,6,0"/>
-                    <Button Style="{StaticResource PrimaryButton}"
-                            Content="Open Rentals"
-                            Command="{Binding OpenRentalsCommand}"
-                            Margin="0,0,6,0"/>
-                    <Button Style="{StaticResource GhostButton}"
-                            Content="Import / Export"
-                            Command="{Binding OpenImportExportCommand}"/>
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
+                    <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="New Item" Command="{Binding NewItemCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Open Items" Command="{Binding OpenItemsCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Open Rentals" Command="{Binding OpenRentalsCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Print Snapshot" Command="{Binding PrintDashboardSnapshotCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Import / Export" Command="{Binding OpenImportExportCommand}"/>
                 </StackPanel>
                 <ItemsControl DockPanel.Dock="Right"
                               ItemsSource="{Binding StatCards}"
@@ -42,151 +39,220 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <Border Grid.Row="0" Grid.Column="0" Style="{StaticResource Card}" Margin="0,0,6,6">
+            <Border Grid.Row="0" Grid.Column="0" Style="{StaticResource Card}" Padding="0" Margin="0,0,6,6">
                 <DockPanel>
-                    <TextBlock Text="Commonly Used Items" Style="{StaticResource SubheadingTextBlock}" DockPanel.Dock="Top" Margin="0,0,0,6"/>
-                    <ListView ItemsSource="{Binding CommonlyUsedItems}"
-                              Style="{StaticResource CardListView}"
-                              VirtualizingPanel.IsVirtualizing="True"
-                              VirtualizingPanel.VirtualizationMode="Recycling"
-                              MaxHeight="200">
-                        <ListView.ItemTemplate>
-                            <DataTemplate>
-                                <DockPanel>
-                                    <Button DockPanel.Dock="Right"
-                                            Command="{Binding DataContext.CheckInItemCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
-                                            CommandParameter="{Binding}">
-                                        <Button.Style>
-                                            <Style TargetType="Button" BasedOn="{StaticResource GhostButton}">
-                                                <Setter Property="Content" Value="Check Out"/>
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding IsCheckedOut}" Value="True">
-                                                        <Setter Property="Content" Value="Check In"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </Button.Style>
-                                    </Button>
-                                    <StackPanel Orientation="Horizontal">
-                                        <StackPanel.ToolTip>
+                    <Border DockPanel.Dock="Top" Style="{StaticResource ToolbarCard}" Margin="0">
+                        <DockPanel LastChildFill="False">
+                            <TextBlock Text="Commonly Used Items" Style="{StaticResource SubheadingTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center"/>
+                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+                                <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedCommonItemCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Check Out / In" Command="{Binding ToggleSelectedCommonItemCommand}"/>
+                            </StackPanel>
+                        </DockPanel>
+                    </Border>
+                    <DataGrid x:Name="CommonItemsGrid"
+                              ItemsSource="{Binding CommonlyUsedItems}"
+                              SelectedItem="{Binding SelectedCommonlyUsedItem}"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True"
+                              CanUserAddRows="False"
+                              SelectionMode="Single"
+                              Style="{StaticResource VirtualizedDataGridStyle}"
+                              MouseDoubleClick="CommonItemsGrid_MouseDoubleClick"
+                              PreviewMouseRightButtonDown="DashboardGrid_PreviewMouseRightButtonDown">
+                        <DataGrid.Columns>
+                            <DataGridTemplateColumn Header="Image" Width="58">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <Border BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Width="42" Height="34" Margin="2">
                                             <Image Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"
-                                                   MaxWidth="150"
-                                                   MaxHeight="150"
-                                                   Stretch="Uniform"/>
-                                        </StackPanel.ToolTip>
-                                        <TextBlock Text="{Binding ItemNumber}" Margin="0,0,8,0" FontWeight="SemiBold"/>
-                                        <TextBlock Text="{Binding Name}" Margin="0,0,8,0"/>
-                                        <TextBlock Text="{Binding CheckoutCount}" Margin="0,0,8,0" ToolTip="Times checked out"/>
-                                        <TextBlock Text="OUT" Foreground="{DynamicResource SuccessBrush}" Margin="0,0,8,0" Visibility="{Binding IsCheckedOut, Converter={StaticResource BoolToVis}}" ToolTip="Currently checked out"/>
-                                        <TextBlock Text="ISSUE" Foreground="{DynamicResource ErrorBrush}" Margin="0,0,8,0" Visibility="{Binding IsIncomplete, Converter={StaticResource BoolToVis}}" ToolTip="Incomplete or missing components"/>
-                                    </StackPanel>
-                                </DockPanel>
-                            </DataTemplate>
-                        </ListView.ItemTemplate>
-                        <ListView.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <VirtualizingStackPanel/>
-                            </ItemsPanelTemplate>
-                        </ListView.ItemsPanel>
-                    </ListView>
+                                                   Stretch="UniformToFill">
+                                                <Image.ToolTip>
+                                                    <Image Source="{Binding ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"
+                                                           MaxWidth="180" MaxHeight="180" Stretch="Uniform"/>
+                                                </Image.ToolTip>
+                                            </Image>
+                                        </Border>
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="110"/>
+                            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*"/>
+                            <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="130"/>
+                            <DataGridTextColumn Header="Use" Binding="{Binding CheckoutCount}" Width="70"/>
+                            <DataGridTemplateColumn Header="Status" Width="130">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="Out" Foreground="{DynamicResource WarningBrush}" Margin="0,0,8,0" Visibility="{Binding IsCheckedOut, Converter={StaticResource BoolToVis}}"/>
+                                            <TextBlock Text="Issue" Foreground="{DynamicResource ErrorBrush}" Visibility="{Binding IsIncomplete, Converter={StaticResource BoolToVis}}"/>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                        </DataGrid.Columns>
+                        <DataGrid.ContextMenu>
+                            <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
+                                <MenuItem Header="Open Item Workflow" Command="{Binding PlacementTarget.DataContext.OpenSelectedCommonItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                <MenuItem Header="Check Out / In" Command="{Binding PlacementTarget.DataContext.ToggleSelectedCommonItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                <MenuItem Header="Print Dashboard Snapshot" Command="{Binding PlacementTarget.DataContext.PrintDashboardSnapshotCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                    </DataGrid>
                 </DockPanel>
             </Border>
 
-            <Border Grid.Row="0" Grid.Column="1" Style="{StaticResource Card}" Margin="0,0,0,6">
-                <StackPanel>
-                    <TextBlock Text="Recent Activity" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,6"/>
-                    <ListView ItemsSource="{Binding RecentActivity}"
-                              ItemTemplate="{StaticResource ActivityLogItemTemplate}"
-                              VirtualizingPanel.IsVirtualizing="True"
-                              VirtualizingPanel.VirtualizationMode="Recycling"
-                              Style="{StaticResource CardListView}">
-                        <ListView.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <VirtualizingStackPanel/>
-                            </ItemsPanelTemplate>
-                        </ListView.ItemsPanel>
-                    </ListView>
-                </StackPanel>
+            <Border Grid.Row="0" Grid.Column="1" Style="{StaticResource Card}" Padding="0" Margin="0,0,0,6">
+                <DockPanel>
+                    <Border DockPanel.Dock="Top" Style="{StaticResource ToolbarCard}" Margin="0">
+                        <DockPanel LastChildFill="False">
+                            <TextBlock Text="Active Rentals" Style="{StaticResource SubheadingTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center"/>
+                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+                                <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedRentalCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Return" Command="{Binding ReturnSelectedRentalCommand}"/>
+                            </StackPanel>
+                        </DockPanel>
+                    </Border>
+                    <DataGrid x:Name="RentedItemsGrid"
+                              ItemsSource="{Binding RentedItems}"
+                              SelectedItem="{Binding SelectedRental}"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True"
+                              CanUserAddRows="False"
+                              SelectionMode="Single"
+                              Style="{StaticResource VirtualizedDataGridStyle}"
+                              MouseDoubleClick="RentedItemsGrid_MouseDoubleClick"
+                              PreviewMouseRightButtonDown="DashboardGrid_PreviewMouseRightButtonDown">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="90"/>
+                            <DataGridTextColumn Header="Customer" Binding="{Binding CustomerName}" Width="*"/>
+                            <DataGridTextColumn Header="Due" Binding="{Binding DueDate, StringFormat={}{0:yyyy-MM-dd}}" Width="105"/>
+                        </DataGrid.Columns>
+                        <DataGrid.ContextMenu>
+                            <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
+                                <MenuItem Header="Open Rentals Workflow" Command="{Binding PlacementTarget.DataContext.OpenSelectedRentalCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                <MenuItem Header="Return Rental" Command="{Binding PlacementTarget.DataContext.ReturnSelectedRentalCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                <MenuItem Header="Print Dashboard Snapshot" Command="{Binding PlacementTarget.DataContext.PrintDashboardSnapshotCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                    </DataGrid>
+                </DockPanel>
             </Border>
 
-            <Border Grid.Row="1" Grid.Column="0" Style="{StaticResource Card}" Margin="0,0,6,0">
-                <StackPanel>
-                    <TextBlock Text="Checked-Out Items" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,6"/>
-                    <ListView ItemsSource="{Binding CheckedOutItems}"
-                              Style="{StaticResource CardListView}"
-                              VirtualizingPanel.IsVirtualizing="True"
-                              VirtualizingPanel.VirtualizationMode="Recycling">
-                        <ListView.ItemTemplate>
-                            <DataTemplate>
-                                <DockPanel>
-                                    <Button Content="Check In"
-                                            Style="{StaticResource GhostButton}"
-                                            DockPanel.Dock="Right"
-                                            Command="{Binding DataContext.CheckInItemCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
-                                            CommandParameter="{Binding}"/>
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock Text="{Binding ItemNumber}" Margin="0,0,8,0"/>
-                                        <TextBlock Text="{Binding CheckedOutBy}" Margin="0,0,8,0"/>
-                                        <TextBlock Text="{Binding CheckedOutTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Style="{StaticResource CaptionTextBlock}"/>
-                                    </StackPanel>
-                                </DockPanel>
-                            </DataTemplate>
-                        </ListView.ItemTemplate>
-                    </ListView>
-                </StackPanel>
+            <Border Grid.Row="1" Grid.Column="0" Style="{StaticResource Card}" Padding="0" Margin="0,0,6,0">
+                <DockPanel>
+                    <Border DockPanel.Dock="Top" Style="{StaticResource ToolbarCard}" Margin="0">
+                        <DockPanel LastChildFill="False">
+                            <TextBlock Text="Checked-Out Items" Style="{StaticResource SubheadingTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center"/>
+                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+                                <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedCheckedOutItemCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Check In" Command="{Binding CheckInSelectedItemCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Print" Command="{Binding PrintCheckedOutItemsCommand}"/>
+                            </StackPanel>
+                        </DockPanel>
+                    </Border>
+                    <DataGrid x:Name="CheckedOutItemsGrid"
+                              ItemsSource="{Binding CheckedOutItems}"
+                              SelectedItem="{Binding SelectedCheckedOutItem}"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True"
+                              CanUserAddRows="False"
+                              SelectionMode="Single"
+                              Style="{StaticResource VirtualizedDataGridStyle}"
+                              MouseDoubleClick="CheckedOutItemsGrid_MouseDoubleClick"
+                              PreviewMouseRightButtonDown="DashboardGrid_PreviewMouseRightButtonDown">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="110"/>
+                            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*"/>
+                            <DataGridTextColumn Header="Holder" Binding="{Binding CheckedOutBy}" Width="140"/>
+                            <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="130"/>
+                            <DataGridTextColumn Header="Out Since" Binding="{Binding CheckedOutTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="140"/>
+                        </DataGrid.Columns>
+                        <DataGrid.ContextMenu>
+                            <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
+                                <MenuItem Header="Open Item Workflow" Command="{Binding PlacementTarget.DataContext.OpenSelectedCheckedOutItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                <MenuItem Header="Check In" Command="{Binding PlacementTarget.DataContext.CheckInSelectedItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                <MenuItem Header="Print Checked-Out Items" Command="{Binding PlacementTarget.DataContext.PrintCheckedOutItemsCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                <MenuItem Header="Print Dashboard Snapshot" Command="{Binding PlacementTarget.DataContext.PrintDashboardSnapshotCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                    </DataGrid>
+                </DockPanel>
             </Border>
 
-            <Border Grid.Row="1" Grid.Column="1" Style="{StaticResource Card}">
-                <StackPanel>
-                    <TextBlock Text="Rented Items" Style="{StaticResource SubheadingTextBlock}" Margin="0,0,0,6"/>
-                    <ListView ItemsSource="{Binding RentedItems}"
-                              Style="{StaticResource CardListView}"
-                              VirtualizingPanel.IsVirtualizing="True"
-                              VirtualizingPanel.VirtualizationMode="Recycling">
-                        <ListView.ItemTemplate>
-                            <DataTemplate>
-                                <DockPanel>
-                                    <Button Content="Return"
-                                            Style="{StaticResource GhostButton}"
-                                            DockPanel.Dock="Right"
-                                            Command="{Binding DataContext.ReturnRentalCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
-                                            CommandParameter="{Binding}"/>
-                                    <StackPanel>
-                                        <TextBlock>
-                                            <Run Text="{Binding ItemNumber}"/>
-                                            <Run Text=" - "/>
-                                            <Run Text="{Binding CustomerName}"/>
-                                        </TextBlock>
-                                        <TextBlock Text="{Binding DueDate, StringFormat=Due {0:yyyy-MM-dd HH:mm}}" Style="{StaticResource CaptionTextBlock}"/>
-                                    </StackPanel>
+            <Border Grid.Row="1" Grid.Column="1" Style="{StaticResource Card}" Padding="0">
+                <TabControl>
+                    <TabItem Header="Recent Activity">
+                        <DockPanel>
+                            <Border DockPanel.Dock="Top" Style="{StaticResource ToolbarCard}" Margin="0">
+                                <TextBlock Text="Audit Trail" Style="{StaticResource SubheadingTextBlock}"/>
+                            </Border>
+                            <DataGrid x:Name="RecentActivityGrid"
+                                      ItemsSource="{Binding RecentActivity}"
+                                      SelectedItem="{Binding SelectedActivity}"
+                                      AutoGenerateColumns="False"
+                                      IsReadOnly="True"
+                                      CanUserAddRows="False"
+                                      SelectionMode="Single"
+                                      Style="{StaticResource VirtualizedDataGridStyle}"
+                                      MouseDoubleClick="RecentActivityGrid_MouseDoubleClick"
+                                      PreviewMouseRightButtonDown="DashboardGrid_PreviewMouseRightButtonDown">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="When" Binding="{Binding Timestamp, StringFormat={}{0:HH:mm}}" Width="70"/>
+                                    <DataGridTextColumn Header="User" Binding="{Binding UserName}" Width="95"/>
+                                    <DataGridTextColumn Header="Action" Binding="{Binding Action}" Width="*"/>
+                                </DataGrid.Columns>
+                                <DataGrid.ContextMenu>
+                                    <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
+                                        <MenuItem Header="Open Items" Command="{Binding PlacementTarget.DataContext.OpenItemsCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                        <MenuItem Header="Open Rentals" Command="{Binding PlacementTarget.DataContext.OpenRentalsCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                        <MenuItem Header="Print Dashboard Snapshot" Command="{Binding PlacementTarget.DataContext.PrintDashboardSnapshotCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                    </ContextMenu>
+                                </DataGrid.ContextMenu>
+                            </DataGrid>
+                        </DockPanel>
+                    </TabItem>
+                    <TabItem Header="Items With Issues">
+                        <DockPanel>
+                            <Border DockPanel.Dock="Top" Style="{StaticResource ToolbarCard}" Margin="0">
+                                <DockPanel LastChildFill="False">
+                                    <TextBlock Text="Needs Attention" Style="{StaticResource SubheadingTextBlock}" DockPanel.Dock="Left"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="Open" Command="{Binding OpenSelectedIncompleteItemCommand}" DockPanel.Dock="Right"/>
                                 </DockPanel>
-                            </DataTemplate>
-                        </ListView.ItemTemplate>
-                    </ListView>
-                    <Separator/>
-                    <TextBlock Text="Items With Issues" Style="{StaticResource SubheadingTextBlock}" Margin="0,2,0,6" Foreground="{DynamicResource ErrorBrush}"/>
-                    <ListView ItemsSource="{Binding IncompleteItems}"
-                              Style="{StaticResource CardListView}"
-                              VirtualizingPanel.IsVirtualizing="True"
-                              VirtualizingPanel.VirtualizationMode="Recycling"
-                              MaxHeight="180">
-                        <ListView.ItemTemplate>
-                            <DataTemplate>
-                                <StackPanel>
-                                    <TextBlock Text="{Binding ItemNumber}" FontWeight="SemiBold"/>
-                                    <TextBlock Text="{Binding Name}" Margin="0,2,0,0"/>
-                                    <TextBlock Text="{Binding MissingComponentsNotes}" Style="{StaticResource CaptionTextBlock}" Foreground="{DynamicResource ErrorBrush}"/>
-                                </StackPanel>
-                            </DataTemplate>
-                        </ListView.ItemTemplate>
-                    </ListView>
-                    <Button Style="{StaticResource GhostButton}"
-                                Content="Print My Items"
-                                Command="{Binding PrintCheckedOutItemsCommand}"
-                                Margin="0,8,0,0"
-                                ToolTip="Print list of items you have checked out"/>
-                </StackPanel>
+                            </Border>
+                            <DataGrid x:Name="IncompleteItemsGrid"
+                                      ItemsSource="{Binding IncompleteItems}"
+                                      SelectedItem="{Binding SelectedIncompleteItem}"
+                                      AutoGenerateColumns="False"
+                                      IsReadOnly="True"
+                                      CanUserAddRows="False"
+                                      SelectionMode="Single"
+                                      Style="{StaticResource VirtualizedDataGridStyle}"
+                                      MouseDoubleClick="IncompleteItemsGrid_MouseDoubleClick"
+                                      PreviewMouseRightButtonDown="DashboardGrid_PreviewMouseRightButtonDown">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="90"/>
+                                    <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
+                                    <DataGridTextColumn Header="Notes" Binding="{Binding MissingComponentsNotes}" Width="160"/>
+                                </DataGrid.Columns>
+                                <DataGrid.ContextMenu>
+                                    <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
+                                        <MenuItem Header="Open Item Workflow" Command="{Binding PlacementTarget.DataContext.OpenSelectedIncompleteItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                        <MenuItem Header="Print Dashboard Snapshot" Command="{Binding PlacementTarget.DataContext.PrintDashboardSnapshotCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                    </ContextMenu>
+                                </DataGrid.ContextMenu>
+                            </DataGrid>
+                        </DockPanel>
+                    </TabItem>
+                </TabControl>
             </Border>
         </Grid>
+
+        <Border Grid.Row="2" Style="{StaticResource ToolbarCard}" Margin="0,6,0,0">
+            <DockPanel LastChildFill="False">
+                <TextBlock Text="{Binding OperationsSummary}" Style="{StaticResource CaptionTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center"/>
+                <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" DockPanel.Dock="Right" VerticalAlignment="Center"/>
+            </DockPanel>
+        </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs
@@ -1,6 +1,10 @@
 using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
@@ -14,10 +18,13 @@ namespace InventoryManagementApp.Views.Pages
             InitializeComponent();
             Loaded += DashboardPage_Loaded;
             Unloaded += DashboardPage_Unloaded;
+            PreviewKeyDown += DashboardPage_PreviewKeyDown;
         }
 
         private async void DashboardPage_Loaded(object sender, RoutedEventArgs e)
         {
+            Focus();
+
             if (DataContext is DashboardViewModel vm)
             {
                 _loadCts = new CancellationTokenSource();
@@ -36,6 +43,148 @@ namespace InventoryManagementApp.Views.Pages
             _loadCts?.Cancel();
             _loadCts?.Dispose();
             _loadCts = null;
+        }
+
+        private void DashboardPage_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (DataContext is not DashboardViewModel vm)
+                return;
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P)
+            {
+                vm.PrintDashboardSnapshotCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.P)
+            {
+                vm.PrintCheckedOutItemsCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.I)
+            {
+                vm.OpenItemsCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.R)
+            {
+                vm.OpenRentalsCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter)
+            {
+                OpenFocusedRow(vm);
+                e.Handled = true;
+            }
+        }
+
+        private void CommonItemsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is DashboardViewModel vm)
+                vm.OpenSelectedCommonItemCommand.Execute(null);
+        }
+
+        private void CheckedOutItemsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is DashboardViewModel vm)
+                vm.OpenSelectedCheckedOutItemCommand.Execute(null);
+        }
+
+        private void RentedItemsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is DashboardViewModel vm)
+                vm.OpenSelectedRentalCommand.Execute(null);
+        }
+
+        private void RecentActivityGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is DashboardViewModel vm)
+                vm.OpenActivityDestinationCommand.Execute(null);
+        }
+
+        private void IncompleteItemsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is DashboardViewModel vm)
+                vm.OpenSelectedIncompleteItemCommand.Execute(null);
+        }
+
+        private void DashboardGrid_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            var row = FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject);
+            if (row == null)
+                return;
+
+            row.IsSelected = true;
+            row.Focus();
+
+            if (DataContext is not DashboardViewModel vm)
+                return;
+
+            switch (row.Item)
+            {
+                case ItemModel item when ReferenceEquals(sender, CommonItemsGrid):
+                    vm.SelectedCommonlyUsedItem = item;
+                    break;
+                case ItemModel item when ReferenceEquals(sender, CheckedOutItemsGrid):
+                    vm.SelectedCheckedOutItem = item;
+                    break;
+                case ItemModel item when ReferenceEquals(sender, IncompleteItemsGrid):
+                    vm.SelectedIncompleteItem = item;
+                    break;
+                case RentalModel rental:
+                    vm.SelectedRental = rental;
+                    break;
+                case ActivityLog activity:
+                    vm.SelectedActivity = activity;
+                    break;
+            }
+        }
+
+        private static void OpenFocusedRow(DashboardViewModel vm)
+        {
+            if (Keyboard.FocusedElement is DependencyObject focusedElement && FindAncestor<DataGrid>(focusedElement) is DataGrid grid)
+            {
+                switch (grid.Name)
+                {
+                    case nameof(CommonItemsGrid):
+                        vm.OpenSelectedCommonItemCommand.Execute(null);
+                        return;
+                    case nameof(CheckedOutItemsGrid):
+                        vm.OpenSelectedCheckedOutItemCommand.Execute(null);
+                        return;
+                    case nameof(RentedItemsGrid):
+                        vm.OpenSelectedRentalCommand.Execute(null);
+                        return;
+                    case nameof(IncompleteItemsGrid):
+                        vm.OpenSelectedIncompleteItemCommand.Execute(null);
+                        return;
+                    case nameof(RecentActivityGrid):
+                        vm.OpenActivityDestinationCommand.Execute(null);
+                        return;
+                }
+            }
+
+            vm.OpenItemsCommand.Execute(null);
+        }
+
+        private static T? FindAncestor<T>(DependencyObject? current) where T : DependencyObject
+        {
+            while (current != null)
+            {
+                if (current is T match)
+                    return match;
+
+                current = VisualTreeHelper.GetParent(current);
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Converts the dashboard from loose list sections into a compact classic desktop operations board with dense grids, pane toolbars, and a bottom status strip.
- Adds row double-click, Enter-key, and row-correct right-click paths from dashboard records into the related item or rental workflows.
- Adds dashboard-level keyboard shortcuts and a printable operations snapshot covering common items, checked-out items, active rentals, and issue rows.

## Why
The primary item search and rental workflows now feel like focused technician/advisor workstations, but the dashboard was still an older card/list snapshot. This makes the first screen more useful as a dense, fast operations board while keeping the app's early WinForms/WPF direction.

## Validation
- Read changed branch files back through the GitHub connector for binding, command, and handler review.
- Checked activity model fields and rental workflow conventions against existing source.
- Local .NET build/tests could not run because this scheduled environment lacks the .NET SDK and direct repository clone is blocked.