### PR TITLE
Guard checkbox permission authorization contract

### DIFF
--- a/InventoryManagementApp.Tests/AuthorizationServicePermissionTests.cs
+++ b/InventoryManagementApp.Tests/AuthorizationServicePermissionTests.cs
@@ -1,0 +1,103 @@
+using System;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Services.Users;
+using Xunit;
+
+public class AuthorizationServicePermissionTests
+{
+    private sealed class TestUserContext : IUserContext
+    {
+        private User? _currentUser;
+
+        public User? CurrentUser
+        {
+            get => _currentUser;
+            set
+            {
+                _currentUser = value;
+                UserChanged?.Invoke(this, value);
+            }
+        }
+
+        public event EventHandler<User?>? UserChanged;
+
+        public bool IsAdmin => CurrentUser?.IsAdmin == true;
+        public string UserName => CurrentUser?.UserName ?? string.Empty;
+        public string Role => CurrentUser?.Role ?? string.Empty;
+    }
+
+    [Fact]
+    public void EnsurePermission_AllowsExplicitCheckboxPermission()
+    {
+        var context = new TestUserContext
+        {
+            CurrentUser = new User
+            {
+                UserName = "advisor",
+                Permissions = User.BuildPermissions(new[] { User.PermissionRentals })
+            }
+        };
+        var auth = new AuthorizationService(context);
+
+        auth.EnsurePermission(User.PermissionRentals);
+
+        Assert.True(auth.HasPermission(User.PermissionRentals));
+    }
+
+    [Fact]
+    public void EnsurePermission_BlocksUncheckedPermission()
+    {
+        var context = new TestUserContext
+        {
+            CurrentUser = new User
+            {
+                UserName = "advisor",
+                Permissions = User.BuildPermissions(new[] { User.PermissionRentals })
+            }
+        };
+        var auth = new AuthorizationService(context);
+
+        var ex = Assert.Throws<UnauthorizedAccessException>(() => auth.EnsurePermission(User.PermissionImportExport));
+
+        Assert.Contains("Import / export", ex.Message);
+    }
+
+    [Fact]
+    public void EnsureAnyPermission_AllowsAnyCheckedPermission()
+    {
+        var context = new TestUserContext
+        {
+            CurrentUser = new User
+            {
+                UserName = "technician",
+                Permissions = User.BuildPermissions(new[] { User.PermissionMaintenance })
+            }
+        };
+        var auth = new AuthorizationService(context);
+
+        auth.EnsureAnyPermission(User.PermissionRentals, User.PermissionMaintenance);
+
+        Assert.True(auth.HasAnyPermission(User.PermissionRentals, User.PermissionMaintenance));
+    }
+
+    [Fact]
+    public void FullAdmin_PassesEveryPermissionCheck()
+    {
+        var context = new TestUserContext
+        {
+            CurrentUser = new User
+            {
+                UserName = "admin",
+                IsAdmin = true,
+                Permissions = User.BuildPermissions(Array.Empty<string>())
+            }
+        };
+        var auth = new AuthorizationService(context);
+
+        auth.EnsurePermission(User.PermissionSettings);
+        auth.EnsureAnyPermission(User.PermissionManageUsers, User.PermissionImportExport);
+
+        Assert.True(auth.HasPermission(User.PermissionSettings));
+    }
+}

--- a/InventoryManagementApp.Tests/SettingsServiceAuthorizationTests.cs
+++ b/InventoryManagementApp.Tests/SettingsServiceAuthorizationTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Services.Core;

--- a/InventoryManagementApp.Tests/SettingsServiceAuthorizationTests.cs
+++ b/InventoryManagementApp.Tests/SettingsServiceAuthorizationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Services.Core;
@@ -11,7 +12,11 @@ public class SettingsServiceAuthorizationTests
     private sealed class NonAdminAuthorizationService : IAuthorizationService
     {
         public bool IsAdmin => false;
+        public bool HasPermission(string permissionKey) => false;
+        public bool HasAnyPermission(params string[] permissionKeys) => false;
         public void EnsureAdmin() => throw new UnauthorizedAccessException();
+        public void EnsurePermission(string permissionKey) => throw new UnauthorizedAccessException();
+        public void EnsureAnyPermission(params string[] permissionKeys) => throw new UnauthorizedAccessException();
     }
 
     [Fact]
@@ -28,4 +33,3 @@ public class SettingsServiceAuthorizationTests
         Assert.Null(await settings.GetSettingAsync("ItemDetailVisibility"));
     }
 }
-

--- a/InventoryManagementApp/ProgressNotes/2026-06-17-permission-contract-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-permission-contract-coverage.md
@@ -1,0 +1,16 @@
+# Permission Contract Coverage - 2026-06-17
+
+## Completed
+
+- Updated the settings authorization test double so it implements the current `IAuthorizationService` permission methods.
+- Added focused `AuthorizationService` coverage for explicit checkbox permissions, blocked unchecked permissions, any-permission checks, and full-admin bypass behavior.
+
+## Why it matters
+
+The admin user editor now writes granular checkbox permissions, and services/navigation depend on the same permission contract. These tests protect that contract so advisor, technician, and admin flows do not drift back to mismatched full-admin-only behavior as more pages and buttons are wired end to end.
+
+## Validation
+
+- GitHub connector readback/compare was used for changed files.
+- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
+- Did not run unrelated tests, per instruction.


### PR DESCRIPTION
## Summary

- Updates the settings authorization test double to match the current `IAuthorizationService` permission contract.
- Adds focused authorization coverage for explicit checkbox permissions, unchecked permissions, any-permission checks, and full-admin access.
- Records the scheduled pass in a progress note.

## Validation

- GitHub connector compare/readback confirmed the focused branch diff.
- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
- Did not run unrelated tests, per instruction.