### PR TITLE
Polish password reset prompt recovery state

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/PasswordPromptWindowXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/PasswordPromptWindowXamlTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.ViewModels
+{
+    public class PasswordPromptWindowXamlTests
+    {
+        [Fact]
+        public void PasswordPromptWindow_UsesPolishedResetRecoveryPanelAndFooter()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "PasswordPromptWindow.xaml");
+
+            Assert.Contains("Secure Access", xaml, StringComparison.Ordinal);
+            Assert.Contains("Password Reset Request", xaml, StringComparison.Ordinal);
+            Assert.Contains("ResetRecoveryPanel", xaml, StringComparison.Ordinal);
+            Assert.Contains("Request Reset", xaml, StringComparison.Ordinal);
+            Assert.Contains("Auth footer status", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PasswordPromptWindow_PreservesPasswordAndCommandWiring()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "PasswordPromptWindow.xaml");
+            var codeBehind = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "PasswordPromptWindow.xaml.cs");
+
+            Assert.Contains("x:Name=\"PromptTextBlock\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"PasswordBox\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("PasswordChanged=\"PasswordBox_PasswordChanged\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"ForgotPasswordButton\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ResetPasswordCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("CancelCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("OkCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ResetRecoveryPanel.Visibility", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("_attemptCount >= MaxAttempts", codeBehind, StringComparison.Ordinal);
+        }
+
+        static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-18-password-reset-prompt-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-18-password-reset-prompt-polish.md
@@ -1,0 +1,15 @@
+# Password Reset Prompt Polish - 2026-06-18
+
+## Completed
+
+- Polished `PasswordPromptWindow.xaml` so the failed-password recovery state no longer feels like a bare link under an error message.
+- Added a dedicated `Password Reset Request` recovery panel that appears after repeated failed attempts and explains the admin-only reset path.
+- Kept the primary unlock/cancel actions anchored in the dialog button bar while moving the reset request into its own structured panel.
+- Added an auth footer status cue so the modal has the same finished workstation feel as the other polished surfaces.
+- Updated `PasswordPromptWindow.xaml.cs` so the new recovery panel follows the same failed-attempt threshold as the existing reset command.
+- Added `PasswordPromptWindowXamlTests` to guard the reset panel markers, password box wiring, reset command binding, dialog commands, and failed-attempt reveal logic.
+
+## Validation
+
+- GitHub connector readback should be used to verify the changed XAML, code-behind, test, and this note on the branch.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks could not be run in this scheduled Linux container because the .NET SDK/Windows WPF runtime and local clone/raw access remain unavailable.

--- a/InventoryManagementApp/Views/Windows/PasswordPromptWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/PasswordPromptWindow.xaml
@@ -4,12 +4,13 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         Title="Enter Password"
-        Width="560" Height="330"
-        MinWidth="520" MinHeight="300"
+        Width="620" Height="440"
+        MinWidth="560" MinHeight="400"
         WindowStartupLocation="CenterScreen"
         Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="14">
+    <Grid Margin="16">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -18,19 +19,32 @@
         </Grid.RowDefinitions>
 
         <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10">
-            <StackPanel>
-                <TextBlock Text="Secure Access" Style="{StaticResource PageTitleTextBlock}"/>
-                <TextBlock x:Name="PromptTextBlock"
-                           Style="{StaticResource CaptionTextBlock}"
-                           TextWrapping="Wrap"
-                           Margin="0,4,0,0"/>
-            </StackPanel>
-        </Border>
-
-        <Border Grid.Row="1" Style="{StaticResource DesktopInsetCard}" Padding="12">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="150"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel>
+                    <TextBlock Text="Secure Access" Style="{StaticResource PageTitleTextBlock}"/>
+                    <TextBlock x:Name="PromptTextBlock"
+                               Style="{StaticResource CaptionTextBlock}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,0"/>
+                </StackPanel>
+                <Border Grid.Column="1"
+                        Style="{StaticResource DesktopNoteCard}"
+                        Padding="10,6"
+                        Margin="12,0,0,0"
+                        VerticalAlignment="Top">
+                    <TextBlock Text="Password required" Style="{StaticResource CaptionTextBlock}"/>
+                </Border>
+            </Grid>
+        </Border>
+
+        <Border Grid.Row="1" Style="{StaticResource DesktopInsetCard}" Padding="14">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="170"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <StackPanel>
@@ -40,32 +54,52 @@
                 <PasswordBox x:Name="PasswordBox"
                              Grid.Column="1"
                              PasswordChar="•"
-                             Margin="10,2,0,0"
-                             MinWidth="250"
+                             Margin="12,2,0,0"
+                             MinWidth="300"
                              PasswordChanged="PasswordBox_PasswordChanged"/>
             </Grid>
         </Border>
 
-        <Button x:Name="ForgotPasswordButton"
-                Grid.Row="2"
-                Content="Forgot password? Start a reset request."
-                Margin="2,8,0,0"
-                Visibility="Collapsed"
-                Style="{StaticResource LinkButton}"
-                Command="{Binding ResetPasswordCommand}"/>
-
         <TextBlock x:Name="ErrorTextBlock"
-                   Grid.Row="3"
+                   Grid.Row="2"
                    Style="{StaticResource ErrorTextBlock}"
                    Visibility="Collapsed"
                    Margin="2,10,0,0"
                    TextWrapping="Wrap"/>
 
-        <controls:DialogButtonBar Grid.Row="4"
-                                  Margin="0,12,0,0"
-                                  LeftButtonText="Cancel"
-                                  LeftCommand="{Binding CancelCommand}"
-                                  RightButtonText="Unlock"
-                                  RightCommand="{Binding OkCommand}"/>
+        <Border x:Name="ResetRecoveryPanel"
+                Grid.Row="3"
+                Style="{StaticResource DesktopNoteCard}"
+                Visibility="Collapsed"
+                Margin="0,10,0,0"
+                Padding="14">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel>
+                    <TextBlock Text="Password Reset Request" Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="After multiple failed attempts, admins can reset to the default password and change it immediately after login. This keeps the reset path visible without hiding the normal unlock action." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,4,18,0"/>
+                </StackPanel>
+                <Button x:Name="ForgotPasswordButton"
+                        Grid.Column="1"
+                        Content="Request Reset"
+                        MinWidth="130"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource SecondaryButton}"
+                        Command="{Binding ResetPasswordCommand}"/>
+            </Grid>
+        </Border>
+
+        <StackPanel Grid.Row="5" Margin="0,12,0,0">
+            <controls:DialogButtonBar LeftButtonText="Cancel"
+                                      LeftCommand="{Binding CancelCommand}"
+                                      RightButtonText="Unlock"
+                                      RightCommand="{Binding OkCommand}"/>
+            <Border Style="{StaticResource DesktopNoteCard}" Margin="0,10,0,0" Padding="10,6">
+                <TextBlock Text="Auth footer status: failed attempts reveal the reset request panel while keeping Cancel and Unlock anchored in the same place." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+            </Border>
+        </StackPanel>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/PasswordPromptWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/PasswordPromptWindow.xaml
@@ -87,7 +87,7 @@
                         Content="Request Reset"
                         MinWidth="130"
                         VerticalAlignment="Center"
-                        Style="{StaticResource SecondaryButton}"
+                        Style="{StaticResource GhostButton}"
                         Command="{Binding ResetPasswordCommand}"/>
             </Grid>
         </Border>

--- a/InventoryManagementApp/Views/Windows/PasswordPromptWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/PasswordPromptWindow.xaml.cs
@@ -66,7 +66,11 @@ namespace InventoryManagementApp.Views.Windows
             ErrorTextBlock.Text = message;
             ErrorTextBlock.Visibility = Visibility.Visible;
 
-            ForgotPasswordButton.Visibility = _attemptCount >= MaxAttempts
+            var showResetRecovery = _attemptCount >= MaxAttempts;
+            ResetRecoveryPanel.Visibility = showResetRecovery
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+            ForgotPasswordButton.Visibility = showResetRecovery
                 ? Visibility.Visible
                 : Visibility.Collapsed;
 


### PR DESCRIPTION
## Summary

- Reworks the password prompt reset state into a deliberate `Password Reset Request` recovery panel that appears after repeated failed attempts.
- Keeps Cancel and Unlock anchored in the dialog button bar while the reset request has its own structured guidance and existing `ResetPasswordCommand` path.
- Updates the code-behind so the recovery panel follows the existing failed-attempt threshold.
- Adds `PasswordPromptWindowXamlTests` to guard the reset panel markers, password box wiring, reset command binding, dialog commands, and reveal logic.
- Records the scheduled progress in `InventoryManagementApp/ProgressNotes/2026-06-18-password-reset-prompt-polish.md`.

## Validation

- GitHub connector compare shows the branch is 5 commits ahead of `master` and 0 behind, with a focused four-file diff.
- GitHub connector readback confirmed the changed XAML, code-behind, XAML test, and progress note on the branch.
- Checked shared resources before finalizing the XAML and replaced a non-existent candidate button style with the existing `GhostButton` style.
- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks could not be run in this scheduled Linux container because the .NET SDK/Windows WPF runtime and local clone/raw access remain unavailable.