### PR TITLE
Add account lockout hardening

### DIFF
--- a/InventoryManagementApp/Models/AuthenticationResult.cs
+++ b/InventoryManagementApp/Models/AuthenticationResult.cs
@@ -4,6 +4,7 @@ namespace InventoryManagementApp.Models
     {
         Success,
         IncorrectPassword,
-        Inactive
+        Inactive,
+        LockedOut
     }
 }

--- a/InventoryManagementApp/Models/Domain/User.cs
+++ b/InventoryManagementApp/Models/Domain/User.cs
@@ -51,6 +51,20 @@ namespace InventoryManagementApp.Models.Domain
         private bool _passwordExpired;
         public bool PasswordExpired { get => _passwordExpired; set => SetProperty(ref _passwordExpired, value); }
 
+        private int _failedLoginAttempts;
+        public int FailedLoginAttempts { get => _failedLoginAttempts; set => SetProperty(ref _failedLoginAttempts, value); }
+
+        private DateTime? _lockoutEndUtc;
+        public DateTime? LockoutEndUtc { get => _lockoutEndUtc; set => SetProperty(ref _lockoutEndUtc, value); }
+
+        public bool IsLockedOut => LockoutEndUtc.HasValue && LockoutEndUtc.Value > DateTime.UtcNow;
+
+        public string LockoutStatus => IsLockedOut
+            ? $"Locked until {LockoutEndUtc!.Value.ToLocalTime():g}"
+            : FailedLoginAttempts > 0
+                ? $"{FailedLoginAttempts} failed login attempt{(FailedLoginAttempts == 1 ? string.Empty : "s")}."
+                : "Ready";
+
         private MediaBrush _initialsBrush = MediaBrushes.Transparent;
         public MediaBrush InitialsBrush { get => _initialsBrush; set => SetProperty(ref _initialsBrush, value); }
     }

--- a/InventoryManagementApp/Services/Core/DatabaseService.cs
+++ b/InventoryManagementApp/Services/Core/DatabaseService.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using InventoryManagementApp.Interfaces;
+using System.Linq;
 
 namespace InventoryManagementApp.Services.Core
 {
@@ -146,7 +147,9 @@ namespace InventoryManagementApp.Services.Core
                     Role TEXT,
                     IsActive INTEGER NOT NULL DEFAULT 1,
                     CreatedAt DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                    PasswordExpired INTEGER NOT NULL DEFAULT 0
+                    PasswordExpired INTEGER NOT NULL DEFAULT 0,
+                    FailedLoginAttempts INTEGER NOT NULL DEFAULT 0,
+                    LockoutEndUtc DATETIME
                 );
                 CREATE TABLE IF NOT EXISTS Customers (
                     CustomerID INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -253,6 +256,8 @@ namespace InventoryManagementApp.Services.Core
                 );";
             using var cmd = new SqliteCommand(sql, conn);
             cmd.ExecuteNonQuery();
+            EnsureColumn("Users", "FailedLoginAttempts", "INTEGER", "0");
+            EnsureColumn("Users", "LockoutEndUtc", "DATETIME");
             EnsureIndex(conn, "Items", "ItemNumber", true);
             EnsureIndex(conn, "Items", "NameDescription");
             EnsureIndex(conn, "Items", "Brand");

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.Data.Sqlite;
 using System.Data;
 using System.Threading;
@@ -25,6 +25,8 @@ namespace InventoryManagementApp.Services.Users
         private readonly ILogger<UserService> _logger;
         private readonly IAuthorizationService _auth;
         private readonly ActivityLogService? _activityLog;
+        private const int MaxFailedLoginAttempts = 5;
+        private static readonly TimeSpan LockoutDuration = TimeSpan.FromMinutes(15);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UserService"/> class.
@@ -42,7 +44,6 @@ namespace InventoryManagementApp.Services.Users
             _logger = logger ?? NullLogger<UserService>.Instance;
             _activityLog = activityLogService;
         }
-
 
         /// <summary>
         /// Parses a value to UTC DateTime, handling various input formats and timezones.
@@ -114,15 +115,16 @@ namespace InventoryManagementApp.Services.Users
                 Role = GetString("Role"),
                 IsActive = HasColumn("IsActive") && rdr["IsActive"] != DBNull.Value && Convert.ToInt32(rdr["IsActive"]) == 1,
                 CreatedAt = createdAt,
-                PasswordExpired = HasColumn("PasswordExpired") && rdr["PasswordExpired"] != DBNull.Value && Convert.ToInt32(rdr["PasswordExpired"]) == 1
+                PasswordExpired = HasColumn("PasswordExpired") && rdr["PasswordExpired"] != DBNull.Value && Convert.ToInt32(rdr["PasswordExpired"]) == 1,
+                FailedLoginAttempts = HasColumn("FailedLoginAttempts") && rdr["FailedLoginAttempts"] != DBNull.Value ? Convert.ToInt32(rdr["FailedLoginAttempts"]) : 0,
+                LockoutEndUtc = ParseToUtcNullable(HasColumn("LockoutEndUtc") ? rdr["LockoutEndUtc"] : DBNull.Value)
             };
         }
-
 
         public async Task<List<User>> GetAllUsersAsync(CancellationToken cancellationToken = default)
         {
             using var conn = _dbService.CreateConnection();
-            const string sql = "SELECT UserID, UserName, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, PasswordExpired FROM Users";
+            const string sql = "SELECT UserID, UserName, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, PasswordExpired, FailedLoginAttempts, LockoutEndUtc FROM Users";
             return await SqliteHelper.ExecuteReaderAsync(conn, sql, MapUser, cancellationToken: cancellationToken);
         }
 
@@ -160,6 +162,19 @@ namespace InventoryManagementApp.Services.Users
             if (u == null) return (AuthenticationResult.IncorrectPassword, null);
             if (!u.IsActive) return (AuthenticationResult.Inactive, null);
 
+            if (IsLockoutActive(u))
+            {
+                _logger.LogWarning("Locked account login attempt for user {UserID}", u.UserID);
+                return (AuthenticationResult.LockedOut, u);
+            }
+
+            if (u.LockoutEndUtc.HasValue && u.LockoutEndUtc.Value <= DateTime.UtcNow)
+            {
+                await ClearLoginFailureStateAsync(conn, u.UserID).ConfigureAwait(false);
+                u.FailedLoginAttempts = 0;
+                u.LockoutEndUtc = null;
+            }
+
             bool success;
             if (string.IsNullOrWhiteSpace(u.PasswordSalt) && SecurityHelper.IsSha256Hash(u.PasswordHash))
             {
@@ -170,10 +185,10 @@ namespace InventoryManagementApp.Services.Users
                     var upgradedResult = await SecurityHelper.HashPasswordAsync(password).ConfigureAwait(false);
                     var p = new[]
                     {
-                new SqliteParameter("@Pwd", upgradedResult.hash),
-                new SqliteParameter("@Salt", upgradedResult.salt),
-                new SqliteParameter("@ID", u.UserID)
-            };
+                        new SqliteParameter("@Pwd", upgradedResult.hash),
+                        new SqliteParameter("@Salt", upgradedResult.salt),
+                        new SqliteParameter("@ID", u.UserID)
+                    };
                     await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET PasswordHash=@Pwd, PasswordSalt=@Salt WHERE UserID=@ID", p);
                     u.PasswordHash = upgradedResult.hash;
                     u.PasswordSalt = upgradedResult.salt;
@@ -186,13 +201,61 @@ namespace InventoryManagementApp.Services.Users
 
             if (success)
             {
+                await ClearLoginFailureStateAsync(conn, u.UserID).ConfigureAwait(false);
+                u.FailedLoginAttempts = 0;
+                u.LockoutEndUtc = null;
                 if (_activityLog != null)
                     await _activityLog.LogActionAsync(u.UserID, u.UserName ?? string.Empty, "User login").ConfigureAwait(false);
                 return (AuthenticationResult.Success, u);
             }
-            return (AuthenticationResult.IncorrectPassword, null);
+
+            var locked = await RecordFailedLoginAsync(conn, u).ConfigureAwait(false);
+            return locked ? (AuthenticationResult.LockedOut, u) : (AuthenticationResult.IncorrectPassword, null);
         }
 
+        static bool IsLockoutActive(User user)
+            => user.LockoutEndUtc.HasValue && user.LockoutEndUtc.Value > DateTime.UtcNow;
+
+        async Task<bool> RecordFailedLoginAsync(SqliteConnection conn, User user)
+        {
+            var failedAttempts = Math.Max(0, user.FailedLoginAttempts) + 1;
+            DateTime? lockoutEndUtc = null;
+            if (failedAttempts >= MaxFailedLoginAttempts)
+            {
+                failedAttempts = MaxFailedLoginAttempts;
+                lockoutEndUtc = DateTime.UtcNow.Add(LockoutDuration);
+            }
+
+            var p = new[]
+            {
+                new SqliteParameter("@Attempts", failedAttempts),
+                new SqliteParameter("@LockoutEndUtc", (object?)lockoutEndUtc ?? DBNull.Value),
+                new SqliteParameter("@ID", user.UserID)
+            };
+            await SqliteHelper.ExecuteNonQueryAsync(conn,
+                "UPDATE Users SET FailedLoginAttempts=@Attempts, LockoutEndUtc=@LockoutEndUtc WHERE UserID=@ID",
+                p).ConfigureAwait(false);
+
+            user.FailedLoginAttempts = failedAttempts;
+            user.LockoutEndUtc = lockoutEndUtc;
+
+            if (lockoutEndUtc.HasValue)
+            {
+                _logger.LogWarning("User {UserID} locked out until {LockoutEndUtc} after failed login attempts", user.UserID, lockoutEndUtc.Value);
+                if (_activityLog != null)
+                    await _activityLog.LogActionAsync(user.UserID, user.UserName ?? string.Empty, "User account locked after failed logins").ConfigureAwait(false);
+            }
+
+            return lockoutEndUtc.HasValue;
+        }
+
+        static Task ClearLoginFailureStateAsync(SqliteConnection conn, int userID)
+        {
+            var p = new[] { new SqliteParameter("@ID", userID) };
+            return SqliteHelper.ExecuteNonQueryAsync(conn,
+                "UPDATE Users SET FailedLoginAttempts=0, LockoutEndUtc=NULL WHERE UserID=@ID",
+                p);
+        }
 
         public async Task<User?> GetCurrentUserAsync()
         {
@@ -262,6 +325,8 @@ namespace InventoryManagementApp.Services.Users
             }
             user.PasswordHash = hashed;
             user.PasswordSalt = salt;
+            user.FailedLoginAttempts = 0;
+            user.LockoutEndUtc = null;
         }
 
         public async Task UpdateUserAsync(User user)
@@ -335,7 +400,7 @@ namespace InventoryManagementApp.Services.Users
             if (!PasswordValidator.IsValid(newPassword, out var error))
                 throw new ArgumentException(error, nameof(newPassword));
 
-            var sql = "UPDATE Users SET PasswordHash=@Pwd, PasswordSalt=@Salt, PasswordExpired=@Expired WHERE UserID=@ID";
+            var sql = "UPDATE Users SET PasswordHash=@Pwd, PasswordSalt=@Salt, PasswordExpired=@Expired, FailedLoginAttempts=0, LockoutEndUtc=NULL WHERE UserID=@ID";
             var result = await SecurityHelper.HashPasswordAsync(newPassword).ConfigureAwait(false);
             string hashed = result.hash;
             string salt = result.salt;
@@ -378,6 +443,5 @@ namespace InventoryManagementApp.Services.Users
             await DeleteUserInternalAsync(userID);
             return true;
         }
-
     }
 }

--- a/InventoryManagementApp/ViewModels/LoginViewModel.cs
+++ b/InventoryManagementApp/ViewModels/LoginViewModel.cs
@@ -287,6 +287,13 @@ namespace InventoryManagementApp.ViewModels
                 return;
             }
 
+            if (user.IsLockedOut)
+            {
+                await LoadUsersCommand.ExecuteAsync(null);
+                await _dialogService.ShowInfoAsync(GetLockoutMessage(user), "Account Locked");
+                return;
+            }
+
             if (!user.IsAdmin &&
                 await SecurityHelper.VerifyPasswordAsync(PasswordDefaults.TemporaryPassword, user.PasswordSalt, user.PasswordHash).ConfigureAwait(false))
             {

--- a/InventoryManagementApp/ViewModels/LoginViewModel.cs
+++ b/InventoryManagementApp/ViewModels/LoginViewModel.cs
@@ -173,8 +173,8 @@ namespace InventoryManagementApp.ViewModels
         {
             var appName = await _settingsService.GetSettingAsync("ApplicationName", cancellationToken);
             return !string.IsNullOrWhiteSpace(appName)
-                ? $"{appName} – Login"
-                : $"{LabelProvider.Instance.ItemLabelSingular} Inventory Management – Login";
+                ? $"{appName} - Login"
+                : $"{LabelProvider.Instance.ItemLabelSingular} Inventory Management - Login";
         }
 
         async Task LoadUsersAsync()
@@ -273,6 +273,8 @@ namespace InventoryManagementApp.ViewModels
                     user.PasswordHash = refreshed.PasswordHash;
                     user.PasswordSalt = refreshed.PasswordSalt;
                     user.PasswordExpired = refreshed.PasswordExpired;
+                    user.FailedLoginAttempts = refreshed.FailedLoginAttempts;
+                    user.LockoutEndUtc = refreshed.LockoutEndUtc;
                 }
             }
 
@@ -319,6 +321,8 @@ namespace InventoryManagementApp.ViewModels
                         user.PasswordHash = refreshed.PasswordHash;
                         user.PasswordSalt = refreshed.PasswordSalt;
                         user.PasswordExpired = refreshed.PasswordExpired;
+                        user.FailedLoginAttempts = refreshed.FailedLoginAttempts;
+                        user.LockoutEndUtc = refreshed.LockoutEndUtc;
                     }
                     await LoadUsersCommand.ExecuteAsync(null);
                     await _dialogService.ShowInfoAsync(
@@ -335,6 +339,15 @@ namespace InventoryManagementApp.ViewModels
                         continue;
                     case AuthenticationResult.Inactive:
                         await _dialogService.ShowInfoAsync("User is inactive. Please contact an administrator.", "Login Failed");
+                        return;
+                    case AuthenticationResult.LockedOut:
+                        if (authResult.User != null)
+                        {
+                            user.FailedLoginAttempts = authResult.User.FailedLoginAttempts;
+                            user.LockoutEndUtc = authResult.User.LockoutEndUtc;
+                        }
+                        await LoadUsersCommand.ExecuteAsync(null);
+                        await _dialogService.ShowInfoAsync(GetLockoutMessage(authResult.User ?? user), "Account Locked");
                         return;
                     case AuthenticationResult.Success:
                         if (authResult.User != null)
@@ -360,6 +373,16 @@ namespace InventoryManagementApp.ViewModels
                 return;
             }
             LoginSucceeded?.Invoke(this, EventArgs.Empty);
+        }
+
+        static string GetLockoutMessage(User user)
+        {
+            if (user.LockoutEndUtc.HasValue && user.LockoutEndUtc.Value > DateTime.UtcNow)
+            {
+                return $"This account is temporarily locked until {user.LockoutEndUtc.Value.ToLocalTime():g} after repeated failed password attempts. Please wait or ask an administrator to reset the password.";
+            }
+
+            return "This account is temporarily locked after repeated failed password attempts. Please wait or ask an administrator to reset the password.";
         }
 
         async Task<bool> PromptChangePasswordAsync(User user)
@@ -392,6 +415,8 @@ namespace InventoryManagementApp.ViewModels
                 user.PasswordHash = refreshed.PasswordHash;
                 user.PasswordSalt = refreshed.PasswordSalt;
                 user.PasswordExpired = refreshed.PasswordExpired;
+                user.FailedLoginAttempts = refreshed.FailedLoginAttempts;
+                user.LockoutEndUtc = refreshed.LockoutEndUtc;
             }
             await LoadUsersCommand.ExecuteAsync(null);
             return true;

--- a/PRODUCTION_READINESS.md
+++ b/PRODUCTION_READINESS.md
@@ -9,6 +9,7 @@ This checklist ensures the Inventory Management Application is ready for product
 - [x] Password hashing using PBKDF2-SHA256 with 100,000+ iterations
 - [x] Default admin password expires on first login
 - [x] User authentication and authorization system
+- [x] Account lockout after repeated failed password attempts
 - [x] Database permissions and access control
 - [x] No hardcoded credentials in source code
 - [x] SSL/TLS support for SMTP email
@@ -122,7 +123,7 @@ For enhanced security in production:
 - [ ] Regular security updates for .NET runtime
 - [ ] Periodic password rotation policy
 - [ ] Audit logging for sensitive operations
-- [ ] Implement rate limiting for login attempts
+- [x] Implement rate limiting for login attempts through account lockout
 - [ ] Use HTTPS if exposing any web services
 
 ## 📊 Ongoing Maintenance
@@ -162,5 +163,5 @@ If issues arise during deployment:
 
 ---
 
-**Last Updated:** 2025-11-04  
+**Last Updated:** 2026-06-16  
 **Application Version:** 1.0.0

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Password handling enforces these requirements:
 - Minimum 8 characters.
 - At least one uppercase letter, one lowercase letter, and one digit.
 - Known default passwords are expired and must be changed.
+- Accounts temporarily lock for 15 minutes after 5 failed password attempts.
 
 SQLite database files can contain customer and rental data. Use appropriate file permissions and regular backups in production.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,10 +68,10 @@ When deploying the Inventory Management Application, follow these security best 
 - Review user access permissions regularly
 
 #### 6. Application Security
-- Review logs regularly for failed login attempts
+- Review logs regularly for failed login attempts and lockout events
 - Monitor for unusual user activity patterns
 - Keep audit logs of administrative actions
-- Implement account lockout after repeated failed logins
+- Use the built-in 5-attempt account lockout to slow repeated password guessing
 - Use the latest version of the application
 
 ### Known Security Considerations
@@ -92,6 +92,7 @@ When deploying the Inventory Management Application, follow these security best 
 - Passwords are hashed using PBKDF2-SHA256 with 100,000+ iterations
 - Legacy password hashes are automatically upgraded on login
 - Default/temporary passwords trigger automatic expiration
+- Five failed password attempts lock the account for 15 minutes; successful login or password reset clears the counter
 - No session timeout is enforced by default (consider implementing for high-security deployments)
 
 ### Security Features
@@ -102,6 +103,7 @@ The application includes the following built-in security features:
 - ✅ Configurable password iteration count
 - ✅ Password complexity requirements
 - ✅ Automatic password expiration for weak passwords
+- ✅ Temporary account lockout after repeated failed logins
 - ✅ User authentication and authorization
 - ✅ Role-based access control (admin vs. regular users)
 - ✅ Activity logging for audit trails
@@ -128,5 +130,5 @@ If you have questions about security but have not discovered a vulnerability, pl
 
 ---
 
-**Last Updated:** 2025-11-04  
+**Last Updated:** 2026-06-16  
 **Application Version:** 1.0.0


### PR DESCRIPTION
## Summary

- Adds durable account lockout state to users: failed login attempts and lockout end time are persisted in SQLite and migrated for existing databases.
- Locks accounts for 15 minutes after 5 failed password attempts, clears the counter on successful login or password change, and records lockout events in logs/activity when available.
- Updates the login workflow so locked accounts get a clear message and temporary-password paths respect active lockouts.
- Updates README, SECURITY, and production readiness docs so account lockout is tracked as an implemented security control.

## Why

The markdown production/security guidance still called out login rate limiting/account lockout as a recommended hardening item. This completes that enhancement in the app instead of leaving it as deployment advice.

## Validation

- Reviewed the changed branch through the GitHub connector against `master`; changes are limited to auth/user/database/docs files.
- Local .NET build/tests were not run because this scheduled container does not include the .NET SDK, and the user requested not to run tests that are not required for the changes made.