### PR TITLE
Polish settings admin configuration tabs

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-18-settings-admin-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-18-settings-admin-polish.md
@@ -1,0 +1,24 @@
+# Settings Admin Polish - 2026-06-18 03:11 NZST
+
+## Completed
+
+- Reworked the Settings Database tab into a connection-readiness panel with a stronger header, connection-string editing area, current-source summary, and explicit guidance for testing before staff continue live work.
+- Reworked the Settings Branding tab into a brand-identity surface with a larger logo preview, current app-name context, logo-path review, browse/save actions, and checklist guidance for workstation identity.
+- Reworked the Settings Backups tab into a backup-and-recovery surface with a clearer recovery destination form, current-folder summary, trust-oriented recovery guidance, and a Windows QA follow-up cue.
+- Preserved the existing Settings command bindings, password box names, code-behind event handlers, tab structure, and service-backed view-model properties.
+
+## Why this mattered
+
+`ToDo.md` called out Settings Database, Branding, and Backups as visually weak, temporary-feeling, or not confidence-building enough for admin configuration. These tabs control live data access, visible workstation identity, and recovery destinations, so they need to look more deliberate than plain form rows.
+
+## Validation
+
+- Reviewed `ToDo.md`, `SettingsPage.xaml`, `SettingsPage.xaml.cs`, `SettingsViewModel.cs`, and shared desktop polish resources through the GitHub connector before editing.
+- Limited implementation to XAML layout/copy/style changes and retained existing bindings such as `TestDbCommand`, `BrowseCompanyLogoCommand`, `SaveCompanyLogoCommand`, `BrowseBackupDirectoryCommand`, and `SaveBackupSettingsCommand`.
+- Preserved `SmtpPasswordBox` and `SmsApiKeyBox` names for the existing code-behind handlers.
+- Local XAML parsing, `dotnet` build/test, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local clone/raw access is blocked.
+
+## Follow-up
+
+- Runtime screenshot review should confirm the new Settings tabs fit standard and narrow admin workstations.
+- Continue targeted UI polish on password-reset prompt and print-preview document styling after this Settings pass.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-18 02:11 NZST
+Last audit date/time: 2026-06-18 03:11 NZST
 
 ## Completed workflows
 
@@ -10,6 +10,7 @@ Last audit date/time: 2026-06-18 02:11 NZST
 - Reports ViewModel now keeps `ReportResults` as a compatibility alias for `ReportLines`, protecting older tests/bindings while the reports page uses the newer dense report grid.
 - Item edit saves now clone all operational fields, show clear validation/database failure messages, and keep the selected row stable when a save fails.
 - Settings now opens with an admin service status panel that summarizes database, email, messaging, backup, branding, and workstation security state with the relevant action buttons available from the same view.
+- Settings Database, Branding, and Backups tabs now have stronger admin polish: connection-readiness guidance, a larger brand/logo identity preview, and a recovery-focused backup destination layout while preserving the existing commands and bindings.
 - QA screenshot capture now has a repository script and latest screenshot set covering login, overview/search, operational pages, reports/activity, import/export, users, settings, and print-label dialog surfaces; the script fails if the expected PNG count is not produced.
 - QA screenshot capture now names the first Settings capture as service status and walks every Settings tab through Backups after the service-status tab was added.
 - Import / Export now uses a compact data workstation layout with separate sections for item data, customer data, backup/image admin work, and run-log review.
@@ -50,7 +51,7 @@ Last audit date/time: 2026-06-18 02:11 NZST
 - Kits now have a completed desktop workflow surface, but runtime add/edit/item-membership dialog validation still needs a Windows/.NET workstation.
 - Customers now have a completed desktop workflow surface, but runtime add/edit/delete/print/copy validation still need a Windows/.NET workstation.
 - Maintenance now has a completed desktop workflow surface, but runtime add/edit/complete/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
-- Calibration now has a completed desktop workflow surface, but runtime add/edit/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
+- Calibration now has a completed desktop workflow surface, but runtime add/edit/delete/print/copy and screenshot validation still needs a Windows/.NET workstation.
 - User permission editing now has a completed persistence/UI/navigation/editor-summary pass, impact review, and matching service-layer permission guards, but runtime login-as-each-role and screenshot validation still needs a Windows/.NET workstation.
 - Reservations now have a completed desktop workflow surface, but runtime add/edit/confirm/cancel/fulfill/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
 - Rentals now have a completed desktop workflow surface, but runtime check-in/extend/request/delete/print/document and screenshot validation still needs a Windows/.NET workstation.
@@ -58,8 +59,9 @@ Last audit date/time: 2026-06-18 02:11 NZST
 - Shell workflow guidance and responsive header behavior have been implemented, but runtime narrow/wide workstation screenshot review still needs a Windows/.NET workstation.
 - Dashboard command-center, KPI, activity drilldown, footer context, and selected-action polish are in place, but runtime dashboard interaction and screenshot validation still need a Windows/.NET workstation.
 - Shared visual hierarchy polish is in place across common shell resources, but runtime screenshot review still needs to confirm the new surface shadow, accent dividers, primary-action emphasis, and denser grid headers look right across light/dark themes and narrow workstations.
-- Auth entry and setup wizard polish are in place for login, password prompt, change-password, and onboarding surfaces, but password-reset prompt, Settings database/branding/backups, and runtime auth/setup screenshot review still need follow-up.
+- Auth entry and setup wizard polish are in place for login, password prompt, change-password, and onboarding surfaces, but password-reset prompt and runtime auth/setup screenshot review still need follow-up.
 - Search Tools first-pass polish is in place for results, checked-out items, recent searches, and unavailable-demand intelligence, but runtime screenshot review still needs to confirm the new right-pane width, summary strip, and action wrapping at standard and narrow workstation sizes.
+- Settings Database, Branding, and Backups first-pass polish is in place, but runtime settings screenshot review still needs to confirm the new connection, logo preview, and recovery panels at standard and narrow admin workstation sizes.
 
 ## Known broken workflows
 
@@ -69,10 +71,10 @@ Last audit date/time: 2026-06-18 02:11 NZST
 
 ## Next recommended target
 
-- Continue targeted UI polish on Settings database/branding/backups, password-reset prompt, and print-preview document styling. Run the enhanced Windows QA screenshot capture when a Windows/.NET workstation is available.
+- Continue targeted UI polish on password-reset prompt and print-preview document styling. Run the enhanced Windows QA screenshot capture when a Windows/.NET workstation is available.
 
 ## Validation status
 
-- GitHub connector readback reviewed the Dashboard XAML, ToDo progress log, and this checklist update.
+- GitHub connector readback reviewed the Settings XAML, ToDo progress log, and this checklist update.
 - Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
 - Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/Views/Pages/SettingsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/SettingsPage.xaml
@@ -159,19 +159,67 @@
                 <Border Style="{StaticResource DesktopContentPane}">
                     <DockPanel>
                         <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                                <Button Style="{StaticResource PrimaryButton}" Content="Test" Command="{Binding TestDbCommand}"/>
-                            </StackPanel>
+                            <DockPanel LastChildFill="False">
+                                <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
+                                    <TextBlock Text="Database Connection" Style="{StaticResource SubheadingTextBlock}"/>
+                                    <TextBlock Text="Review the workstation data source before changing live inventory records." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <Button DockPanel.Dock="Right" Style="{StaticResource PrimaryButton}" Content="Test Connection" Command="{Binding TestDbCommand}" VerticalAlignment="Center"/>
+                            </DockPanel>
                         </Border>
-                        <Grid Style="{StaticResource DesktopSettingsForm}">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="170"/>
-                                <ColumnDefinition Width="*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Text="Connection String" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                            <TextBox Grid.Column="1" Text="{Binding ConnectionString}" Margin="6,0,0,0"/>
-                        </Grid>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <Grid Margin="14" VerticalAlignment="Top">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="2*" MinWidth="420"/>
+                                    <ColumnDefinition Width="12"/>
+                                    <ColumnDefinition Width="1.2*" MinWidth="260"/>
+                                </Grid.ColumnDefinitions>
+
+                                <Border Grid.Column="0" Style="{StaticResource DesktopInsetCard}">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="170"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+
+                                        <TextBlock Grid.Row="0" Grid.ColumnSpan="2" Text="Connection string" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
+                                        <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="Use the exact SQLite or server connection path this workstation should trust. Test before closing Settings." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,12"/>
+                                        <TextBlock Grid.Row="2" Text="Connection String" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                                        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding ConnectionString}" Margin="8,0,0,8" TextWrapping="Wrap" MinHeight="64" AcceptsReturn="True"/>
+                                        <Button Grid.Row="3" Grid.Column="1" Style="{StaticResource PrimaryButton}" Content="Test Connection" Command="{Binding TestDbCommand}" Margin="8,0,0,0"/>
+                                    </Grid>
+                                </Border>
+
+                                <StackPanel Grid.Column="2">
+                                    <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,12">
+                                        <StackPanel>
+                                            <TextBlock Text="Current source" Style="{StaticResource SectionHeader}"/>
+                                            <TextBlock Text="{Binding ConnectionString}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxHeight="72"/>
+                                        </StackPanel>
+                                    </Border>
+
+                                    <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,12">
+                                        <StackPanel>
+                                            <TextBlock Text="Before changing" Style="{StaticResource SectionHeader}"/>
+                                            <TextBlock Text="Confirm backups are pointed at a safe folder, then test the new connection while no one is mid-rental or import." TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                    </Border>
+
+                                    <Border Style="{StaticResource DesktopSummaryCard}">
+                                        <StackPanel>
+                                            <TextBlock Text="What this affects" Style="{StaticResource SectionHeader}"/>
+                                            <TextBlock Text="Inventory, rentals, reservations, customers, settings, audit history, and generated reports all depend on this data source." TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                    </Border>
+                                </StackPanel>
+                            </Grid>
+                        </ScrollViewer>
                     </DockPanel>
                 </Border>
             </TabItem>
@@ -330,29 +378,81 @@
 
             <TabItem Style="{StaticResource DesktopSectionListTabItem}" Header="06 Branding">
                 <Border Style="{StaticResource DesktopContentPane}">
-                    <Grid Style="{StaticResource DesktopSettingsForm}">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="170"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
-                        <TextBlock Text="Application Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding ApplicationName}" Margin="6,0,0,4"/>
-                        <TextBlock Grid.Row="1" Text="Company Logo" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal" Margin="6,0,0,0">
-                            <Border Width="44" Height="44" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Margin="0,0,6,0">
-                                <Image Width="44" Height="44" Source="{Binding CompanyLogoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=logo}" Stretch="Uniform" ClipToBounds="True"/>
-                            </Border>
-                            <TextBlock Text="{Binding CompanyLogoPath}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
-                        </StackPanel>
-                        <Button Grid.Row="1" Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Change Logo" Command="{Binding BrowseCompanyLogoCommand}" Margin="6,0,4,0"/>
-                        <Button Grid.Row="1" Grid.Column="3" Style="{StaticResource PrimaryButton}" Content="Save Logo" Command="{Binding SaveCompanyLogoCommand}"/>
-                    </Grid>
+                    <DockPanel>
+                        <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
+                            <DockPanel LastChildFill="False">
+                                <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
+                                    <TextBlock Text="Brand Identity" Style="{StaticResource SubheadingTextBlock}"/>
+                                    <TextBlock Text="Shape the app title, logo, and visible workstation identity used across the shell and output previews." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Change Logo" Command="{Binding BrowseCompanyLogoCommand}" Margin="0,0,4,0"/>
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Save Logo" Command="{Binding SaveCompanyLogoCommand}"/>
+                                </StackPanel>
+                            </DockPanel>
+                        </Border>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <Grid Margin="14" VerticalAlignment="Top">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="1.35*" MinWidth="320"/>
+                                    <ColumnDefinition Width="12"/>
+                                    <ColumnDefinition Width="2*" MinWidth="420"/>
+                                </Grid.ColumnDefinitions>
+
+                                <StackPanel Grid.Column="0">
+                                    <Border Style="{StaticResource DesktopSummaryCard}" Padding="18" Margin="0,0,0,12">
+                                        <StackPanel HorizontalAlignment="Stretch">
+                                            <Border Width="112" Height="112" HorizontalAlignment="Left" Background="{DynamicResource SurfaceBrush}" BorderBrush="{DynamicResource AccentBrush}" BorderThickness="1,1,1,3" Margin="0,0,0,12">
+                                                <Image Source="{Binding CompanyLogoPath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=logo}" Stretch="Uniform" ClipToBounds="True" Margin="10"/>
+                                            </Border>
+                                            <TextBlock Text="{Binding ApplicationName}" Style="{StaticResource HeadingTextBlock}" TextWrapping="Wrap"/>
+                                            <TextBlock Text="Current workstation brand" Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,10"/>
+                                            <TextBlock Text="{Binding CompanyLogoPath}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxHeight="80"/>
+                                        </StackPanel>
+                                    </Border>
+
+                                    <Border Style="{StaticResource DesktopNoteCard}">
+                                        <StackPanel>
+                                            <TextBlock Text="Branding checklist" Style="{StaticResource SectionHeader}"/>
+                                            <TextBlock Text="Use a clear square logo, keep the app name short enough for the header, and save after browsing so the shell and setup flow stay aligned." TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                    </Border>
+                                </StackPanel>
+
+                                <Border Grid.Column="2" Style="{StaticResource DesktopInsetCard}">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="170"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+
+                                        <TextBlock Grid.Row="0" Grid.ColumnSpan="3" Text="Brand setup" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
+                                        <TextBlock Grid.Row="1" Grid.ColumnSpan="3" Text="These values are the first things staff see at sign-in and the visual cue customers see in printed handoffs." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,12"/>
+
+                                        <TextBlock Grid.Row="2" Text="Application Name" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                                        <TextBox Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" Text="{Binding ApplicationName}" Margin="8,0,0,8"/>
+
+                                        <TextBlock Grid.Row="3" Text="Company Logo" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                                        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding CompanyLogoPath}" Margin="8,0,6,8" IsReadOnly="True"/>
+                                        <Button Grid.Row="3" Grid.Column="2" Style="{StaticResource GhostButton}" Content="Browse" Command="{Binding BrowseCompanyLogoCommand}" Margin="0,0,0,8"/>
+
+                                        <StackPanel Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="8,0,0,0">
+                                            <Button Style="{StaticResource PrimaryButton}" Content="Save Logo" Command="{Binding SaveCompanyLogoCommand}" Margin="0,0,4,0"/>
+                                            <Button Style="{StaticResource GhostButton}" Content="Choose Another" Command="{Binding BrowseCompanyLogoCommand}"/>
+                                        </StackPanel>
+                                    </Grid>
+                                </Border>
+                            </Grid>
+                        </ScrollViewer>
+                    </DockPanel>
                 </Border>
             </TabItem>
 
@@ -390,21 +490,74 @@
                 <Border Style="{StaticResource DesktopContentPane}">
                     <DockPanel>
                         <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="Actions" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                                <Button Style="{StaticResource PrimaryButton}" Content="Save" Command="{Binding SaveBackupSettingsCommand}"/>
-                            </StackPanel>
+                            <DockPanel LastChildFill="False">
+                                <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
+                                    <TextBlock Text="Backup and Recovery Folder" Style="{StaticResource SubheadingTextBlock}"/>
+                                    <TextBlock Text="Choose where exports and recovery files should land before staff start end-of-day work." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
+                                    <Button Style="{StaticResource GhostButton}" Content="Browse" Command="{Binding BrowseBackupDirectoryCommand}" Margin="0,0,4,0"/>
+                                    <Button Style="{StaticResource PrimaryButton}" Content="Save Backup" Command="{Binding SaveBackupSettingsCommand}"/>
+                                </StackPanel>
+                            </DockPanel>
                         </Border>
-                        <Grid Style="{StaticResource DesktopSettingsForm}">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="170"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Text="Backup Folder" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                            <TextBox Grid.Column="1" Text="{Binding BackupDirectory}" Margin="6,0,4,0"/>
-                            <Button Grid.Column="2" Style="{StaticResource PrimaryButton}" Content="Browse" Command="{Binding BrowseBackupDirectoryCommand}"/>
-                        </Grid>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <Grid Margin="14" VerticalAlignment="Top">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="2*" MinWidth="420"/>
+                                    <ColumnDefinition Width="12"/>
+                                    <ColumnDefinition Width="1.1*" MinWidth="260"/>
+                                </Grid.ColumnDefinitions>
+
+                                <Border Grid.Column="0" Style="{StaticResource DesktopInsetCard}">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="170"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+
+                                        <TextBlock Grid.Row="0" Grid.ColumnSpan="3" Text="Recovery destination" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
+                                        <TextBlock Grid.Row="1" Grid.ColumnSpan="3" Text="Pick a stable folder that is included in your normal workstation or network backup routine." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,12"/>
+
+                                        <TextBlock Grid.Row="2" Text="Backup Folder" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                                        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding BackupDirectory}" Margin="8,0,6,8"/>
+                                        <Button Grid.Row="2" Grid.Column="2" Style="{StaticResource GhostButton}" Content="Browse" Command="{Binding BrowseBackupDirectoryCommand}" Margin="0,0,0,8"/>
+
+                                        <Button Grid.Row="3" Grid.Column="1" Style="{StaticResource PrimaryButton}" Content="Save Backup Settings" Command="{Binding SaveBackupSettingsCommand}" Margin="8,0,0,0"/>
+                                    </Grid>
+                                </Border>
+
+                                <StackPanel Grid.Column="2">
+                                    <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,12">
+                                        <StackPanel>
+                                            <TextBlock Text="Current backup folder" Style="{StaticResource SectionHeader}"/>
+                                            <TextBlock Text="{Binding BackupDirectory}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxHeight="88"/>
+                                        </StackPanel>
+                                    </Border>
+
+                                    <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,12">
+                                        <StackPanel>
+                                            <TextBlock Text="Recovery confidence" Style="{StaticResource SectionHeader}"/>
+                                            <TextBlock Text="A visible, named backup destination makes export runs easier to verify and reduces the chance of staff saving recovery data to a temporary folder." TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                    </Border>
+
+                                    <Border Style="{StaticResource DesktopSummaryCard}">
+                                        <StackPanel>
+                                            <TextBlock Text="After saving" Style="{StaticResource SectionHeader}"/>
+                                            <TextBlock Text="Run an export or image backup from Import / Export and confirm the file appears in this folder during Windows QA." TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                    </Border>
+                                </StackPanel>
+                            </Grid>
+                        </ScrollViewer>
                     </DockPanel>
                 </Border>
             </TabItem>

--- a/ToDo.md
+++ b/ToDo.md
@@ -1,6 +1,7 @@
 Please update the ui this is each screen shot photo and feedback on each. this prompt will run every hour so keep track of what has been done. once complete just carry out polish passes..
 
 Progress log:
+- 2026-06-18 03:11 NZST: Polished the Settings Database, Branding, and Backups tabs. `SettingsPage` now gives connection setup a readiness panel, gives branding a larger logo/app identity preview, and gives backups a recovery-focused destination layout while preserving existing bindings, commands, tab structure, password-box names, and code-behind handlers. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-18-settings-admin-polish.md`.
 - 2026-06-18 02:11 NZST: Polished the Dashboard KPI and activity surface. `DashboardPage` now has a stronger command-center header, more prominent stat cards, a four-part priority strip for checked-out items/rentals/issues/activity, clearer operational pane captions, and visible recent-activity destination context while preserving existing grid names, commands, bindings, context menus, and keyboard paths. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-18-dashboard-kpi-activity-polish.md`.
 - 2026-06-18 01:11 NZST: Polished the Search Tools results and intelligence surface. `ItemSearchPage` now gives the search results and checked-out panes stronger pane headers, expands the intelligence area, adds a session-pulse summary strip, clarifies repeat/open/print/clear actions, and gives recent-search and unavailable-demand tables roomier scanning while preserving existing grid names, click handlers, bindings, and keyboard paths. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-18-search-intelligence-polish.md`.
 - 2026-06-18 00:11 NZST: Polished the first-run setup wizard onboarding surface. `SetupWizardWindow` now has a stronger launch header, setup checklist, guided field descriptions, framed company-logo preview, ready-check validation area, and a `Complete Setup` action while preserving existing setup commands and password bindings. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-18-setup-wizard-onboarding-polish.md`.
@@ -41,13 +42,13 @@ Overall: the UI is operationally competent and consistent, but most screens stil
 01-users.png: useful layout, but the user detail boxes on the right feel empty and under-styled.
 02-users-narrow.png: still works in a tighter width, which is good; however, it becomes visually cramped quickly.
 03-settings-service-status.png: this is one of the better admin screens because grouped panels create some rhythm.
-04-settings-database.png: weakest settings page visually; it looks more like an unfinished scaffold than a finished screen.
+04-settings-database.png: weakest settings page visually; it looks more like an unfinished scaffold than a finished screen. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/SettingsPage.xaml`; runtime screenshot review still needed.
 05-settings-general.png: clear form layout and good explanatory notes; still needs stronger typography and contrast hierarchy.
 06-settings-item-display.png: practical bulk-edit page, but it is visually too austere for such a central configuration area.
 07-settings-email.png: functional and readable; one of the more form-complete screens, though still plain.
-08-settings-branding.png: ironically this branding page least conveys brand; the logo area and spacing feel temporary.
+08-settings-branding.png: ironically this branding page least conveys brand; the logo area and spacing feel temporary. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/SettingsPage.xaml`; runtime screenshot review still needed.
 09-settings-messaging.png: simple and understandable, but visually extremely minimal.
-10-settings-backups.png: backup path UI works, but the screen feels empty and not especially trustworthy-looking.
+10-settings-backups.png: backup path UI works, but the screen feels empty and not especially trustworthy-looking. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/SettingsPage.xaml`; runtime screenshot review still needed.
 06-dialogs 01-10
 01-print-labels.png: straightforward and usable, but too plain for a modal that triggers output.
 02-info-dialog.png: readable, but oversized empty space makes it feel low-polish.


### PR DESCRIPTION
## Summary

- Reworks the Settings Database tab into a connection-readiness surface with current-source context, clearer testing guidance, and a more substantial connection editor.
- Reworks the Branding tab with a larger logo preview, app-name identity context, clearer browse/save actions, and workstation branding guidance.
- Reworks the Backups tab into a recovery-focused destination layout with current-folder summary and Windows QA follow-up guidance.
- Updates `ToDo.md`, the completion checklist, and a detailed progress note for this scheduled Settings UI pass.

## Validation

- Compared the branch against current `master`; it is ahead by four focused commits and behind by zero.
- Read back the changed Settings XAML, ToDo progress log, and progress note through the GitHub connector.
- Confirmed existing command bindings and named password boxes were preserved in the edited Settings page.
- Local `dotnet` build/test, WPF screenshots, local XAML parsing, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local clone/raw access remains blocked by the network tunnel.

Did not run unrelated tests, per instruction.