### PR TITLE
Polish auth password dialogs

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-17-auth-entry-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-17-auth-entry-polish.md
@@ -5,19 +5,21 @@
 - Reworked the login account-selection window into a two-panel workstation entry screen.
 - Added a branded left rail with the company logo, trust-oriented access copy, and concise role/handoff context.
 - Replaced the bare account grid presentation with a stronger pane header, profile count, larger user cards, and clearer "Open workstation" affordance.
-- Preserved the existing `SelectUserCommand`, `SelectedUser` Enter key path, `CompanyLogo`, `WindowTitle`, and `UserAvatar` bindings.
+- Polished the password prompt into a clearer secure-access dialog with stronger header framing, password field context, reset affordance copy, and an `Unlock` action label.
+- Polished the change-password dialog with a trust-oriented header, password requirement note, clearer field descriptions, wider password inputs, wrapped validation text, and a `Save Password` action label.
+- Preserved the existing `SelectUserCommand`, `SelectedUser` Enter key path, `CompanyLogo`, `WindowTitle`, `UserAvatar`, password prompt, reset, and save command bindings.
 
 ## Why this mattered
 
-`ToDo.md` called out the auth/login first impression as clean but unfinished. This pass makes the first screen feel intentional and aligned with the rest of the polished workstation surfaces without changing authentication behavior.
+`ToDo.md` called out the auth/login first impression as clean but unfinished, and the password/change-password prompts as visually weak for sensitive authentication moments. This pass makes the first screen and credential dialogs feel more intentional and aligned with the rest of the polished workstation surfaces without changing authentication behavior.
 
 ## Validation
 
-- Reviewed the existing `LoginWindow.xaml` and `LoginWindow.xaml.cs` through the GitHub connector before editing.
-- Kept the change scoped to XAML layout/bindings so the existing view model command flow remains intact.
+- Reviewed the existing auth XAML and login/password code-behind through the GitHub connector before editing.
+- Kept the changes scoped to XAML layout, labels, and binding-preserving control structure so the existing view model command flow remains intact.
 - Local XAML parsing, `dotnet` build/test, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local clone/raw access is blocked.
 
 ## Follow-up
 
-- Runtime screenshot review should confirm the new login split layout at standard and narrow workstation sizes.
-- Continue targeted polish on password/change-password/reset prompts, then Settings database/branding/backups and print-preview document styling.
+- Runtime screenshot review should confirm the new login split layout and password dialog spacing at standard and narrow workstation sizes.
+- Continue targeted polish on password-reset prompt, setup wizard onboarding, Settings database/branding/backups, and print-preview document styling.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -34,10 +34,10 @@ Last audit date/time: 2026-06-17 23:11 NZST
 - The main shell now shows page-aware workflow guidance and permission-aware quick jumps so technicians, advisors, data users, and admins can drill to the next related workbench without hunting through the app.
 - The main header now wraps search, user identity, and session actions more safely on narrower workstations, and the screenshot review gallery now includes a visual/workflow checklist for future QA passes.
 - Dashboard recent activity now has a visible Open Related action, row-correct related-workflow context menu, activity-type routing to Rentals or Import / Export where available, and selected-row footer destination context.
-- Dashboard footer context now follows the most recently selected dashboard row type, with regression coverage for activity and rental selections replacing stale older row summaries.
+- Dashboard footer context now follows the most recently selected dashboard row type, with regression coverage for activity and rental selections replacing stale older dashboard summary context.
 - Dashboard row-specific actions now disable until the matching row type is selected, Open Related no longer falls through to the item workflow with no activity selected, and successful check-in/return/reload flows clear stale dashboard selections.
 - Shared visual hierarchy polish now loads after the desktop shell resources, lifting common cards, toolbar/action strips, pane headers, summary cards, primary buttons, and dense grid headers so repeated workbench surfaces have stronger hierarchy without editing each page one by one.
-- Login now has a more deliberate two-panel workstation entry surface with branded company context, role/access guidance, profile count, and stronger user cards while keeping the existing account-selection command flow intact.
+- Auth entry surfaces now have a more deliberate first impression: login uses a two-panel workstation entry with branded context and stronger user cards, while password prompt and change-password dialogs use secure-access framing, clearer field guidance, wider inputs, and stronger action labels.
 
 ## Partially complete workflows
 
@@ -55,7 +55,7 @@ Last audit date/time: 2026-06-17 23:11 NZST
 - Shell workflow guidance and responsive header behavior have been implemented, but runtime narrow/wide workstation screenshot review still needs a Windows/.NET workstation.
 - Dashboard activity drilldown, footer context, and selected-action state have been tightened, but runtime dashboard interaction and screenshot validation still need a Windows/.NET workstation.
 - Shared visual hierarchy polish is in place across common shell resources, but runtime screenshot review still needs to confirm the new surface shadow, accent dividers, primary-action emphasis, and denser grid headers look right across light/dark themes and narrow workstations.
-- Auth entry polish is in place for the main login account-selection surface, but password/change-password/reset prompts and runtime auth screenshot review still need follow-up.
+- Auth entry polish is in place for login, password prompt, and change-password surfaces, but password-reset prompt, setup wizard onboarding, and runtime auth screenshot review still need follow-up.
 
 ## Known broken workflows
 
@@ -65,10 +65,10 @@ Last audit date/time: 2026-06-17 23:11 NZST
 
 ## Next recommended target
 
-- Continue targeted auth polish on password, change-password, and password-reset prompts, then move to the strongest remaining Settings feedback: database, branding, and backup pages. Run the enhanced Windows QA screenshot capture when a Windows/.NET workstation is available.
+- Continue targeted UI polish on password-reset prompt, setup wizard onboarding, Settings database/branding/backups, and print-preview document styling. Run the enhanced Windows QA screenshot capture when a Windows/.NET workstation is available.
 
 ## Validation status
 
-- GitHub connector readback reviewed the auth entry XAML, existing login code-behind, `ToDo.md` progress log, and this checklist update on the branch before merge.
+- GitHub connector readback reviewed the auth dialog branch changes, ToDo progress log, and this checklist update.
 - Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
 - Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/Views/Windows/ChangePasswordWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ChangePasswordWindow.xaml
@@ -4,27 +4,62 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         Title="Change Password"
-        SizeToContent="WidthAndHeight"
+        Width="560" Height="410"
+        MinWidth="520" MinHeight="380"
         WindowStartupLocation="CenterScreen"
         Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="20">
+    <Grid Margin="16">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" Text="New Password" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
-        <PasswordBox Grid.Row="1" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
-        <TextBlock Grid.Row="2" Text="Confirm Password" Margin="0,10,0,0" HorizontalAlignment="Center" Style="{StaticResource SubheadingTextBlock}"/>
-        <PasswordBox Grid.Row="3" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" Width="140" HorizontalAlignment="Center"/>
-        <TextBlock Grid.Row="4" Text="{Binding ValidationMessage}" Margin="0,10,0,0" Style="{StaticResource ErrorTextBlock}" HorizontalAlignment="Center"/>
-        <controls:DialogButtonBar Grid.Row="5"
+
+        <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10">
+            <StackPanel>
+                <TextBlock Text="Set A New Password" Style="{StaticResource PageTitleTextBlock}"/>
+                <TextBlock Text="Use a strong password so this workstation can keep rental, customer, and admin records protected." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,4,0,0"/>
+            </StackPanel>
+        </Border>
+
+        <Border Grid.Row="1" Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10">
+            <TextBlock Text="Passwords should be at least 8 characters and include uppercase, lowercase, and a number." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+        </Border>
+
+        <Border Grid.Row="2" Style="{StaticResource DesktopInsetCard}" Padding="14">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="170"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <StackPanel Grid.Row="0">
+                    <TextBlock Text="New Password" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="Enter the replacement password" Style="{StaticResource CaptionTextBlock}" Margin="0,3,0,0"/>
+                </StackPanel>
+                <PasswordBox Grid.Row="0" Grid.Column="1" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" MinWidth="260" Margin="10,2,0,12"/>
+
+                <StackPanel Grid.Row="1">
+                    <TextBlock Text="Confirm Password" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="Repeat it to avoid typos" Style="{StaticResource CaptionTextBlock}" Margin="0,3,0,0"/>
+                </StackPanel>
+                <PasswordBox Grid.Row="1" Grid.Column="1" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" MinWidth="260" Margin="10,2,0,12"/>
+
+                <TextBlock Grid.Row="2" Grid.ColumnSpan="2" Text="{Binding ValidationMessage}" Style="{StaticResource ErrorTextBlock}" TextWrapping="Wrap"/>
+            </Grid>
+        </Border>
+
+        <controls:DialogButtonBar Grid.Row="3"
+                                  Margin="0,12,0,0"
                                   LeftButtonText="Cancel"
                                   LeftCommand="{Binding CancelCommand}"
-                                  RightButtonText="OK"
+                                  RightButtonText="Save Password"
                                   RightCommand="{Binding SaveCommand}"/>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/PasswordPromptWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/PasswordPromptWindow.xaml
@@ -4,7 +4,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         Title="Enter Password"
-        Width="520" Height="260"
+        Width="560" Height="330"
+        MinWidth="520" MinHeight="300"
         WindowStartupLocation="CenterScreen"
         Background="{DynamicResource BackgroundBrush}">
     <Grid Margin="14">
@@ -16,31 +17,39 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <TextBlock x:Name="PromptTextBlock"
-                   Style="{StaticResource SubheadingTextBlock}"
-                   Margin="0,0,0,8"/>
+        <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10">
+            <StackPanel>
+                <TextBlock Text="Secure Access" Style="{StaticResource PageTitleTextBlock}"/>
+                <TextBlock x:Name="PromptTextBlock"
+                           Style="{StaticResource CaptionTextBlock}"
+                           TextWrapping="Wrap"
+                           Margin="0,4,0,0"/>
+            </StackPanel>
+        </Border>
 
-        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="10">
+        <Border Grid.Row="1" Style="{StaticResource DesktopInsetCard}" Padding="12">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="140"/>
+                    <ColumnDefinition Width="150"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Text="Password"
-                           Style="{StaticResource LabelTextBlock}"
-                           VerticalAlignment="Center"/>
+                <StackPanel>
+                    <TextBlock Text="Password" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="Required to unlock this profile" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                </StackPanel>
                 <PasswordBox x:Name="PasswordBox"
                              Grid.Column="1"
                              PasswordChar="•"
-                             Margin="8,0,0,0"
+                             Margin="10,2,0,0"
+                             MinWidth="250"
                              PasswordChanged="PasswordBox_PasswordChanged"/>
             </Grid>
         </Border>
 
         <Button x:Name="ForgotPasswordButton"
                 Grid.Row="2"
-                Content="Forgot password? Click here to reset."
-                Margin="2,6,0,0"
+                Content="Forgot password? Start a reset request."
+                Margin="2,8,0,0"
                 Visibility="Collapsed"
                 Style="{StaticResource LinkButton}"
                 Command="{Binding ResetPasswordCommand}"/>
@@ -49,13 +58,14 @@
                    Grid.Row="3"
                    Style="{StaticResource ErrorTextBlock}"
                    Visibility="Collapsed"
-                   Margin="2,8,0,0"
+                   Margin="2,10,0,0"
                    TextWrapping="Wrap"/>
 
         <controls:DialogButtonBar Grid.Row="4"
+                                  Margin="0,12,0,0"
                                   LeftButtonText="Cancel"
                                   LeftCommand="{Binding CancelCommand}"
-                                  RightButtonText="OK"
+                                  RightButtonText="Unlock"
                                   RightCommand="{Binding OkCommand}"/>
     </Grid>
 </Window>

--- a/ToDo.md
+++ b/ToDo.md
@@ -1,7 +1,7 @@
 Please update the ui this is each screen shot photo and feedback on each. this prompt will run every hour so keep track of what has been done. once complete just carry out polish passes..
 
 Progress log:
-- 2026-06-17 23:11 NZST: Polished the login account-selection surface (`InventoryManagementApp/Views/Windows/LoginWindow.xaml`) into a more deliberate two-panel workstation entry screen with branded company context, role/access guidance, profile count, and stronger user cards while preserving the existing sign-in command path. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-17-auth-entry-polish.md`.
+- 2026-06-17 23:11 NZST: Polished the auth entry surface and sensitive password dialogs. The login account-selection surface now has a deliberate two-panel workstation entry layout with branded company context, role/access guidance, profile count, and stronger user cards. `PasswordPromptWindow` and `ChangePasswordWindow` now use secure-access framing, clearer field guidance, wider password inputs, and stronger action labels while preserving the existing command paths. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-17-auth-entry-polish.md`.
 - 2026-06-17 22:32 NZST: Added a shared visual hierarchy polish layer (`InventoryManagementApp/Resources/PolishedVisualHierarchy.xaml`) and loaded it in `App.xaml`. This targets the repeated flat/box-heavy feedback by improving common cards, toolbar/action strips, pane headers, summary cards, primary buttons, and dense grid headers across the app. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-17-shared-visual-hierarchy-polish.md`.
 
 Overall: the UI is operationally competent and consistent, but most screens still look like a solid internal tool rather than a polished commercial product. The strongest positives are workflow clarity and consistent layout; the main weakness is flat visual hierarchy.
@@ -66,9 +66,9 @@ Overall: the UI is operationally competent and consistent, but most screens stil
 17-kit-item-edit.png: efficient and readable, though minimal to the point of feeling temporary.
 18-users-edit.png: one of the most complete dialogs functionally; still busy and text-heavy, but convincingly useful.
 19-rent-item-popup.png: one of the better transactional dialogs; clear customer selection and next-step guidance.
-20-change-password.png: too bare; this should feel more intentional and trustworthy.
+20-change-password.png: too bare; this should feel more intentional and trustworthy. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/ChangePasswordWindow.xaml`; runtime screenshot review still needed.
 06-dialogs 21-30
-21-password-prompt.png: clear, but visually weak for a sensitive auth step.
+21-password-prompt.png: clear, but visually weak for a sensitive auth step. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/PasswordPromptWindow.xaml`; runtime screenshot review still needed.
 22-password-reset-prompt.png: the reset affordance is good; the red error copy helps, but the whole screen still feels unstyled.
 23-setup-wizard.png: good structure, but it does not feel like an onboarding experience yet.
 24-activity-detail-dialog.png: clear and simple, though very plain.


### PR DESCRIPTION
## Summary

- Polishes `PasswordPromptWindow` with secure-access framing, clearer password field context, reset affordance copy, and an `Unlock` action label.
- Polishes `ChangePasswordWindow` with a trust-oriented header, password requirement note, clearer field descriptions, wider inputs, wrapped validation text, and a `Save Password` action label.
- Updates `ToDo.md`, the auth progress note, and the completion checklist so the hourly UI polish log reflects the completed auth-dialog pass.

## Validation

- Compared the branch against current `master`; it is ahead by five focused commits and behind by zero.
- Read back the changed password prompt, change-password dialog, and progress note through the GitHub connector.
- Local `dotnet` build/test, WPF screenshots, local XAML parsing, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local clone/raw access remains blocked by the network tunnel.

Did not run unrelated tests, per instruction.