### PR TITLE
Upgrade reservations advisor workbench

### DIFF
--- a/InventoryManagementApp/Models/Domain/Reservation.cs
+++ b/InventoryManagementApp/Models/Domain/Reservation.cs
@@ -58,7 +58,11 @@ namespace InventoryManagementApp.Models.Domain
         public DateTime StartDate
         {
             get => _startDate;
-            set => SetProperty(ref _startDate, value);
+            set
+            {
+                if (SetProperty(ref _startDate, value))
+                    OnPropertyChanged(nameof(StatusDisplay));
+            }
         }
 
         private DateTime _endDate;
@@ -79,7 +83,15 @@ namespace InventoryManagementApp.Models.Domain
         public string Status
         {
             get => _status;
-            set => SetProperty(ref _status, value);
+            set
+            {
+                if (SetProperty(ref _status, value))
+                {
+                    OnPropertyChanged(nameof(IsActive));
+                    OnPropertyChanged(nameof(IsFulfilled));
+                    OnPropertyChanged(nameof(StatusDisplay));
+                }
+            }
         }
 
         private string _notes = string.Empty;
@@ -107,7 +119,14 @@ namespace InventoryManagementApp.Models.Domain
         public int? RentalID
         {
             get => _rentalID;
-            set => SetProperty(ref _rentalID, value);
+            set
+            {
+                if (SetProperty(ref _rentalID, value))
+                {
+                    OnPropertyChanged(nameof(IsFulfilled));
+                    OnPropertyChanged(nameof(StatusDisplay));
+                }
+            }
         }
 
         public bool IsActive => Status == "Pending" || Status == "Confirmed";

--- a/InventoryManagementApp/ProgressNotes/2026-06-17-reservation-advisor-workbench.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-reservation-advisor-workbench.md
@@ -1,0 +1,17 @@
+# Reservation Advisor Workbench - 2026-06-17
+
+## Completed
+
+- Rebuilt Reservations from a plain toolbar/grid into a two-pane advisor workbench with hold directory, quick filters, selected-hold detail, timing, next action, shelf checklist, and repeated action buttons.
+- Added selected-reservation details, copy handoff, print handoff, printable filtered directory, and open-detail behavior so advisors can carry a reservation from hold review through shelf pickup and checkout fulfillment.
+- Added quick Active, Pending, Confirmed, and Upcoming filters plus clear search support.
+- Hardened reservation filtering against missing legacy/imported item, customer, status, or notes values and expanded search to reservation number, status, and notes.
+- Preserved useful selection after load, add, edit, confirm, cancel, fulfill, delete, search, and filter changes where possible.
+- Added row double-click details and row-correct right-click context menus so each button/menu action operates on the row the advisor is handling.
+- Updated reservation status notifications so fulfilled/in-progress/active display state refreshes immediately after status or rental ID changes.
+
+## Validation
+
+- GitHub connector readback reviewed the reservation model, view model, page XAML, and code-behind changes on the branch.
+- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
+- Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 08:11 NZST
+Last audit date/time: 2026-06-17 08:22 NZST
 
 ## Completed workflows
 
@@ -24,6 +24,7 @@ Last audit date/time: 2026-06-17 08:11 NZST
 - Calibration now uses a two-pane technician bench with certificate handoff details, timing and next-action guidance, shelf-release checklist, quick overdue/due-soon/current filters, copy handoff, print actions, stable useful selection, null-safe expanded search, and row-correct context menus.
 - QA screenshot manifests now list each captured PNG with dimensions and byte size so future screenshot reviews can spot cropped or suspicious captures faster.
 - Admin user management now supports durable checkbox permissions, advisor/technician/admin presets, access summaries in the directory/detail/copy/print flows, and permission-based navigation visibility for operations, insights, data, and admin sections.
+- Reservations now use a two-pane advisor workbench with hold directory, quick status filters, selected-hold detail, timing, next action, shelf checklist, copy handoff, print handoff, printable filtered directory, stable useful selection, null-safe expanded search, and row-correct double-click/right-click actions.
 
 ## Partially complete workflows
 
@@ -36,6 +37,7 @@ Last audit date/time: 2026-06-17 08:11 NZST
 - Maintenance now has a completed desktop workflow surface, but runtime add/edit/complete/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 - Calibration now has a completed desktop workflow surface, but runtime add/edit/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 - User permission editing now has a completed persistence/UI/navigation pass, but runtime login-as-each-role and screenshot validation still need a Windows/.NET workstation.
+- Reservations now have a completed desktop workflow surface, but runtime add/edit/confirm/cancel/fulfill/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 
 ## Known broken workflows
 
@@ -45,15 +47,10 @@ Last audit date/time: 2026-06-17 08:11 NZST
 
 ## Next recommended target
 
-- Continue the end-to-end workflow audit from a technician/advisor/admin perspective, with the next useful pass focused on Reservations or Categories depending on which page still exposes the most incomplete action/result path on `master`.
+- Continue the end-to-end workflow audit from a technician/advisor/admin perspective, with the next useful pass focused on Categories or Reports runtime polish depending on which page still exposes the most incomplete action/result path on `master`.
 
 ## Validation status
 
-- GitHub connector readback reviewed the user permission branch files, including user model/database/service changes, editor XAML/view model, user directory, navigation gating, progress note, and completion checklist.
-- The branch was replayed onto the current `master` after `master` moved during the run; the final branch is ahead of `master` and not behind.
-- `dotnet --info`: not run because `dotnet` is not installed in this scheduled container.
-- `dotnet restore InventoryManagementApp.sln`: not run because the .NET SDK is unavailable.
-- `dotnet build InventoryManagementApp.sln --no-restore`: not run because the .NET SDK is unavailable.
-- `dotnet test InventoryManagementApp.sln --no-build`: not run because the .NET SDK is unavailable.
-- `scripts/run-app-qa-screenshots.ps1`: not run because this scheduled Linux container cannot launch the Windows WPF app.
-- `bash ./scripts/check-banned-words.sh`: not run because no local checkout is available in this scheduled container.
+- GitHub connector readback reviewed the reservation branch files, including reservation model notifications, workflow view model, workbench XAML, row interaction code-behind, progress note, and completion checklist.
+- Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, and `scripts/run-app-qa-screenshots.ps1` were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
+- Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ViewModels/ReservationManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ReservationManagementViewModel.cs
@@ -3,7 +3,10 @@ using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Documents;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.Services.Reservations;
 using InventoryManagementApp.Interfaces;
@@ -18,6 +21,62 @@ namespace InventoryManagementApp.ViewModels
         public ObservableCollection<Reservation> Reservations { get; }
         public ObservableCollection<Reservation> FilteredReservations { get; }
 
+        public string ReservationResultsSummary
+        {
+            get
+            {
+                var activeCount = Reservations.Count(r => r.IsActive);
+                var shown = $"{FilteredReservations.Count} of {Reservations.Count} reservation{(Reservations.Count == 1 ? string.Empty : "s")} shown";
+                var active = $"{activeCount} active";
+                return string.IsNullOrWhiteSpace(SearchText)
+                    ? $"{shown} | {active} | filter: {SelectedFilter}"
+                    : $"{shown} for \"{SearchText.Trim()}\" | {active} | filter: {SelectedFilter}";
+            }
+        }
+
+        public string SelectedReservationTitle => SelectedReservation == null
+            ? "No reservation selected"
+            : $"Reservation #{SelectedReservation.ReservationID} - {ValueOrNotRecorded(SelectedReservation.ItemNumber)}";
+
+        public string SelectedReservationSubtitle => SelectedReservation == null
+            ? "Select or double-click a reservation to see customer, item, timing, and fulfillment guidance."
+            : $"{ValueOrNotRecorded(SelectedReservation.CustomerName)} | {SelectedReservation.StatusDisplay} | Qty {SelectedReservation.Quantity}";
+
+        public string SelectedReservationTiming => SelectedReservation == null
+            ? "No date range selected."
+            : $"Requested {SelectedReservation.StartDate:yyyy-MM-dd} through {SelectedReservation.EndDate:yyyy-MM-dd} | Created {SelectedReservation.CreatedAt:yyyy-MM-dd HH:mm}";
+
+        public string SelectedReservationNextAction
+        {
+            get
+            {
+                if (SelectedReservation == null)
+                    return "Choose a hold before confirming availability, cancelling, fulfilling with a rental ID, or printing a shelf handoff.";
+
+                return SelectedReservation.Status switch
+                {
+                    "Pending" => "Confirm the hold when the item is available, or edit the dates/customer before committing stock.",
+                    "Confirmed" when SelectedReservation.StartDate.Date <= DateTime.Now.Date => "Collect the tool from the shelf, start the rental checkout, then fulfill this reservation with the Rental ID.",
+                    "Confirmed" => "Keep this hold staged for the start date, print/copy the handoff, or cancel if the customer no longer needs it.",
+                    "Fulfilled" => "Reservation is complete. Use the linked Rental ID for checkout, return, invoice, or history review.",
+                    "Cancelled" => "Reservation is cancelled. Keep it for audit history or delete it if it was entered in error.",
+                    _ => "Review the hold status, customer, dates, and notes before choosing the next operation."
+                };
+            }
+        }
+
+        public string SelectedReservationShelfChecklist => SelectedReservation == null
+            ? "Shelf checklist appears after selecting a reservation."
+            : "1. Verify item number and quantity. 2. Check condition and calibration/maintenance flags. 3. Match customer at pickup. 4. Create rental and record the Rental ID here.";
+
+        public string SelectedReservationDetail => SelectedReservation == null
+            ? "No reservation selected."
+            : CreateReservationHandoffText(SelectedReservation);
+
+        public string SelectedReservationSummary => SelectedReservation == null
+            ? "Select a reservation to confirm, cancel, fulfill, print, copy, edit, or delete."
+            : $"Ready: #{SelectedReservation.ReservationID} | {ValueOrNotRecorded(SelectedReservation.CustomerName)} | {ValueOrNotRecorded(SelectedReservation.ItemName)} | {SelectedReservation.StartDate:yyyy-MM-dd} to {SelectedReservation.EndDate:yyyy-MM-dd} | {SelectedReservation.StatusDisplay}";
+
         private Reservation? _selectedReservation;
         public Reservation? SelectedReservation
         {
@@ -26,11 +85,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 if (SetProperty(ref _selectedReservation, value))
                 {
-                    EditReservationCommand.NotifyCanExecuteChanged();
-                    DeleteReservationCommand.NotifyCanExecuteChanged();
-                    ConfirmReservationCommand.NotifyCanExecuteChanged();
-                    CancelReservationCommand.NotifyCanExecuteChanged();
-                    FulfillReservationCommand.NotifyCanExecuteChanged();
+                    NotifySelectionChanged();
                 }
             }
         }
@@ -71,6 +126,15 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand CancelReservationCommand { get; }
         public IAsyncRelayCommand FulfillReservationCommand { get; }
         public IAsyncRelayCommand RefreshCommand { get; }
+        public IRelayCommand OpenReservationDetailsCommand { get; }
+        public IRelayCommand CopyReservationHandoffCommand { get; }
+        public IRelayCommand PrintReservationHandoffCommand { get; }
+        public IRelayCommand PrintReservationDirectoryCommand { get; }
+        public IRelayCommand ClearReservationSearchCommand { get; }
+        public IRelayCommand ShowActiveReservationsCommand { get; }
+        public IRelayCommand ShowPendingReservationsCommand { get; }
+        public IRelayCommand ShowConfirmedReservationsCommand { get; }
+        public IRelayCommand ShowUpcomingReservationsCommand { get; }
 
         public ReservationManagementViewModel(
             ReservationService reservationService,
@@ -100,19 +164,29 @@ namespace InventoryManagementApp.ViewModels
             CancelReservationCommand = new AsyncRelayCommand(CancelReservationAsync, CanCancel);
             FulfillReservationCommand = new AsyncRelayCommand(FulfillReservationAsync, CanFulfill);
             RefreshCommand = new AsyncRelayCommand(LoadReservationsAsync);
+            OpenReservationDetailsCommand = new RelayCommand(OpenReservationDetails, () => SelectedReservation != null);
+            CopyReservationHandoffCommand = new RelayCommand(CopyReservationHandoff, () => SelectedReservation != null);
+            PrintReservationHandoffCommand = new RelayCommand(PrintReservationHandoff, () => SelectedReservation != null);
+            PrintReservationDirectoryCommand = new RelayCommand(PrintReservationDirectory);
+            ClearReservationSearchCommand = new RelayCommand(ClearReservationSearch);
+            ShowActiveReservationsCommand = new RelayCommand(() => SelectedFilter = "Active");
+            ShowPendingReservationsCommand = new RelayCommand(() => SelectedFilter = "Pending");
+            ShowConfirmedReservationsCommand = new RelayCommand(() => SelectedFilter = "Confirmed");
+            ShowUpcomingReservationsCommand = new RelayCommand(() => SelectedFilter = "Upcoming (7 days)");
         }
 
         private async Task LoadReservationsAsync()
         {
             try
             {
+                var preferredReservationId = SelectedReservation?.ReservationID;
                 var reservations = await _reservationService.GetAllReservationsAsync();
                 Reservations.Clear();
                 foreach (var reservation in reservations)
                 {
                     Reservations.Add(reservation);
                 }
-                ApplyFilter();
+                ApplyFilter(preferredReservationId);
             }
             catch (Exception ex)
             {
@@ -154,7 +228,7 @@ namespace InventoryManagementApp.ViewModels
                     var id = await _reservationService.CreateReservationAsync(newReservation);
                     newReservation.ReservationID = id;
                     Reservations.Insert(0, newReservation);
-                    ApplyFilter();
+                    ApplyFilter(id);
                     await _dialogService.ShowInfoAsync("Success", "Reservation created successfully");
                 }
                 catch (Exception ex)
@@ -168,24 +242,7 @@ namespace InventoryManagementApp.ViewModels
         {
             if (SelectedReservation == null) return;
 
-            var clone = new Reservation
-            {
-                ReservationID = SelectedReservation.ReservationID,
-                ItemID = SelectedReservation.ItemID,
-                CustomerID = SelectedReservation.CustomerID,
-                ItemNumber = SelectedReservation.ItemNumber,
-                ItemName = SelectedReservation.ItemName,
-                CustomerName = SelectedReservation.CustomerName,
-                ReservationDate = SelectedReservation.ReservationDate,
-                StartDate = SelectedReservation.StartDate,
-                EndDate = SelectedReservation.EndDate,
-                Quantity = SelectedReservation.Quantity,
-                Status = SelectedReservation.Status,
-                Notes = SelectedReservation.Notes,
-                CreatedByUserID = SelectedReservation.CreatedByUserID,
-                CreatedAt = SelectedReservation.CreatedAt,
-                RentalID = SelectedReservation.RentalID
-            };
+            var clone = CloneReservation(SelectedReservation);
 
             var result = await _dialogService.ShowReservationEditDialogAsync(clone, isNew: false);
             if (result)
@@ -193,9 +250,10 @@ namespace InventoryManagementApp.ViewModels
                 try
                 {
                     await _reservationService.UpdateReservationAsync(clone);
+                    var originalId = SelectedReservation.ReservationID;
                     var index = Reservations.IndexOf(SelectedReservation);
                     if (index >= 0) Reservations[index] = clone;
-                    ApplyFilter();
+                    ApplyFilter(originalId);
                     await _dialogService.ShowInfoAsync("Success", "Reservation updated successfully");
                 }
                 catch (Exception ex)
@@ -209,16 +267,17 @@ namespace InventoryManagementApp.ViewModels
         {
             if (SelectedReservation == null) return;
 
+            var reservation = SelectedReservation;
             var confirmed = await _dialogService.ShowConfirmAsync(
                 "Delete Reservation",
-                $"Are you sure you want to delete this reservation?");
+                $"Delete reservation #{reservation.ReservationID} for {ValueOrNotRecorded(reservation.CustomerName)}?");
 
             if (confirmed)
             {
                 try
                 {
-                    await _reservationService.DeleteReservationAsync(SelectedReservation.ReservationID);
-                    Reservations.Remove(SelectedReservation);
+                    await _reservationService.DeleteReservationAsync(reservation.ReservationID);
+                    Reservations.Remove(reservation);
                     ApplyFilter();
                     await _dialogService.ShowInfoAsync("Success", "Reservation deleted successfully");
                 }
@@ -235,12 +294,10 @@ namespace InventoryManagementApp.ViewModels
 
             try
             {
-                await _reservationService.ConfirmReservationAsync(SelectedReservation.ReservationID);
+                var reservationId = SelectedReservation.ReservationID;
+                await _reservationService.ConfirmReservationAsync(reservationId);
                 SelectedReservation.Status = "Confirmed";
-                ApplyFilter();
-                ConfirmReservationCommand.NotifyCanExecuteChanged();
-                CancelReservationCommand.NotifyCanExecuteChanged();
-                FulfillReservationCommand.NotifyCanExecuteChanged();
+                ApplyFilter(reservationId);
                 await _dialogService.ShowInfoAsync("Success", "Reservation confirmed");
             }
             catch (Exception ex)
@@ -253,20 +310,18 @@ namespace InventoryManagementApp.ViewModels
         {
             if (SelectedReservation == null) return;
 
+            var reservation = SelectedReservation;
             var confirmed = await _dialogService.ShowConfirmAsync(
                 "Cancel Reservation",
-                "Are you sure you want to cancel this reservation?");
+                $"Cancel reservation #{reservation.ReservationID} for {ValueOrNotRecorded(reservation.CustomerName)}?");
 
             if (confirmed)
             {
                 try
                 {
-                    await _reservationService.CancelReservationAsync(SelectedReservation.ReservationID);
-                    SelectedReservation.Status = "Cancelled";
-                    ApplyFilter();
-                    ConfirmReservationCommand.NotifyCanExecuteChanged();
-                    CancelReservationCommand.NotifyCanExecuteChanged();
-                    FulfillReservationCommand.NotifyCanExecuteChanged();
+                    await _reservationService.CancelReservationAsync(reservation.ReservationID);
+                    reservation.Status = "Cancelled";
+                    ApplyFilter(reservation.ReservationID);
                     await _dialogService.ShowInfoAsync("Success", "Reservation cancelled");
                 }
                 catch (Exception ex)
@@ -282,19 +337,17 @@ namespace InventoryManagementApp.ViewModels
 
             var rentalIdText = await _dialogService.ShowInputDialogAsync(
                 "Fulfill Reservation",
-                "Enter the Rental ID that fulfills this reservation:");
+                "Enter the Rental ID created during checkout for this reservation:");
 
             if (!string.IsNullOrWhiteSpace(rentalIdText) && int.TryParse(rentalIdText, out var rentalId))
             {
                 try
                 {
-                    await _reservationService.FulfillReservationAsync(SelectedReservation.ReservationID, rentalId);
+                    var reservationId = SelectedReservation.ReservationID;
+                    await _reservationService.FulfillReservationAsync(reservationId, rentalId);
                     SelectedReservation.Status = "Fulfilled";
                     SelectedReservation.RentalID = rentalId;
-                    ApplyFilter();
-                    ConfirmReservationCommand.NotifyCanExecuteChanged();
-                    CancelReservationCommand.NotifyCanExecuteChanged();
-                    FulfillReservationCommand.NotifyCanExecuteChanged();
+                    ApplyFilter(reservationId);
                     await _dialogService.ShowInfoAsync("Success", "Reservation marked as fulfilled");
                 }
                 catch (Exception ex)
@@ -304,19 +357,23 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        private void ApplyFilter()
+        private void ApplyFilter(int? preferredReservationId = null)
         {
+            preferredReservationId ??= SelectedReservation?.ReservationID;
             FilteredReservations.Clear();
 
             var filtered = Reservations.AsEnumerable();
 
             if (!string.IsNullOrWhiteSpace(SearchText))
             {
-                var search = SearchText.ToLowerInvariant();
+                var search = SearchText.Trim();
                 filtered = filtered.Where(r =>
-                    r.ItemNumber.ToLowerInvariant().Contains(search) ||
-                    r.ItemName.ToLowerInvariant().Contains(search) ||
-                    r.CustomerName.ToLowerInvariant().Contains(search));
+                    Contains(r.ReservationID.ToString(), search) ||
+                    Contains(r.ItemNumber, search) ||
+                    Contains(r.ItemName, search) ||
+                    Contains(r.CustomerName, search) ||
+                    Contains(r.Status, search) ||
+                    Contains(r.Notes, search));
             }
 
             filtered = SelectedFilter switch
@@ -330,11 +387,257 @@ namespace InventoryManagementApp.ViewModels
                 _ => filtered
             };
 
-            foreach (var reservation in filtered)
+            foreach (var reservation in filtered.OrderBy(r => r.StartDate).ThenBy(r => r.CustomerName))
             {
                 FilteredReservations.Add(reservation);
             }
+
+            SelectBestReservationAfterRefresh(preferredReservationId);
+            OnPropertyChanged(nameof(ReservationResultsSummary));
         }
+
+        private void ClearReservationSearch()
+        {
+            SearchText = string.Empty;
+            SelectedFilter = "Active";
+            ApplyFilter();
+        }
+
+        private void OpenReservationDetails()
+        {
+            if (SelectedReservation == null)
+                return;
+
+            _dialogService.ShowInfo(CreateReservationHandoffText(SelectedReservation), $"Reservation #{SelectedReservation.ReservationID}");
+        }
+
+        private void CopyReservationHandoff()
+        {
+            if (SelectedReservation == null)
+                return;
+
+            try
+            {
+                Clipboard.SetText(CreateReservationHandoffText(SelectedReservation));
+                _dialogService.ShowInfo("Reservation handoff copied to the clipboard.", "Reservation Handoff");
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowInfo($"Failed to copy reservation handoff: {ex.Message}", "Copy Failed");
+            }
+        }
+
+        private void PrintReservationHandoff()
+        {
+            if (SelectedReservation == null)
+                return;
+
+            try
+            {
+                var reservation = SelectedReservation;
+                var doc = CreateReservationDocument($"Reservation Handoff - #{reservation.ReservationID}");
+                var table = CreateKeyValueTable();
+                var group = table.RowGroups[0];
+                AddKeyValueRow(group, "Reservation #:", reservation.ReservationID.ToString());
+                AddKeyValueRow(group, "Status:", reservation.StatusDisplay);
+                AddKeyValueRow(group, "Customer:", reservation.CustomerName);
+                AddKeyValueRow(group, "Item:", $"{ValueOrNotRecorded(reservation.ItemNumber)} - {ValueOrNotRecorded(reservation.ItemName)}");
+                AddKeyValueRow(group, "Quantity:", reservation.Quantity.ToString());
+                AddKeyValueRow(group, "Dates:", $"{reservation.StartDate:yyyy-MM-dd} to {reservation.EndDate:yyyy-MM-dd}");
+                AddKeyValueRow(group, "Rental ID:", reservation.RentalID?.ToString() ?? "Not fulfilled yet");
+                AddKeyValueRow(group, "Notes:", ValueOrNotRecorded(reservation.Notes));
+                AddKeyValueRow(group, "Next action:", SelectedReservationNextAction);
+                AddKeyValueRow(group, "Shelf checklist:", SelectedReservationShelfChecklist);
+                doc.Blocks.Add(table);
+                _dialogService.ShowPrintPreview(doc, $"Reservation {reservation.ReservationID}", string.Empty);
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowInfo($"Failed to print reservation handoff: {ex.Message}", "Print Failed");
+            }
+        }
+
+        private void PrintReservationDirectory()
+        {
+            if (FilteredReservations.Count == 0)
+            {
+                _dialogService.ShowInfo("There are no reservations to print for the current filter.", "Reservation Directory");
+                return;
+            }
+
+            try
+            {
+                var doc = CreateReservationDocument("Reservation Directory", fontSize: 11);
+                doc.Blocks.Add(new Paragraph(new Run($"Printed {DateTime.Now:yyyy-MM-dd HH:mm} | {ReservationResultsSummary}"))
+                {
+                    FontSize = 10,
+                    Margin = new Thickness(0, 0, 0, 10)
+                });
+
+                var table = new Table { CellSpacing = 0 };
+                table.Columns.Add(new TableColumn { Width = new GridLength(80) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(110) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(165) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(165) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(85) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(85) });
+                table.Columns.Add(new TableColumn { Width = new GridLength(85) });
+
+                var group = new TableRowGroup();
+                table.RowGroups.Add(group);
+                AddPrintRow(group, true, "Hold #", "Item #", "Item", "Customer", "Start", "End", "Status");
+
+                foreach (var reservation in FilteredReservations)
+                {
+                    AddPrintRow(
+                        group,
+                        false,
+                        reservation.ReservationID.ToString(),
+                        reservation.ItemNumber,
+                        reservation.ItemName,
+                        reservation.CustomerName,
+                        reservation.StartDate.ToString("yyyy-MM-dd"),
+                        reservation.EndDate.ToString("yyyy-MM-dd"),
+                        reservation.StatusDisplay);
+                }
+
+                doc.Blocks.Add(table);
+                _dialogService.ShowPrintPreview(doc, "Reservation Directory", string.Empty);
+            }
+            catch (Exception ex)
+            {
+                _dialogService.ShowInfo($"Failed to print reservation directory: {ex.Message}", "Print Failed");
+            }
+        }
+
+        private void SelectBestReservationAfterRefresh(int? preferredReservationId = null)
+        {
+            if (FilteredReservations.Count == 0)
+            {
+                SelectedReservation = null;
+                return;
+            }
+
+            SelectedReservation = preferredReservationId.HasValue
+                ? FilteredReservations.FirstOrDefault(r => r.ReservationID == preferredReservationId.Value) ?? FilteredReservations.FirstOrDefault()
+                : FilteredReservations.FirstOrDefault();
+        }
+
+        private void NotifySelectionChanged()
+        {
+            EditReservationCommand.NotifyCanExecuteChanged();
+            DeleteReservationCommand.NotifyCanExecuteChanged();
+            ConfirmReservationCommand.NotifyCanExecuteChanged();
+            CancelReservationCommand.NotifyCanExecuteChanged();
+            FulfillReservationCommand.NotifyCanExecuteChanged();
+            OpenReservationDetailsCommand.NotifyCanExecuteChanged();
+            CopyReservationHandoffCommand.NotifyCanExecuteChanged();
+            PrintReservationHandoffCommand.NotifyCanExecuteChanged();
+            OnPropertyChanged(nameof(SelectedReservationTitle));
+            OnPropertyChanged(nameof(SelectedReservationSubtitle));
+            OnPropertyChanged(nameof(SelectedReservationTiming));
+            OnPropertyChanged(nameof(SelectedReservationNextAction));
+            OnPropertyChanged(nameof(SelectedReservationShelfChecklist));
+            OnPropertyChanged(nameof(SelectedReservationDetail));
+            OnPropertyChanged(nameof(SelectedReservationSummary));
+        }
+
+        private static Reservation CloneReservation(Reservation source) => new()
+        {
+            ReservationID = source.ReservationID,
+            ItemID = source.ItemID,
+            CustomerID = source.CustomerID,
+            ItemNumber = source.ItemNumber,
+            ItemName = source.ItemName,
+            CustomerName = source.CustomerName,
+            ReservationDate = source.ReservationDate,
+            StartDate = source.StartDate,
+            EndDate = source.EndDate,
+            Quantity = source.Quantity,
+            Status = source.Status,
+            Notes = source.Notes,
+            CreatedByUserID = source.CreatedByUserID,
+            CreatedAt = source.CreatedAt,
+            RentalID = source.RentalID
+        };
+
+        private static bool Contains(string? value, string search) =>
+            !string.IsNullOrWhiteSpace(value) && value.Contains(search, StringComparison.OrdinalIgnoreCase);
+
+        private static string CreateReservationHandoffText(Reservation reservation)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine($"Reservation #{reservation.ReservationID}");
+            builder.AppendLine($"Status: {reservation.StatusDisplay}");
+            builder.AppendLine($"Customer: {ValueOrNotRecorded(reservation.CustomerName)}");
+            builder.AppendLine($"Item: {ValueOrNotRecorded(reservation.ItemNumber)} - {ValueOrNotRecorded(reservation.ItemName)}");
+            builder.AppendLine($"Quantity: {reservation.Quantity}");
+            builder.AppendLine($"Dates: {reservation.StartDate:yyyy-MM-dd} to {reservation.EndDate:yyyy-MM-dd}");
+            builder.AppendLine($"Rental ID: {(reservation.RentalID.HasValue ? reservation.RentalID.Value.ToString() : "Not fulfilled yet")}");
+            builder.AppendLine($"Notes: {ValueOrNotRecorded(reservation.Notes)}");
+            builder.AppendLine();
+            builder.AppendLine("Shelf handoff: verify item number and quantity, check condition, match customer at pickup, create the rental, then fulfill this reservation with the Rental ID.");
+            return builder.ToString();
+        }
+
+        private static FlowDocument CreateReservationDocument(string title, double fontSize = 12)
+        {
+            var doc = new FlowDocument
+            {
+                PagePadding = new Thickness(40),
+                ColumnWidth = double.PositiveInfinity,
+                FontFamily = new System.Windows.Media.FontFamily("Segoe UI"),
+                FontSize = fontSize
+            };
+            doc.Blocks.Add(new Paragraph(new Run(title))
+            {
+                FontSize = 18,
+                FontWeight = FontWeights.SemiBold,
+                Margin = new Thickness(0, 0, 0, 8)
+            });
+            return doc;
+        }
+
+        private static Table CreateKeyValueTable()
+        {
+            var table = new Table { CellSpacing = 0 };
+            table.Columns.Add(new TableColumn { Width = new GridLength(135) });
+            table.Columns.Add(new TableColumn { Width = new GridLength(520) });
+            table.RowGroups.Add(new TableRowGroup());
+            return table;
+        }
+
+        private static void AddKeyValueRow(TableRowGroup group, string label, string? value)
+        {
+            var row = new TableRow();
+            AddCell(row, label, isHeader: true);
+            AddCell(row, ValueOrNotRecorded(value));
+            group.Rows.Add(row);
+        }
+
+        private static void AddPrintRow(TableRowGroup group, bool isHeader, params string?[] values)
+        {
+            var row = new TableRow();
+            foreach (var value in values)
+            {
+                AddCell(row, ValueOrNotRecorded(value), isHeader);
+            }
+            group.Rows.Add(row);
+        }
+
+        private static void AddCell(TableRow row, string text, bool isHeader = false)
+        {
+            row.Cells.Add(new TableCell(new Paragraph(new Run(text)))
+            {
+                Padding = new Thickness(4, 3, 4, 3),
+                BorderBrush = System.Windows.Media.Brushes.LightGray,
+                BorderThickness = new Thickness(0, 0, 0, 0.5),
+                FontWeight = isHeader ? FontWeights.SemiBold : FontWeights.Normal
+            });
+        }
+
+        private static string ValueOrNotRecorded(string? value) =>
+            string.IsNullOrWhiteSpace(value) ? "Not recorded" : value.Trim();
 
         private bool CanEdit() => SelectedReservation != null && SelectedReservation.Status != "Fulfilled";
 

--- a/InventoryManagementApp/Views/Pages/ReservationPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ReservationPage.xaml
@@ -1,77 +1,210 @@
 <Page x:Class="InventoryManagementApp.Views.Pages.ReservationPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      Background="{DynamicResource BackgroundBrush}">
+      Background="{DynamicResource BackgroundBrush}"
+      Focusable="True">
     <Grid Margin="0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <Border Style="{StaticResource ToolbarCard}">
-            <DockPanel LastChildFill="False">
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddReservationCommand}" Margin="0,0,8,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Edit" Command="{Binding EditReservationCommand}" Margin="0,0,8,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Delete" Command="{Binding DeleteReservationCommand}" Margin="0,0,8,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Confirm" Command="{Binding ConfirmReservationCommand}" Margin="0,0,8,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Cancel" Command="{Binding CancelReservationCommand}" Margin="0,0,8,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Fulfill" Command="{Binding FulfillReservationCommand}" Margin="0,0,8,0"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Refresh" Command="{Binding RefreshCommand}"/>
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
-                    <TextBox Width="180" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,6,0"/>
-                    <ComboBox Width="150" ItemsSource="{Binding FilterOptions}" SelectedItem="{Binding SelectedFilter}"/>
-                </StackPanel>
+            <DockPanel LastChildFill="True">
+                <WrapPanel DockPanel.Dock="Left" VerticalAlignment="Center">
+                    <TextBlock Text="Reservations" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,4"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddReservationCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Confirm" Command="{Binding ConfirmReservationCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Fulfill" Command="{Binding FulfillReservationCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Edit" Command="{Binding EditReservationCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Cancel" Command="{Binding CancelReservationCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteReservationCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Copy" Command="{Binding CopyReservationHandoffCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print" Command="{Binding PrintReservationHandoffCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print List" Command="{Binding PrintReservationDirectoryCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,0,4,4"/>
+                </WrapPanel>
+                <WrapPanel DockPanel.Dock="Right" HorizontalAlignment="Right" VerticalAlignment="Center">
+                    <TextBlock Text="Find" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,4"/>
+                    <TextBox Width="190"
+                             Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                             ToolTip="Search reservation number, item, customer, status, or notes"
+                             Margin="0,0,4,4"/>
+                    <ComboBox Width="150"
+                              ItemsSource="{Binding FilterOptions}"
+                              SelectedItem="{Binding SelectedFilter}"
+                              Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearReservationSearchCommand}" Margin="0,0,4,4"/>
+                </WrapPanel>
             </DockPanel>
         </Border>
 
-        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0" Margin="0,6,0,0">
-            <Grid>
-                <DataGrid ItemsSource="{Binding FilteredReservations}"
-                          SelectedItem="{Binding SelectedReservation}"
-                          AutoGenerateColumns="False"
-                          IsReadOnly="True"
-                          Style="{StaticResource VirtualizedDataGridStyle}">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Reservation #" Binding="{Binding ReservationID}" Width="120"/>
-                        <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="140"/>
-                        <DataGridTextColumn Header="Item" Binding="{Binding ItemName}" Width="200"/>
-                        <DataGridTextColumn Header="Customer" Binding="{Binding CustomerName}" Width="200"/>
-                        <DataGridTextColumn Header="Start" Binding="{Binding StartDate, StringFormat={}{0:yyyy-MM-dd}}" Width="140"/>
-                        <DataGridTextColumn Header="End" Binding="{Binding EndDate, StringFormat={}{0:yyyy-MM-dd}}" Width="140"/>
-                        <DataGridTextColumn Header="Qty" Binding="{Binding Quantity}" Width="80"/>
-                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="120"/>
-                    </DataGrid.Columns>
-                    <DataGrid.ContextMenu>
-                        <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
-                                    DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                            <MenuItem Header="Add" Command="{Binding AddReservationCommand}"/>
-                            <MenuItem Header="Edit" Command="{Binding EditReservationCommand}"/>
-                            <MenuItem Header="Delete" Command="{Binding DeleteReservationCommand}"/>
-                            <MenuItem Header="Confirm" Command="{Binding ConfirmReservationCommand}"/>
-                            <MenuItem Header="Cancel" Command="{Binding CancelReservationCommand}"/>
-                            <MenuItem Header="Fulfill" Command="{Binding FulfillReservationCommand}"/>
-                        </ContextMenu>
-                    </DataGrid.ContextMenu>
-                </DataGrid>
-                <TextBlock Text="No reservations"
-                           HorizontalAlignment="Center"
-                           VerticalAlignment="Center"
-                           FontSize="16"
-                           FontWeight="SemiBold">
-                    <TextBlock.Style>
-                        <Style TargetType="TextBlock">
-                            <Setter Property="Visibility" Value="Collapsed"/>
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding FilteredReservations.Count}" Value="0">
-                                    <Setter Property="Visibility" Value="Visible"/>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </TextBlock.Style>
-                </TextBlock>
-            </Grid>
+        <Grid Grid.Row="1" Margin="0,6,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" MinWidth="520"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="1.35*" MinWidth="280"/>
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+                        <DockPanel>
+                            <TextBlock Text="01 Hold Directory" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                            <TextBlock Text="{Binding ReservationResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                        </DockPanel>
+                    </Border>
+
+                    <WrapPanel Grid.Row="1" Margin="6,5,6,4">
+                        <Button Style="{StaticResource GhostButton}" Content="Active" Command="{Binding ShowActiveReservationsCommand}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Pending" Command="{Binding ShowPendingReservationsCommand}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Confirmed" Command="{Binding ShowConfirmedReservationsCommand}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Upcoming" Command="{Binding ShowUpcomingReservationsCommand}" Margin="0,0,4,4"/>
+                    </WrapPanel>
+
+                    <DataGrid x:Name="ReservationGrid"
+                              Grid.Row="2"
+                              ItemsSource="{Binding FilteredReservations}"
+                              SelectedItem="{Binding SelectedReservation, Mode=TwoWay}"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True"
+                              SelectionMode="Single"
+                              Style="{StaticResource VirtualizedDataGridStyle}">
+                        <DataGrid.RowStyle>
+                            <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                                <EventSetter Event="MouseDoubleClick" Handler="ReservationRow_MouseDoubleClick"/>
+                                <EventSetter Event="PreviewMouseRightButtonDown" Handler="ReservationRow_PreviewMouseRightButtonDown"/>
+                            </Style>
+                        </DataGrid.RowStyle>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Hold #" Binding="{Binding ReservationID}" Width="80"/>
+                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="115"/>
+                            <DataGridTextColumn Header="Item" Binding="{Binding ItemName}" Width="1.45*"/>
+                            <DataGridTextColumn Header="Customer" Binding="{Binding CustomerName}" Width="1.35*"/>
+                            <DataGridTextColumn Header="Start" Binding="{Binding StartDate, StringFormat={}{0:yyyy-MM-dd}}" Width="105"/>
+                            <DataGridTextColumn Header="End" Binding="{Binding EndDate, StringFormat={}{0:yyyy-MM-dd}}" Width="105"/>
+                            <DataGridTextColumn Header="Qty" Binding="{Binding Quantity}" Width="55"/>
+                            <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="105"/>
+                        </DataGrid.Columns>
+                        <DataGrid.ContextMenu>
+                            <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
+                                        DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                <MenuItem Header="Open Details" Command="{Binding OpenReservationDetailsCommand}"/>
+                                <MenuItem Header="Copy Handoff" Command="{Binding CopyReservationHandoffCommand}"/>
+                                <MenuItem Header="Print Handoff" Command="{Binding PrintReservationHandoffCommand}"/>
+                                <Separator/>
+                                <MenuItem Header="Add" Command="{Binding AddReservationCommand}"/>
+                                <MenuItem Header="Edit" Command="{Binding EditReservationCommand}"/>
+                                <MenuItem Header="Confirm" Command="{Binding ConfirmReservationCommand}"/>
+                                <MenuItem Header="Cancel" Command="{Binding CancelReservationCommand}"/>
+                                <MenuItem Header="Fulfill" Command="{Binding FulfillReservationCommand}"/>
+                                <Separator/>
+                                <MenuItem Header="Print Current Results" Command="{Binding PrintReservationDirectoryCommand}"/>
+                                <MenuItem Header="Delete" Command="{Binding DeleteReservationCommand}"/>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                    </DataGrid>
+
+                    <TextBlock Grid.Row="2"
+                               Text="No reservations match this filter"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"
+                               FontSize="13"
+                               FontWeight="SemiBold">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding FilteredReservations.Count}" Value="0">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Grid>
+            </Border>
+
+            <GridSplitter Grid.Column="1"
+                          Width="6"
+                          HorizontalAlignment="Stretch"
+                          VerticalAlignment="Stretch"
+                          Background="{DynamicResource BorderBrushBase}"/>
+
+            <Border Grid.Column="2" Style="{StaticResource Card}" Padding="8">
+                <DockPanel LastChildFill="True">
+                    <Border DockPanel.Dock="Top"
+                            Background="{DynamicResource SurfaceAltBrush}"
+                            BorderBrush="{DynamicResource BorderBrushAlt}"
+                            BorderThickness="1"
+                            Padding="6"
+                            Margin="0,0,0,6">
+                        <StackPanel>
+                            <TextBlock Text="Selected Hold" Style="{StaticResource SectionHeader}"/>
+                            <TextBlock Text="{Binding SelectedReservationTitle}"
+                                       Style="{StaticResource PageTitleTextBlock}"
+                                       TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding SelectedReservationSubtitle}"
+                                       FontSize="11"
+                                       Margin="0,2,0,0"
+                                       TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+
+                    <StackPanel DockPanel.Dock="Top" Margin="0,0,0,6">
+                        <TextBlock Text="Timing" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="{Binding SelectedReservationTiming}" TextWrapping="Wrap"/>
+                    </StackPanel>
+
+                    <StackPanel DockPanel.Dock="Top" Margin="0,0,0,6">
+                        <TextBlock Text="Next Action" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="{Binding SelectedReservationNextAction}" TextWrapping="Wrap"/>
+                    </StackPanel>
+
+                    <StackPanel DockPanel.Dock="Top" Margin="0,0,0,6">
+                        <TextBlock Text="Shelf Checklist" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="{Binding SelectedReservationShelfChecklist}" TextWrapping="Wrap"/>
+                    </StackPanel>
+
+                    <StackPanel DockPanel.Dock="Bottom" Margin="0,6,0,0">
+                        <TextBlock Text="Actions" Style="{StaticResource SectionHeader}"/>
+                        <UniformGrid Columns="2">
+                            <Button Style="{StaticResource PrimaryButton}" Content="Confirm" Command="{Binding ConfirmReservationCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource PrimaryButton}" Content="Fulfill" Command="{Binding FulfillReservationCommand}" Margin="0,0,0,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Details" Command="{Binding OpenReservationDetailsCommand}" Margin="0,0,4,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Copy" Command="{Binding CopyReservationHandoffCommand}" Margin="0,0,0,4"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Print" Command="{Binding PrintReservationHandoffCommand}" Margin="0,0,4,0"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Edit" Command="{Binding EditReservationCommand}"/>
+                        </UniformGrid>
+                    </StackPanel>
+
+                    <Border BorderBrush="{DynamicResource BorderBrushAlt}"
+                            BorderThickness="1"
+                            Background="{DynamicResource TextBoxBackgroundBrush}"
+                            Padding="6">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <TextBlock Text="{Binding SelectedReservationDetail}" TextWrapping="Wrap"/>
+                        </ScrollViewer>
+                    </Border>
+                </DockPanel>
+            </Border>
+        </Grid>
+
+        <Border Grid.Row="2" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
+            <DockPanel LastChildFill="True">
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                    <Button Style="{StaticResource PrimaryButton}" Content="Add Hold" Command="{Binding AddReservationCommand}" Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print List" Command="{Binding PrintReservationDirectoryCommand}"/>
+                </StackPanel>
+                <TextBlock Text="{Binding SelectedReservationSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0"/>
+            </DockPanel>
         </Border>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/ReservationPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReservationPage.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
@@ -17,6 +18,23 @@ namespace InventoryManagementApp.Views.Pages
             if (DataContext is ReservationManagementViewModel vm)
             {
                 await vm.LoadReservationsCommand.ExecuteAsync(null);
+            }
+        }
+
+        private void ReservationRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is ReservationManagementViewModel vm && vm.OpenReservationDetailsCommand.CanExecute(null))
+            {
+                vm.OpenReservationDetailsCommand.Execute(null);
+            }
+        }
+
+        private void ReservationRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is DataGridRow row && !row.IsSelected)
+            {
+                row.IsSelected = true;
+                row.Focus();
             }
         }
     }


### PR DESCRIPTION
## Summary

- Redesigns Reservations into a two-pane advisor workbench with hold directory, selected-hold detail, timing, next-action guidance, shelf checklist, and repeated action buttons.
- Adds quick Active, Pending, Confirmed, and Upcoming filters, clear search, copy handoff, print handoff, printable filtered directory, and open-detail behavior.
- Keeps useful reservation selection after load, add, edit, confirm, cancel, fulfill, delete, search, and filter changes where possible.
- Hardens reservation search against missing legacy/imported text values and expands search to reservation number, status, and notes.
- Adds row double-click details and row-correct right-click context menus so advisor actions operate on the intended hold.
- Updates reservation status notifications so fulfilled/in-progress/active display state refreshes immediately after status or rental ID changes.
- Records the completed reservation workflow pass in progress notes and the completion checklist.

## Why

The user asked to keep finishing each app function end to end from the perspective of technicians, advisors, and admins. Reservations still looked like a plain grid with a toolbar, even though the surrounding operational pages now provide selected-record context and handoff actions. This makes the hold-to-shelf-to-checkout flow visible and actionable from the same screen.

## Validation

- Compared `codex/reservation-advisor-workbench` against `master`; the branch is ahead and not behind.
- Read back the reservation model, view model, page XAML, row interaction code-behind, progress note, and completion checklist through the GitHub connector.
- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
- Did not run unrelated tests, per instruction.