### PR TITLE
Complete searchable popup workflows

### DIFF
--- a/InventoryManagementApp.Tests/RentItemPopupViewModelTests.cs
+++ b/InventoryManagementApp.Tests/RentItemPopupViewModelTests.cs
@@ -42,6 +42,72 @@ namespace InventoryManagementApp.Tests
             Assert.True(vm.CheckOutCommand.CanExecute(null));
         }
 
+        [Fact]
+        public void CustomerSearchText_FiltersByMobileAndAddress()
+        {
+            var first = new CustomerModel
+            {
+                CustomerID = 1,
+                Company = "North Yard",
+                Contact = "Alex Stone",
+                Email = "alex@example.com",
+                Phone = "111-111",
+                Mobile = "022-555-9911",
+                Address = "7 Shelf Road"
+            };
+            var second = new CustomerModel
+            {
+                CustomerID = 2,
+                Company = "South Workshop",
+                Contact = "Morgan Lee",
+                Email = "morgan@example.com",
+                Phone = "222-222",
+                Mobile = "027-000-0000",
+                Address = "18 Bench Lane"
+            };
+            var vm = new RentItemPopupViewModel(new ItemModel(), new[] { first, second }, new RecordingCustomerService(), new StubDialogService());
+
+            vm.CustomerSearchText = "bench";
+
+            var match = Assert.Single(vm.FilteredCustomers);
+            Assert.Same(second, match);
+            Assert.Same(second, vm.SelectedCustomer);
+            Assert.Equal("1 of 2 customers shown", vm.CustomerCountSummary);
+        }
+
+        [Fact]
+        public void ClearCustomerSearch_RestoresTheFullCustomerList()
+        {
+            var first = new CustomerModel { CustomerID = 1, Company = "North Yard", Mobile = "022-555-9911" };
+            var second = new CustomerModel { CustomerID = 2, Company = "South Workshop", Mobile = "027-000-0000" };
+            var vm = new RentItemPopupViewModel(new ItemModel(), new[] { first, second }, new RecordingCustomerService(), new StubDialogService());
+            vm.CustomerSearchText = "022";
+
+            vm.ClearCustomerSearchCommand.Execute(null);
+
+            Assert.Equal(2, vm.FilteredCustomers.Count);
+            Assert.Contains(first, vm.FilteredCustomers);
+            Assert.Contains(second, vm.FilteredCustomers);
+            Assert.Equal("2 customers available", vm.CustomerCountSummary);
+        }
+
+        [Fact]
+        public void Confirm_UsesSelectedCustomerAndSelectedDueDate()
+        {
+            var customer = new CustomerModel { CustomerID = 3, Company = "Ready Rentals" };
+            var dueDate = new DateTime(2026, 6, 25);
+            var vm = new RentItemPopupViewModel(new ItemModel(), new[] { customer }, new RecordingCustomerService(), new StubDialogService())
+            {
+                SelectedCustomer = customer,
+                SelectedDueDate = dueDate
+            };
+
+            vm.CheckOutCommand.Execute(null);
+
+            Assert.Same(customer, vm.SelectedCustomerResult);
+            Assert.Equal(dueDate, vm.SelectedDueDateResult);
+        }
+
         private sealed class RecordingCustomerService : ICustomerService
         {
             public CustomerModel? AddedCustomer { get; private set; }

--- a/InventoryManagementApp.Tests/ReservationEditViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ReservationEditViewModelTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Data;
 using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Models.ImportExport;
 using InventoryManagementApp.ViewModels;
 using Microsoft.Data.Sqlite;

--- a/InventoryManagementApp.Tests/ReservationEditViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ReservationEditViewModelTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using InventoryManagementApp.Data;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models.ImportExport;
+using InventoryManagementApp.ViewModels;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ReservationEditViewModelTests
+    {
+        [Fact]
+        public async Task SearchItemsCommand_LoadsMatchesAndAppliesSelectedItem()
+        {
+            var reservation = new Reservation
+            {
+                ItemNumber = "OLD",
+                ItemName = "Old item"
+            };
+            var item = new ItemModel
+            {
+                ItemID = 8,
+                ItemNumber = "TW-8",
+                Name = "Torque wrench",
+                Location = "Rack 4"
+            };
+            var vm = new ReservationEditViewModel(
+                reservation,
+                isNew: true,
+                onSave: () => { },
+                onCancel: () => { },
+                new StubItemService(item));
+
+            vm.ItemSearchText = "torque";
+            await vm.SearchItemsCommand.ExecutionTask!;
+
+            var match = Assert.Single(vm.ItemSearchResults);
+            Assert.Same(item, match);
+            Assert.Same(item, vm.SelectedSearchItem);
+
+            vm.ApplySelectedItemCommand.Execute(null);
+
+            Assert.Equal("TW-8", reservation.ItemNumber);
+            Assert.Equal("Torque wrench", reservation.ItemName);
+        }
+
+        private sealed class StubItemService : IItemService
+        {
+            readonly ItemModel _item;
+
+            public StubItemService(ItemModel item)
+            {
+                _item = item;
+            }
+
+            public async IAsyncEnumerable<ItemModel> SearchItemsAsync(string? searchText, ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+            {
+                await Task.Yield();
+                yield return _item;
+            }
+
+            public Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<ItemModel?> GetItemByIDAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public IAsyncEnumerable<ItemModel> GetItemsAsync(ItemPage page, SortField sortField = SortField.Name, SortDirection sortDirection = SortDirection.Ascending, bool? isRentalItem = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<int> CountItemsAsync(ItemFilter filter, CancellationToken ct) => throw new NotImplementedException();
+            public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct) => throw new NotImplementedException();
+            public Task<bool> ToggleItemCheckOutStatusAsync(int itemID, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ItemModel>> GetItemsCheckedOutByAsync(string userName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ItemModel>> GetCheckedOutItemsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task ExportItemsToCsvAsync(string filePath, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<int>> ImportItemsAsync(string filePath, IDataImporter<ItemModel> importer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task ExportItemsAsync(string filePath, IDataExporter<ItemModel> exporter, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<string> GenerateNextItemNumberAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task UpdateItemQuantitiesAsync(int itemID, int qtyChange, bool isRental, SqliteConnection? conn = null, SqliteTransaction? tx = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ItemModel>> GetMostCommonlyUsedItemsAsync(int limit, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<List<ItemModel>> GetIncompleteItemsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-16-searchable-rent-popup.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-16-searchable-rent-popup.md
@@ -1,0 +1,19 @@
+# Searchable Rent Popup Flow - 2026-06-16
+
+## Completed
+
+- Finished the customer-search workflow already suggested by `RentItemPopupViewModel` by binding the rent popup to `FilteredCustomers` instead of a plain customer dropdown.
+- Added a compact split customer picker so advisors can search by company, contact, email, phone, mobile, or address while renting an item.
+- Added selected-customer review text for company/contact, email, phone, mobile, address, due-back date, and next action before confirming the rental.
+- Added quick rental-day controls and a clear-search command to reduce repeated advisor mouse/scroll work.
+- Added focused `RentItemPopupViewModelTests` coverage for mobile/address filtering, clearing search, and confirming selected customer plus due date.
+
+## Why It Matters
+
+An advisor renting out an item should not have to scroll a long customer dropdown or guess whether the right customer is selected. This makes the rental popup behave like the rest of the compact desktop workflows: search first, verify the record, then complete the operation.
+
+## Validation Notes
+
+- Implemented through the GitHub connector because direct repository clone is blocked in this scheduled environment.
+- Local `dotnet` validation was not run because the scheduled container does not include the .NET SDK and the user asked not to run tests that are not required for the changes made.
+- The changed XAML and view model should be validated by the repository build checks after merge.

--- a/InventoryManagementApp/ProgressNotes/2026-06-16-searchable-rent-popup.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-16-searchable-rent-popup.md
@@ -1,4 +1,4 @@
-# Searchable Rent Popup Flow - 2026-06-16
+# Searchable Popup Flow - 2026-06-16
 
 ## Completed
 
@@ -6,11 +6,14 @@
 - Added a compact split customer picker so advisors can search by company, contact, email, phone, mobile, or address while renting an item.
 - Added selected-customer review text for company/contact, email, phone, mobile, address, due-back date, and next action before confirming the rental.
 - Added quick rental-day controls and a clear-search command to reduce repeated advisor mouse/scroll work.
+- Added item lookup inside `ReservationEditWindow` so admin/advisor users can search inventory by item text, select a result, and apply the item number/name into the hold/request record without leaving the popup.
+- Routed `ReservationEditWindow` through the app service provider so the popup receives `IItemService` for real item search while preserving the existing constructor fallback.
 - Added focused `RentItemPopupViewModelTests` coverage for mobile/address filtering, clearing search, and confirming selected customer plus due date.
+- Added `ReservationEditViewModelTests` coverage for searching item results and applying the selected item to the reservation record.
 
 ## Why It Matters
 
-An advisor renting out an item should not have to scroll a long customer dropdown or guess whether the right customer is selected. This makes the rental popup behave like the rest of the compact desktop workflows: search first, verify the record, then complete the operation.
+An advisor renting out an item should not have to scroll a long customer dropdown or guess whether the right customer is selected. Likewise, an admin or advisor creating a request/hold should not have to type exact item details from memory. These popups now behave like the rest of the compact desktop workflows: search first, verify the record, then complete the operation.
 
 ## Validation Notes
 

--- a/InventoryManagementApp/Services/DialogService.cs
+++ b/InventoryManagementApp/Services/DialogService.cs
@@ -304,7 +304,7 @@ namespace InventoryManagementApp.Services
 
         bool ShowReservationDialog(Reservation reservation, bool isNew)
         {
-            var win = new ReservationEditWindow(reservation, isNew);
+            var win = ActivatorUtilities.CreateInstance<ReservationEditWindow>(_serviceProvider, reservation, isNew);
             TrySetOwner(win);
             return ShowDialogSafe(win);
         }

--- a/InventoryManagementApp/ViewModels/RentItemPopupViewModel.cs
+++ b/InventoryManagementApp/ViewModels/RentItemPopupViewModel.cs
@@ -17,7 +17,27 @@ namespace InventoryManagementApp.ViewModels.Rental
 
         public ObservableCollection<CustomerModel> Customers { get; }
         public ObservableCollection<CustomerModel> FilteredCustomers { get; }
-        
+
+        public string CustomerCountSummary => FilteredCustomers.Count == Customers.Count
+            ? $"{Customers.Count} customer{(Customers.Count == 1 ? string.Empty : "s")} available"
+            : $"{FilteredCustomers.Count} of {Customers.Count} customer{(Customers.Count == 1 ? string.Empty : "s")} shown";
+
+        public string SelectedCustomerSummary => SelectedCustomer == null
+            ? "No customer selected"
+            : $"{ValueOrNotRecorded(SelectedCustomer.Company)} | {ValueOrNotRecorded(SelectedCustomer.Contact)}";
+
+        public string SelectedCustomerContactLine => SelectedCustomer == null
+            ? "Search or select a customer before confirming the rental."
+            : $"Email: {ValueOrNotRecorded(SelectedCustomer.Email)} | Phone: {ValueOrNotRecorded(SelectedCustomer.Phone)} | Mobile: {ValueOrNotRecorded(SelectedCustomer.Mobile)}";
+
+        public string SelectedCustomerAddressLine => SelectedCustomer == null
+            ? "Customer details will appear here for final advisor review."
+            : $"Address: {ValueOrNotRecorded(SelectedCustomer.Address)}";
+
+        public string SelectedCustomerActionHint => SelectedCustomer == null
+            ? "Next action: choose the customer collecting this item."
+            : $"Next action: confirm the rental for {ValueOrNotRecorded(SelectedCustomer.Company)} due back {SelectedDueDate:yyyy-MM-dd}.";
+
         CustomerModel? _selectedCustomer;
         public CustomerModel? SelectedCustomer
         {
@@ -25,7 +45,13 @@ namespace InventoryManagementApp.ViewModels.Rental
             set
             {
                 if (SetProperty(ref _selectedCustomer, value))
+                {
                     CheckOutCommand.NotifyCanExecuteChanged();
+                    OnPropertyChanged(nameof(SelectedCustomerSummary));
+                    OnPropertyChanged(nameof(SelectedCustomerContactLine));
+                    OnPropertyChanged(nameof(SelectedCustomerAddressLine));
+                    OnPropertyChanged(nameof(SelectedCustomerActionHint));
+                }
             }
         }
 
@@ -59,7 +85,11 @@ namespace InventoryManagementApp.ViewModels.Rental
         public DateTime SelectedDueDate
         {
             get => _selectedDueDate;
-            set => SetProperty(ref _selectedDueDate, value);
+            set
+            {
+                if (SetProperty(ref _selectedDueDate, value))
+                    OnPropertyChanged(nameof(SelectedCustomerActionHint));
+            }
         }
 
         public event EventHandler? RequestClose;
@@ -71,17 +101,19 @@ namespace InventoryManagementApp.ViewModels.Rental
         public IRelayCommand CancelCommand { get; }
         public IAsyncRelayCommand AddCustomerCommand { get; }
         public IRelayCommand SetRentalDaysCommand { get; }
+        public IRelayCommand ClearCustomerSearchCommand { get; }
 
         public RentItemPopupViewModel(ItemModel item, IEnumerable<CustomerModel> customers, ICustomerService customerService, IDialogService dialogService)
         {
             _customerService = customerService;
             _dialogService = dialogService;
-            Customers = new ObservableCollection<CustomerModel>(customers);
-            FilteredCustomers = new ObservableCollection<CustomerModel>(customers);
+            Customers = new ObservableCollection<CustomerModel>(customers.OrderBy(c => c.Company).ThenBy(c => c.Contact));
+            FilteredCustomers = new ObservableCollection<CustomerModel>(Customers);
             CheckOutCommand = new RelayCommand(Confirm, CanConfirm);
             CancelCommand = new RelayCommand(Cancel);
             AddCustomerCommand = new AsyncRelayCommand(AddCustomerAsync);
             SetRentalDaysCommand = new RelayCommand<string>(SetRentalDays);
+            ClearCustomerSearchCommand = new RelayCommand(ClearCustomerSearch, () => !string.IsNullOrWhiteSpace(CustomerSearchText));
         }
 
         bool CanConfirm() => SelectedCustomer != null;
@@ -104,7 +136,8 @@ namespace InventoryManagementApp.ViewModels.Rental
             if (customer == null) return;
             await _customerService.AddCustomerAsync(customer);
             Customers.Add(customer);
-            FilteredCustomers.Add(customer);
+            CustomerSearchText = string.Empty;
+            FilterCustomers();
             SelectedCustomer = customer;
         }
 
@@ -116,31 +149,51 @@ namespace InventoryManagementApp.ViewModels.Rental
             }
         }
 
+        void ClearCustomerSearch()
+        {
+            CustomerSearchText = string.Empty;
+        }
+
         void FilterCustomers()
         {
+            var selected = SelectedCustomer;
             FilteredCustomers.Clear();
-            
+
+            IEnumerable<CustomerModel> matches;
             if (string.IsNullOrWhiteSpace(CustomerSearchText))
             {
-                foreach (var customer in Customers)
-                {
-                    FilteredCustomers.Add(customer);
-                }
+                matches = Customers;
             }
             else
             {
-                var searchTerm = CustomerSearchText.ToLowerInvariant();
-                var matches = Customers.Where(c =>
-                    (c.Company?.ToLowerInvariant().Contains(searchTerm) ?? false) ||
-                    (c.Contact?.ToLowerInvariant().Contains(searchTerm) ?? false) ||
-                    (c.Email?.ToLowerInvariant().Contains(searchTerm) ?? false) ||
-                    (c.Phone?.ToLowerInvariant().Contains(searchTerm) ?? false));
-                
-                foreach (var customer in matches)
-                {
-                    FilteredCustomers.Add(customer);
-                }
+                var searchTerm = CustomerSearchText.Trim();
+                matches = Customers.Where(c =>
+                    Contains(c.Company, searchTerm) ||
+                    Contains(c.Contact, searchTerm) ||
+                    Contains(c.Email, searchTerm) ||
+                    Contains(c.Phone, searchTerm) ||
+                    Contains(c.Mobile, searchTerm) ||
+                    Contains(c.Address, searchTerm));
             }
+
+            foreach (var customer in matches.OrderBy(c => c.Company).ThenBy(c => c.Contact))
+            {
+                FilteredCustomers.Add(customer);
+            }
+
+            if (selected != null && !FilteredCustomers.Contains(selected))
+                SelectedCustomer = null;
+            else if (SelectedCustomer == null && FilteredCustomers.Count == 1)
+                SelectedCustomer = FilteredCustomers[0];
+
+            OnPropertyChanged(nameof(CustomerCountSummary));
+            ClearCustomerSearchCommand.NotifyCanExecuteChanged();
         }
+
+        static bool Contains(string? value, string searchTerm)
+            => !string.IsNullOrWhiteSpace(value) && value.Contains(searchTerm, StringComparison.OrdinalIgnoreCase);
+
+        static string ValueOrNotRecorded(string? value)
+            => string.IsNullOrWhiteSpace(value) ? "Not recorded" : value;
     }
 }

--- a/InventoryManagementApp/ViewModels/ReservationEditViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ReservationEditViewModel.cs
@@ -1,13 +1,22 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using InventoryManagementApp.Data;
+using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
 
 namespace InventoryManagementApp.ViewModels
 {
     public class ReservationEditViewModel : ObservableObject
     {
+        readonly IItemService? _itemService;
+        CancellationTokenSource? _searchCts;
+
         public Reservation Reservation { get; }
 
         public bool IsNew { get; }
@@ -16,14 +25,58 @@ namespace InventoryManagementApp.ViewModels
 
         public ObservableCollection<string> StatusOptions { get; }
 
+        public ObservableCollection<ItemModel> ItemSearchResults { get; } = new();
+
+        public string ItemSearchSummary => _itemService == null
+            ? "Item lookup is not available in this session."
+            : ItemSearchResults.Count == 1
+                ? "1 item match"
+                : $"{ItemSearchResults.Count} item matches";
+
+        public string SelectedItemSummary => SelectedSearchItem == null
+            ? "No lookup item selected."
+            : $"{ValueOrNotRecorded(SelectedSearchItem.ItemNumber)} | {ValueOrNotRecorded(SelectedSearchItem.Name)} | {ValueOrNotRecorded(SelectedSearchItem.Location)}";
+
+        string _itemSearchText = string.Empty;
+        public string ItemSearchText
+        {
+            get => _itemSearchText;
+            set
+            {
+                if (SetProperty(ref _itemSearchText, value))
+                    SearchItemsCommand.Execute(null);
+            }
+        }
+
+        ItemModel? _selectedSearchItem;
+        public ItemModel? SelectedSearchItem
+        {
+            get => _selectedSearchItem;
+            set
+            {
+                if (SetProperty(ref _selectedSearchItem, value))
+                {
+                    ApplySelectedItemCommand.NotifyCanExecuteChanged();
+                    OnPropertyChanged(nameof(SelectedItemSummary));
+                }
+            }
+        }
+
         public IRelayCommand SaveCommand { get; }
 
         public IRelayCommand CancelCommand { get; }
 
-        public ReservationEditViewModel(Reservation reservation, bool isNew, Action onSave, Action onCancel)
+        public IAsyncRelayCommand SearchItemsCommand { get; }
+
+        public IRelayCommand ClearItemSearchCommand { get; }
+
+        public IRelayCommand ApplySelectedItemCommand { get; }
+
+        public ReservationEditViewModel(Reservation reservation, bool isNew, Action onSave, Action onCancel, IItemService? itemService = null)
         {
             Reservation = reservation;
             IsNew = isNew;
+            _itemService = itemService;
             StatusOptions = new ObservableCollection<string>
             {
                 "Pending",
@@ -33,6 +86,68 @@ namespace InventoryManagementApp.ViewModels
             };
             SaveCommand = new RelayCommand(onSave);
             CancelCommand = new RelayCommand(onCancel);
+            SearchItemsCommand = new AsyncRelayCommand(SearchItemsAsync, () => _itemService != null);
+            ClearItemSearchCommand = new RelayCommand(ClearItemSearch, () => !string.IsNullOrWhiteSpace(ItemSearchText));
+            ApplySelectedItemCommand = new RelayCommand(ApplySelectedItem, () => SelectedSearchItem != null);
         }
+
+        async Task SearchItemsAsync()
+        {
+            if (_itemService == null)
+                return;
+
+            _searchCts?.Cancel();
+            _searchCts?.Dispose();
+            _searchCts = new CancellationTokenSource();
+            var cancellationToken = _searchCts.Token;
+            var term = ItemSearchText?.Trim() ?? string.Empty;
+            ItemSearchResults.Clear();
+            SelectedSearchItem = null;
+
+            if (string.IsNullOrWhiteSpace(term))
+            {
+                OnPropertyChanged(nameof(ItemSearchSummary));
+                ClearItemSearchCommand.NotifyCanExecuteChanged();
+                return;
+            }
+
+            var matches = new List<ItemModel>();
+            await foreach (var item in _itemService.SearchItemsAsync(term, new ItemPage(1, 20), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken)
+                .WithCancellation(cancellationToken))
+            {
+                matches.Add(item);
+            }
+
+            foreach (var item in matches.OrderBy(i => i.ItemNumber).ThenBy(i => i.Name))
+                ItemSearchResults.Add(item);
+
+            if (ItemSearchResults.Count == 1)
+                SelectedSearchItem = ItemSearchResults[0];
+
+            OnPropertyChanged(nameof(ItemSearchSummary));
+            ClearItemSearchCommand.NotifyCanExecuteChanged();
+        }
+
+        void ClearItemSearch()
+        {
+            ItemSearchText = string.Empty;
+            ItemSearchResults.Clear();
+            SelectedSearchItem = null;
+            OnPropertyChanged(nameof(ItemSearchSummary));
+            ClearItemSearchCommand.NotifyCanExecuteChanged();
+        }
+
+        void ApplySelectedItem()
+        {
+            if (SelectedSearchItem == null)
+                return;
+
+            Reservation.ItemNumber = SelectedSearchItem.ItemNumber;
+            Reservation.ItemName = SelectedSearchItem.Name;
+            OnPropertyChanged(nameof(Reservation));
+        }
+
+        static string ValueOrNotRecorded(string? value)
+            => string.IsNullOrWhiteSpace(value) ? "Not recorded" : value;
     }
 }

--- a/InventoryManagementApp/ViewModels/ReservationEditViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ReservationEditViewModel.cs
@@ -112,10 +112,17 @@ namespace InventoryManagementApp.ViewModels
             }
 
             var matches = new List<ItemModel>();
-            await foreach (var item in _itemService.SearchItemsAsync(term, new ItemPage(1, 20), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken)
-                .WithCancellation(cancellationToken))
+            try
             {
-                matches.Add(item);
+                await foreach (var item in _itemService.SearchItemsAsync(term, new ItemPage(1, 20), SortField.Name, SortDirection.Ascending, cancellationToken: cancellationToken)
+                    .WithCancellation(cancellationToken))
+                {
+                    matches.Add(item);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                return;
             }
 
             foreach (var item in matches.OrderBy(i => i.ItemNumber).ThenBy(i => i.Name))

--- a/InventoryManagementApp/Views/Windows/RentItemPopupWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/RentItemPopupWindow.xaml
@@ -4,55 +4,121 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
         Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Rent {0}'}"
-        Width="760" Height="360" MinWidth="680" MinHeight="320"
+        Width="860" Height="520" MinWidth="780" MinHeight="460"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
     <DockPanel Margin="8">
         <Border DockPanel.Dock="Top" Style="{StaticResource ToolbarCard}">
             <DockPanel LastChildFill="True">
                 <TextBlock Text="Rent Item" Style="{StaticResource PageTitleTextBlock}" DockPanel.Dock="Left" Margin="0,0,12,0"/>
-                <TextBlock Text="Select the customer and due-back date before confirming the rental." Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center"/>
+                <TextBlock Text="Search the customer directory, confirm the collector, then set the due-back date." Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center"/>
             </DockPanel>
         </Border>
 
         <Border Style="{StaticResource Card}" Padding="0" Margin="0,0,0,8">
             <DockPanel LastChildFill="True">
                 <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
-                    <TextBlock Text="01 Rental Details" Style="{StaticResource SectionHeader}" Margin="0"/>
+                    <DockPanel LastChildFill="True">
+                        <TextBlock Text="01 Customer And Rental Details" Style="{StaticResource SectionHeader}" Margin="0" DockPanel.Dock="Left"/>
+                        <TextBlock Text="{Binding CustomerCountSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                    </DockPanel>
                 </Border>
 
                 <Grid Margin="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="8"/>
+                        <ColumnDefinition Width="300"/>
+                    </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="135"/>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
 
-                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Customer" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                    <ComboBox Grid.Row="0" Grid.Column="1"
-                              ItemsSource="{Binding Customers}"
-                              DisplayMemberPath="Company"
-                              SelectedItem="{Binding SelectedCustomer, Mode=TwoWay}"
-                              Margin="8,3"
-                              MinWidth="320"
-                              ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
-                    <Button Grid.Row="0" Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Add Customer" Command="{Binding AddCustomerCommand}" Margin="8,3,0,3"/>
+                    <Grid Grid.Row="0" Grid.Column="0" Margin="0,0,0,6">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="110"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="Find customer" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                        <TextBox Grid.Column="1"
+                                 Text="{Binding CustomerSearchText, UpdateSourceTrigger=PropertyChanged}"
+                                 Margin="8,0"
+                                 MinWidth="260"/>
+                        <Button Grid.Column="2" Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearCustomerSearchCommand}" Margin="0,0,6,0"/>
+                        <Button Grid.Column="3" Style="{StaticResource PrimaryButton}" Content="Add Customer" Command="{Binding AddCustomerCommand}"/>
+                    </Grid>
 
-                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Due Back" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                    <DatePicker Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2"
-                                SelectedDate="{Binding SelectedDueDate, Mode=TwoWay}"
-                                Margin="8,3"
-                                Width="160"
-                                HorizontalAlignment="Left"/>
-
-                    <Border Grid.Row="2" Grid.ColumnSpan="3" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="6" Margin="0,10,0,0">
-                        <TextBlock Text="Confirm only after the item has been physically picked or set aside for the customer." TextWrapping="Wrap"/>
+                    <Border Grid.Row="1" Grid.Column="0" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource ControlBackgroundBrush}">
+                        <ListBox ItemsSource="{Binding FilteredCustomers}"
+                                 SelectedItem="{Binding SelectedCustomer, Mode=TwoWay}"
+                                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                 ItemContainerStyle="{StaticResource DropdownItemStyle}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid Margin="2" MinHeight="52">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="190"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Row="0" Grid.Column="0" Text="{Binding Company}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Contact}" TextTrimming="CharacterEllipsis" Margin="8,0,0,0"/>
+                                        <TextBlock Grid.Row="1" Grid.Column="0" Text="{Binding Email}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Phone}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis" Margin="8,0,0,0"/>
+                                        <TextBlock Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding Address}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
                     </Border>
+
+                    <GridSplitter Grid.Row="0" Grid.RowSpan="2" Grid.Column="1" Width="8" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+
+                    <DockPanel Grid.Row="0" Grid.RowSpan="2" Grid.Column="2" LastChildFill="True">
+                        <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="8" Margin="0,0,0,8">
+                            <StackPanel>
+                                <TextBlock Text="02 Selected Customer" Style="{StaticResource SectionHeader}" Margin="0,0,0,6"/>
+                                <TextBlock Text="{Binding SelectedCustomerSummary}" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,0,0,6"/>
+                                <TextBlock Text="{Binding SelectedCustomerContactLine}" TextWrapping="Wrap" Margin="0,0,0,4"/>
+                                <TextBlock Text="{Binding SelectedCustomerAddressLine}" TextWrapping="Wrap" Style="{StaticResource CaptionTextBlock}"/>
+                            </StackPanel>
+                        </Border>
+
+                        <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="8" Margin="0,0,0,8">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="110"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Due Back" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                                <DatePicker Grid.Row="0" Grid.Column="1" SelectedDate="{Binding SelectedDueDate, Mode=TwoWay}" Margin="0,0,0,6"/>
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="Quick days" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                                <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal" Margin="0,0,0,6">
+                                    <Button Content="7" Command="{Binding SetRentalDaysCommand}" CommandParameter="7" Margin="0,0,4,0"/>
+                                    <Button Content="14" Command="{Binding SetRentalDaysCommand}" CommandParameter="14" Margin="0,0,4,0"/>
+                                    <Button Content="30" Command="{Binding SetRentalDaysCommand}" CommandParameter="30"/>
+                                </StackPanel>
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="Rental days" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                                <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding RentalDays, UpdateSourceTrigger=PropertyChanged}" Width="70" HorizontalAlignment="Left"/>
+                            </Grid>
+                        </Border>
+
+                        <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="8">
+                            <TextBlock Text="{Binding SelectedCustomerActionHint}" TextWrapping="Wrap"/>
+                        </Border>
+                    </DockPanel>
                 </Grid>
             </DockPanel>
         </Border>

--- a/InventoryManagementApp/Views/Windows/RentItemPopupWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/RentItemPopupWindow.xaml
@@ -54,8 +54,7 @@
                     <Border Grid.Row="1" Grid.Column="0" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource ControlBackgroundBrush}">
                         <ListBox ItemsSource="{Binding FilteredCustomers}"
                                  SelectedItem="{Binding SelectedCustomer, Mode=TwoWay}"
-                                 ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                 ItemContainerStyle="{StaticResource DropdownItemStyle}">
+                                 ScrollViewer.VerticalScrollBarVisibility="Auto">
                             <ListBox.ItemTemplate>
                                 <DataTemplate>
                                     <Grid Margin="2" MinHeight="52">

--- a/InventoryManagementApp/Views/Windows/ReservationEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ReservationEditWindow.xaml
@@ -3,10 +3,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
         Title="Reservation"
-        Width="720"
-        Height="500"
-        MinWidth="680"
-        MinHeight="460"
+        Width="780"
+        Height="560"
+        MinWidth="720"
+        MinHeight="520"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
     <Grid Margin="8">
@@ -65,6 +65,7 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="160"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
@@ -79,21 +80,61 @@
                     <TextBlock Grid.Row="1" Grid.Column="0" Text="Item Name" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
                     <TextBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding Reservation.ItemName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
 
-                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Customer" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding Reservation.CustomerName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+                    <Border Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="4" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="6" Margin="0,0,0,6">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="90"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Find item" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,4"/>
+                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ItemSearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,6,4"/>
+                            <Button Grid.Row="0" Grid.Column="2" Content="Clear" Command="{Binding ClearItemSearchCommand}" Margin="0,0,6,4"/>
+                            <Button Grid.Row="0" Grid.Column="3" Style="{StaticResource PrimaryButton}" Content="Apply" Command="{Binding ApplySelectedItemCommand}" Margin="0,0,0,4"/>
+                            <ListBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="4" ItemsSource="{Binding ItemSearchResults}" SelectedItem="{Binding SelectedSearchItem, Mode=TwoWay}" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid Margin="2">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="105"/>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="120"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Grid.Column="0" Text="{Binding ItemNumber}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                                            <TextBlock Grid.Column="1" Text="{Binding Name}" TextTrimming="CharacterEllipsis" Margin="8,0"/>
+                                            <TextBlock Grid.Column="2" Text="{Binding Location}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis"/>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                            <DockPanel Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="4" Margin="0,4,0,0">
+                                <TextBlock Text="{Binding ItemSearchSummary}" Style="{StaticResource CaptionTextBlock}" DockPanel.Dock="Left"/>
+                                <TextBlock Text="{Binding SelectedItemSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                            </DockPanel>
+                        </Grid>
+                    </Border>
 
-                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Start Date" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
-                    <DatePicker Grid.Row="3" Grid.Column="1" SelectedDate="{Binding Reservation.StartDate}" Margin="0,0,8,6"/>
-                    <TextBlock Grid.Row="3" Grid.Column="2" Text="End Date" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
-                    <DatePicker Grid.Row="3" Grid.Column="3" SelectedDate="{Binding Reservation.EndDate}" Margin="0,0,0,6"/>
+                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Customer" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding Reservation.CustomerName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
 
-                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Quantity" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Reservation.Quantity, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,6"/>
-                    <TextBlock Grid.Row="4" Grid.Column="2" Text="Rental ID" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="4" Grid.Column="3" Text="{Binding Reservation.RentalID, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Start Date" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
+                    <DatePicker Grid.Row="4" Grid.Column="1" SelectedDate="{Binding Reservation.StartDate}" Margin="0,0,8,6"/>
+                    <TextBlock Grid.Row="4" Grid.Column="2" Text="End Date" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
+                    <DatePicker Grid.Row="4" Grid.Column="3" SelectedDate="{Binding Reservation.EndDate}" Margin="0,0,0,6"/>
 
-                    <TextBlock Grid.Row="5" Grid.Column="0" Text="Notes" Style="{StaticResource LabelTextBlock}" Margin="0,2,8,0"/>
-                    <TextBox Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding Reservation.Notes, UpdateSourceTrigger=PropertyChanged}" AcceptsReturn="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" MinHeight="110"/>
+                    <TextBlock Grid.Row="5" Grid.Column="0" Text="Quantity" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Reservation.Quantity, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,6"/>
+                    <TextBlock Grid.Row="5" Grid.Column="2" Text="Rental ID" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,6" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="5" Grid.Column="3" Text="{Binding Reservation.RentalID, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+
+                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Notes" Style="{StaticResource LabelTextBlock}" Margin="0,2,8,0"/>
+                    <TextBox Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding Reservation.Notes, UpdateSourceTrigger=PropertyChanged}" AcceptsReturn="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" MinHeight="90"/>
                 </Grid>
             </Border>
         </Grid>

--- a/InventoryManagementApp/Views/Windows/ReservationEditWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/ReservationEditWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
 using InventoryManagementApp.Utilities.Extensions;
@@ -7,12 +8,13 @@ namespace InventoryManagementApp.Views.Windows
 {
     public partial class ReservationEditWindow : Window
     {
-        public ReservationEditWindow(Reservation reservation, bool isNew)
+        public ReservationEditWindow(Reservation reservation, bool isNew, IItemService? itemService = null)
         {
             InitializeComponent();
             DataContext = new ReservationEditViewModel(reservation, isNew,
                 onSave: () => DialogResult = true,
-                onCancel: () => DialogResult = false);
+                onCancel: () => DialogResult = false,
+                itemService);
             this.DisposeDataContextOnUnload();
         }
     }


### PR DESCRIPTION
## Summary

- Upgrades the rent popup from a plain customer dropdown to a searchable customer picker backed by the existing filtered customer collection.
- Adds customer selection review details, customer-count status, clear search, quick rental-day controls, and focused tests for mobile/address filtering, clearing, and confirm behavior.
- Adds item lookup inside the reservation editor popup so admin/advisor users can search inventory, select an item, and apply item number/name without leaving the popup.
- Routes the reservation editor through app services so it can receive `IItemService`, and adds view-model coverage for item search/apply behavior.
- Records the completed popup workflow enhancement in a progress note.

## Why

The markdown audit and user workflow notes called out incomplete popup flows, especially the inability to search records while entering item/tool details. Advisors renting an item and admins/advisors creating holds now get search-first, verify-then-confirm popup workflows.

## Validation

- Read back changed files through the GitHub connector and reviewed the focused diff against `master`.
- Confirmed local validation remains blocked in this scheduled container: `dotnet` and `gh` are not installed, and direct repository clone is blocked.
- Did not run unrelated tests, per user instruction.