### PR TITLE
Add shell workflow guidance and screenshot review checklist

### DIFF
--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -4,14 +4,15 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         xmlns:pages="clr-namespace:InventoryManagementApp.Views.Pages"
-        Title="{Binding WindowTitle}" Width="1280" Height="800" WindowStartupLocation="CenterScreen"
+        Title="{Binding WindowTitle}" Width="1280" Height="800" MinWidth="920" MinHeight="620" WindowStartupLocation="CenterScreen"
         Background="{DynamicResource BackgroundBrush}">
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="214"/>
+            <ColumnDefinition Width="214" MinWidth="190" MaxWidth="230"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
@@ -22,39 +23,34 @@
                 BorderBrush="{DynamicResource BorderBrushBase}"
                 BorderThickness="0,0,0,1"
                 Padding="8,5">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="260"/>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-                <StackPanel VerticalAlignment="Center">
-                    <TextBlock Text="{Binding WindowTitle}" Style="{StaticResource HeadingTextBlock}"/>
-                    <TextBlock Text="Workshop inventory and rental control" Style="{StaticResource CaptionTextBlock}"/>
+            <WrapPanel Orientation="Horizontal" VerticalAlignment="Center">
+                <StackPanel Width="250" MinWidth="210" VerticalAlignment="Center" Margin="0,0,10,4">
+                    <TextBlock Text="{Binding WindowTitle}" Style="{StaticResource HeadingTextBlock}" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock Text="Workshop inventory and rental control" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis"/>
                 </StackPanel>
-                <pages:SearchBar Grid.Column="1"
-                                 Width="460"
+                <pages:SearchBar Width="420"
+                                 MinWidth="260"
                                  HorizontalAlignment="Left"
                                  VerticalAlignment="Center"
-                                 Margin="10,0,0,0"
+                                 Margin="0,0,10,4"
                                  Text="{Binding GlobalSearchText}"
                                  SearchCommand="{Binding GlobalSearchCommand}"
                                  SearchLabel=""/>
-                <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center" Margin="10,0,0,0">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,0,4">
                     <Border Width="26" Height="26" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Margin="0,0,6,0">
                         <controls:UserAvatar UserName="{Binding CurrentUserName}"
                                               UserPhotoPath="{Binding CurrentUserPhotoPath}"
                                               Foreground="{Binding CurrentUserInitialsBrush}"
                                               FontSize="13"/>
                     </Border>
-                    <StackPanel Margin="0,0,8,0" VerticalAlignment="Center">
-                        <TextBlock Text="{Binding CurrentUserName}" FontWeight="SemiBold" TextWrapping="NoWrap"/>
-                        <TextBlock Text="{Binding CurrentUserRole}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap"/>
+                    <StackPanel Width="132" Margin="0,0,8,0" VerticalAlignment="Center">
+                        <TextBlock Text="{Binding CurrentUserName}" FontWeight="SemiBold" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
+                        <TextBlock Text="{Binding CurrentUserRole}" Style="{StaticResource CaptionTextBlock}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
                     </StackPanel>
                     <Button Style="{StaticResource GhostButton}" Content="Switch User" Command="{Binding SwitchUserCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource GhostButton}" Content="Exit" Command="{Binding ExitCommand}"/>
                 </StackPanel>
-            </Grid>
+            </WrapPanel>
         </Border>
 
         <Border Grid.Row="1" Grid.ColumnSpan="2"
@@ -71,7 +67,7 @@
             </WrapPanel>
         </Border>
 
-        <Border Grid.Row="2" Grid.Column="0"
+        <Border Grid.Row="2" Grid.RowSpan="2" Grid.Column="0"
                 Background="{DynamicResource SurfaceBrush}"
                 BorderBrush="{DynamicResource BorderBrushBase}"
                 BorderThickness="0,0,1,0"
@@ -102,7 +98,7 @@
                                    Foreground="{DynamicResource ForegroundMutedBrush}"/>
                         <StackPanel Grid.Column="1" Margin="6,0,0,0" VerticalAlignment="Center">
                             <TextBlock Text="Sections" Style="{StaticResource PageTitleTextBlock}"/>
-                            <TextBlock Text="{Binding CurrentNavSectionTitle}" Style="{StaticResource CaptionTextBlock}"/>
+                            <TextBlock Text="{Binding CurrentNavSectionTitle}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis"/>
                         </StackPanel>
                     </Grid>
                 </Border>
@@ -132,7 +128,35 @@
             </Grid>
         </Border>
 
-        <Frame Grid.Row="2"
+        <Border Grid.Row="2" Grid.Column="1"
+                Background="{DynamicResource SurfaceBrush}"
+                BorderBrush="{DynamicResource BorderBrushBase}"
+                BorderThickness="0,0,0,1"
+                Padding="8,6">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel VerticalAlignment="Center" Margin="0,0,12,0">
+                    <TextBlock Text="{Binding CurrentPageTitle}" Style="{StaticResource PageTitleTextBlock}" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock Text="{Binding CurrentWorkflowGuide}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                </StackPanel>
+                <WrapPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                    <Button Style="{StaticResource GhostButton}"
+                            Content="{Binding CurrentWorkflowPrimaryActionText}"
+                            Command="{Binding CurrentWorkflowPrimaryCommand}"
+                            Visibility="{Binding HasCurrentWorkflowPrimaryAction, Converter={StaticResource BoolToVis}}"
+                            Margin="0,0,4,0"/>
+                    <Button Style="{StaticResource GhostButton}"
+                            Content="{Binding CurrentWorkflowSecondaryActionText}"
+                            Command="{Binding CurrentWorkflowSecondaryCommand}"
+                            Visibility="{Binding HasCurrentWorkflowSecondaryAction, Converter={StaticResource BoolToVis}}"/>
+                </WrapPanel>
+            </Grid>
+        </Border>
+
+        <Frame Grid.Row="3"
                Grid.Column="1"
                Name="MainFrame"
                NavigationUIVisibility="Hidden"

--- a/InventoryManagementApp/ProgressNotes/2026-06-17-shell-workflow-guidance.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-shell-workflow-guidance.md
@@ -1,0 +1,18 @@
+# Shell Workflow Guidance - 2026-06-17
+
+## Completed
+
+- Added a shell-level workflow guidance strip that updates with the current page and explains the next operational step in technician, advisor, data, insight, or admin language.
+- Added permission-aware quick jumps from each page to related workbenches, such as Search to Rentals, Customers to Reservations, Settings to Users, and technician pages to each other.
+- Reworked the main header into a wrapping layout with a minimum window size and trimmed user/title text so search, identity, and session controls hold together on narrower workstations.
+- Enhanced the QA screenshot gallery output with a visual and workflow review checklist for layout, clipping, handoff, drilling, and role-completion checks.
+
+## Why it matters
+
+The individual pages have been upgraded into focused workbenches, but users still need to move between them without guessing where the next step lives. This pass gives the shell a consistent operator handoff layer so a technician, advisor, or admin can see the page purpose and jump to the most likely follow-up without backing out or hunting through every section.
+
+## Validation
+
+- Read and changed `MainWindow.xaml`, `MainViewModel.cs`, and `scripts/run-app-qa-screenshots.ps1` through the GitHub connector.
+- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
+- Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 17:11 NZST
+Last audit date/time: 2026-06-17 17:49 NZST
 
 ## Completed workflows
 
@@ -31,6 +31,8 @@ Last audit date/time: 2026-06-17 17:11 NZST
 - QA screenshot review now produces a browser-friendly `index.html` gallery grouped by app area and fails when unexpected PNG captures appear without updating the expected screenshot manifest.
 - Rentals now use a rental desk workbench with a main rental directory, selected-rental advisor handoff, customer/timing/shelf context, check-in/extend/request/document actions, open request queue, row-correct context menus, wrapping toolbar actions, and a compact footer for repeated desk work.
 - Categories now use an admin workbench layout with a directory pane, selected-category handoff, next action, setup checklist, name review, status feedback, row-correct context menus, keyboard shortcuts, printable directory output, and printable selected-category sheets.
+- The main shell now shows page-aware workflow guidance and permission-aware quick jumps so technicians, advisors, data users, and admins can drill to the next related workbench without hunting through the app.
+- The main header now wraps search, user identity, and session actions more safely on narrower workstations, and the screenshot review gallery now includes a visual/workflow checklist for future QA passes.
 
 ## Partially complete workflows
 
@@ -45,6 +47,7 @@ Last audit date/time: 2026-06-17 17:11 NZST
 - Reservations now have a completed desktop workflow surface, but runtime add/edit/confirm/cancel/fulfill/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 - Rentals now have a completed desktop workflow surface, but runtime check-in/extend/request/delete/print/document and screenshot validation still need a Windows/.NET workstation.
 - Categories now have a completed desktop workflow surface, but runtime create/rename/delete/filter/print/copy and screenshot validation still need a Windows/.NET workstation.
+- Shell workflow guidance and responsive header behavior have been implemented, but runtime narrow/wide workstation screenshot review still needs a Windows/.NET workstation.
 
 ## Known broken workflows
 
@@ -54,10 +57,10 @@ Last audit date/time: 2026-06-17 17:11 NZST
 
 ## Next recommended target
 
-- Continue the end-to-end workflow audit from a technician/advisor/admin perspective, with the next useful pass focused on using the new screenshot review index to identify any cramped or inconsistent pages after a Windows QA capture run.
+- Run the enhanced Windows QA screenshot capture and review the generated checklist/index for any remaining cramped shell/page combinations, especially at narrow workstation widths.
 
 ## Validation status
 
-- GitHub connector readback reviewed the admin permission impact review branch.
+- GitHub connector readback reviewed the shell workflow guidance branch and progress note.
 - Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, and `scripts/run-app-qa-screenshots.ps1` were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
 - Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -86,8 +86,58 @@ namespace InventoryManagementApp.ViewModels
         public string CurrentPageTitle
         {
             get => _currentPageTitle;
-            private set => SetProperty(ref _currentPageTitle, value);
+            private set
+            {
+                if (SetProperty(ref _currentPageTitle, value))
+                    RefreshShellWorkflow();
+            }
         }
+
+        private string _currentWorkflowGuide = "Search or open a dashboard view to start the workflow.";
+        public string CurrentWorkflowGuide
+        {
+            get => _currentWorkflowGuide;
+            private set => SetProperty(ref _currentWorkflowGuide, value);
+        }
+
+        private string _currentWorkflowPrimaryActionText = string.Empty;
+        public string CurrentWorkflowPrimaryActionText
+        {
+            get => _currentWorkflowPrimaryActionText;
+            private set => SetProperty(ref _currentWorkflowPrimaryActionText, value);
+        }
+
+        private string _currentWorkflowSecondaryActionText = string.Empty;
+        public string CurrentWorkflowSecondaryActionText
+        {
+            get => _currentWorkflowSecondaryActionText;
+            private set => SetProperty(ref _currentWorkflowSecondaryActionText, value);
+        }
+
+        private IAsyncRelayCommand? _currentWorkflowPrimaryCommand;
+        public IAsyncRelayCommand? CurrentWorkflowPrimaryCommand
+        {
+            get => _currentWorkflowPrimaryCommand;
+            private set
+            {
+                if (SetProperty(ref _currentWorkflowPrimaryCommand, value))
+                    OnPropertyChanged(nameof(HasCurrentWorkflowPrimaryAction));
+            }
+        }
+
+        private IAsyncRelayCommand? _currentWorkflowSecondaryCommand;
+        public IAsyncRelayCommand? CurrentWorkflowSecondaryCommand
+        {
+            get => _currentWorkflowSecondaryCommand;
+            private set
+            {
+                if (SetProperty(ref _currentWorkflowSecondaryCommand, value))
+                    OnPropertyChanged(nameof(HasCurrentWorkflowSecondaryAction));
+            }
+        }
+
+        public bool HasCurrentWorkflowPrimaryAction => CurrentWorkflowPrimaryCommand != null && !string.IsNullOrWhiteSpace(CurrentWorkflowPrimaryActionText);
+        public bool HasCurrentWorkflowSecondaryAction => CurrentWorkflowSecondaryCommand != null && !string.IsNullOrWhiteSpace(CurrentWorkflowSecondaryActionText);
 
         private string _currentNavSectionTitle = "Overview";
         public string CurrentNavSectionTitle
@@ -244,6 +294,7 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(IsAdminSectionVisible));
             OnPropertyChanged(nameof(IsDataSectionVisible));
             SetNavSection(SelectedNavSectionKey);
+            RefreshShellWorkflow();
         }
 
         void CloseNonMainWindows()
@@ -829,6 +880,142 @@ namespace InventoryManagementApp.ViewModels
             _globalSearchDebounceTimer.Stop();
         }
 
+        void RefreshShellWorkflow()
+        {
+            var title = CurrentPageTitle ?? string.Empty;
+            var lowerTitle = title.ToLowerInvariant();
+            var itemLabelPlural = LabelProvider.Instance.ItemLabelPlural;
+
+            if (lowerTitle.Contains("search"))
+            {
+                SetWorkflow(
+                    $"Find an item, open details, then move to Rentals or Reservations when the shelf status requires an advisor handoff.",
+                    "Open Rentals", Can(User.PermissionRentals) ? OpenRentalsCommand : null,
+                    "Dashboard", OpenDashboardCommand);
+            }
+            else if (lowerTitle.Contains("dashboard"))
+            {
+                SetWorkflow(
+                    "Review live workload, then drill into the operations page that owns the selected issue or activity.",
+                    $"Manage {itemLabelPlural}", Can(User.PermissionManageItems) ? OpenManageItemsCommand : null,
+                    "Reports", Can(User.PermissionReports) ? OpenReportsCommand : null);
+            }
+            else if (lowerTitle.Contains("rental"))
+            {
+                SetWorkflow(
+                    "Complete checkout, check-in, extension, request, document, and open-request follow-up from this rental desk.",
+                    "Customers", Can(User.PermissionCustomers) ? OpenCustomersCommand : null,
+                    "Reservations", Can(User.PermissionReservations) ? OpenReservationsCommand : null);
+            }
+            else if (lowerTitle.Contains("customer"))
+            {
+                SetWorkflow(
+                    "Confirm contact and address details, then continue to Rentals or Reservations for the customer handoff.",
+                    "Rentals", Can(User.PermissionRentals) ? OpenRentalsCommand : null,
+                    "Reservations", Can(User.PermissionReservations) ? OpenReservationsCommand : null);
+            }
+            else if (lowerTitle.Contains("reservation"))
+            {
+                SetWorkflow(
+                    "Track holds from request through confirmation, shelf pickup, fulfillment, cancellation, or printed handoff.",
+                    "Rentals", Can(User.PermissionRentals) ? OpenRentalsCommand : null,
+                    $"Search {itemLabelPlural}", OpenSearchItemsCommand);
+            }
+            else if (lowerTitle.Contains("maintenance"))
+            {
+                SetWorkflow(
+                    "Work the technician backlog, complete bench actions, and return ready items to the shelf workflow.",
+                    "Calibration", Can(User.PermissionCalibration) ? OpenCalibrationCommand : null,
+                    $"Search {itemLabelPlural}", OpenSearchItemsCommand);
+            }
+            else if (lowerTitle.Contains("calibration"))
+            {
+                SetWorkflow(
+                    "Review due certificates, complete shelf-release checks, and use Maintenance for repair follow-up.",
+                    "Maintenance", Can(User.PermissionMaintenance) ? OpenMaintenanceCommand : null,
+                    $"Search {itemLabelPlural}", OpenSearchItemsCommand);
+            }
+            else if (lowerTitle.Contains("kit"))
+            {
+                SetWorkflow(
+                    "Audit kit membership and availability, then jump to item search or rentals for pickup work.",
+                    $"Search {itemLabelPlural}", OpenSearchItemsCommand,
+                    "Rentals", Can(User.PermissionRentals) ? OpenRentalsCommand : null);
+            }
+            else if (lowerTitle.Contains("categor"))
+            {
+                SetWorkflow(
+                    "Keep category setup aligned with item records so operational filters and reports stay useful.",
+                    $"Manage {itemLabelPlural}", Can(User.PermissionManageItems) ? OpenManageItemsCommand : null,
+                    "Reports", Can(User.PermissionReports) ? OpenReportsCommand : null);
+            }
+            else if (lowerTitle.Contains("report"))
+            {
+                SetWorkflow(
+                    "Use report rows as a triage launch point, then open the source workflow that owns the result.",
+                    "Dashboard", OpenDashboardCommand,
+                    "Activity Logs", Can(User.PermissionActivityLogs) ? OpenActivityLogsCommand : null);
+            }
+            else if (lowerTitle.Contains("activity"))
+            {
+                SetWorkflow(
+                    "Audit who changed what, copy evidence, then open Reports or Settings when follow-up is needed.",
+                    "Reports", Can(User.PermissionReports) ? OpenReportsCommand : null,
+                    "Settings", Can(User.PermissionSettings) ? OpenSettingsCommand : null);
+            }
+            else if (lowerTitle.Contains("import") || lowerTitle.Contains("export"))
+            {
+                SetWorkflow(
+                    "Run item, customer, backup, and image data work, then review reports to confirm the operational result.",
+                    "Reports", Can(User.PermissionReports) ? OpenReportsCommand : null,
+                    $"Manage {itemLabelPlural}", Can(User.PermissionManageItems) ? OpenManageItemsCommand : null);
+            }
+            else if (lowerTitle.Contains("user"))
+            {
+                SetWorkflow(
+                    "Manage users, passwords, lockouts, photos, and permission sets, then verify service access in Settings when required.",
+                    "Settings", Can(User.PermissionSettings) ? OpenSettingsCommand : null,
+                    "Activity Logs", Can(User.PermissionActivityLogs) ? OpenActivityLogsCommand : null);
+            }
+            else if (lowerTitle.Contains("setting"))
+            {
+                SetWorkflow(
+                    "Review service status and adjust workstation, label, backup, messaging, branding, email, and database configuration.",
+                    "Users", Can(User.PermissionManageUsers) ? OpenUsersCommand : null,
+                    "Import / Export", Can(User.PermissionImportExport) ? OpenImportExportCommand : null);
+            }
+            else if (lowerTitle.Contains("manage") && lowerTitle.Contains(itemLabelPlural.ToLowerInvariant()))
+            {
+                SetWorkflow(
+                    "Maintain item records, photos, stock, shelf state, and repair flags before the desk or technician workflows use them.",
+                    "Rentals", Can(User.PermissionRentals) ? OpenRentalsCommand : null,
+                    "Categories", Can(User.PermissionCategories) ? OpenCategoriesCommand : null);
+            }
+            else
+            {
+                SetWorkflow(
+                    $"Use {CurrentNavSectionTitle} navigation to continue the workflow; related actions appear here when a page is open.",
+                    $"Search {itemLabelPlural}", OpenSearchItemsCommand,
+                    "Dashboard", OpenDashboardCommand);
+            }
+        }
+
+        void SetWorkflow(
+            string guide,
+            string primaryText,
+            IAsyncRelayCommand? primaryCommand,
+            string secondaryText,
+            IAsyncRelayCommand? secondaryCommand)
+        {
+            CurrentWorkflowGuide = guide;
+            CurrentWorkflowPrimaryActionText = primaryCommand == null ? string.Empty : primaryText;
+            CurrentWorkflowPrimaryCommand = primaryCommand;
+            CurrentWorkflowSecondaryActionText = secondaryCommand == null ? string.Empty : secondaryText;
+            CurrentWorkflowSecondaryCommand = secondaryCommand;
+            OnPropertyChanged(nameof(HasCurrentWorkflowPrimaryAction));
+            OnPropertyChanged(nameof(HasCurrentWorkflowSecondaryAction));
+        }
+
         void SetNavSection(string key)
         {
             var items = BuildNavItems(key);
@@ -864,6 +1051,8 @@ namespace InventoryManagementApp.ViewModels
             CurrentNavItems.Clear();
             foreach (var item in items)
                 CurrentNavItems.Add(item);
+
+            RefreshShellWorkflow();
         }
 
         List<NavItem> BuildNavItems(string key)

--- a/scripts/run-app-qa-screenshots.ps1
+++ b/scripts/run-app-qa-screenshots.ps1
@@ -101,6 +101,15 @@ $expectedScreenshotFiles = @(
     "05-admin\09-settings-backups.png",
     "06-dialogs\01-print-labels.png"
 )
+$reviewChecklist = @(
+    "Header, search, and signed-in user controls wrap without overlapping or clipping.",
+    "The workflow guidance strip matches the active page and offers useful related jumps.",
+    "Each capture shows a clear selected-row or empty-state path to the next action.",
+    "Toolbar and context actions remain reachable on narrow and wide workstations.",
+    "Text in grids, handoff panels, and buttons fits its container without hiding important values.",
+    "Admin-only pages explain what the setting or permission change affects before saving.",
+    "Technician and advisor flows can be completed from the current page or one visible drill-down."
+)
 $expectedScreenshotSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 foreach ($expectedFile in $expectedScreenshotFiles) {
     [void]$expectedScreenshotSet.Add($expectedFile)
@@ -253,6 +262,11 @@ try {
     Add-Content -Path $readmePath -Value ("Minimum PNG size checked: {0} bytes" -f $minimumScreenshotBytes)
     Add-Content -Path $readmePath -Value ("Minimum PNG dimensions checked: {0}x{1}" -f $minimumScreenshotWidth, $minimumScreenshotHeight)
     Add-Content -Path $readmePath -Value ""
+    Add-Content -Path $readmePath -Value "Review checklist:"
+    foreach ($reviewItem in $reviewChecklist) {
+        Add-Content -Path $readmePath -Value ("- {0}" -f $reviewItem)
+    }
+    Add-Content -Path $readmePath -Value ""
     Add-Content -Path $readmePath -Value "Captured files:"
     foreach ($capture in $captureRows) {
         Add-Content -Path $readmePath -Value ("- `{0}` - {1}x{2}, {3} bytes" -f $capture.Path, $capture.Width, $capture.Height, $capture.Bytes)
@@ -267,12 +281,17 @@ try {
     $html.Add('<meta name="viewport" content="width=device-width, initial-scale=1">'.Replace('\"', '"'))
     $html.Add('<title>QA Screenshot Review</title>')
     $html.Add('<style>')
-    $html.Add('body{margin:0;font-family:Segoe UI,Arial,sans-serif;background:#f5f7fa;color:#17202a;}header{position:sticky;top:0;background:#ffffff;border-bottom:1px solid #d8dee8;padding:14px 20px;z-index:1;}h1{font-size:20px;margin:0 0 4px;}p{margin:0;color:#526071;}main{padding:20px;}section{margin:0 0 28px;}h2{font-size:16px;margin:0 0 10px;} .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,1fr));gap:14px;}figure{margin:0;background:#fff;border:1px solid #d8dee8;border-radius:6px;overflow:hidden;}img{display:block;width:100%;height:auto;background:#eef2f6;}figcaption{padding:8px 10px;font-size:12px;color:#526071;line-height:1.35;}code{color:#17202a;font-weight:600;} .meta{display:block;margin-top:3px;}@media (max-width:520px){main{padding:12px}.grid{grid-template-columns:1fr;}}')
+    $html.Add('body{margin:0;font-family:Segoe UI,Arial,sans-serif;background:#f5f7fa;color:#17202a;}header{position:sticky;top:0;background:#ffffff;border-bottom:1px solid #d8dee8;padding:14px 20px;z-index:1;}h1{font-size:20px;margin:0 0 4px;}p{margin:0;color:#526071;}main{padding:20px;}section{margin:0 0 28px;}h2{font-size:16px;margin:0 0 10px;}.review{background:#fff;border:1px solid #d8dee8;border-radius:6px;padding:12px;margin:0 0 22px;}.review ul{margin:8px 0 0;padding-left:20px;color:#344154;line-height:1.45;}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,1fr));gap:14px;}figure{margin:0;background:#fff;border:1px solid #d8dee8;border-radius:6px;overflow:hidden;}img{display:block;width:100%;height:auto;background:#eef2f6;}figcaption{padding:8px 10px;font-size:12px;color:#526071;line-height:1.35;}code{color:#17202a;font-weight:600;}.meta{display:block;margin-top:3px;}@media (max-width:520px){main{padding:12px}.grid{grid-template-columns:1fr;}}')
     $html.Add('</style>')
     $html.Add('</head>')
     $html.Add('<body>')
     $html.Add("<header><h1>QA Screenshot Review</h1><p>Generated $(Convert-ToHtmlAttribute (Get-Date -Format 'yyyy-MM-dd HH:mm:ss')) | $($captureRows.Count) captures | minimum $minimumScreenshotWidth x $minimumScreenshotHeight px and $minimumScreenshotBytes bytes</p></header>")
     $html.Add('<main>')
+    $html.Add('<section class="review"><h2>Visual and workflow checklist</h2><ul>'.Replace('\"', '"'))
+    foreach ($reviewItem in $reviewChecklist) {
+        $html.Add("<li>$(Convert-ToHtmlAttribute $reviewItem)</li>")
+    }
+    $html.Add('</ul></section>')
     foreach ($folder in $expectedFolders) {
         $folderCaptures = @($captureRows | Where-Object { $_.Folder -eq $folder })
         if ($folderCaptures.Count -eq 0) { continue }


### PR DESCRIPTION
## Summary

- Adds a shell-level workflow guidance strip that changes with the active page and explains the next technician, advisor, data, insight, or admin step.
- Adds permission-aware quick jumps between related workbenches so users can drill from Search, Rentals, Customers, Reservations, Reports, Settings, and technician pages without hunting through sections.
- Reworks the main header into a wrapping layout with minimum window bounds and trimmed title/user text for narrower workstations.
- Enhances the QA screenshot gallery with a visual/workflow checklist for clipping, handoff, drilling, action reachability, and role-completion review.
- Records the completed shell pass in progress notes and the completion checklist.

## Validation

- Compared `codex/shell-workflow-guidance` against `master`; the branch is ahead by 5 commits and not behind.
- Read back the changed main shell XAML, main view model workflow mapping, screenshot script checklist, and progress note through the GitHub connector.
- GitHub reported no commit statuses for the branch head at review time.
- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local cloning/raw fetches remain blocked by the network tunnel.
- Did not run unrelated tests, per instruction.