### PR TITLE
Upgrade import export workflow workstation

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-17-import-export-workstation.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-import-export-workstation.md
@@ -1,0 +1,20 @@
+# Import / Export Workstation Upgrade - 2026-06-17
+
+## Completed
+
+- Converted `ImportExportPage` from a sparse button/log view into a compact desktop data workstation.
+- Added separate left-navigation sections for overview, item data exchange, customer exchange, backup/image admin work, and the operation run log.
+- Kept the common advisor/admin actions visible in the top toolbar: item import/export, customer import/export, database backup, and active import cancellation.
+- Added operator guidance and status summaries for item data, customer data, image import availability, database backup, and current run state.
+- Made import/export log rows selectable and actionable with double-click detail, right-click selection, copy selected row, print current log, and clear log actions.
+- Updated `ImportExportViewModel` so operation log state has selected-row detail, count/status summaries, and a clear command.
+- Hardened `scripts/run-app-qa-screenshots.ps1` so QA screenshot runs must include every expected screenshot folder and append the captured file list to the run README.
+
+## Why it matters
+
+The data page is now usable as an end-to-end admin/advisor handoff surface rather than just a launch pad for file dialogs. A user can see what each operation does, run the right action, review the exact result, copy it for follow-up, and print a run log after bulk import/export work.
+
+## Validation
+
+- GitHub connector readback should be used to confirm the changed XAML/code-behind/viewmodel/script on the branch.
+- Local `dotnet` build/test and WPF screenshot execution remain blocked in this scheduled Linux container because the .NET SDK, Windows WPF runtime, `gh`, and direct local clone are unavailable.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 01:11 NZST
+Last audit date/time: 2026-06-17 02:11 NZST
 
 ## Completed workflows
 
@@ -12,6 +12,9 @@ Last audit date/time: 2026-06-17 01:11 NZST
 - Settings now opens with an admin service status panel that summarizes database, email, messaging, backup, branding, and workstation security state with the relevant action buttons available from the same view.
 - QA screenshot capture now has a repository script and latest screenshot set covering login, overview/search, operational pages, reports/activity, import/export, users, settings, and print-label dialog surfaces; the script fails if the expected PNG count is not produced.
 - QA screenshot capture now names the first Settings capture as service status and walks every Settings tab through Backups after the service-status tab was added.
+- Import / Export now uses a compact data workstation layout with separate sections for item data, customer data, backup/image admin work, and run-log review.
+- Import / Export operation logs now support selected-row detail, copy, print, clear, double-click drilldown, and row-correct right-click actions.
+- QA screenshot wrapper validation now requires every expected screenshot folder to contain PNG output and appends the captured file list to the run README.
 
 ## Partially complete workflows
 
@@ -19,6 +22,7 @@ Last audit date/time: 2026-06-17 01:11 NZST
 - Checkout/check-in refresh behavior was improved in the prior audit, but broader runtime UI review is still pending.
 - Customer CSV import already uses a transaction, but customer workflow coverage still needs broader review.
 - Reports page has a compact operational grid, summary panel, print/copy actions, and safe empty unknown-report handling; runtime screenshot and full report generation checks remain pending.
+- Import / Export has been redesigned and wired for log actions, but runtime file-dialog, print, and screenshot checks still need a Windows/.NET workstation.
 
 ## Known broken workflows
 
@@ -32,7 +36,7 @@ Last audit date/time: 2026-06-17 01:11 NZST
 
 ## Validation status
 
-- GitHub connector readback reviewed the Settings QA screenshot harness update, screenshot wrapper, progress note, and completion checklist on the branch.
+- GitHub connector readback reviewed the Import / Export workstation branch files, screenshot wrapper, progress note, and completion checklist.
 - `dotnet --info`: failed because `dotnet` is not installed in this scheduled container.
 - `dotnet restore InventoryManagementApp.sln`: not run because the .NET SDK is unavailable.
 - `dotnet build InventoryManagementApp.sln --no-restore`: not run because the .NET SDK is unavailable.

--- a/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
@@ -36,8 +36,48 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand ImportCustomersCommand { get; }
         public IAsyncRelayCommand ExportCustomersCommand { get; }
         public IAsyncRelayCommand OpenImageImportMappingWindowCommand { get; }
+        public IRelayCommand ClearImportExportLogsCommand { get; }
 
         public bool IsCurrentUserAdmin => _userContext.IsAdmin;
+        public bool HasLogEntries => ImportExportLogs.Count > 0;
+        public string LogSummary => HasLogEntries
+            ? $"{ImportExportLogs.Count} operation log entr{(ImportExportLogs.Count == 1 ? "y" : "ies")} recorded this session."
+            : "No import, export, image, or backup operations have been run in this session.";
+
+        public string ItemDataSummary =>
+            $"Import {LabelProvider.Instance.ItemLabelPlural} from CSV with mapping, JSON, or XML. Export the current item catalog to CSV, JSON, or XML.";
+
+        public string CustomerDataSummary =>
+            "Import customers from mapped CSV, JSON, or XML. Export the customer directory to CSV, JSON, or XML for advisor handoff or cleanup.";
+
+        public string ImageImportSummary => IsCurrentUserAdmin
+            ? $"Admin image import is available for matching photos to {LabelProvider.Instance.ItemLabelPlural}."
+            : $"Image import is admin-only. Ask an admin to map photos to {LabelProvider.Instance.ItemLabelPlural}.";
+
+        public string BackupSummary =>
+            "Create a database backup before large imports, bulk cleanup, or workstation changes.";
+
+        private string? _selectedImportExportLog;
+        public string? SelectedImportExportLog
+        {
+            get => _selectedImportExportLog;
+            set
+            {
+                if (SetProperty(ref _selectedImportExportLog, value))
+                {
+                    OnPropertyChanged(nameof(SelectedLogTitle));
+                    OnPropertyChanged(nameof(SelectedLogDetail));
+                }
+            }
+        }
+
+        public string SelectedLogTitle => string.IsNullOrWhiteSpace(SelectedImportExportLog)
+            ? "No operation selected"
+            : "Selected operation";
+
+        public string SelectedLogDetail => string.IsNullOrWhiteSpace(SelectedImportExportLog)
+            ? "Run an import, export, image import, or backup action. Select a log row to copy or print the exact result."
+            : SelectedImportExportLog;
 
         /// <summary>
         /// Command that triggers an asynchronous database backup.
@@ -74,8 +114,17 @@ namespace InventoryManagementApp.ViewModels
             _logger = logger ?? NullLogger<ImportExportViewModel>.Instance;
             OpenImageImportMappingWindowCommand = openImageImportMappingWindowCommand ?? new AsyncRelayCommand(ct => Task.CompletedTask);
             _userContext = userContext ?? new DummyUserContext();
-            _userContext.UserChanged += (_, _) => OnPropertyChanged(nameof(IsCurrentUserAdmin));
+            _userContext.UserChanged += (_, _) =>
+            {
+                OnPropertyChanged(nameof(IsCurrentUserAdmin));
+                OnPropertyChanged(nameof(ImageImportSummary));
+            };
             _rentalConfigService = rentalConfigService;
+            ImportExportLogs.CollectionChanged += (_, _) =>
+            {
+                OnPropertyChanged(nameof(HasLogEntries));
+                OnPropertyChanged(nameof(LogSummary));
+            };
             
             // Initialize importers and exporters
             _itemImporters = new List<IDataImporter<ItemModel>>
@@ -107,6 +156,7 @@ namespace InventoryManagementApp.ViewModels
             ImportCustomersCommand = new AsyncRelayCommand(ct => ImportCustomersAsync(ct));
             ExportCustomersCommand = new AsyncRelayCommand(ct => ExportCustomersAsync(ct));
             BackupDatabaseCommand = new AsyncRelayCommand(ct => BackupDatabaseAsync(ct));
+            ClearImportExportLogsCommand = new RelayCommand(ClearImportExportLogs, () => HasLogEntries);
         }
 
         private sealed class DummyUserContext : IUserContext
@@ -127,6 +177,20 @@ namespace InventoryManagementApp.ViewModels
             public bool IsAdmin => false;
             public string UserName => string.Empty;
             public string Role => string.Empty;
+        }
+
+        void AddLog(string message)
+        {
+            ImportExportLogs.Add(message);
+            SelectedImportExportLog = message;
+            ClearImportExportLogsCommand.NotifyCanExecuteChanged();
+        }
+
+        void ClearImportExportLogs()
+        {
+            ImportExportLogs.Clear();
+            SelectedImportExportLog = null;
+            ClearImportExportLogsCommand.NotifyCanExecuteChanged();
         }
 
         async Task ImportItemsAsync(CancellationToken cancellationToken)
@@ -165,7 +229,7 @@ namespace InventoryManagementApp.ViewModels
                     {
                         var singular = LabelProvider.Instance.ItemLabelSingular;
                         var errorMessage = $"Mapping for {singular} number is required.";
-                        ImportExportLogs.Add(errorMessage);
+                        AddLog(errorMessage);
                         _logger.LogWarning("Import aborted: missing {ItemLabelSingular} number mapping", singular);
                         await _dialogService.ShowInfoAsync(errorMessage, $"Import {plural}");
                         return;
@@ -181,7 +245,7 @@ namespace InventoryManagementApp.ViewModels
                     if (importer == null)
                     {
                         var errorMessage = $"No importer found for file type: {extension}";
-                        ImportExportLogs.Add(errorMessage);
+                        AddLog(errorMessage);
                         await _dialogService.ShowInfoAsync(errorMessage, $"Import {plural}");
                         return;
                     }
@@ -191,11 +255,11 @@ namespace InventoryManagementApp.ViewModels
                 }
                 
                 var successMessage = $"Successfully imported {plural} from {path}.";
-                ImportExportLogs.Add(successMessage);
+                AddLog(successMessage);
                 if (skippedRows.Any())
                 {
                     var skippedMessage = $"Skipped rows: {string.Join(", ", skippedRows)}";
-                    ImportExportLogs.Add(skippedMessage);
+                    AddLog(skippedMessage);
                     successMessage += $" {skippedMessage}";
                 }
                 await _dialogService.ShowInfoAsync(successMessage, $"Import {plural}");
@@ -203,14 +267,14 @@ namespace InventoryManagementApp.ViewModels
             catch (OperationCanceledException)
             {
                 var plural = LabelProvider.Instance.ItemLabelPlural;
-                ImportExportLogs.Add($"{plural} import was cancelled.");
+                AddLog($"{plural} import was cancelled.");
                 await _dialogService.ShowInfoAsync($"{plural} import was cancelled.", $"Import {plural}");
             }
             catch (Exception ex)
             {
                 var plural = LabelProvider.Instance.ItemLabelPlural;
                 _logger.LogError(ex, "Failed to import {ItemLabelPlural} from {Path}", plural, path);
-                ImportExportLogs.Add($"Failed to import {plural} from {path}: {ex.Message}");
+                AddLog($"Failed to import {plural} from {path}: {ex.Message}");
                 await _dialogService.ShowInfoAsync($"Failed to import {plural} from {path}: {ex.Message}", $"Import {plural}");
             }
         }
@@ -234,23 +298,23 @@ namespace InventoryManagementApp.ViewModels
                 if (exporter == null)
                 {
                     var errorMessage = $"No exporter found for file type: {extension}";
-                    ImportExportLogs.Add(errorMessage);
+                    AddLog(errorMessage);
                     return;
                 }
                 
                 await _itemService.ExportItemsAsync(path, exporter, cancellationToken);
-                ImportExportLogs.Add($"Successfully exported {plural} to {path} ({exporter.FormatName} format).");
+                AddLog($"Successfully exported {plural} to {path} ({exporter.FormatName} format).");
             }
             catch (OperationCanceledException)
             {
                 var plural = LabelProvider.Instance.ItemLabelPlural;
-                ImportExportLogs.Add($"{plural} export was cancelled.");
+                AddLog($"{plural} export was cancelled.");
             }
             catch (Exception ex)
             {
                 var plural = LabelProvider.Instance.ItemLabelPlural;
                 _logger.LogError(ex, "Failed to export {ItemLabelPlural} to {Path}", plural, path);
-                ImportExportLogs.Add($"Failed to export {plural} to {path}: {ex.Message}");
+                AddLog($"Failed to export {plural} to {path}: {ex.Message}");
             }
         }
 
@@ -279,9 +343,9 @@ namespace InventoryManagementApp.ViewModels
                     if (map == null)
                         return;
                     var result = await _customerService.ImportCustomersFromCsvAsync(path, map, cancellationToken);
-                    ImportExportLogs.Add($"Successfully imported customers from {path}. Imported {result.ImportedCount} customers.");
+                    AddLog($"Successfully imported customers from {path}. Imported {result.ImportedCount} customers.");
                     foreach (var msg in result.SkippedRows)
-                        ImportExportLogs.Add($"Skipped {msg}");
+                        AddLog($"Skipped {msg}");
                 }
                 else
                 {
@@ -290,23 +354,23 @@ namespace InventoryManagementApp.ViewModels
                     if (importer == null)
                     {
                         var errorMessage = $"No importer found for file type: {extension}";
-                        ImportExportLogs.Add(errorMessage);
+                        AddLog(errorMessage);
                         await _dialogService.ShowInfoAsync(errorMessage, "Import Customers");
                         return;
                     }
                     
                     var importedCount = await _customerService.ImportCustomersAsync(path, importer, cancellationToken);
-                    ImportExportLogs.Add($"Successfully imported {importedCount} customers from {path} ({importer.FormatName} format).");
+                    AddLog($"Successfully imported {importedCount} customers from {path} ({importer.FormatName} format).");
                 }
             }
             catch (OperationCanceledException)
             {
-                ImportExportLogs.Add("Customer import was cancelled.");
+                AddLog("Customer import was cancelled.");
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to import customers from {Path}", path);
-                ImportExportLogs.Add($"Failed to import customers from {path}: {ex.Message}");
+                AddLog($"Failed to import customers from {path}: {ex.Message}");
             }
         }
 
@@ -328,21 +392,21 @@ namespace InventoryManagementApp.ViewModels
                 if (exporter == null)
                 {
                     var errorMessage = $"No exporter found for file type: {extension}";
-                    ImportExportLogs.Add(errorMessage);
+                    AddLog(errorMessage);
                     return;
                 }
                 
                 await _customerService.ExportCustomersAsync(path, exporter, cancellationToken);
-                ImportExportLogs.Add($"Successfully exported customers to {path} ({exporter.FormatName} format).");
+                AddLog($"Successfully exported customers to {path} ({exporter.FormatName} format).");
             }
             catch (OperationCanceledException)
             {
-                ImportExportLogs.Add("Customer export was cancelled.");
+                AddLog("Customer export was cancelled.");
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to export customers to {Path}", path);
-                ImportExportLogs.Add($"Failed to export customers to {path}: {ex.Message}");
+                AddLog($"Failed to export customers to {path}: {ex.Message}");
             }
         }
 
@@ -364,16 +428,16 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 await _databaseService.BackupDatabaseAsync(path, cancellationToken);
-                ImportExportLogs.Add($"Successfully backed up database to {path}.");
+                AddLog($"Successfully backed up database to {path}.");
             }
             catch (OperationCanceledException)
             {
-                ImportExportLogs.Add("Database backup was cancelled.");
+                AddLog("Database backup was cancelled.");
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to backup database to {Path}", path);
-                ImportExportLogs.Add($"Failed to backup database to {path}: {ex.Message}");
+                AddLog($"Failed to backup database to {path}: {ex.Message}");
             }
         }
     }

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml
@@ -8,64 +8,293 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Style="{StaticResource Card}">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-
-                <!-- Items -->
-                <StackPanel Grid.Column="0" Margin="0,0,6,0">
-                    <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}" Style="{StaticResource SectionHeader}" />
-                    <WrapPanel>
-                        <Button Style="{StaticResource CompactPrimaryButton}"
-                                Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}"
-                                ContentStringFormat="Import {0} CSV"
-                                Command="{Binding ImportItemsCommand}"/>
-                        <Button Style="{StaticResource CompactPrimaryButton}"
-                                Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}"
-                                ContentStringFormat="Import {0} Images"
-                                Command="{Binding OpenImageImportMappingWindowCommand}"
-                                Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
-                        <Button Style="{StaticResource CompactPrimaryButton}"
-                                Content="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}"
-                                ContentStringFormat="Export {0} CSV"
-                                Command="{Binding ExportItemsCommand}"/>
-                        <Button Style="{StaticResource CompactPrimaryButton}"
-                                Content="Backup Database"
-                                Command="{Binding BackupDatabaseCommand}"/>
-                        <Button Style="{StaticResource CompactPrimaryButton}"
-                                Content="Cancel Import"
-                                Command="{Binding CancelImportItemsCommand}"
-                                IsEnabled="{Binding ImportItemsCommand.IsRunning}"/>
-                    </WrapPanel>
+        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}">
+            <DockPanel LastChildFill="False">
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
+                    <TextBlock Text="Data Workstation" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <Button Style="{StaticResource PrimaryButton}"
+                            Content="Import Items"
+                            Command="{Binding ImportItemsCommand}"
+                            Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}"
+                            Content="Export Items"
+                            Command="{Binding ExportItemsCommand}"
+                            Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}"
+                            Content="Import Customers"
+                            Command="{Binding ImportCustomersCommand}"
+                            Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}"
+                            Content="Export Customers"
+                            Command="{Binding ExportCustomersCommand}"
+                            Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}"
+                            Content="Backup DB"
+                            Command="{Binding BackupDatabaseCommand}"
+                            Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}"
+                            Content="Cancel Import"
+                            Command="{Binding CancelImportItemsCommand}"
+                            IsEnabled="{Binding ImportItemsCommand.IsRunning}"/>
                 </StackPanel>
-
-                <!-- Customers -->
-                <StackPanel Grid.Column="1" Margin="6,0,0,0">
-                    <TextBlock Text="Customers" Style="{StaticResource SectionHeader}" />
-                    <WrapPanel>
-                        <Button Style="{StaticResource CompactPrimaryButton}"
-                                Content="Import Customers CSV"
-                                Command="{Binding ImportCustomersCommand}"/>
-                        <Button Style="{StaticResource CompactPrimaryButton}"
-                                Content="Export Customers CSV"
-                                Command="{Binding ExportCustomersCommand}"/>
-                    </WrapPanel>
-                </StackPanel>
-            </Grid>
+                <TextBlock DockPanel.Dock="Right"
+                           Text="Import, export, photo mapping, backup, and operation results stay together."
+                           Style="{StaticResource CaptionTextBlock}"
+                           VerticalAlignment="Center"/>
+            </DockPanel>
         </Border>
 
-        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0" Margin="0,6,0,0">
-            <DataGrid ItemsSource="{Binding ImportExportLogs}" IsReadOnly="True" AutoGenerateColumns="False"
-                      Style="{StaticResource VirtualizedDataGridStyle}">
-                <DataGrid.Columns>
-                    <DataGridTextColumn Header="Message" Binding="{Binding}" />
-                </DataGrid.Columns>
-            </DataGrid>
+        <TabControl Grid.Row="1" Style="{StaticResource DesktopSectionListTabControl}">
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="01 Overview">
+                <Border Style="{StaticResource DesktopContentPane}">
+                    <Grid Margin="8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+
+                        <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource SurfaceAltBrush}" Padding="8" Margin="0,0,6,6">
+                            <StackPanel>
+                                <TextBlock Text="Item Data" Style="{StaticResource PageTitleTextBlock}"/>
+                                <TextBlock Text="{Binding ItemDataSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,8"/>
+                                <WrapPanel>
+                                    <Button Style="{StaticResource PrimaryButton}"
+                                            Content="Import Items CSV / JSON / XML"
+                                            Command="{Binding ImportItemsCommand}"
+                                            Margin="0,0,4,0"/>
+                                    <Button Style="{StaticResource GhostButton}"
+                                            Content="Export Items"
+                                            Command="{Binding ExportItemsCommand}"/>
+                                </WrapPanel>
+                            </StackPanel>
+                        </Border>
+
+                        <Border Grid.Column="1" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource SurfaceAltBrush}" Padding="8" Margin="0,0,0,6">
+                            <StackPanel>
+                                <TextBlock Text="Customer Data" Style="{StaticResource PageTitleTextBlock}"/>
+                                <TextBlock Text="{Binding CustomerDataSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,8"/>
+                                <WrapPanel>
+                                    <Button Style="{StaticResource PrimaryButton}"
+                                            Content="Import Customers"
+                                            Command="{Binding ImportCustomersCommand}"
+                                            Margin="0,0,4,0"/>
+                                    <Button Style="{StaticResource GhostButton}"
+                                            Content="Export Customers"
+                                            Command="{Binding ExportCustomersCommand}"/>
+                                </WrapPanel>
+                            </StackPanel>
+                        </Border>
+
+                        <Border Grid.Row="1" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource SurfaceAltBrush}" Padding="8" Margin="0,0,6,6">
+                            <StackPanel>
+                                <TextBlock Text="Photo Mapping" Style="{StaticResource PageTitleTextBlock}"/>
+                                <TextBlock Text="{Binding ImageImportSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,8"/>
+                                <Button Style="{StaticResource PrimaryButton}"
+                                        Content="Import Item Images"
+                                        Command="{Binding OpenImageImportMappingWindowCommand}"
+                                        HorizontalAlignment="Left"
+                                        Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
+                            </StackPanel>
+                        </Border>
+
+                        <Border Grid.Row="1" Grid.Column="1" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource SurfaceAltBrush}" Padding="8" Margin="0,0,0,6">
+                            <StackPanel>
+                                <TextBlock Text="Database Backup" Style="{StaticResource PageTitleTextBlock}"/>
+                                <TextBlock Text="{Binding BackupSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,8"/>
+                                <Button Style="{StaticResource PrimaryButton}"
+                                        Content="Backup Database"
+                                        Command="{Binding BackupDatabaseCommand}"
+                                        HorizontalAlignment="Left"/>
+                            </StackPanel>
+                        </Border>
+
+                        <Border Grid.Row="2" Grid.ColumnSpan="2" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource TextBoxBackgroundBrush}" Padding="8">
+                            <DockPanel LastChildFill="True">
+                                <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0,0,0,6">
+                                    <TextBlock Text="Current run status" Style="{StaticResource SectionHeader}" Margin="0,0,10,0"/>
+                                    <ProgressBar Width="160" Height="14" IsIndeterminate="True" Visibility="{Binding ImportItemsCommand.IsRunning, Converter={StaticResource BoolToVis}}"/>
+                                </StackPanel>
+                                <TextBlock Text="{Binding LogSummary}" TextWrapping="Wrap"/>
+                            </DockPanel>
+                        </Border>
+                    </Grid>
+                </Border>
+            </TabItem>
+
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="02 Item Data">
+                <Border Style="{StaticResource DesktopContentPane}">
+                    <DockPanel>
+                        <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Item Exchange" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Import CSV / JSON / XML" Command="{Binding ImportItemsCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Export CSV / JSON / XML" Command="{Binding ExportItemsCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Cancel Import" Command="{Binding CancelImportItemsCommand}" IsEnabled="{Binding ImportItemsCommand.IsRunning}"/>
+                            </StackPanel>
+                        </Border>
+                        <StackPanel Margin="8">
+                            <TextBlock Text="{Binding ItemLabelPlural, Source={x:Static helpers:LabelProvider.Instance}}" Style="{StaticResource PageTitleTextBlock}"/>
+                            <TextBlock Text="{Binding ItemDataSummary}" TextWrapping="Wrap" Margin="0,3,0,10"/>
+                            <TextBlock Text="CSV imports open the mapping dialog and require item number plus name. JSON and XML imports use direct format matching. Export prompts for the target format from the file extension." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </DockPanel>
+                </Border>
+            </TabItem>
+
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="03 Customers">
+                <Border Style="{StaticResource DesktopContentPane}">
+                    <DockPanel>
+                        <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Customer Exchange" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Import Customers" Command="{Binding ImportCustomersCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Export Customers" Command="{Binding ExportCustomersCommand}"/>
+                            </StackPanel>
+                        </Border>
+                        <StackPanel Margin="8">
+                            <TextBlock Text="Customers" Style="{StaticResource PageTitleTextBlock}"/>
+                            <TextBlock Text="{Binding CustomerDataSummary}" TextWrapping="Wrap" Margin="0,3,0,10"/>
+                            <TextBlock Text="Use this before advisor handoff, customer cleanup, and directory migration. Imported rows and skipped rows are written into the run log below." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </DockPanel>
+                </Border>
+            </TabItem>
+
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="04 Backup / Images">
+                <Border Style="{StaticResource DesktopContentPane}">
+                    <DockPanel>
+                        <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Admin Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Backup Database" Command="{Binding BackupDatabaseCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Import Item Images" Command="{Binding OpenImageImportMappingWindowCommand}" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
+                            </StackPanel>
+                        </Border>
+                        <Grid Margin="8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource SurfaceAltBrush}" Padding="8" Margin="0,0,6,0">
+                                <StackPanel>
+                                    <TextBlock Text="Backup" Style="{StaticResource PageTitleTextBlock}"/>
+                                    <TextBlock Text="{Binding BackupSummary}" TextWrapping="Wrap" Margin="0,3,0,8"/>
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Choose Backup File" Command="{Binding BackupDatabaseCommand}" HorizontalAlignment="Left"/>
+                                </StackPanel>
+                            </Border>
+                            <Border Grid.Column="1" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource SurfaceAltBrush}" Padding="8">
+                                <StackPanel>
+                                    <TextBlock Text="Image Import" Style="{StaticResource PageTitleTextBlock}"/>
+                                    <TextBlock Text="{Binding ImageImportSummary}" TextWrapping="Wrap" Margin="0,3,0,8"/>
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Open Image Mapping" Command="{Binding OpenImageImportMappingWindowCommand}" HorizontalAlignment="Left" Visibility="{Binding IsCurrentUserAdmin, Converter={StaticResource BoolToVis}}"/>
+                                </StackPanel>
+                            </Border>
+                        </Grid>
+                    </DockPanel>
+                </Border>
+            </TabItem>
+
+            <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="05 Run Log">
+                <Border Style="{StaticResource DesktopContentPane}">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <Border Grid.Row="0" Style="{StaticResource DesktopSectionActionStrip}">
+                            <DockPanel LastChildFill="False">
+                                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
+                                    <TextBlock Text="Operation Results" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="Copy Selected" Click="CopySelectedLog_Click" Margin="0,0,4,0"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="Print Log" Click="PrintLogs_Click" Margin="0,0,4,0"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearImportExportLogsCommand}"/>
+                                </StackPanel>
+                                <TextBlock DockPanel.Dock="Right" Text="{Binding LogSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center"/>
+                            </DockPanel>
+                        </Border>
+
+                        <Grid Grid.Row="1" Margin="8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="2.6*"/>
+                                <ColumnDefinition Width="6"/>
+                                <ColumnDefinition Width="1.2*"/>
+                            </Grid.ColumnDefinitions>
+
+                            <Border Style="{StaticResource Card}" Padding="0">
+                                <DataGrid x:Name="ImportExportLogGrid"
+                                          ItemsSource="{Binding ImportExportLogs}"
+                                          SelectedItem="{Binding SelectedImportExportLog, Mode=TwoWay}"
+                                          IsReadOnly="True"
+                                          AutoGenerateColumns="False"
+                                          Style="{StaticResource VirtualizedDataGridStyle}"
+                                          MouseDoubleClick="ImportExportLogGrid_MouseDoubleClick">
+                                    <DataGrid.RowStyle>
+                                        <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                                            <EventSetter Event="PreviewMouseRightButtonDown" Handler="ImportExportLogRow_PreviewMouseRightButtonDown"/>
+                                        </Style>
+                                    </DataGrid.RowStyle>
+                                    <DataGrid.ContextMenu>
+                                        <ContextMenu>
+                                            <MenuItem Header="Open Log Detail" Click="OpenSelectedLog_Click"/>
+                                            <MenuItem Header="Copy Selected Log" Click="CopySelectedLog_Click"/>
+                                            <Separator/>
+                                            <MenuItem Header="Print Current Log" Click="PrintLogs_Click"/>
+                                        </ContextMenu>
+                                    </DataGrid.ContextMenu>
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="Result" Binding="{Binding}" Width="*"/>
+                                    </DataGrid.Columns>
+                                </DataGrid>
+                            </Border>
+
+                            <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+
+                            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="8">
+                                <DockPanel LastChildFill="True">
+                                    <StackPanel DockPanel.Dock="Top" Margin="0,0,0,6">
+                                        <TextBlock Text="{Binding SelectedLogTitle}" Style="{StaticResource SectionHeader}"/>
+                                        <TextBlock Text="{Binding LogSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                    </StackPanel>
+                                    <StackPanel DockPanel.Dock="Bottom" Margin="0,6,0,0">
+                                        <TextBlock Text="Actions" Style="{StaticResource SectionHeader}"/>
+                                        <UniformGrid Columns="2">
+                                            <Button Style="{StaticResource GhostButton}" Content="Copy" Click="CopySelectedLog_Click" Margin="0,0,4,0"/>
+                                            <Button Style="{StaticResource GhostButton}" Content="Print" Click="PrintLogs_Click"/>
+                                        </UniformGrid>
+                                    </StackPanel>
+                                    <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource TextBoxBackgroundBrush}" Padding="6">
+                                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                            <TextBlock Text="{Binding SelectedLogDetail}" TextWrapping="Wrap"/>
+                                        </ScrollViewer>
+                                    </Border>
+                                </DockPanel>
+                            </Border>
+                        </Grid>
+                    </Grid>
+                </Border>
+            </TabItem>
+        </TabControl>
+
+        <Border Grid.Row="2"
+                Background="{DynamicResource SurfaceAltBrush}"
+                BorderBrush="{DynamicResource BorderBrushAlt}"
+                BorderThickness="1,0,1,1"
+                Padding="6,3">
+            <DockPanel>
+                <TextBlock DockPanel.Dock="Left" Text="{Binding LogSummary}" FontSize="11" VerticalAlignment="Center"/>
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                    <TextBlock Text="Item import running" FontSize="11" Margin="0,0,6,0" Visibility="{Binding ImportItemsCommand.IsRunning, Converter={StaticResource BoolToVis}}"/>
+                    <ProgressBar Width="140" Height="14" IsIndeterminate="True" Visibility="{Binding ImportItemsCommand.IsRunning, Converter={StaticResource BoolToVis}}"/>
+                </StackPanel>
+            </DockPanel>
         </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
@@ -1,4 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Input;
+using InventoryManagementApp.ViewModels;
+using WpfMessageBox = System.Windows.MessageBox;
+using WpfPrintDialog = System.Windows.Controls.PrintDialog;
 
 namespace InventoryManagementApp.Views.Pages
 {
@@ -7,6 +16,121 @@ namespace InventoryManagementApp.Views.Pages
         public ImportExportPage()
         {
             InitializeComponent();
+        }
+
+        private void ImportExportLogGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            OpenSelectedLog_Click(sender, e);
+        }
+
+        private void ImportExportLogRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is DataGridRow row && !row.IsSelected)
+            {
+                row.IsSelected = true;
+                e.Handled = true;
+            }
+        }
+
+        private void OpenSelectedLog_Click(object sender, RoutedEventArgs e)
+        {
+            if (ImportExportLogGrid.SelectedItem is not string log || string.IsNullOrWhiteSpace(log))
+            {
+                WpfMessageBox.Show("Select an import/export log row first.", "Import / Export", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            WpfMessageBox.Show(log, "Import / Export Result", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        private void CopySelectedLog_Click(object sender, RoutedEventArgs e)
+        {
+            if (ImportExportLogGrid.SelectedItem is not string log || string.IsNullOrWhiteSpace(log))
+            {
+                WpfMessageBox.Show("Select an import/export log row first.", "Import / Export", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            Clipboard.SetText(log);
+        }
+
+        private void PrintLogs_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is not ImportExportViewModel vm || vm.ImportExportLogs.Count == 0)
+            {
+                WpfMessageBox.Show("There are no import/export log rows to print.", "Import / Export", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var printDialog = new WpfPrintDialog();
+            if (printDialog.ShowDialog() != true)
+                return;
+
+            var document = BuildPrintDocument(vm.ImportExportLogs.ToList(), vm.LogSummary);
+            document.PageWidth = printDialog.PrintableAreaWidth;
+            document.PageHeight = printDialog.PrintableAreaHeight;
+            document.PagePadding = new Thickness(36);
+            document.ColumnWidth = printDialog.PrintableAreaWidth;
+            printDialog.PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator, "Import / Export Log");
+        }
+
+        private static FlowDocument BuildPrintDocument(IReadOnlyCollection<string> logs, string summary)
+        {
+            var document = new FlowDocument
+            {
+                FontFamily = new System.Windows.Media.FontFamily("Segoe UI"),
+                FontSize = 11
+            };
+
+            document.Blocks.Add(new Paragraph(new Run("Import / Export Operation Log"))
+            {
+                FontSize = 16,
+                FontWeight = FontWeights.SemiBold,
+                Margin = new Thickness(0, 0, 0, 4)
+            });
+            document.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:g} - {summary}"))
+            {
+                FontSize = 10,
+                Margin = new Thickness(0, 0, 0, 10)
+            });
+
+            var table = new Table { CellSpacing = 0 };
+            table.Columns.Add(new TableColumn { Width = new GridLength(55) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(680) });
+
+            var rowGroup = new TableRowGroup();
+            table.RowGroups.Add(rowGroup);
+
+            var header = new TableRow { FontWeight = FontWeights.SemiBold };
+            rowGroup.Rows.Add(header);
+            AddCell(header, "#");
+            AddCell(header, "Result");
+
+            var number = 1;
+            foreach (var log in logs)
+            {
+                var row = new TableRow();
+                rowGroup.Rows.Add(row);
+                AddCell(row, number.ToString());
+                AddCell(row, log);
+                number++;
+            }
+
+            document.Blocks.Add(table);
+            return document;
+        }
+
+        private static void AddCell(TableRow row, string text)
+        {
+            row.Cells.Add(new TableCell(new Paragraph(new Run(text ?? string.Empty))
+            {
+                Margin = new Thickness(2)
+            })
+            {
+                BorderBrush = System.Windows.Media.Brushes.Gray,
+                BorderThickness = new Thickness(0, 0, 0, 0.5),
+                Padding = new Thickness(3, 2, 3, 2)
+            });
         }
     }
 }

--- a/scripts/run-app-qa-screenshots.ps1
+++ b/scripts/run-app-qa-screenshots.ps1
@@ -33,6 +33,15 @@ if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
     $OutputRoot = Join-Path $repoRoot ".qa-screenshots"
 }
 
+$expectedFolders = @(
+    "00-auth",
+    "01-overview",
+    "02-operations",
+    "03-insights",
+    "04-data",
+    "05-admin",
+    "06-dialogs"
+)
 $sessionOutput = Join-Path $OutputRoot "latest"
 $runRoot = Join-Path $repoRoot ".qa-run"
 $runDirectory = Join-Path $runRoot "latest"
@@ -103,8 +112,27 @@ try {
         throw "QA screenshot run produced $($screenshots.Count) PNG file(s); expected at least $ExpectedScreenshotCount."
     }
 
-    Add-Content -Path (Join-Path $sessionOutput "README.md") -Value ""
-    Add-Content -Path (Join-Path $sessionOutput "README.md") -Value ("Captured screenshots: {0}" -f $screenshots.Count)
+    foreach ($folder in $expectedFolders) {
+        $folderPath = Join-Path $sessionOutput $folder
+        if (-not (Test-Path -LiteralPath $folderPath)) {
+            throw "QA screenshot run did not create expected folder '$folder'."
+        }
+
+        $folderScreenshots = @(Get-ChildItem -LiteralPath $folderPath -File -Filter "*.png" -ErrorAction SilentlyContinue)
+        if ($folderScreenshots.Count -eq 0) {
+            throw "QA screenshot folder '$folder' did not contain any PNG files."
+        }
+    }
+
+    $readmePath = Join-Path $sessionOutput "README.md"
+    Add-Content -Path $readmePath -Value ""
+    Add-Content -Path $readmePath -Value ("Captured screenshots: {0}" -f $screenshots.Count)
+    Add-Content -Path $readmePath -Value ""
+    Add-Content -Path $readmePath -Value "Captured files:"
+    foreach ($screenshot in ($screenshots | Sort-Object FullName)) {
+        $relativePath = Resolve-Path -LiteralPath $screenshot.FullName -Relative
+        Add-Content -Path $readmePath -Value ("- `{0}`" -f $relativePath)
+    }
     Write-Step "QA screenshots saved to '$sessionOutput' ($($screenshots.Count) PNG files)."
 }
 finally {


### PR DESCRIPTION
## Summary

- Redesign Import / Export into a compact desktop data workstation with overview, item data, customer data, backup/image admin, and run-log sections.
- Add selectable operation log state with detail, copy, print, clear, double-click, and row-correct context-menu actions.
- Harden the QA screenshot wrapper so successful runs must include every expected screenshot folder and record the captured file list.
- Update progress notes and the completion checklist for the workflow audit.

## Validation

- GitHub connector readback reviewed the changed XAML, code-behind, view model, screenshot script, and notes.
- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows WPF runtime, and direct local clone is still blocked by the network tunnel.