### PR TITLE
Polish reservation workbench flow and wrapping

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-17-reservation-workbench-flow-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-reservation-workbench-flow-polish.md
@@ -1,0 +1,21 @@
+# Reservation Workbench Flow Polish - 2026-06-17
+
+## Completed
+
+- Reworked the Reservations toolbar into two wrapping rows so action buttons and search/filter controls do not compete for the same horizontal space on narrower workstations.
+- Tightened reservation grid column widths and detail-panel title sizing so hold, item, customer, date, quantity, and status information remains visible with less clipping pressure.
+- Added page-level keyboard paths for common advisor/admin outcomes: search, add hold, open details, copy handoff, print list, print selected handoff, confirm, fulfill, and cancel.
+- Improved right-click behavior so context menus act on the row under the pointer, matching the row-correct pattern used in other workbenches.
+- Kept text-editing shortcuts safe by allowing normal text copy while focus is inside a text entry control.
+
+## User workflow impact
+
+- Advisors can search for a hold, inspect the selected handoff, confirm or fulfill it, and print/copy the handoff without losing their place.
+- Technicians and shelf runners get clearer selected-hold context with less visual crowding when the window is narrower.
+- Admin users retain the same durable actions while the page better exposes the current selection and finishing action.
+
+## Validation
+
+- Read and updated the target XAML/code-behind through the GitHub connector because local cloning remains blocked by the network tunnel.
+- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime.
+- Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/Views/Pages/ReservationPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ReservationPage.xaml
@@ -11,40 +11,47 @@
         </Grid.RowDefinitions>
 
         <Border Style="{StaticResource ToolbarCard}">
-            <DockPanel LastChildFill="True">
-                <WrapPanel DockPanel.Dock="Left" VerticalAlignment="Center">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <WrapPanel Grid.Row="0" VerticalAlignment="Center">
                     <TextBlock Text="Reservations" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,4"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddReservationCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Confirm" Command="{Binding ConfirmReservationCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource PrimaryButton}" Content="Fulfill" Command="{Binding FulfillReservationCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Add" Command="{Binding AddReservationCommand}" Margin="0,0,4,4" ToolTip="Create a new hold"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Confirm" Command="{Binding ConfirmReservationCommand}" Margin="0,0,4,4" ToolTip="Confirm the selected pending hold"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Fulfill" Command="{Binding FulfillReservationCommand}" Margin="0,0,4,4" ToolTip="Complete the selected confirmed hold with a rental ID"/>
                     <Button Style="{StaticResource GhostButton}" Content="Edit" Command="{Binding EditReservationCommand}" Margin="0,0,4,4"/>
                     <Button Style="{StaticResource GhostButton}" Content="Cancel" Command="{Binding CancelReservationCommand}" Margin="0,0,4,4"/>
                     <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteReservationCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Copy" Command="{Binding CopyReservationHandoffCommand}" Margin="0,0,4,4"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print" Command="{Binding PrintReservationHandoffCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Copy" Command="{Binding CopyReservationHandoffCommand}" Margin="0,0,4,4" ToolTip="Copy selected hold handoff"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print" Command="{Binding PrintReservationHandoffCommand}" Margin="0,0,4,4" ToolTip="Print selected hold handoff"/>
                     <Button Style="{StaticResource GhostButton}" Content="Print List" Command="{Binding PrintReservationDirectoryCommand}" Margin="0,0,4,4"/>
                     <Button Style="{StaticResource GhostButton}" Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,0,4,4"/>
                 </WrapPanel>
-                <WrapPanel DockPanel.Dock="Right" HorizontalAlignment="Right" VerticalAlignment="Center">
+                <WrapPanel Grid.Row="1" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="0,2,0,0">
                     <TextBlock Text="Find" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,4"/>
-                    <TextBox Width="190"
+                    <TextBox Width="230"
+                             MinWidth="150"
                              Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
                              ToolTip="Search reservation number, item, customer, status, or notes"
                              Margin="0,0,4,4"/>
-                    <ComboBox Width="150"
+                    <ComboBox Width="160"
+                              MinWidth="130"
                               ItemsSource="{Binding FilterOptions}"
                               SelectedItem="{Binding SelectedFilter}"
                               Margin="0,0,4,4"/>
                     <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearReservationSearchCommand}" Margin="0,0,4,4"/>
+                    <TextBlock Text="{Binding SelectedReservationSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,0,0,4"/>
                 </WrapPanel>
-            </DockPanel>
+            </Grid>
         </Border>
 
         <Grid Grid.Row="1" Margin="0,6,0,0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="3*" MinWidth="520"/>
-                <ColumnDefinition Width="6"/>
-                <ColumnDefinition Width="1.35*" MinWidth="280"/>
+                <ColumnDefinition Width="2.5*" MinWidth="430"/>
+                <ColumnDefinition Width="4"/>
+                <ColumnDefinition Width="1.15*" MinWidth="300"/>
             </Grid.ColumnDefinitions>
 
             <Border Grid.Column="0" Style="{StaticResource Card}" Padding="0">
@@ -58,7 +65,7 @@
                     <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
                         <DockPanel>
                             <TextBlock Text="01 Hold Directory" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
-                            <TextBlock Text="{Binding ReservationResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                            <TextBlock Text="{Binding ReservationResultsSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" TextWrapping="Wrap"/>
                         </DockPanel>
                     </Border>
 
@@ -84,14 +91,14 @@
                             </Style>
                         </DataGrid.RowStyle>
                         <DataGrid.Columns>
-                            <DataGridTextColumn Header="Hold #" Binding="{Binding ReservationID}" Width="80"/>
-                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="115"/>
-                            <DataGridTextColumn Header="Item" Binding="{Binding ItemName}" Width="1.45*"/>
-                            <DataGridTextColumn Header="Customer" Binding="{Binding CustomerName}" Width="1.35*"/>
-                            <DataGridTextColumn Header="Start" Binding="{Binding StartDate, StringFormat={}{0:yyyy-MM-dd}}" Width="105"/>
-                            <DataGridTextColumn Header="End" Binding="{Binding EndDate, StringFormat={}{0:yyyy-MM-dd}}" Width="105"/>
-                            <DataGridTextColumn Header="Qty" Binding="{Binding Quantity}" Width="55"/>
-                            <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="105"/>
+                            <DataGridTextColumn Header="Hold #" Binding="{Binding ReservationID}" Width="68"/>
+                            <DataGridTextColumn Header="Item #" Binding="{Binding ItemNumber}" Width="96"/>
+                            <DataGridTextColumn Header="Item" Binding="{Binding ItemName}" Width="1.3*"/>
+                            <DataGridTextColumn Header="Customer" Binding="{Binding CustomerName}" Width="1.2*"/>
+                            <DataGridTextColumn Header="Start" Binding="{Binding StartDate, StringFormat={}{0:yyyy-MM-dd}}" Width="92"/>
+                            <DataGridTextColumn Header="End" Binding="{Binding EndDate, StringFormat={}{0:yyyy-MM-dd}}" Width="92"/>
+                            <DataGridTextColumn Header="Qty" Binding="{Binding Quantity}" Width="48"/>
+                            <DataGridTextColumn Header="Status" Binding="{Binding StatusDisplay}" Width="96"/>
                         </DataGrid.Columns>
                         <DataGrid.ContextMenu>
                             <ContextMenu Style="{StaticResource {x:Type ContextMenu}}"
@@ -133,7 +140,7 @@
             </Border>
 
             <GridSplitter Grid.Column="1"
-                          Width="6"
+                          Width="4"
                           HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch"
                           Background="{DynamicResource BorderBrushBase}"/>
@@ -149,7 +156,8 @@
                         <StackPanel>
                             <TextBlock Text="Selected Hold" Style="{StaticResource SectionHeader}"/>
                             <TextBlock Text="{Binding SelectedReservationTitle}"
-                                       Style="{StaticResource PageTitleTextBlock}"
+                                       FontSize="15"
+                                       FontWeight="SemiBold"
                                        TextWrapping="Wrap"/>
                             <TextBlock Text="{Binding SelectedReservationSubtitle}"
                                        FontSize="11"
@@ -199,11 +207,11 @@
 
         <Border Grid.Row="2" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
             <DockPanel LastChildFill="True">
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
-                    <Button Style="{StaticResource PrimaryButton}" Content="Add Hold" Command="{Binding AddReservationCommand}" Margin="0,0,4,0"/>
-                    <Button Style="{StaticResource GhostButton}" Content="Print List" Command="{Binding PrintReservationDirectoryCommand}"/>
-                </StackPanel>
-                <TextBlock Text="{Binding SelectedReservationSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0"/>
+                <WrapPanel DockPanel.Dock="Right">
+                    <Button Style="{StaticResource PrimaryButton}" Content="Add Hold" Command="{Binding AddReservationCommand}" Margin="0,0,4,4"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Print List" Command="{Binding PrintReservationDirectoryCommand}" Margin="0,0,0,4"/>
+                </WrapPanel>
+                <TextBlock Text="{Binding SelectedReservationSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="2,0,10,0" TextWrapping="Wrap"/>
             </DockPanel>
         </Border>
     </Grid>

--- a/InventoryManagementApp/Views/Pages/ReservationPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReservationPage.xaml.cs
@@ -1,6 +1,8 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Media;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
@@ -11,14 +13,18 @@ namespace InventoryManagementApp.Views.Pages
         {
             InitializeComponent();
             Loaded += ReservationPage_Loaded;
+            PreviewKeyDown += ReservationPage_PreviewKeyDown;
         }
 
         private async void ReservationPage_Loaded(object sender, RoutedEventArgs e)
         {
+            Focus();
             if (DataContext is ReservationManagementViewModel vm)
             {
                 await vm.LoadReservationsCommand.ExecuteAsync(null);
             }
+
+            FocusFirstSearchBox();
         }
 
         private void ReservationRow_MouseDoubleClick(object sender, MouseButtonEventArgs e)
@@ -31,11 +37,136 @@ namespace InventoryManagementApp.Views.Pages
 
         private void ReservationRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            if (sender is DataGridRow row && !row.IsSelected)
+            SelectRowForContextMenu(sender, e);
+        }
+
+        private void ReservationPage_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (DataContext is not ReservationManagementViewModel vm)
+                return;
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.F)
             {
-                row.IsSelected = true;
-                row.Focus();
+                FocusFirstSearchBox();
+                e.Handled = true;
+                return;
             }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.N)
+            {
+                vm.AddReservationCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.P)
+            {
+                vm.PrintReservationDirectoryCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.P && vm.PrintReservationHandoffCommand.CanExecute(null))
+            {
+                vm.PrintReservationHandoffCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (!IsTextInputFocused() && Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.C && vm.CopyReservationHandoffCommand.CanExecute(null))
+            {
+                vm.CopyReservationHandoffCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.D && vm.OpenReservationDetailsCommand.CanExecute(null))
+            {
+                vm.OpenReservationDetailsCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.Control && e.Key == Key.Enter && vm.ConfirmReservationCommand.CanExecute(null))
+            {
+                vm.ConfirmReservationCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.Enter && vm.FulfillReservationCommand.CanExecute(null))
+            {
+                vm.FulfillReservationCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Enter && vm.OpenReservationDetailsCommand.CanExecute(null))
+            {
+                vm.OpenReservationDetailsCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (Keyboard.Modifiers == ModifierKeys.None && e.Key == Key.Delete && vm.CancelReservationCommand.CanExecute(null))
+            {
+                vm.CancelReservationCommand.Execute(null);
+                e.Handled = true;
+            }
+        }
+
+        private void FocusFirstSearchBox()
+        {
+            var searchBox = FindDescendant<TextBox>(this);
+            if (searchBox == null)
+                return;
+
+            searchBox.Focus();
+            searchBox.SelectAll();
+        }
+
+        private void SelectRowForContextMenu(object sender, MouseButtonEventArgs e)
+        {
+            var row = sender as DataGridRow ?? FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject);
+            if (row == null)
+                return;
+
+            row.IsSelected = true;
+            row.Focus();
+        }
+
+        private static bool IsTextInputFocused()
+        {
+            return Keyboard.FocusedElement is TextBoxBase or PasswordBox;
+        }
+
+        private static T? FindAncestor<T>(DependencyObject? current) where T : DependencyObject
+        {
+            while (current != null)
+            {
+                if (current is T match)
+                    return match;
+
+                current = VisualTreeHelper.GetParent(current);
+            }
+
+            return null;
+        }
+
+        private static T? FindDescendant<T>(DependencyObject current) where T : DependencyObject
+        {
+            for (var index = 0; index < VisualTreeHelper.GetChildrenCount(current); index++)
+            {
+                var child = VisualTreeHelper.GetChild(current, index);
+                if (child is T match)
+                    return match;
+
+                var nested = FindDescendant<T>(child);
+                if (nested != null)
+                    return nested;
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary

- Reworks the Reservations toolbar into wrapping action/search rows so the page behaves better on narrower workstations.
- Tightens reservation grid/detail sizing and keeps selected-hold context visible near the controls.
- Adds keyboard paths for advisor/admin outcomes: search, add, details, copy/print handoff, print list, confirm, fulfill, and cancel.
- Makes right-click context menus act on the row under the pointer and preserves normal text-copy behavior inside text fields.
- Records the completed reservation workbench polish in progress notes.

## Validation

- Compared the branch against `master` and read back the changed Reservation XAML/code-behind through the GitHub connector.
- GitHub reported no commit statuses for the branch head at review time.
- Local `dotnet` build/test and WPF screenshot execution were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local cloning/raw fetches remain blocked by the network tunnel.
- Did not run unrelated tests, per instruction.