### PR TITLE
Polish rentals workbench hierarchy

### DIFF
--- a/InventoryManagementApp/ProgressNotes/2026-06-18-rentals-workbench-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-18-rentals-workbench-polish.md
@@ -1,0 +1,25 @@
+# Rentals Workbench Polish - 2026-06-18 05:11 NZST
+
+## Completed
+
+- Reworked `ManageRentalsPage` into a stronger rental desk workbench with a clear page header, colocated rental/document actions, and four operational summary cards for filtered rentals, checked-out items, open requests, and the selected rental.
+- Moved search, date range, status filtering, clear, print-list, and print-checked-out actions into a denser rental directory subheader so the primary toolbar can stay focused on selected-rental actions.
+- Strengthened the rental directory with shared desktop pane headers and a styled empty state while preserving the existing `Rentals`, `SelectedRental`, filter, context-menu, double-click, and right-click selection paths.
+- Reframed the advisor handoff pane into customer, timing, shelf/document, and checklist cards so staff can act on the selected rental without scanning one long block of text.
+- Reworked the open request queue header and selected-request pane with clearer queue purpose, request metrics, carded holder/next-action context, and a styled empty state while preserving the existing request commands and queue bindings.
+
+## Why this mattered
+
+`ToDo.md` called out `02-rentals.png` as one of the most useful operations screens structurally, but also one of the busiest and most in need of stronger section hierarchy. This pass keeps the existing rental and request workflows intact while making the screen read more like a polished rental desk than a dense collection of panels.
+
+## Validation
+
+- Reviewed `ToDo.md`, `ManageRentalsPage.xaml`, `ManageRentalsViewModel.cs`, and shared visual hierarchy resources through the GitHub connector before editing.
+- Limited the implementation to XAML layout and bindings that already exist in `ManageRentalsViewModel` and existing page event handlers.
+- Preserved `RentalRow_MouseDoubleClick`, `RentalRow_PreviewMouseRightButtonDown`, `RequestRow_MouseDoubleClick`, and `RequestRow_PreviewMouseRightButtonDown` event hooks.
+- Local XAML parsing, `dotnet` build/test, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local clone/raw access is blocked.
+
+## Follow-up
+
+- Runtime screenshot review should confirm the new rentals workbench fits both standard and narrow workstation captures.
+- Continue targeted UI polish on Customers, Maintenance, Calibration, Reservations, Kits, Categories, Reports, Activity Logs, Import / Export, password-reset prompt, and print-preview document styling.

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml
@@ -4,8 +4,21 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       Background="{DynamicResource BackgroundBrush}"
       Focusable="True">
-    <Grid Margin="0">
+    <Page.Resources>
+        <Style x:Key="RentalStatCard" TargetType="Border" BasedOn="{StaticResource DesktopSummaryCard}">
+            <Setter Property="Padding" Value="12,10"/>
+            <Setter Property="MinHeight" Value="76"/>
+            <Setter Property="Margin" Value="0,0,8,0"/>
+        </Style>
+        <Style x:Key="RentalDetailText" TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlock}">
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="Margin" Value="0,2,0,0"/>
+        </Style>
+    </Page.Resources>
+
+    <Grid Margin="4">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="2*"/>
             <RowDefinition Height="8"/>
@@ -13,53 +26,63 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Style="{StaticResource ToolbarCard}">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-
-                <DockPanel Grid.Row="0" LastChildFill="True" Margin="0,0,0,8">
-                    <TextBlock DockPanel.Dock="Right"
-                               Text="Checkout, check-in, desk documents, and request follow-up stay in one flow."
-                               Style="{StaticResource CaptionTextBlock}"
-                               VerticalAlignment="Center"
-                               TextWrapping="Wrap"
-                               Margin="12,0,0,0"/>
-                    <WrapPanel VerticalAlignment="Center">
-                        <TextBlock Text="Rental workflow" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenRentalDetailsCommand}" Margin="0,0,6,6"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Check In" Command="{Binding CheckInCommand}" Margin="0,0,6,6"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Extend" Command="{Binding ExtendCommand}" Margin="0,0,6,6"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Request" Command="{Binding PlaceRequestCommand}" Margin="0,0,6,6"/>
-                        <Button Style="{StaticResource GhostButton}" Content="History" Command="{Binding OpenHistoryCommand}" Margin="0,0,6,6"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Pick Slip" Command="{Binding PrintPickingSlipCommand}" Margin="0,0,6,6"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Invoice" Command="{Binding PrintInvoiceCommand}" Margin="0,0,6,6"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Print Rental" Command="{Binding PrintRentalCommand}" Margin="0,0,6,6"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Print List" Command="{Binding PrintSearchResultsCommand}" Margin="0,0,6,6"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteRentalCommand}" Margin="0,0,0,6"/>
-                    </WrapPanel>
-                </DockPanel>
-
-                <Border Grid.Row="1"
-                        Background="{DynamicResource SurfaceBrush}"
-                        BorderBrush="{DynamicResource BorderBrushAlt}"
-                        BorderThickness="1"
-                        Padding="10,8">
-                    <WrapPanel>
-                        <TextBlock Text="Find rental" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,10,8"/>
-                        <TextBox x:Name="SearchTextBox" Width="260" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,8" ToolTip="Search item number, location, or customer"/>
-                        <DatePicker SelectedDate="{Binding FilterFrom, UpdateSourceTrigger=PropertyChanged}" Width="140" Margin="0,0,8,8"/>
-                        <DatePicker SelectedDate="{Binding FilterTo, UpdateSourceTrigger=PropertyChanged}" Width="140" Margin="0,0,8,8"/>
-                        <ComboBox ItemsSource="{Binding StatusOptions}" SelectedItem="{Binding SelectedStatus, UpdateSourceTrigger=PropertyChanged}" Width="124" Margin="0,0,8,8"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearFilterCommand}"/>
-                    </WrapPanel>
-                </Border>
-            </Grid>
+        <Border Grid.Row="0" Style="{StaticResource ToolbarCard}">
+            <DockPanel LastChildFill="False">
+                <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
+                    <TextBlock Text="Rentals" Style="{StaticResource PageTitleTextBlock}"/>
+                    <TextBlock Text="Run active checkouts, returns, customer documents, and follow-up requests from one rental desk." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                </StackPanel>
+                <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" Margin="16,0,0,0">
+                    <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenRentalDetailsCommand}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Check In" Command="{Binding CheckInCommand}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Extend" Command="{Binding ExtendCommand}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource PrimaryButton}" Content="Request" Command="{Binding PlaceRequestCommand}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Pick Slip" Command="{Binding PrintPickingSlipCommand}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Invoice" Command="{Binding PrintInvoiceCommand}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource GhostButton}" Content="History" Command="{Binding OpenHistoryCommand}" Margin="0,0,6,6"/>
+                    <Button Style="{StaticResource GhostButton}" Content="Delete" Command="{Binding DeleteRentalCommand}" Margin="0,0,0,6"/>
+                </WrapPanel>
+            </DockPanel>
         </Border>
 
-        <Grid Grid.Row="1" Margin="0,6,0,0">
+        <Grid Grid.Row="1" Margin="0,0,0,6">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="1.25*"/>
+            </Grid.ColumnDefinitions>
+            <Border Grid.Column="0" Style="{StaticResource RentalStatCard}">
+                <StackPanel>
+                    <TextBlock Text="Filtered Rentals" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="{Binding Rentals.Count}" Style="{StaticResource HeadingTextBlock}"/>
+                    <TextBlock Text="Rows matching the current search, date range, and status" Style="{StaticResource RentalDetailText}"/>
+                </StackPanel>
+            </Border>
+            <Border Grid.Column="1" Style="{StaticResource RentalStatCard}">
+                <StackPanel>
+                    <TextBlock Text="Checked Out" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="{Binding ActiveRentals.Count}" Style="{StaticResource HeadingTextBlock}"/>
+                    <TextBlock Text="Active customer handoffs that still need return or extension" Style="{StaticResource RentalDetailText}"/>
+                </StackPanel>
+            </Border>
+            <Border Grid.Column="2" Style="{StaticResource RentalStatCard}">
+                <StackPanel>
+                    <TextBlock Text="Open Requests" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="{Binding PendingRequests.Count}" Style="{StaticResource HeadingTextBlock}"/>
+                    <TextBlock Text="Customer holds waiting for advisor follow-up" Style="{StaticResource RentalDetailText}"/>
+                </StackPanel>
+            </Border>
+            <Border Grid.Column="3" Style="{StaticResource RentalStatCard}" Margin="0">
+                <StackPanel>
+                    <TextBlock Text="Selected Rental" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="{Binding SelectedRental.ItemNumber, TargetNullValue=No rental selected}" Style="{StaticResource HeadingTextBlock}" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock Text="{Binding SelectedRental.CustomerName, StringFormat='Customer: {0}', TargetNullValue='Select a row to review customer, timing, and document actions.'}" Style="{StaticResource RentalDetailText}"/>
+                </StackPanel>
+            </Border>
+        </Grid>
+
+        <Grid Grid.Row="2" Margin="0,0,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="1.7*" MinWidth="460"/>
                 <ColumnDefinition Width="8"/>
@@ -73,19 +96,31 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
-                    <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="8,6">
-                        <DockPanel>
-                            <TextBlock Text="01 Rental Desk" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
-                            <TextBlock Text="{Binding SearchSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                    <Border Style="{StaticResource DesktopPaneHeader}">
+                        <DockPanel LastChildFill="False">
+                            <StackPanel DockPanel.Dock="Left">
+                                <TextBlock Text="Rental Desk" Style="{StaticResource SectionHeader}" Margin="0"/>
+                                <TextBlock Text="Search, return, extend, document, or inspect the selected rental." Style="{StaticResource CaptionTextBlock}"/>
+                            </StackPanel>
+                            <TextBlock DockPanel.Dock="Right" Text="{Binding SearchSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" Margin="12,0,0,0"/>
                         </DockPanel>
                     </Border>
-                    <Border Grid.Row="1" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="8,6">
-                        <DockPanel LastChildFill="True">
-                            <WrapPanel DockPanel.Dock="Right">
-                                <Button Style="{StaticResource GhostButton}" Content="Print Checked Out" Command="{Binding PrintCheckedOutCommand}" Margin="0,0,4,0"/>
-                                <Button Style="{StaticResource GhostButton}" Content="Print Requests" Command="{Binding PrintRequestsCommand}"/>
+                    <Border Grid.Row="1" Style="{StaticResource DesktopPaneSubheader}">
+                        <DockPanel LastChildFill="False">
+                            <WrapPanel DockPanel.Dock="Left" VerticalAlignment="Center">
+                                <TextBlock Text="Find" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,6,6"/>
+                                <TextBox x:Name="SearchTextBox" Width="250" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,6" ToolTip="Search item number, location, or customer"/>
+                                <TextBlock Text="From" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="2,0,6,6"/>
+                                <DatePicker SelectedDate="{Binding FilterFrom, UpdateSourceTrigger=PropertyChanged}" Width="132" Margin="0,0,8,6"/>
+                                <TextBlock Text="To" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="2,0,6,6"/>
+                                <DatePicker SelectedDate="{Binding FilterTo, UpdateSourceTrigger=PropertyChanged}" Width="132" Margin="0,0,8,6"/>
+                                <ComboBox ItemsSource="{Binding StatusOptions}" SelectedItem="{Binding SelectedStatus, UpdateSourceTrigger=PropertyChanged}" Width="118" Margin="0,0,8,6"/>
                             </WrapPanel>
-                            <TextBlock Text="{Binding CheckedOutSummary}" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,10,0"/>
+                            <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" Margin="12,0,0,0">
+                                <Button Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearFilterCommand}" Margin="0,0,4,6"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Print List" Command="{Binding PrintSearchResultsCommand}" Margin="0,0,4,6"/>
+                                <Button Style="{StaticResource GhostButton}" Content="Print Checked Out" Command="{Binding PrintCheckedOutCommand}" Margin="0,0,0,6"/>
+                            </WrapPanel>
                         </DockPanel>
                     </Border>
                     <DataGrid Grid.Row="2"
@@ -125,9 +160,9 @@
                             </ContextMenu>
                         </DataGrid.ContextMenu>
                     </DataGrid>
-                    <TextBlock Grid.Row="2" Text="No rental records match this search" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="13" FontWeight="SemiBold">
-                        <TextBlock.Style>
-                            <Style TargetType="TextBlock">
+                    <Border Grid.Row="2" Width="300" HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding Rentals.Count}" Value="0">
@@ -135,8 +170,12 @@
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
+                        </Border.Style>
+                        <StackPanel>
+                            <TextBlock Text="No rentals found" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                            <TextBlock Text="Adjust the search, date range, or status filter to find an active or returned rental." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
                 </Grid>
             </Border>
 
@@ -149,9 +188,12 @@
                         <RowDefinition Height="*"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
-                    <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="8,6">
-                        <DockPanel>
-                            <TextBlock Text="02 Advisor Handoff" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                    <Border Style="{StaticResource DesktopPaneHeader}">
+                        <DockPanel LastChildFill="False">
+                            <StackPanel DockPanel.Dock="Left">
+                                <TextBlock Text="Advisor Handoff" Style="{StaticResource SectionHeader}" Margin="0"/>
+                                <TextBlock Text="Selected rental context, customer contact, timing, shelf, and documents." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                            </StackPanel>
                         </DockPanel>
                     </Border>
                     <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
@@ -162,20 +204,32 @@
                                        TextWrapping="Wrap"/>
                             <TextBlock Text="{Binding SelectedRental.Status, StringFormat='Status: {0}', TargetNullValue='Choose a rental to see check-in and billing actions'}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,2,0,10"/>
 
-                            <TextBlock Text="Customer" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
-                            <TextBlock Text="{Binding SelectedRental.CustomerName, TargetNullValue='No customer selected'}" TextWrapping="Wrap" Margin="0,0,0,2"/>
-                            <TextBlock Text="{Binding SelectedRental.CustomerContact, StringFormat='Contact: {0}', TargetNullValue='Contact: Not recorded'}" TextWrapping="Wrap" Margin="0,0,0,2"/>
-                            <TextBlock Text="{Binding SelectedRental.CustomerPhone, StringFormat='Phone: {0}', TargetNullValue='Phone: Not recorded'}" TextWrapping="Wrap" Margin="0,0,0,2"/>
-                            <TextBlock Text="{Binding SelectedRental.CustomerEmail, StringFormat='Email: {0}', TargetNullValue='Email: Not recorded'}" TextWrapping="Wrap" Margin="0,0,0,10"/>
+                            <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10">
+                                <StackPanel>
+                                    <TextBlock Text="Customer" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
+                                    <TextBlock Text="{Binding SelectedRental.CustomerName, TargetNullValue='No customer selected'}" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,0,0,2"/>
+                                    <TextBlock Text="{Binding SelectedRental.CustomerContact, StringFormat='Contact: {0}', TargetNullValue='Contact: Not recorded'}" TextWrapping="Wrap" Margin="0,0,0,2"/>
+                                    <TextBlock Text="{Binding SelectedRental.CustomerPhone, StringFormat='Phone: {0}', TargetNullValue='Phone: Not recorded'}" TextWrapping="Wrap" Margin="0,0,0,2"/>
+                                    <TextBlock Text="{Binding SelectedRental.CustomerEmail, StringFormat='Email: {0}', TargetNullValue='Email: Not recorded'}" TextWrapping="Wrap"/>
+                                </StackPanel>
+                            </Border>
 
-                            <TextBlock Text="Timing" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
-                            <TextBlock Text="{Binding SelectedRental.RentalDate, StringFormat='Checked out: {0:yyyy-MM-dd HH:mm}', TargetNullValue='Checked out: -'}" TextWrapping="Wrap" Margin="0,0,0,2"/>
-                            <TextBlock Text="{Binding SelectedRental.DueDate, StringFormat='Due back: {0:yyyy-MM-dd HH:mm}', TargetNullValue='Due back: -'}" TextWrapping="Wrap" Margin="0,0,0,2"/>
-                            <TextBlock Text="{Binding SelectedRental.ReturnDate, StringFormat='Returned: {0:yyyy-MM-dd HH:mm}', TargetNullValue='Returned: Not returned yet'}" TextWrapping="Wrap" Margin="0,0,0,10"/>
+                            <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10">
+                                <StackPanel>
+                                    <TextBlock Text="Timing" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
+                                    <TextBlock Text="{Binding SelectedRental.RentalDate, StringFormat='Checked out: {0:yyyy-MM-dd HH:mm}', TargetNullValue='Checked out: -'}" TextWrapping="Wrap" Margin="0,0,0,2"/>
+                                    <TextBlock Text="{Binding SelectedRental.DueDate, StringFormat='Due back: {0:yyyy-MM-dd HH:mm}', TargetNullValue='Due back: -'}" TextWrapping="Wrap" Margin="0,0,0,2"/>
+                                    <TextBlock Text="{Binding SelectedRental.ReturnDate, StringFormat='Returned: {0:yyyy-MM-dd HH:mm}', TargetNullValue='Returned: Not returned yet'}" TextWrapping="Wrap"/>
+                                </StackPanel>
+                            </Border>
 
-                            <TextBlock Text="Shelf and documents" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
-                            <TextBlock Text="{Binding SelectedRental.ItemLocation, StringFormat='Shelf: {0}', TargetNullValue='Shelf: Not recorded'}" TextWrapping="Wrap" Margin="0,0,0,2"/>
-                            <TextBlock Text="Confirm the item number, collect or return it from the listed shelf, print the pick slip or invoice when needed, then check it in or extend it before ending the customer handoff." TextWrapping="Wrap" Margin="0,0,0,14"/>
+                            <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10">
+                                <StackPanel>
+                                    <TextBlock Text="Shelf and documents" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,3"/>
+                                    <TextBlock Text="{Binding SelectedRental.ItemLocation, StringFormat='Shelf: {0}', TargetNullValue='Shelf: Not recorded'}" TextWrapping="Wrap" Margin="0,0,0,2"/>
+                                    <TextBlock Text="Confirm the item number, collect or return it from the listed shelf, print the pick slip or invoice when needed, then check it in or extend it before ending the customer handoff." TextWrapping="Wrap"/>
+                                </StackPanel>
+                            </Border>
 
                             <WrapPanel Margin="0,0,0,8">
                                 <Button Style="{StaticResource PrimaryButton}" Content="Check In" Command="{Binding CheckInCommand}" Margin="0,0,4,4"/>
@@ -186,7 +240,7 @@
                                 <Button Style="{StaticResource GhostButton}" Content="Invoice" Command="{Binding PrintInvoiceCommand}" Margin="0,0,4,4"/>
                             </WrapPanel>
 
-                            <Border BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="8" Margin="0,6,0,0">
+                            <Border Style="{StaticResource DesktopNoteCard}" Margin="0,6,0,0">
                                 <StackPanel>
                                     <TextBlock Text="Desk checklist" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/>
                                     <TextBlock Text="For checkout: confirm customer, item number, due date, and print documents. For check-in: inspect condition, check in the rental, then review open requests for the same item before returning it to the shelf." TextWrapping="Wrap"/>
@@ -194,7 +248,7 @@
                             </Border>
                         </StackPanel>
                     </ScrollViewer>
-                    <Border Grid.Row="2" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,1,0,0" Padding="8,6">
+                    <Border Grid.Row="2" Style="{StaticResource DesktopPaneSubheader}">
                         <UniformGrid Columns="2">
                             <Button Style="{StaticResource GhostButton}" Content="History" Command="{Binding OpenHistoryCommand}" Margin="0,0,4,4"/>
                             <Button Style="{StaticResource GhostButton}" Content="Print Rental" Command="{Binding PrintRentalCommand}" Margin="0,0,0,4"/>
@@ -206,25 +260,27 @@
             </Border>
         </Grid>
 
-        <GridSplitter Grid.Row="2" Height="8" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
+        <GridSplitter Grid.Row="3" Height="8" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
 
-        <Border Grid.Row="3" Style="{StaticResource Card}" Padding="0">
+        <Border Grid.Row="4" Style="{StaticResource Card}" Padding="0">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="8,6">
-                    <DockPanel>
-                        <WrapPanel DockPanel.Dock="Left">
-                            <TextBlock Text="03 Open Request Queue" Style="{StaticResource SectionHeader}" Margin="0" VerticalAlignment="Center"/>
-                            <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenRequestDetailsCommand}" Margin="8,0,4,0"/>
-                            <Button Style="{StaticResource PrimaryButton}" Content="Confirm" Command="{Binding ConfirmRequestCommand}" Margin="0,0,4,0"/>
-                            <Button Style="{StaticResource PrimaryButton}" Content="Cancel" Command="{Binding CancelRequestCommand}" Margin="0,0,4,0"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Print Request" Command="{Binding PrintRequestCommand}" Margin="0,0,4,0"/>
-                            <Button Style="{StaticResource GhostButton}" Content="Print Queue" Command="{Binding PrintRequestsCommand}"/>
+                <Border Style="{StaticResource DesktopPaneHeader}">
+                    <DockPanel LastChildFill="False">
+                        <StackPanel DockPanel.Dock="Left">
+                            <TextBlock Text="Open Request Queue" Style="{StaticResource SectionHeader}" Margin="0"/>
+                            <TextBlock Text="Confirm, cancel, print, and route customer holds tied to unavailable rental items." Style="{StaticResource CaptionTextBlock}"/>
+                        </StackPanel>
+                        <WrapPanel DockPanel.Dock="Right" VerticalAlignment="Center" Margin="12,0,0,0">
+                            <Button Style="{StaticResource PrimaryButton}" Content="Details" Command="{Binding OpenRequestDetailsCommand}" Margin="0,0,4,6"/>
+                            <Button Style="{StaticResource PrimaryButton}" Content="Confirm" Command="{Binding ConfirmRequestCommand}" Margin="0,0,4,6"/>
+                            <Button Style="{StaticResource PrimaryButton}" Content="Cancel" Command="{Binding CancelRequestCommand}" Margin="0,0,4,6"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Print Request" Command="{Binding PrintRequestCommand}" Margin="0,0,4,6"/>
+                            <Button Style="{StaticResource GhostButton}" Content="Print Queue" Command="{Binding PrintRequestsCommand}" Margin="0,0,0,6"/>
                         </WrapPanel>
-                        <TextBlock Text="{Binding RequestSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
                     </DockPanel>
                 </Border>
                 <Grid Grid.Row="1">
@@ -266,12 +322,26 @@
                         <ScrollViewer VerticalScrollBarVisibility="Auto">
                             <StackPanel>
                                 <TextBlock Text="Selected Request" Style="{StaticResource SectionHeader}" Margin="0,0,0,6"/>
-                                <TextBlock Text="{Binding SelectedRequestSummary}" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,0,0,6"/>
-                                <TextBlock Text="{Binding SelectedRequestDateLine}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,8"/>
-                                <TextBlock Text="Current Holder" Style="{StaticResource LabelTextBlock}" Margin="0,4,0,2"/>
-                                <TextBlock Text="{Binding SelectedRequestHolderLine}" TextWrapping="Wrap" Margin="0,0,0,8"/>
-                                <TextBlock Text="Next Action" Style="{StaticResource LabelTextBlock}" Margin="0,4,0,2"/>
-                                <TextBlock Text="{Binding SelectedRequestNextAction}" TextWrapping="Wrap" Margin="0,0,0,8"/>
+                                <TextBlock Text="{Binding RequestSummary}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,8"/>
+                                <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,8">
+                                    <StackPanel>
+                                        <TextBlock Text="Request handoff" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/>
+                                        <TextBlock Text="{Binding SelectedRequestSummary}" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,0,0,6"/>
+                                        <TextBlock Text="{Binding SelectedRequestDateLine}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                    </StackPanel>
+                                </Border>
+                                <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,8">
+                                    <StackPanel>
+                                        <TextBlock Text="Current holder" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
+                                        <TextBlock Text="{Binding SelectedRequestHolderLine}" TextWrapping="Wrap"/>
+                                    </StackPanel>
+                                </Border>
+                                <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,8">
+                                    <StackPanel>
+                                        <TextBlock Text="Next action" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,2"/>
+                                        <TextBlock Text="{Binding SelectedRequestNextAction}" TextWrapping="Wrap"/>
+                                    </StackPanel>
+                                </Border>
                                 <UniformGrid Columns="2" Margin="0,4,0,0">
                                     <Button Style="{StaticResource PrimaryButton}" Content="Confirm" Command="{Binding ConfirmRequestCommand}" Margin="0,0,4,4"/>
                                     <Button Style="{StaticResource PrimaryButton}" Content="Cancel" Command="{Binding CancelRequestCommand}" Margin="0,0,0,4"/>
@@ -281,9 +351,9 @@
                             </StackPanel>
                         </ScrollViewer>
                     </Border>
-                    <TextBlock Grid.Column="0" Text="No open requests for unavailable items" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="13" FontWeight="SemiBold">
-                        <TextBlock.Style>
-                            <Style TargetType="TextBlock">
+                    <Border Grid.Column="0" Width="320" HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding PendingRequests.Count}" Value="0">
@@ -291,13 +361,17 @@
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
+                        </Border.Style>
+                        <StackPanel>
+                            <TextBlock Text="No open requests" Style="{StaticResource SectionHeader}" Margin="0,0,0,4"/>
+                            <TextBlock Text="Requests placed from active unavailable rentals will appear here for confirm, cancel, print, and customer follow-up actions." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
                 </Grid>
             </Grid>
         </Border>
 
-        <Border Grid.Row="4" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
+        <Border Grid.Row="5" Style="{StaticResource ToolbarCard}" Margin="0,4,0,0">
             <DockPanel LastChildFill="True">
                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
                     <Button Style="{StaticResource PrimaryButton}" Content="Check In" Command="{Binding CheckInCommand}" Margin="0,0,4,0"/>
@@ -307,6 +381,6 @@
             </DockPanel>
         </Border>
 
-        <ProgressBar Grid.Row="4" IsIndeterminate="True" Height="4" VerticalAlignment="Top" Visibility="{Binding IsLoading, Converter={StaticResource BoolToVis}}"/>
+        <ProgressBar Grid.Row="5" IsIndeterminate="True" Height="4" VerticalAlignment="Top" Visibility="{Binding IsLoading, Converter={StaticResource BoolToVis}}"/>
     </Grid>
 </Page>

--- a/ToDo.md
+++ b/ToDo.md
@@ -1,6 +1,7 @@
 Please update the ui this is each screen shot photo and feedback on each. this prompt will run every hour so keep track of what has been done. once complete just carry out polish passes..
 
 Progress log:
+- 2026-06-18 05:11 NZST: Polished the Rentals workbench. `ManageRentalsPage` now has a stronger rental desk header, filtered/checked-out/request/selected-rental summary cards, a clearer search and document-action strip, carded advisor handoff context, and a stronger open-request queue hierarchy while preserving existing rental/request commands, bindings, double-click handlers, and row-correct context menu hooks. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-18-rentals-workbench-polish.md`.
 - 2026-06-18 04:11 NZST: Polished the Manage Tools item directory. `ManageItemsPage` now has a stronger inventory workbench header, loaded-row/pending-edit/page-size/selected-item summary cards, visible sort and page-size controls, photo/status/activity-rich rows, clearer right-click actions, and a selected-item handoff pane while preserving existing commands, visibility bindings, incremental loading, and row image cleanup. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-18-manage-items-workbench-polish.md`.
 - 2026-06-18 03:11 NZST: Polished the Settings Database, Branding, and Backups tabs. `SettingsPage` now gives connection setup a readiness panel, gives branding a larger logo/app identity preview, and gives backups a recovery-focused destination layout while preserving existing bindings, commands, tab structure, password-box names, and code-behind handlers. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-18-settings-admin-polish.md`.
 - 2026-06-18 02:11 NZST: Polished the Dashboard KPI and activity surface. `DashboardPage` now has a stronger command-center header, more prominent stat cards, a four-part priority strip for checked-out items/rentals/issues/activity, clearer operational pane captions, and visible recent-activity destination context while preserving existing grid names, commands, bindings, context menus, and keyboard paths. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-18-dashboard-kpi-activity-polish.md`.
@@ -22,14 +23,14 @@ Overall: the UI is operationally competent and consistent, but most screens stil
 07-dashboard-recent-activity-narrow.png: adapts better than expected, but the narrower layout makes the already-dense chrome feel even tighter. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/DashboardPage.xaml`; runtime screenshot review still needed.
 02-operations
 01-manage-tools.png: clear inventory directory screen, but it feels sparse in an unfinished way rather than clean by design. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/ManageItemsPage.xaml`; runtime screenshot review still needed.
-02-rentals.png: one of the most useful screens structurally; also one of the busiest, and it needs stronger section hierarchy.
+02-rentals.png: one of the most useful screens structurally; also one of the busiest, and it needs stronger section hierarchy. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml`; runtime screenshot review still needed.
 03-customers.png: good handoff guidance on the right; the left table and top toolbar still feel visually generic.
 04-maintenance.png: strong workflow framing; the technician handoff panel is useful, but the page is visually very repetitive.
 05-calibration.png: good domain-specific copy and process cues; still too flat to feel premium.
 06-reservations.png: understandable and complete, but the top action band feels crowded and visually undifferentiated.
 07-kits.png: good separation between kit directory, membership, and selected kit; one of the clearer operations screens.
 08-categories.png: the admin handoff content is useful, but the screen needs better visual weight and less empty-white-box feeling.
-09-rentals-narrow.png: still usable, which is a positive; however, the compression exposes how dependent the UI is on thin borders instead of strong hierarchy.
+09-rentals-narrow.png: still usable, which is a positive; however, the compression exposes how dependent the UI is on thin borders instead of strong hierarchy. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml`; runtime screenshot review still needed.
 03-insights
 01-reports.png: very clear reporting shell, but visually sterile; it needs stronger emphasis on the report selector and result state.
 02-activity-logs.png: better than the blank reports view because real data gives it life; still reads more like an admin console than a polished product.


### PR DESCRIPTION
## Summary

- Reworks `ManageRentalsPage` into a stronger rental desk workbench with a clearer header and colocated selected-rental actions.
- Adds filtered-rental, checked-out, open-request, and selected-rental summary cards so the screen has stronger hierarchy before the dense grids.
- Moves search/date/status filtering and print-list actions into a denser directory subheader, and reframes advisor/request details into carded handoff sections.
- Adds a dated progress note and updates `ToDo.md` so the hourly UI polish log records this rentals pass.

## Validation

- Compared the branch against current `master`; it is ahead by three focused commits and behind by zero.
- Read back the changed rentals XAML, progress note, and ToDo log through the GitHub connector.
- Confirmed the edited XAML uses existing `ManageRentalsViewModel` bindings and preserves rental/request double-click and right-click row event hooks.
- Local XAML parsing, `dotnet` build/test, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local clone/raw access remains blocked by the network tunnel.

Did not run unrelated tests, per instruction.