### PR TITLE
Upgrade kit management operations workstation

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-17-kit-workstation.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-kit-workstation.md
@@ -1,0 +1,14 @@
+# Kit Workstation Workflow Pass - 2026-06-17
+
+## Completed
+
+- Upgraded `KitManagementPage` from a pair of plain grids into a compact desktop kit workstation.
+- Added selected-kit context, membership summaries, selected-item guidance, and availability next-action copy so advisors and technicians can understand what to do before staging or renting a kit.
+- Added row double-click details, row-correct right-click actions, keyboard shortcuts, copy selected kit details, printable kit directory output, and printable kit pick sheets.
+- Kept existing kit create/edit/delete, item membership, and availability service calls intact while making those functions reachable from the toolbar, detail pane, bottom strip, and context menus.
+- Hardened the QA screenshot wrapper so it now requires the exact named screenshots expected from the app, not just a loose count of PNGs in broad folders.
+
+## Validation
+
+- GitHub connector readback should be used to review the changed XAML, code-behind, view model, screenshot script, and completion checklist on the branch.
+- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows WPF runtime, and direct local cloning remains blocked by the network tunnel.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 02:11 NZST
+Last audit date/time: 2026-06-17 03:11 NZST
 
 ## Completed workflows
 
@@ -15,6 +15,8 @@ Last audit date/time: 2026-06-17 02:11 NZST
 - Import / Export now uses a compact data workstation layout with separate sections for item data, customer data, backup/image admin work, and run-log review.
 - Import / Export operation logs now support selected-row detail, copy, print, clear, double-click drilldown, and row-correct right-click actions.
 - QA screenshot wrapper validation now requires every expected screenshot folder to contain PNG output and appends the captured file list to the run README.
+- Kits now use a compact desktop workstation with kit directory, item membership, selected-kit detail, availability guidance, row-correct context menus, double-click drilldown, keyboard shortcuts, copy selected kit details, printable kit directory output, and printable kit pick sheets.
+- QA screenshot wrapper validation now checks for each expected named screenshot file so missing captures fail loudly instead of passing on folder count alone.
 
 ## Partially complete workflows
 
@@ -23,6 +25,7 @@ Last audit date/time: 2026-06-17 02:11 NZST
 - Customer CSV import already uses a transaction, but customer workflow coverage still needs broader review.
 - Reports page has a compact operational grid, summary panel, print/copy actions, and safe empty unknown-report handling; runtime screenshot and full report generation checks remain pending.
 - Import / Export has been redesigned and wired for log actions, but runtime file-dialog, print, and screenshot checks still need a Windows/.NET workstation.
+- Kits now have a completed desktop workflow surface, but runtime add/edit/item-membership dialog validation still needs a Windows/.NET workstation.
 
 ## Known broken workflows
 
@@ -36,7 +39,7 @@ Last audit date/time: 2026-06-17 02:11 NZST
 
 ## Validation status
 
-- GitHub connector readback reviewed the Import / Export workstation branch files, screenshot wrapper, progress note, and completion checklist.
+- GitHub connector readback reviewed the Kit workstation branch files, screenshot wrapper, progress note, and completion checklist.
 - `dotnet --info`: failed because `dotnet` is not installed in this scheduled container.
 - `dotnet restore InventoryManagementApp.sln`: not run because the .NET SDK is unavailable.
 - `dotnet build InventoryManagementApp.sln --no-restore`: not run because the .NET SDK is unavailable.

--- a/InventoryManagementApp/ViewModels/KitManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/KitManagementViewModel.cs
@@ -3,7 +3,11 @@ using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Documents;
+using System.Windows.Media;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Services.Kits;
 using InventoryManagementApp.Interfaces;
@@ -19,6 +23,28 @@ namespace InventoryManagementApp.ViewModels
         public ObservableCollection<Kit> FilteredKits { get; }
         public ObservableCollection<KitItem> KitItems { get; }
 
+        public string KitResultsSummary => $"{FilteredKits.Count} kit{(FilteredKits.Count == 1 ? string.Empty : "s")} shown | {Kits.Count(k => k.IsActive)} active | {Kits.Count(k => !k.IsActive)} inactive";
+
+        public string SelectedKitSummary => SelectedKit == null
+            ? "Select a kit to review membership, check availability, copy details, print a pick sheet, or maintain its item list."
+            : $"{ValueOrNotRecorded(SelectedKit.KitNumber)} | {ValueOrNotRecorded(SelectedKit.Name)} | {KitItems.Count} item line{(KitItems.Count == 1 ? string.Empty : "s")} | {(SelectedKit.IsActive ? "Active" : "Inactive")}";
+
+        public string SelectedKitDetail => SelectedKit == null
+            ? "No kit selected. Choose a row from the directory to see the operational detail here."
+            : $"Kit # {ValueOrNotRecorded(SelectedKit.KitNumber)}\nName: {ValueOrNotRecorded(SelectedKit.Name)}\nCategory: {ValueOrNotRecorded(SelectedKit.Category)}\nStatus: {(SelectedKit.IsActive ? "Active" : "Inactive")}\nItems: {KitItems.Count}\nUpdated: {SelectedKit.UpdatedAt:yyyy-MM-dd HH:mm}\n\n{ValueOrNotRecorded(SelectedKit.Description)}";
+
+        public string KitItemsSummary => SelectedKit == null
+            ? "No kit selected"
+            : $"{KitItems.Count} item line{(KitItems.Count == 1 ? string.Empty : "s")} in {ValueOrNotRecorded(SelectedKit.KitNumber)} | {KitItems.Count(i => !i.IsOptional)} required | {KitItems.Count(i => i.IsOptional)} optional";
+
+        public string SelectedKitItemSummary => SelectedKitItem == null
+            ? "Select a kit item to edit quantity, mark optional, or remove it from this kit."
+            : $"{ValueOrNotRecorded(SelectedKitItem.ItemNumber)} | {ValueOrNotRecorded(SelectedKitItem.ItemName)} | Qty {SelectedKitItem.Quantity} | {(SelectedKitItem.IsOptional ? "Optional" : "Required")}";
+
+        public string SelectedKitAvailabilitySummary => SelectedKit == null
+            ? "Availability check is ready once a kit is selected."
+            : "Use Check Availability before promising the kit; required item quantities are checked against current stock.";
+
         private Kit? _selectedKit;
         public Kit? SelectedKit
         {
@@ -32,6 +58,14 @@ namespace InventoryManagementApp.ViewModels
                     ViewKitItemsCommand.NotifyCanExecuteChanged();
                     AddKitItemCommand.NotifyCanExecuteChanged();
                     CheckAvailabilityCommand.NotifyCanExecuteChanged();
+                    OpenKitDetailsCommand.NotifyCanExecuteChanged();
+                    CopySelectedKitCommand.NotifyCanExecuteChanged();
+                    PrintSelectedKitCommand.NotifyCanExecuteChanged();
+                    OnPropertyChanged(nameof(SelectedKitSummary));
+                    OnPropertyChanged(nameof(SelectedKitDetail));
+                    OnPropertyChanged(nameof(KitItemsSummary));
+                    OnPropertyChanged(nameof(SelectedKitAvailabilitySummary));
+
                     if (value != null)
                     {
                         _ = LoadKitItemsAsync(value.KitID);
@@ -39,6 +73,8 @@ namespace InventoryManagementApp.ViewModels
                     else
                     {
                         KitItems.Clear();
+                        SelectedKitItem = null;
+                        RefreshKitItemSummaries();
                     }
                 }
             }
@@ -54,6 +90,7 @@ namespace InventoryManagementApp.ViewModels
                 {
                     EditKitItemCommand.NotifyCanExecuteChanged();
                     RemoveKitItemCommand.NotifyCanExecuteChanged();
+                    OnPropertyChanged(nameof(SelectedKitItemSummary));
                 }
             }
         }
@@ -96,6 +133,11 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand RemoveKitItemCommand { get; }
         public IAsyncRelayCommand CheckAvailabilityCommand { get; }
         public IAsyncRelayCommand RefreshCommand { get; }
+        public IRelayCommand ClearSearchCommand { get; }
+        public IRelayCommand OpenKitDetailsCommand { get; }
+        public IRelayCommand CopySelectedKitCommand { get; }
+        public IRelayCommand PrintKitListCommand { get; }
+        public IRelayCommand PrintSelectedKitCommand { get; }
 
         public KitManagementViewModel(
             KitService kitService,
@@ -124,6 +166,11 @@ namespace InventoryManagementApp.ViewModels
             RemoveKitItemCommand = new AsyncRelayCommand(RemoveKitItemAsync, CanEditOrRemoveKitItem);
             CheckAvailabilityCommand = new AsyncRelayCommand(CheckAvailabilityAsync, CanEditOrDelete);
             RefreshCommand = new AsyncRelayCommand(LoadKitsAsync);
+            ClearSearchCommand = new RelayCommand(ClearSearch);
+            OpenKitDetailsCommand = new RelayCommand(OpenKitDetails, CanEditOrDelete);
+            CopySelectedKitCommand = new RelayCommand(CopySelectedKit, CanEditOrDelete);
+            PrintKitListCommand = new RelayCommand(PrintKitList);
+            PrintSelectedKitCommand = new RelayCommand(PrintSelectedKit, CanEditOrDelete);
         }
 
         private async Task LoadKitsAsync()
@@ -131,12 +178,13 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 var kits = await _kitService.GetAllKitsAsync();
+                var previouslySelectedKitId = SelectedKit?.KitID;
                 Kits.Clear();
                 foreach (var kit in kits)
                 {
                     Kits.Add(kit);
                 }
-                ApplyFilter();
+                ApplyFilter(previouslySelectedKitId);
             }
             catch (Exception ex)
             {
@@ -148,12 +196,15 @@ namespace InventoryManagementApp.ViewModels
         {
             try
             {
+                var selectedKitItemId = SelectedKitItem?.KitItemID;
                 var items = await _kitService.GetKitItemsAsync(kitID);
                 KitItems.Clear();
                 foreach (var item in items)
                 {
                     KitItems.Add(item);
                 }
+                SelectedKitItem = KitItems.FirstOrDefault(i => i.KitItemID == selectedKitItemId) ?? KitItems.FirstOrDefault();
+                RefreshKitItemSummaries();
             }
             catch (Exception ex)
             {
@@ -178,7 +229,7 @@ namespace InventoryManagementApp.ViewModels
                     var id = await _kitService.CreateKitAsync(newKit);
                     newKit.KitID = id;
                     Kits.Insert(0, newKit);
-                    ApplyFilter();
+                    ApplyFilter(newKit.KitID);
                     await _dialogService.ShowInfoAsync("Success", "Kit created successfully");
                 }
                 catch (Exception ex)
@@ -213,7 +264,7 @@ namespace InventoryManagementApp.ViewModels
                     await _kitService.UpdateKitAsync(clone);
                     var index = Kits.IndexOf(SelectedKit);
                     if (index >= 0) Kits[index] = clone;
-                    ApplyFilter();
+                    ApplyFilter(clone.KitID);
                     await _dialogService.ShowInfoAsync("Success", "Kit updated successfully");
                 }
                 catch (Exception ex)
@@ -227,9 +278,10 @@ namespace InventoryManagementApp.ViewModels
         {
             if (SelectedKit == null) return;
 
+            var kitName = SelectedKit.Name;
             var confirmed = await _dialogService.ShowConfirmAsync(
                 "Delete Kit",
-                $"Are you sure you want to delete kit '{SelectedKit.Name}'? This will also remove all items from the kit.");
+                $"Delete kit '{kitName}' and remove every item line attached to it?");
 
             if (confirmed)
             {
@@ -237,6 +289,7 @@ namespace InventoryManagementApp.ViewModels
                 {
                     await _kitService.DeleteKitAsync(SelectedKit.KitID);
                     Kits.Remove(SelectedKit);
+                    SelectedKit = null;
                     ApplyFilter();
                     await _dialogService.ShowInfoAsync("Success", "Kit deleted successfully");
                 }
@@ -272,6 +325,8 @@ namespace InventoryManagementApp.ViewModels
                     var id = await _kitService.AddKitItemAsync(newKitItem);
                     newKitItem.KitItemID = id;
                     KitItems.Add(newKitItem);
+                    SelectedKitItem = newKitItem;
+                    RefreshKitItemSummaries();
                     await _dialogService.ShowInfoAsync("Success", "Item added to kit successfully");
                 }
                 catch (Exception ex)
@@ -304,6 +359,8 @@ namespace InventoryManagementApp.ViewModels
                     await _kitService.UpdateKitItemAsync(clone);
                     var index = KitItems.IndexOf(SelectedKitItem);
                     if (index >= 0) KitItems[index] = clone;
+                    SelectedKitItem = clone;
+                    RefreshKitItemSummaries();
                     await _dialogService.ShowInfoAsync("Success", "Kit item updated successfully");
                 }
                 catch (Exception ex)
@@ -317,9 +374,10 @@ namespace InventoryManagementApp.ViewModels
         {
             if (SelectedKitItem == null) return;
 
+            var itemName = ValueOrNotRecorded(SelectedKitItem.ItemName);
             var confirmed = await _dialogService.ShowConfirmAsync(
                 "Remove Item from Kit",
-                $"Are you sure you want to remove this item from the kit?");
+                $"Remove '{itemName}' from this kit?");
 
             if (confirmed)
             {
@@ -327,6 +385,8 @@ namespace InventoryManagementApp.ViewModels
                 {
                     await _kitService.RemoveKitItemAsync(SelectedKitItem.KitItemID);
                     KitItems.Remove(SelectedKitItem);
+                    SelectedKitItem = KitItems.FirstOrDefault();
+                    RefreshKitItemSummaries();
                     await _dialogService.ShowInfoAsync("Success", "Item removed from kit successfully");
                 }
                 catch (Exception ex)
@@ -344,8 +404,8 @@ namespace InventoryManagementApp.ViewModels
             {
                 var isAvailable = await _kitService.CheckKitAvailabilityAsync(SelectedKit.KitID);
                 var message = isAvailable
-                    ? "All required items in this kit are available."
-                    : "Some required items in this kit are not available in sufficient quantities.";
+                    ? $"{SelectedKit.Name} is ready. All required kit items have enough available quantity."
+                    : $"{SelectedKit.Name} is short. Review the required item lines before promising or staging this kit.";
                 await _dialogService.ShowInfoAsync("Kit Availability", message);
             }
             catch (Exception ex)
@@ -354,7 +414,156 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        private void ApplyFilter()
+        private void ClearSearch()
+        {
+            SearchText = string.Empty;
+            SelectedFilter = "Active";
+            ApplyFilter();
+        }
+
+        private void OpenKitDetails()
+        {
+            if (SelectedKit == null) return;
+
+            var details = BuildSelectedKitDetails();
+            _dialogService.ShowInfo(details, $"Kit Details - {ValueOrNotRecorded(SelectedKit.Name)}");
+        }
+
+        private void CopySelectedKit()
+        {
+            if (SelectedKit == null) return;
+
+            try
+            {
+                Clipboard.SetText(BuildSelectedKitDetails());
+                _dialogService.ShowInfo("Kit details copied to the clipboard.", "Copy Kit Details");
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowInfo($"Failed to copy kit details: {ex.Message}", "Copy Failed");
+            }
+        }
+
+        private void PrintKitList()
+        {
+            if (FilteredKits.Count == 0)
+            {
+                _dialogService.ShowInfo("There are no kits to print for the current filter.", "Kit Directory");
+                return;
+            }
+
+            try
+            {
+                var doc = CreateKitDocument("Kit Directory", fontSize: 11);
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | {KitResultsSummary}"))
+                {
+                    FontSize = 10,
+                    Margin = new Thickness(0, 0, 0, 10)
+                });
+
+                var table = new Table { CellSpacing = 0 };
+                table.Columns.Add(new TableColumn { Width = new GridLength(120) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(210) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(150) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(90) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(230) });
+
+                var group = new TableRowGroup();
+                table.RowGroups.Add(group);
+                AddPrintRow(group, true, "Kit #", "Name", "Category", "Status", "Description");
+                foreach (var kit in FilteredKits)
+                {
+                    AddPrintRow(group, false, kit.KitNumber, kit.Name, kit.Category, kit.IsActive ? "Active" : "Inactive", kit.Description);
+                }
+
+                doc.Blocks.Add(table);
+                _dialogService.ShowPrintPreview(doc, "Kit Directory", string.Empty);
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowInfo($"Failed to print kit directory: {ex.Message}", "Print Failed");
+            }
+        }
+
+        private void PrintSelectedKit()
+        {
+            if (SelectedKit == null) return;
+
+            try
+            {
+                var kit = SelectedKit;
+                var doc = CreateKitDocument($"Kit Pick Sheet - {ValueOrNotRecorded(kit.Name)}");
+                var detailTable = CreateKeyValueTable();
+                var detailGroup = detailTable.RowGroups[0];
+                AddKeyValueRow(detailGroup, "Kit #:", kit.KitNumber);
+                AddKeyValueRow(detailGroup, "Name:", kit.Name);
+                AddKeyValueRow(detailGroup, "Category:", kit.Category);
+                AddKeyValueRow(detailGroup, "Status:", kit.IsActive ? "Active" : "Inactive");
+                AddKeyValueRow(detailGroup, "Description:", kit.Description);
+                AddKeyValueRow(detailGroup, "Advisor note:", "Check availability before staging this kit and confirm required item quantities before checkout.");
+                doc.Blocks.Add(detailTable);
+
+                doc.Blocks.Add(new Paragraph(new Bold(new Run("Kit Items")))
+                {
+                    FontSize = 15,
+                    Margin = new Thickness(0, 14, 0, 6)
+                });
+
+                var itemTable = new Table { CellSpacing = 0 };
+                itemTable.Columns.Add(new TableColumn { Width = new GridLength(130) });
+                itemTable.Columns.Add(new TableColumn { Width = new GridLength(280) });
+                itemTable.Columns.Add(new TableColumn { Width = new GridLength(80) });
+                itemTable.Columns.Add(new TableColumn { Width = new GridLength(100) });
+                var itemGroup = new TableRowGroup();
+                itemTable.RowGroups.Add(itemGroup);
+                AddPrintRow(itemGroup, true, "Item #", "Item", "Qty", "Required");
+                foreach (var item in KitItems)
+                {
+                    AddPrintRow(itemGroup, false, item.ItemNumber, item.ItemName, item.Quantity.ToString(), item.IsOptional ? "Optional" : "Required");
+                }
+                doc.Blocks.Add(itemTable);
+
+                _dialogService.ShowPrintPreview(doc, $"Kit {kit.KitNumber}", string.Empty);
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowInfo($"Failed to print kit sheet: {ex.Message}", "Print Failed");
+            }
+        }
+
+        private string BuildSelectedKitDetails()
+        {
+            if (SelectedKit == null)
+                return string.Empty;
+
+            var kit = SelectedKit;
+            var details = new StringBuilder();
+            details.AppendLine($"Kit #: {ValueOrNotRecorded(kit.KitNumber)}");
+            details.AppendLine($"Name: {ValueOrNotRecorded(kit.Name)}");
+            details.AppendLine($"Category: {ValueOrNotRecorded(kit.Category)}");
+            details.AppendLine($"Status: {(kit.IsActive ? "Active" : "Inactive")}");
+            details.AppendLine($"Updated: {kit.UpdatedAt:yyyy-MM-dd HH:mm}");
+            details.AppendLine();
+            details.AppendLine(ValueOrNotRecorded(kit.Description));
+            details.AppendLine();
+            details.AppendLine("Kit items:");
+            if (KitItems.Count == 0)
+            {
+                details.AppendLine("- No items assigned.");
+            }
+            else
+            {
+                foreach (var item in KitItems)
+                {
+                    details.AppendLine($"- {ValueOrNotRecorded(item.ItemNumber)} | {ValueOrNotRecorded(item.ItemName)} | Qty {item.Quantity} | {(item.IsOptional ? "Optional" : "Required")}");
+                }
+            }
+            details.AppendLine();
+            details.AppendLine("Next steps: check availability, stage required items, then use rentals to complete checkout.");
+            return details.ToString();
+        }
+
+        private void ApplyFilter(int? preferredKitId = null)
         {
             FilteredKits.Clear();
 
@@ -362,12 +571,12 @@ namespace InventoryManagementApp.ViewModels
 
             if (!string.IsNullOrWhiteSpace(SearchText))
             {
-                var search = SearchText.ToLowerInvariant();
+                var search = SearchText.Trim();
                 filtered = filtered.Where(k =>
-                    k.KitNumber.ToLowerInvariant().Contains(search) ||
-                    k.Name.ToLowerInvariant().Contains(search) ||
-                    k.Description.ToLowerInvariant().Contains(search) ||
-                    k.Category.ToLowerInvariant().Contains(search));
+                    Contains(k.KitNumber, search) ||
+                    Contains(k.Name, search) ||
+                    Contains(k.Description, search) ||
+                    Contains(k.Category, search));
             }
 
             filtered = SelectedFilter switch
@@ -381,10 +590,92 @@ namespace InventoryManagementApp.ViewModels
             {
                 FilteredKits.Add(kit);
             }
+
+            var selectedKit = preferredKitId.HasValue
+                ? FilteredKits.FirstOrDefault(k => k.KitID == preferredKitId.Value)
+                : FilteredKits.FirstOrDefault(k => SelectedKit != null && k.KitID == SelectedKit.KitID);
+            SelectedKit = selectedKit ?? FilteredKits.FirstOrDefault();
+
+            OnPropertyChanged(nameof(KitResultsSummary));
+            OnPropertyChanged(nameof(SelectedKitSummary));
+            OnPropertyChanged(nameof(SelectedKitDetail));
+            OnPropertyChanged(nameof(SelectedKitAvailabilitySummary));
+            PrintKitListCommand.NotifyCanExecuteChanged();
+        }
+
+        private void RefreshKitItemSummaries()
+        {
+            OnPropertyChanged(nameof(KitItemsSummary));
+            OnPropertyChanged(nameof(SelectedKitSummary));
+            OnPropertyChanged(nameof(SelectedKitDetail));
+            OnPropertyChanged(nameof(SelectedKitItemSummary));
         }
 
         private bool CanEditOrDelete() => SelectedKit != null;
 
         private bool CanEditOrRemoveKitItem() => SelectedKitItem != null;
+
+        static bool Contains(string? source, string search) =>
+            !string.IsNullOrWhiteSpace(source) && source.Contains(search, StringComparison.OrdinalIgnoreCase);
+
+        static FlowDocument CreateKitDocument(string title, double fontSize = 16)
+        {
+            var doc = new FlowDocument
+            {
+                PagePadding = new Thickness(36),
+                FontFamily = new FontFamily("Calibri"),
+                FontSize = fontSize
+            };
+
+            doc.Blocks.Add(new Paragraph(new Bold(new Run(title)))
+            {
+                FontSize = 20,
+                TextAlignment = TextAlignment.Center,
+                Margin = new Thickness(0, 0, 0, 10)
+            });
+
+            return doc;
+        }
+
+        static Table CreateKeyValueTable()
+        {
+            var table = new Table();
+            table.Columns.Add(new TableColumn { Width = new GridLength(150) });
+            table.Columns.Add(new TableColumn());
+            table.RowGroups.Add(new TableRowGroup());
+            return table;
+        }
+
+        static void AddKeyValueRow(TableRowGroup group, string label, string? value)
+        {
+            var row = new TableRow();
+            row.Cells.Add(new TableCell(new Paragraph(new Run(label)) { FontWeight = FontWeights.Bold }));
+            row.Cells.Add(new TableCell(new Paragraph(new Run(ValueOrNotRecorded(value)))));
+            group.Rows.Add(row);
+        }
+
+        static void AddPrintRow(TableRowGroup group, bool isHeader, params string?[] values)
+        {
+            var row = new TableRow();
+            foreach (var value in values)
+            {
+                var paragraph = new Paragraph(new Run(ValueOrNotRecorded(value)))
+                {
+                    Margin = new Thickness(3),
+                    FontSize = isHeader ? 10 : 9,
+                    FontWeight = isHeader ? FontWeights.Bold : FontWeights.Normal
+                };
+                var cell = new TableCell(paragraph)
+                {
+                    BorderBrush = Brushes.Gray,
+                    BorderThickness = new Thickness(0.5),
+                    Padding = new Thickness(2)
+                };
+                row.Cells.Add(cell);
+            }
+            group.Rows.Add(row);
+        }
+
+        static string ValueOrNotRecorded(string? value) => string.IsNullOrWhiteSpace(value) ? "Not recorded" : value;
     }
 }

--- a/InventoryManagementApp/Views/Pages/KitManagementPage.xaml
+++ b/InventoryManagementApp/Views/Pages/KitManagementPage.xaml
@@ -6,67 +6,209 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <Border Style="{StaticResource ToolbarCard}">
             <DockPanel LastChildFill="False">
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Add Kit" Command="{Binding AddKitCommand}" Margin="0,0,8,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditKitCommand}" Margin="0,0,8,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Delete" Command="{Binding DeleteKitCommand}" Margin="0,0,8,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Check Availability" Command="{Binding CheckAvailabilityCommand}" Margin="0,0,8,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
+                    <TextBlock Text="Kit Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Add Kit" Command="{Binding AddKitCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenKitDetailsCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditKitCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Check Availability" Command="{Binding CheckAvailabilityCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Print Kit" Command="{Binding PrintSelectedKitCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteKitCommand}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
-                    <TextBox Width="180" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,6,0"/>
-                    <ComboBox Width="140" ItemsSource="{Binding FilterOptions}" SelectedItem="{Binding SelectedFilter}"/>
+                    <TextBlock Text="Filter" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,6,0" ToolTip="Search kit number, name, category, or description"/>
+                    <ComboBox Width="140" ItemsSource="{Binding FilterOptions}" SelectedItem="{Binding SelectedFilter}" Margin="0,0,6,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearSearchCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
                 </StackPanel>
             </DockPanel>
         </Border>
 
         <Grid Grid.Row="1" Margin="0,6,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2.1*"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="1.1*"/>
+            </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="1.1*"/>
+                <RowDefinition Height="6"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
-            <Border Style="{StaticResource Card}" Padding="0" Margin="0,0,0,6">
-                <DataGrid ItemsSource="{Binding FilteredKits}"
-                          SelectedItem="{Binding SelectedKit}"
-                          AutoGenerateColumns="False"
-                          IsReadOnly="True"
-                          Style="{StaticResource VirtualizedDataGridStyle}">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Kit #" Binding="{Binding KitNumber}" Width="140"/>
-                        <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="200"/>
-                        <DataGridTextColumn Header="Category" Binding="{Binding Category}" Width="160"/>
-                        <DataGridTextColumn Header="Status" Binding="{Binding IsActive}" Width="100"/>
-                        <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="300"/>
-                    </DataGrid.Columns>
-                </DataGrid>
-            </Border>
 
-            <Border Grid.Row="1" Style="{StaticResource Card}" Padding="8">
-                <DockPanel LastChildFill="True">
-                    <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,8">
-                        <Button Style="{StaticResource PrimaryButton}" Content="Add Item" Command="{Binding AddKitItemCommand}" Margin="0,0,8,0"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Edit Item" Command="{Binding EditKitItemCommand}" Margin="0,0,8,0"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Remove Item" Command="{Binding RemoveKitItemCommand}" Margin="0,0,8,0"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Reload Items" Command="{Binding ViewKitItemsCommand}"/>
-                    </StackPanel>
-                    <DataGrid ItemsSource="{Binding KitItems}"
-                              SelectedItem="{Binding SelectedKitItem}"
+            <Border Grid.Row="0" Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                        <DockPanel>
+                            <TextBlock Text="01 Kit Directory" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                            <TextBlock Text="{Binding KitResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                        </DockPanel>
+                    </Border>
+                    <DataGrid x:Name="KitsGrid"
+                              Grid.Row="1"
+                              ItemsSource="{Binding FilteredKits}"
+                              SelectedItem="{Binding SelectedKit}"
                               AutoGenerateColumns="False"
                               IsReadOnly="True"
+                              SelectionMode="Single"
                               Style="{StaticResource VirtualizedDataGridStyle}">
+                        <DataGrid.RowStyle>
+                            <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                                <EventSetter Event="MouseDoubleClick" Handler="KitRow_MouseDoubleClick"/>
+                                <EventSetter Event="PreviewMouseRightButtonDown" Handler="DataGridRow_PreviewMouseRightButtonDown"/>
+                            </Style>
+                        </DataGrid.RowStyle>
                         <DataGrid.Columns>
-                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="140"/>
-                            <DataGridTextColumn Header="Item" Binding="{Binding ItemName}" Width="200"/>
-                            <DataGridTextColumn Header="Quantity" Binding="{Binding Quantity}" Width="100"/>
-                            <DataGridTextColumn Header="Optional" Binding="{Binding IsOptional}" Width="100"/>
+                            <DataGridTextColumn Header="Kit #" Binding="{Binding KitNumber}" Width="120"/>
+                            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*"/>
+                            <DataGridTextColumn Header="Category" Binding="{Binding Category}" Width="150"/>
+                            <DataGridCheckBoxColumn Header="Active" Binding="{Binding IsActive}" Width="80"/>
+                            <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*"/>
+                            <DataGridTextColumn Header="Updated" Binding="{Binding UpdatedAt, StringFormat={}{0:yyyy-MM-dd}}" Width="110"/>
                         </DataGrid.Columns>
+                        <DataGrid.ContextMenu>
+                            <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                <MenuItem Header="Open Details" Command="{Binding OpenKitDetailsCommand}"/>
+                                <MenuItem Header="Check Availability" Command="{Binding CheckAvailabilityCommand}"/>
+                                <MenuItem Header="Copy Details" Command="{Binding CopySelectedKitCommand}"/>
+                                <MenuItem Header="Print Kit Sheet" Command="{Binding PrintSelectedKitCommand}"/>
+                                <Separator/>
+                                <MenuItem Header="Edit Kit" Command="{Binding EditKitCommand}"/>
+                                <MenuItem Header="Delete Kit" Command="{Binding DeleteKitCommand}"/>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
                     </DataGrid>
-                </DockPanel>
+                    <TextBlock Grid.Row="1" Text="No kits match this filter" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="13" FontWeight="SemiBold">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding FilteredKits.Count}" Value="0">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Grid>
+            </Border>
+
+            <Border Grid.Row="2" Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                        <DockPanel>
+                            <TextBlock Text="02 Kit Item Membership" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                            <TextBlock Text="{Binding KitItemsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                        </DockPanel>
+                    </Border>
+                    <DockPanel Grid.Row="1" LastChildFill="True">
+                        <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                            <StackPanel Orientation="Horizontal">
+                                <Button Style="{StaticResource PrimaryButton}" Content="Add Item" Command="{Binding AddKitItemCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Edit Item" Command="{Binding EditKitItemCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Remove Item" Command="{Binding RemoveKitItemCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Reload Items" Command="{Binding ViewKitItemsCommand}"/>
+                            </StackPanel>
+                        </Border>
+                        <DataGrid x:Name="KitItemsGrid"
+                                  ItemsSource="{Binding KitItems}"
+                                  SelectedItem="{Binding SelectedKitItem}"
+                                  AutoGenerateColumns="False"
+                                  IsReadOnly="True"
+                                  SelectionMode="Single"
+                                  Style="{StaticResource VirtualizedDataGridStyle}">
+                            <DataGrid.RowStyle>
+                                <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                                    <EventSetter Event="MouseDoubleClick" Handler="KitItemRow_MouseDoubleClick"/>
+                                    <EventSetter Event="PreviewMouseRightButtonDown" Handler="DataGridRow_PreviewMouseRightButtonDown"/>
+                                </Style>
+                            </DataGrid.RowStyle>
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="130"/>
+                                <DataGridTextColumn Header="Item" Binding="{Binding ItemName}" Width="2*"/>
+                                <DataGridTextColumn Header="Qty" Binding="{Binding Quantity}" Width="80"/>
+                                <DataGridCheckBoxColumn Header="Optional" Binding="{Binding IsOptional}" Width="100"/>
+                            </DataGrid.Columns>
+                            <DataGrid.ContextMenu>
+                                <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                    <MenuItem Header="Edit Item" Command="{Binding EditKitItemCommand}"/>
+                                    <MenuItem Header="Remove Item" Command="{Binding RemoveKitItemCommand}"/>
+                                    <Separator/>
+                                    <MenuItem Header="Reload Items" Command="{Binding ViewKitItemsCommand}"/>
+                                </ContextMenu>
+                            </DataGrid.ContextMenu>
+                        </DataGrid>
+                        <TextBlock Text="No items assigned to this kit" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="13" FontWeight="SemiBold">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding KitItems.Count}" Value="0">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </DockPanel>
+                </Grid>
+            </Border>
+
+            <Border Grid.Row="0" Grid.RowSpan="3" Grid.Column="2" Style="{StaticResource Card}" Padding="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                        <TextBlock Text="03 Selected Kit" Style="{StaticResource SectionHeader}" Margin="0"/>
+                    </Border>
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Padding="8">
+                        <StackPanel>
+                            <TextBlock Text="{Binding SelectedKitSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,8"/>
+                            <TextBlock Text="Kit Detail" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
+                            <TextBlock Text="{Binding SelectedKitDetail}" TextWrapping="Wrap" Margin="0,0,0,10"/>
+                            <TextBlock Text="Availability" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
+                            <TextBlock Text="{Binding SelectedKitAvailabilitySummary}" TextWrapping="Wrap" Margin="0,0,0,10"/>
+                            <TextBlock Text="Selected Item" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
+                            <TextBlock Text="{Binding SelectedKitItemSummary}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </ScrollViewer>
+                    <Border Grid.Row="2" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,1,0,0" Padding="5,3">
+                        <WrapPanel>
+                            <Button Style="{StaticResource PrimaryButton}" Content="Check Availability" Command="{Binding CheckAvailabilityCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Copy" Command="{Binding CopySelectedKitCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Print Kit" Command="{Binding PrintSelectedKitCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Print Directory" Command="{Binding PrintKitListCommand}" Margin="0,0,4,4"/>
+                        </WrapPanel>
+                    </Border>
+                </Grid>
             </Border>
         </Grid>
+
+        <Border Grid.Row="2" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
+            <DockPanel LastChildFill="True">
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                    <Button Style="{StaticResource PrimaryButton}" Content="Add Item" Command="{Binding AddKitItemCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print Directory" Command="{Binding PrintKitListCommand}"/>
+                </StackPanel>
+                <TextBlock Text="{Binding SelectedKitSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0"/>
+            </DockPanel>
+        </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/KitManagementPage.xaml
+++ b/InventoryManagementApp/Views/Pages/KitManagementPage.xaml
@@ -107,6 +107,7 @@
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
@@ -115,15 +116,15 @@
                             <TextBlock Text="{Binding KitItemsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
                         </DockPanel>
                     </Border>
-                    <DockPanel Grid.Row="1" LastChildFill="True">
-                        <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
-                            <StackPanel Orientation="Horizontal">
-                                <Button Style="{StaticResource PrimaryButton}" Content="Add Item" Command="{Binding AddKitItemCommand}" Margin="0,0,4,0"/>
-                                <Button Style="{StaticResource PrimaryButton}" Content="Edit Item" Command="{Binding EditKitItemCommand}" Margin="0,0,4,0"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Remove Item" Command="{Binding RemoveKitItemCommand}" Margin="0,0,4,0"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Reload Items" Command="{Binding ViewKitItemsCommand}"/>
-                            </StackPanel>
-                        </Border>
+                    <Border Grid.Row="1" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                        <StackPanel Orientation="Horizontal">
+                            <Button Style="{StaticResource PrimaryButton}" Content="Add Item" Command="{Binding AddKitItemCommand}" Margin="0,0,4,0"/>
+                            <Button Style="{StaticResource PrimaryButton}" Content="Edit Item" Command="{Binding EditKitItemCommand}" Margin="0,0,4,0"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Remove Item" Command="{Binding RemoveKitItemCommand}" Margin="0,0,4,0"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Reload Items" Command="{Binding ViewKitItemsCommand}"/>
+                        </StackPanel>
+                    </Border>
+                    <Grid Grid.Row="2">
                         <DataGrid x:Name="KitItemsGrid"
                                   ItemsSource="{Binding KitItems}"
                                   SelectedItem="{Binding SelectedKitItem}"
@@ -164,7 +165,7 @@
                                 </Style>
                             </TextBlock.Style>
                         </TextBlock>
-                    </DockPanel>
+                    </Grid>
                 </Grid>
             </Border>
 

--- a/InventoryManagementApp/Views/Pages/KitManagementPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/KitManagementPage.xaml.cs
@@ -1,5 +1,7 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
@@ -10,6 +12,7 @@ namespace InventoryManagementApp.Views.Pages
         {
             InitializeComponent();
             Loaded += KitManagementPage_Loaded;
+            PreviewKeyDown += KitManagementPage_PreviewKeyDown;
         }
 
         private async void KitManagementPage_Loaded(object sender, RoutedEventArgs e)
@@ -18,6 +21,74 @@ namespace InventoryManagementApp.Views.Pages
             {
                 await vm.LoadKitsCommand.ExecuteAsync(null);
             }
+        }
+
+        private async void KitManagementPage_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (DataContext is not KitManagementViewModel vm)
+                return;
+
+            if (e.Key == Key.Enter && vm.OpenKitDetailsCommand.CanExecute(null))
+            {
+                vm.OpenKitDetailsCommand.Execute(null);
+                e.Handled = true;
+            }
+            else if (e.Key == Key.F5 && vm.RefreshCommand.CanExecute(null))
+            {
+                await vm.RefreshCommand.ExecuteAsync(null);
+                e.Handled = true;
+            }
+            else if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P && vm.PrintSelectedKitCommand.CanExecute(null))
+            {
+                vm.PrintSelectedKitCommand.Execute(null);
+                e.Handled = true;
+            }
+            else if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.D && vm.PrintKitListCommand.CanExecute(null))
+            {
+                vm.PrintKitListCommand.Execute(null);
+                e.Handled = true;
+            }
+        }
+
+        private void KitRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is KitManagementViewModel vm && vm.OpenKitDetailsCommand.CanExecute(null))
+            {
+                vm.OpenKitDetailsCommand.Execute(null);
+                e.Handled = true;
+            }
+        }
+
+        private async void KitItemRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is KitManagementViewModel vm && vm.EditKitItemCommand.CanExecute(null))
+            {
+                await vm.EditKitItemCommand.ExecuteAsync(null);
+                e.Handled = true;
+            }
+        }
+
+        private void DataGridRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is DataGridRow row)
+            {
+                row.IsSelected = true;
+                var dataGrid = FindParent<DataGrid>(row);
+                if (dataGrid != null)
+                    dataGrid.SelectedItem = row.Item;
+            }
+        }
+
+        private static T? FindParent<T>(DependencyObject child) where T : DependencyObject
+        {
+            var parent = VisualTreeHelper.GetParent(child);
+            while (parent != null)
+            {
+                if (parent is T typedParent)
+                    return typedParent;
+                parent = VisualTreeHelper.GetParent(parent);
+            }
+            return null;
         }
     }
 }

--- a/scripts/run-app-qa-screenshots.ps1
+++ b/scripts/run-app-qa-screenshots.ps1
@@ -42,6 +42,39 @@ $expectedFolders = @(
     "05-admin",
     "06-dialogs"
 )
+$expectedScreenshotFiles = @(
+    "00-auth\01-login-window.png",
+    "01-overview\01-search-tools-results.png",
+    "01-overview\02-search-tools-recent-searches.png",
+    "01-overview\03-search-tools-unavailable-demand.png",
+    "01-overview\04-dashboard-summary.png",
+    "01-overview\05-dashboard-recent-activity.png",
+    "01-overview\06-dashboard-items-with-issues.png",
+    "02-operations\01-manage-tools.png",
+    "02-operations\02-rentals.png",
+    "02-operations\03-customers.png",
+    "02-operations\04-maintenance.png",
+    "02-operations\05-calibration.png",
+    "02-operations\06-reservations.png",
+    "02-operations\07-kits.png",
+    "02-operations\08-categories.png",
+    "03-insights\01-reports.png",
+    "03-insights\02-activity-logs.png",
+    "04-data\01-import-export.png",
+    "05-admin\01-users.png",
+    "05-admin\02-settings-service-status.png",
+    "05-admin\03-settings-database.png",
+    "05-admin\04-settings-general.png",
+    "05-admin\05-settings-item-display.png",
+    "05-admin\06-settings-email.png",
+    "05-admin\07-settings-branding.png",
+    "05-admin\08-settings-messaging.png",
+    "05-admin\09-settings-backups.png",
+    "06-dialogs\01-print-labels.png"
+)
+if ($ExpectedScreenshotCount -lt $expectedScreenshotFiles.Count) {
+    $ExpectedScreenshotCount = $expectedScreenshotFiles.Count
+}
 $sessionOutput = Join-Path $OutputRoot "latest"
 $runRoot = Join-Path $repoRoot ".qa-run"
 $runDirectory = Join-Path $runRoot "latest"
@@ -124,6 +157,18 @@ try {
         }
     }
 
+    $missingExpectedFiles = @()
+    foreach ($expectedFile in $expectedScreenshotFiles) {
+        $expectedPath = Join-Path $sessionOutput $expectedFile
+        if (-not (Test-Path -LiteralPath $expectedPath)) {
+            $missingExpectedFiles += $expectedFile
+        }
+    }
+
+    if ($missingExpectedFiles.Count -gt 0) {
+        throw "QA screenshot run missed expected capture(s): $($missingExpectedFiles -join ', ')."
+    }
+
     $readmePath = Join-Path $sessionOutput "README.md"
     Add-Content -Path $readmePath -Value ""
     Add-Content -Path $readmePath -Value ("Captured screenshots: {0}" -f $screenshots.Count)
@@ -141,6 +186,6 @@ finally {
     }
 
     if (-not $KeepRunDirectory -and (Test-Path -LiteralPath $runRoot)) {
-        Remove-Item -LiteralPath $runRoot -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $runRoot -Recurse -Force
     }
 }


### PR DESCRIPTION
## Summary

- Redesigns Kits into a compact desktop operations workstation with kit directory, item membership, selected-kit detail, selected-item guidance, and availability next-action context.
- Adds row double-click details, row-correct right-click context menus, keyboard shortcuts, copy selected kit details, printable kit directory output, and printable kit pick sheets.
- Tightens QA screenshot validation so the wrapper requires the exact expected named screenshots, not only a loose PNG count/folder presence.
- Updates progress notes and the app completion checklist for the kit workflow pass.

## Why

Kits still looked and behaved like an incomplete admin grid while the rest of the app has been moving toward end-to-end technician/advisor workflows. This makes kits usable from selection through staging/availability review, membership maintenance, printout, and operational handoff.

## Validation

- Compared the branch against `master` through the GitHub connector.
- Read back changed XAML, code-behind, view model, screenshot script, and notes from the branch.
- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime, and direct local clone is still blocked by the network tunnel.
- Did not run unrelated tests, per instruction.