### PR TITLE
Upgrade customer workflow workstation

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-17-customer-workstation.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-customer-workstation.md
@@ -1,0 +1,16 @@
+# 2026-06-17 Customer Workstation Pass
+
+## Completed
+
+- Redesigned the Customers page into a two-pane workflow surface with a customer directory on the left and an advisor handoff panel on the right.
+- Added selected-customer contact, address, and operational next-step summaries so desk users can verify the customer before starting rentals, reservations, collection promises, or printed handoffs.
+- Added a copy-contact handoff command and exposed it from the toolbar, selected-customer panel, footer, and row context menu.
+- Improved refresh behavior so the selected customer is preserved after load/search/edit where possible and the first visible customer is selected when a list is available.
+- Fixed the customer row right-click behavior so context menus still open after selecting the row under the pointer.
+- Hardened the QA screenshot wrapper so runs fail when a required PNG is missing or suspiciously tiny, catching blank capture regressions earlier.
+
+## Validation
+
+- Reviewed the changed Customers page XAML, code-behind, view model, screenshot wrapper, and checklist through the GitHub connector.
+- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
+- Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 03:11 NZST
+Last audit date/time: 2026-06-17 05:20 NZST
 
 ## Completed workflows
 
@@ -17,15 +17,17 @@ Last audit date/time: 2026-06-17 03:11 NZST
 - QA screenshot wrapper validation now requires every expected screenshot folder to contain PNG output and appends the captured file list to the run README.
 - Kits now use a compact desktop workstation with kit directory, item membership, selected-kit detail, availability guidance, row-correct context menus, double-click drilldown, keyboard shortcuts, copy selected kit details, printable kit directory output, and printable kit pick sheets.
 - QA screenshot wrapper validation now checks for each expected named screenshot file so missing captures fail loudly instead of passing on folder count alone.
+- Customers now use a two-pane advisor workstation with customer directory, selected-customer contact/address/next-step handoff, copy contact, detail/edit/print actions in the right panel, stable selection after refresh/search/edit, and row-correct context menus that still open after right-click selection.
+- QA screenshot wrapper validation now rejects suspiciously tiny PNG output so blank or broken captures fail earlier.
 
 ## Partially complete workflows
 
 - Item import/export coverage exists, but solution-wide validation still needs to run in an environment with the .NET SDK.
 - Checkout/check-in refresh behavior was improved in the prior audit, but broader runtime UI review is still pending.
-- Customer CSV import already uses a transaction, but customer workflow coverage still needs broader review.
 - Reports page has a compact operational grid, summary panel, print/copy actions, and safe empty unknown-report handling; runtime screenshot and full report generation checks remain pending.
 - Import / Export has been redesigned and wired for log actions, but runtime file-dialog, print, and screenshot checks still need a Windows/.NET workstation.
 - Kits now have a completed desktop workflow surface, but runtime add/edit/item-membership dialog validation still needs a Windows/.NET workstation.
+- Customers now have a completed desktop workflow surface, but runtime add/edit/delete/print/copy validation still needs a Windows/.NET workstation.
 
 ## Known broken workflows
 
@@ -35,11 +37,11 @@ Last audit date/time: 2026-06-17 03:11 NZST
 
 ## Next recommended target
 
-- Continue the end-to-end workflow audit from a technician/advisor/admin perspective, with the next useful pass focused on runtime screenshot review on a Windows/.NET workstation and any missing actions discovered there.
+- Continue the end-to-end workflow audit from a technician/advisor/admin perspective, with the next useful pass focused on Maintenance, Calibration, Reservations, or Categories depending on which page still exposes the most incomplete action/result path on `master`.
 
 ## Validation status
 
-- GitHub connector readback reviewed the Kit workstation branch files, screenshot wrapper, progress note, and completion checklist.
+- GitHub connector readback reviewed the Customer workstation branch files, screenshot wrapper, progress note, and completion checklist.
 - `dotnet --info`: failed because `dotnet` is not installed in this scheduled container.
 - `dotnet restore InventoryManagementApp.sln`: not run because the .NET SDK is unavailable.
 - `dotnet build InventoryManagementApp.sln --no-restore`: not run because the .NET SDK is unavailable.

--- a/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
@@ -21,10 +21,32 @@ namespace InventoryManagementApp.ViewModels
 
         public ObservableCollection<CustomerModel> Customers { get; } = new();
 
-        public string CustomerResultsSummary => $"{Customers.Count} customer{(Customers.Count == 1 ? string.Empty : "s")} shown";
+        public string CustomerResultsSummary
+        {
+            get
+            {
+                var baseSummary = $"{Customers.Count} customer{(Customers.Count == 1 ? string.Empty : "s")} shown";
+                return string.IsNullOrWhiteSpace(CustomerSearchTerm)
+                    ? baseSummary
+                    : $"{baseSummary} for \"{CustomerSearchTerm.Trim()}\"";
+            }
+        }
+
         public string SelectedCustomerSummary => SelectedCustomer == null
-            ? "Select or double-click a customer row to view contact details, print a customer sheet, edit, or delete."
-            : $"{ValueOrNotRecorded(SelectedCustomer.Company)} | {ValueOrNotRecorded(SelectedCustomer.Contact)} | {ValueOrNotRecorded(SelectedCustomer.Phone)} | {ValueOrNotRecorded(SelectedCustomer.Email)}";
+            ? "Select or double-click a customer row to view contact details, copy a handoff, print a customer sheet, edit, or delete."
+            : $"Ready: {ValueOrNotRecorded(SelectedCustomer.Company)} | {ValueOrNotRecorded(SelectedCustomer.Contact)} | {ValueOrNotRecorded(SelectedCustomer.Phone)} | {ValueOrNotRecorded(SelectedCustomer.Email)}";
+
+        public string CustomerContactSummary => SelectedCustomer == null
+            ? "Select a customer to see phone, mobile, and email contact details."
+            : $"Phone: {ValueOrNotRecorded(SelectedCustomer.Phone)} | Mobile: {ValueOrNotRecorded(SelectedCustomer.Mobile)} | Email: {ValueOrNotRecorded(SelectedCustomer.Email)}";
+
+        public string CustomerAddressSummary => SelectedCustomer == null
+            ? "No address is selected yet."
+            : ValueOrNotRecorded(SelectedCustomer.Address);
+
+        public string CustomerOperationsSummary => SelectedCustomer == null
+            ? "Choose a customer before starting a rental, reservation, delivery promise, or printed handoff."
+            : "Verify this contact, then use Rentals or Requests to review open activity before promising availability or collection times.";
 
         private CustomerModel? _selectedCustomer;
         public CustomerModel? SelectedCustomer
@@ -39,7 +61,11 @@ namespace InventoryManagementApp.ViewModels
                     ((AsyncRelayCommand)EditCustomerCommand).NotifyCanExecuteChanged();
                     OpenCustomerDetailsCommand.NotifyCanExecuteChanged();
                     PrintSelectedCustomerCommand.NotifyCanExecuteChanged();
+                    CopySelectedCustomerCommand.NotifyCanExecuteChanged();
                     OnPropertyChanged(nameof(SelectedCustomerSummary));
+                    OnPropertyChanged(nameof(CustomerContactSummary));
+                    OnPropertyChanged(nameof(CustomerAddressSummary));
+                    OnPropertyChanged(nameof(CustomerOperationsSummary));
 
                     if (value != null)
                     {
@@ -75,7 +101,11 @@ namespace InventoryManagementApp.ViewModels
         public string CustomerSearchTerm
         {
             get => _customerSearchTerm;
-            set => SetProperty(ref _customerSearchTerm, value);
+            set
+            {
+                if (SetProperty(ref _customerSearchTerm, value))
+                    OnPropertyChanged(nameof(CustomerResultsSummary));
+            }
         }
 
         public IAsyncRelayCommand AddCustomerCommand { get; }
@@ -89,6 +119,7 @@ namespace InventoryManagementApp.ViewModels
         public IRelayCommand OpenCustomerDetailsCommand { get; }
         public IRelayCommand PrintCustomerDirectoryCommand { get; }
         public IRelayCommand PrintSelectedCustomerCommand { get; }
+        public IRelayCommand CopySelectedCustomerCommand { get; }
 
         public CustomerManagementViewModel(ICustomerService customerService, IDialogService dialogService)
         {
@@ -105,6 +136,7 @@ namespace InventoryManagementApp.ViewModels
             OpenCustomerDetailsCommand = new RelayCommand(OpenCustomerDetails, () => SelectedCustomer != null);
             PrintCustomerDirectoryCommand = new RelayCommand(PrintCustomerDirectory);
             PrintSelectedCustomerCommand = new RelayCommand(PrintSelectedCustomer, () => SelectedCustomer != null);
+            CopySelectedCustomerCommand = new RelayCommand(CopySelectedCustomer, () => SelectedCustomer != null);
         }
 
         public async Task LoadCustomersAsync()
@@ -113,8 +145,10 @@ namespace InventoryManagementApp.ViewModels
 
             try
             {
+                var preferredCustomerId = SelectedCustomer?.CustomerID;
                 var all = await _customerService.GetAllCustomersAsync();
                 Customers.ReplaceRange(all);
+                SelectBestCustomerAfterRefresh(preferredCustomerId);
                 OnPropertyChanged(nameof(CustomerResultsSummary));
             }
             catch (Exception ex)
@@ -133,7 +167,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 await _customerService.AddCustomerAsync(customer);
                 await LoadCustomersAsync();
-                ClearNewCustomerFields();
+                SelectBestCustomerAfterRefresh(customer.CustomerID);
             }
             catch (UnauthorizedAccessException)
             {
@@ -148,9 +182,10 @@ namespace InventoryManagementApp.ViewModels
         async Task UpdateCustomerAsync()
         {
             if (SelectedCustomer == null || _customerService == null || _dialogService == null) return;
+            var selectedId = SelectedCustomer.CustomerID;
             var updated = new CustomerModel
             {
-                CustomerID = SelectedCustomer.CustomerID,
+                CustomerID = selectedId,
                 Company = NewCustomerName,
                 Email = NewCustomerEmail,
                 Contact = NewCustomerContact,
@@ -163,6 +198,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 await _customerService.UpdateCustomerAsync(updated);
                 await LoadCustomersAsync();
+                SelectBestCustomerAfterRefresh(selectedId);
             }
             catch (UnauthorizedAccessException)
             {
@@ -180,6 +216,7 @@ namespace InventoryManagementApp.ViewModels
 
             try
             {
+                var preferredCustomerId = SelectedCustomer?.CustomerID;
                 var all = await _customerService.GetAllCustomersAsync();
                 if (!string.IsNullOrWhiteSpace(CustomerSearchTerm))
                 {
@@ -194,6 +231,7 @@ namespace InventoryManagementApp.ViewModels
                         .ToList();
                 }
                 Customers.ReplaceRange(all);
+                SelectBestCustomerAfterRefresh(preferredCustomerId);
                 OnPropertyChanged(nameof(CustomerResultsSummary));
             }
             catch (Exception ex)
@@ -254,6 +292,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 await _customerService.UpdateCustomerAsync(edited);
                 await LoadCustomersAsync();
+                SelectBestCustomerAfterRefresh(edited.CustomerID);
             }
             catch (UnauthorizedAccessException)
             {
@@ -271,20 +310,25 @@ namespace InventoryManagementApp.ViewModels
                 return;
 
             var customer = SelectedCustomer;
-            var details = new StringBuilder();
-            details.AppendLine($"Customer #: {customer.CustomerID}");
-            details.AppendLine($"Company: {ValueOrNotRecorded(customer.Company)}");
-            details.AppendLine($"Primary contact: {ValueOrNotRecorded(customer.Contact)}");
-            details.AppendLine();
-            details.AppendLine($"Phone: {ValueOrNotRecorded(customer.Phone)}");
-            details.AppendLine($"Mobile: {ValueOrNotRecorded(customer.Mobile)}");
-            details.AppendLine($"Email: {ValueOrNotRecorded(customer.Email)}");
-            details.AppendLine();
-            details.AppendLine($"Address: {ValueOrNotRecorded(customer.Address)}");
-            details.AppendLine();
-            details.AppendLine("Next steps: edit the contact, print a customer sheet, then use rentals or requests to review open activity for this customer.");
+            var details = CreateCustomerHandoffText(customer);
 
-            _dialogService.ShowInfo(details.ToString(), $"Customer Details - {ValueOrNotRecorded(customer.Company)}");
+            _dialogService.ShowInfo(details, $"Customer Details - {ValueOrNotRecorded(customer.Company)}");
+        }
+
+        void CopySelectedCustomer()
+        {
+            if (SelectedCustomer == null || _dialogService == null)
+                return;
+
+            try
+            {
+                Clipboard.SetText(CreateCustomerHandoffText(SelectedCustomer));
+                _dialogService.ShowInfo("Customer contact handoff copied to the clipboard.", "Customer Handoff");
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowInfo($"Failed to copy customer handoff: {ex.Message}", "Copy Failed");
+            }
         }
 
         void PrintCustomerDirectory()
@@ -359,6 +403,36 @@ namespace InventoryManagementApp.ViewModels
             {
                 _dialogService.ShowInfo($"Failed to print customer sheet: {ex.Message}", "Print Failed");
             }
+        }
+
+        void SelectBestCustomerAfterRefresh(int? preferredCustomerId = null)
+        {
+            if (Customers.Count == 0)
+            {
+                SelectedCustomer = null;
+                return;
+            }
+
+            SelectedCustomer = preferredCustomerId.HasValue
+                ? Customers.FirstOrDefault(c => c.CustomerID == preferredCustomerId.Value) ?? Customers.FirstOrDefault()
+                : Customers.FirstOrDefault();
+        }
+
+        static string CreateCustomerHandoffText(CustomerModel customer)
+        {
+            var details = new StringBuilder();
+            details.AppendLine($"Customer #: {customer.CustomerID}");
+            details.AppendLine($"Company: {ValueOrNotRecorded(customer.Company)}");
+            details.AppendLine($"Primary contact: {ValueOrNotRecorded(customer.Contact)}");
+            details.AppendLine();
+            details.AppendLine($"Phone: {ValueOrNotRecorded(customer.Phone)}");
+            details.AppendLine($"Mobile: {ValueOrNotRecorded(customer.Mobile)}");
+            details.AppendLine($"Email: {ValueOrNotRecorded(customer.Email)}");
+            details.AppendLine();
+            details.AppendLine($"Address: {ValueOrNotRecorded(customer.Address)}");
+            details.AppendLine();
+            details.AppendLine("Next steps: verify the contact, then use Rentals or Requests to review open activity before promising availability or collection times.");
+            return details.ToString();
         }
 
         static FlowDocument CreateCustomerDocument(string title, double fontSize = 16)

--- a/InventoryManagementApp/Views/Pages/CustomersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CustomersPage.xaml
@@ -115,7 +115,7 @@
                     </Border>
                     <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
                         <StackPanel Margin="10">
-                            <TextBlock Text="{Binding SelectedCustomer.Company, TargetNullValue=No customer selected, FallbackValue=No customer selected}"
+                            <TextBlock Text="{Binding SelectedCustomer.Company, TargetNullValue='No customer selected', FallbackValue='No customer selected'}"
                                        FontSize="18"
                                        FontWeight="SemiBold"
                                        TextWrapping="Wrap"/>

--- a/InventoryManagementApp/Views/Pages/CustomersPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CustomersPage.xaml
@@ -10,19 +10,21 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
+
         <Border Style="{StaticResource ToolbarCard}">
             <DockPanel LastChildFill="False">
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
-                    <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <TextBlock Text="Customer workflow" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddCustomerCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCustomerDetailsCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditCustomerCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Print Customer" Command="{Binding PrintSelectedCustomerCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Copy Contact" Command="{Binding CopySelectedCustomerCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Print Sheet" Command="{Binding PrintSelectedCustomerCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Print Directory" Command="{Binding PrintCustomerDirectoryCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteCustomerCommand}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
-                    <TextBlock Text="Filter" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <TextBlock Text="Find customer" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
                     <pages:SearchBar Width="340"
                                      Text="{Binding CustomerSearchTerm, UpdateSourceTrigger=PropertyChanged}"
                                      SearchCommand="{Binding SearchCustomersCommand}"
@@ -31,71 +33,129 @@
                 </StackPanel>
             </DockPanel>
         </Border>
-        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
-                    <DockPanel>
-                        <TextBlock Text="01 Customer Directory" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
-                        <TextBlock Text="{Binding CustomerResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
-                    </DockPanel>
-                </Border>
-                <DataGrid Grid.Row="1"
-                          ItemsSource="{Binding Customers}"
-                          SelectedItem="{Binding SelectedCustomer}"
-                          IsReadOnly="True"
-                          AutoGenerateColumns="False"
-                          SelectionMode="Single"
-                          Style="{StaticResource VirtualizedDataGridStyle}">
-                    <DataGrid.RowStyle>
-                        <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
-                            <EventSetter Event="MouseDoubleClick" Handler="CustomerRow_MouseDoubleClick"/>
-                            <EventSetter Event="PreviewMouseRightButtonDown" Handler="CustomerRow_PreviewMouseRightButtonDown"/>
-                        </Style>
-                    </DataGrid.RowStyle>
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Company" Binding="{Binding Company}" Width="2*"/>
-                        <DataGridTextColumn Header="Contact" Binding="{Binding Contact}" Width="180"/>
-                        <DataGridTextColumn Header="Phone" Binding="{Binding Phone}" Width="130"/>
-                        <DataGridTextColumn Header="Mobile" Binding="{Binding Mobile}" Width="130"/>
-                        <DataGridTextColumn Header="Email" Binding="{Binding Email}" Width="220"/>
-                        <DataGridTextColumn Header="Address" Binding="{Binding Address}" Width="2*"/>
-                    </DataGrid.Columns>
-                    <DataGrid.ContextMenu>
-                        <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                            <MenuItem Header="Open Details" Command="{Binding OpenCustomerDetailsCommand}"/>
-                            <MenuItem Header="Edit" Command="{Binding EditCustomerCommand}"/>
-                            <MenuItem Header="Print Customer Sheet" Command="{Binding PrintSelectedCustomerCommand}"/>
-                            <Separator/>
-                            <MenuItem Header="Print Directory" Command="{Binding PrintCustomerDirectoryCommand}"/>
-                            <MenuItem Header="Delete" Command="{Binding DeleteCustomerCommand}"/>
-                        </ContextMenu>
-                    </DataGrid.ContextMenu>
-                </DataGrid>
-                <TextBlock Grid.Row="1" Text="No customers match this search" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="13" FontWeight="SemiBold">
-                    <TextBlock.Style>
-                        <Style TargetType="TextBlock">
-                            <Setter Property="Visibility" Value="Collapsed"/>
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding Customers.Count}" Value="0">
-                                    <Setter Property="Visibility" Value="Visible"/>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </TextBlock.Style>
-                </TextBlock>
-            </Grid>
-        </Border>
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" MinWidth="520"/>
+                <ColumnDefinition Width="8"/>
+                <ColumnDefinition Width="420" MinWidth="360"/>
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                        <DockPanel>
+                            <TextBlock Text="01 Customer Directory" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                            <TextBlock Text="{Binding CustomerResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                        </DockPanel>
+                    </Border>
+                    <DataGrid Grid.Row="1"
+                              ItemsSource="{Binding Customers}"
+                              SelectedItem="{Binding SelectedCustomer}"
+                              IsReadOnly="True"
+                              AutoGenerateColumns="False"
+                              SelectionMode="Single"
+                              Style="{StaticResource VirtualizedDataGridStyle}">
+                        <DataGrid.RowStyle>
+                            <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                                <EventSetter Event="MouseDoubleClick" Handler="CustomerRow_MouseDoubleClick"/>
+                                <EventSetter Event="PreviewMouseRightButtonDown" Handler="CustomerRow_PreviewMouseRightButtonDown"/>
+                            </Style>
+                        </DataGrid.RowStyle>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Company" Binding="{Binding Company}" Width="2*"/>
+                            <DataGridTextColumn Header="Contact" Binding="{Binding Contact}" Width="170"/>
+                            <DataGridTextColumn Header="Phone" Binding="{Binding Phone}" Width="120"/>
+                            <DataGridTextColumn Header="Mobile" Binding="{Binding Mobile}" Width="120"/>
+                            <DataGridTextColumn Header="Email" Binding="{Binding Email}" Width="210"/>
+                            <DataGridTextColumn Header="Address" Binding="{Binding Address}" Width="2*"/>
+                        </DataGrid.Columns>
+                        <DataGrid.ContextMenu>
+                            <ContextMenu Style="{StaticResource {x:Type ContextMenu}}" DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                <MenuItem Header="Open Details" Command="{Binding OpenCustomerDetailsCommand}"/>
+                                <MenuItem Header="Edit" Command="{Binding EditCustomerCommand}"/>
+                                <MenuItem Header="Copy Contact Handoff" Command="{Binding CopySelectedCustomerCommand}"/>
+                                <MenuItem Header="Print Customer Sheet" Command="{Binding PrintSelectedCustomerCommand}"/>
+                                <Separator/>
+                                <MenuItem Header="Print Directory" Command="{Binding PrintCustomerDirectoryCommand}"/>
+                                <MenuItem Header="Delete" Command="{Binding DeleteCustomerCommand}"/>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                    </DataGrid>
+                    <TextBlock Grid.Row="1" Text="No customers match this search" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="13" FontWeight="SemiBold">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Customers.Count}" Value="0">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Grid>
+            </Border>
+
+            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                        <DockPanel>
+                            <TextBlock Text="02 Advisor Handoff" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                            <TextBlock Text="Selected customer" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                        </DockPanel>
+                    </Border>
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                        <StackPanel Margin="10">
+                            <TextBlock Text="{Binding SelectedCustomer.Company, TargetNullValue=No customer selected, FallbackValue=No customer selected}"
+                                       FontSize="18"
+                                       FontWeight="SemiBold"
+                                       TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding CustomerContactSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,10"/>
+
+                            <TextBlock Text="Contact path" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
+                            <TextBlock Text="{Binding CustomerContactSummary}" TextWrapping="Wrap" Margin="0,0,0,10"/>
+
+                            <TextBlock Text="Address" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
+                            <TextBlock Text="{Binding CustomerAddressSummary}" TextWrapping="Wrap" Margin="0,0,0,10"/>
+
+                            <TextBlock Text="Operational next step" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
+                            <TextBlock Text="{Binding CustomerOperationsSummary}" TextWrapping="Wrap" Margin="0,0,0,14"/>
+
+                            <UniformGrid Columns="2" Margin="0,0,0,8">
+                                <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCustomerDetailsCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditCustomerCommand}" Margin="4,0,0,4"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Copy" Command="{Binding CopySelectedCustomerCommand}" Margin="0,4,4,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Print" Command="{Binding PrintSelectedCustomerCommand}" Margin="4,4,0,0"/>
+                            </UniformGrid>
+
+                            <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="8" Margin="0,6,0,0">
+                                <StackPanel>
+                                    <TextBlock Text="Desk checklist" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/>
+                                    <TextBlock Text="Confirm the customer, verify the phone or email, print or copy the handoff, then switch to Rentals or Requests before promising availability." TextWrapping="Wrap"/>
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+                    </ScrollViewer>
+                </Grid>
+            </Border>
+        </Grid>
+
         <Border Grid.Row="2" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
             <DockPanel LastChildFill="True">
                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCustomerDetailsCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Copy Contact" Command="{Binding CopySelectedCustomerCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource GhostButton}" Content="Clear Search" Command="{Binding ClearCustomerSearchCommand}"/>
                 </StackPanel>
-                <TextBlock Text="{Binding SelectedCustomerSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0"/>
+                <TextBlock Text="{Binding SelectedCustomerSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0" TextWrapping="Wrap"/>
             </DockPanel>
         </Border>
     </Grid>

--- a/InventoryManagementApp/Views/Pages/CustomersPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CustomersPage.xaml.cs
@@ -34,7 +34,7 @@ namespace InventoryManagementApp.Views.Pages
             if (sender is DataGridRow row && !row.IsSelected)
             {
                 row.IsSelected = true;
-                e.Handled = true;
+                row.Focus();
             }
         }
     }

--- a/scripts/run-app-qa-screenshots.ps1
+++ b/scripts/run-app-qa-screenshots.ps1
@@ -33,6 +33,7 @@ if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
     $OutputRoot = Join-Path $repoRoot ".qa-screenshots"
 }
 
+$minimumScreenshotBytes = 1024
 $expectedFolders = @(
     "00-auth",
     "01-overview",
@@ -169,9 +170,16 @@ try {
         throw "QA screenshot run missed expected capture(s): $($missingExpectedFiles -join ', ')."
     }
 
+    $undersizedScreenshots = @($screenshots | Where-Object { $_.Length -lt $minimumScreenshotBytes })
+    if ($undersizedScreenshots.Count -gt 0) {
+        $undersizedList = $undersizedScreenshots | ForEach-Object { $_.FullName }
+        throw "QA screenshot run produced suspiciously small PNG capture(s): $($undersizedList -join ', ')."
+    }
+
     $readmePath = Join-Path $sessionOutput "README.md"
     Add-Content -Path $readmePath -Value ""
     Add-Content -Path $readmePath -Value ("Captured screenshots: {0}" -f $screenshots.Count)
+    Add-Content -Path $readmePath -Value ("Minimum PNG size checked: {0} bytes" -f $minimumScreenshotBytes)
     Add-Content -Path $readmePath -Value ""
     Add-Content -Path $readmePath -Value "Captured files:"
     foreach ($screenshot in ($screenshots | Sort-Object FullName)) {


### PR DESCRIPTION
## Summary

- Redesigns Customers into a two-pane advisor workstation with customer directory, selected-customer contact/address detail, and operational handoff guidance.
- Adds copy-contact handoff support and exposes it from the toolbar, selected-customer panel, footer, and row context menu.
- Preserves customer selection after load/search/edit where possible, selects the first visible customer for immediate handoff context, and fixes right-click row selection so the context menu still opens on the clicked customer.
- Hardens the QA screenshot wrapper so it rejects suspiciously tiny PNG captures in addition to missing expected files/folders.
- Updates progress notes and the completion checklist for the customer workflow pass.

## Why

The user asked to continue improving end-to-end app flows from technician, advisor, and admin perspectives. Customers was still mostly a directory plus footer actions; an advisor renting or reserving a tool needs a quick customer verification and handoff surface without hunting through buttons.

## Validation

- Compared the branch against `master` through the GitHub connector.
- Read back changed XAML, code-behind, view model, screenshot script, progress note, and checklist from the branch.
- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
- Did not run unrelated tests, per instruction.