### PR TITLE
Polish login account selection surface

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-17-auth-entry-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-auth-entry-polish.md
@@ -1,0 +1,23 @@
+# Auth Entry Polish Pass - 2026-06-17 23:11 NZST
+
+## Completed
+
+- Reworked the login account-selection window into a two-panel workstation entry screen.
+- Added a branded left rail with the company logo, trust-oriented access copy, and concise role/handoff context.
+- Replaced the bare account grid presentation with a stronger pane header, profile count, larger user cards, and clearer "Open workstation" affordance.
+- Preserved the existing `SelectUserCommand`, `SelectedUser` Enter key path, `CompanyLogo`, `WindowTitle`, and `UserAvatar` bindings.
+
+## Why this mattered
+
+`ToDo.md` called out the auth/login first impression as clean but unfinished. This pass makes the first screen feel intentional and aligned with the rest of the polished workstation surfaces without changing authentication behavior.
+
+## Validation
+
+- Reviewed the existing `LoginWindow.xaml` and `LoginWindow.xaml.cs` through the GitHub connector before editing.
+- Kept the change scoped to XAML layout/bindings so the existing view model command flow remains intact.
+- Local XAML parsing, `dotnet` build/test, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local clone/raw access is blocked.
+
+## Follow-up
+
+- Runtime screenshot review should confirm the new login split layout at standard and narrow workstation sizes.
+- Continue targeted polish on password/change-password/reset prompts, then Settings database/branding/backups and print-preview document styling.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 22:32 NZST
+Last audit date/time: 2026-06-17 23:11 NZST
 
 ## Completed workflows
 
@@ -37,6 +37,7 @@ Last audit date/time: 2026-06-17 22:32 NZST
 - Dashboard footer context now follows the most recently selected dashboard row type, with regression coverage for activity and rental selections replacing stale older row summaries.
 - Dashboard row-specific actions now disable until the matching row type is selected, Open Related no longer falls through to the item workflow with no activity selected, and successful check-in/return/reload flows clear stale dashboard selections.
 - Shared visual hierarchy polish now loads after the desktop shell resources, lifting common cards, toolbar/action strips, pane headers, summary cards, primary buttons, and dense grid headers so repeated workbench surfaces have stronger hierarchy without editing each page one by one.
+- Login now has a more deliberate two-panel workstation entry surface with branded company context, role/access guidance, profile count, and stronger user cards while keeping the existing account-selection command flow intact.
 
 ## Partially complete workflows
 
@@ -49,11 +50,12 @@ Last audit date/time: 2026-06-17 22:32 NZST
 - Calibration now has a completed desktop workflow surface, but runtime add/edit/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 - User permission editing now has a completed persistence/UI/navigation/editor-summary pass, impact review, and matching service-layer permission guards, but runtime login-as-each-role and screenshot validation still needs a Windows/.NET workstation.
 - Reservations now have a completed desktop workflow surface, but runtime add/edit/confirm/cancel/fulfill/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
-- Rentals now have a completed desktop workflow surface, but runtime check-in/extend/request/delete/print/document and screenshot validation still need a Windows/.NET workstation.
+- Rentals now have a completed desktop workflow surface, but runtime check-in/extend/request/delete/print/document and screenshot validation still needs a Windows/.NET workstation.
 - Categories now have a completed desktop workflow surface, but runtime create/rename/delete/filter/print/copy and screenshot validation still needs a Windows/.NET workstation.
 - Shell workflow guidance and responsive header behavior have been implemented, but runtime narrow/wide workstation screenshot review still needs a Windows/.NET workstation.
 - Dashboard activity drilldown, footer context, and selected-action state have been tightened, but runtime dashboard interaction and screenshot validation still need a Windows/.NET workstation.
 - Shared visual hierarchy polish is in place across common shell resources, but runtime screenshot review still needs to confirm the new surface shadow, accent dividers, primary-action emphasis, and denser grid headers look right across light/dark themes and narrow workstations.
+- Auth entry polish is in place for the main login account-selection surface, but password/change-password/reset prompts and runtime auth screenshot review still need follow-up.
 
 ## Known broken workflows
 
@@ -63,10 +65,10 @@ Last audit date/time: 2026-06-17 22:32 NZST
 
 ## Next recommended target
 
-- Run the enhanced Windows QA screenshot capture and review the generated checklist/index after the shared polish pass, then continue with targeted work on the strongest remaining feedback: login/auth dialogs, Settings database/branding/backup pages, and print preview document styling.
+- Continue targeted auth polish on password, change-password, and password-reset prompts, then move to the strongest remaining Settings feedback: database, branding, and backup pages. Run the enhanced Windows QA screenshot capture when a Windows/.NET workstation is available.
 
 ## Validation status
 
-- GitHub connector readback reviewed the shared polish resource, `App.xaml` merge order, `ToDo.md` progress log, and this checklist update on `master`.
-- Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, and `scripts/run-app-qa-screenshots.ps1` were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
+- GitHub connector readback reviewed the auth entry XAML, existing login code-behind, `ToDo.md` progress log, and this checklist update on the branch before merge.
+- Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
 - Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/Views/Windows/LoginWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/LoginWindow.xaml
@@ -8,7 +8,8 @@
         mc:Ignorable="av"
         x:Class="InventoryManagementApp.Views.Windows.LoginWindow"
         Title="{Binding WindowTitle}"
-        Width="900" Height="560"
+        Width="940" Height="600"
+        MinWidth="760" MinHeight="520"
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
         Background="{DynamicResource BackgroundBrush}">
@@ -17,68 +18,172 @@
         <KeyBinding Key="Enter" Command="{Binding SelectUserCommand}" CommandParameter="{Binding SelectedUser}"/>
     </Window.InputBindings>
 
-    <Grid Margin="10">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
+    <Grid Margin="12">
+        <Border Style="{StaticResource Card}" Padding="0" ClipToBounds="True">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="300" MinWidth="260"/>
+                    <ColumnDefinition Width="*" MinWidth="420"/>
+                </Grid.ColumnDefinitions>
 
-        <!-- Header -->
-        <Border Style="{StaticResource ToolbarCard}">
-            <DockPanel LastChildFill="False">
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
-                    <Image Source="{Binding CompanyLogo}" Width="32" Height="32" Margin="0,0,8,0"/>
-                    <TextBlock Text="{Binding WindowTitle}" Style="{StaticResource HeadingTextBlock}" VerticalAlignment="Center"/>
-                </StackPanel>
-                <TextBlock DockPanel.Dock="Right" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" 
-                           Text="Select your account to continue"/>
-            </DockPanel>
-        </Border>
+                <Border Background="{DynamicResource SurfaceAltBrush}"
+                        BorderBrush="{DynamicResource AccentBrush}"
+                        BorderThickness="0,0,2,0"
+                        Padding="24">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
 
-        <!-- Users -->
-        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="8">
-            <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-                <ItemsControl x:Name="UsersListBox"
-                              ItemsSource="{Binding Users}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" IsItemsHost="True"/>
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <Button Command="{Binding DataContext.SelectUserCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
-                                    CommandParameter="{Binding}"
-                                    Padding="0" Background="Transparent" BorderThickness="0" Cursor="Hand">
-                                <Grid Width="120" Margin="4">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="78"/>
-                                        <RowDefinition Height="Auto"/>
-                                    </Grid.RowDefinitions>
-                                    <Border Background="{DynamicResource SurfaceAltBrush}"
-                                            CornerRadius="{StaticResource RadiusSmall}"
-                                            BorderBrush="{DynamicResource BorderBrushAlt}"
-                                            BorderThickness="1"
-                                            ClipToBounds="True">
-                                        <controls:UserAvatar UserName="{Binding UserName}"
-                                                            UserPhotoPath="{Binding UserPhotoPath}"
-                                                            Foreground="{Binding InitialsBrush}"
-                                                            FontSize="40"/>
-                                    </Border>
-                                    <TextBlock Grid.Row="1"
-                                               Text="{Binding UserName}"
-                                               HorizontalAlignment="Center"
-                                               TextAlignment="Center"
-                                               TextWrapping="Wrap"
-                                               MaxWidth="112"
-                                               Margin="0,6,0,0"
+                        <StackPanel>
+                            <Border Width="72" Height="72"
+                                    HorizontalAlignment="Left"
+                                    Background="{DynamicResource SurfaceBrush}"
+                                    BorderBrush="{DynamicResource BorderBrushAlt}"
+                                    BorderThickness="1"
+                                    Padding="10">
+                                <Image Source="{Binding CompanyLogo}" Stretch="Uniform"/>
+                            </Border>
+                            <TextBlock Text="{Binding WindowTitle}"
+                                       Style="{StaticResource HeadingTextBlock}"
+                                       FontSize="22"
+                                       TextWrapping="Wrap"
+                                       Margin="0,18,0,0"/>
+                            <TextBlock Text="Secure workstation access for tool inventory, rentals, service work, and admin tasks."
+                                       Style="{StaticResource DialogMessageTextBlock}"
+                                       Foreground="{DynamicResource ForegroundMutedBrush}"
+                                       Margin="0,8,0,0"/>
+                        </StackPanel>
+
+                        <StackPanel Grid.Row="1" VerticalAlignment="Center" Margin="0,24">
+                            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10">
+                                <StackPanel>
+                                    <TextBlock Text="Role based access"
+                                               Style="{StaticResource SectionHeader}"/>
+                                    <TextBlock Text="Choose your profile to load the pages, shortcuts, and guarded actions available for your role."
                                                Style="{StaticResource CaptionTextBlock}"/>
-                                </Grid>
-                            </Button>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </ScrollViewer>
+                                </StackPanel>
+                            </Border>
+                            <Border Style="{StaticResource DesktopNoteCard}">
+                                <StackPanel>
+                                    <TextBlock Text="Ready for handoff"
+                                               Style="{StaticResource SectionHeader}"/>
+                                    <TextBlock Text="Profiles keep repeated counter, bench, data, and admin work separated without changing the workstation setup."
+                                               Style="{StaticResource CaptionTextBlock}"/>
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+
+                        <StackPanel Grid.Row="2">
+                            <TextBlock Text="Inventory Management"
+                                       Style="{StaticResource CaptionTextBlock}"
+                                       FontWeight="SemiBold"/>
+                            <TextBlock Text="Select a user card to continue."
+                                       Style="{StaticResource CaptionTextBlock}"
+                                       Margin="0,3,0,0"/>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <Grid Grid.Column="1" Margin="18">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <Border Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,12">
+                        <DockPanel LastChildFill="False">
+                            <StackPanel DockPanel.Dock="Left">
+                                <TextBlock Text="Choose your account"
+                                           Style="{StaticResource HeadingTextBlock}"/>
+                                <TextBlock Text="Workstation permissions and quick jumps load after sign in."
+                                           Style="{StaticResource CaptionTextBlock}"
+                                           Margin="0,3,0,0"/>
+                            </StackPanel>
+                            <Border DockPanel.Dock="Right"
+                                    VerticalAlignment="Center"
+                                    Background="{DynamicResource SurfaceBrush}"
+                                    BorderBrush="{DynamicResource BorderBrushAlt}"
+                                    BorderThickness="1"
+                                    Padding="10,5">
+                                <TextBlock Text="{Binding Users.Count, StringFormat={}{0} profiles}"
+                                           Style="{StaticResource CaptionTextBlock}"
+                                           FontWeight="SemiBold"/>
+                            </Border>
+                        </DockPanel>
+                    </Border>
+
+                    <Border Grid.Row="1" Style="{StaticResource DesktopInsetCard}" Padding="14">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                            <ItemsControl x:Name="UsersListBox"
+                                          ItemsSource="{Binding Users}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <WrapPanel Orientation="Horizontal" HorizontalAlignment="Left" IsItemsHost="True"/>
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Button Command="{Binding DataContext.SelectUserCommand, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                CommandParameter="{Binding}"
+                                                Padding="0"
+                                                Background="Transparent"
+                                                BorderBrush="Transparent"
+                                                BorderThickness="1"
+                                                MinWidth="0"
+                                                MinHeight="0"
+                                                Cursor="Hand"
+                                                ToolTip="Sign in as this account">
+                                            <Border Width="148"
+                                                    MinHeight="154"
+                                                    Margin="6"
+                                                    Background="{DynamicResource SurfaceAltBrush}"
+                                                    BorderBrush="{DynamicResource BorderBrushAlt}"
+                                                    BorderThickness="1"
+                                                    Padding="10"
+                                                    SnapsToDevicePixels="True">
+                                                <Grid>
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="86"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                    </Grid.RowDefinitions>
+                                                    <Border Background="{DynamicResource SurfaceBrush}"
+                                                            BorderBrush="{DynamicResource BorderBrushBase}"
+                                                            BorderThickness="1"
+                                                            ClipToBounds="True">
+                                                        <controls:UserAvatar UserName="{Binding UserName}"
+                                                                            UserPhotoPath="{Binding UserPhotoPath}"
+                                                                            Foreground="{Binding InitialsBrush}"
+                                                                            FontSize="42"/>
+                                                    </Border>
+                                                    <TextBlock Grid.Row="1"
+                                                               Text="{Binding UserName}"
+                                                               HorizontalAlignment="Center"
+                                                               TextAlignment="Center"
+                                                               TextWrapping="Wrap"
+                                                               TextTrimming="CharacterEllipsis"
+                                                               MaxWidth="126"
+                                                               Margin="0,10,0,0"
+                                                               Style="{StaticResource SubheadingTextBlock}"/>
+                                                    <TextBlock Grid.Row="2"
+                                                               Text="Open workstation"
+                                                               HorizontalAlignment="Center"
+                                                               TextAlignment="Center"
+                                                               Style="{StaticResource CaptionTextBlock}"
+                                                               Margin="0,4,0,0"/>
+                                                </Grid>
+                                            </Border>
+                                        </Button>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
+                    </Border>
+                </Grid>
+            </Grid>
         </Border>
     </Grid>
 </Window>

--- a/ToDo.md
+++ b/ToDo.md
@@ -1,11 +1,12 @@
 Please update the ui this is each screen shot photo and feedback on each. this prompt will run every hour so keep track of what has been done. once complete just carry out polish passes..
 
 Progress log:
+- 2026-06-17 23:11 NZST: Polished the login account-selection surface (`InventoryManagementApp/Views/Windows/LoginWindow.xaml`) into a more deliberate two-panel workstation entry screen with branded company context, role/access guidance, profile count, and stronger user cards while preserving the existing sign-in command path. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-17-auth-entry-polish.md`.
 - 2026-06-17 22:32 NZST: Added a shared visual hierarchy polish layer (`InventoryManagementApp/Resources/PolishedVisualHierarchy.xaml`) and loaded it in `App.xaml`. This targets the repeated flat/box-heavy feedback by improving common cards, toolbar/action strips, pane headers, summary cards, primary buttons, and dense grid headers across the app. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-17-shared-visual-hierarchy-polish.md`.
 
 Overall: the UI is operationally competent and consistent, but most screens still look like a solid internal tool rather than a polished commercial product. The strongest positives are workflow clarity and consistent layout; the main weakness is flat visual hierarchy.
 00-auth
-01-login-window.png: too bare for a first impression; it is clean, but it feels unfinished rather than intentionally minimal.
+01-login-window.png: too bare for a first impression; it is clean, but it feels unfinished rather than intentionally minimal. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/LoginWindow.xaml`; runtime screenshot review still needed.
 01-overview
 01-search-tools-results.png: functional split layout, but the right-side intelligence area feels cramped and visually secondary despite being important.
 02-search-tools-recent-searches.png: same strengths as above; recent-search intelligence is useful, but the screen still feels box-heavy and low-energy.


### PR DESCRIPTION
## Summary

- Reworks the login account-selection window into a two-panel workstation entry screen.
- Adds branded company context, role/access guidance, profile count, and stronger user cards so the auth first impression feels intentional instead of bare.
- Preserves the existing `SelectUserCommand`, Enter key command path, `CompanyLogo`, `WindowTitle`, and `UserAvatar` bindings.
- Records the completed auth polish in `ToDo.md`, the detailed progress note, and the completion checklist.

## Validation

- Compared the branch against current `master`; it is ahead by four focused commits and behind by zero.
- Read back the updated login XAML and progress-log excerpts through the GitHub connector.
- GitHub reported no commit statuses for the branch head at review time.
- Did not run local XAML parsing, `dotnet` build/test, WPF screenshots, or local banned-word checks because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local clone/raw access remains blocked by the network tunnel.

Did not run unrelated tests, per instruction.