### PR TITLE
Upgrade reports into a triage workbench

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-17-reports-triage-workbench.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-reports-triage-workbench.md
@@ -1,0 +1,16 @@
+# Reports Triage Workbench Pass - 2026-06-17
+
+## Completed
+
+- Upgraded Reports from a passive output grid into an admin triage workbench with destination-aware report rows.
+- Added source-page routing for report rows so double-clicking, the toolbar action, selected-row panel action, or context menu opens the relevant workflow: items, rentals, customers, users, activity logs, reservations, maintenance, calibration, kits, or dashboard.
+- Added destination metadata to report lines and included it in the grid, selected-row handoff, copied handoff, and printed report output.
+- Kept selected report context visible with a tighter right-side handoff panel, report summary, operator path guidance, and wrapping toolbar actions for smaller screens.
+- Added row-correct right-click selection so context-menu actions operate on the intended report row.
+
+## Validation
+
+- Parsed the updated `ReportsPage.xaml` locally as well-formed XML.
+- Scanned the changed Reports files for known stale non-inventory banned terms and found none.
+- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
+- Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ViewModels/ReportsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ReportsViewModel.cs
@@ -42,7 +42,12 @@ namespace InventoryManagementApp.ViewModels
             set
             {
                 if (SetProperty(ref _selectedReportLine, value))
+                {
                     OnPropertyChanged(nameof(SelectedLineDetail));
+                    OnPropertyChanged(nameof(SelectedLineDestination));
+                    OnPropertyChanged(nameof(SelectedLineDestinationKey));
+                    OnPropertyChanged(nameof(SelectedLineHandoff));
+                }
             }
         }
 
@@ -98,7 +103,19 @@ namespace InventoryManagementApp.ViewModels
 
         public string LastRunText => LastRunAt.HasValue ? LastRunAt.Value.ToString("g") : "Not run";
         public int ReportLineCount => ReportLines.Count;
+        public string ReportOperatorPath => string.IsNullOrWhiteSpace(SelectedReport)
+            ? "Choose a report, run it, then open the source page from any row that needs follow-up."
+            : $"Run {SelectedReport}, select a row, then open {BuildDestinationName(SelectedReport, SelectedReportLine?.Category)} to continue the workflow.";
         public string SelectedLineDetail => SelectedReportLine?.Text ?? "Select or double-click a report row to inspect the detail.";
+        public string SelectedLineDestination => SelectedReportLine == null
+            ? BuildDestinationName(SelectedReport, null)
+            : SelectedReportLine.DestinationName;
+        public string SelectedLineDestinationKey => SelectedReportLine == null
+            ? BuildDestinationKey(SelectedReport, null)
+            : SelectedReportLine.DestinationKey;
+        public string SelectedLineHandoff => SelectedReportLine == null
+            ? "No report row selected."
+            : $"{SelectedReportLine.Category}: {SelectedReportLine.Text}{Environment.NewLine}Next action: {SelectedReportLine.ActionHint}{Environment.NewLine}Destination: {SelectedReportLine.DestinationName}";
 
         public IAsyncRelayCommand RunReportCommand { get; }
         public IRelayCommand ClearReportCommand { get; }
@@ -171,6 +188,7 @@ namespace InventoryManagementApp.ViewModels
                 ReportStatus = "Report failed.";
                 LastRunAt = DateTime.Now;
                 OnPropertyChanged(nameof(ReportLineCount));
+                OnPropertyChanged(nameof(ReportOperatorPath));
                 ClearReportCommand.NotifyCanExecuteChanged();
             }
             finally
@@ -196,13 +214,25 @@ namespace InventoryManagementApp.ViewModels
             var detailLines = lines.Skip(1).ToList();
             for (var i = 0; i < detailLines.Count; i++)
             {
-                ReportLines.Add(new ReportLine(i + 1, ClassifyLine(detailLines[i]), detailLines[i], BuildActionHint(detailLines[i])));
+                var category = ClassifyLine(detailLines[i]);
+                ReportLines.Add(new ReportLine(
+                    i + 1,
+                    category,
+                    detailLines[i],
+                    BuildActionHint(detailLines[i]),
+                    BuildDestinationKey(SelectedReport, category),
+                    BuildDestinationName(SelectedReport, category)));
             }
 
             LastRunAt = DateTime.Now;
             ReportSummary = BuildSummary(detailLines);
-            ReportStatus = $"{SelectedReport} completed with {ReportLines.Count} line(s).";
+            ReportStatus = ReportLines.Count == 0
+                ? $"{SelectedReport} completed with no rows to action."
+                : $"{SelectedReport} completed with {ReportLines.Count} line(s). Select a row or open the source page.";
+            if (ReportLines.Count > 0)
+                SelectedReportLine = ReportLines[0];
             OnPropertyChanged(nameof(ReportLineCount));
+            OnPropertyChanged(nameof(ReportOperatorPath));
             ClearReportCommand.NotifyCanExecuteChanged();
         }
 
@@ -216,6 +246,7 @@ namespace InventoryManagementApp.ViewModels
             ReportStatus = "Report cleared.";
             LastRunAt = null;
             OnPropertyChanged(nameof(ReportLineCount));
+            OnPropertyChanged(nameof(ReportOperatorPath));
             ClearReportCommand.NotifyCanExecuteChanged();
         }
 
@@ -229,6 +260,7 @@ namespace InventoryManagementApp.ViewModels
                 "Overdue Maintenance" => "Items requiring maintenance attention before further checkout.",
                 "Overdue Calibrations" => "Calibrations that should be handled before field use.",
                 "Activity Log" => "Recent inventory activity for operational review.",
+                "Users" => "Admin access, lockout, and account review output.",
                 _ => $"Operational output for {reportName}."
             };
         }
@@ -256,24 +288,70 @@ namespace InventoryManagementApp.ViewModels
                 return "Maintenance";
             if (ContainsAny(line, "calibration", "calibrated"))
                 return "Calibration";
+            if (ContainsAny(line, "kit", "bundle"))
+                return "Kit";
             if (ContainsAny(line, "item", "equipment", "inventory", "stock"))
                 return "Inventory";
-            if (ContainsAny(line, "customer", "technician", "advisor", "user"))
-                return "Person";
+            if (ContainsAny(line, "customer"))
+                return "Customer";
+            if (ContainsAny(line, "technician", "advisor", "user", "lockout", "password", "permission"))
+                return "User";
             return "Detail";
         }
 
         private static string BuildActionHint(string line)
         {
             if (ContainsAny(line, "overdue", "late"))
-                return "Open the related rental or item record and follow up.";
+                return "Open the related rental, maintenance, or calibration workflow and follow up.";
             if (ContainsAny(line, "reservation", "request", "hold"))
                 return "Check availability and contact the waiting user or customer.";
             if (ContainsAny(line, "maintenance", "repair", "calibration"))
                 return "Review the item before it is rented or checked out again.";
             if (ContainsAny(line, "checked out", "rented", "rental"))
                 return "Confirm holder, due-back date, and return status.";
+            if (ContainsAny(line, "user", "permission", "password", "lockout"))
+                return "Open Users and verify access, account state, or reset needs.";
             return "Use the source page to drill into the related record.";
+        }
+
+        private static string BuildDestinationKey(string reportName, string? category)
+        {
+            if (ContainsAny(reportName, "Activity"))
+                return "ActivityLogs";
+            if (ContainsAny(reportName, "Customer") || string.Equals(category, "Customer", StringComparison.OrdinalIgnoreCase))
+                return "Customers";
+            if (ContainsAny(reportName, "User") || string.Equals(category, "User", StringComparison.OrdinalIgnoreCase))
+                return "Users";
+            if (ContainsAny(reportName, "Rental") || string.Equals(category, "Rental", StringComparison.OrdinalIgnoreCase))
+                return "Rentals";
+            if (ContainsAny(reportName, "Reservation") || string.Equals(category, "Request", StringComparison.OrdinalIgnoreCase))
+                return "Reservations";
+            if (ContainsAny(reportName, "Maintenance") || string.Equals(category, "Maintenance", StringComparison.OrdinalIgnoreCase))
+                return "Maintenance";
+            if (ContainsAny(reportName, "Calibration") || string.Equals(category, "Calibration", StringComparison.OrdinalIgnoreCase))
+                return "Calibration";
+            if (ContainsAny(reportName, "Kit") || string.Equals(category, "Kit", StringComparison.OrdinalIgnoreCase))
+                return "Kits";
+            if (ContainsAny(reportName, "Inventory", "Rented Items") || string.Equals(category, "Inventory", StringComparison.OrdinalIgnoreCase) || string.Equals(category, "Overdue", StringComparison.OrdinalIgnoreCase))
+                return "Items";
+            return "Dashboard";
+        }
+
+        private static string BuildDestinationName(string reportName, string? category)
+        {
+            return BuildDestinationKey(reportName, category) switch
+            {
+                "ActivityLogs" => "Activity Logs",
+                "Customers" => "Customers",
+                "Users" => "Users",
+                "Rentals" => "Rentals",
+                "Reservations" => "Reservations",
+                "Maintenance" => "Maintenance",
+                "Calibration" => "Calibration",
+                "Kits" => "Kits",
+                "Items" => "Items",
+                _ => "Dashboard"
+            };
         }
 
         private static bool ContainsAny(string text, params string[] terms)
@@ -284,17 +362,21 @@ namespace InventoryManagementApp.ViewModels
 
     public sealed class ReportLine
     {
-        public ReportLine(int number, string category, string text, string actionHint)
+        public ReportLine(int number, string category, string text, string actionHint, string destinationKey, string destinationName)
         {
             Number = number;
             Category = category;
             Text = text;
             ActionHint = actionHint;
+            DestinationKey = destinationKey;
+            DestinationName = destinationName;
         }
 
         public int Number { get; }
         public string Category { get; }
         public string Text { get; }
         public string ActionHint { get; }
+        public string DestinationKey { get; }
+        public string DestinationName { get; }
     }
 }

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml
@@ -11,30 +11,32 @@
         </Grid.RowDefinitions>
 
         <Border Style="{StaticResource ToolbarCard}">
-            <DockPanel LastChildFill="False">
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
+            <DockPanel LastChildFill="True">
+                <WrapPanel DockPanel.Dock="Left" VerticalAlignment="Center">
                     <TextBlock Text="Report" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
                     <ComboBox Width="230"
+                              MinWidth="180"
                               ItemsSource="{Binding ReportTypes}"
                               SelectedItem="{Binding SelectedReport}"
                               ItemContainerStyle="{StaticResource DropdownItemStyle}"
                               ToolTip="Choose the report to run"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Run" Command="{Binding RunReportCommand}" Margin="6,0,0,0"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Open Source Page" Click="OpenSourcePage_Click" Margin="4,0,0,0"/>
                     <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearReportCommand}" Margin="4,0,0,0"/>
-                </StackPanel>
+                </WrapPanel>
 
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
+                <WrapPanel DockPanel.Dock="Right" HorizontalAlignment="Right" VerticalAlignment="Center">
                     <Button Style="{StaticResource PrimaryButton}" Content="Print Report" Click="PrintReport_Click" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Copy Row" Click="CopySelectedRow_Click"/>
-                </StackPanel>
+                    <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedRow_Click"/>
+                </WrapPanel>
             </DockPanel>
         </Border>
 
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2.7*"/>
+                <ColumnDefinition Width="2.55*" MinWidth="440"/>
                 <ColumnDefinition Width="4"/>
-                <ColumnDefinition Width="1.15*"/>
+                <ColumnDefinition Width="1.25*" MinWidth="300"/>
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
@@ -55,12 +57,12 @@
                                    TextWrapping="Wrap"
                                    Foreground="{DynamicResource MutedForegroundBrush}"/>
                     </StackPanel>
-                    <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                    <WrapPanel Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Center">
                         <TextBlock Text="Rows:" Style="{StaticResource LabelTextBlock}" Margin="0,0,4,0"/>
                         <TextBlock Text="{Binding ReportLineCount}" Margin="0,0,12,0"/>
                         <TextBlock Text="Last Run:" Style="{StaticResource LabelTextBlock}" Margin="0,0,4,0"/>
                         <TextBlock Text="{Binding LastRunText}"/>
-                    </StackPanel>
+                    </WrapPanel>
                 </Grid>
             </Border>
 
@@ -70,19 +72,24 @@
                           SelectedItem="{Binding SelectedReportLine, Mode=TwoWay}"
                           IsReadOnly="True"
                           AutoGenerateColumns="False"
+                          CanUserAddRows="False"
+                          SelectionMode="Single"
                           MouseDoubleClick="ReportGrid_MouseDoubleClick"
+                          PreviewMouseRightButtonDown="ReportGrid_PreviewMouseRightButtonDown"
                           Style="{StaticResource VirtualizedDataGridStyle}">
                     <DataGrid.ContextMenu>
                         <ContextMenu>
-                            <MenuItem Header="Copy Selected Row" Click="CopySelectedRow_Click"/>
+                            <MenuItem Header="Open Source Page" Click="OpenSourcePage_Click"/>
+                            <MenuItem Header="Copy Handoff" Click="CopySelectedRow_Click"/>
                             <MenuItem Header="Print Report" Click="PrintReport_Click"/>
                         </ContextMenu>
                     </DataGrid.ContextMenu>
                     <DataGrid.Columns>
-                        <DataGridTextColumn Header="#" Binding="{Binding Number}" Width="50"/>
-                        <DataGridTextColumn Header="Type" Binding="{Binding Category}" Width="110"/>
+                        <DataGridTextColumn Header="#" Binding="{Binding Number}" Width="46"/>
+                        <DataGridTextColumn Header="Type" Binding="{Binding Category}" Width="105"/>
+                        <DataGridTextColumn Header="Destination" Binding="{Binding DestinationName}" Width="130"/>
                         <DataGridTextColumn Header="Report Detail" Binding="{Binding Text}" Width="*"/>
-                        <DataGridTextColumn Header="Next Action" Binding="{Binding ActionHint}" Width="260"/>
+                        <DataGridTextColumn Header="Next Action" Binding="{Binding ActionHint}" Width="250"/>
                     </DataGrid.Columns>
                 </DataGrid>
             </Border>
@@ -111,11 +118,16 @@
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
-                        <TextBlock Text="Selected Row Detail" Style="{StaticResource SectionHeader}"/>
-                        <TextBox Grid.Row="1"
-                                 Text="{Binding SelectedLineDetail, Mode=OneWay}"
+                        <TextBlock Text="Selected Row Handoff" Style="{StaticResource SectionHeader}"/>
+                        <UniformGrid Grid.Row="1" Columns="2" Margin="0,4,0,5">
+                            <Button Style="{StaticResource PrimaryButton}" Content="Open Source" Click="OpenSourcePage_Click" Margin="0,0,4,0"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Copy Handoff" Click="CopySelectedRow_Click"/>
+                        </UniformGrid>
+                        <TextBox Grid.Row="2"
+                                 Text="{Binding SelectedLineHandoff, Mode=OneWay}"
                                  IsReadOnly="True"
                                  TextWrapping="Wrap"
                                  AcceptsReturn="True"
@@ -126,9 +138,14 @@
 
                 <Border Grid.Row="2" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
                     <StackPanel>
-                        <TextBlock Text="Operator path" Style="{StaticResource SectionHeader}"/>
-                        <TextBlock Text="Double-click a row or use the context menu to copy details for follow-up. Use the source page named by the report type to open the related item, rental, customer, request, maintenance, or calibration record."
+                        <TextBlock Text="Operator Path" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="{Binding ReportOperatorPath}"
                                    FontSize="11"
+                                   TextWrapping="Wrap"
+                                   Foreground="{DynamicResource MutedForegroundBrush}"/>
+                        <TextBlock Text="{Binding SelectedLineDestination, StringFormat=Destination: {0}}"
+                                   FontSize="11"
+                                   Margin="0,5,0,0"
                                    TextWrapping="Wrap"
                                    Foreground="{DynamicResource MutedForegroundBrush}"/>
                     </StackPanel>
@@ -142,7 +159,7 @@
                          DockPanel.Dock="Right"
                          IsIndeterminate="True"
                          Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"/>
-            <TextBlock Text="{Binding ReportStatus}" VerticalAlignment="Center"/>
+            <TextBlock Text="{Binding ReportStatus}" VerticalAlignment="Center" TextWrapping="Wrap"/>
         </DockPanel>
     </Grid>
 </Page>

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Documents;
+using System.Windows.Input;
 using InventoryManagementApp.ViewModels;
 using WpfMessageBox = System.Windows.MessageBox;
 using WpfPrintDialog = System.Windows.Controls.PrintDialog;
@@ -17,9 +19,21 @@ namespace InventoryManagementApp.Views.Pages
             InitializeComponent();
         }
 
-        private void ReportGrid_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        private void ReportGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            CopySelectedRow_Click(sender, e);
+            OpenSelectedDestination();
+        }
+
+        private void OpenSourcePage_Click(object sender, RoutedEventArgs e)
+        {
+            OpenSelectedDestination();
+        }
+
+        private void ReportGrid_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            var row = FindParent<DataGridRow>(e.OriginalSource as DependencyObject);
+            if (row != null && !row.IsSelected)
+                row.IsSelected = true;
         }
 
         private void CopySelectedRow_Click(object sender, RoutedEventArgs e)
@@ -30,7 +44,7 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            System.Windows.Clipboard.SetText($"{line.Category}: {line.Text}{Environment.NewLine}Next action: {line.ActionHint}");
+            System.Windows.Clipboard.SetText(FormatHandoff(line));
         }
 
         private void PrintReport_Click(object sender, RoutedEventArgs e)
@@ -51,6 +65,67 @@ namespace InventoryManagementApp.Views.Pages
             document.PagePadding = new Thickness(36);
             document.ColumnWidth = printDialog.PrintableAreaWidth;
             printDialog.PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator, vm.ReportTitle);
+        }
+
+        private void OpenSelectedDestination()
+        {
+            var line = ReportGrid.SelectedItem as ReportLine;
+            var key = line?.DestinationKey;
+            if (string.IsNullOrWhiteSpace(key) && DataContext is ReportsViewModel vm)
+                key = vm.SelectedLineDestinationKey;
+
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                WpfMessageBox.Show("Run a report and select a row first.", "Reports", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            if (Window.GetWindow(this)?.DataContext is not MainViewModel main)
+            {
+                WpfMessageBox.Show("The destination page is not available from this window.", "Reports", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            switch (key)
+            {
+                case "ActivityLogs":
+                    main.OpenActivityLogsCommand.Execute(null);
+                    break;
+                case "Customers":
+                    main.OpenCustomersCommand.Execute(null);
+                    break;
+                case "Users":
+                    main.OpenUsersCommand.Execute(null);
+                    break;
+                case "Rentals":
+                    main.OpenRentalsCommand.Execute(null);
+                    break;
+                case "Reservations":
+                    main.OpenReservationsCommand.Execute(null);
+                    break;
+                case "Maintenance":
+                    main.OpenMaintenanceCommand.Execute(null);
+                    break;
+                case "Calibration":
+                    main.OpenCalibrationCommand.Execute(null);
+                    break;
+                case "Kits":
+                    main.OpenKitManagementCommand.Execute(null);
+                    break;
+                case "Items":
+                    main.OpenManageItemsCommand.Execute(null);
+                    break;
+                default:
+                    main.OpenDashboardCommand.Execute(null);
+                    break;
+            }
+        }
+
+        private static string FormatHandoff(ReportLine line)
+        {
+            return $"{line.Category}: {line.Text}{Environment.NewLine}" +
+                   $"Next action: {line.ActionHint}{Environment.NewLine}" +
+                   $"Destination: {line.DestinationName}";
         }
 
         private static FlowDocument BuildReportDocument(string title, string summary, string lastRunText, IReadOnlyCollection<ReportLine> lines)
@@ -78,7 +153,7 @@ namespace InventoryManagementApp.Views.Pages
             });
 
             var table = new Table { CellSpacing = 0 };
-            foreach (var width in new[] { 45.0, 95.0, 330.0, 230.0 })
+            foreach (var width in new[] { 45.0, 85.0, 105.0, 300.0, 205.0 })
                 table.Columns.Add(new TableColumn { Width = new GridLength(width) });
 
             var rowGroup = new TableRowGroup();
@@ -88,6 +163,7 @@ namespace InventoryManagementApp.Views.Pages
             rowGroup.Rows.Add(header);
             AddCell(header, "#");
             AddCell(header, "Type");
+            AddCell(header, "Destination");
             AddCell(header, "Report Detail");
             AddCell(header, "Next Action");
 
@@ -97,6 +173,7 @@ namespace InventoryManagementApp.Views.Pages
                 rowGroup.Rows.Add(row);
                 AddCell(row, line.Number.ToString());
                 AddCell(row, line.Category);
+                AddCell(row, line.DestinationName);
                 AddCell(row, line.Text);
                 AddCell(row, line.ActionHint);
             }
@@ -116,6 +193,20 @@ namespace InventoryManagementApp.Views.Pages
                 BorderThickness = new Thickness(0, 0, 0, 0.5),
                 Padding = new Thickness(3, 2, 3, 2)
             });
+        }
+
+        private static T? FindParent<T>(DependencyObject? child) where T : DependencyObject
+        {
+            while (child != null)
+            {
+                if (child is T parent)
+                    return parent;
+                child = child is Popup popup
+                    ? popup.PlacementTarget
+                    : System.Windows.Media.VisualTreeHelper.GetParent(child);
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary

- Upgrades Reports from a passive output grid into an admin triage workbench with destination-aware rows.
- Adds source-page routing from double-click, toolbar, selected-row panel, and context-menu actions so report results can open the relevant workflow page.
- Adds destination metadata to report rows, selected-row handoff text, copied handoff output, and printed reports.
- Tightens the Reports layout with wrapping toolbar actions, a selected-row handoff panel, operator path guidance, and row-correct context menus.
- Records the completed Reports workflow pass in progress notes.

## Validation

- Parsed the updated `ReportsPage.xaml` locally as well-formed XML.
- Scanned the changed Reports files for known stale non-inventory banned terms and found none.
- Compared `codex/reports-triage-workbench` against `master`; the branch is ahead by 4 commits and not behind.
- Read back the changed Reports XAML, code-behind, view model, and progress note through the GitHub connector.
- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
- Did not run unrelated tests, per instruction.