### PR TITLE
Refine user permission editor review

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-17-user-permission-editor-review.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-user-permission-editor-review.md
@@ -1,0 +1,18 @@
+# User Permission Editor Review - 2026-06-17
+
+## Completed
+
+- Tightened the admin user editor so permission changes now explain their result while an admin is editing the record.
+- Added live summaries for full-admin/custom/no-access state, sections the user can see and use, and sections hidden or blocked by the current checkbox set.
+- Reworked the user editor window with a scrollable body, wider permission panel, wrapped status controls, and clearer sidebar context so the permission workflow remains usable on shorter displays.
+
+## Why it matters
+
+Admins can now answer the practical question behind the checkbox list before saving: what will this person actually be able to access, and what will disappear or be blocked for them?
+
+## Validation
+
+- Read back the changed `UsersEditViewModel.cs` and `UsersEditWindow.xaml` through the GitHub connector.
+- Compared `codex/qa-permission-screenshot-coverage` against `master`; the branch is ahead by two commits and not behind before opening the PR.
+- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
+- Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 11:11 NZST
+Last audit date/time: 2026-06-17 13:11 NZST
 
 ## Completed workflows
 
@@ -24,6 +24,7 @@ Last audit date/time: 2026-06-17 11:11 NZST
 - Calibration now uses a two-pane technician bench with certificate handoff details, timing and next-action guidance, shelf-release checklist, quick overdue/due-soon/current filters, copy handoff, print actions, stable useful selection, null-safe expanded search, and row-correct context menus.
 - QA screenshot manifests now list each captured PNG with dimensions and byte size so future screenshot reviews can spot cropped or suspicious captures faster.
 - Admin user management now supports durable checkbox permissions, advisor/technician/admin presets, access summaries in the directory/detail/copy/print flows, and permission-based navigation visibility for operations, insights, data, and admin sections.
+- Admin user permission editing now shows live access-result, allowed-area, and hidden/blocked summaries beside the checkbox permissions, with a scrollable layout for shorter admin screens.
 - Reservations now use a two-pane advisor workbench with hold directory, quick status filters, selected-hold detail, timing, next action, shelf checklist, copy handoff, print handoff, printable filtered directory, stable useful selection, null-safe expanded search, and row-correct double-click/right-click actions.
 - QA screenshot review now produces a browser-friendly `index.html` gallery grouped by app area and fails when unexpected PNG captures appear without updating the expected screenshot manifest.
 - Rentals now use a rental desk workbench with a main rental directory, selected-rental advisor handoff, customer/timing/shelf context, check-in/extend/request/document actions, open request queue, row-correct context menus, wrapping toolbar actions, and a compact footer for repeated desk work.
@@ -38,7 +39,7 @@ Last audit date/time: 2026-06-17 11:11 NZST
 - Customers now have a completed desktop workflow surface, but runtime add/edit/delete/print/copy validation still needs a Windows/.NET workstation.
 - Maintenance now has a completed desktop workflow surface, but runtime add/edit/complete/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 - Calibration now has a completed desktop workflow surface, but runtime add/edit/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
-- User permission editing now has a completed persistence/UI/navigation pass, but runtime login-as-each-role and screenshot validation still needs a Windows/.NET workstation.
+- User permission editing now has a completed persistence/UI/navigation/editor-summary pass, but runtime login-as-each-role and screenshot validation still needs a Windows/.NET workstation.
 - Reservations now have a completed desktop workflow surface, but runtime add/edit/confirm/cancel/fulfill/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 - Rentals now have a completed desktop workflow surface, but runtime check-in/extend/request/delete/print/document and screenshot validation still need a Windows/.NET workstation.
 - Categories now have a completed desktop workflow surface, but runtime create/rename/delete/filter/print/copy and screenshot validation still need a Windows/.NET workstation.
@@ -55,7 +56,7 @@ Last audit date/time: 2026-06-17 11:11 NZST
 
 ## Validation status
 
-- GitHub connector readback reviewed the category workbench XAML, code-behind, view model, progress note, and completion checklist.
-- The existing QA screenshot routine captures the redesigned Categories page at `02-operations/08-categories.png`, but the screenshot run itself could not be executed in this scheduled Linux container.
+- GitHub connector readback reviewed the user permission editor view model, XAML, and progress note.
+- Compared `codex/qa-permission-screenshot-coverage` against `master`; the branch is ahead and not behind before opening the PR.
 - Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, and `scripts/run-app-qa-screenshots.ps1` were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
 - Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ViewModels/UsersEditViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UsersEditViewModel.cs
@@ -4,8 +4,10 @@ using CommunityToolkit.Mvvm.Input;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models.Domain;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Application = System.Windows.Application;
 using MediaBrush = System.Windows.Media.Brush;
@@ -21,6 +23,20 @@ namespace InventoryManagementApp.ViewModels
         private readonly IFileDialogService _fileDialog;
 
         public string AccessSummary => EditingUser.AccessSummary;
+
+        public string PermissionStatusSummary => EditingUser.IsAdmin
+            ? "Full administrator: this user can see every section and use every admin-level action."
+            : GetAllowedPermissionLabels().Any()
+                ? $"Custom access: {EditingUser.UserName} can see {GetAllowedPermissionLabels().Count()} section{(GetAllowedPermissionLabels().Count() == 1 ? string.Empty : "s")}."
+                : "No access assigned: this user can sign in only if they are active, but no app sections will be available.";
+
+        public string AllowedPermissionSummary => EditingUser.IsAdmin
+            ? "Every app section, setting, and guarded action is available."
+            : BuildPermissionSummary(GetAllowedPermissionLabels(), "No app sections assigned.");
+
+        public string HiddenPermissionSummary => EditingUser.IsAdmin
+            ? "Nothing is hidden while Full administrator is ticked."
+            : BuildPermissionSummary(GetHiddenPermissionLabels(), "Nothing hidden for the selected permissions.");
 
         public bool CanManageItems { get => Has(User.PermissionManageItems); set => Set(User.PermissionManageItems, value); }
         public bool CanUseRentals { get => Has(User.PermissionRentals); set => Set(User.PermissionRentals, value); }
@@ -80,7 +96,7 @@ namespace InventoryManagementApp.ViewModels
 
         void EditingUser_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(User.IsAdmin) || e.PropertyName == nameof(User.Permissions))
+            if (e.PropertyName == nameof(User.IsAdmin) || e.PropertyName == nameof(User.Permissions) || e.PropertyName == nameof(User.UserName))
                 NotifyAllPermissionProperties();
         }
 
@@ -89,7 +105,7 @@ namespace InventoryManagementApp.ViewModels
         void Set(string permissionKey, bool allowed)
         {
             EditingUser.SetPermission(permissionKey, allowed);
-            OnPropertyChanged(nameof(AccessSummary));
+            NotifyAllPermissionProperties();
         }
 
         void ApplyPreset(params string[] permissionKeys)
@@ -97,6 +113,27 @@ namespace InventoryManagementApp.ViewModels
             EditingUser.IsAdmin = false;
             EditingUser.Permissions = User.BuildPermissions(permissionKeys);
             NotifyAllPermissionProperties();
+        }
+
+        IEnumerable<string> GetAllowedPermissionLabels()
+        {
+            if (EditingUser.IsAdmin)
+                return User.PermissionLabels.Values;
+
+            return User.PermissionLabels
+                .Where(permission => EditingUser.HasPermission(permission.Key))
+                .Select(permission => permission.Value);
+        }
+
+        IEnumerable<string> GetHiddenPermissionLabels()
+            => User.PermissionLabels
+                .Where(permission => !EditingUser.HasPermission(permission.Key))
+                .Select(permission => permission.Value);
+
+        static string BuildPermissionSummary(IEnumerable<string> labels, string emptyText)
+        {
+            var list = labels.ToList();
+            return list.Count == 0 ? emptyText : string.Join(", ", list);
         }
 
         void NotifyAllPermissionProperties()
@@ -116,6 +153,9 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(CanManageUsers));
             OnPropertyChanged(nameof(CanUseSettings));
             OnPropertyChanged(nameof(AccessSummary));
+            OnPropertyChanged(nameof(PermissionStatusSummary));
+            OnPropertyChanged(nameof(AllowedPermissionSummary));
+            OnPropertyChanged(nameof(HiddenPermissionSummary));
         }
 
         void BrowseImage()

--- a/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
@@ -3,7 +3,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
-        Title="User Profile" Width="860" Height="660" MinWidth="780" MinHeight="600" WindowStartupLocation="CenterOwner"
+        Title="User Profile" Width="960" Height="720" MinWidth="760" MinHeight="560" WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
     <Grid Margin="10">
         <Grid.RowDefinitions>
@@ -13,199 +13,218 @@
         </Grid.RowDefinitions>
 
         <Border Style="{StaticResource ToolbarCard}" Margin="0,0,0,6">
-            <DockPanel>
-                <StackPanel DockPanel.Dock="Left">
-                    <TextBlock Text="{Binding Title}" Style="{StaticResource PageTitleTextBlock}"/>
-                    <TextBlock Text="Maintain identity, contact details, status, photo, and the exact app areas this user can access." Style="{StaticResource CaptionTextBlock}"/>
-                </StackPanel>
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
+            <DockPanel LastChildFill="True">
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center" Margin="10,0,0,0">
                     <Button Style="{StaticResource PrimaryButton}" Content="Browse Image" Command="{Binding BrowseImageCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource GhostButton}" Content="Remove Image" Command="{Binding RemoveImageCommand}"/>
+                </StackPanel>
+                <StackPanel>
+                    <TextBlock Text="{Binding Title}" Style="{StaticResource PageTitleTextBlock}"/>
+                    <TextBlock Text="Maintain identity, contact details, status, photo, and the exact app areas this user can see or operate." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                 </StackPanel>
             </DockPanel>
         </Border>
 
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="150"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+            <Grid MinHeight="470">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="150"/>
+                    <ColumnDefinition Width="*" MinWidth="560"/>
+                </Grid.ColumnDefinitions>
 
-            <Border Grid.Column="0"
-                    Background="{DynamicResource SurfaceAltBrush}"
-                    BorderBrush="{DynamicResource BorderBrushAlt}"
-                    BorderThickness="1"
-                    Padding="8"
-                    Margin="0,0,8,0">
-                <StackPanel>
-                    <Border Width="116" Height="116" CornerRadius="4" VerticalAlignment="Top" Background="{DynamicResource TextBoxBackgroundBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1">
+                <Border Grid.Column="0"
+                        Background="{DynamicResource SurfaceAltBrush}"
+                        BorderBrush="{DynamicResource BorderBrushAlt}"
+                        BorderThickness="1"
+                        Padding="8"
+                        Margin="0,0,8,0">
+                    <StackPanel>
+                        <Border Width="116" Height="116" CornerRadius="4" VerticalAlignment="Top" Background="{DynamicResource TextBoxBackgroundBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1">
+                            <Grid>
+                                <Image Width="116" Height="116"
+                                       Source="{Binding EditingUser.UserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
+                                       Stretch="UniformToFill" ClipToBounds="True">
+                                    <Image.Style>
+                                        <Style TargetType="Image">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource ExistingFilePathToBoolConverter}}" Value="True">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Image.Style>
+                                </Image>
+                                <TextBlock Text="{Binding EditingUser.UserName, Converter={StaticResource NameToInitialsConverter}}"
+                                           HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"
+                                           FontWeight="Bold"
+                                           FontSize="42"
+                                           Foreground="{Binding EditingUser.InitialsBrush}">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource ExistingFilePathToBoolConverter}}" Value="True">
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </Grid>
+                        </Border>
+
+                        <TextBlock Text="{Binding EditingUser.UserName, TargetNullValue='New user'}" Style="{StaticResource SectionHeader}" Margin="0,8,0,2" TextWrapping="Wrap"/>
+                        <TextBlock Text="{Binding EditingUser.Role, TargetNullValue='Set role and contact details'}" FontSize="11" TextWrapping="Wrap"/>
+                        <TextBlock Text="{Binding EditingUser.UserID, StringFormat='User #: {0}'}" FontSize="11" Margin="0,6,0,8"/>
+                        <TextBlock Text="Access result" Style="{StaticResource LabelTextBlock}" Margin="0,4,0,2"/>
+                        <TextBlock Text="{Binding PermissionStatusSummary}" FontSize="11" TextWrapping="Wrap"/>
+                        <TextBlock Text="Current access" Style="{StaticResource LabelTextBlock}" Margin="0,10,0,2"/>
+                        <TextBlock Text="{Binding EditingUser.AccessSummary}" FontSize="11" TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Border>
+
+                <Grid Grid.Column="1">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1.05*" MinWidth="260"/>
+                        <ColumnDefinition Width="8"/>
+                        <ColumnDefinition Width="1.35*" MinWidth="300"/>
+                    </Grid.ColumnDefinitions>
+
+                    <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
                         <Grid>
-                            <Image Width="116" Height="116"
-                                   Source="{Binding EditingUser.UserPhotoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=user}"
-                                   Stretch="UniformToFill" ClipToBounds="True">
-                                <Image.Style>
-                                    <Style TargetType="Image">
-                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource ExistingFilePathToBoolConverter}}" Value="True">
-                                                <Setter Property="Visibility" Value="Visible"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </Image.Style>
-                            </Image>
-                            <TextBlock Text="{Binding EditingUser.UserName, Converter={StaticResource NameToInitialsConverter}}"
-                                       HorizontalAlignment="Center"
-                                       VerticalAlignment="Center"
-                                       FontWeight="Bold"
-                                       FontSize="42"
-                                       Foreground="{Binding EditingUser.InitialsBrush}">
-                                <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding EditingUser.UserPhotoPath, Converter={StaticResource ExistingFilePathToBoolConverter}}" Value="True">
-                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </TextBlock.Style>
-                            </TextBlock>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+
+                            <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="6,4">
+                                <TextBlock Text="01 Profile Fields" Style="{StaticResource SectionHeader}" Margin="0"/>
+                            </Border>
+
+                            <Grid Grid.Row="1" Margin="8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="95"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Username:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                                <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding EditingUser.UserName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="Role:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                                <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding EditingUser.Role, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="Email:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                                <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding EditingUser.Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+
+                                <TextBlock Grid.Row="3" Grid.Column="0" Text="Phone:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                                <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding EditingUser.Phone, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+
+                                <TextBlock Grid.Row="4" Grid.Column="0" Text="Mobile:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                                <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding EditingUser.Mobile, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+
+                                <TextBlock Grid.Row="5" Grid.Column="0" Text="Address:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Top" Margin="0,3,8,6"/>
+                                <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding EditingUser.Address, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6" Height="64" TextWrapping="Wrap" AcceptsReturn="True"/>
+
+                                <TextBlock Grid.Row="6" Grid.Column="0" Text="Access:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
+                                <CheckBox Grid.Row="6" Grid.Column="1" Content="Full administrator" IsChecked="{Binding EditingUser.IsAdmin, Mode=TwoWay}" Margin="0,0,0,6"/>
+
+                                <TextBlock Grid.Row="7" Grid.Column="0" Text="Status:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                <WrapPanel Grid.Row="7" Grid.Column="1">
+                                    <CheckBox Content="Active" IsChecked="{Binding EditingUser.IsActive, Mode=TwoWay}" Margin="0,0,16,6"/>
+                                    <CheckBox Content="Password expired" IsChecked="{Binding EditingUser.PasswordExpired, Mode=TwoWay}" Margin="0,0,0,6"/>
+                                </WrapPanel>
+                            </Grid>
                         </Grid>
                     </Border>
 
-                    <TextBlock Text="{Binding EditingUser.UserName, TargetNullValue='New user'}" Style="{StaticResource SectionHeader}" Margin="0,8,0,2" TextWrapping="Wrap"/>
-                    <TextBlock Text="{Binding EditingUser.Role, TargetNullValue='Set role and contact details'}" FontSize="11" TextWrapping="Wrap"/>
-                    <TextBlock Text="{Binding EditingUser.UserID, StringFormat='User #: {0}'}" FontSize="11" Margin="0,6,0,8"/>
-                    <TextBlock Text="Access" Style="{StaticResource LabelTextBlock}" Margin="0,4,0,2"/>
-                    <TextBlock Text="{Binding EditingUser.AccessSummary}" FontSize="11" TextWrapping="Wrap"/>
-                </StackPanel>
-            </Border>
+                    <GridSplitter Grid.Column="1" Width="8" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
 
-            <Grid Grid.Column="1">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="1.05*"/>
-                    <ColumnDefinition Width="8"/>
-                    <ColumnDefinition Width="1.25*"/>
-                </Grid.ColumnDefinitions>
-
-                <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="*"/>
-                        </Grid.RowDefinitions>
-
-                        <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="6,4">
-                            <TextBlock Text="01 Profile Fields" Style="{StaticResource SectionHeader}" Margin="0"/>
-                        </Border>
-
-                        <Grid Grid.Row="1" Margin="8">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="95"/>
-                                <ColumnDefinition Width="*"/>
-                            </Grid.ColumnDefinitions>
+                    <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
+                        <Grid>
                             <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
 
-                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Username:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding EditingUser.UserName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+                            <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="6,4">
+                                <DockPanel>
+                                    <TextBlock Text="02 Permissions" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                                    <TextBlock Text="Tick visible and usable areas" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                                </DockPanel>
+                            </Border>
 
-                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Role:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding EditingUser.Role, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
+                            <WrapPanel Grid.Row="1" Margin="8,8,8,4">
+                                <Button Style="{StaticResource GhostButton}" Content="Advisor" Command="{Binding SelectAdvisorPresetCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Technician" Command="{Binding SelectTechnicianPresetCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Admin" Command="{Binding SelectAdminPresetCommand}" Margin="0,0,4,4"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearPermissionsCommand}" Margin="0,0,4,4"/>
+                            </WrapPanel>
 
-                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Email:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding EditingUser.Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
-
-                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Phone:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding EditingUser.Phone, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
-
-                            <TextBlock Grid.Row="4" Grid.Column="0" Text="Mobile:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding EditingUser.Mobile, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6"/>
-
-                            <TextBlock Grid.Row="5" Grid.Column="0" Text="Address:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Top" Margin="0,3,8,6"/>
-                            <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding EditingUser.Address, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,6" Height="64" TextWrapping="Wrap" AcceptsReturn="True"/>
-
-                            <TextBlock Grid.Row="6" Grid.Column="0" Text="Access:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                            <CheckBox Grid.Row="6" Grid.Column="1" Content="Full administrator" IsChecked="{Binding EditingUser.IsAdmin, Mode=TwoWay}" Margin="0,0,0,6"/>
-
-                            <TextBlock Grid.Row="7" Grid.Column="0" Text="Status:" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                            <StackPanel Grid.Row="7" Grid.Column="1" Orientation="Horizontal">
-                                <CheckBox Content="Active" IsChecked="{Binding EditingUser.IsActive, Mode=TwoWay}" Margin="0,0,16,0"/>
-                                <CheckBox Content="Password expired" IsChecked="{Binding EditingUser.PasswordExpired, Mode=TwoWay}"/>
-                            </StackPanel>
+                            <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
+                                <Grid Margin="8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <StackPanel Grid.Column="0" Margin="0,0,10,0">
+                                        <TextBlock Text="Operations" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/>
+                                        <CheckBox Content="Manage items" IsChecked="{Binding CanManageItems, Mode=TwoWay}" Margin="0,0,0,4"/>
+                                        <CheckBox Content="Rentals / checkout" IsChecked="{Binding CanUseRentals, Mode=TwoWay}" Margin="0,0,0,4"/>
+                                        <CheckBox Content="Customers" IsChecked="{Binding CanUseCustomers, Mode=TwoWay}" Margin="0,0,0,4"/>
+                                        <CheckBox Content="Maintenance" IsChecked="{Binding CanUseMaintenance, Mode=TwoWay}" Margin="0,0,0,4"/>
+                                        <CheckBox Content="Calibration" IsChecked="{Binding CanUseCalibration, Mode=TwoWay}" Margin="0,0,0,4"/>
+                                        <CheckBox Content="Reservations / holds" IsChecked="{Binding CanUseReservations, Mode=TwoWay}" Margin="0,0,0,4"/>
+                                        <CheckBox Content="Kits" IsChecked="{Binding CanUseKits, Mode=TwoWay}" Margin="0,0,0,4"/>
+                                        <CheckBox Content="Categories" IsChecked="{Binding CanUseCategories, Mode=TwoWay}" Margin="0,0,0,4"/>
+                                        <CheckBox Content="Print labels" IsChecked="{Binding CanPrintLabels, Mode=TwoWay}" Margin="0,0,0,4"/>
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="1">
+                                        <TextBlock Text="Management" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/>
+                                        <CheckBox Content="Reports" IsChecked="{Binding CanUseReports, Mode=TwoWay}" Margin="0,0,0,4"/>
+                                        <CheckBox Content="Activity logs" IsChecked="{Binding CanUseActivityLogs, Mode=TwoWay}" Margin="0,0,0,4"/>
+                                        <CheckBox Content="Import / export" IsChecked="{Binding CanUseImportExport, Mode=TwoWay}" Margin="0,0,0,4"/>
+                                        <CheckBox Content="Manage users" IsChecked="{Binding CanManageUsers, Mode=TwoWay}" Margin="0,0,0,4"/>
+                                        <CheckBox Content="Settings" IsChecked="{Binding CanUseSettings, Mode=TwoWay}" Margin="0,0,0,10"/>
+                                        <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="6" Background="{DynamicResource SurfaceAltBrush}" Margin="0,0,0,6">
+                                            <StackPanel>
+                                                <TextBlock Text="Access result" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
+                                                <TextBlock Text="{Binding PermissionStatusSummary}" TextWrapping="Wrap"/>
+                                            </StackPanel>
+                                        </Border>
+                                        <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="6" Background="{DynamicResource SurfaceAltBrush}" Margin="0,0,0,6">
+                                            <StackPanel>
+                                                <TextBlock Text="Can see and use" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
+                                                <TextBlock Text="{Binding AllowedPermissionSummary}" TextWrapping="Wrap"/>
+                                            </StackPanel>
+                                        </Border>
+                                        <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="6" Background="{DynamicResource TextBoxBackgroundBrush}">
+                                            <StackPanel>
+                                                <TextBlock Text="Hidden or blocked" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
+                                                <TextBlock Text="{Binding HiddenPermissionSummary}" TextWrapping="Wrap"/>
+                                            </StackPanel>
+                                        </Border>
+                                    </StackPanel>
+                                </Grid>
+                            </ScrollViewer>
                         </Grid>
-                    </Grid>
-                </Border>
-
-                <GridSplitter Grid.Column="1" Width="8" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
-
-                <Border Grid.Column="2" Style="{StaticResource Card}" Padding="0">
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="*"/>
-                        </Grid.RowDefinitions>
-
-                        <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="6,4">
-                            <DockPanel>
-                                <TextBlock Text="02 Permissions" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
-                                <TextBlock Text="Tick the areas this user can see and use" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
-                            </DockPanel>
-                        </Border>
-
-                        <WrapPanel Grid.Row="1" Margin="8,8,8,4">
-                            <Button Style="{StaticResource GhostButton}" Content="Advisor" Command="{Binding SelectAdvisorPresetCommand}" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Technician" Command="{Binding SelectTechnicianPresetCommand}" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Admin" Command="{Binding SelectAdminPresetCommand}" Margin="0,0,4,4"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearPermissionsCommand}" Margin="0,0,4,4"/>
-                        </WrapPanel>
-
-                        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
-                            <Grid Margin="8">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <StackPanel Grid.Column="0" Margin="0,0,10,0">
-                                    <TextBlock Text="Operations" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/>
-                                    <CheckBox Content="Manage items" IsChecked="{Binding CanManageItems, Mode=TwoWay}" Margin="0,0,0,4"/>
-                                    <CheckBox Content="Rentals / checkout" IsChecked="{Binding CanUseRentals, Mode=TwoWay}" Margin="0,0,0,4"/>
-                                    <CheckBox Content="Customers" IsChecked="{Binding CanUseCustomers, Mode=TwoWay}" Margin="0,0,0,4"/>
-                                    <CheckBox Content="Maintenance" IsChecked="{Binding CanUseMaintenance, Mode=TwoWay}" Margin="0,0,0,4"/>
-                                    <CheckBox Content="Calibration" IsChecked="{Binding CanUseCalibration, Mode=TwoWay}" Margin="0,0,0,4"/>
-                                    <CheckBox Content="Reservations / holds" IsChecked="{Binding CanUseReservations, Mode=TwoWay}" Margin="0,0,0,4"/>
-                                    <CheckBox Content="Kits" IsChecked="{Binding CanUseKits, Mode=TwoWay}" Margin="0,0,0,4"/>
-                                    <CheckBox Content="Categories" IsChecked="{Binding CanUseCategories, Mode=TwoWay}" Margin="0,0,0,4"/>
-                                    <CheckBox Content="Print labels" IsChecked="{Binding CanPrintLabels, Mode=TwoWay}" Margin="0,0,0,4"/>
-                                </StackPanel>
-                                <StackPanel Grid.Column="1">
-                                    <TextBlock Text="Management" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/>
-                                    <CheckBox Content="Reports" IsChecked="{Binding CanUseReports, Mode=TwoWay}" Margin="0,0,0,4"/>
-                                    <CheckBox Content="Activity logs" IsChecked="{Binding CanUseActivityLogs, Mode=TwoWay}" Margin="0,0,0,4"/>
-                                    <CheckBox Content="Import / export" IsChecked="{Binding CanUseImportExport, Mode=TwoWay}" Margin="0,0,0,4"/>
-                                    <CheckBox Content="Manage users" IsChecked="{Binding CanManageUsers, Mode=TwoWay}" Margin="0,0,0,4"/>
-                                    <CheckBox Content="Settings" IsChecked="{Binding CanUseSettings, Mode=TwoWay}" Margin="0,0,0,10"/>
-                                    <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="6" Background="{DynamicResource SurfaceAltBrush}">
-                                        <TextBlock Text="{Binding EditingUser.AccessSummary}" TextWrapping="Wrap"/>
-                                    </Border>
-                                </StackPanel>
-                            </Grid>
-                        </ScrollViewer>
-                    </Grid>
-                </Border>
+                    </Border>
+                </Grid>
             </Grid>
-        </Grid>
+        </ScrollViewer>
 
         <controls:SaveCancelBar Grid.Row="2" Margin="0,8,0,0"/>
     </Grid>


### PR DESCRIPTION
## Summary

- Adds live permission outcome summaries to the user editor so admins can see whether a user has full admin, custom, or no app-section access before saving.
- Shows exactly which sections the selected checkbox set allows and which sections will be hidden or blocked.
- Reworks the user editor window into a scrollable, wider permission layout with wrapped status controls and clearer profile/access context for smaller screens.
- Records the completed admin permission editor review in progress notes and the completion checklist.

## Why

The user asked for the admin users page to manage permissions with tick boxes, and for each function to be clear end to end from a user/admin perspective. The checkbox permission model existed, but the edit dialog did not clearly translate those ticks into what the user could or could not access. This pass makes that result visible while editing.

## Validation

- Compared `codex/qa-permission-screenshot-coverage` against `master`; the branch is ahead by 4 commits and not behind.
- Read back the changed `UsersEditViewModel.cs`, `UsersEditWindow.xaml`, and progress files through the GitHub connector.
- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
- Did not run unrelated tests, per instruction.