### PR TITLE
Harden dashboard selected-row summary

### DIFF
--- a/InventoryManagementApp.Tests/DashboardSelectionSummaryTests.cs
+++ b/InventoryManagementApp.Tests/DashboardSelectionSummaryTests.cs
@@ -1,0 +1,77 @@
+using System;
+using CommunityToolkit.Mvvm.Input;
+using InventoryManagementApp.Data;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Services.Users;
+using InventoryManagementApp.ViewModels;
+using Moq;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class DashboardSelectionSummaryTests
+    {
+        [Fact]
+        public void SelectedRecordSummary_FollowsMostRecentActivitySelection()
+        {
+            using var db = new DatabaseService(":memory:");
+            var vm = CreateViewModel(db);
+
+            vm.SelectedCommonlyUsedItem = new ItemModel
+            {
+                ItemNumber = "DRILL-01",
+                Name = "Hammer drill",
+                Location = "Shelf A"
+            };
+
+            vm.SelectedActivity = new ActivityLog
+            {
+                Timestamp = new DateTime(2026, 6, 17, 9, 15, 0),
+                UserName = "Alex",
+                Action = "Imported items from CSV"
+            };
+
+            Assert.Contains("open Import / Export", vm.SelectedRecordSummary);
+            Assert.Contains("Imported items from CSV", vm.SelectedRecordSummary);
+            Assert.DoesNotContain("Hammer drill", vm.SelectedRecordSummary);
+        }
+
+        [Fact]
+        public void SelectedRecordSummary_FollowsMostRecentRentalSelection()
+        {
+            using var db = new DatabaseService(":memory:");
+            var vm = CreateViewModel(db);
+
+            vm.SelectedActivity = new ActivityLog
+            {
+                Timestamp = new DateTime(2026, 6, 17, 9, 15, 0),
+                UserName = "Alex",
+                Action = "Reservation created for cordless saw"
+            };
+            vm.SelectedRental = new Rental
+            {
+                ItemNumber = "SAW-02",
+                CustomerName = "Jordan Lee",
+                DueDate = new DateTime(2026, 6, 24)
+            };
+
+            Assert.Contains("Rental: SAW-02 for Jordan Lee", vm.SelectedRecordSummary);
+            Assert.DoesNotContain("Reservation created", vm.SelectedRecordSummary);
+        }
+
+        private static DashboardViewModel CreateViewModel(DatabaseService db)
+        {
+            return new DashboardViewModel(
+                Mock.Of<IItemService>(),
+                Mock.Of<IRentalService>(),
+                Mock.Of<ICustomerService>(),
+                Mock.Of<IUserService>(),
+                new ActivityLogService(db),
+                new RelayCommand(() => { }),
+                new RelayCommand(() => { }),
+                new RelayCommand(() => { }));
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-17-dashboard-selection-summary-hardening.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-dashboard-selection-summary-hardening.md
@@ -1,0 +1,16 @@
+# Dashboard Selection Summary Hardening - 2026-06-17
+
+## Completed
+
+- Fixed the Dashboard footer summary so it follows the most recently selected dashboard record type instead of whichever older grid selection appears first in the view-model priority order.
+- Preserved existing row selections and actions while adding explicit selection-kind tracking for common items, checked-out items, incomplete items, rentals, and recent activity rows.
+- Added focused regression tests proving activity and rental selections replace stale footer context from previously selected rows.
+
+## Why it matters
+
+Dashboard rows now behave more predictably during quick triage. When an advisor or admin moves from a common item to a recent activity row, or from an activity row to a rental row, the footer describes the row they are actually acting on.
+
+## Validation
+
+- GitHub connector readback should be used to verify the focused dashboard view-model and test changes.
+- Full `dotnet` build/test and WPF screenshot review remain blocked in this scheduled Linux container because local cloning, the .NET SDK, and Windows/WPF runtime are unavailable.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 20:11 NZST
+Last audit date/time: 2026-06-17 21:11 NZST
 
 ## Completed workflows
 
@@ -34,6 +34,7 @@ Last audit date/time: 2026-06-17 20:11 NZST
 - The main shell now shows page-aware workflow guidance and permission-aware quick jumps so technicians, advisors, data users, and admins can drill to the next related workbench without hunting through the app.
 - The main header now wraps search, user identity, and session actions more safely on narrower workstations, and the screenshot review gallery now includes a visual/workflow checklist for future QA passes.
 - Dashboard recent activity now has a visible Open Related action, row-correct related-workflow context menu, activity-type routing to Rentals or Import / Export where available, and selected-row footer destination context.
+- Dashboard footer context now follows the most recently selected dashboard row type, with regression coverage for activity and rental selections replacing stale older row summaries.
 
 ## Partially complete workflows
 
@@ -41,15 +42,15 @@ Last audit date/time: 2026-06-17 20:11 NZST
 - Reports page has a compact operational grid, summary panel, print/copy actions, and safe empty unknown-report handling; runtime screenshot and full report generation checks remain pending.
 - Import / Export has been redesigned and wired for log actions plus permission-matched image mapping, but runtime file-dialog, print, image-mapping, and screenshot checks still need a Windows/.NET workstation.
 - Kits now have a completed desktop workflow surface, but runtime add/edit/item-membership dialog validation still needs a Windows/.NET workstation.
-- Customers now have a completed desktop workflow surface, but runtime add/edit/delete/print/copy validation still needs a Windows/.NET workstation.
+- Customers now have a completed desktop workflow surface, but runtime add/edit/delete/print/copy validation still need a Windows/.NET workstation.
 - Maintenance now has a completed desktop workflow surface, but runtime add/edit/complete/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 - Calibration now has a completed desktop workflow surface, but runtime add/edit/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 - User permission editing now has a completed persistence/UI/navigation/editor-summary pass, impact review, and matching service-layer permission guards, but runtime login-as-each-role and screenshot validation still needs a Windows/.NET workstation.
 - Reservations now have a completed desktop workflow surface, but runtime add/edit/confirm/cancel/fulfill/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 - Rentals now have a completed desktop workflow surface, but runtime check-in/extend/request/delete/print/document and screenshot validation still need a Windows/.NET workstation.
-- Categories now have a completed desktop workflow surface, but runtime create/rename/delete/filter/print/copy and screenshot validation still need a Windows/.NET workstation.
+- Categories now have a completed desktop workflow surface, but runtime create/rename/delete/filter/print/copy and screenshot validation still needs a Windows/.NET workstation.
 - Shell workflow guidance and responsive header behavior have been implemented, but runtime narrow/wide workstation screenshot review still needs a Windows/.NET workstation.
-- Dashboard activity drilldown has been tightened, but runtime dashboard interaction and screenshot validation still need a Windows/.NET workstation.
+- Dashboard activity drilldown and footer context have been tightened, but runtime dashboard interaction and screenshot validation still need a Windows/.NET workstation.
 
 ## Known broken workflows
 
@@ -59,10 +60,10 @@ Last audit date/time: 2026-06-17 20:11 NZST
 
 ## Next recommended target
 
-- Run the enhanced Windows QA screenshot capture and review the generated checklist/index for any remaining cramped shell/page combinations, especially Dashboard recent activity, narrow workstation widths, and shell quick-jump wrapping.
+- Run the enhanced Windows QA screenshot capture and review the generated checklist/index for any remaining cramped shell/page combinations, especially Dashboard recent activity, narrow workstation widths, shell quick-jump wrapping, and dashboard footer context while moving between grids.
 
 ## Validation status
 
-- GitHub connector readback reviewed the dashboard activity drilldown branch and progress note.
+- GitHub connector readback reviewed the dashboard selection summary branch and focused regression test additions.
 - Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, and `scripts/run-app-qa-screenshots.ps1` were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
 - Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ViewModels/DashboardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DashboardViewModel.cs
@@ -22,6 +22,16 @@ namespace InventoryManagementApp.ViewModels
 {
     public class DashboardViewModel : ObservableObject
     {
+        enum DashboardRecordKind
+        {
+            None,
+            CommonItem,
+            CheckedOutItem,
+            IncompleteItem,
+            Rental,
+            Activity
+        }
+
         readonly IItemService _itemService;
         readonly IRentalService _rentalService;
         readonly ICustomerService _customerService;
@@ -40,6 +50,7 @@ namespace InventoryManagementApp.ViewModels
         ItemModel? _selectedIncompleteItem;
         RentalModel? _selectedRental;
         ActivityLog? _selectedActivity;
+        DashboardRecordKind _selectedRecordKind = DashboardRecordKind.None;
 
         public ObservableCollection<StatCard> StatCards { get; } = new();
         public ObservableCollection<ActivityLog> RecentActivity { get; } = new();
@@ -54,7 +65,11 @@ namespace InventoryManagementApp.ViewModels
             set
             {
                 if (SetProperty(ref _selectedCommonlyUsedItem, value))
+                {
+                    if (value != null)
+                        _selectedRecordKind = DashboardRecordKind.CommonItem;
                     UpdateSelectedRecordSummary();
+                }
             }
         }
 
@@ -64,7 +79,11 @@ namespace InventoryManagementApp.ViewModels
             set
             {
                 if (SetProperty(ref _selectedCheckedOutItem, value))
+                {
+                    if (value != null)
+                        _selectedRecordKind = DashboardRecordKind.CheckedOutItem;
                     UpdateSelectedRecordSummary();
+                }
             }
         }
 
@@ -74,7 +93,11 @@ namespace InventoryManagementApp.ViewModels
             set
             {
                 if (SetProperty(ref _selectedIncompleteItem, value))
+                {
+                    if (value != null)
+                        _selectedRecordKind = DashboardRecordKind.IncompleteItem;
                     UpdateSelectedRecordSummary();
+                }
             }
         }
 
@@ -84,7 +107,11 @@ namespace InventoryManagementApp.ViewModels
             set
             {
                 if (SetProperty(ref _selectedRental, value))
+                {
+                    if (value != null)
+                        _selectedRecordKind = DashboardRecordKind.Rental;
                     UpdateSelectedRecordSummary();
+                }
             }
         }
 
@@ -94,7 +121,11 @@ namespace InventoryManagementApp.ViewModels
             set
             {
                 if (SetProperty(ref _selectedActivity, value))
+                {
+                    if (value != null)
+                        _selectedRecordKind = DashboardRecordKind.Activity;
                     UpdateSelectedRecordSummary();
+                }
             }
         }
 
@@ -426,18 +457,33 @@ namespace InventoryManagementApp.ViewModels
 
         private void UpdateSelectedRecordSummary()
         {
-            SelectedRecordSummary = SelectedCommonlyUsedItem != null
-                ? DescribeItem("Common item", SelectedCommonlyUsedItem)
-                : SelectedCheckedOutItem != null
-                    ? DescribeItem("Checked out", SelectedCheckedOutItem)
-                    : SelectedIncompleteItem != null
-                        ? DescribeItem("Issue", SelectedIncompleteItem)
-                        : SelectedRental != null
-                            ? $"Rental: {SelectedRental.ItemNumber} for {SelectedRental.CustomerName} | due {SelectedRental.DueDate:yyyy-MM-dd}"
-                            : SelectedActivity != null
-                                ? DescribeActivity(SelectedActivity)
-                                : "Select or double-click a row to open the related workflow.";
+            SelectedRecordSummary = _selectedRecordKind switch
+            {
+                DashboardRecordKind.CommonItem when SelectedCommonlyUsedItem != null => DescribeItem("Common item", SelectedCommonlyUsedItem),
+                DashboardRecordKind.CheckedOutItem when SelectedCheckedOutItem != null => DescribeItem("Checked out", SelectedCheckedOutItem),
+                DashboardRecordKind.IncompleteItem when SelectedIncompleteItem != null => DescribeItem("Issue", SelectedIncompleteItem),
+                DashboardRecordKind.Rental when SelectedRental != null => $"Rental: {SelectedRental.ItemNumber} for {SelectedRental.CustomerName} | due {SelectedRental.DueDate:yyyy-MM-dd}",
+                DashboardRecordKind.Activity when SelectedActivity != null => DescribeActivity(SelectedActivity),
+                _ => BuildFallbackSelectedRecordSummary()
+            };
             OnPropertyChanged(nameof(SelectedRecordSummary));
+        }
+
+        private string BuildFallbackSelectedRecordSummary()
+        {
+            if (SelectedCommonlyUsedItem != null)
+                return DescribeItem("Common item", SelectedCommonlyUsedItem);
+            if (SelectedCheckedOutItem != null)
+                return DescribeItem("Checked out", SelectedCheckedOutItem);
+            if (SelectedIncompleteItem != null)
+                return DescribeItem("Issue", SelectedIncompleteItem);
+            if (SelectedRental != null)
+                return $"Rental: {SelectedRental.ItemNumber} for {SelectedRental.CustomerName} | due {SelectedRental.DueDate:yyyy-MM-dd}";
+            if (SelectedActivity != null)
+                return DescribeActivity(SelectedActivity);
+
+            _selectedRecordKind = DashboardRecordKind.None;
+            return "Select or double-click a row to open the related workflow.";
         }
 
         private static string DescribeItem(string prefix, ItemModel item)


### PR DESCRIPTION
## Summary

- Tracks the most recently selected Dashboard record type so the footer summary follows the row a user just touched instead of an older selection from another grid.
- Keeps existing row selections and actions intact while making summary selection explicit for common items, checked-out items, incomplete items, rentals, and recent activity.
- Adds regression tests for activity and rental selections replacing stale older dashboard summary context.
- Records the completed hardening in progress notes and the completion checklist.

## Validation

- Compared the branch against current `master`; it is ahead by four focused commits and behind by zero.
- Read back the changed Dashboard view model and new regression test through the GitHub connector.
- Did not run local `dotnet` build/test or WPF screenshots because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local cloning/raw fetches remain blocked by the network tunnel.

Did not run unrelated tests, per instruction.