### PR TITLE
Add admin settings service status panel

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-17-admin-settings-status-panel.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-admin-settings-status-panel.md
@@ -1,0 +1,20 @@
+# Admin Settings Status Panel
+
+Date: 2026-06-17 NZST
+
+## Completed
+
+- Added a new first Settings tab named `01 Service Status`.
+- Surfaced database, email, messaging, backup, branding, and security/workstation settings in one admin-facing snapshot.
+- Added the relevant action buttons beside each status group so admins can test DB/email, save email, save messaging, save backup, browse backup folders, and update/save the company logo without hunting through separate tabs.
+- Renumbered the existing Settings sections so the detailed edit tabs remain available after the new status tab.
+
+## Why it matters
+
+Admin users need Settings to work as an operations page, not only a set of isolated forms. The new status panel makes the current service state visible before an advisor or technician relies on reminders, backups, branding, or workstation security behavior.
+
+## Validation limits
+
+- Local WPF rendering and screenshot capture are still blocked in this scheduled Linux container because the app requires a Windows/WPF runtime.
+- Local .NET build/test validation is still blocked because `dotnet` is not installed.
+- The QA screenshot runner should be adjusted in a follow-up to name the first Settings capture as service status and include the new final Backups tab after the tab order change.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-16 23:48 NZST
+Last audit date/time: 2026-06-17 00:11 NZST
 
 ## Completed workflows
 
@@ -9,6 +9,7 @@ Last audit date/time: 2026-06-16 23:48 NZST
 - Reservation editor supports item lookup inside the popup so advisors/admins can search inventory and apply item details without leaving the workflow.
 - Reports ViewModel now keeps `ReportResults` as a compatibility alias for `ReportLines`, protecting older tests/bindings while the reports page uses the newer dense report grid.
 - Item edit saves now clone all operational fields, show clear validation/database failure messages, and keep the selected row stable when a save fails.
+- Settings now opens with an admin service status panel that summarizes database, email, messaging, backup, branding, and workstation security state with the relevant action buttons available from the same view.
 - QA screenshot capture now has a repository script and latest screenshot set covering login, overview/search, operational pages, reports/activity, import/export, users, settings, and print-label dialog surfaces; the script now fails if the expected PNG count is not produced.
 
 ## Partially complete workflows
@@ -17,6 +18,7 @@ Last audit date/time: 2026-06-16 23:48 NZST
 - Checkout/check-in refresh behavior was improved in the prior audit, but broader runtime UI review is still pending.
 - Customer CSV import already uses a transaction, but customer workflow coverage still needs broader review.
 - Reports page has a compact operational grid, summary panel, print/copy actions, and safe empty unknown-report handling; runtime screenshot and full report generation checks remain pending.
+- Settings now has a service-status landing tab, but the QA screenshot runner should be updated to name that first settings capture correctly and include the final Backups tab after the tab order change.
 
 ## Known broken workflows
 
@@ -26,11 +28,11 @@ Last audit date/time: 2026-06-16 23:48 NZST
 
 ## Next recommended target
 
-- Run the .NET build/test and QA screenshot script on a Windows/.NET workstation, then use the generated screenshots to target any remaining visual or navigation defects.
+- Adjust the QA screenshot runner's Settings tab capture sequence for the new service-status tab, then run the .NET build/test and QA screenshot script on a Windows/.NET workstation.
 
 ## Validation status
 
-- GitHub connector readback reviewed the item edit save code, new regression test, screenshot runner, and completion checklist on `master`.
+- GitHub connector readback reviewed the Settings page update, progress note, and completion checklist on the branch.
 - `dotnet --info`: failed because `dotnet` is not installed in this scheduled container.
 - `dotnet restore InventoryManagementApp.sln`: not run because the .NET SDK is unavailable.
 - `dotnet build InventoryManagementApp.sln --no-restore`: not run because the .NET SDK is unavailable.

--- a/InventoryManagementApp/Views/Pages/SettingsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/SettingsPage.xaml
@@ -21,7 +21,7 @@
                     <Button Style="{StaticResource PrimaryButton}" Content="Save Backup" Command="{Binding SaveBackupSettingsCommand}"/>
                 </StackPanel>
                 <TextBlock DockPanel.Dock="Right"
-                           Text="Settings apply to local workstation behavior and shared service configuration."
+                           Text="Admin service setup, workstation branding, security timing, and reminder channels."
                            Style="{StaticResource CaptionTextBlock}"
                            VerticalAlignment="Center"/>
             </DockPanel>
@@ -29,7 +29,133 @@
 
         <TabControl Grid.Row="1"
                     Style="{StaticResource DesktopSectionListTabControl}">
-            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="01 Database">
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="01 Service Status">
+                <Border Style="{StaticResource DesktopContentPane}">
+                    <DockPanel>
+                        <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
+                            <DockPanel LastChildFill="False">
+                                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
+                                    <TextBlock Text="Admin Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Test DB" Command="{Binding TestDbCommand}" Margin="0,0,4,0"/>
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Test Email" Command="{Binding TestEmailCommand}" Margin="0,0,4,0"/>
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Save Email" Command="{Binding SaveEmailSettingsCommand}" Margin="0,0,4,0"/>
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Save Messaging" Command="{Binding SaveMessagingSettingsCommand}" Margin="0,0,4,0"/>
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Save Backup" Command="{Binding SaveBackupSettingsCommand}"/>
+                                </StackPanel>
+                                <TextBlock DockPanel.Dock="Right" Text="Current configuration snapshot" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center"/>
+                            </DockPanel>
+                        </Border>
+
+                        <Grid Margin="0,8,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="2*"/>
+                                <ColumnDefinition Width="2*"/>
+                                <ColumnDefinition Width="2*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
+                            <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource SurfaceAltBrush}" Padding="8" Margin="0,0,6,6">
+                                <StackPanel>
+                                    <TextBlock Text="Database" Style="{StaticResource PageTitleTextBlock}"/>
+                                    <TextBlock Text="Connection" Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,4"/>
+                                    <TextBlock Text="{Binding ConnectionString}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"/>
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Test Connection" Command="{Binding TestDbCommand}" HorizontalAlignment="Left" Margin="0,8,0,0"/>
+                                </StackPanel>
+                            </Border>
+
+                            <Border Grid.Column="1" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource SurfaceAltBrush}" Padding="8" Margin="0,0,6,6">
+                                <StackPanel>
+                                    <TextBlock Text="Email" Style="{StaticResource PageTitleTextBlock}"/>
+                                    <TextBlock Text="Reminder channel" Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,4"/>
+                                    <UniformGrid Columns="2">
+                                        <TextBlock Text="Enabled" Style="{StaticResource LabelTextBlock}"/>
+                                        <TextBlock Text="{Binding EmailEnabled}"/>
+                                        <TextBlock Text="Provider" Style="{StaticResource LabelTextBlock}"/>
+                                        <TextBlock Text="{Binding SelectedEmailProvider}"/>
+                                        <TextBlock Text="SMTP" Style="{StaticResource LabelTextBlock}"/>
+                                        <TextBlock Text="{Binding SmtpHost}" TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Text="Port" Style="{StaticResource LabelTextBlock}"/>
+                                        <TextBlock Text="{Binding SmtpPort}"/>
+                                        <TextBlock Text="Sender" Style="{StaticResource LabelTextBlock}"/>
+                                        <TextBlock Text="{Binding FromEmail}" TextTrimming="CharacterEllipsis"/>
+                                    </UniformGrid>
+                                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                        <Button Style="{StaticResource PrimaryButton}" Content="Test" Command="{Binding TestEmailCommand}" Margin="0,0,4,0"/>
+                                        <Button Style="{StaticResource PrimaryButton}" Content="Save" Command="{Binding SaveEmailSettingsCommand}"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+
+                            <Border Grid.Column="2" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource SurfaceAltBrush}" Padding="8" Margin="0,0,0,6">
+                                <StackPanel>
+                                    <TextBlock Text="Messaging" Style="{StaticResource PageTitleTextBlock}"/>
+                                    <TextBlock Text="SMS reminder channel" Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,4"/>
+                                    <UniformGrid Columns="2">
+                                        <TextBlock Text="Provider" Style="{StaticResource LabelTextBlock}"/>
+                                        <TextBlock Text="{Binding SelectedSmsProvider}"/>
+                                        <TextBlock Text="Sender" Style="{StaticResource LabelTextBlock}"/>
+                                        <TextBlock Text="{Binding SmsSender}" TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Text="API Key" Style="{StaticResource LabelTextBlock}"/>
+                                        <TextBlock Text="Configured in secure field"/>
+                                    </UniformGrid>
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Save Messaging" Command="{Binding SaveMessagingSettingsCommand}" HorizontalAlignment="Left" Margin="0,8,0,0"/>
+                                </StackPanel>
+                            </Border>
+
+                            <Border Grid.Row="1" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource SurfaceAltBrush}" Padding="8" Margin="0,0,6,0">
+                                <StackPanel>
+                                    <TextBlock Text="Backup" Style="{StaticResource PageTitleTextBlock}"/>
+                                    <TextBlock Text="Export and recovery folder" Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,4"/>
+                                    <TextBlock Text="{Binding BackupDirectory}" TextWrapping="Wrap"/>
+                                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                        <Button Style="{StaticResource PrimaryButton}" Content="Browse" Command="{Binding BrowseBackupDirectoryCommand}" Margin="0,0,4,0"/>
+                                        <Button Style="{StaticResource PrimaryButton}" Content="Save" Command="{Binding SaveBackupSettingsCommand}"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+
+                            <Border Grid.Row="1" Grid.Column="1" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource SurfaceAltBrush}" Padding="8" Margin="0,0,6,0">
+                                <StackPanel>
+                                    <TextBlock Text="Branding" Style="{StaticResource PageTitleTextBlock}"/>
+                                    <TextBlock Text="Window title and logo" Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,4"/>
+                                    <UniformGrid Columns="2">
+                                        <TextBlock Text="App" Style="{StaticResource LabelTextBlock}"/>
+                                        <TextBlock Text="{Binding ApplicationName}" TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Text="Logo" Style="{StaticResource LabelTextBlock}"/>
+                                        <TextBlock Text="{Binding CompanyLogoPath}" TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Text="Theme" Style="{StaticResource LabelTextBlock}"/>
+                                        <TextBlock Text="{Binding Theme}"/>
+                                    </UniformGrid>
+                                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                        <Button Style="{StaticResource PrimaryButton}" Content="Change Logo" Command="{Binding BrowseCompanyLogoCommand}" Margin="0,0,4,0"/>
+                                        <Button Style="{StaticResource PrimaryButton}" Content="Save Logo" Command="{Binding SaveCompanyLogoCommand}"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+
+                            <Border Grid.Row="1" Grid.Column="2" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource SurfaceAltBrush}" Padding="8">
+                                <StackPanel>
+                                    <TextBlock Text="Security" Style="{StaticResource PageTitleTextBlock}"/>
+                                    <TextBlock Text="Workstation access timing" Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,4"/>
+                                    <UniformGrid Columns="2">
+                                        <TextBlock Text="Password Iterations" Style="{StaticResource LabelTextBlock}"/>
+                                        <TextBlock Text="{Binding PasswordIterations}"/>
+                                        <TextBlock Text="Auto Logout" Style="{StaticResource LabelTextBlock}"/>
+                                        <TextBlock Text="{Binding AutoLogoutMinutes, StringFormat={}{0} minutes}"/>
+                                        <TextBlock Text="Item Card Size" Style="{StaticResource LabelTextBlock}"/>
+                                        <TextBlock Text="{Binding ItemCardSize, StringFormat={}{0:0.0}x}"/>
+                                    </UniformGrid>
+                                </StackPanel>
+                            </Border>
+                        </Grid>
+                    </DockPanel>
+                </Border>
+            </TabItem>
+
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="02 Database">
                 <Border Style="{StaticResource DesktopContentPane}">
                     <DockPanel>
                         <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
@@ -50,7 +176,7 @@
                 </Border>
             </TabItem>
 
-            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="02 General">
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="03 General">
                 <Border Style="{StaticResource DesktopContentPane}">
                     <Grid Style="{StaticResource DesktopSettingsForm}">
                         <Grid.ColumnDefinitions>
@@ -78,7 +204,7 @@
                 </Border>
             </TabItem>
 
-            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="03 Item Display">
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="04 Item Display">
                 <Border Style="{StaticResource DesktopContentPane}">
                     <DockPanel>
                         <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
@@ -101,7 +227,7 @@
                 </Border>
             </TabItem>
 
-            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="04 Email">
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="05 Email">
                 <Border Style="{StaticResource DesktopContentPane}">
                     <DockPanel>
                         <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
@@ -162,7 +288,7 @@
                 </Border>
             </TabItem>
 
-            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="05 Branding">
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="06 Branding">
                 <Border Style="{StaticResource DesktopContentPane}">
                     <Grid Style="{StaticResource DesktopSettingsForm}">
                         <Grid.ColumnDefinitions>
@@ -190,7 +316,7 @@
                 </Border>
             </TabItem>
 
-            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="06 Messaging">
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="07 Messaging">
                 <Border Style="{StaticResource DesktopContentPane}">
                     <DockPanel>
                         <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
@@ -220,7 +346,7 @@
                 </Border>
             </TabItem>
 
-            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="07 Backups">
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="08 Backups">
                 <Border Style="{StaticResource DesktopContentPane}">
                     <DockPanel>
                         <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">


### PR DESCRIPTION
## Summary

- Adds a new first Settings tab, `01 Service Status`, that gives admins a single operational snapshot for database, email, messaging, backup, branding, and security/workstation settings.
- Places the relevant action buttons beside each status group so admins can test DB/email, save email/messaging/backup settings, browse backup folders, and change/save the company logo without hunting through separate tabs.
- Renumbers the existing Settings tabs and records the completed work plus the screenshot-runner follow-up in progress notes.

## Why

The user asked for remaining functions to be finished end to end from a real technician/advisor/admin perspective. Settings was still a set of scattered configuration forms; admins had to know which tab held the needed action. This makes Settings open as an operations panel with the current state and next action visible immediately.

## Validation

- Reviewed the branch diff against `master` through the GitHub connector.
- Read back the changed Settings XAML and progress notes from the branch.
- Local .NET build/test and WPF screenshot validation remain blocked in this scheduled Linux container because `dotnet`, `gh`, and a Windows/WPF runtime are unavailable, and direct GitHub clone/raw fetches are blocked by the network tunnel.
- Did not run unrelated tests, per instruction.