### PR TITLE
Fix settings QA screenshot coverage

### DIFF
--- a/InventoryManagementApp/App.xaml.cs
+++ b/InventoryManagementApp/App.xaml.cs
@@ -67,7 +67,7 @@ namespace InventoryManagementApp
                 { 
                     Log.Error(e.Exception, "Unobserved task exception"); 
                 } 
-                catch (Exception logEx) 
+                catch (Exception logEx)
                 { 
                     // Fallback if logging fails - write to debug output
                     System.Diagnostics.Debug.WriteLine($"Failed to log unobserved exception: {logEx.Message}");
@@ -555,8 +555,8 @@ namespace InventoryManagementApp
             await CapturePageAsync(mainWindow, mainViewModel.OpenImportExportCommand.ExecuteAsync(null), Path.Combine(dataDir, "01-import-export.png"), runLogPath, "Import export");
 
             await CapturePageAsync(mainWindow, mainViewModel.OpenUsersCommand.ExecuteAsync(null), Path.Combine(adminDir, "01-users.png"), runLogPath, "Users");
-            await CapturePageAsync(mainWindow, mainViewModel.OpenSettingsCommand.ExecuteAsync(null), Path.Combine(adminDir, "02-settings-database.png"), runLogPath, "Settings database");
-            for (var tabIndex = 1; tabIndex <= 6; tabIndex++)
+            await CapturePageAsync(mainWindow, mainViewModel.OpenSettingsCommand.ExecuteAsync(null), Path.Combine(adminDir, "02-settings-service-status.png"), runLogPath, "Settings service status");
+            for (var tabIndex = 1; tabIndex <= 7; tabIndex++)
             {
                 await CaptureSelectedTabPageAsync(
                     mainWindow,
@@ -589,12 +589,13 @@ namespace InventoryManagementApp
 
         static string GetSettingsTabSlug(int tabIndex) => tabIndex switch
         {
-            1 => "general",
-            2 => "item-display",
-            3 => "email",
-            4 => "branding",
-            5 => "messaging",
-            6 => "backups",
+            1 => "database",
+            2 => "general",
+            3 => "item-display",
+            4 => "email",
+            5 => "branding",
+            6 => "messaging",
+            7 => "backups",
             _ => $"tab-{tabIndex + 1:00}"
         };
 

--- a/InventoryManagementApp/ProgressNotes/2026-06-17-settings-qa-screenshot-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-settings-qa-screenshot-coverage.md
@@ -1,0 +1,17 @@
+# Settings QA Screenshot Coverage - 2026-06-17
+
+## Completed
+
+- Updated the in-app QA screenshot harness so the first Settings capture is named `02-settings-service-status.png`, matching the new admin service-status landing tab.
+- Extended the Settings capture loop through tab index 7 so the run captures Database, General, Item Display, Email, Branding, Messaging, and Backups after the service-status tab.
+- Kept the PowerShell wrapper's expected screenshot count at 28, which now maps to the expanded Settings coverage rather than the stale pre-service-status sequence.
+- Updated the completion checklist so the next audit knows Settings screenshot coverage has been adjusted.
+
+## Why it matters
+
+Admins now have service status as the first Settings view, so screenshot review needs to prove that landing panel and every underlying configuration tab can still be reached. This keeps the QA run aligned with the actual admin flow instead of missing the final Settings page after the tab order changed.
+
+## Validation
+
+- Read back the changed branch files through the GitHub connector.
+- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not include the .NET SDK or a Windows/WPF runtime, and direct cloning remains blocked by the network tunnel.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 00:11 NZST
+Last audit date/time: 2026-06-17 01:11 NZST
 
 ## Completed workflows
 
@@ -10,7 +10,8 @@ Last audit date/time: 2026-06-17 00:11 NZST
 - Reports ViewModel now keeps `ReportResults` as a compatibility alias for `ReportLines`, protecting older tests/bindings while the reports page uses the newer dense report grid.
 - Item edit saves now clone all operational fields, show clear validation/database failure messages, and keep the selected row stable when a save fails.
 - Settings now opens with an admin service status panel that summarizes database, email, messaging, backup, branding, and workstation security state with the relevant action buttons available from the same view.
-- QA screenshot capture now has a repository script and latest screenshot set covering login, overview/search, operational pages, reports/activity, import/export, users, settings, and print-label dialog surfaces; the script now fails if the expected PNG count is not produced.
+- QA screenshot capture now has a repository script and latest screenshot set covering login, overview/search, operational pages, reports/activity, import/export, users, settings, and print-label dialog surfaces; the script fails if the expected PNG count is not produced.
+- QA screenshot capture now names the first Settings capture as service status and walks every Settings tab through Backups after the service-status tab was added.
 
 ## Partially complete workflows
 
@@ -18,7 +19,6 @@ Last audit date/time: 2026-06-17 00:11 NZST
 - Checkout/check-in refresh behavior was improved in the prior audit, but broader runtime UI review is still pending.
 - Customer CSV import already uses a transaction, but customer workflow coverage still needs broader review.
 - Reports page has a compact operational grid, summary panel, print/copy actions, and safe empty unknown-report handling; runtime screenshot and full report generation checks remain pending.
-- Settings now has a service-status landing tab, but the QA screenshot runner should be updated to name that first settings capture correctly and include the final Backups tab after the tab order change.
 
 ## Known broken workflows
 
@@ -28,11 +28,11 @@ Last audit date/time: 2026-06-17 00:11 NZST
 
 ## Next recommended target
 
-- Adjust the QA screenshot runner's Settings tab capture sequence for the new service-status tab, then run the .NET build/test and QA screenshot script on a Windows/.NET workstation.
+- Continue the end-to-end workflow audit from a technician/advisor/admin perspective, with the next useful pass focused on runtime screenshot review on a Windows/.NET workstation and any missing actions discovered there.
 
 ## Validation status
 
-- GitHub connector readback reviewed the Settings page update, progress note, and completion checklist on the branch.
+- GitHub connector readback reviewed the Settings QA screenshot harness update, screenshot wrapper, progress note, and completion checklist on the branch.
 - `dotnet --info`: failed because `dotnet` is not installed in this scheduled container.
 - `dotnet restore InventoryManagementApp.sln`: not run because the .NET SDK is unavailable.
 - `dotnet build InventoryManagementApp.sln --no-restore`: not run because the .NET SDK is unavailable.


### PR DESCRIPTION
## Summary

- Renames the first Settings QA capture to `02-settings-service-status.png` so it matches the new admin service-status landing tab.
- Extends the Settings screenshot loop through the Backups tab after the new tab order, covering Database, General, Item Display, Email, Branding, Messaging, and Backups.
- Updates the app completion checklist and adds a dated progress note for the screenshot coverage fix.

## Why

The Settings UI now starts with an admin service-status panel. The QA harness still treated the first Settings capture as Database and stopped before the shifted final Backups tab, so screenshot review could miss an admin configuration surface.

## Validation

- Compared the branch against `master` through the GitHub connector.
- Read back the changed `App.xaml.cs`, screenshot wrapper, checklist, and progress note from the branch.
- Local build/test and WPF screenshot execution were not run because this scheduled Linux container has no .NET SDK or Windows/WPF runtime, and direct cloning remains blocked by the network tunnel.
- Did not run unrelated tests, per instruction.