### PR TITLE
Show admin permission impact in user editor

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-17-admin-permission-impact-review.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-admin-permission-impact-review.md
@@ -1,0 +1,17 @@
+# Admin Permission Impact Review - 2026-06-17
+
+## Completed
+
+- Expanded the user permission editor with live operational-impact and guarded-action summaries.
+- Admins can now see which workbench families, data/reporting areas, and admin-level service actions a checkbox set will allow before saving.
+- Added next-step guidance for full-admin, custom-access, and no-access user states so accidental under- or over-permissioning is easier to spot.
+
+## Why it matters
+
+The checkbox permission model now explains the result in practical workflow language. An admin editing a user can see whether that person can finish rental desk, technician bench, data import, settings, or user-management work before the account is saved.
+
+## Validation
+
+- Read the current user model, user editor view model, user editor XAML, Users page, and main navigation permissions through the GitHub connector.
+- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
+- Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 16:11 NZST
+Last audit date/time: 2026-06-17 17:11 NZST
 
 ## Completed workflows
 
@@ -25,7 +25,7 @@ Last audit date/time: 2026-06-17 16:11 NZST
 - Calibration now uses a two-pane technician bench with certificate handoff details, timing and next-action guidance, shelf-release checklist, quick overdue/due-soon/current filters, copy handoff, print actions, stable useful selection, null-safe expanded search, and row-correct context menus.
 - QA screenshot manifests now list each captured PNG with dimensions and byte size so future screenshot reviews can spot cropped or suspicious captures faster.
 - Admin user management now supports durable checkbox permissions, advisor/technician/admin presets, access summaries in the directory/detail/copy/print flows, and permission-based navigation visibility for operations, insights, data, and admin sections.
-- Admin user permission editing now shows live access-result, allowed-area, and hidden/blocked summaries beside the checkbox permissions, with a scrollable layout for shorter admin screens.
+- Admin user permission editing now shows live access-result, allowed-area, hidden/blocked, operational-impact, guarded-action, and next-step summaries beside the checkbox permissions, with a scrollable layout for shorter admin screens.
 - Service-layer authorization now matches checkbox permissions more closely: user administration requires Manage users, settings writes require Settings, inventory edits require Manage items, and bulk/image imports require Import / export while full admins keep all-access rights.
 - Reservations now use a two-pane advisor workbench with hold directory, quick status filters, selected-hold detail, timing, next action, shelf checklist, copy handoff, print handoff, printable filtered directory, stable useful selection, null-safe expanded search, and row-correct double-click/right-click actions.
 - QA screenshot review now produces a browser-friendly `index.html` gallery grouped by app area and fails when unexpected PNG captures appear without updating the expected screenshot manifest.
@@ -41,7 +41,7 @@ Last audit date/time: 2026-06-17 16:11 NZST
 - Customers now have a completed desktop workflow surface, but runtime add/edit/delete/print/copy validation still needs a Windows/.NET workstation.
 - Maintenance now has a completed desktop workflow surface, but runtime add/edit/complete/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 - Calibration now has a completed desktop workflow surface, but runtime add/edit/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
-- User permission editing now has a completed persistence/UI/navigation/editor-summary pass and matching service-layer permission guards, but runtime login-as-each-role and screenshot validation still needs a Windows/.NET workstation.
+- User permission editing now has a completed persistence/UI/navigation/editor-summary pass, impact review, and matching service-layer permission guards, but runtime login-as-each-role and screenshot validation still needs a Windows/.NET workstation.
 - Reservations now have a completed desktop workflow surface, but runtime add/edit/confirm/cancel/fulfill/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 - Rentals now have a completed desktop workflow surface, but runtime check-in/extend/request/delete/print/document and screenshot validation still need a Windows/.NET workstation.
 - Categories now have a completed desktop workflow surface, but runtime create/rename/delete/filter/print/copy and screenshot validation still need a Windows/.NET workstation.
@@ -58,6 +58,6 @@ Last audit date/time: 2026-06-17 16:11 NZST
 
 ## Validation status
 
-- GitHub connector readback reviewed the Import / Export permission UI change and progress note.
+- GitHub connector readback reviewed the admin permission impact review branch.
 - Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, and `scripts/run-app-qa-screenshots.ps1` were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
 - Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ViewModels/UsersEditViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UsersEditViewModel.cs
@@ -38,6 +38,29 @@ namespace InventoryManagementApp.ViewModels
             ? "Nothing is hidden while Full administrator is ticked."
             : BuildPermissionSummary(GetHiddenPermissionLabels(), "Nothing hidden for the selected permissions.");
 
+        public string WorkflowImpactSummary => EditingUser.IsAdmin
+            ? BuildChecklistSummary(new[]
+            {
+                "All operational, insight, data, and admin workbenches are visible.",
+                "All guarded service actions are available, including settings, users, inventory edits, and imports."
+            }, "")
+            : BuildChecklistSummary(GetWorkflowImpactLines(), "No end-to-end workflow access is assigned yet.");
+
+        public string GuardedActionSummary => EditingUser.IsAdmin
+            ? BuildChecklistSummary(new[]
+            {
+                "Can manage users and reset passwords.",
+                "Can change settings and workstation configuration.",
+                "Can create, update, delete, import, and export inventory data."
+            }, "")
+            : BuildChecklistSummary(GetGuardedActionLines(), "No admin-level guarded actions are assigned.");
+
+        public string AdminNextStepSummary => EditingUser.IsAdmin
+            ? "Save this user as a full administrator only when they should have unrestricted app control."
+            : GetAllowedPermissionLabels().Any()
+                ? "Review the visible sections, operational impact, and guarded actions below before saving this custom access profile."
+                : "Tick at least one section or choose a preset before saving, unless this inactive/no-access account is intentional.";
+
         public bool CanManageItems { get => Has(User.PermissionManageItems); set => Set(User.PermissionManageItems, value); }
         public bool CanUseRentals { get => Has(User.PermissionRentals); set => Set(User.PermissionRentals, value); }
         public bool CanUseCustomers { get => Has(User.PermissionCustomers); set => Set(User.PermissionCustomers, value); }
@@ -130,10 +153,54 @@ namespace InventoryManagementApp.ViewModels
                 .Where(permission => !EditingUser.HasPermission(permission.Key))
                 .Select(permission => permission.Value);
 
+        IEnumerable<string> GetWorkflowImpactLines()
+        {
+            if (Has(User.PermissionManageItems))
+                yield return "Inventory desk: can manage item records and complete stock/status changes.";
+            if (Has(User.PermissionRentals))
+                yield return "Rental desk: can check items out, check them in, extend rentals, and print rental documents.";
+            if (Has(User.PermissionCustomers))
+                yield return "Customer desk: can find customers, maintain contact details, and print handoff sheets.";
+            if (Has(User.PermissionReservations))
+                yield return "Holds desk: can review, confirm, cancel, fulfill, and print reservation handoffs.";
+            if (Has(User.PermissionMaintenance) || Has(User.PermissionCalibration))
+                yield return "Technician bench: can review maintenance/calibration queues and complete shelf-readiness work.";
+            if (Has(User.PermissionKits))
+                yield return "Kit bench: can inspect kit membership, availability, and pick sheets.";
+            if (Has(User.PermissionCategories))
+                yield return "Category setup: can organize item categories used by the operational pages.";
+            if (Has(User.PermissionPrintLabels))
+                yield return "Label station: can open the print-label workflow for shelf and tool labeling.";
+            if (Has(User.PermissionReports) || Has(User.PermissionActivityLogs))
+                yield return "Insights: can review reports or audit activity when those boxes are ticked.";
+            if (Has(User.PermissionImportExport))
+                yield return "Data workstation: can import/export data and run image mapping where allowed.";
+            if (Has(User.PermissionManageUsers) || Has(User.PermissionSettings))
+                yield return "Admin area: can open Users or Settings when the matching admin boxes are ticked.";
+        }
+
+        IEnumerable<string> GetGuardedActionLines()
+        {
+            if (Has(User.PermissionManageUsers))
+                yield return "Manage users: add/edit users, reset passwords, upload photos, and remove accounts.";
+            if (Has(User.PermissionSettings))
+                yield return "Settings: update branding, labels, backups, messaging, email, database, and security options.";
+            if (Has(User.PermissionManageItems))
+                yield return "Manage items: create, update, delete, and save inventory records.";
+            if (Has(User.PermissionImportExport))
+                yield return "Import / export: run bulk data imports/exports and item image imports.";
+        }
+
         static string BuildPermissionSummary(IEnumerable<string> labels, string emptyText)
         {
             var list = labels.ToList();
             return list.Count == 0 ? emptyText : string.Join(", ", list);
+        }
+
+        static string BuildChecklistSummary(IEnumerable<string> lines, string emptyText)
+        {
+            var list = lines.Where(line => !string.IsNullOrWhiteSpace(line)).ToList();
+            return list.Count == 0 ? emptyText : string.Join(Environment.NewLine, list.Select(line => $"- {line}"));
         }
 
         void NotifyAllPermissionProperties()
@@ -156,6 +223,9 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(PermissionStatusSummary));
             OnPropertyChanged(nameof(AllowedPermissionSummary));
             OnPropertyChanged(nameof(HiddenPermissionSummary));
+            OnPropertyChanged(nameof(WorkflowImpactSummary));
+            OnPropertyChanged(nameof(GuardedActionSummary));
+            OnPropertyChanged(nameof(AdminNextStepSummary));
         }
 
         void BrowseImage()

--- a/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/UsersEditWindow.xaml
@@ -3,7 +3,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
-        Title="User Profile" Width="960" Height="720" MinWidth="760" MinHeight="560" WindowStartupLocation="CenterOwner"
+        Title="User Profile" Width="1020" Height="760" MinWidth="800" MinHeight="600" WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
     <Grid Margin="10">
         <Grid.RowDefinitions>
@@ -26,10 +26,10 @@
         </Border>
 
         <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-            <Grid MinHeight="470">
+            <Grid MinHeight="500">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="150"/>
-                    <ColumnDefinition Width="*" MinWidth="560"/>
+                    <ColumnDefinition Width="*" MinWidth="600"/>
                 </Grid.ColumnDefinitions>
 
                 <Border Grid.Column="0"
@@ -87,9 +87,9 @@
 
                 <Grid Grid.Column="1">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="1.05*" MinWidth="260"/>
+                        <ColumnDefinition Width="1.05*" MinWidth="270"/>
                         <ColumnDefinition Width="8"/>
-                        <ColumnDefinition Width="1.35*" MinWidth="300"/>
+                        <ColumnDefinition Width="1.45*" MinWidth="330"/>
                     </Grid.ColumnDefinitions>
 
                     <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
@@ -203,6 +203,7 @@
                                             <StackPanel>
                                                 <TextBlock Text="Access result" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
                                                 <TextBlock Text="{Binding PermissionStatusSummary}" TextWrapping="Wrap"/>
+                                                <TextBlock Text="{Binding AdminNextStepSummary}" Style="{StaticResource CaptionTextBlock}" Margin="0,4,0,0" TextWrapping="Wrap"/>
                                             </StackPanel>
                                         </Border>
                                         <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="6" Background="{DynamicResource SurfaceAltBrush}" Margin="0,0,0,6">
@@ -211,10 +212,22 @@
                                                 <TextBlock Text="{Binding AllowedPermissionSummary}" TextWrapping="Wrap"/>
                                             </StackPanel>
                                         </Border>
-                                        <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="6" Background="{DynamicResource TextBoxBackgroundBrush}">
+                                        <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="6" Background="{DynamicResource TextBoxBackgroundBrush}" Margin="0,0,0,6">
                                             <StackPanel>
                                                 <TextBlock Text="Hidden or blocked" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
                                                 <TextBlock Text="{Binding HiddenPermissionSummary}" TextWrapping="Wrap"/>
+                                            </StackPanel>
+                                        </Border>
+                                        <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="6" Background="{DynamicResource SurfaceAltBrush}" Margin="0,0,0,6">
+                                            <StackPanel>
+                                                <TextBlock Text="Operational impact" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
+                                                <TextBlock Text="{Binding WorkflowImpactSummary}" TextWrapping="Wrap"/>
+                                            </StackPanel>
+                                        </Border>
+                                        <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="6" Background="{DynamicResource TextBoxBackgroundBrush}">
+                                            <StackPanel>
+                                                <TextBlock Text="Guarded actions" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
+                                                <TextBlock Text="{Binding GuardedActionSummary}" TextWrapping="Wrap"/>
                                             </StackPanel>
                                         </Border>
                                     </StackPanel>


### PR DESCRIPTION
## Summary

- Adds live operational-impact and guarded-action summaries to the user permission editor.
- Adds next-step guidance for full-admin, custom-access, and no-access states so admins can see what a checkbox set means before saving.
- Records the completed admin permission review in progress notes and the completion checklist.

## Why

The permission checkboxes were functional, but admins still had to infer the practical result. This makes the editor explain whether a user can finish rental desk, technician bench, data import, settings, or user-management work from the selected permissions.

## Validation

- Compared `codex/admin-permission-impact-review` against `master`; the branch is ahead by 4 commits and not behind.
- Read back the changed user editor view model, user editor XAML, progress note, and checklist through the GitHub connector.
- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local cloning/raw fetches remain blocked by the network tunnel.
- Did not run unrelated tests, per instruction.