### PR TITLE
Polish setup wizard onboarding

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-18-setup-wizard-onboarding-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-18-setup-wizard-onboarding-polish.md
@@ -1,0 +1,24 @@
+# Setup Wizard Onboarding Polish - 2026-06-18 00:11 NZST
+
+## Completed
+
+- Reworked the initial setup wizard into a more deliberate first-run onboarding surface with a stronger header, setup-stage label, and clearer launch context.
+- Added a left-side setup checklist that explains the four setup decisions: workspace name, item language, branding, and admin access.
+- Rebuilt the main form into a pane-header layout with field guidance beside each input so the wizard feels guided instead of scaffold-like.
+- Improved the company-logo area with a larger framed preview, clearer empty-state copy, and a less dominant browse action.
+- Reframed validation as a ready check and changed the primary action from `OK` to `Complete Setup` while preserving the existing save, cancel, password, and browse-logo bindings.
+
+## Why this mattered
+
+`ToDo.md` called out the setup wizard as structurally good but not yet feeling like onboarding. This pass keeps the existing setup behavior intact while making the first-run experience more intentional, trustworthy, and aligned with the auth polish already completed.
+
+## Validation
+
+- Reviewed `SetupWizardWindow.xaml` and its code-behind through the GitHub connector before editing.
+- Kept the changes scoped to XAML layout and copy while preserving `NewPasswordBox`, `ConfirmPasswordBox`, `BrowseCompanyLogoCommand`, `CancelCommand`, and `SaveCommand` wiring.
+- Local XAML parsing, `dotnet` build/test, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local clone/raw access is blocked.
+
+## Follow-up
+
+- Runtime screenshot review should confirm the new setup wizard spacing at minimum and standard window sizes.
+- Continue targeted polish on Settings database/branding/backups and print-preview document styling.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-17 23:11 NZST
+Last audit date/time: 2026-06-18 00:11 NZST
 
 ## Completed workflows
 
@@ -34,10 +34,11 @@ Last audit date/time: 2026-06-17 23:11 NZST
 - The main shell now shows page-aware workflow guidance and permission-aware quick jumps so technicians, advisors, data users, and admins can drill to the next related workbench without hunting through the app.
 - The main header now wraps search, user identity, and session actions more safely on narrower workstations, and the screenshot review gallery now includes a visual/workflow checklist for future QA passes.
 - Dashboard recent activity now has a visible Open Related action, row-correct related-workflow context menu, activity-type routing to Rentals or Import / Export where available, and selected-row footer destination context.
-- Dashboard footer context now follows the most recently selected dashboard row type, with regression coverage for activity and rental selections replacing stale older dashboard summary context.
+- Dashboard footer context now follows the most recently selected dashboard row type, with regression coverage for activity and rental selections replacing stale dashboard summary context.
 - Dashboard row-specific actions now disable until the matching row type is selected, Open Related no longer falls through to the item workflow with no activity selected, and successful check-in/return/reload flows clear stale dashboard selections.
 - Shared visual hierarchy polish now loads after the desktop shell resources, lifting common cards, toolbar/action strips, pane headers, summary cards, primary buttons, and dense grid headers so repeated workbench surfaces have stronger hierarchy without editing each page one by one.
 - Auth entry surfaces now have a more deliberate first impression: login uses a two-panel workstation entry with branded context and stronger user cards, while password prompt and change-password dialogs use secure-access framing, clearer field guidance, wider inputs, and stronger action labels.
+- The setup wizard now presents first-run onboarding with a stronger launch header, setup checklist, guided field descriptions, framed logo preview, ready-check validation, and a `Complete Setup` action while preserving the existing setup command flow.
 
 ## Partially complete workflows
 
@@ -55,7 +56,7 @@ Last audit date/time: 2026-06-17 23:11 NZST
 - Shell workflow guidance and responsive header behavior have been implemented, but runtime narrow/wide workstation screenshot review still needs a Windows/.NET workstation.
 - Dashboard activity drilldown, footer context, and selected-action state have been tightened, but runtime dashboard interaction and screenshot validation still need a Windows/.NET workstation.
 - Shared visual hierarchy polish is in place across common shell resources, but runtime screenshot review still needs to confirm the new surface shadow, accent dividers, primary-action emphasis, and denser grid headers look right across light/dark themes and narrow workstations.
-- Auth entry polish is in place for login, password prompt, and change-password surfaces, but password-reset prompt, setup wizard onboarding, and runtime auth screenshot review still need follow-up.
+- Auth entry and setup wizard polish are in place for login, password prompt, change-password, and onboarding surfaces, but password-reset prompt, Settings database/branding/backups, and runtime auth/setup screenshot review still need follow-up.
 
 ## Known broken workflows
 
@@ -65,10 +66,10 @@ Last audit date/time: 2026-06-17 23:11 NZST
 
 ## Next recommended target
 
-- Continue targeted UI polish on password-reset prompt, setup wizard onboarding, Settings database/branding/backups, and print-preview document styling. Run the enhanced Windows QA screenshot capture when a Windows/.NET workstation is available.
+- Continue targeted UI polish on Settings database/branding/backups and print-preview document styling. Run the enhanced Windows QA screenshot capture when a Windows/.NET workstation is available.
 
 ## Validation status
 
-- GitHub connector readback reviewed the auth dialog branch changes, ToDo progress log, and this checklist update.
+- GitHub connector readback reviewed the setup wizard onboarding polish, ToDo progress log, and this checklist update.
 - Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
 - Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/Views/Windows/SetupWizardWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/SetupWizardWindow.xaml
@@ -3,10 +3,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         Title="Initial Setup"
-        Width="760"
-        Height="640"
-        MinWidth="680"
-        MinHeight="560"
+        Width="820"
+        Height="660"
+        MinWidth="720"
+        MinHeight="590"
         WindowStartupLocation="CenterScreen"
         Background="{DynamicResource BackgroundBrush}">
     <Grid Margin="18">
@@ -17,76 +17,179 @@
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0" Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,12">
-            <StackPanel>
-                <TextBlock Text="Prepare the workstation" Style="{StaticResource PageTitleTextBlock}"/>
-                <TextBlock Text="Set the shared app name, item labels, company branding, and the initial admin password before anyone starts using the desk." Style="{StaticResource CaptionTextBlock}" Margin="0,4,0,0"/>
-            </StackPanel>
+            <DockPanel LastChildFill="True">
+                <StackPanel DockPanel.Dock="Left">
+                    <TextBlock Text="Prepare the workstation" Style="{StaticResource PageTitleTextBlock}"/>
+                    <TextBlock Text="Set the workspace name, item language, brand mark, and first administrator password before the desk goes live."
+                               Style="{StaticResource CaptionTextBlock}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,0"/>
+                </StackPanel>
+                <Border DockPanel.Dock="Right"
+                        Background="{DynamicResource SurfaceBrush}"
+                        BorderBrush="{DynamicResource AccentBrush}"
+                        BorderThickness="1"
+                        CornerRadius="4"
+                        Padding="10,6"
+                        Margin="14,0,0,0"
+                        VerticalAlignment="Center">
+                    <TextBlock Text="First-run setup" Style="{StaticResource LabelTextBlock}"/>
+                </Border>
+            </DockPanel>
         </Border>
 
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2.1*"/>
+                <ColumnDefinition Width="1.05*"/>
                 <ColumnDefinition Width="14"/>
-                <ColumnDefinition Width="1.1*"/>
+                <ColumnDefinition Width="2.1*"/>
             </Grid.ColumnDefinitions>
 
-            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="14">
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="190"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
+            <Border Grid.Column="0" Style="{StaticResource DesktopSummaryCard}" Padding="16">
+                <StackPanel>
+                    <TextBlock Text="Setup checklist" Style="{StaticResource SectionHeader}"/>
+                    <TextBlock Text="These choices shape the names, branding, and access rules every workstation user sees."
+                               Style="{StaticResource CaptionTextBlock}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,14"/>
 
-                    <TextBlock Text="Application Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                    <TextBox Grid.Column="1" Text="{Binding ApplicationName}" Margin="8,0,0,10"/>
+                    <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10">
+                        <StackPanel>
+                            <TextBlock Text="1. Name the workspace" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="Use the shop, department, or company name operators recognize." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                        </StackPanel>
+                    </Border>
 
-                    <TextBlock Grid.Row="1" Text="Item Label Singular" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding ItemLabelSingular}" Margin="8,0,0,10"/>
+                    <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10">
+                        <StackPanel>
+                            <TextBlock Text="2. Confirm item language" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="The singular and plural labels appear across search, rentals, reports, and printed handoffs." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                        </StackPanel>
+                    </Border>
 
-                    <TextBlock Grid.Row="2" Text="Item Label Plural" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding ItemLabelPlural}" Margin="8,0,0,10"/>
+                    <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10">
+                        <StackPanel>
+                            <TextBlock Text="3. Add brand context" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="A clear logo makes login, documents, and previews feel like the right system." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                        </StackPanel>
+                    </Border>
 
-                    <TextBlock Grid.Row="3" Text="Admin Password" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                    <PasswordBox Grid.Row="3" Grid.Column="1" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" Margin="8,0,0,10"/>
-
-                    <TextBlock Grid.Row="4" Text="Confirm Password" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                    <PasswordBox Grid.Row="4" Grid.Column="1" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" Margin="8,0,0,0"/>
-                </Grid>
+                    <Border Style="{StaticResource DesktopNoteCard}">
+                        <StackPanel>
+                            <TextBlock Text="4. Protect admin access" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="The first password unlocks setup, users, settings, and other sensitive work." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
             </Border>
 
-            <StackPanel Grid.Column="2">
-                <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,12">
-                    <StackPanel>
-                        <TextBlock Text="Branding" Style="{StaticResource SectionHeader}"/>
-                        <Border Width="92" Height="92" Background="{DynamicResource SurfaceBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Margin="0,0,0,10">
-                            <Image Source="{Binding CompanyLogoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=logo}" Stretch="Uniform"/>
+            <Grid Grid.Column="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <Border Grid.Row="0" Style="{StaticResource Card}" Padding="0">
+                    <DockPanel>
+                        <Border DockPanel.Dock="Top" Style="{StaticResource DesktopPaneHeader}" Margin="0">
+                            <StackPanel>
+                                <TextBlock Text="Workspace details" Style="{StaticResource SubheadingTextBlock}"/>
+                                <TextBlock Text="Complete each field, then save setup to open the app with the finished identity."
+                                           Style="{StaticResource CaptionTextBlock}"
+                                           TextWrapping="Wrap"
+                                           Margin="0,3,0,0"/>
+                            </StackPanel>
                         </Border>
-                        <TextBlock Text="{Binding CompanyLogoPath}" TextWrapping="Wrap" Margin="0,0,0,10"/>
-                        <Button Content="Browse Logo" Command="{Binding BrowseCompanyLogoCommand}" Style="{StaticResource PrimaryButton}" HorizontalAlignment="Left"/>
-                    </StackPanel>
+
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <Grid Margin="16">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="170"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <StackPanel Grid.Row="0" Margin="0,0,0,12">
+                                    <TextBlock Text="Application name" Style="{StaticResource LabelTextBlock}"/>
+                                    <TextBlock Text="Shown in the shell, login, and reports." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                                </StackPanel>
+                                <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ApplicationName}" Margin="10,2,0,12"/>
+
+                                <StackPanel Grid.Row="1" Margin="0,0,0,12">
+                                    <TextBlock Text="Item label" Style="{StaticResource LabelTextBlock}"/>
+                                    <TextBlock Text="Singular wording for one asset." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                                </StackPanel>
+                                <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding ItemLabelSingular}" Margin="10,2,0,12"/>
+
+                                <StackPanel Grid.Row="2" Margin="0,0,0,12">
+                                    <TextBlock Text="Items label" Style="{StaticResource LabelTextBlock}"/>
+                                    <TextBlock Text="Plural wording for lists and reports." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                                </StackPanel>
+                                <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding ItemLabelPlural}" Margin="10,2,0,12"/>
+
+                                <StackPanel Grid.Row="3" Margin="0,0,0,12">
+                                    <TextBlock Text="Admin password" Style="{StaticResource LabelTextBlock}"/>
+                                    <TextBlock Text="Use a memorable secure password for the first admin." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                                </StackPanel>
+                                <PasswordBox Grid.Row="3" Grid.Column="1" x:Name="NewPasswordBox" PasswordChanged="NewPasswordBox_PasswordChanged" Margin="10,2,0,12"/>
+
+                                <StackPanel Grid.Row="4" Margin="0,0,0,12">
+                                    <TextBlock Text="Confirm password" Style="{StaticResource LabelTextBlock}"/>
+                                    <TextBlock Text="Re-enter it to prevent lockout before setup completes." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                                </StackPanel>
+                                <PasswordBox Grid.Row="4" Grid.Column="1" x:Name="ConfirmPasswordBox" PasswordChanged="ConfirmPasswordBox_PasswordChanged" Margin="10,2,0,12"/>
+
+                                <Border Grid.Row="5" Grid.ColumnSpan="2" Style="{StaticResource DesktopNoteCard}" Margin="0,4,0,0">
+                                    <DockPanel LastChildFill="True">
+                                        <Border DockPanel.Dock="Left"
+                                                Width="88"
+                                                Height="88"
+                                                Background="{DynamicResource SurfaceBrush}"
+                                                BorderBrush="{DynamicResource AccentBrush}"
+                                                BorderThickness="1"
+                                                CornerRadius="4"
+                                                Margin="0,0,14,0">
+                                            <Image Source="{Binding CompanyLogoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=logo}" Stretch="Uniform" Margin="8"/>
+                                        </Border>
+                                        <StackPanel>
+                                            <TextBlock Text="Company logo" Style="{StaticResource LabelTextBlock}"/>
+                                            <TextBlock Text="{Binding CompanyLogoPath, TargetNullValue='No custom logo selected yet.'}" TextWrapping="Wrap" Style="{StaticResource CaptionTextBlock}" Margin="0,4,0,10"/>
+                                            <Button Content="Browse Logo" Command="{Binding BrowseCompanyLogoCommand}" Style="{StaticResource GhostButton}" HorizontalAlignment="Left"/>
+                                        </StackPanel>
+                                    </DockPanel>
+                                </Border>
+                            </Grid>
+                        </ScrollViewer>
+                    </DockPanel>
                 </Border>
 
-                <Border Style="{StaticResource DesktopSummaryCard}">
-                    <StackPanel>
-                        <TextBlock Text="Validation" Style="{StaticResource SectionHeader}"/>
-                        <TextBlock Text="{Binding ValidationMessage, TargetNullValue='Choose a name, set labels, and enter the matching admin password to continue.'}" Style="{StaticResource ErrorTextBlock}" TextWrapping="Wrap"/>
-                    </StackPanel>
+                <Border Grid.Row="1" Style="{StaticResource DesktopSummaryCard}" Margin="0,12,0,0">
+                    <DockPanel LastChildFill="True">
+                        <StackPanel DockPanel.Dock="Left" Width="150" Margin="0,0,12,0">
+                            <TextBlock Text="Ready check" Style="{StaticResource SectionHeader}"/>
+                            <TextBlock Text="Setup can finish once the required values pass validation." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                        </StackPanel>
+                        <TextBlock Text="{Binding ValidationMessage, TargetNullValue='Choose a name, set labels, and enter the matching admin password to continue.'}"
+                                   Style="{StaticResource ErrorTextBlock}"
+                                   TextWrapping="Wrap"
+                                   VerticalAlignment="Center"/>
+                    </DockPanel>
                 </Border>
-            </StackPanel>
+            </Grid>
         </Grid>
 
         <controls:DialogButtonBar Grid.Row="2"
                                   Margin="0,12,0,0"
                                   LeftButtonText="Cancel"
                                   LeftCommand="{Binding CancelCommand}"
-                                  RightButtonText="OK"
+                                  RightButtonText="Complete Setup"
                                   RightCommand="{Binding SaveCommand}"/>
     </Grid>
 </Window>

--- a/ToDo.md
+++ b/ToDo.md
@@ -1,6 +1,7 @@
 Please update the ui this is each screen shot photo and feedback on each. this prompt will run every hour so keep track of what has been done. once complete just carry out polish passes..
 
 Progress log:
+- 2026-06-18 00:11 NZST: Polished the first-run setup wizard onboarding surface. `SetupWizardWindow` now has a stronger launch header, setup checklist, guided field descriptions, framed company-logo preview, ready-check validation area, and a `Complete Setup` action while preserving existing setup commands and password bindings. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-18-setup-wizard-onboarding-polish.md`.
 - 2026-06-17 23:11 NZST: Polished the auth entry surface and sensitive password dialogs. The login account-selection surface now has a deliberate two-panel workstation entry layout with branded company context, role/access guidance, profile count, and stronger user cards. `PasswordPromptWindow` and `ChangePasswordWindow` now use secure-access framing, clearer field guidance, wider password inputs, and stronger action labels while preserving the existing command paths. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-17-auth-entry-polish.md`.
 - 2026-06-17 22:32 NZST: Added a shared visual hierarchy polish layer (`InventoryManagementApp/Resources/PolishedVisualHierarchy.xaml`) and loaded it in `App.xaml`. This targets the repeated flat/box-heavy feedback by improving common cards, toolbar/action strips, pane headers, summary cards, primary buttons, and dense grid headers across the app. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-17-shared-visual-hierarchy-polish.md`.
 
@@ -70,7 +71,7 @@ Overall: the UI is operationally competent and consistent, but most screens stil
 06-dialogs 21-30
 21-password-prompt.png: clear, but visually weak for a sensitive auth step. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/PasswordPromptWindow.xaml`; runtime screenshot review still needed.
 22-password-reset-prompt.png: the reset affordance is good; the red error copy helps, but the whole screen still feels unstyled.
-23-setup-wizard.png: good structure, but it does not feel like an onboarding experience yet.
+23-setup-wizard.png: good structure, but it does not feel like an onboarding experience yet. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/SetupWizardWindow.xaml`; runtime screenshot review still needed.
 24-activity-detail-dialog.png: clear and simple, though very plain.
 25-category-detail-dialog.png: readable and specific; still closer to a system dialog than a polished detail sheet.
 26-import-export-result-dialog.png: good concise result summary; visually generic.


### PR DESCRIPTION
## Summary

- Reworks `SetupWizardWindow` into a more deliberate first-run onboarding surface with a stronger launch header, setup checklist, and guided field descriptions.
- Improves the company-logo area with a framed preview and clearer empty-state copy.
- Reframes validation as a ready check and changes the primary action from `OK` to `Complete Setup` while preserving existing setup/password command wiring.
- Updates `ToDo.md`, the completion checklist, and the detailed progress note for this hourly UI polish pass.

## Validation

- Compared the branch against current `master`; it is ahead by four focused commits and behind by zero.
- Read back the updated setup wizard XAML, ToDo progress log, and setup progress note through the GitHub connector.
- Local `dotnet` build/test, WPF screenshots, local XAML parsing, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local clone/raw access remains blocked by the network tunnel.

Did not run unrelated tests, per instruction.