### PR TITLE
[codex] Add request queue actions to rentals workflow

### DIFF
--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -34,6 +34,40 @@ namespace InventoryManagementApp.ViewModels
         public string SearchSummary => $"{Rentals.Count} result{(Rentals.Count == 1 ? string.Empty : "s")} shown";
         public string CheckedOutSummary => $"{ActiveRentals.Count} item{(ActiveRentals.Count == 1 ? string.Empty : "s")} currently checked out";
         public string RequestSummary => $"{PendingRequests.Count} open request{(PendingRequests.Count == 1 ? string.Empty : "s")}";
+        public string SelectedRequestSummary => SelectedRequest == null
+            ? "Select a request to see customer, holder, and next action."
+            : $"{ValueOrNotRecorded(SelectedRequest.ItemNumber)} | {ValueOrNotRecorded(SelectedRequest.CustomerName)} | {SelectedRequest.StatusDisplay}";
+        public string SelectedRequestDateLine => SelectedRequest == null
+            ? "No request selected."
+            : $"Requested {FormatDate(SelectedRequest.ReservationDate)} | Needed {SelectedRequest.StartDate:yyyy-MM-dd} to {SelectedRequest.EndDate:yyyy-MM-dd}";
+        public string SelectedRequestHolderLine
+        {
+            get
+            {
+                if (SelectedRequest == null)
+                    return "Select a request to inspect current availability.";
+
+                var activeRental = FindActiveRentalForRequest(SelectedRequest);
+                return activeRental == null
+                    ? "No active checkout found for this item. It may be ready to pick or rent."
+                    : $"Currently out to {ValueOrNotRecorded(activeRental.CustomerName)}; due back {activeRental.DueDate:yyyy-MM-dd HH:mm}.";
+            }
+        }
+        public string SelectedRequestNextAction
+        {
+            get
+            {
+                if (SelectedRequest == null)
+                    return "Next action: choose a request from the queue.";
+                if (_reservationService == null || SelectedRequest.ReservationID <= 0)
+                    return "Next action: open details or print this request; durable status changes are not available in this session.";
+                if (string.Equals(SelectedRequest.Status, "Pending", StringComparison.OrdinalIgnoreCase))
+                    return "Next action: confirm the hold, contact the current holder, or cancel it if the customer no longer needs it.";
+                if (string.Equals(SelectedRequest.Status, "Confirmed", StringComparison.OrdinalIgnoreCase))
+                    return "Next action: watch for check-in, pick the item, then complete the rental from the normal rental workflow.";
+                return "Next action: review the request details and history before changing it.";
+            }
+        }
 
         private string _searchText = string.Empty;
         public string SearchText
@@ -111,6 +145,13 @@ namespace InventoryManagementApp.ViewModels
                 if (SetProperty(ref _selectedRequest, value))
                 {
                     OpenRequestDetailsCommand.NotifyCanExecuteChanged();
+                    ConfirmRequestCommand.NotifyCanExecuteChanged();
+                    CancelRequestCommand.NotifyCanExecuteChanged();
+                    PrintRequestCommand.NotifyCanExecuteChanged();
+                    OnPropertyChanged(nameof(SelectedRequestSummary));
+                    OnPropertyChanged(nameof(SelectedRequestDateLine));
+                    OnPropertyChanged(nameof(SelectedRequestHolderLine));
+                    OnPropertyChanged(nameof(SelectedRequestNextAction));
                 }
             }
         }
@@ -130,6 +171,9 @@ namespace InventoryManagementApp.ViewModels
         public IRelayCommand OpenRentalDetailsCommand { get; }
         public IAsyncRelayCommand PlaceRequestCommand { get; }
         public IRelayCommand OpenRequestDetailsCommand { get; }
+        public IAsyncRelayCommand ConfirmRequestCommand { get; }
+        public IAsyncRelayCommand CancelRequestCommand { get; }
+        public IRelayCommand PrintRequestCommand { get; }
         public IRelayCommand PrintRentalCommand { get; }
         public IRelayCommand PrintSearchResultsCommand { get; }
         public IRelayCommand PrintCheckedOutCommand { get; }
@@ -165,6 +209,9 @@ namespace InventoryManagementApp.ViewModels
             OpenRentalDetailsCommand = new RelayCommand(OpenRentalDetails, () => SelectedRental != null);
             PlaceRequestCommand = new AsyncRelayCommand(PlaceRequestAsync, CanPlaceRequestForSelectedRental);
             OpenRequestDetailsCommand = new RelayCommand(OpenRequestDetails, () => SelectedRequest != null);
+            ConfirmRequestCommand = new AsyncRelayCommand(ConfirmRequestAsync, CanUpdateSelectedRequest);
+            CancelRequestCommand = new AsyncRelayCommand(CancelRequestAsync, CanUpdateSelectedRequest);
+            PrintRequestCommand = new RelayCommand(PrintRequest, () => SelectedRequest != null);
             PrintRentalCommand = new RelayCommand(PrintRental, () => SelectedRental != null);
             PrintSearchResultsCommand = new RelayCommand(PrintSearchResults);
             PrintCheckedOutCommand = new RelayCommand(PrintCheckedOut);
@@ -206,9 +253,11 @@ namespace InventoryManagementApp.ViewModels
 
             try
             {
+                var selectedRequestId = SelectedRequest?.ReservationID;
                 var requests = await _reservationService.GetActiveReservationsAsync();
                 PendingRequests.ReplaceRange(requests);
-                SelectedRequest = PendingRequests.FirstOrDefault(r => SelectedRequest?.ReservationID == r.ReservationID);
+                SelectedRequest = PendingRequests.FirstOrDefault(r => selectedRequestId.HasValue && r.ReservationID == selectedRequestId.Value)
+                    ?? PendingRequests.FirstOrDefault();
             }
             catch (Exception ex)
             {
@@ -474,12 +523,111 @@ namespace InventoryManagementApp.ViewModels
             details.AppendLine($"Requested: {FormatDate(request.ReservationDate)}");
             details.AppendLine($"Needed from: {FormatDate(request.StartDate)}");
             details.AppendLine($"Needed until: {FormatDate(request.EndDate)}");
+            details.AppendLine($"Current holder: {SelectedRequestHolderLine}");
             details.AppendLine();
             details.AppendLine($"Notes: {ValueOrNotRecorded(request.Notes)}");
             details.AppendLine();
-            details.AppendLine("Next steps: contact the current holder, monitor check-in, then fulfill or update this reservation when availability opens.");
+            details.AppendLine(SelectedRequestNextAction);
 
             _dialogService.ShowInfo(details.ToString(), $"Request Details - {request.ItemNumber}");
+        }
+
+        async Task ConfirmRequestAsync()
+        {
+            if (SelectedRequest == null || _reservationService == null)
+                return;
+
+            var requestId = SelectedRequest.ReservationID;
+            try
+            {
+                IsLoading = true;
+                var updated = await _reservationService.ConfirmReservationAsync(requestId);
+                if (!updated)
+                {
+                    await _dialogService.ShowInfoAsync("The selected request could not be confirmed. It may have been removed or changed by another user.", "Confirm Request");
+                    return;
+                }
+
+                await LoadPendingRequestsAsync();
+                await _dialogService.ShowInfoAsync("Request confirmed and remains in the open request queue.", "Confirm Request");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to confirm request {ReservationID}", requestId);
+                await _dialogService.ShowInfoAsync($"Failed to confirm request: {ex.Message}", "Error");
+            }
+            finally
+            {
+                IsLoading = false;
+            }
+        }
+
+        async Task CancelRequestAsync()
+        {
+            if (SelectedRequest == null || _reservationService == null)
+                return;
+
+            var request = SelectedRequest;
+            var confirmed = await _dialogService.ShowConfirmAsync("Cancel Request", $"Cancel request #{request.ReservationID} for item {request.ItemNumber}?");
+            if (!confirmed)
+                return;
+
+            try
+            {
+                IsLoading = true;
+                var updated = await _reservationService.CancelReservationAsync(request.ReservationID);
+                if (!updated)
+                {
+                    await _dialogService.ShowInfoAsync("The selected request could not be cancelled. It may have been removed or changed by another user.", "Cancel Request");
+                    return;
+                }
+
+                await LoadPendingRequestsAsync();
+                await _dialogService.ShowInfoAsync("Request cancelled and removed from the open request queue.", "Cancel Request");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to cancel request {ReservationID}", request.ReservationID);
+                await _dialogService.ShowInfoAsync($"Failed to cancel request: {ex.Message}", "Error");
+            }
+            finally
+            {
+                IsLoading = false;
+            }
+        }
+
+        void PrintRequest()
+        {
+            if (SelectedRequest == null)
+                return;
+
+            try
+            {
+                var request = SelectedRequest;
+                var doc = CreateRentalDocument("Request Information");
+                var table = CreateKeyValueTable();
+                var group = table.RowGroups[0];
+                AddKeyValueRow(group, "Request #:", request.ReservationID > 0 ? request.ReservationID.ToString() : "Not saved");
+                AddKeyValueRow(group, "Item #:", request.ItemNumber);
+                AddKeyValueRow(group, "Item:", request.ItemName);
+                AddKeyValueRow(group, "Customer:", request.CustomerName);
+                AddKeyValueRow(group, "Status:", request.StatusDisplay);
+                AddKeyValueRow(group, "Quantity:", request.Quantity.ToString());
+                AddKeyValueRow(group, "Requested:", FormatDate(request.ReservationDate));
+                AddKeyValueRow(group, "Needed From:", request.StartDate.ToString("yyyy-MM-dd"));
+                AddKeyValueRow(group, "Needed Until:", request.EndDate.ToString("yyyy-MM-dd"));
+                AddKeyValueRow(group, "Current Holder:", SelectedRequestHolderLine);
+                AddKeyValueRow(group, "Next Action:", SelectedRequestNextAction);
+                AddKeyValueRow(group, "Notes:", request.Notes);
+                doc.Blocks.Add(table);
+
+                _dialogService.ShowPrintPreview(doc, $"Request {request.ReservationID}", string.Empty);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to print request {ReservationID}", SelectedRequest?.ReservationID);
+                _dialogService.ShowInfo($"Failed to print request: {ex.Message}", "Error");
+            }
         }
 
         void PrintRental()
@@ -737,11 +885,26 @@ namespace InventoryManagementApp.ViewModels
         {
             ActiveRentals.ReplaceRange(_allRentals.Where(IsRentalActive));
             OnPropertyChanged(nameof(CheckedOutSummary));
+            OnPropertyChanged(nameof(SelectedRequestHolderLine));
+            OnPropertyChanged(nameof(SelectedRequestNextAction));
         }
 
         bool CanReturnSelectedRental() => SelectedRental != null && IsRentalActive(SelectedRental);
 
         bool CanPlaceRequestForSelectedRental() => SelectedRental != null && IsRentalActive(SelectedRental);
+
+        bool CanUpdateSelectedRequest() => SelectedRequest != null
+            && SelectedRequest.ReservationID > 0
+            && SelectedRequest.IsActive
+            && _reservationService != null;
+
+        RentalModel? FindActiveRentalForRequest(Reservation? request)
+        {
+            if (request == null)
+                return null;
+
+            return ActiveRentals.FirstOrDefault(r => r.ItemID == request.ItemID);
+        }
 
         static bool IsRentalActive(RentalModel rental)
         {

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
@@ -177,47 +177,79 @@
                         <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
                             <TextBlock Text="03 Open Requests" Style="{StaticResource SectionHeader}" Margin="0"/>
                             <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenRequestDetailsCommand}" Margin="8,0,4,0"/>
-                            <Button Style="{StaticResource PrimaryButton}" Content="Print" Command="{Binding PrintRequestsCommand}"/>
+                            <Button Style="{StaticResource PrimaryButton}" Content="Confirm" Command="{Binding ConfirmRequestCommand}" Margin="0,0,4,0"/>
+                            <Button Style="{StaticResource PrimaryButton}" Content="Cancel" Command="{Binding CancelRequestCommand}" Margin="0,0,4,0"/>
+                            <Button Style="{StaticResource PrimaryButton}" Content="Print Request" Command="{Binding PrintRequestCommand}" Margin="0,0,4,0"/>
+                            <Button Style="{StaticResource PrimaryButton}" Content="Print Queue" Command="{Binding PrintRequestsCommand}"/>
                         </StackPanel>
                         <TextBlock Text="{Binding RequestSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
                     </DockPanel>
                 </Border>
-                <DataGrid Grid.Row="1" ItemsSource="{Binding PendingRequests}" SelectedItem="{Binding SelectedRequest}" SelectionMode="Single" IsReadOnly="True" AutoGenerateColumns="False" Style="{StaticResource VirtualizedDataGridStyle}">
-                    <DataGrid.RowStyle>
-                        <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
-                            <EventSetter Event="MouseDoubleClick" Handler="RequestRow_MouseDoubleClick"/>
-                            <EventSetter Event="PreviewMouseRightButtonDown" Handler="RequestRow_PreviewMouseRightButtonDown"/>
-                        </Style>
-                    </DataGrid.RowStyle>
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="120"/>
-                        <DataGridTextColumn Header="Item" Binding="{Binding ItemName}" Width="180"/>
-                        <DataGridTextColumn Header="Customer" Binding="{Binding CustomerName}" Width="220"/>
-                        <DataGridTextColumn Header="Requested" Binding="{Binding ReservationDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="145"/>
-                        <DataGridTextColumn Header="Needed From" Binding="{Binding StartDate, StringFormat={}{0:yyyy-MM-dd}}" Width="120"/>
-                        <DataGridTextColumn Header="Needed Until" Binding="{Binding EndDate, StringFormat={}{0:yyyy-MM-dd}}" Width="120"/>
-                        <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="110"/>
-                        <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" Width="*"/>
-                    </DataGrid.Columns>
-                    <DataGrid.ContextMenu>
-                        <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                            <MenuItem Header="Open Request Details" Command="{Binding OpenRequestDetailsCommand}"/>
-                            <MenuItem Header="Print Requests" Command="{Binding PrintRequestsCommand}"/>
-                        </ContextMenu>
-                    </DataGrid.ContextMenu>
-                </DataGrid>
-                <TextBlock Grid.Row="1" Text="No open requests for unavailable items" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="13" FontWeight="SemiBold">
-                    <TextBlock.Style>
-                        <Style TargetType="TextBlock">
-                            <Setter Property="Visibility" Value="Collapsed"/>
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding PendingRequests.Count}" Value="0">
-                                    <Setter Property="Visibility" Value="Visible"/>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </TextBlock.Style>
-                </TextBlock>
+                <Grid Grid.Row="1">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="6"/>
+                        <ColumnDefinition Width="310"/>
+                    </Grid.ColumnDefinitions>
+                    <DataGrid Grid.Column="0" ItemsSource="{Binding PendingRequests}" SelectedItem="{Binding SelectedRequest}" SelectionMode="Single" IsReadOnly="True" AutoGenerateColumns="False" Style="{StaticResource VirtualizedDataGridStyle}">
+                        <DataGrid.RowStyle>
+                            <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                                <EventSetter Event="MouseDoubleClick" Handler="RequestRow_MouseDoubleClick"/>
+                                <EventSetter Event="PreviewMouseRightButtonDown" Handler="RequestRow_PreviewMouseRightButtonDown"/>
+                            </Style>
+                        </DataGrid.RowStyle>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="110"/>
+                            <DataGridTextColumn Header="Item" Binding="{Binding ItemName}" Width="170"/>
+                            <DataGridTextColumn Header="Customer" Binding="{Binding CustomerName}" Width="190"/>
+                            <DataGridTextColumn Header="Requested" Binding="{Binding ReservationDate, StringFormat={}{0:yyyy-MM-dd HH:mm}}" Width="135"/>
+                            <DataGridTextColumn Header="Needed From" Binding="{Binding StartDate, StringFormat={}{0:yyyy-MM-dd}}" Width="115"/>
+                            <DataGridTextColumn Header="Needed Until" Binding="{Binding EndDate, StringFormat={}{0:yyyy-MM-dd}}" Width="115"/>
+                            <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="100"/>
+                            <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" Width="*"/>
+                        </DataGrid.Columns>
+                        <DataGrid.ContextMenu>
+                            <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                <MenuItem Header="Open Request Details" Command="{Binding OpenRequestDetailsCommand}"/>
+                                <MenuItem Header="Confirm Request" Command="{Binding ConfirmRequestCommand}"/>
+                                <MenuItem Header="Cancel Request" Command="{Binding CancelRequestCommand}"/>
+                                <Separator/>
+                                <MenuItem Header="Print Request" Command="{Binding PrintRequestCommand}"/>
+                                <MenuItem Header="Print Request Queue" Command="{Binding PrintRequestsCommand}"/>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                    </DataGrid>
+                    <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+                    <Border Grid.Column="2" Background="{DynamicResource SurfaceBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1,0,0,0" Padding="8">
+                        <StackPanel>
+                            <TextBlock Text="Selected Request" Style="{StaticResource SectionHeader}" Margin="0,0,0,6"/>
+                            <TextBlock Text="{Binding SelectedRequestSummary}" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,0,0,6"/>
+                            <TextBlock Text="{Binding SelectedRequestDateLine}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,6"/>
+                            <TextBlock Text="Current Holder" Style="{StaticResource LabelTextBlock}" Margin="0,4,0,2"/>
+                            <TextBlock Text="{Binding SelectedRequestHolderLine}" TextWrapping="Wrap" Margin="0,0,0,8"/>
+                            <TextBlock Text="Next Action" Style="{StaticResource LabelTextBlock}" Margin="0,4,0,2"/>
+                            <TextBlock Text="{Binding SelectedRequestNextAction}" TextWrapping="Wrap" Margin="0,0,0,8"/>
+                            <UniformGrid Columns="2" Margin="0,4,0,0">
+                                <Button Style="{StaticResource PrimaryButton}" Content="Confirm" Command="{Binding ConfirmRequestCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Cancel" Command="{Binding CancelRequestCommand}" Margin="0,0,0,4"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Details" Command="{Binding OpenRequestDetailsCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Print" Command="{Binding PrintRequestCommand}"/>
+                            </UniformGrid>
+                        </StackPanel>
+                    </Border>
+                    <TextBlock Grid.Column="0" Text="No open requests for unavailable items" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="13" FontWeight="SemiBold">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding PendingRequests.Count}" Value="0">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Grid>
             </Grid>
         </Border>
 

--- a/InventoryManagementApp/Views/Windows/ReservationEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ReservationEditWindow.xaml
@@ -3,61 +3,101 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
         Title="Reservation"
-        Width="640"
-        Height="540"
+        Width="720"
+        Height="500"
+        MinWidth="680"
+        MinHeight="460"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="16">
+    <Grid Margin="8">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Grid>
+        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}" Padding="6,4" Margin="0,0,0,6">
+            <DockPanel>
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
+                    <TextBlock Text="Reservation" Style="{StaticResource SectionHeader}" Margin="0,0,10,0"/>
+                    <TextBlock Text="Item" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                    <TextBlock Text="{Binding Reservation.ItemNumber}" VerticalAlignment="Center" FontWeight="SemiBold" Margin="0,0,14,0"/>
+                    <TextBlock Text="Status" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                    <TextBlock Text="{Binding Reservation.Status}" VerticalAlignment="Center" FontWeight="SemiBold"/>
+                </StackPanel>
+                <TextBlock DockPanel.Dock="Right" Text="Compact hold/request editor" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center"/>
+            </DockPanel>
+        </Border>
+
+        <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="160"/>
+                <ColumnDefinition Width="190"/>
+                <ColumnDefinition Width="8"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="0" Grid.Column="0" Text="Item #" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Reservation.ItemNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <Border Grid.Column="0" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="8">
+                <StackPanel>
+                    <TextBlock Text="Request Snapshot" Style="{StaticResource SectionHeader}" Margin="0,0,0,8"/>
+                    <TextBlock Text="Item #" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="{Binding Reservation.ItemNumber}" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,0,0,8"/>
+                    <TextBlock Text="Customer" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="{Binding Reservation.CustomerName}" TextWrapping="Wrap" Margin="0,0,0,8"/>
+                    <TextBlock Text="Needed" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="{Binding Reservation.StartDate, StringFormat={}{0:yyyy-MM-dd}}" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding Reservation.EndDate, StringFormat=to {0:yyyy-MM-dd}}" TextWrapping="Wrap" Margin="0,0,0,8"/>
+                    <TextBlock Text="Quantity" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="{Binding Reservation.Quantity}" Margin="0,0,0,8"/>
+                    <TextBlock Text="Use this window to capture who needs the item, when it is needed, and what the advisor should know before fulfillment." TextWrapping="Wrap" Style="{StaticResource CaptionTextBlock}"/>
+                </StackPanel>
+            </Border>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Item Name" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Reservation.ItemName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <GridSplitter Grid.Column="1" Width="8" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Customer" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Reservation.CustomerName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <Border Grid.Column="2" Background="{DynamicResource SurfaceBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="10">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="120"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="90"/>
+                        <ColumnDefinition Width="150"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="Start Date" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8"/>
-            <DatePicker Grid.Row="3" Grid.Column="1" SelectedDate="{Binding Reservation.StartDate}" Margin="0,0,0,8"/>
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Item #" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Reservation.ItemNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,6"/>
+                    <TextBlock Grid.Row="0" Grid.Column="2" Text="Status" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
+                    <ComboBox Grid.Row="0" Grid.Column="3" ItemsSource="{Binding StatusOptions}" SelectedItem="{Binding Reservation.Status}" Margin="0,0,0,6"/>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Text="End Date" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8"/>
-            <DatePicker Grid.Row="4" Grid.Column="1" SelectedDate="{Binding Reservation.EndDate}" Margin="0,0,0,8"/>
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Item Name" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding Reservation.ItemName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Quantity" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Reservation.Quantity, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Customer" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding Reservation.CustomerName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
 
-            <TextBlock Grid.Row="6" Grid.Column="0" Text="Status" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8"/>
-            <ComboBox Grid.Row="6" Grid.Column="1" ItemsSource="{Binding StatusOptions}" SelectedItem="{Binding Reservation.Status}" Margin="0,0,0,8"/>
+                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Start Date" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
+                    <DatePicker Grid.Row="3" Grid.Column="1" SelectedDate="{Binding Reservation.StartDate}" Margin="0,0,8,6"/>
+                    <TextBlock Grid.Row="3" Grid.Column="2" Text="End Date" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
+                    <DatePicker Grid.Row="3" Grid.Column="3" SelectedDate="{Binding Reservation.EndDate}" Margin="0,0,0,6"/>
 
-            <TextBlock Grid.Row="7" Grid.Column="0" Text="Rental ID" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding Reservation.RentalID, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Quantity" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Reservation.Quantity, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,6"/>
+                    <TextBlock Grid.Row="4" Grid.Column="2" Text="Rental ID" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="4" Grid.Column="3" Text="{Binding Reservation.RentalID, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
 
-            <TextBlock Grid.Row="8" Grid.Column="0" Text="Notes" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,0"/>
-            <TextBox Grid.Row="8" Grid.Column="1" Text="{Binding Reservation.Notes, UpdateSourceTrigger=PropertyChanged}" AcceptsReturn="True" Height="80"/>
+                    <TextBlock Grid.Row="5" Grid.Column="0" Text="Notes" Style="{StaticResource LabelTextBlock}" Margin="0,2,8,0"/>
+                    <TextBox Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding Reservation.Notes, UpdateSourceTrigger=PropertyChanged}" AcceptsReturn="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" MinHeight="110"/>
+                </Grid>
+            </Border>
         </Grid>
 
-        <controls:SaveCancelBar Grid.Row="1"/>
+        <controls:SaveCancelBar Grid.Row="2" Margin="0,8,0,0"/>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary

- Added advisor-facing request queue actions to `ManageRentalsPage`: confirm request, cancel request, print selected request, and print the full queue.
- Added a selected-request detail pane with current-holder context and next-action guidance so unavailable item requests are not a dead end.
- Wired confirm/cancel through the existing durable `ReservationService` methods and refreshed the open request queue after status changes.
- Redesigned `ReservationEditWindow` into a compact classic desktop form with a toolbar, request snapshot, dense labeled fields, and the existing save/cancel bar.

## Why

The rentals workflow already allowed advisors to place requests for unavailable items, but the open request queue did not let them work those requests forward. This makes the hold/request workflow actionable from the same screen technicians and advisors already use.

## Validation

- Compared the branch against `master`; change is limited to the rentals view model/page and reservation edit popup.
- Read changed files back from GitHub to check command names, bindings, and service method usage.
- Local .NET validation could not be run because this scheduled runtime cannot clone GitHub directly and does not include the .NET SDK; GitHub checks should validate build/guardrails after PR creation.