### PR TITLE
Upgrade calibration technician bench

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-17-calibration-technician-bench.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-calibration-technician-bench.md
@@ -1,0 +1,23 @@
+# Calibration Technician Bench - 2026-06-17
+
+## Completed
+
+- Upgraded `CalibrationPage` from a single register grid into a two-pane technician calibration bench.
+- Added a selected-certificate handoff panel with certificate, timing, next-action, and shelf-release checklist context.
+- Added quick Overdue, Due Soon, and Current filters plus clear-search support so technicians can work due lists without leaving the page.
+- Added copy-calibration-handoff behavior for selected rows and exposed it from the toolbar, selected panel, footer, and context menu.
+- Preserved useful selection after load, add, edit, delete, search, and filter changes where possible.
+- Hardened calibration search against missing legacy/imported text fields and expanded it to standard, result, and notes.
+- Fixed calibration right-click row selection so context menus act on the clicked row and still open.
+
+## Validation
+
+- Parsed the updated `CalibrationPage.xaml` locally as well-formed XML.
+- Read the updated branch files back through the GitHub connector.
+- Compared the branch against `master`; the diff is limited to the calibration page, code-behind, view model, and this progress note/checklist work.
+- The QA screenshot runner could not be executed in this Linux container because WPF requires a Windows/.NET runtime, and local clone remains blocked by the network tunnel.
+- `dotnet build` and `dotnet test` were not run because the .NET SDK is unavailable in this container and the user asked not to run unrelated tests.
+
+## Follow-up
+
+- Run `scripts/run-app-qa-screenshots.ps1` on a Windows workstation with the .NET SDK to visually verify `02-operations/05-calibration.png` after this UI change.

--- a/InventoryManagementApp/ProgressNotes/2026-06-17-calibration-technician-bench.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-calibration-technician-bench.md
@@ -9,12 +9,13 @@
 - Preserved useful selection after load, add, edit, delete, search, and filter changes where possible.
 - Hardened calibration search against missing legacy/imported text fields and expanded it to standard, result, and notes.
 - Fixed calibration right-click row selection so context menus act on the clicked row and still open.
+- Enhanced `scripts/run-app-qa-screenshots.ps1` so the generated screenshot README records each PNG capture with dimensions and byte size.
 
 ## Validation
 
 - Parsed the updated `CalibrationPage.xaml` locally as well-formed XML.
-- Read the updated branch files back through the GitHub connector.
-- Compared the branch against `master`; the diff is limited to the calibration page, code-behind, view model, and this progress note/checklist work.
+- Read the updated branch files back through the GitHub connector, including the QA screenshot manifest enhancement.
+- Compared the branch against `master`; the diff is limited to calibration workflow files, the screenshot wrapper, and progress/checklist notes.
 - The QA screenshot runner could not be executed in this Linux container because WPF requires a Windows/.NET runtime, and local clone remains blocked by the network tunnel.
 - `dotnet build` and `dotnet test` were not run because the .NET SDK is unavailable in this container and the user asked not to run unrelated tests.
 

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 07:42 NZST
+Last audit date/time: 2026-06-17 07:48 NZST
 
 ## Completed workflows
 
@@ -22,6 +22,7 @@ Last audit date/time: 2026-06-17 07:42 NZST
 - Maintenance now uses a two-pane technician workbench with schedule backlog context, selected work-order detail, timing, next action, bench checklist, quick overdue/upcoming/scheduled filters, copy handoff, print actions, stable useful selection, and null-safe search across legacy/imported records.
 - QA screenshot wrapper validation now rejects expected PNG captures that are too small in pixel dimensions, catching failed or cropped screenshots beyond file-size checks.
 - Calibration now uses a two-pane technician bench with certificate handoff details, timing and next-action guidance, shelf-release checklist, quick overdue/due-soon/current filters, copy handoff, print actions, stable useful selection, null-safe expanded search, and row-correct context menus.
+- QA screenshot manifests now list each captured PNG with dimensions and byte size so future screenshot reviews can spot cropped or suspicious captures faster.
 
 ## Partially complete workflows
 
@@ -46,7 +47,7 @@ Last audit date/time: 2026-06-17 07:42 NZST
 
 ## Validation status
 
-- GitHub connector readback reviewed the Calibration workbench branch files, progress note, and completion checklist.
+- GitHub connector readback reviewed the Calibration workbench branch files, screenshot wrapper, progress note, and completion checklist.
 - `CalibrationPage.xaml` was parsed locally as well-formed XML from the generated branch content.
 - `dotnet --info`: failed because `dotnet` is not installed in this scheduled container.
 - `dotnet restore InventoryManagementApp.sln`: not run because the .NET SDK is unavailable.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 06:19 NZST
+Last audit date/time: 2026-06-17 07:42 NZST
 
 ## Completed workflows
 
@@ -21,6 +21,7 @@ Last audit date/time: 2026-06-17 06:19 NZST
 - QA screenshot wrapper validation now rejects suspiciously tiny PNG output so blank or broken captures fail earlier.
 - Maintenance now uses a two-pane technician workbench with schedule backlog context, selected work-order detail, timing, next action, bench checklist, quick overdue/upcoming/scheduled filters, copy handoff, print actions, stable useful selection, and null-safe search across legacy/imported records.
 - QA screenshot wrapper validation now rejects expected PNG captures that are too small in pixel dimensions, catching failed or cropped screenshots beyond file-size checks.
+- Calibration now uses a two-pane technician bench with certificate handoff details, timing and next-action guidance, shelf-release checklist, quick overdue/due-soon/current filters, copy handoff, print actions, stable useful selection, null-safe expanded search, and row-correct context menus.
 
 ## Partially complete workflows
 
@@ -31,6 +32,7 @@ Last audit date/time: 2026-06-17 06:19 NZST
 - Kits now have a completed desktop workflow surface, but runtime add/edit/item-membership dialog validation still needs a Windows/.NET workstation.
 - Customers now have a completed desktop workflow surface, but runtime add/edit/delete/print/copy validation still needs a Windows/.NET workstation.
 - Maintenance now has a completed desktop workflow surface, but runtime add/edit/complete/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
+- Calibration now has a completed desktop workflow surface, but runtime add/edit/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 
 ## Known broken workflows
 
@@ -40,11 +42,12 @@ Last audit date/time: 2026-06-17 06:19 NZST
 
 ## Next recommended target
 
-- Continue the end-to-end workflow audit from a technician/advisor/admin perspective, with the next useful pass focused on Calibration, Reservations, or Categories depending on which page still exposes the most incomplete action/result path on `master`.
+- Continue the end-to-end workflow audit from a technician/advisor/admin perspective, with the next useful pass focused on Reservations or Categories depending on which page still exposes the most incomplete action/result path on `master`.
 
 ## Validation status
 
-- GitHub connector readback reviewed the Maintenance workbench branch files, screenshot wrapper, progress note, and completion checklist.
+- GitHub connector readback reviewed the Calibration workbench branch files, progress note, and completion checklist.
+- `CalibrationPage.xaml` was parsed locally as well-formed XML from the generated branch content.
 - `dotnet --info`: failed because `dotnet` is not installed in this scheduled container.
 - `dotnet restore InventoryManagementApp.sln`: not run because the .NET SDK is unavailable.
 - `dotnet build InventoryManagementApp.sln --no-restore`: not run because the .NET SDK is unavailable.

--- a/InventoryManagementApp/ViewModels/CalibrationManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CalibrationManagementViewModel.cs
@@ -22,9 +22,55 @@ namespace InventoryManagementApp.ViewModels
         public ObservableCollection<CalibrationRecord> FilteredCalibrationRecords { get; }
 
         public string CalibrationResultsSummary => $"{FilteredCalibrationRecords.Count} of {CalibrationRecords.Count} calibration record{(CalibrationRecords.Count == 1 ? string.Empty : "s")} shown";
+        public string CalibrationBacklogSummary
+        {
+            get
+            {
+                var overdue = CalibrationRecords.Count(r => r.IsOverdue);
+                var dueSoon = CalibrationRecords.Count(r => r.IsDueSoon);
+                var current = CalibrationRecords.Count(r => IsCurrent(r));
+                return $"{overdue} overdue | {dueSoon} due soon | {current} current";
+            }
+        }
+
         public string SelectedRecordSummary => SelectedRecord == null
-            ? "Select or double-click a calibration row to view certificate details, print the record, edit, or delete."
+            ? "Select or double-click a calibration row to review certificate details, copy the shelf handoff, print the record, edit, or delete."
             : $"{ValueOrNotRecorded(SelectedRecord.ItemNumber)} | {ValueOrNotRecorded(SelectedRecord.ItemName)} | {SelectedRecord.StatusDisplay} | due {SelectedRecord.NextCalibrationDue:yyyy-MM-dd}";
+
+        public string SelectedCalibrationDetail => SelectedRecord == null
+            ? "No calibration selected. Choose a certificate row or add a record before taking an action."
+            : $"Certificate {ValueOrNotRecorded(SelectedRecord.CertificateNumber)} for {ValueOrNotRecorded(SelectedRecord.ItemNumber)} - {ValueOrNotRecorded(SelectedRecord.ItemName)}. Standard: {ValueOrNotRecorded(SelectedRecord.Standard)}. Result: {ValueOrNotRecorded(SelectedRecord.Result)}. Notes: {ValueOrNotRecorded(SelectedRecord.Notes)}";
+
+        public string SelectedCalibrationTimingSummary => SelectedRecord == null
+            ? "No due date selected."
+            : $"Calibrated {SelectedRecord.CalibrationDate:yyyy-MM-dd}. Next due {SelectedRecord.NextCalibrationDue:yyyy-MM-dd}. Calibrated by {ValueOrNotRecorded(SelectedRecord.CalibratedBy)}. Cost {SelectedRecord.Cost:C}.";
+
+        public string SelectedCalibrationNextAction
+        {
+            get
+            {
+                if (SelectedRecord == null)
+                {
+                    return "Add a calibration record or select an existing certificate to see the next operational step.";
+                }
+
+                if (SelectedRecord.IsOverdue)
+                {
+                    return "This item is overdue. Hold it from issue, renew calibration, then print or copy the updated certificate handoff before returning it to the shelf.";
+                }
+
+                if (SelectedRecord.IsDueSoon)
+                {
+                    return "Calibration is due soon. Stage the item for renewal, confirm the certificate details, and print or copy the handoff for the technician queue.";
+                }
+
+                return "Calibration is current. Verify the item tag, certificate number, and standard before releasing or renting the item.";
+            }
+        }
+
+        public string SelectedCalibrationBenchChecklist => SelectedRecord == null
+            ? "Select a certificate first, then verify the item tag, certificate number, due date, result, and shelf release status before the tool is issued."
+            : "Verify item tag and location, confirm certificate number and standard, check due date/result, update missing notes if needed, and keep the printed or copied handoff with the tool.";
 
         private CalibrationRecord? _selectedRecord;
         public CalibrationRecord? SelectedRecord
@@ -38,7 +84,8 @@ namespace InventoryManagementApp.ViewModels
                     DeleteCalibrationCommand.NotifyCanExecuteChanged();
                     OpenCalibrationDetailsCommand.NotifyCanExecuteChanged();
                     PrintSelectedCalibrationCommand.NotifyCanExecuteChanged();
-                    OnPropertyChanged(nameof(SelectedRecordSummary));
+                    CopySelectedCalibrationCommand.NotifyCanExecuteChanged();
+                    OnSelectedRecordSummariesChanged();
                 }
             }
         }
@@ -79,6 +126,11 @@ namespace InventoryManagementApp.ViewModels
         public IRelayCommand OpenCalibrationDetailsCommand { get; }
         public IRelayCommand PrintCalibrationListCommand { get; }
         public IRelayCommand PrintSelectedCalibrationCommand { get; }
+        public IRelayCommand CopySelectedCalibrationCommand { get; }
+        public IRelayCommand ClearSearchCommand { get; }
+        public IRelayCommand ShowOverdueCommand { get; }
+        public IRelayCommand ShowDueSoonCommand { get; }
+        public IRelayCommand ShowCurrentCommand { get; }
 
         public CalibrationManagementViewModel(
             CalibrationService calibrationService,
@@ -105,19 +157,25 @@ namespace InventoryManagementApp.ViewModels
             OpenCalibrationDetailsCommand = new RelayCommand(OpenCalibrationDetails, CanEditOrDelete);
             PrintCalibrationListCommand = new RelayCommand(PrintCalibrationList);
             PrintSelectedCalibrationCommand = new RelayCommand(PrintSelectedCalibration, CanEditOrDelete);
+            CopySelectedCalibrationCommand = new RelayCommand(CopySelectedCalibration, CanEditOrDelete);
+            ClearSearchCommand = new RelayCommand(ClearSearch);
+            ShowOverdueCommand = new RelayCommand(() => SelectedFilter = "Overdue");
+            ShowDueSoonCommand = new RelayCommand(() => SelectedFilter = "Due Soon");
+            ShowCurrentCommand = new RelayCommand(() => SelectedFilter = "Current");
         }
 
         private async Task LoadCalibrationAsync()
         {
             try
             {
+                var selectedId = SelectedRecord?.CalibrationID;
                 var records = await _calibrationService.GetAllCalibrationRecordsAsync();
                 CalibrationRecords.Clear();
                 foreach (var record in records)
                 {
                     CalibrationRecords.Add(record);
                 }
-                ApplyFilter();
+                ApplyFilter(selectedId);
             }
             catch (Exception ex)
             {
@@ -142,7 +200,7 @@ namespace InventoryManagementApp.ViewModels
                     var id = await _calibrationService.CreateCalibrationRecordAsync(newRecord);
                     newRecord.CalibrationID = id;
                     CalibrationRecords.Insert(0, newRecord);
-                    ApplyFilter();
+                    ApplyFilter(newRecord.CalibrationID);
                     await _dialogService.ShowInfoAsync("Success", "Calibration record created successfully");
                 }
                 catch (Exception ex)
@@ -182,8 +240,7 @@ namespace InventoryManagementApp.ViewModels
                     await _calibrationService.UpdateCalibrationRecordAsync(clone);
                     var index = CalibrationRecords.IndexOf(SelectedRecord);
                     if (index >= 0) CalibrationRecords[index] = clone;
-                    SelectedRecord = clone;
-                    ApplyFilter();
+                    ApplyFilter(clone.CalibrationID);
                     await _dialogService.ShowInfoAsync("Success", "Calibration record updated successfully");
                 }
                 catch (Exception ex)
@@ -199,15 +256,15 @@ namespace InventoryManagementApp.ViewModels
 
             var confirmed = await _dialogService.ShowConfirmAsync(
                 "Delete Calibration Record",
-                $"Delete calibration certificate {ValueOrNotRecorded(SelectedRecord.CertificateNumber)} for {ValueOrNotRecorded(SelectedRecord.ItemName)}?");
+                $"Delete calibration certificate {ValueOrNotRecorded(SelectedRecord.CertificateNumber)} for {ValueOrNotRecorded(SelectedRecord.ItemName)} due {SelectedRecord.NextCalibrationDue:yyyy-MM-dd}?");
 
             if (confirmed)
             {
                 try
                 {
-                    await _calibrationService.DeleteCalibrationRecordAsync(SelectedRecord.CalibrationID);
-                    CalibrationRecords.Remove(SelectedRecord);
-                    SelectedRecord = null;
+                    var deletedRecord = SelectedRecord;
+                    await _calibrationService.DeleteCalibrationRecordAsync(deletedRecord.CalibrationID);
+                    CalibrationRecords.Remove(deletedRecord);
                     ApplyFilter();
                     await _dialogService.ShowInfoAsync("Success", "Calibration record deleted successfully");
                 }
@@ -218,36 +275,57 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        private void ApplyFilter()
+        private void ClearSearch()
         {
+            SearchText = string.Empty;
+            SelectedFilter = "All";
+            ApplyFilter();
+        }
+
+        private void ApplyFilter(int? preferredCalibrationId = null)
+        {
+            preferredCalibrationId ??= SelectedRecord?.CalibrationID;
             FilteredCalibrationRecords.Clear();
 
             var filtered = CalibrationRecords.AsEnumerable();
 
             if (!string.IsNullOrWhiteSpace(SearchText))
             {
-                var search = SearchText.ToLowerInvariant();
+                var search = SearchText.Trim().ToLowerInvariant();
                 filtered = filtered.Where(r =>
-                    r.ItemNumber.ToLowerInvariant().Contains(search) ||
-                    r.ItemName.ToLowerInvariant().Contains(search) ||
-                    r.CertificateNumber.ToLowerInvariant().Contains(search) ||
-                    r.CalibratedBy.ToLowerInvariant().Contains(search));
+                    Searchable(r.ItemNumber).Contains(search) ||
+                    Searchable(r.ItemName).Contains(search) ||
+                    Searchable(r.CertificateNumber).Contains(search) ||
+                    Searchable(r.CalibratedBy).Contains(search) ||
+                    Searchable(r.Standard).Contains(search) ||
+                    Searchable(r.Result).Contains(search) ||
+                    Searchable(r.Notes).Contains(search));
             }
 
             filtered = SelectedFilter switch
             {
-                "Current" => filtered.Where(r => !r.IsOverdue && !r.IsDueSoon),
+                "Current" => filtered.Where(IsCurrent),
                 "Due Soon" => filtered.Where(r => r.IsDueSoon),
                 "Overdue" => filtered.Where(r => r.IsOverdue),
                 _ => filtered
             };
 
-            foreach (var record in filtered)
+            var filteredList = filtered
+                .OrderBy(r => IsCurrent(r) ? 1 : 0)
+                .ThenBy(r => r.NextCalibrationDue)
+                .ThenBy(r => Searchable(r.ItemNumber))
+                .ToList();
+
+            foreach (var record in filteredList)
             {
                 FilteredCalibrationRecords.Add(record);
             }
 
+            SelectedRecord = FilteredCalibrationRecords.FirstOrDefault(r => r.CalibrationID == preferredCalibrationId)
+                ?? FilteredCalibrationRecords.FirstOrDefault();
+
             OnPropertyChanged(nameof(CalibrationResultsSummary));
+            OnPropertyChanged(nameof(CalibrationBacklogSummary));
         }
 
         private void OpenCalibrationDetails()
@@ -270,11 +348,38 @@ namespace InventoryManagementApp.ViewModels
             details.AppendLine();
             details.AppendLine($"Notes: {ValueOrNotRecorded(record.Notes)}");
             details.AppendLine();
-            details.AppendLine(record.IsOverdue
-                ? "Next action: treat this item as blocked until calibration is renewed or the record is updated."
-                : "Next action: print the certificate sheet, edit certificate details, or review due-soon work from this page.");
+            details.AppendLine(SelectedCalibrationNextAction);
 
             _dialogService.ShowInfo(details.ToString(), $"Calibration Details - {ValueOrNotRecorded(record.ItemNumber)}");
+        }
+
+        private void CopySelectedCalibration()
+        {
+            if (SelectedRecord == null) return;
+
+            var record = SelectedRecord;
+            var handoff = new StringBuilder();
+            handoff.AppendLine("Calibration handoff");
+            handoff.AppendLine($"Item: {ValueOrNotRecorded(record.ItemNumber)} - {ValueOrNotRecorded(record.ItemName)}");
+            handoff.AppendLine($"Status: {record.StatusDisplay}");
+            handoff.AppendLine($"Certificate: {ValueOrNotRecorded(record.CertificateNumber)}");
+            handoff.AppendLine($"Standard: {ValueOrNotRecorded(record.Standard)}");
+            handoff.AppendLine($"Result: {ValueOrNotRecorded(record.Result)}");
+            handoff.AppendLine($"Calibrated: {record.CalibrationDate:yyyy-MM-dd}");
+            handoff.AppendLine($"Next due: {record.NextCalibrationDue:yyyy-MM-dd}");
+            handoff.AppendLine($"Calibrated by: {ValueOrNotRecorded(record.CalibratedBy)}");
+            handoff.AppendLine($"Notes: {ValueOrNotRecorded(record.Notes)}");
+            handoff.AppendLine($"Next action: {SelectedCalibrationNextAction}");
+
+            try
+            {
+                Clipboard.SetText(handoff.ToString());
+                _dialogService.ShowInfo("Calibration handoff copied to the clipboard.", "Copied");
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowInfo($"Unable to copy calibration handoff: {ex.Message}", "Copy Failed");
+            }
         }
 
         private void PrintCalibrationList()
@@ -288,7 +393,7 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 var doc = CreateCalibrationDocument("Calibration Due Report", fontSize: 11);
-                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | {CalibrationResultsSummary}"))
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | Filter: {SelectedFilter} | Search: {ValueOrNotRecorded(SearchText)} | {CalibrationResultsSummary} | {CalibrationBacklogSummary}"))
                 {
                     FontSize = 10,
                     Margin = new Thickness(0, 0, 0, 10)
@@ -341,6 +446,7 @@ namespace InventoryManagementApp.ViewModels
                 AddKeyValueRow(group, "Result:", record.Result);
                 AddKeyValueRow(group, "Cost:", record.Cost.ToString("C"));
                 AddKeyValueRow(group, "Notes:", record.Notes);
+                AddKeyValueRow(group, "Next action:", SelectedCalibrationNextAction);
                 doc.Blocks.Add(table);
 
                 _dialogService.ShowPrintPreview(doc, $"Calibration {record.CalibrationID}", string.Empty);
@@ -352,6 +458,19 @@ namespace InventoryManagementApp.ViewModels
         }
 
         private bool CanEditOrDelete() => SelectedRecord != null;
+
+        private void OnSelectedRecordSummariesChanged()
+        {
+            OnPropertyChanged(nameof(SelectedRecordSummary));
+            OnPropertyChanged(nameof(SelectedCalibrationDetail));
+            OnPropertyChanged(nameof(SelectedCalibrationTimingSummary));
+            OnPropertyChanged(nameof(SelectedCalibrationNextAction));
+            OnPropertyChanged(nameof(SelectedCalibrationBenchChecklist));
+        }
+
+        private static bool IsCurrent(CalibrationRecord record) => !record.IsOverdue && !record.IsDueSoon;
+
+        private static string Searchable(string? value) => value?.ToLowerInvariant() ?? string.Empty;
 
         private static FlowDocument CreateCalibrationDocument(string title, double fontSize = 16)
         {

--- a/InventoryManagementApp/Views/Pages/CalibrationPage.xaml
+++ b/InventoryManagementApp/Views/Pages/CalibrationPage.xaml
@@ -12,99 +12,174 @@
         <Border Style="{StaticResource ToolbarCard}">
             <DockPanel LastChildFill="False">
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
-                    <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddCalibrationCommand}" Margin="0,0,4,0"/>
+                    <TextBlock Text="Calibration workflow" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Add Record" Command="{Binding AddCalibrationCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCalibrationDetailsCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditCalibrationCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Copy Handoff" Command="{Binding CopySelectedCalibrationCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Print Record" Command="{Binding PrintSelectedCalibrationCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Print Due" Command="{Binding PrintCalibrationListCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteCalibrationCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteCalibrationCommand}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
-                    <TextBlock Text="Filter" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                    <TextBox Width="180" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,4,0"/>
-                    <ComboBox Width="150" ItemsSource="{Binding FilterOptions}" SelectedItem="{Binding SelectedFilter}"/>
+                    <TextBlock Text="Find certificate" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <TextBox Width="220" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,6,0" ToolTip="Search item number, name, certificate, calibrated by, standard, result, or notes"/>
+                    <ComboBox Width="150" ItemsSource="{Binding FilterOptions}" SelectedItem="{Binding SelectedFilter}" Margin="0,0,6,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearSearchCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
                 </StackPanel>
             </DockPanel>
         </Border>
 
-        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
-                    <DockPanel>
-                        <TextBlock Text="01 Calibration Register" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
-                        <TextBlock Text="{Binding CalibrationResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
-                    </DockPanel>
-                </Border>
-                <DataGrid Grid.Row="1"
-                          ItemsSource="{Binding FilteredCalibrationRecords}"
-                          SelectedItem="{Binding SelectedRecord}"
-                          SelectionMode="Single"
-                          AutoGenerateColumns="False"
-                          IsReadOnly="True"
-                          Style="{StaticResource VirtualizedDataGridStyle}">
-                    <DataGrid.RowStyle>
-                        <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
-                            <EventSetter Event="MouseDoubleClick" Handler="CalibrationRow_MouseDoubleClick"/>
-                            <EventSetter Event="PreviewMouseRightButtonDown" Handler="CalibrationRow_PreviewMouseRightButtonDown"/>
-                        </Style>
-                    </DataGrid.RowStyle>
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="115"/>
-                        <DataGridTextColumn Header="Name" Binding="{Binding ItemName}" Width="2*"/>
-                        <DataGridTextColumn Header="Calibrated" Binding="{Binding CalibrationDate, StringFormat={}{0:yyyy-MM-dd}}" Width="115"/>
-                        <DataGridTextColumn Header="Next Due" Binding="{Binding NextCalibrationDue, StringFormat={}{0:yyyy-MM-dd}}" Width="115"/>
-                        <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="105"/>
-                        <DataGridTextColumn Header="Calibrated By" Binding="{Binding CalibratedBy}" Width="140"/>
-                        <DataGridTextColumn Header="Certificate" Binding="{Binding CertificateNumber}" Width="145"/>
-                        <DataGridTextColumn Header="Result" Binding="{Binding Result}" Width="95"/>
-                        <DataGridTextColumn Header="Standard" Binding="{Binding Standard}" Width="140"/>
-                        <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" Width="2*"/>
-                    </DataGrid.Columns>
-                    <DataGrid.ContextMenu>
-                        <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
-                                    DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                            <MenuItem Header="Open Details" Command="{Binding OpenCalibrationDetailsCommand}"/>
-                            <MenuItem Header="Edit" Command="{Binding EditCalibrationCommand}"/>
-                            <Separator/>
-                            <MenuItem Header="Print Record" Command="{Binding PrintSelectedCalibrationCommand}"/>
-                            <MenuItem Header="Print Due Report" Command="{Binding PrintCalibrationListCommand}"/>
-                            <Separator/>
-                            <MenuItem Header="Delete" Command="{Binding DeleteCalibrationCommand}"/>
-                        </ContextMenu>
-                    </DataGrid.ContextMenu>
-                </DataGrid>
-                <TextBlock Grid.Row="1"
-                           Text="No calibration records"
-                           HorizontalAlignment="Center"
-                           VerticalAlignment="Center"
-                           FontSize="13"
-                           FontWeight="SemiBold">
-                    <TextBlock.Style>
-                        <Style TargetType="TextBlock">
-                            <Setter Property="Visibility" Value="Collapsed"/>
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding FilteredCalibrationRecords.Count}" Value="0">
-                                    <Setter Property="Visibility" Value="Visible"/>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </TextBlock.Style>
-                </TextBlock>
-            </Grid>
-        </Border>
+        <Grid Grid.Row="1" Margin="0,6,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" MinWidth="610"/>
+                <ColumnDefinition Width="8"/>
+                <ColumnDefinition Width="430" MinWidth="380"/>
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                        <DockPanel>
+                            <TextBlock Text="01 Calibration Register" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                            <TextBlock Text="{Binding CalibrationResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                        </DockPanel>
+                    </Border>
+                    <Border Grid.Row="1" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                        <DockPanel LastChildFill="True">
+                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                                <Button Style="{StaticResource GhostButton}" Content="Overdue" Command="{Binding ShowOverdueCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Due Soon" Command="{Binding ShowDueSoonCommand}" Margin="0,0,4,0"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Current" Command="{Binding ShowCurrentCommand}"/>
+                            </StackPanel>
+                            <TextBlock Text="{Binding CalibrationBacklogSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,10,0"/>
+                        </DockPanel>
+                    </Border>
+                    <DataGrid Grid.Row="2"
+                              ItemsSource="{Binding FilteredCalibrationRecords}"
+                              SelectedItem="{Binding SelectedRecord}"
+                              SelectionMode="Single"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True"
+                              Style="{StaticResource VirtualizedDataGridStyle}">
+                        <DataGrid.RowStyle>
+                            <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                                <EventSetter Event="MouseDoubleClick" Handler="CalibrationRow_MouseDoubleClick"/>
+                                <EventSetter Event="PreviewMouseRightButtonDown" Handler="CalibrationRow_PreviewMouseRightButtonDown"/>
+                            </Style>
+                        </DataGrid.RowStyle>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="110"/>
+                            <DataGridTextColumn Header="Name" Binding="{Binding ItemName}" Width="2*"/>
+                            <DataGridTextColumn Header="Calibrated" Binding="{Binding CalibrationDate, StringFormat={}{0:yyyy-MM-dd}}" Width="105"/>
+                            <DataGridTextColumn Header="Next Due" Binding="{Binding NextCalibrationDue, StringFormat={}{0:yyyy-MM-dd}}" Width="105"/>
+                            <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="95"/>
+                            <DataGridTextColumn Header="By" Binding="{Binding CalibratedBy}" Width="120"/>
+                            <DataGridTextColumn Header="Certificate" Binding="{Binding CertificateNumber}" Width="135"/>
+                            <DataGridTextColumn Header="Result" Binding="{Binding Result}" Width="85"/>
+                            <DataGridTextColumn Header="Standard" Binding="{Binding Standard}" Width="125"/>
+                        </DataGrid.Columns>
+                        <DataGrid.ContextMenu>
+                            <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
+                                        DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                <MenuItem Header="Open Details" Command="{Binding OpenCalibrationDetailsCommand}"/>
+                                <MenuItem Header="Copy Calibration Handoff" Command="{Binding CopySelectedCalibrationCommand}"/>
+                                <MenuItem Header="Print Record" Command="{Binding PrintSelectedCalibrationCommand}"/>
+                                <Separator/>
+                                <MenuItem Header="Edit" Command="{Binding EditCalibrationCommand}"/>
+                                <MenuItem Header="Print Due Report" Command="{Binding PrintCalibrationListCommand}"/>
+                                <MenuItem Header="Delete" Command="{Binding DeleteCalibrationCommand}"/>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                    </DataGrid>
+                    <TextBlock Grid.Row="2"
+                               Text="No calibration records match this filter"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"
+                               FontSize="13"
+                               FontWeight="SemiBold">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding FilteredCalibrationRecords.Count}" Value="0">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Grid>
+            </Border>
+
+            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                        <DockPanel>
+                            <TextBlock Text="02 Certificate Handoff" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                            <TextBlock Text="Selected calibration" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                        </DockPanel>
+                    </Border>
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                        <StackPanel Margin="10">
+                            <TextBlock Text="{Binding SelectedRecord.ItemName, TargetNullValue='No calibration selected', FallbackValue='No calibration selected'}"
+                                       FontSize="18"
+                                       FontWeight="SemiBold"
+                                       TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,10"/>
+
+                            <TextBlock Text="Certificate" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
+                            <TextBlock Text="{Binding SelectedCalibrationDetail}" TextWrapping="Wrap" Margin="0,0,0,10"/>
+
+                            <TextBlock Text="Timing" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
+                            <TextBlock Text="{Binding SelectedCalibrationTimingSummary}" TextWrapping="Wrap" Margin="0,0,0,10"/>
+
+                            <TextBlock Text="Next action" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
+                            <TextBlock Text="{Binding SelectedCalibrationNextAction}" TextWrapping="Wrap" Margin="0,0,0,14"/>
+
+                            <UniformGrid Columns="2" Margin="0,0,0,8">
+                                <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCalibrationDetailsCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditCalibrationCommand}" Margin="4,0,0,4"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Copy" Command="{Binding CopySelectedCalibrationCommand}" Margin="0,4,4,0"/>
+                                <Button Style="{StaticResource PrimaryButton}" Content="Print" Command="{Binding PrintSelectedCalibrationCommand}" Margin="4,4,0,0"/>
+                            </UniformGrid>
+
+                            <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="8" Margin="0,6,0,0">
+                                <StackPanel>
+                                    <TextBlock Text="Shelf release checklist" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/>
+                                    <TextBlock Text="{Binding SelectedCalibrationBenchChecklist}" TextWrapping="Wrap"/>
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+                    </ScrollViewer>
+                    <Border Grid.Row="2" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,1,0,0" Padding="5,3">
+                        <WrapPanel>
+                            <Button Style="{StaticResource PrimaryButton}" Content="Print Due" Command="{Binding PrintCalibrationListCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Clear Search" Command="{Binding ClearSearchCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,0,4,4"/>
+                        </WrapPanel>
+                    </Border>
+                </Grid>
+            </Border>
+        </Grid>
+
         <Border Grid.Row="2" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
             <DockPanel LastChildFill="True">
                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenCalibrationDetailsCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Copy Handoff" Command="{Binding CopySelectedCalibrationCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource GhostButton}" Content="Print Due" Command="{Binding PrintCalibrationListCommand}"/>
                 </StackPanel>
-                <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0"/>
+                <TextBlock Text="{Binding SelectedRecordSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0" TextWrapping="Wrap"/>
             </DockPanel>
         </Border>
     </Grid>

--- a/InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs
@@ -34,7 +34,7 @@ namespace InventoryManagementApp.Views.Pages
             if (sender is DataGridRow row && !row.IsSelected)
             {
                 row.IsSelected = true;
-                e.Handled = true;
+                row.Focus();
             }
         }
     }

--- a/scripts/run-app-qa-screenshots.ps1
+++ b/scripts/run-app-qa-screenshots.ps1
@@ -220,7 +220,8 @@ try {
     Add-Content -Path $readmePath -Value "Captured files:"
     foreach ($screenshot in ($screenshots | Sort-Object FullName)) {
         $relativePath = Resolve-Path -LiteralPath $screenshot.FullName -Relative
-        Add-Content -Path $readmePath -Value ("- `{0}`" -f $relativePath)
+        $dimensions = Get-PngDimensions -File $screenshot
+        Add-Content -Path $readmePath -Value ("- `{0}` - {1}x{2}, {3} bytes" -f $relativePath, $dimensions.Width, $dimensions.Height, $screenshot.Length)
     }
     Write-Step "QA screenshots saved to '$sessionOutput' ($($screenshots.Count) PNG files)."
 }


### PR DESCRIPTION
## Summary

- Redesigns Calibration into a two-pane technician bench with register, selected-certificate handoff, timing, next-action guidance, and shelf-release checklist context.
- Adds quick overdue/due-soon/current filters, clear search, copy calibration handoff, repeated print/detail/edit/delete actions, stable useful selection, and row-correct context menu behavior.
- Hardens calibration search against missing legacy/imported text fields and expands search to standard, result, and notes.
- Enhances the QA screenshot runner manifest so each captured PNG is listed with dimensions and byte size for easier screenshot review.
- Updates progress notes and the completion checklist for the calibration workflow pass.

## Why

The user asked to continue finishing every function end to end from a technician/advisor/admin perspective. Calibration was still mainly a register with toolbar actions, so a technician checking a calibrated item from the shelf could not see due state, certificate context, and release steps in one place.

## Validation

- Parsed the updated `CalibrationPage.xaml` locally as well-formed XML.
- Compared the branch against `master` through the GitHub connector.
- Read back the updated Calibration XAML, code-behind, view model, QA screenshot script, progress note, and checklist from the branch.
- Local `dotnet` build/test and WPF screenshot execution were not run because this Linux container does not have the .NET SDK or Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
- Did not run unrelated tests, per instruction.