### PR TITLE
Upgrade maintenance technician workbench

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-17-maintenance-workbench.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-maintenance-workbench.md
@@ -1,0 +1,18 @@
+# 2026-06-17 - Maintenance Technician Workbench
+
+## Completed
+
+- Redesigned Maintenance into a two-pane technician workbench with the maintenance schedule on the left and selected work-order handoff on the right.
+- Added backlog context for overdue, upcoming, scheduled, and completed maintenance so technicians can see risk before opening each row.
+- Added quick filter buttons for overdue, upcoming, and scheduled work, plus a clear-search action.
+- Added selected-maintenance detail, timing, next-action, and bench-checklist summaries for the technician flow from shelf check through service completion and record handoff.
+- Added copy-maintenance-handoff support from the toolbar, selected-work panel, and row context menu.
+- Kept selection stable after load, edit, add, complete, delete, search, and filter changes where possible, defaulting to the first visible record when useful.
+- Hardened maintenance search against missing imported/legacy text values such as item name, type, description, performer, and notes.
+- Strengthened the QA screenshot wrapper to reject expected PNGs that are present but too small in pixel dimensions, catching failed or cropped captures more reliably.
+
+## Validation
+
+- GitHub connector readback reviewed the changed Maintenance XAML, Maintenance view model, screenshot wrapper, progress note, and checklist on the branch.
+- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
+- Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 05:20 NZST
+Last audit date/time: 2026-06-17 06:19 NZST
 
 ## Completed workflows
 
@@ -17,8 +17,10 @@ Last audit date/time: 2026-06-17 05:20 NZST
 - QA screenshot wrapper validation now requires every expected screenshot folder to contain PNG output and appends the captured file list to the run README.
 - Kits now use a compact desktop workstation with kit directory, item membership, selected-kit detail, availability guidance, row-correct context menus, double-click drilldown, keyboard shortcuts, copy selected kit details, printable kit directory output, and printable kit pick sheets.
 - QA screenshot wrapper validation now checks for each expected named screenshot file so missing captures fail loudly instead of passing on folder count alone.
-- Customers now use a two-pane advisor workstation with customer directory, selected-customer contact/address/next-step handoff, copy contact, detail/edit/print actions in the right panel, stable selection after refresh/search/edit, and row-correct context menus that still open after right-click selection.
+- Customers now use a two-pane advisor workstation with customer directory, selected-customer contact/address/next-step handoff, copy contact, detail/edit/print actions in the right panel, stable selection after refresh/search/edit where possible, and row-correct context menus that still open after right-click selection.
 - QA screenshot wrapper validation now rejects suspiciously tiny PNG output so blank or broken captures fail earlier.
+- Maintenance now uses a two-pane technician workbench with schedule backlog context, selected work-order detail, timing, next action, bench checklist, quick overdue/upcoming/scheduled filters, copy handoff, print actions, stable useful selection, and null-safe search across legacy/imported records.
+- QA screenshot wrapper validation now rejects expected PNG captures that are too small in pixel dimensions, catching failed or cropped screenshots beyond file-size checks.
 
 ## Partially complete workflows
 
@@ -28,6 +30,7 @@ Last audit date/time: 2026-06-17 05:20 NZST
 - Import / Export has been redesigned and wired for log actions, but runtime file-dialog, print, and screenshot checks still need a Windows/.NET workstation.
 - Kits now have a completed desktop workflow surface, but runtime add/edit/item-membership dialog validation still needs a Windows/.NET workstation.
 - Customers now have a completed desktop workflow surface, but runtime add/edit/delete/print/copy validation still needs a Windows/.NET workstation.
+- Maintenance now has a completed desktop workflow surface, but runtime add/edit/complete/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 
 ## Known broken workflows
 
@@ -37,11 +40,11 @@ Last audit date/time: 2026-06-17 05:20 NZST
 
 ## Next recommended target
 
-- Continue the end-to-end workflow audit from a technician/advisor/admin perspective, with the next useful pass focused on Maintenance, Calibration, Reservations, or Categories depending on which page still exposes the most incomplete action/result path on `master`.
+- Continue the end-to-end workflow audit from a technician/advisor/admin perspective, with the next useful pass focused on Calibration, Reservations, or Categories depending on which page still exposes the most incomplete action/result path on `master`.
 
 ## Validation status
 
-- GitHub connector readback reviewed the Customer workstation branch files, screenshot wrapper, progress note, and completion checklist.
+- GitHub connector readback reviewed the Maintenance workbench branch files, screenshot wrapper, progress note, and completion checklist.
 - `dotnet --info`: failed because `dotnet` is not installed in this scheduled container.
 - `dotnet restore InventoryManagementApp.sln`: not run because the .NET SDK is unavailable.
 - `dotnet build InventoryManagementApp.sln --no-restore`: not run because the .NET SDK is unavailable.

--- a/InventoryManagementApp/ViewModels/MaintenanceManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MaintenanceManagementViewModel.cs
@@ -22,9 +22,61 @@ namespace InventoryManagementApp.ViewModels
         public ObservableCollection<MaintenanceRecord> FilteredMaintenanceRecords { get; }
 
         public string MaintenanceResultsSummary => $"{FilteredMaintenanceRecords.Count} of {MaintenanceRecords.Count} maintenance record{(MaintenanceRecords.Count == 1 ? string.Empty : "s")} shown";
+        public string MaintenanceBacklogSummary
+        {
+            get
+            {
+                var scheduled = MaintenanceRecords.Count(r => IsScheduled(r));
+                var overdue = MaintenanceRecords.Count(r => r.IsOverdue);
+                var upcoming = MaintenanceRecords.Count(r => IsUpcoming(r));
+                var completed = MaintenanceRecords.Count(r => IsCompleted(r));
+                return $"{overdue} overdue | {upcoming} upcoming | {scheduled} scheduled | {completed} completed";
+            }
+        }
+
         public string SelectedRecordSummary => SelectedRecord == null
-            ? "Select or double-click a maintenance row to view details, complete work, print the record, edit, or delete."
+            ? "Select or double-click maintenance work to review it, complete it, copy the technician handoff, edit, print, or delete."
             : $"{ValueOrNotRecorded(SelectedRecord.ItemNumber)} | {ValueOrNotRecorded(SelectedRecord.ItemName)} | {SelectedRecord.StatusDisplay} | scheduled {SelectedRecord.ScheduledDate:yyyy-MM-dd}";
+
+        public string SelectedMaintenanceDetail => SelectedRecord == null
+            ? "No work selected. Choose a maintenance row or create new work before taking an action."
+            : $"{ValueOrNotRecorded(SelectedRecord.MaintenanceType)} for {ValueOrNotRecorded(SelectedRecord.ItemNumber)} - {ValueOrNotRecorded(SelectedRecord.ItemName)}. Description: {ValueOrNotRecorded(SelectedRecord.Description)}. Notes: {ValueOrNotRecorded(SelectedRecord.Notes)}";
+
+        public string SelectedMaintenanceTimingSummary => SelectedRecord == null
+            ? "No schedule selected."
+            : $"Scheduled {SelectedRecord.ScheduledDate:yyyy-MM-dd}. Completed {FormatDate(SelectedRecord.CompletedDate)}. Performed by {ValueOrNotRecorded(SelectedRecord.PerformedBy)}. Cost {SelectedRecord.Cost:C}.";
+
+        public string SelectedMaintenanceNextAction
+        {
+            get
+            {
+                if (SelectedRecord == null)
+                {
+                    return "Add a maintenance record or select existing work to see the next operational step.";
+                }
+
+                if (SelectedRecord.IsOverdue)
+                {
+                    return "This work is overdue. Hold the item from issue, complete or reschedule the job, then print or copy the updated record for the bench file.";
+                }
+
+                if (IsScheduled(SelectedRecord))
+                {
+                    return "Confirm the item is on the shelf or staged for service, perform the work, mark it complete, and print or copy the record for handoff.";
+                }
+
+                if (IsCompleted(SelectedRecord))
+                {
+                    return "This work is complete. Review the notes, print the record if needed, or edit the entry if follow-up details are missing.";
+                }
+
+                return "Review the work details, update the status, and keep the record with the item before it is released.";
+            }
+        }
+
+        public string SelectedMaintenanceBenchChecklist => SelectedRecord == null
+            ? "Select work first, then verify the tool tag, confirm service notes, complete or edit the record, and print/copy the handoff before releasing the item."
+            : "Verify item tag and location, capture who performed the work, record cost/notes, mark complete when finished, and keep the printed or copied handoff with the tool.";
 
         private MaintenanceRecord? _selectedRecord;
         public MaintenanceRecord? SelectedRecord
@@ -39,7 +91,8 @@ namespace InventoryManagementApp.ViewModels
                     CompleteMaintenanceCommand.NotifyCanExecuteChanged();
                     OpenMaintenanceDetailsCommand.NotifyCanExecuteChanged();
                     PrintSelectedMaintenanceCommand.NotifyCanExecuteChanged();
-                    OnPropertyChanged(nameof(SelectedRecordSummary));
+                    CopySelectedMaintenanceCommand.NotifyCanExecuteChanged();
+                    OnSelectedRecordSummariesChanged();
                 }
             }
         }
@@ -81,6 +134,11 @@ namespace InventoryManagementApp.ViewModels
         public IRelayCommand OpenMaintenanceDetailsCommand { get; }
         public IRelayCommand PrintMaintenanceListCommand { get; }
         public IRelayCommand PrintSelectedMaintenanceCommand { get; }
+        public IRelayCommand CopySelectedMaintenanceCommand { get; }
+        public IRelayCommand ClearSearchCommand { get; }
+        public IRelayCommand ShowOverdueCommand { get; }
+        public IRelayCommand ShowUpcomingCommand { get; }
+        public IRelayCommand ShowScheduledCommand { get; }
 
         public MaintenanceManagementViewModel(
             MaintenanceService maintenanceService,
@@ -109,19 +167,25 @@ namespace InventoryManagementApp.ViewModels
             OpenMaintenanceDetailsCommand = new RelayCommand(OpenMaintenanceDetails, CanEditOrDelete);
             PrintMaintenanceListCommand = new RelayCommand(PrintMaintenanceList);
             PrintSelectedMaintenanceCommand = new RelayCommand(PrintSelectedMaintenance, CanEditOrDelete);
+            CopySelectedMaintenanceCommand = new RelayCommand(CopySelectedMaintenance, CanEditOrDelete);
+            ClearSearchCommand = new RelayCommand(ClearSearch);
+            ShowOverdueCommand = new RelayCommand(() => SelectedFilter = "Overdue");
+            ShowUpcomingCommand = new RelayCommand(() => SelectedFilter = "Upcoming (30 days)");
+            ShowScheduledCommand = new RelayCommand(() => SelectedFilter = "Scheduled");
         }
 
         private async Task LoadMaintenanceAsync()
         {
             try
             {
+                var selectedId = SelectedRecord?.MaintenanceID;
                 var records = await _maintenanceService.GetAllMaintenanceRecordsAsync();
                 MaintenanceRecords.Clear();
                 foreach (var record in records)
                 {
                     MaintenanceRecords.Add(record);
                 }
-                ApplyFilter();
+                ApplyFilter(selectedId);
             }
             catch (Exception ex)
             {
@@ -146,7 +210,7 @@ namespace InventoryManagementApp.ViewModels
                     var id = await _maintenanceService.CreateMaintenanceRecordAsync(newRecord);
                     newRecord.MaintenanceID = id;
                     MaintenanceRecords.Insert(0, newRecord);
-                    ApplyFilter();
+                    ApplyFilter(newRecord.MaintenanceID);
                     await _dialogService.ShowInfoAsync("Success", "Maintenance record created successfully");
                 }
                 catch (Exception ex)
@@ -186,8 +250,7 @@ namespace InventoryManagementApp.ViewModels
                     await _maintenanceService.UpdateMaintenanceRecordAsync(clone);
                     var index = MaintenanceRecords.IndexOf(SelectedRecord);
                     if (index >= 0) MaintenanceRecords[index] = clone;
-                    SelectedRecord = clone;
-                    ApplyFilter();
+                    ApplyFilter(clone.MaintenanceID);
                     await _dialogService.ShowInfoAsync("Success", "Maintenance record updated successfully");
                 }
                 catch (Exception ex)
@@ -209,9 +272,9 @@ namespace InventoryManagementApp.ViewModels
             {
                 try
                 {
-                    await _maintenanceService.DeleteMaintenanceRecordAsync(SelectedRecord.MaintenanceID);
-                    MaintenanceRecords.Remove(SelectedRecord);
-                    SelectedRecord = null;
+                    var deletedRecord = SelectedRecord;
+                    await _maintenanceService.DeleteMaintenanceRecordAsync(deletedRecord.MaintenanceID);
+                    MaintenanceRecords.Remove(deletedRecord);
                     ApplyFilter();
                     await _dialogService.ShowInfoAsync("Success", "Maintenance record deleted successfully");
                 }
@@ -234,20 +297,16 @@ namespace InventoryManagementApp.ViewModels
             {
                 try
                 {
+                    var completedId = SelectedRecord.MaintenanceID;
                     await _maintenanceService.CompleteMaintenanceAsync(
-                        SelectedRecord.MaintenanceID,
+                        completedId,
                         performedBy,
                         "");
                     SelectedRecord.Status = "Completed";
                     SelectedRecord.CompletedDate = DateTime.Now;
                     SelectedRecord.PerformedBy = performedBy;
-                    ApplyFilter();
-                    EditMaintenanceCommand.NotifyCanExecuteChanged();
-                    DeleteMaintenanceCommand.NotifyCanExecuteChanged();
-                    CompleteMaintenanceCommand.NotifyCanExecuteChanged();
-                    OpenMaintenanceDetailsCommand.NotifyCanExecuteChanged();
-                    PrintSelectedMaintenanceCommand.NotifyCanExecuteChanged();
-                    OnPropertyChanged(nameof(SelectedRecordSummary));
+                    ApplyFilter(completedId);
+                    NotifyCommandStatesAndSummaries();
                     await _dialogService.ShowInfoAsync("Success", "Maintenance marked as completed");
                 }
                 catch (Exception ex)
@@ -257,37 +316,57 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        private void ApplyFilter()
+        private void ClearSearch()
         {
+            SearchText = string.Empty;
+            SelectedFilter = "All";
+            ApplyFilter();
+        }
+
+        private void ApplyFilter(int? preferredMaintenanceId = null)
+        {
+            preferredMaintenanceId ??= SelectedRecord?.MaintenanceID;
             FilteredMaintenanceRecords.Clear();
 
             var filtered = MaintenanceRecords.AsEnumerable();
 
             if (!string.IsNullOrWhiteSpace(SearchText))
             {
-                var search = SearchText.ToLowerInvariant();
+                var search = SearchText.Trim().ToLowerInvariant();
                 filtered = filtered.Where(r =>
-                    r.ItemNumber.ToLowerInvariant().Contains(search) ||
-                    r.ItemName.ToLowerInvariant().Contains(search) ||
-                    r.MaintenanceType.ToLowerInvariant().Contains(search) ||
-                    r.Description.ToLowerInvariant().Contains(search));
+                    Searchable(r.ItemNumber).Contains(search) ||
+                    Searchable(r.ItemName).Contains(search) ||
+                    Searchable(r.MaintenanceType).Contains(search) ||
+                    Searchable(r.Description).Contains(search) ||
+                    Searchable(r.PerformedBy).Contains(search) ||
+                    Searchable(r.Notes).Contains(search));
             }
 
             filtered = SelectedFilter switch
             {
-                "Scheduled" => filtered.Where(r => r.Status == "Scheduled" && r.ScheduledDate >= DateTime.Now),
-                "Completed" => filtered.Where(r => r.Status == "Completed"),
+                "Scheduled" => filtered.Where(r => IsScheduled(r) && r.ScheduledDate >= DateTime.Now),
+                "Completed" => filtered.Where(IsCompleted),
                 "Overdue" => filtered.Where(r => r.IsOverdue),
-                "Upcoming (30 days)" => filtered.Where(r => r.Status == "Scheduled" && r.ScheduledDate >= DateTime.Now && r.ScheduledDate <= DateTime.Now.AddDays(30)),
+                "Upcoming (30 days)" => filtered.Where(IsUpcoming),
                 _ => filtered
             };
 
-            foreach (var record in filtered)
+            var filteredList = filtered
+                .OrderBy(r => IsCompleted(r) ? 1 : 0)
+                .ThenBy(r => r.ScheduledDate)
+                .ThenBy(r => Searchable(r.ItemNumber))
+                .ToList();
+
+            foreach (var record in filteredList)
             {
                 FilteredMaintenanceRecords.Add(record);
             }
 
+            SelectedRecord = FilteredMaintenanceRecords.FirstOrDefault(r => r.MaintenanceID == preferredMaintenanceId)
+                ?? FilteredMaintenanceRecords.FirstOrDefault();
+
             OnPropertyChanged(nameof(MaintenanceResultsSummary));
+            OnPropertyChanged(nameof(MaintenanceBacklogSummary));
         }
 
         private void OpenMaintenanceDetails()
@@ -309,11 +388,37 @@ namespace InventoryManagementApp.ViewModels
             details.AppendLine($"Description: {ValueOrNotRecorded(record.Description)}");
             details.AppendLine($"Notes: {ValueOrNotRecorded(record.Notes)}");
             details.AppendLine();
-            details.AppendLine(record.IsOverdue
-                ? "Next action: complete or reschedule this overdue maintenance before the item is issued again."
-                : "Next action: review work notes, complete scheduled work, or print this record for the bench file.");
+            details.AppendLine(SelectedMaintenanceNextAction);
 
             _dialogService.ShowInfo(details.ToString(), $"Maintenance Details - {ValueOrNotRecorded(record.ItemNumber)}");
+        }
+
+        private void CopySelectedMaintenance()
+        {
+            if (SelectedRecord == null) return;
+
+            var record = SelectedRecord;
+            var handoff = new StringBuilder();
+            handoff.AppendLine("Maintenance handoff");
+            handoff.AppendLine($"Item: {ValueOrNotRecorded(record.ItemNumber)} - {ValueOrNotRecorded(record.ItemName)}");
+            handoff.AppendLine($"Type: {ValueOrNotRecorded(record.MaintenanceType)}");
+            handoff.AppendLine($"Status: {record.StatusDisplay}");
+            handoff.AppendLine($"Scheduled: {record.ScheduledDate:yyyy-MM-dd}");
+            handoff.AppendLine($"Completed: {FormatDate(record.CompletedDate)}");
+            handoff.AppendLine($"Performed by: {ValueOrNotRecorded(record.PerformedBy)}");
+            handoff.AppendLine($"Description: {ValueOrNotRecorded(record.Description)}");
+            handoff.AppendLine($"Notes: {ValueOrNotRecorded(record.Notes)}");
+            handoff.AppendLine($"Next action: {SelectedMaintenanceNextAction}");
+
+            try
+            {
+                Clipboard.SetText(handoff.ToString());
+                _dialogService.ShowInfo("Maintenance handoff copied to the clipboard.", "Copied");
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowInfo($"Unable to copy maintenance handoff: {ex.Message}", "Copy Failed");
+            }
         }
 
         private void PrintMaintenanceList()
@@ -327,7 +432,7 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 var doc = CreateMaintenanceDocument("Maintenance Schedule", fontSize: 11);
-                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | {MaintenanceResultsSummary}"))
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | {MaintenanceResultsSummary} | {MaintenanceBacklogSummary}"))
                 {
                     FontSize = 10,
                     Margin = new Thickness(0, 0, 0, 10)
@@ -379,6 +484,7 @@ namespace InventoryManagementApp.ViewModels
                 AddKeyValueRow(group, "Cost:", record.Cost.ToString("C"));
                 AddKeyValueRow(group, "Description:", record.Description);
                 AddKeyValueRow(group, "Notes:", record.Notes);
+                AddKeyValueRow(group, "Next action:", SelectedMaintenanceNextAction);
                 doc.Blocks.Add(table);
 
                 _dialogService.ShowPrintPreview(doc, $"Maintenance {record.MaintenanceID}", string.Empty);
@@ -391,7 +497,40 @@ namespace InventoryManagementApp.ViewModels
 
         private bool CanEditOrDelete() => SelectedRecord != null;
 
-        private bool CanComplete() => SelectedRecord != null && SelectedRecord.Status == "Scheduled";
+        private bool CanComplete() => SelectedRecord != null && IsScheduled(SelectedRecord);
+
+        private void NotifyCommandStatesAndSummaries()
+        {
+            EditMaintenanceCommand.NotifyCanExecuteChanged();
+            DeleteMaintenanceCommand.NotifyCanExecuteChanged();
+            CompleteMaintenanceCommand.NotifyCanExecuteChanged();
+            OpenMaintenanceDetailsCommand.NotifyCanExecuteChanged();
+            PrintSelectedMaintenanceCommand.NotifyCanExecuteChanged();
+            CopySelectedMaintenanceCommand.NotifyCanExecuteChanged();
+            OnSelectedRecordSummariesChanged();
+            OnPropertyChanged(nameof(MaintenanceBacklogSummary));
+            OnPropertyChanged(nameof(MaintenanceResultsSummary));
+        }
+
+        private void OnSelectedRecordSummariesChanged()
+        {
+            OnPropertyChanged(nameof(SelectedRecordSummary));
+            OnPropertyChanged(nameof(SelectedMaintenanceDetail));
+            OnPropertyChanged(nameof(SelectedMaintenanceTimingSummary));
+            OnPropertyChanged(nameof(SelectedMaintenanceNextAction));
+            OnPropertyChanged(nameof(SelectedMaintenanceBenchChecklist));
+        }
+
+        private static bool IsScheduled(MaintenanceRecord record) =>
+            string.Equals(record.Status, "Scheduled", StringComparison.OrdinalIgnoreCase);
+
+        private static bool IsCompleted(MaintenanceRecord record) =>
+            string.Equals(record.Status, "Completed", StringComparison.OrdinalIgnoreCase);
+
+        private static bool IsUpcoming(MaintenanceRecord record) =>
+            IsScheduled(record) && record.ScheduledDate >= DateTime.Now && record.ScheduledDate <= DateTime.Now.AddDays(30);
+
+        private static string Searchable(string? value) => value?.ToLowerInvariant() ?? string.Empty;
 
         private static FlowDocument CreateMaintenanceDocument(string title, double fontSize = 16)
         {

--- a/InventoryManagementApp/Views/Pages/MaintenancePage.xaml
+++ b/InventoryManagementApp/Views/Pages/MaintenancePage.xaml
@@ -12,100 +12,176 @@
         <Border Style="{StaticResource ToolbarCard}">
             <DockPanel LastChildFill="False">
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
-                    <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddMaintenanceCommand}" Margin="0,0,4,0"/>
+                    <TextBlock Text="Maintenance workflow" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Add Work" Command="{Binding AddMaintenanceCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenMaintenanceDetailsCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditMaintenanceCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Complete" Command="{Binding CompleteMaintenanceCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Copy Handoff" Command="{Binding CopySelectedMaintenanceCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Print Record" Command="{Binding PrintSelectedMaintenanceCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Print Schedule" Command="{Binding PrintMaintenanceListCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteMaintenanceCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteMaintenanceCommand}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
-                    <TextBlock Text="Filter" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                    <TextBox Width="180" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,4,0"/>
-                    <ComboBox Width="150" ItemsSource="{Binding FilterOptions}" SelectedItem="{Binding SelectedFilter}"/>
+                    <TextBlock Text="Find work" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,6,0" ToolTip="Search item number, name, maintenance type, description, technician, or notes"/>
+                    <ComboBox Width="155" ItemsSource="{Binding FilterOptions}" SelectedItem="{Binding SelectedFilter}" Margin="0,0,6,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearSearchCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
                 </StackPanel>
             </DockPanel>
         </Border>
 
-        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
-                    <DockPanel>
-                        <TextBlock Text="01 Maintenance Workbench" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
-                        <TextBlock Text="{Binding MaintenanceResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
-                    </DockPanel>
-                </Border>
-                <DataGrid Grid.Row="1"
-                          ItemsSource="{Binding FilteredMaintenanceRecords}"
-                          SelectedItem="{Binding SelectedRecord}"
-                          SelectionMode="Single"
-                          AutoGenerateColumns="False"
-                          IsReadOnly="True"
-                          Style="{StaticResource VirtualizedDataGridStyle}">
-                    <DataGrid.RowStyle>
-                        <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
-                            <EventSetter Event="MouseDoubleClick" Handler="MaintenanceRow_MouseDoubleClick"/>
-                            <EventSetter Event="PreviewMouseRightButtonDown" Handler="MaintenanceRow_PreviewMouseRightButtonDown"/>
-                        </Style>
-                    </DataGrid.RowStyle>
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="115"/>
-                        <DataGridTextColumn Header="Name" Binding="{Binding ItemName}" Width="2*"/>
-                        <DataGridTextColumn Header="Type" Binding="{Binding MaintenanceType}" Width="120"/>
-                        <DataGridTextColumn Header="Scheduled" Binding="{Binding ScheduledDate, StringFormat={}{0:yyyy-MM-dd}}" Width="115"/>
-                        <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="105"/>
-                        <DataGridTextColumn Header="Performed By" Binding="{Binding PerformedBy}" Width="145"/>
-                        <DataGridTextColumn Header="Completed" Binding="{Binding CompletedDate, StringFormat={}{0:yyyy-MM-dd}}" Width="115"/>
-                        <DataGridTextColumn Header="Cost" Binding="{Binding Cost, StringFormat={}{0:C}}" Width="90"/>
-                        <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" Width="2*"/>
-                    </DataGrid.Columns>
-                    <DataGrid.ContextMenu>
-                        <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
-                                    DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                            <MenuItem Header="Open Details" Command="{Binding OpenMaintenanceDetailsCommand}"/>
-                            <MenuItem Header="Edit" Command="{Binding EditMaintenanceCommand}"/>
-                            <MenuItem Header="Complete" Command="{Binding CompleteMaintenanceCommand}"/>
-                            <Separator/>
-                            <MenuItem Header="Print Record" Command="{Binding PrintSelectedMaintenanceCommand}"/>
-                            <MenuItem Header="Print Schedule" Command="{Binding PrintMaintenanceListCommand}"/>
-                            <Separator/>
-                            <MenuItem Header="Delete" Command="{Binding DeleteMaintenanceCommand}"/>
-                        </ContextMenu>
-                    </DataGrid.ContextMenu>
-                </DataGrid>
-                <TextBlock Grid.Row="1"
-                           Text="No maintenance records"
-                           HorizontalAlignment="Center"
-                           VerticalAlignment="Center"
-                           FontSize="13"
-                           FontWeight="SemiBold">
-                    <TextBlock.Style>
-                        <Style TargetType="TextBlock">
-                            <Setter Property="Visibility" Value="Collapsed"/>
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding FilteredMaintenanceRecords.Count}" Value="0">
-                                    <Setter Property="Visibility" Value="Visible"/>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </TextBlock.Style>
-                </TextBlock>
-            </Grid>
-        </Border>
+        <Grid Grid.Row="1" Margin="0,6,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" MinWidth="600"/>
+                <ColumnDefinition Width="8"/>
+                <ColumnDefinition Width="430" MinWidth="380"/>
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                        <DockPanel>
+                            <TextBlock Text="01 Maintenance Schedule" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                            <TextBlock Text="{Binding MaintenanceResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                        </DockPanel>
+                    </Border>
+                    <Border Grid.Row="1" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                        <DockPanel LastChildFill="True">
+                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                                <Button Style="{StaticResource GhostButton}" Content="Overdue" Command="{Binding ShowOverdueCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Upcoming" Command="{Binding ShowUpcomingCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Scheduled" Command="{Binding ShowScheduledCommand}"/>
+                            </StackPanel>
+                            <TextBlock Text="{Binding MaintenanceBacklogSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,10,0"/>
+                        </DockPanel>
+                    </Border>
+                    <DataGrid Grid.Row="2"
+                              ItemsSource="{Binding FilteredMaintenanceRecords}"
+                              SelectedItem="{Binding SelectedRecord}"
+                              SelectionMode="Single"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True"
+                              Style="{StaticResource VirtualizedDataGridStyle}">
+                        <DataGrid.RowStyle>
+                            <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                                <EventSetter Event="MouseDoubleClick" Handler="MaintenanceRow_MouseDoubleClick"/>
+                                <EventSetter Event="PreviewMouseRightButtonDown" Handler="MaintenanceRow_PreviewMouseRightButtonDown"/>
+                            </Style>
+                        </DataGrid.RowStyle>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="110"/>
+                            <DataGridTextColumn Header="Name" Binding="{Binding ItemName}" Width="2*"/>
+                            <DataGridTextColumn Header="Type" Binding="{Binding MaintenanceType}" Width="120"/>
+                            <DataGridTextColumn Header="Scheduled" Binding="{Binding ScheduledDate, StringFormat={}{0:yyyy-MM-dd}}" Width="110"/>
+                            <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="105"/>
+                            <DataGridTextColumn Header="Performed By" Binding="{Binding PerformedBy}" Width="135"/>
+                            <DataGridTextColumn Header="Completed" Binding="{Binding CompletedDate, StringFormat={}{0:yyyy-MM-dd}}" Width="110"/>
+                            <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" Width="2*"/>
+                        </DataGrid.Columns>
+                        <DataGrid.ContextMenu>
+                            <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
+                                        DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                <MenuItem Header="Open Details" Command="{Binding OpenMaintenanceDetailsCommand}"/>
+                                <MenuItem Header="Complete Work" Command="{Binding CompleteMaintenanceCommand}"/>
+                                <MenuItem Header="Copy Technician Handoff" Command="{Binding CopySelectedMaintenanceCommand}"/>
+                                <MenuItem Header="Print Work Record" Command="{Binding PrintSelectedMaintenanceCommand}"/>
+                                <Separator/>
+                                <MenuItem Header="Edit" Command="{Binding EditMaintenanceCommand}"/>
+                                <MenuItem Header="Print Schedule" Command="{Binding PrintMaintenanceListCommand}"/>
+                                <MenuItem Header="Delete" Command="{Binding DeleteMaintenanceCommand}"/>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                    </DataGrid>
+                    <TextBlock Grid.Row="2"
+                               Text="No maintenance work matches this filter"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"
+                               FontSize="13"
+                               FontWeight="SemiBold">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding FilteredMaintenanceRecords.Count}" Value="0">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Grid>
+            </Border>
+
+            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                        <DockPanel>
+                            <TextBlock Text="02 Technician Handoff" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                            <TextBlock Text="Selected work" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                        </DockPanel>
+                    </Border>
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                        <StackPanel Margin="10">
+                            <TextBlock Text="{Binding SelectedRecord.ItemName, TargetNullValue='No maintenance selected', FallbackValue='No maintenance selected'}"
+                                       FontSize="18"
+                                       FontWeight="SemiBold"
+                                       TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,10"/>
+
+                            <TextBlock Text="Work order" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
+                            <TextBlock Text="{Binding SelectedMaintenanceDetail}" TextWrapping="Wrap" Margin="0,0,0,10"/>
+
+                            <TextBlock Text="Timing" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
+                            <TextBlock Text="{Binding SelectedMaintenanceTimingSummary}" TextWrapping="Wrap" Margin="0,0,0,10"/>
+
+                            <TextBlock Text="Next action" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
+                            <TextBlock Text="{Binding SelectedMaintenanceNextAction}" TextWrapping="Wrap" Margin="0,0,0,14"/>
+
+                            <UniformGrid Columns="2" Margin="0,0,0,8">
+                                <Button Style="{StaticResource PrimaryButton}" Content="Complete" Command="{Binding CompleteMaintenanceCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditMaintenanceCommand}" Margin="4,0,0,4"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Copy" Command="{Binding CopySelectedMaintenanceCommand}" Margin="0,4,4,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Print" Command="{Binding PrintSelectedMaintenanceCommand}" Margin="4,4,0,0"/>
+                            </UniformGrid>
+
+                            <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="8" Margin="0,6,0,0">
+                                <StackPanel>
+                                    <TextBlock Text="Bench checklist" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/>
+                                    <TextBlock Text="{Binding SelectedMaintenanceBenchChecklist}" TextWrapping="Wrap"/>
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+                    </ScrollViewer>
+                    <Border Grid.Row="2" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,1,0,0" Padding="5,3">
+                        <WrapPanel>
+                            <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenMaintenanceDetailsCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Print Schedule" Command="{Binding PrintMaintenanceListCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Clear Search" Command="{Binding ClearSearchCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,0,4,4"/>
+                        </WrapPanel>
+                    </Border>
+                </Grid>
+            </Border>
+        </Grid>
+
         <Border Grid.Row="2" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
             <DockPanel LastChildFill="True">
                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenMaintenanceDetailsCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Complete" Command="{Binding CompleteMaintenanceCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource GhostButton}" Content="Print Schedule" Command="{Binding PrintMaintenanceListCommand}"/>
                 </StackPanel>
-                <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0"/>
+                <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0" TextWrapping="Wrap"/>
             </DockPanel>
         </Border>
     </Grid>

--- a/scripts/run-app-qa-screenshots.ps1
+++ b/scripts/run-app-qa-screenshots.ps1
@@ -28,12 +28,35 @@ function Ensure-Directory {
     }
 }
 
+function Get-PngDimensions {
+    param([System.IO.FileInfo]$File)
+
+    Add-Type -AssemblyName PresentationCore
+    $stream = [System.IO.File]::OpenRead($File.FullName)
+    try {
+        $decoder = [System.Windows.Media.Imaging.BitmapDecoder]::Create(
+            $stream,
+            [System.Windows.Media.Imaging.BitmapCreateOptions]::IgnoreColorProfile,
+            [System.Windows.Media.Imaging.BitmapCacheOption]::OnLoad)
+        $frame = $decoder.Frames[0]
+        return [pscustomobject]@{
+            Width = $frame.PixelWidth
+            Height = $frame.PixelHeight
+        }
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
     $OutputRoot = Join-Path $repoRoot ".qa-screenshots"
 }
 
 $minimumScreenshotBytes = 1024
+$minimumScreenshotWidth = 640
+$minimumScreenshotHeight = 360
 $expectedFolders = @(
     "00-auth",
     "01-overview",
@@ -119,7 +142,7 @@ try {
     Get-ChildItem -LiteralPath $runDirectory -Filter "*.db*" -File -Recurse -Force -ErrorAction SilentlyContinue |
         Remove-Item -Force -ErrorAction SilentlyContinue
     if (Test-Path -LiteralPath (Join-Path $runDirectory "Logs")) {
-        Remove-Item -LiteralPath (Join-Path $runDirectory "Logs") -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath (Join-Path $runDirectory "Logs") -Recurse -Force
     }
 
     Write-Step "Starting QA screenshot run."
@@ -176,10 +199,23 @@ try {
         throw "QA screenshot run produced suspiciously small PNG capture(s): $($undersizedList -join ', ')."
     }
 
+    $dimensionFailures = @()
+    foreach ($screenshot in $screenshots) {
+        $dimensions = Get-PngDimensions -File $screenshot
+        if ($dimensions.Width -lt $minimumScreenshotWidth -or $dimensions.Height -lt $minimumScreenshotHeight) {
+            $dimensionFailures += "{0} ({1}x{2})" -f $screenshot.FullName, $dimensions.Width, $dimensions.Height
+        }
+    }
+
+    if ($dimensionFailures.Count -gt 0) {
+        throw "QA screenshot run produced unexpectedly small-dimension PNG capture(s): $($dimensionFailures -join ', ')."
+    }
+
     $readmePath = Join-Path $sessionOutput "README.md"
     Add-Content -Path $readmePath -Value ""
     Add-Content -Path $readmePath -Value ("Captured screenshots: {0}" -f $screenshots.Count)
     Add-Content -Path $readmePath -Value ("Minimum PNG size checked: {0} bytes" -f $minimumScreenshotBytes)
+    Add-Content -Path $readmePath -Value ("Minimum PNG dimensions checked: {0}x{1}" -f $minimumScreenshotWidth, $minimumScreenshotHeight)
     Add-Content -Path $readmePath -Value ""
     Add-Content -Path $readmePath -Value "Captured files:"
     foreach ($screenshot in ($screenshots | Sort-Object FullName)) {


### PR DESCRIPTION
## Summary

- Redesigns Maintenance into a two-pane technician workbench with schedule/backlog context, selected work-order detail, timing, next action, and bench checklist guidance.
- Adds quick overdue/upcoming/scheduled filters, clear search, copy technician handoff, repeated print/detail/complete actions, and row context menu access where technicians need it.
- Keeps maintenance selection useful after load, add, edit, complete, delete, search, and filter changes where possible, while hardening search against missing legacy/imported text fields.
- Strengthens the QA screenshot wrapper so expected captures must also meet minimum pixel dimensions, catching failed or cropped screenshots beyond file count and file size checks.
- Updates progress notes and the completion checklist for the maintenance workflow pass.

## Why

The user asked to continue finishing each function end to end from technician, advisor, and admin perspectives. Maintenance still exposed most of the flow as a grid and toolbar; a technician checking a tool from the shelf needs a selected work-order surface that shows urgency, the next action, and the handoff path without hunting through buttons.

## Validation

- Compared the branch against `master` through the GitHub connector.
- Read back changed Maintenance XAML, Maintenance view model, screenshot script, progress note, and checklist from the branch.
- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
- Did not run unrelated tests, per instruction.