### PR TITLE
[codex] Polish print preview shell

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/PrintPreviewWindowXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/PrintPreviewWindowXamlTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.ViewModels
+{
+    public class PrintPreviewWindowXamlTests
+    {
+        [Fact]
+        public void PrintPreviewWindow_UsesPolishedReviewShellAndStatusFooter()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "PrintPreviewWindow.xaml");
+
+            Assert.Contains("Preview Workstation", xaml, StringComparison.Ordinal);
+            Assert.Contains("Document Canvas", xaml, StringComparison.Ordinal);
+            Assert.Contains("Print checklist", xaml, StringComparison.Ordinal);
+            Assert.Contains("Branding confidence", xaml, StringComparison.Ordinal);
+            Assert.Contains("Ready for final print review", xaml, StringComparison.Ordinal);
+            Assert.Contains("Preview footer status", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PrintPreviewWindow_PreservesDocumentViewerAndPrintCommands()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "PrintPreviewWindow.xaml");
+
+            Assert.Contains("x:Name=\"PreviewLogo\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"PreviewTitle\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"DocViewer\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("PageSetupCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrintCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("CloseCommand", xaml, StringComparison.Ordinal);
+        }
+
+        static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-18-print-preview-shell-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-18-print-preview-shell-polish.md
@@ -1,0 +1,26 @@
+# Print Preview Shell Polish - 2026-06-18 15:11 NZST
+
+## Completed
+
+- Reworked `PrintPreviewWindow.xaml` from a plain toolbar and embedded document viewer into a more deliberate print review workstation.
+- Added a stronger branded header with the existing preview logo/title bindings, clear Page Setup/Print/Close actions, and review guidance.
+- Wrapped the `FlowDocumentScrollViewer` in a white document canvas so invoices, directories, handoff sheets, reports, and logs feel like reviewed output instead of raw content in a box.
+- Added a right-side print checklist and branding-confidence guidance so the preview surface feels consistent for customer-facing and operations-facing documents.
+- Added a fixed footer status strip to align with the broader app request for stable bottom status areas.
+- Added `PrintPreviewWindowXamlTests` to guard the new shell markers while preserving `PreviewLogo`, `PreviewTitle`, `DocViewer`, `PageSetupCommand`, `PrintCommand`, and `CloseCommand`.
+
+## Why this mattered
+
+`ToDo.md` calls out nearly every print preview as readable but visually thin. Polishing the shared preview shell improves all of those output surfaces at once without having to touch each report generator separately.
+
+## Validation
+
+- Reviewed `ToDo.md`, `PrintPreviewWindow.xaml`, and `PrintPreviewWindow.xaml.cs` through the GitHub connector before editing.
+- Kept the existing code-behind names and command bindings intact.
+- Added focused XAML contract coverage for the updated preview shell.
+- Local XAML parsing, `dotnet` build/test, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and local clone/raw access is blocked.
+
+## Follow-up
+
+- Runtime Windows QA should confirm the preview shell fits invoices, directories, audit logs, and report outputs at standard and narrow workstation sizes.
+- Next useful UI targets are password-reset prompt polish, remaining edit/detail dialogs, and document-specific print styling for the highest-value outputs.

--- a/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml
@@ -3,44 +3,151 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Print Preview"
-        Width="1200" Height="800"
+        Width="1220" Height="820"
+        MinWidth="980" MinHeight="680"
         WindowStartupLocation="CenterScreen"
         Background="{DynamicResource BackgroundBrush}">
-    <DockPanel Margin="10">
-        <Border DockPanel.Dock="Top"
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0"
                 Background="{DynamicResource SurfaceAltBrush}"
-                BorderBrush="{DynamicResource BorderBrushAlt}"
-                BorderThickness="1"
-                Padding="10"
+                BorderBrush="{DynamicResource AccentBrush}"
+                BorderThickness="1,1,1,3"
+                Padding="14"
                 CornerRadius="8">
             <DockPanel LastChildFill="False">
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,8,0">
-                    <Image x:Name="PreviewLogo"
-                           Width="32" Height="32"
-                           Stretch="Uniform"
-                           Margin="0,0,8,0"/>
-                    <TextBlock x:Name="PreviewTitle"
-                               Style="{StaticResource HeadingTextBlock}"
-                               VerticalAlignment="Center"/>
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,16,0">
+                    <Border Width="48" Height="48"
+                            Background="{DynamicResource SurfaceBrush}"
+                            BorderBrush="{DynamicResource BorderBrushAlt}"
+                            BorderThickness="1"
+                            CornerRadius="6"
+                            Margin="0,0,12,0">
+                        <Image x:Name="PreviewLogo"
+                               Width="34" Height="34"
+                               Stretch="Uniform"
+                               VerticalAlignment="Center"
+                               HorizontalAlignment="Center"/>
+                    </Border>
+                    <StackPanel VerticalAlignment="Center">
+                        <TextBlock Text="Preview Workstation" Style="{StaticResource CaptionTextBlock}"/>
+                        <TextBlock x:Name="PreviewTitle"
+                                   Style="{StaticResource HeadingTextBlock}"
+                                   TextWrapping="Wrap"
+                                   MaxWidth="580"/>
+                        <TextBlock Text="Review page setup, content, and branding before sending output to the printer."
+                                   Style="{StaticResource CaptionTextBlock}"
+                                   TextWrapping="Wrap"
+                                   MaxWidth="620"
+                                   Margin="0,3,0,0"/>
+                    </StackPanel>
                 </StackPanel>
+
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
-                    <Button Style="{StaticResource PrimaryButton}"
+                    <Button Style="{StaticResource GhostButton}"
                             Content="Page Setup"
-                            Command="{Binding PageSetupCommand}"/>
+                            Command="{Binding PageSetupCommand}"
+                            MinWidth="108"/>
                     <Button Style="{StaticResource PrimaryButton}"
                             Content="Print"
                             Margin="8,0,0,0"
-                            Command="{Binding PrintCommand}"/>
-                    <Button Style="{StaticResource PrimaryButton}"
+                            Command="{Binding PrintCommand}"
+                            MinWidth="88"/>
+                    <Button Style="{StaticResource GhostButton}"
                             Content="Close"
                             Margin="8,0,0,0"
-                            Command="{Binding CloseCommand}"/>
+                            Command="{Binding CloseCommand}"
+                            MinWidth="88"/>
                 </StackPanel>
             </DockPanel>
         </Border>
 
-        <Border Style="{StaticResource Card}" Padding="0" Margin="0,8,0,0">
-            <FlowDocumentScrollViewer x:Name="DocViewer"/>
+        <Grid Grid.Row="1" Margin="0,10,0,10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="280"/>
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0"
+                    Background="{DynamicResource SurfaceBrush}"
+                    BorderBrush="{DynamicResource BorderBrushAlt}"
+                    BorderThickness="1"
+                    CornerRadius="8"
+                    Padding="12">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <DockPanel Grid.Row="0" LastChildFill="False" Margin="0,0,0,10">
+                        <StackPanel DockPanel.Dock="Left">
+                            <TextBlock Text="Document Canvas" Style="{StaticResource SubheadingTextBlock}"/>
+                            <TextBlock Text="Live preview of the printable content with the current app logo and report title." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                        <TextBlock DockPanel.Dock="Right" Text="Output Review" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center"/>
+                    </DockPanel>
+
+                    <Border Grid.Row="1"
+                            Background="White"
+                            BorderBrush="#D4D9E2"
+                            BorderThickness="1"
+                            Padding="8"
+                            CornerRadius="4">
+                        <FlowDocumentScrollViewer x:Name="DocViewer"
+                                                  Background="White"
+                                                  IsToolBarVisible="False"
+                                                  VerticalScrollBarVisibility="Auto"/>
+                    </Border>
+                </Grid>
+            </Border>
+
+            <StackPanel Grid.Column="1" Margin="10,0,0,0">
+                <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10">
+                    <StackPanel>
+                        <TextBlock Text="Print checklist" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="1. Confirm the title and logo match the handoff." TextWrapping="Wrap" Margin="0,6,0,0"/>
+                        <TextBlock Text="2. Use Page Setup when content needs a wider sheet." TextWrapping="Wrap" Margin="0,4,0,0"/>
+                        <TextBlock Text="3. Print only after the preview reads cleanly." TextWrapping="Wrap" Margin="0,4,0,0"/>
+                    </StackPanel>
+                </Border>
+
+                <Border Style="{StaticResource DesktopNoteCard}" Margin="0,0,0,10">
+                    <StackPanel>
+                        <TextBlock Text="Branding confidence" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="This frame gives every directory, sheet, invoice, and handoff preview the same review surface before staff produce customer-facing output." TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Border>
+
+                <Border Style="{StaticResource DesktopSummaryCard}">
+                    <StackPanel>
+                        <TextBlock Text="Available actions" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="Page setup adjusts the document width, Print opens the Windows printer dialog, and Close returns to the originating workflow." TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Grid>
+
+        <Border Grid.Row="2"
+                Background="{DynamicResource SurfaceAltBrush}"
+                BorderBrush="{DynamicResource BorderBrushAlt}"
+                BorderThickness="1"
+                CornerRadius="6"
+                Padding="10,7">
+            <DockPanel LastChildFill="False">
+                <TextBlock DockPanel.Dock="Left"
+                           Text="Ready for final print review"
+                           Style="{StaticResource CaptionTextBlock}"
+                           VerticalAlignment="Center"/>
+                <TextBlock DockPanel.Dock="Right"
+                           Text="Preview footer status"
+                           Style="{StaticResource CaptionTextBlock}"
+                           VerticalAlignment="Center"/>
+            </DockPanel>
         </Border>
-    </DockPanel>
+    </Grid>
 </Window>


### PR DESCRIPTION
## Summary

- Reworks `PrintPreviewWindow` into a more deliberate print review workstation with a stronger branded header, document canvas, right-side checklist, and stable footer status strip.
- Preserves the existing preview logo/title/document viewer names and Page Setup, Print, and Close command bindings.
- Adds `PrintPreviewWindowXamlTests` to guard the new preview shell markers and command wiring.
- Records the completed pass in `InventoryManagementApp/ProgressNotes/2026-06-18-print-preview-shell-polish.md`.

## Validation

- GitHub connector readback confirmed the changed XAML, new XAML test, and progress note on the branch.
- GitHub connector compare confirmed the branch is 3 commits ahead of `master` and not behind.
- Local `dotnet` build/test, WPF screenshots, local XAML parsing, and local banned-word checks could not be run in this scheduled Linux container because the .NET SDK/Windows WPF runtime and local clone/raw access remain blocked.