### PR TITLE
[codex] Polish dashboard activity drilldown

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-17-dashboard-activity-drilldown.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-dashboard-activity-drilldown.md
@@ -1,0 +1,17 @@
+# Dashboard Activity Drilldown Polish - 2026-06-17
+
+## Completed
+
+- Added a visible `Open Related` action to the Dashboard recent activity pane so audit rows behave like the other dashboard work queues.
+- Replaced the generic recent-activity context menu choices with a single row-correct related-workflow action plus snapshot printing.
+- Updated dashboard activity routing so rental and reservation activity opens the rental desk, import/export activity opens the data workstation, and other inventory-like activity opens the item workflow.
+- Extended the selected-row footer for activity rows with the destination workbench name before the raw activity text.
+
+## Why it matters
+
+Dashboard users can now treat recent activity as a launch point instead of a passive audit list. A technician, advisor, or admin reviewing the operations board gets a clearer next action and a button that follows the type of work shown by the selected row.
+
+## Validation
+
+- GitHub connector readback should be used to verify the focused dashboard XAML and view-model changes.
+- Full `dotnet` build/test and WPF screenshot review remain blocked in this scheduled Linux container because local cloning, the .NET SDK, and Windows/WPF runtime are unavailable.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 17:49 NZST
+Last audit date/time: 2026-06-17 20:11 NZST
 
 ## Completed workflows
 
@@ -33,6 +33,7 @@ Last audit date/time: 2026-06-17 17:49 NZST
 - Categories now use an admin workbench layout with a directory pane, selected-category handoff, next action, setup checklist, name review, status feedback, row-correct context menus, keyboard shortcuts, printable directory output, and printable selected-category sheets.
 - The main shell now shows page-aware workflow guidance and permission-aware quick jumps so technicians, advisors, data users, and admins can drill to the next related workbench without hunting through the app.
 - The main header now wraps search, user identity, and session actions more safely on narrower workstations, and the screenshot review gallery now includes a visual/workflow checklist for future QA passes.
+- Dashboard recent activity now has a visible Open Related action, row-correct related-workflow context menu, activity-type routing to Rentals or Import / Export where available, and selected-row footer destination context.
 
 ## Partially complete workflows
 
@@ -48,6 +49,7 @@ Last audit date/time: 2026-06-17 17:49 NZST
 - Rentals now have a completed desktop workflow surface, but runtime check-in/extend/request/delete/print/document and screenshot validation still need a Windows/.NET workstation.
 - Categories now have a completed desktop workflow surface, but runtime create/rename/delete/filter/print/copy and screenshot validation still need a Windows/.NET workstation.
 - Shell workflow guidance and responsive header behavior have been implemented, but runtime narrow/wide workstation screenshot review still needs a Windows/.NET workstation.
+- Dashboard activity drilldown has been tightened, but runtime dashboard interaction and screenshot validation still need a Windows/.NET workstation.
 
 ## Known broken workflows
 
@@ -57,10 +59,10 @@ Last audit date/time: 2026-06-17 17:49 NZST
 
 ## Next recommended target
 
-- Run the enhanced Windows QA screenshot capture and review the generated checklist/index for any remaining cramped shell/page combinations, especially at narrow workstation widths.
+- Run the enhanced Windows QA screenshot capture and review the generated checklist/index for any remaining cramped shell/page combinations, especially Dashboard recent activity, narrow workstation widths, and shell quick-jump wrapping.
 
 ## Validation status
 
-- GitHub connector readback reviewed the shell workflow guidance branch and progress note.
+- GitHub connector readback reviewed the dashboard activity drilldown branch and progress note.
 - Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, and `scripts/run-app-qa-screenshots.ps1` were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
 - Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ViewModels/DashboardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DashboardViewModel.cs
@@ -408,11 +408,20 @@ namespace InventoryManagementApp.ViewModels
 
         private void OpenActivityDestination()
         {
-            var action = SelectedActivity?.Action ?? string.Empty;
-            if (action.Contains("rental", StringComparison.OrdinalIgnoreCase) || action.Contains("return", StringComparison.OrdinalIgnoreCase))
-                OpenRentalsWorkflow();
-            else
-                OpenItemsWorkflow();
+            var destination = ActivityLogsViewModel.BuildDestinationKey(SelectedActivity?.Action);
+            switch (destination)
+            {
+                case "Rentals":
+                case "Reservations":
+                    OpenRentalsWorkflow();
+                    break;
+                case "ImportExport":
+                    OpenImportExportWorkflow();
+                    break;
+                default:
+                    OpenItemsWorkflow();
+                    break;
+            }
         }
 
         private void UpdateSelectedRecordSummary()
@@ -426,7 +435,7 @@ namespace InventoryManagementApp.ViewModels
                         : SelectedRental != null
                             ? $"Rental: {SelectedRental.ItemNumber} for {SelectedRental.CustomerName} | due {SelectedRental.DueDate:yyyy-MM-dd}"
                             : SelectedActivity != null
-                                ? $"Activity: {SelectedActivity.Timestamp:yyyy-MM-dd HH:mm} | {SelectedActivity.UserName} | {SelectedActivity.Action}"
+                                ? DescribeActivity(SelectedActivity)
                                 : "Select or double-click a row to open the related workflow.";
             OnPropertyChanged(nameof(SelectedRecordSummary));
         }
@@ -436,6 +445,12 @@ namespace InventoryManagementApp.ViewModels
             var status = item.IsCheckedOut ? "checked out" : "available";
             var issue = item.IsIncomplete ? " | issue noted" : string.Empty;
             return $"{prefix}: {item.ItemNumber} - {item.Name} | {item.Location} | {status}{issue}";
+        }
+
+        private static string DescribeActivity(ActivityLog activity)
+        {
+            var destination = ActivityLogsViewModel.BuildDestinationName(ActivityLogsViewModel.BuildDestinationKey(activity.Action));
+            return $"Activity: {activity.Timestamp:yyyy-MM-dd HH:mm} | {activity.UserName} | open {destination} | {activity.Action}";
         }
 
         private async Task PrintCheckedOutItemsAsync()

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml
@@ -14,7 +14,7 @@
 
         <Border Grid.Row="0" Style="{StaticResource ToolbarCard}">
             <DockPanel LastChildFill="False">
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Top">
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
                     <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="New Item" Command="{Binding NewItemCommand}" Margin="0,0,4,0"/>
                     <Button Style="{StaticResource PrimaryButton}" Content="Open Items" Command="{Binding OpenItemsCommand}" Margin="0,0,4,0"/>
@@ -185,7 +185,10 @@
                     <TabItem Header="Recent Activity">
                         <DockPanel>
                             <Border DockPanel.Dock="Top" Style="{StaticResource DesktopPaneHeader}" Margin="0">
-                                <TextBlock Text="Audit Trail" Style="{StaticResource SubheadingTextBlock}"/>
+                                <DockPanel LastChildFill="False">
+                                    <TextBlock Text="Audit Trail" Style="{StaticResource SubheadingTextBlock}" DockPanel.Dock="Left" VerticalAlignment="Center"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="Open Related" Command="{Binding OpenActivityDestinationCommand}" DockPanel.Dock="Right"/>
+                                </DockPanel>
                             </Border>
                             <DataGrid x:Name="RecentActivityGrid"
                                       ItemsSource="{Binding RecentActivity}"
@@ -204,8 +207,7 @@
                                 </DataGrid.Columns>
                                 <DataGrid.ContextMenu>
                                     <ContextMenu Style="{StaticResource {x:Type ContextMenu}}">
-                                        <MenuItem Header="Open Items" Command="{Binding PlacementTarget.DataContext.OpenItemsCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
-                                        <MenuItem Header="Open Rentals" Command="{Binding PlacementTarget.DataContext.OpenRentalsCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
+                                        <MenuItem Header="Open Related Workflow" Command="{Binding PlacementTarget.DataContext.OpenActivityDestinationCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                         <MenuItem Header="Print Dashboard Snapshot" Command="{Binding PlacementTarget.DataContext.PrintDashboardSnapshotCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"/>
                                     </ContextMenu>
                                 </DataGrid.ContextMenu>


### PR DESCRIPTION
## What changed

- Added a visible `Open Related` action to the Dashboard recent activity pane.
- Replaced generic recent-activity context menu choices with a row-correct related-workflow action and snapshot printing.
- Routed dashboard activity rows by destination type: rentals/reservations to the rental desk, import/export activity to the data workstation, and inventory-like activity to the item workflow.
- Added selected-row footer context that names the destination workflow for activity rows.
- Updated completion/progress notes for the scheduled run.

## Why

Dashboard recent activity should behave like the other operational queues. A technician, advisor, or admin reviewing the board can now drill from an audit row into the relevant workflow instead of guessing between broad page buttons.

## Validation

- Compared the branch against current `master`; branch is ahead by four focused commits and behind by zero.
- Read back the changed Dashboard XAML and view-model sections through the GitHub connector.
- Did not run `dotnet` tests or WPF screenshots because this scheduled Linux container still lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked.