### PR TITLE
Align service authorization with user permissions

### DIFF
--- a/InventoryManagementApp/Interfaces/IAuthorizationService.cs
+++ b/InventoryManagementApp/Interfaces/IAuthorizationService.cs
@@ -3,6 +3,10 @@ namespace InventoryManagementApp.Interfaces
     public interface IAuthorizationService
     {
         bool IsAdmin { get; }
+        bool HasPermission(string permissionKey);
+        bool HasAnyPermission(params string[] permissionKeys);
         void EnsureAdmin();
+        void EnsurePermission(string permissionKey);
+        void EnsureAnyPermission(params string[] permissionKeys);
     }
 }

--- a/InventoryManagementApp/ProgressNotes/2026-06-17-permission-specific-service-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-permission-specific-service-guards.md
@@ -1,0 +1,20 @@
+# Permission-Specific Service Guards - 2026-06-17
+
+## Completed
+
+- Added permission-aware authorization methods to `IAuthorizationService` so services can require one exact app area instead of treating all elevated rights as interchangeable.
+- Kept full administrators as all-access users while allowing scoped permissions to pass only their own service operations.
+- User administration now requires `Manage users` for add, update, reset-another-user-password, and delete operations.
+- Settings writes now require `Settings`, including theme, security, label, detail visibility, auto-logout, and card-size changes.
+- Inventory item create/update/delete/save operations now require `Manage items`.
+- Bulk item imports and image imports now require `Import / export`, while direct image updates can be performed by either `Manage items` or `Import / export`.
+
+## Why it matters
+
+The permissions editor and navigation now have matching service-layer protection. A user can be given a narrow operational role without accidentally inheriting unrelated admin operations just because another elevated permission was ticked.
+
+## Validation
+
+- Reviewed the branch diff through the GitHub connector.
+- Local `dotnet` build/test and WPF runtime checks could not run in this scheduled Linux container because the .NET SDK and Windows/WPF runtime are unavailable, and local cloning remains blocked by the network tunnel.
+- Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 13:11 NZST
+Last audit date/time: 2026-06-17 14:11 NZST
 
 ## Completed workflows
 
@@ -25,6 +25,7 @@ Last audit date/time: 2026-06-17 13:11 NZST
 - QA screenshot manifests now list each captured PNG with dimensions and byte size so future screenshot reviews can spot cropped or suspicious captures faster.
 - Admin user management now supports durable checkbox permissions, advisor/technician/admin presets, access summaries in the directory/detail/copy/print flows, and permission-based navigation visibility for operations, insights, data, and admin sections.
 - Admin user permission editing now shows live access-result, allowed-area, and hidden/blocked summaries beside the checkbox permissions, with a scrollable layout for shorter admin screens.
+- Service-layer authorization now matches checkbox permissions more closely: user administration requires Manage users, settings writes require Settings, inventory edits require Manage items, and bulk/image imports require Import / export while full admins keep all-access rights.
 - Reservations now use a two-pane advisor workbench with hold directory, quick status filters, selected-hold detail, timing, next action, shelf checklist, copy handoff, print handoff, printable filtered directory, stable useful selection, null-safe expanded search, and row-correct double-click/right-click actions.
 - QA screenshot review now produces a browser-friendly `index.html` gallery grouped by app area and fails when unexpected PNG captures appear without updating the expected screenshot manifest.
 - Rentals now use a rental desk workbench with a main rental directory, selected-rental advisor handoff, customer/timing/shelf context, check-in/extend/request/document actions, open request queue, row-correct context menus, wrapping toolbar actions, and a compact footer for repeated desk work.
@@ -39,7 +40,7 @@ Last audit date/time: 2026-06-17 13:11 NZST
 - Customers now have a completed desktop workflow surface, but runtime add/edit/delete/print/copy validation still needs a Windows/.NET workstation.
 - Maintenance now has a completed desktop workflow surface, but runtime add/edit/complete/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 - Calibration now has a completed desktop workflow surface, but runtime add/edit/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
-- User permission editing now has a completed persistence/UI/navigation/editor-summary pass, but runtime login-as-each-role and screenshot validation still needs a Windows/.NET workstation.
+- User permission editing now has a completed persistence/UI/navigation/editor-summary pass and matching service-layer permission guards, but runtime login-as-each-role and screenshot validation still needs a Windows/.NET workstation.
 - Reservations now have a completed desktop workflow surface, but runtime add/edit/confirm/cancel/fulfill/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 - Rentals now have a completed desktop workflow surface, but runtime check-in/extend/request/delete/print/document and screenshot validation still need a Windows/.NET workstation.
 - Categories now have a completed desktop workflow surface, but runtime create/rename/delete/filter/print/copy and screenshot validation still need a Windows/.NET workstation.
@@ -56,7 +57,6 @@ Last audit date/time: 2026-06-17 13:11 NZST
 
 ## Validation status
 
-- GitHub connector readback reviewed the user permission editor view model, XAML, and progress note.
-- Compared `codex/qa-permission-screenshot-coverage` against `master`; the branch is ahead and not behind before opening the PR.
+- GitHub connector compare/readback reviewed the permission-specific service guard branch.
 - Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, and `scripts/run-app-qa-screenshots.ps1` were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
 - Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -67,18 +67,18 @@ namespace InventoryManagementApp.Services.Items
         }
 
         /// <summary>
-        /// Adds a new item to the inventory. Requires admin privileges.
+        /// Adds a new item to the inventory. Requires manage-items permission.
         /// </summary>
         /// <param name="item">The item to add.</param>
         /// <param name="cancellationToken">Cancellation token for the operation.</param>
         /// <exception cref="ArgumentNullException">Thrown if item is null.</exception>
-        /// <exception cref="UnauthorizedAccessException">Thrown if user lacks admin privileges.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown if user lacks manage-items permission.</exception>
         public async Task AddItemAsync(ItemModel item, CancellationToken cancellationToken = default)
         {
             if (item is null)
                 throw new ArgumentNullException(nameof(item));
             
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionManageItems);
             await AddItemInternalAsync(item, cancellationToken).ConfigureAwait(false);
             if (_activityLog != null)
             {
@@ -88,18 +88,18 @@ namespace InventoryManagementApp.Services.Items
         }
 
         /// <summary>
-        /// Updates an existing item in the inventory. Requires admin privileges.
+        /// Updates an existing item in the inventory. Requires manage-items permission.
         /// </summary>
         /// <param name="item">The item with updated information.</param>
         /// <param name="cancellationToken">Cancellation token for the operation.</param>
         /// <exception cref="ArgumentNullException">Thrown if item is null.</exception>
-        /// <exception cref="UnauthorizedAccessException">Thrown if user lacks admin privileges.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown if user lacks manage-items permission.</exception>
         public async Task UpdateItemAsync(ItemModel item, CancellationToken cancellationToken = default)
         {
             if (item is null)
                 throw new ArgumentNullException(nameof(item));
             
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionManageItems);
             await UpdateItemInternalAsync(item, cancellationToken).ConfigureAwait(false);
             if (_activityLog != null)
             {
@@ -109,18 +109,18 @@ namespace InventoryManagementApp.Services.Items
         }
 
         /// <summary>
-        /// Deletes an item from the inventory. Requires admin privileges.
+        /// Deletes an item from the inventory. Requires manage-items permission.
         /// </summary>
         /// <param name="itemID">The ID of the item to delete.</param>
         /// <param name="cancellationToken">Cancellation token for the operation.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if itemID is less than 1.</exception>
-        /// <exception cref="UnauthorizedAccessException">Thrown if user lacks admin privileges.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown if user lacks manage-items permission.</exception>
         public async Task DeleteItemAsync(int itemID, CancellationToken cancellationToken = default)
         {
             if (itemID < 1)
                 throw new ArgumentOutOfRangeException(nameof(itemID), "Item ID must be greater than 0.");
             
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionManageItems);
             await DeleteItemInternalAsync(itemID, cancellationToken).ConfigureAwait(false);
             if (_activityLog != null)
             {
@@ -155,13 +155,13 @@ namespace InventoryManagementApp.Services.Items
 
         public Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken cancellationToken = default)
         {
-            _auth.EnsureAdmin();
+            _auth.EnsureAnyPermission(User.PermissionManageItems, User.PermissionImportExport);
             return _repository.UpdateItemImageAsync(itemID, imagePath, cancellationToken);
         }
 
         public Task<List<int>> ImportItemsFromCsvAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionImportExport);
             return ImportItemsFromCsvInternalAsync(filePath, map, cancellationToken);
         }
 
@@ -170,7 +170,7 @@ namespace InventoryManagementApp.Services.Items
 
         public Task<ImageImportResult> ImportItemImagesAsync(string folderPath, Func<ItemModel, IEnumerable<string>> keySelector, IProgress<ImageImportProgress>? progress = null, CancellationToken cancellationToken = default)
         {
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionImportExport);
             return ImportItemImagesInternalAsync(folderPath, keySelector, progress, cancellationToken);
         }
 
@@ -599,7 +599,7 @@ namespace InventoryManagementApp.Services.Items
 
         public Task SaveChangesAsync(IEnumerable<ItemModel> changes, CancellationToken ct)
         {
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionManageItems);
             return _repository.SaveChangesAsync(changes, ct);
         }
 
@@ -615,7 +615,7 @@ namespace InventoryManagementApp.Services.Items
 
         public async Task<List<int>> ImportItemsAsync(string filePath, IDataImporter<ItemModel> importer, CancellationToken cancellationToken = default)
         {
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionImportExport);
             
             var (items, skippedRows) = await importer.ImportAsync(filePath, cancellationToken).ConfigureAwait(false);
             

--- a/InventoryManagementApp/Services/Settings/SettingsService.cs
+++ b/InventoryManagementApp/Services/Settings/SettingsService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Data.Sqlite;
+using Microsoft.Data.Sqlite;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,6 +9,7 @@ using System.Globalization;
 using InventoryManagementApp.Services.Core;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models;
+using InventoryManagementApp.Models.Domain;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using InventoryManagementApp.Services.Users;
@@ -49,17 +50,17 @@ namespace InventoryManagementApp.Services.Settings
         }
 
         /// <summary>
-        /// Saves a setting to the database. Requires admin privileges.
+        /// Saves a setting to the database. Requires settings permission.
         /// </summary>
         /// <param name="key">The setting key.</param>
         /// <param name="value">The setting value.</param>
         /// <param name="cancellationToken">Cancellation token for the operation.</param>
         /// <exception cref="ArgumentException">Thrown if key is null or whitespace.</exception>
-        /// <exception cref="UnauthorizedAccessException">Thrown if user lacks admin privileges.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown if user lacks settings permission.</exception>
         /// <exception cref="InvalidOperationException">Thrown if the database operation fails.</exception>
         public async Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
         {
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionSettings);
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentException("Key cannot be null or empty.", nameof(key));
 
@@ -173,7 +174,7 @@ namespace InventoryManagementApp.Services.Settings
         /// </exception>
         public async Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
         {
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionSettings);
             if (settings == null)
                 throw new ArgumentNullException(nameof(settings));
 
@@ -220,7 +221,7 @@ namespace InventoryManagementApp.Services.Settings
 
         public async Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
         {
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionSettings);
             try
             {
                 const string sql = "DELETE FROM Settings WHERE Key = @Key";
@@ -271,7 +272,7 @@ namespace InventoryManagementApp.Services.Settings
 
         public async Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default)
         {
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionSettings);
             if (iterations <= 0)
                 throw new ArgumentOutOfRangeException(nameof(iterations));
             await SaveSettingAsync(PasswordIterationsKey, iterations.ToString(), cancellationToken).ConfigureAwait(false);
@@ -285,7 +286,7 @@ namespace InventoryManagementApp.Services.Settings
 
         public async Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default)
         {
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionSettings);
             if (minutes < 0)
                 throw new ArgumentOutOfRangeException(nameof(minutes));
             await SaveSettingAsync(AutoLogoutMinutesKey, minutes.ToString(), cancellationToken).ConfigureAwait(false);
@@ -299,7 +300,7 @@ namespace InventoryManagementApp.Services.Settings
 
         public async Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default)
         {
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionSettings);
             await SaveSettingAsync(ItemLabelSingularKey, label, cancellationToken).ConfigureAwait(false);
         }
 
@@ -311,7 +312,7 @@ namespace InventoryManagementApp.Services.Settings
 
         public async Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default)
         {
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionSettings);
             await SaveSettingAsync(ItemLabelPluralKey, label, cancellationToken).ConfigureAwait(false);
         }
 
@@ -335,7 +336,7 @@ namespace InventoryManagementApp.Services.Settings
             else
             {
                 visibility = Enum.GetValues<ItemDetailField>().ToDictionary(f => f, _ => true);
-                if (_auth.IsAdmin)
+                if (_auth.HasPermission(User.PermissionSettings))
                 {
                     await SaveItemDetailVisibilityAsync(visibility, cancellationToken).ConfigureAwait(false);
                 }
@@ -345,7 +346,7 @@ namespace InventoryManagementApp.Services.Settings
 
         public async Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
         {
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionSettings);
             var dict = visibility.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value);
             var json = JsonSerializer.Serialize(dict);
             await SaveSettingAsync(ItemDetailVisibilityKey, json, cancellationToken).ConfigureAwait(false);
@@ -366,7 +367,7 @@ namespace InventoryManagementApp.Services.Settings
 
         public async Task SaveItemCardSizeAsync(double size, CancellationToken cancellationToken = default)
         {
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionSettings);
             if (size <= 0.2)
                 throw new ArgumentOutOfRangeException(nameof(size));
             var value = size.ToString("0.###", CultureInfo.InvariantCulture);

--- a/InventoryManagementApp/Services/Users/AuthorizationService.cs
+++ b/InventoryManagementApp/Services/Users/AuthorizationService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using InventoryManagementApp.Interfaces;
@@ -17,25 +18,46 @@ namespace InventoryManagementApp.Services.Users
             _logger = logger ?? NullLogger<AuthorizationService>.Instance;
         }
 
-        public bool IsAdmin => HasElevatedAccess();
+        public bool IsAdmin => _userContext.CurrentUser?.IsAdmin == true;
+
+        public bool HasPermission(string permissionKey)
+            => _userContext.CurrentUser?.HasPermission(permissionKey) == true;
+
+        public bool HasAnyPermission(params string[] permissionKeys)
+            => _userContext.CurrentUser?.HasAnyPermission(permissionKeys) == true;
 
         public void EnsureAdmin()
         {
-            if (!HasElevatedAccess())
+            if (!IsAdmin)
             {
-                _logger.LogWarning("Unauthorized access attempt by {User}", _userContext.UserName);
-                throw new UnauthorizedAccessException("Admin privileges required.");
+                _logger.LogWarning("Unauthorized admin-only access attempt by {User}", _userContext.UserName);
+                throw new UnauthorizedAccessException("Full admin access is required.");
             }
         }
 
-        bool HasElevatedAccess()
+        public void EnsurePermission(string permissionKey)
         {
-            var user = _userContext.CurrentUser;
-            return user?.IsAdmin == true || user?.HasAnyPermission(
-                User.PermissionManageItems,
-                User.PermissionImportExport,
-                User.PermissionManageUsers,
-                User.PermissionSettings) == true;
+            if (IsAdmin || HasPermission(permissionKey))
+                return;
+
+            var label = User.PermissionLabels.TryGetValue(permissionKey, out var display)
+                ? display
+                : permissionKey;
+            _logger.LogWarning("Unauthorized {Permission} access attempt by {User}", label, _userContext.UserName);
+            throw new UnauthorizedAccessException($"The '{label}' permission is required.");
+        }
+
+        public void EnsureAnyPermission(params string[] permissionKeys)
+        {
+            if (IsAdmin || HasAnyPermission(permissionKeys))
+                return;
+
+            var labels = permissionKeys
+                .Select(key => User.PermissionLabels.TryGetValue(key, out var display) ? display : key)
+                .ToList();
+            var required = labels.Count == 0 ? "required" : string.Join(" or ", labels);
+            _logger.LogWarning("Unauthorized access attempt by {User}. Required: {Permissions}", _userContext.UserName, required);
+            throw new UnauthorizedAccessException($"The {required} permission is required.");
         }
     }
 }

--- a/InventoryManagementApp/Services/Users/NoOpAuthorizationService.cs
+++ b/InventoryManagementApp/Services/Users/NoOpAuthorizationService.cs
@@ -5,6 +5,10 @@ namespace InventoryManagementApp.Services.Users
     public class NoOpAuthorizationService : IAuthorizationService
     {
         public bool IsAdmin => true;
+        public bool HasPermission(string permissionKey) => true;
+        public bool HasAnyPermission(params string[] permissionKeys) => true;
         public void EnsureAdmin() { }
+        public void EnsurePermission(string permissionKey) { }
+        public void EnsureAnyPermission(params string[] permissionKeys) { }
     }
 }

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -261,7 +261,7 @@ namespace InventoryManagementApp.Services.Users
             }
             else
             {
-                _auth.EnsureAdmin();
+                _auth.EnsurePermission(User.PermissionManageUsers);
             }
             const string sql = @"
                 INSERT INTO Users
@@ -319,7 +319,7 @@ namespace InventoryManagementApp.Services.Users
 
         public async Task UpdateUserAsync(User user)
         {
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionManageUsers);
             const string sql = @"
                 UPDATE Users SET
                   UserName      = @UserName,
@@ -384,7 +384,7 @@ namespace InventoryManagementApp.Services.Users
         public async Task<bool> ChangeUserPasswordAsync(int userID, string newPassword)
         {
             if (_context.CurrentUser?.UserID != userID)
-                _auth.EnsureAdmin();
+                _auth.EnsurePermission(User.PermissionManageUsers);
 
             newPassword = (newPassword ?? string.Empty).Trim();
             if (!PasswordValidator.IsValid(newPassword, out var error))
@@ -420,7 +420,7 @@ namespace InventoryManagementApp.Services.Users
 
         public async Task<bool> TryDeleteUserAsync(int userID)
         {
-            _auth.EnsureAdmin();
+            _auth.EnsurePermission(User.PermissionManageUsers);
             var user = await GetUserByIDAsync(userID, CancellationToken.None);
             if (user == null) return false;
             if (user.IsAdmin)


### PR DESCRIPTION
## Summary

- add permission-specific checks to the authorization service contract
- require Manage users for user admin operations, Settings for settings writes, Manage items for inventory edits, and Import / export for bulk item/image imports
- document the completed permission guard pass in progress notes and the completion checklist

## Validation

- reviewed the GitHub connector compare/readback for the focused branch diff
- not run: local .NET build/test or WPF screenshots because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local cloning remains blocked by the network tunnel
- did not run unrelated tests, per instruction