### PR TITLE
Align image import UI with import export permission

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-17-import-export-image-permission-ui.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-import-export-image-permission-ui.md
@@ -1,0 +1,17 @@
+# Import / Export Image Permission UI - 2026-06-17
+
+## Completed
+
+- Aligned the Import / Export photo-mapping visibility with the checkbox permission model.
+- Users granted Import / export now see the image import entry points instead of being blocked by an outdated full-admin-only UI check.
+- Updated the photo-mapping summary so restricted users are told exactly which permission is required.
+
+## Why it matters
+
+An admin can now grant a data operator the Import / export checkbox and have the page behave consistently from navigation through the image-mapping action. The UI no longer hides a workflow that the service layer already allows for that permission.
+
+## Validation
+
+- Reviewed the current Import / Export view model and permission service behavior through the GitHub connector.
+- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
+- Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 14:11 NZST
+Last audit date/time: 2026-06-17 16:11 NZST
 
 ## Completed workflows
 
@@ -14,6 +14,7 @@ Last audit date/time: 2026-06-17 14:11 NZST
 - QA screenshot capture now names the first Settings capture as service status and walks every Settings tab through Backups after the service-status tab was added.
 - Import / Export now uses a compact data workstation layout with separate sections for item data, customer data, backup/image admin work, and run-log review.
 - Import / Export operation logs now support selected-row detail, copy, print, clear, double-click drilldown, and row-correct right-click actions.
+- Import / Export image mapping now follows the Import / export checkbox permission instead of an outdated full-admin-only UI gate, matching the service-layer import permission guard.
 - QA screenshot wrapper validation now requires every expected screenshot folder to contain PNG output and appends the captured file list to the run README.
 - Kits now use a compact desktop workstation with kit directory, item membership, selected-kit detail, availability guidance, row-correct context menus, double-click drilldown, keyboard shortcuts, copy selected kit details, printable kit directory output, and printable kit pick sheets.
 - QA screenshot wrapper validation now checks for each expected named screenshot file so missing captures fail loudly instead of passing on folder count alone.
@@ -35,7 +36,7 @@ Last audit date/time: 2026-06-17 14:11 NZST
 
 - Item import/export coverage exists, but solution-wide validation still needs to run in an environment with the .NET SDK.
 - Reports page has a compact operational grid, summary panel, print/copy actions, and safe empty unknown-report handling; runtime screenshot and full report generation checks remain pending.
-- Import / Export has been redesigned and wired for log actions, but runtime file-dialog, print, and screenshot checks still need a Windows/.NET workstation.
+- Import / Export has been redesigned and wired for log actions plus permission-matched image mapping, but runtime file-dialog, print, image-mapping, and screenshot checks still need a Windows/.NET workstation.
 - Kits now have a completed desktop workflow surface, but runtime add/edit/item-membership dialog validation still needs a Windows/.NET workstation.
 - Customers now have a completed desktop workflow surface, but runtime add/edit/delete/print/copy validation still needs a Windows/.NET workstation.
 - Maintenance now has a completed desktop workflow surface, but runtime add/edit/complete/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
@@ -57,6 +58,6 @@ Last audit date/time: 2026-06-17 14:11 NZST
 
 ## Validation status
 
-- GitHub connector compare/readback reviewed the permission-specific service guard branch.
+- GitHub connector readback reviewed the Import / Export permission UI change and progress note.
 - Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, and `scripts/run-app-qa-screenshots.ps1` were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
 - Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
@@ -38,7 +38,8 @@ namespace InventoryManagementApp.ViewModels
         public IAsyncRelayCommand OpenImageImportMappingWindowCommand { get; }
         public IRelayCommand ClearImportExportLogsCommand { get; }
 
-        public bool IsCurrentUserAdmin => _userContext.IsAdmin;
+        public bool CanImportImages => _userContext.IsAdmin || _userContext.CurrentUser?.HasPermission(User.PermissionImportExport) == true;
+        public bool IsCurrentUserAdmin => CanImportImages;
         public bool HasLogEntries => ImportExportLogs.Count > 0;
         public string LogSummary => HasLogEntries
             ? $"{ImportExportLogs.Count} operation log entr{(ImportExportLogs.Count == 1 ? "y" : "ies")} recorded this session."
@@ -50,9 +51,9 @@ namespace InventoryManagementApp.ViewModels
         public string CustomerDataSummary =>
             "Import customers from mapped CSV, JSON, or XML. Export the customer directory to CSV, JSON, or XML for advisor handoff or cleanup.";
 
-        public string ImageImportSummary => IsCurrentUserAdmin
-            ? $"Admin image import is available for matching photos to {LabelProvider.Instance.ItemLabelPlural}."
-            : $"Image import is admin-only. Ask an admin to map photos to {LabelProvider.Instance.ItemLabelPlural}.";
+        public string ImageImportSummary => CanImportImages
+            ? $"Image import is available for matching photos to {LabelProvider.Instance.ItemLabelPlural}."
+            : $"Image import requires the {User.PermissionLabels[User.PermissionImportExport]} permission. Ask an admin to grant it before mapping photos to {LabelProvider.Instance.ItemLabelPlural}.";
 
         public string BackupSummary =>
             "Create a database backup before large imports, bulk cleanup, or workstation changes.";
@@ -116,6 +117,7 @@ namespace InventoryManagementApp.ViewModels
             _userContext = userContext ?? new DummyUserContext();
             _userContext.UserChanged += (_, _) =>
             {
+                OnPropertyChanged(nameof(CanImportImages));
                 OnPropertyChanged(nameof(IsCurrentUserAdmin));
                 OnPropertyChanged(nameof(ImageImportSummary));
             };


### PR DESCRIPTION
## Summary
- Align Import / Export photo-mapping visibility with the Import / export checkbox permission.
- Update the image import summary so scoped data operators see the correct permission requirement instead of an outdated full-admin message.
- Record the completed workflow in progress notes and the completion checklist.

## Validation
- Reviewed changed files and branch compare through the GitHub connector.
- Local dotnet build/test and WPF screenshot execution were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local cloning/raw fetches remain blocked by the network tunnel.
- Did not run unrelated tests, per instruction.