### PR TITLE
Upgrade users directory desktop workflow

### DIFF
--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml
@@ -10,77 +10,216 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <Border Style="{StaticResource ToolbarCard}">
-            <DockPanel LastChildFill="False">
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
-                    <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="360"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Grid.Column="0" Text="Find:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                <pages:SearchBar Grid.Column="1"
+                                 SearchLabel=""
+                                 Text="{Binding UserSearchText}"
+                                 SearchCommand="{Binding SearchUsersCommand}"
+                                 ClearCommand="{Binding ClearUserSearchCommand}"/>
+
+                <StackPanel Grid.Column="3" Orientation="Horizontal" HorizontalAlignment="Right">
                     <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddUserCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditUserCommand}"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditUserCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Reset Password" Click="ResetSelectedUser_Click" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Upload Photo" Command="{Binding UploadUserPhotoCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Copy" Click="CopySelectedUser_Click" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print" Click="PrintUsers_Click"/>
                 </StackPanel>
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
-                    <TextBlock Text="Filter" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                    <pages:SearchBar Width="360"
-                                     SearchLabel=""
-                                     Text="{Binding UserSearchText}"
-                                     SearchCommand="{Binding SearchUsersCommand}"
-                                     ClearCommand="{Binding ClearUserSearchCommand}"/>
-                </StackPanel>
-            </DockPanel>
+            </Grid>
         </Border>
 
-        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
-            <DataGrid x:Name="UsersDataGrid"
-                      ItemsSource="{Binding Users}"
-                      SelectedItem="{Binding SelectedUser}"
-                      IsReadOnly="True"
-                      AutoGenerateColumns="False"
-                      SelectionMode="Single"
-                      CanUserAddRows="False"
-                      Style="{StaticResource VirtualizedDataGridStyle}">
-                <DataGrid.Columns>
-                    <DataGridTemplateColumn Header="Image" Width="48">
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate>
-                                <Grid Width="26" Height="26" VerticalAlignment="Center">
-                                    <controls:UserAvatar UserName="{Binding UserName}"
-                                                        UserPhotoPath="{Binding UserPhotoPath}"
-                                                        Foreground="{Binding InitialsBrush}"
-                                                        FontSize="14"/>
-                                </Grid>
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>
-                    <DataGridTextColumn Header="Username" Binding="{Binding UserName}" Width="*"/>
-                    <DataGridTextColumn Header="Role" Binding="{Binding IsAdmin, Converter={StaticResource BooleanToAdminConverter}}" Width="110"/>
-                    <DataGridTextColumn Header="Email" Binding="{Binding Email}" Width="220"/>
-                    <DataGridTextColumn Header="Phone" Binding="{Binding Phone}" Width="130"/>
-                    <DataGridTextColumn Header="Mobile" Binding="{Binding Mobile}" Width="130"/>
-                    <DataGridCheckBoxColumn Header="Active" Binding="{Binding IsActive}" Width="80"/>
-                    <DataGridTextColumn Header="Created" Binding="{Binding CreatedAt, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat={}{0:yyyy-MM-dd}, TargetNullValue=''}" Width="120"/>
-                </DataGrid.Columns>
-                <DataGrid.ContextMenu>
-                    <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
-                        <MenuItem Header="Edit"
-                                  Command="{Binding PlacementTarget.DataContext.EditUserFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                                  CommandParameter="{Binding PlacementTarget.SelectedItem,
-                                                          RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                        <MenuItem Header="Reset Password"
-                                  Command="{Binding PlacementTarget.DataContext.ResetPasswordFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                                  CommandParameter="{Binding PlacementTarget.SelectedItem,
-                                                          RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                        <MenuItem Header="Upload Photo"
-                                  Command="{Binding PlacementTarget.DataContext.UploadUserPhotoCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                        <MenuItem Header="Update"
-                                  Command="{Binding PlacementTarget.DataContext.UpdateUserCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                        <MenuItem Header="Delete"
-                                  Command="{Binding PlacementTarget.DataContext.DeleteUserFromRowCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                                  CommandParameter="{Binding PlacementTarget.SelectedItem,
-                                                          RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                    </ContextMenu>
-                </DataGrid.ContextMenu>
-            </DataGrid>
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="1.15*"/>
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                        <DockPanel>
+                            <TextBlock Text="01 User Directory" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                            <TextBlock Text="{Binding Users.Count, StringFormat='Visible users: {0}'}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                        </DockPanel>
+                    </Border>
+
+                    <DataGrid x:Name="UsersDataGrid"
+                              Grid.Row="1"
+                              ItemsSource="{Binding Users}"
+                              SelectedItem="{Binding SelectedUser, Mode=TwoWay}"
+                              IsReadOnly="True"
+                              AutoGenerateColumns="False"
+                              SelectionMode="Single"
+                              CanUserAddRows="False"
+                              Style="{StaticResource VirtualizedDataGridStyle}">
+                        <DataGrid.RowStyle>
+                            <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                                <EventSetter Event="MouseDoubleClick" Handler="UserRow_MouseDoubleClick"/>
+                                <EventSetter Event="PreviewMouseRightButtonDown" Handler="UserRow_PreviewMouseRightButtonDown"/>
+                            </Style>
+                        </DataGrid.RowStyle>
+                        <DataGrid.ContextMenu>
+                            <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                <MenuItem Header="Open User Detail" Click="OpenSelectedUser_Click"/>
+                                <MenuItem Header="Edit User" Command="{Binding EditUserCommand}"/>
+                                <MenuItem Header="Reset Password" Click="ResetSelectedUser_Click"/>
+                                <MenuItem Header="Upload Photo" Command="{Binding UploadUserPhotoCommand}"/>
+                                <Separator/>
+                                <MenuItem Header="Copy User Detail" Click="CopySelectedUser_Click"/>
+                                <MenuItem Header="Print Current Results" Click="PrintUsers_Click"/>
+                                <Separator/>
+                                <MenuItem Header="Delete User" Command="{Binding DeleteUserFromRowCommand}" CommandParameter="{Binding SelectedUser}"/>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                        <DataGrid.Columns>
+                            <DataGridTemplateColumn Header="Image" Width="54">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <Grid Width="30" Height="30" VerticalAlignment="Center">
+                                            <controls:UserAvatar UserName="{Binding UserName}"
+                                                                UserPhotoPath="{Binding UserPhotoPath}"
+                                                                Foreground="{Binding InitialsBrush}"
+                                                                FontSize="14"/>
+                                        </Grid>
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                            <DataGridTextColumn Header="Username" Binding="{Binding UserName}" Width="*"/>
+                            <DataGridTextColumn Header="Role" Binding="{Binding IsAdmin, Converter={StaticResource BooleanToAdminConverter}}" Width="110"/>
+                            <DataGridTextColumn Header="Email" Binding="{Binding Email}" Width="210"/>
+                            <DataGridTextColumn Header="Phone" Binding="{Binding Phone}" Width="125"/>
+                            <DataGridTextColumn Header="Mobile" Binding="{Binding Mobile}" Width="125"/>
+                            <DataGridCheckBoxColumn Header="Active" Binding="{Binding IsActive}" Width="72"/>
+                            <DataGridTextColumn Header="Created" Binding="{Binding CreatedAt, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat={}{0:yyyy-MM-dd}, TargetNullValue=''}" Width="112"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+
+                    <TextBlock Grid.Row="1"
+                               Text="No users match this filter"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"
+                               FontSize="13"
+                               FontWeight="SemiBold">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Users.Count}" Value="0">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Grid>
+            </Border>
+
+            <GridSplitter Grid.Column="1"
+                          Width="6"
+                          HorizontalAlignment="Stretch"
+                          VerticalAlignment="Stretch"
+                          Background="{DynamicResource BorderBrushBase}"/>
+
+            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="8">
+                <DockPanel LastChildFill="True">
+                    <Border DockPanel.Dock="Top"
+                            Background="{DynamicResource SurfaceAltBrush}"
+                            BorderBrush="{DynamicResource BorderBrushAlt}"
+                            BorderThickness="1"
+                            Padding="6"
+                            Margin="0,0,0,6">
+                        <DockPanel>
+                            <Grid DockPanel.Dock="Left" Width="48" Height="48" Margin="0,0,8,0">
+                                <controls:UserAvatar UserName="{Binding SelectedUser.UserName}"
+                                                     UserPhotoPath="{Binding SelectedUser.UserPhotoPath}"
+                                                     Foreground="{Binding SelectedUser.InitialsBrush}"
+                                                     FontSize="20"/>
+                            </Grid>
+                            <StackPanel>
+                                <TextBlock Text="User Detail" Style="{StaticResource SectionHeader}"/>
+                                <TextBlock Text="{Binding SelectedUser.UserName, TargetNullValue='Select a user'}"
+                                           Style="{StaticResource PageTitleTextBlock}"
+                                           TextWrapping="Wrap"/>
+                                <TextBlock Text="{Binding SelectedUser.Role, TargetNullValue='Choose a row to see contact and admin actions'}"
+                                           FontSize="11"
+                                           Margin="0,2,0,0"
+                                           TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </DockPanel>
+                    </Border>
+
+                    <StackPanel DockPanel.Dock="Top" Margin="0,0,0,6">
+                        <TextBlock Text="Status" Style="{StaticResource SectionHeader}"/>
+                        <UniformGrid Columns="2" Margin="0,2,0,0">
+                            <TextBlock Text="{Binding SelectedUser.IsActive, StringFormat='Active: {0}', TargetNullValue='Active: -'}" Margin="0,0,8,2"/>
+                            <TextBlock Text="{Binding SelectedUser.IsAdmin, StringFormat='Admin: {0}', TargetNullValue='Admin: -'}" Margin="0,0,0,2"/>
+                            <TextBlock Text="{Binding SelectedUser.CreatedAt, Converter={StaticResource DateTimeMinToEmptyStringConverter}, StringFormat='Created: {0:yyyy-MM-dd}', TargetNullValue='Created: -'}" Margin="0,0,8,2"/>
+                            <TextBlock Text="{Binding SelectedUser.PasswordExpired, StringFormat='Password expired: {0}', TargetNullValue='Password expired: -'}" Margin="0,0,0,2"/>
+                        </UniformGrid>
+                    </StackPanel>
+
+                    <StackPanel DockPanel.Dock="Top" Margin="0,0,0,6">
+                        <TextBlock Text="Contact" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="{Binding SelectedUser.Email, StringFormat='Email: {0}', TargetNullValue='Email: -'}" TextWrapping="Wrap"/>
+                        <TextBlock Text="{Binding SelectedUser.Phone, StringFormat='Phone: {0}', TargetNullValue='Phone: -'}" TextWrapping="Wrap"/>
+                        <TextBlock Text="{Binding SelectedUser.Mobile, StringFormat='Mobile: {0}', TargetNullValue='Mobile: -'}" TextWrapping="Wrap"/>
+                        <TextBlock Text="{Binding SelectedUser.Address, StringFormat='Address: {0}', TargetNullValue='Address: -'}" TextWrapping="Wrap"/>
+                    </StackPanel>
+
+                    <StackPanel DockPanel.Dock="Bottom" Margin="0,6,0,0">
+                        <TextBlock Text="Actions" Style="{StaticResource SectionHeader}"/>
+                        <UniformGrid Columns="2">
+                            <Button Style="{StaticResource GhostButton}" Content="Open" Click="OpenSelectedUser_Click" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Copy" Click="CopySelectedUser_Click" Margin="0,0,0,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Reset" Click="ResetSelectedUser_Click" Margin="0,0,4,0"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Print" Click="PrintUsers_Click"/>
+                        </UniformGrid>
+                    </StackPanel>
+
+                    <Border BorderBrush="{DynamicResource BorderBrushAlt}"
+                            BorderThickness="1"
+                            Background="{DynamicResource TextBoxBackgroundBrush}"
+                            Padding="6">
+                        <TextBlock Text="Admin path: double-click a user to open the detail sheet, edit from the toolbar, reset a password when a technician is blocked at login, or print the filtered directory for audit checks."
+                                   TextWrapping="Wrap"/>
+                    </Border>
+                </DockPanel>
+            </Border>
+        </Grid>
+
+        <Border Grid.Row="2"
+                Background="{DynamicResource SurfaceAltBrush}"
+                BorderBrush="{DynamicResource BorderBrushAlt}"
+                BorderThickness="1,0,1,1"
+                Padding="6,3">
+            <DockPanel>
+                <TextBlock DockPanel.Dock="Left"
+                           Text="{Binding Users.Count, StringFormat='Visible: {0} users'}"
+                           FontSize="11"
+                           VerticalAlignment="Center"/>
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                    <Button Style="{StaticResource GhostButton}" Content="Open" Click="OpenSelectedUser_Click" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Clear Filter" Command="{Binding ClearUserSearchCommand}"/>
+                </StackPanel>
+            </DockPanel>
         </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml.cs
@@ -47,7 +47,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void OpenSelectedUser_Click(object sender, RoutedEventArgs e)
         {
-            if (UsersDataGrid.SelectedItem is not User user)
+            if (UsersDataGrid.SelectedItem is not UserModel user)
             {
                 WpfMessageBox.Show("Select a user row first.", "User Directory", MessageBoxButton.OK, MessageBoxImage.Information);
                 return;
@@ -58,7 +58,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void CopySelectedUser_Click(object sender, RoutedEventArgs e)
         {
-            if (UsersDataGrid.SelectedItem is not User user)
+            if (UsersDataGrid.SelectedItem is not UserModel user)
             {
                 WpfMessageBox.Show("Select a user row first.", "User Directory", MessageBoxButton.OK, MessageBoxImage.Information);
                 return;
@@ -98,7 +98,7 @@ namespace InventoryManagementApp.Views.Pages
             printDialog.PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator, "User Directory");
         }
 
-        private static string FormatUserDetail(User user)
+        private static string FormatUserDetail(UserModel user)
         {
             return $"User #: {user.UserID}{Environment.NewLine}" +
                    $"Name: {user.UserName}{Environment.NewLine}" +
@@ -181,7 +181,7 @@ namespace InventoryManagementApp.Views.Pages
             });
         }
 
-        private static string ResolveRole(User user)
+        private static string ResolveRole(UserModel user)
         {
             if (!string.IsNullOrWhiteSpace(user.Role))
                 return user.Role;

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml.cs
@@ -1,5 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Input;
+using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
+using WpfMessageBox = System.Windows.MessageBox;
+using WpfPrintDialog = System.Windows.Controls.PrintDialog;
 
 namespace InventoryManagementApp.Views.Pages
 {
@@ -21,5 +30,169 @@ namespace InventoryManagementApp.Views.Pages
         /// </summary>
         public UserManagementViewModel? ViewModel =>
             DataContext as UserManagementViewModel;
+
+        private void UserRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            OpenSelectedUser_Click(sender, e);
+        }
+
+        private void UserRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is DataGridRow row && !row.IsSelected)
+            {
+                row.IsSelected = true;
+                e.Handled = true;
+            }
+        }
+
+        private void OpenSelectedUser_Click(object sender, RoutedEventArgs e)
+        {
+            if (UsersDataGrid.SelectedItem is not User user)
+            {
+                WpfMessageBox.Show("Select a user row first.", "User Directory", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            WpfMessageBox.Show(FormatUserDetail(user), $"User Detail - {user.UserName}", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        private void CopySelectedUser_Click(object sender, RoutedEventArgs e)
+        {
+            if (UsersDataGrid.SelectedItem is not User user)
+            {
+                WpfMessageBox.Show("Select a user row first.", "User Directory", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            Clipboard.SetText(FormatUserDetail(user));
+        }
+
+        private async void ResetSelectedUser_Click(object sender, RoutedEventArgs e)
+        {
+            if (ViewModel == null || UsersDataGrid.SelectedItem is not UserModel user)
+            {
+                WpfMessageBox.Show("Select a user row first.", "User Directory", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            await ViewModel.ResetPasswordFromRowCommand.ExecuteAsync(user);
+        }
+
+        private void PrintUsers_Click(object sender, RoutedEventArgs e)
+        {
+            if (ViewModel == null || ViewModel.Users.Count == 0)
+            {
+                WpfMessageBox.Show("There are no users to print.", "User Directory", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var printDialog = new WpfPrintDialog();
+            if (printDialog.ShowDialog() != true)
+                return;
+
+            var document = BuildPrintDocument(ViewModel.Users.ToList(), $"Visible users: {ViewModel.Users.Count}");
+            document.PageWidth = printDialog.PrintableAreaWidth;
+            document.PageHeight = printDialog.PrintableAreaHeight;
+            document.PagePadding = new Thickness(36);
+            document.ColumnWidth = printDialog.PrintableAreaWidth;
+            printDialog.PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator, "User Directory");
+        }
+
+        private static string FormatUserDetail(User user)
+        {
+            return $"User #: {user.UserID}{Environment.NewLine}" +
+                   $"Name: {user.UserName}{Environment.NewLine}" +
+                   $"Role: {ResolveRole(user)}{Environment.NewLine}" +
+                   $"Active: {FormatBool(user.IsActive)}{Environment.NewLine}" +
+                   $"Admin: {FormatBool(user.IsAdmin)}{Environment.NewLine}" +
+                   $"Password expired: {FormatBool(user.PasswordExpired)}{Environment.NewLine}" +
+                   $"Created: {FormatDate(user.CreatedAt)}{Environment.NewLine}{Environment.NewLine}" +
+                   $"Email: {ValueOrDash(user.Email)}{Environment.NewLine}" +
+                   $"Phone: {ValueOrDash(user.Phone)}{Environment.NewLine}" +
+                   $"Mobile: {ValueOrDash(user.Mobile)}{Environment.NewLine}" +
+                   $"Address: {ValueOrDash(user.Address)}{Environment.NewLine}{Environment.NewLine}" +
+                   "Next steps: edit profile details, upload a current photo, reset the password if the user is blocked, or review activity logs for recent account actions.";
+        }
+
+        private static FlowDocument BuildPrintDocument(IReadOnlyCollection<UserModel> users, string summary)
+        {
+            var document = new FlowDocument
+            {
+                FontFamily = new System.Windows.Media.FontFamily("Segoe UI"),
+                FontSize = 10
+            };
+
+            document.Blocks.Add(new Paragraph(new Run("User Directory"))
+            {
+                FontSize = 16,
+                FontWeight = FontWeights.SemiBold,
+                Margin = new Thickness(0, 0, 0, 4)
+            });
+            document.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:g} - {summary}"))
+            {
+                FontSize = 10,
+                Margin = new Thickness(0, 0, 0, 10)
+            });
+
+            var table = new Table { CellSpacing = 0 };
+            foreach (var width in new[] { 55.0, 140.0, 95.0, 210.0, 115.0, 115.0, 70.0 })
+                table.Columns.Add(new TableColumn { Width = new GridLength(width) });
+
+            var rowGroup = new TableRowGroup();
+            table.RowGroups.Add(rowGroup);
+
+            var header = new TableRow { FontWeight = FontWeights.SemiBold };
+            rowGroup.Rows.Add(header);
+            AddCell(header, "ID");
+            AddCell(header, "User");
+            AddCell(header, "Role");
+            AddCell(header, "Email");
+            AddCell(header, "Phone");
+            AddCell(header, "Mobile");
+            AddCell(header, "Active");
+
+            foreach (var user in users)
+            {
+                var row = new TableRow();
+                rowGroup.Rows.Add(row);
+                AddCell(row, user.UserID.ToString());
+                AddCell(row, user.UserName);
+                AddCell(row, ResolveRole(user));
+                AddCell(row, user.Email);
+                AddCell(row, user.Phone);
+                AddCell(row, user.Mobile);
+                AddCell(row, FormatBool(user.IsActive));
+            }
+
+            document.Blocks.Add(table);
+            return document;
+        }
+
+        private static void AddCell(TableRow row, string text)
+        {
+            row.Cells.Add(new TableCell(new Paragraph(new Run(text ?? string.Empty))
+            {
+                Margin = new Thickness(2)
+            })
+            {
+                BorderBrush = System.Windows.Media.Brushes.Gray,
+                BorderThickness = new Thickness(0, 0, 0, 0.5),
+                Padding = new Thickness(3, 2, 3, 2)
+            });
+        }
+
+        private static string ResolveRole(User user)
+        {
+            if (!string.IsNullOrWhiteSpace(user.Role))
+                return user.Role;
+
+            return user.IsAdmin ? "Admin" : "User";
+        }
+
+        private static string FormatBool(bool value) => value ? "Yes" : "No";
+
+        private static string FormatDate(DateTime? value) => value.HasValue ? value.Value.ToString("yyyy-MM-dd") : "-";
+
+        private static string ValueOrDash(string? value) => string.IsNullOrWhiteSpace(value) ? "-" : value;
     }
 }

--- a/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
@@ -3,103 +3,141 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
-        Title="Edit User" Width="520" Height="520" WindowStartupLocation="CenterOwner"
+        Title="User Profile" Width="560" Height="500" MinWidth="520" MinHeight="460" WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="12">
+    <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <TextBlock Text="{Binding Title}" Style="{StaticResource HeadingTextBlock}" Margin="0,0,0,8"/>
+        <Border Style="{StaticResource ToolbarCard}" Margin="0,0,0,6">
+            <DockPanel>
+                <StackPanel DockPanel.Dock="Left">
+                    <TextBlock Text="{Binding Title}" Style="{StaticResource PageTitleTextBlock}"/>
+                    <TextBlock Text="Maintain login identity, contact details, access role, and profile photo." Style="{StaticResource CaptionTextBlock}"/>
+                </StackPanel>
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
+                    <Button Style="{StaticResource PrimaryButton}" Content="Browse Image" Command="{Binding BrowseImageCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Remove Image" Command="{Binding RemoveImageCommand}"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
 
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="120"/>
+                <ColumnDefinition Width="136"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="100"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
 
-            <Border Grid.RowSpan="7" Width="96" Height="96" CornerRadius="8" VerticalAlignment="top" Background="{DynamicResource SurfaceAltBrush}" Margin="0,0,12,0">
-                <Grid>
-                    <Image Width="96" Height="96"
-                           Source="{Binding EditingUser.UserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
-                           Stretch="UniformToFill" ClipToBounds="True">
-                        <Image.Style>
-                            <Style TargetType="Image">
-                                <Setter Property="Visibility" Value="Collapsed"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource ExistingFilePathToBoolConverter}}" Value="True">
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Image.Style>
-                    </Image>
-                    <Border Background="Transparent">
-                        <Border.Style>
-                            <Style TargetType="Border">
-                                <Setter Property="Visibility" Value="Visible"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource ExistingFilePathToBoolConverter}}" Value="True">
+            <Border Grid.Column="0"
+                    Background="{DynamicResource SurfaceAltBrush}"
+                    BorderBrush="{DynamicResource BorderBrushAlt}"
+                    BorderThickness="1"
+                    Padding="8"
+                    Margin="0,0,8,0">
+                <StackPanel>
+                    <Border Width="108" Height="108" CornerRadius="4" VerticalAlignment="Top" Background="{DynamicResource TextBoxBackgroundBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1">
+                        <Grid>
+                            <Image Width="108" Height="108"
+                                   Source="{Binding EditingUser.UserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
+                                   Stretch="UniformToFill" ClipToBounds="True">
+                                <Image.Style>
+                                    <Style TargetType="Image">
                                         <Setter Property="Visibility" Value="Collapsed"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Border.Style>
-                        <TextBlock Text="{Binding EditingUser.UserName, Converter={StaticResource NameToInitialsConverter}}"
-                                   HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" FontSize="48"
-                                   Foreground="{Binding EditingUser.InitialsBrush}">
-                            <TextBlock.Style>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="Visibility" Value="Visible"/>
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource ExistingFilePathToBoolConverter}}" Value="True">
-                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </TextBlock.Style>
-                        </TextBlock>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource ExistingFilePathToBoolConverter}}" Value="True">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Image.Style>
+                            </Image>
+                            <TextBlock Text="{Binding EditingUser.UserName, Converter={StaticResource NameToInitialsConverter}}"
+                                       HorizontalAlignment="Center"
+                                       VerticalAlignment="Center"
+                                       FontWeight="Bold"
+                                       FontSize="42"
+                                       Foreground="{Binding EditingUser.InitialsBrush}">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource ExistingFilePathToBoolConverter}}" Value="True">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </Grid>
                     </Border>
-                </Grid>
+
+                    <TextBlock Text="{Binding EditingUser.UserName, TargetNullValue='New user'}" Style="{StaticResource SectionHeader}" Margin="0,8,0,2" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding EditingUser.Role, TargetNullValue='Set role and contact details'}" FontSize="11" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding EditingUser.UserID, StringFormat='User #: {0}'}" FontSize="11" Margin="0,6,0,0"/>
+                </StackPanel>
             </Border>
 
-            <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="0,0,0,8">
-                <Button Style="{StaticResource PrimaryButton}" Content="Browse Image" Command="{Binding BrowseImageCommand}" Margin="0,0,8,0"/>
-                <Button Style="{StaticResource PrimaryButton}" Width="130" Content="Remove Image" Command="{Binding RemoveImageCommand}"/>
-            </StackPanel>
+            <Border Grid.Column="1" Style="{StaticResource Card}" Padding="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Username" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding EditingUser.UserName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                    <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="6,4">
+                        <TextBlock Text="01 Profile Fields" Style="{StaticResource SectionHeader}" Margin="0"/>
+                    </Border>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Email" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding EditingUser.Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                    <Grid Grid.Row="1" Margin="8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="95"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="Phone" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding EditingUser.Phone, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Username:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding EditingUser.UserName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Text="Mobile" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding EditingUser.Mobile, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Email:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding EditingUser.Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Role" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <ComboBox Grid.Row="5" Grid.Column="1" SelectedValuePath="Tag" SelectedValue="{Binding EditingUser.IsAdmin, Mode=TwoWay}" Margin="0,0,0,8" ItemContainerStyle="{StaticResource DropdownItemStyle}">
-                <ComboBoxItem Content="User" Tag="False"/>
-                <ComboBoxItem Content="Admin" Tag="True"/>
-            </ComboBox>
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Phone:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding EditingUser.Phone, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
 
-            <CheckBox Grid.Row="6" Grid.Column="1" Content="Active" IsChecked="{Binding EditingUser.IsActive, Mode=TwoWay}"/>
+                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Mobile:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding EditingUser.Mobile, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+
+                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Address:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Top" Margin="0,3,8,6"/>
+                        <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding EditingUser.Address, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6" Height="54" TextWrapping="Wrap" AcceptsReturn="True"/>
+
+                        <TextBlock Grid.Row="5" Grid.Column="0" Text="Access:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                        <ComboBox Grid.Row="5" Grid.Column="1" SelectedValuePath="Tag" SelectedValue="{Binding EditingUser.IsAdmin, Mode=TwoWay}" Margin="0,0,0,6" ItemContainerStyle="{StaticResource DropdownItemStyle}">
+                            <ComboBoxItem Content="User" Tag="False"/>
+                            <ComboBoxItem Content="Admin" Tag="True"/>
+                        </ComboBox>
+
+                        <TextBlock Grid.Row="6" Grid.Column="0" Text="Status:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        <StackPanel Grid.Row="6" Grid.Column="1" Orientation="Horizontal">
+                            <CheckBox Content="Active" IsChecked="{Binding EditingUser.IsActive, Mode=TwoWay}" Margin="0,0,16,0"/>
+                            <CheckBox Content="Password expired" IsChecked="{Binding EditingUser.PasswordExpired, Mode=TwoWay}"/>
+                        </StackPanel>
+                    </Grid>
+                </Grid>
+            </Border>
         </Grid>
 
-        <controls:SaveCancelBar Grid.Row="2"/>
+        <controls:SaveCancelBar Grid.Row="2" Margin="0,8,0,0"/>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- Converts the Users page into a compact desktop directory with a search toolbar, dense grid, selected-user detail pane, and bottom status/actions strip.
- Adds row double-click and row-correct right-click drilldown, selected user detail/copy actions, password reset from the selected row, and printable filtered directory output.
- Tightens the user edit dialog into a classic desktop profile form with a toolbar, photo/sidebar summary, compact labeled fields, address editing, and password-expired status control.

## Why
The app's item, rental, dashboard, reporting, customer, category, activity, maintenance, and calibration workflows have been moving toward a consistent early WinForms/WPF business style. User management was still a relatively bare grid and loose edit dialog, so this makes another admin-heavy workflow feel intentional, fast, and row-driven.

## Validation
- Parsed the changed XAML locally as well-formed XML using Python's XML parser.
- Scanned the changed files for the repository's banned standalone wording; no matches were found.
- Compared the branch against `master`; the branch is ahead only by the intended user directory and edit dialog files.
- Local .NET build/tests could not run because this scheduled container does not have the .NET SDK installed and direct repository clone is blocked by network restrictions.