### PR TITLE
Polish dialog and output windows

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/DialogOutputWindowXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/DialogOutputWindowXamlTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.ViewModels
+{
+    public class DialogOutputWindowXamlTests
+    {
+        [Fact]
+        public void MessageDialogs_UsePolishedHeadersFootersAndPreserveCommands()
+        {
+            var info = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "InfoDialogWindow.xaml");
+            var confirm = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "ConfirmDialogWindow.xaml");
+            var input = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "InputDialogWindow.xaml");
+
+            Assert.Contains("Information Notice", info, StringComparison.Ordinal);
+            Assert.Contains("Message reviewed when OK is selected.", info, StringComparison.Ordinal);
+            Assert.Contains("OkCommand", info, StringComparison.Ordinal);
+
+            Assert.Contains("Confirm Action", confirm, StringComparison.Ordinal);
+            Assert.Contains("Action Review", confirm, StringComparison.Ordinal);
+            Assert.Contains("CancelCommand", confirm, StringComparison.Ordinal);
+            Assert.Contains("OkCommand", confirm, StringComparison.Ordinal);
+
+            Assert.Contains("Input Required", input, StringComparison.Ordinal);
+            Assert.Contains("Input is applied only after OK is selected.", input, StringComparison.Ordinal);
+            Assert.Contains("InputText, UpdateSourceTrigger=PropertyChanged", input, StringComparison.Ordinal);
+            Assert.Contains("CancelCommand", input, StringComparison.Ordinal);
+            Assert.Contains("OkCommand", input, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OutputAndMappingDialogs_UseWorkbenchStructureAndPreserveCommands()
+        {
+            var labels = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "PrintLabelWindow.xaml");
+            var mapping = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "ImportMappingWindow.xaml");
+            var imageMapping = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "ImageImportMappingWindow.xaml");
+
+            Assert.Contains("Label Output Workbench", labels, StringComparison.Ordinal);
+            Assert.Contains("Queued Label Items", labels, StringComparison.Ordinal);
+            Assert.Contains("PreviewCommand", labels, StringComparison.Ordinal);
+            Assert.Contains("PrintCommand", labels, StringComparison.Ordinal);
+            Assert.Contains("CloseCommand", labels, StringComparison.Ordinal);
+
+            Assert.Contains("Import Mapping Workbench", mapping, StringComparison.Ordinal);
+            Assert.Contains("Field Mapping Table", mapping, StringComparison.Ordinal);
+            Assert.Contains("DataContext.ColumnHeaders", mapping, StringComparison.Ordinal);
+            Assert.Contains("CancelCommand", mapping, StringComparison.Ordinal);
+            Assert.Contains("OkCommand", mapping, StringComparison.Ordinal);
+
+            Assert.Contains("Picture Matching Setup", imageMapping, StringComparison.Ordinal);
+            Assert.Contains("Import confidence", imageMapping, StringComparison.Ordinal);
+            Assert.Contains("UseItemNumber", imageMapping, StringComparison.Ordinal);
+            Assert.Contains("UsePartNumber", imageMapping, StringComparison.Ordinal);
+            Assert.Contains("UseName", imageMapping, StringComparison.Ordinal);
+            Assert.Contains("CancelCommand", imageMapping, StringComparison.Ordinal);
+            Assert.Contains("OkCommand", imageMapping, StringComparison.Ordinal);
+        }
+
+        static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-18-dialog-output-window-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-18-dialog-output-window-polish.md
@@ -1,0 +1,20 @@
+# Dialog Output Window Polish - 2026-06-18 19:11 NZST
+
+## Completed
+
+- Polished the basic information, confirmation, and input dialogs with consistent header framing, clearer message bodies, stable action areas, and footer status cues.
+- Polished the label output dialog into a fuller review workbench with template guidance, queued item context, aligned Preview/Print/Close actions, and a footer readiness note.
+- Polished the CSV import mapping dialog with a guided three-step mapping overview, stronger field mapping table header, and a footer confirmation cue.
+- Polished the image import mapping dialog with clearer photo matching guidance, more readable identifier options, and import-confidence context.
+- Added `DialogOutputWindowXamlTests` to guard the updated dialog markers while preserving existing command bindings and data-entry paths.
+
+## Preserved
+
+- Existing dialog window classes and constructors.
+- Existing `OkCommand`, `CancelCommand`, `PreviewCommand`, `PrintCommand`, `CloseCommand`, and mapping bindings.
+- Existing label template, QR, CSV column selection, and image matching view-model bindings.
+
+## Validation Notes
+
+- GitHub connector read/write was used because local clone/raw repository access remains blocked by the network tunnel.
+- Local `dotnet`, WPF screenshots, and local banned-word checks were not available in this scheduled Linux container.

--- a/InventoryManagementApp/Views/Windows/ConfirmDialogWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ConfirmDialogWindow.xaml
@@ -16,7 +16,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Style="{StaticResource PageHeaderCard}" Padding="16,14">
+        <Border Style="{StaticResource ToolbarCard}" Padding="16,14">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -25,11 +25,11 @@
                 <StackPanel>
                     <TextBlock Text="Confirm Action" Style="{StaticResource HeadingTextBlock}"/>
                     <TextBlock Text="Choose the outcome intentionally before the app continues."
-                               Style="{StaticResource MutedTextBlock}"
+                               Style="{StaticResource CaptionTextBlock}"
                                Margin="0,4,0,0"/>
                 </StackPanel>
-                <Border Grid.Column="1" Style="{StaticResource SummaryStatCard}" Padding="12,8" VerticalAlignment="Center">
-                    <TextBlock Text="Decision" Style="{StaticResource SummaryStatLabel}"/>
+                <Border Grid.Column="1" Style="{StaticResource Card}" Padding="12,8" VerticalAlignment="Center">
+                    <TextBlock Text="Decision" Style="{StaticResource LabelTextBlock}"/>
                 </Border>
             </Grid>
         </Border>
@@ -40,7 +40,7 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
-                <Border Width="44" Height="44" CornerRadius="8" Background="{DynamicResource WarningSoftBrush}" VerticalAlignment="Top">
+                <Border Width="44" Height="44" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource AccentBrush}" BorderThickness="1" VerticalAlignment="Top">
                     <TextBlock Text="?" FontSize="24" FontWeight="SemiBold" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                 </Border>
                 <StackPanel Grid.Column="1" Margin="14,0,0,0">
@@ -58,8 +58,8 @@
                                   RightButtonText="Yes"
                                   RightCommand="{Binding OkCommand}"/>
 
-        <Border Grid.Row="3" Style="{StaticResource StatusFooterBar}" Margin="0,12,0,0">
-            <TextBlock Text="No returns to the current screen; Yes confirms this action." Style="{StaticResource MutedTextBlock}"/>
+        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,12,0,0" Padding="10,7">
+            <TextBlock Text="No returns to the current screen; Yes confirms this action." Style="{StaticResource CaptionTextBlock}"/>
         </Border>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/ConfirmDialogWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ConfirmDialogWindow.xaml
@@ -1,24 +1,65 @@
-﻿<!-- Views/ConfirmDialogWindow.xaml -->
+<!-- Views/ConfirmDialogWindow.xaml -->
 <Window x:Class="InventoryManagementApp.Views.Windows.ConfirmDialogWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         Title="Confirm"
-        Width="480" Height="220"
-        WindowStartupLocation="CenterScreen"
+        Width="540" Height="300"
+        MinWidth="520" MinHeight="280"
+        WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="14">
+    <Grid Margin="16">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <Border Style="{StaticResource Card}">
-            <TextBlock Text="{Binding Message}" Style="{StaticResource DialogMessageTextBlock}"/>
+
+        <Border Style="{StaticResource PageHeaderCard}" Padding="16,14">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel>
+                    <TextBlock Text="Confirm Action" Style="{StaticResource HeadingTextBlock}"/>
+                    <TextBlock Text="Choose the outcome intentionally before the app continues."
+                               Style="{StaticResource MutedTextBlock}"
+                               Margin="0,4,0,0"/>
+                </StackPanel>
+                <Border Grid.Column="1" Style="{StaticResource SummaryStatCard}" Padding="12,8" VerticalAlignment="Center">
+                    <TextBlock Text="Decision" Style="{StaticResource SummaryStatLabel}"/>
+                </Border>
+            </Grid>
         </Border>
-        <controls:DialogButtonBar Grid.Row="1"
+
+        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,12,0,12" Padding="18">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Border Width="44" Height="44" CornerRadius="8" Background="{DynamicResource WarningSoftBrush}" VerticalAlignment="Top">
+                    <TextBlock Text="?" FontSize="24" FontWeight="SemiBold" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                </Border>
+                <StackPanel Grid.Column="1" Margin="14,0,0,0">
+                    <TextBlock Text="Action Review" Style="{StaticResource SectionHeader}"/>
+                    <TextBlock Text="{Binding Message}"
+                               Style="{StaticResource DialogMessageTextBlock}"
+                               Margin="0,6,0,0"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <controls:DialogButtonBar Grid.Row="2"
                                   LeftButtonText="No"
                                   LeftCommand="{Binding CancelCommand}"
                                   RightButtonText="Yes"
                                   RightCommand="{Binding OkCommand}"/>
+
+        <Border Grid.Row="3" Style="{StaticResource StatusFooterBar}" Margin="0,12,0,0">
+            <TextBlock Text="No returns to the current screen; Yes confirms this action." Style="{StaticResource MutedTextBlock}"/>
+        </Border>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml
@@ -5,25 +5,71 @@
         xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
         Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Import {0} Pictures'}"
-        Width="600" Height="220"
-        WindowStartupLocation="CenterScreen"
+        Width="680" Height="360"
+        MinWidth="640" MinHeight="330"
+        WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <DockPanel Margin="10">
-        <Border Style="{StaticResource Card}" DockPanel.Dock="Top">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <Border Style="{StaticResource PageHeaderCard}" Padding="16,14">
             <StackPanel>
-                <TextBlock Text="Match images by:" Style="{StaticResource SectionHeader}"/>
-                <WrapPanel>
-                    <CheckBox Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0}Number'}" IsChecked="{Binding UseItemNumber}" Margin="6,0"/>
-                    <CheckBox Content="PartNumber" IsChecked="{Binding UsePartNumber}" Margin="6,0"/>
-                    <CheckBox Content="Name" IsChecked="{Binding UseName}" Margin="6,0"/>
-                </WrapPanel>
+                <TextBlock Text="Picture Matching Setup" Style="{StaticResource HeadingTextBlock}"/>
+                <TextBlock Text="Choose which item fields can match incoming image filenames during photo import."
+                           Style="{StaticResource MutedTextBlock}"
+                           Margin="0,4,0,0"/>
             </StackPanel>
         </Border>
 
-        <controls:DialogButtonBar DockPanel.Dock="Bottom"
+        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,12,0,12" Padding="18">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel>
+                    <TextBlock Text="Match images by" Style="{StaticResource SectionHeader}"/>
+                    <TextBlock Text="Enable the identifiers that are expected to appear in image file names. More than one option can be selected."
+                               Style="{StaticResource MutedTextBlock}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,12"/>
+                    <WrapPanel>
+                        <CheckBox Content="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} Number'}"
+                                  IsChecked="{Binding UseItemNumber}"
+                                  Margin="0,0,16,8"/>
+                        <CheckBox Content="Part Number"
+                                  IsChecked="{Binding UsePartNumber}"
+                                  Margin="0,0,16,8"/>
+                        <CheckBox Content="Name"
+                                  IsChecked="{Binding UseName}"
+                                  Margin="0,0,16,8"/>
+                    </WrapPanel>
+                </StackPanel>
+                <Border Grid.Column="1" Style="{StaticResource SummaryStatCard}" Padding="14" Margin="18,0,0,0">
+                    <StackPanel>
+                        <TextBlock Text="Import confidence" Style="{StaticResource SummaryStatLabel}"/>
+                        <TextBlock Text="Pick the most reliable filename identifiers first, then review the mapped photos in the data operations workflow."
+                                   Style="{StaticResource MutedTextBlock}"
+                                   TextWrapping="Wrap"
+                                   Margin="0,6,0,0"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Border>
+
+        <controls:DialogButtonBar Grid.Row="2"
                                   LeftButtonText="Cancel"
                                   LeftCommand="{Binding CancelCommand}"
                                   RightButtonText="OK"
                                   RightCommand="{Binding OkCommand}"/>
-    </DockPanel>
+
+        <Border Grid.Row="3" Style="{StaticResource StatusFooterBar}" Margin="0,12,0,0">
+            <TextBlock Text="Image matching rules are applied after OK is selected." Style="{StaticResource MutedTextBlock}"/>
+        </Border>
+    </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml
@@ -17,11 +17,11 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Style="{StaticResource PageHeaderCard}" Padding="16,14">
+        <Border Style="{StaticResource ToolbarCard}" Padding="16,14">
             <StackPanel>
                 <TextBlock Text="Picture Matching Setup" Style="{StaticResource HeadingTextBlock}"/>
                 <TextBlock Text="Choose which item fields can match incoming image filenames during photo import."
-                           Style="{StaticResource MutedTextBlock}"
+                           Style="{StaticResource CaptionTextBlock}"
                            Margin="0,4,0,0"/>
             </StackPanel>
         </Border>
@@ -35,7 +35,7 @@
                 <StackPanel>
                     <TextBlock Text="Match images by" Style="{StaticResource SectionHeader}"/>
                     <TextBlock Text="Enable the identifiers that are expected to appear in image file names. More than one option can be selected."
-                               Style="{StaticResource MutedTextBlock}"
+                               Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,4,0,12"/>
                     <WrapPanel>
@@ -50,11 +50,11 @@
                                   Margin="0,0,16,8"/>
                     </WrapPanel>
                 </StackPanel>
-                <Border Grid.Column="1" Style="{StaticResource SummaryStatCard}" Padding="14" Margin="18,0,0,0">
+                <Border Grid.Column="1" Style="{StaticResource Card}" Padding="14" Margin="18,0,0,0">
                     <StackPanel>
-                        <TextBlock Text="Import confidence" Style="{StaticResource SummaryStatLabel}"/>
+                        <TextBlock Text="Import confidence" Style="{StaticResource SectionHeader}"/>
                         <TextBlock Text="Pick the most reliable filename identifiers first, then review the mapped photos in the data operations workflow."
-                                   Style="{StaticResource MutedTextBlock}"
+                                   Style="{StaticResource CaptionTextBlock}"
                                    TextWrapping="Wrap"
                                    Margin="0,6,0,0"/>
                     </StackPanel>
@@ -68,8 +68,8 @@
                                   RightButtonText="OK"
                                   RightCommand="{Binding OkCommand}"/>
 
-        <Border Grid.Row="3" Style="{StaticResource StatusFooterBar}" Margin="0,12,0,0">
-            <TextBlock Text="Image matching rules are applied after OK is selected." Style="{StaticResource MutedTextBlock}"/>
+        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,12,0,0" Padding="10,7">
+            <TextBlock Text="Image matching rules are applied after OK is selected." Style="{StaticResource CaptionTextBlock}"/>
         </Border>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/ImportMappingWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ImportMappingWindow.xaml
@@ -4,48 +4,127 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         Title="Import Mapping"
-        Width="1040" Height="620"
-        WindowStartupLocation="CenterScreen"
+        Width="1100" Height="700"
+        MinWidth="960" MinHeight="620"
+        WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <DockPanel Margin="10">
-        <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="10">
-            <TextBlock Text="Map CSV Columns to Fields" Style="{StaticResource HeadingTextBlock}"/>
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <Border Style="{StaticResource PageHeaderCard}" Padding="16,14">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel>
+                    <TextBlock Text="Import Mapping Workbench" Style="{StaticResource HeadingTextBlock}"/>
+                    <TextBlock Text="Match each application field to the incoming CSV column before the import continues."
+                               Style="{StaticResource MutedTextBlock}"
+                               Margin="0,4,0,0"/>
+                </StackPanel>
+                <Border Grid.Column="1" Style="{StaticResource SummaryStatCard}" Padding="12,8" VerticalAlignment="Center">
+                    <StackPanel>
+                        <TextBlock Text="Column Review" Style="{StaticResource SummaryStatLabel}"/>
+                        <TextBlock Text="Required fields first" Style="{StaticResource MutedTextBlock}" Margin="0,2,0,0"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
         </Border>
 
-        <Border Style="{StaticResource Card}" Margin="0,8,0,8" DockPanel.Dock="Top">
-            <DataGrid ItemsSource="{Binding Mappings}"
-                      AutoGenerateColumns="False"
-                      HeadersVisibility="Column"
-                      CanUserAddRows="False"
-                      CanUserDeleteRows="False"
-                      IsReadOnly="False"
-                      Style="{StaticResource VirtualizedDataGridStyle}"
-                      ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
-                <DataGrid.Columns>
-                    <DataGridTextColumn Header="Property" Binding="{Binding PropertyName}" IsReadOnly="True" Width="2*"/>
-                    <DataGridTemplateColumn Header="CSV Column" Width="3*">
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding SelectedColumn}" VerticalAlignment="Center"/>
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                        <DataGridTemplateColumn.CellEditingTemplate>
-                            <DataTemplate>
-                                <ComboBox ItemsSource="{Binding DataContext.ColumnHeaders, RelativeSource={RelativeSource AncestorType=Window}}"
-                                          SelectedItem="{Binding SelectedColumn, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                          Margin="0"
-                                          ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellEditingTemplate>
-                    </DataGridTemplateColumn>
-                </DataGrid.Columns>
-            </DataGrid>
+        <Border Grid.Row="1" Style="{StaticResource ToolbarCard}" Margin="0,12,0,10" Padding="12">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel>
+                    <TextBlock Text="1. Review fields" Style="{StaticResource SectionHeader}"/>
+                    <TextBlock Text="Required destination fields should be mapped before optional detail fields."
+                               Style="{StaticResource MutedTextBlock}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,12,0"/>
+                </StackPanel>
+                <StackPanel Grid.Column="1">
+                    <TextBlock Text="2. Choose CSV columns" Style="{StaticResource SectionHeader}"/>
+                    <TextBlock Text="Use the drop-down in each row to pair incoming columns with app fields."
+                               Style="{StaticResource MutedTextBlock}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,12,0"/>
+                </StackPanel>
+                <StackPanel Grid.Column="2">
+                    <TextBlock Text="3. Confirm mapping" Style="{StaticResource SectionHeader}"/>
+                    <TextBlock Text="Cancel returns to data operations; OK accepts the selected mapping."
+                               Style="{StaticResource MutedTextBlock}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,0"/>
+                </StackPanel>
+            </Grid>
         </Border>
 
-        <controls:DialogButtonBar DockPanel.Dock="Bottom"
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Border Style="{StaticResource PaneHeaderBar}" Padding="12,10">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Field Mapping Table" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Grid.Column="1" Text="Destination field to CSV column" Style="{StaticResource MutedTextBlock}"/>
+                    </Grid>
+                </Border>
+                <DataGrid Grid.Row="1"
+                          ItemsSource="{Binding Mappings}"
+                          AutoGenerateColumns="False"
+                          HeadersVisibility="Column"
+                          CanUserAddRows="False"
+                          CanUserDeleteRows="False"
+                          IsReadOnly="False"
+                          Style="{StaticResource VirtualizedDataGridStyle}"
+                          ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Property" Binding="{Binding PropertyName}" IsReadOnly="True" Width="2*"/>
+                        <DataGridTemplateColumn Header="CSV Column" Width="3*">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding SelectedColumn}" VerticalAlignment="Center"/>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                            <DataGridTemplateColumn.CellEditingTemplate>
+                                <DataTemplate>
+                                    <ComboBox ItemsSource="{Binding DataContext.ColumnHeaders, RelativeSource={RelativeSource AncestorType=Window}}"
+                                              SelectedItem="{Binding SelectedColumn, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                              Margin="0"
+                                              ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellEditingTemplate>
+                        </DataGridTemplateColumn>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Grid>
+        </Border>
+
+        <controls:DialogButtonBar Grid.Row="3"
+                                  Margin="0,12,0,0"
                                   LeftButtonText="Cancel"
                                   LeftCommand="{Binding CancelCommand}"
                                   RightButtonText="OK"
                                   RightCommand="{Binding OkCommand}"/>
-    </DockPanel>
+
+        <Border Grid.Row="4" Style="{StaticResource StatusFooterBar}" Margin="0,12,0,0">
+            <TextBlock Text="Mapping choices are applied only after OK is selected." Style="{StaticResource MutedTextBlock}"/>
+        </Border>
+    </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/ImportMappingWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ImportMappingWindow.xaml
@@ -17,7 +17,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Style="{StaticResource PageHeaderCard}" Padding="16,14">
+        <Border Style="{StaticResource ToolbarCard}" Padding="16,14">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -26,13 +26,13 @@
                 <StackPanel>
                     <TextBlock Text="Import Mapping Workbench" Style="{StaticResource HeadingTextBlock}"/>
                     <TextBlock Text="Match each application field to the incoming CSV column before the import continues."
-                               Style="{StaticResource MutedTextBlock}"
+                               Style="{StaticResource CaptionTextBlock}"
                                Margin="0,4,0,0"/>
                 </StackPanel>
-                <Border Grid.Column="1" Style="{StaticResource SummaryStatCard}" Padding="12,8" VerticalAlignment="Center">
+                <Border Grid.Column="1" Style="{StaticResource Card}" Padding="12,8" VerticalAlignment="Center">
                     <StackPanel>
-                        <TextBlock Text="Column Review" Style="{StaticResource SummaryStatLabel}"/>
-                        <TextBlock Text="Required fields first" Style="{StaticResource MutedTextBlock}" Margin="0,2,0,0"/>
+                        <TextBlock Text="Column Review" Style="{StaticResource LabelTextBlock}"/>
+                        <TextBlock Text="Required fields first" Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,0"/>
                     </StackPanel>
                 </Border>
             </Grid>
@@ -48,21 +48,21 @@
                 <StackPanel>
                     <TextBlock Text="1. Review fields" Style="{StaticResource SectionHeader}"/>
                     <TextBlock Text="Required destination fields should be mapped before optional detail fields."
-                               Style="{StaticResource MutedTextBlock}"
+                               Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,4,12,0"/>
                 </StackPanel>
                 <StackPanel Grid.Column="1">
                     <TextBlock Text="2. Choose CSV columns" Style="{StaticResource SectionHeader}"/>
                     <TextBlock Text="Use the drop-down in each row to pair incoming columns with app fields."
-                               Style="{StaticResource MutedTextBlock}"
+                               Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,4,12,0"/>
                 </StackPanel>
                 <StackPanel Grid.Column="2">
                     <TextBlock Text="3. Confirm mapping" Style="{StaticResource SectionHeader}"/>
                     <TextBlock Text="Cancel returns to data operations; OK accepts the selected mapping."
-                               Style="{StaticResource MutedTextBlock}"
+                               Style="{StaticResource CaptionTextBlock}"
                                TextWrapping="Wrap"
                                Margin="0,4,0,0"/>
                 </StackPanel>
@@ -75,14 +75,14 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                <Border Style="{StaticResource PaneHeaderBar}" Padding="12,10">
+                <Border Style="{StaticResource ToolbarCard}" Padding="12,10" Margin="0">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <TextBlock Text="Field Mapping Table" Style="{StaticResource SectionHeader}"/>
-                        <TextBlock Grid.Column="1" Text="Destination field to CSV column" Style="{StaticResource MutedTextBlock}"/>
+                        <TextBlock Grid.Column="1" Text="Destination field to CSV column" Style="{StaticResource CaptionTextBlock}"/>
                     </Grid>
                 </Border>
                 <DataGrid Grid.Row="1"
@@ -123,8 +123,8 @@
                                   RightButtonText="OK"
                                   RightCommand="{Binding OkCommand}"/>
 
-        <Border Grid.Row="4" Style="{StaticResource StatusFooterBar}" Margin="0,12,0,0">
-            <TextBlock Text="Mapping choices are applied only after OK is selected." Style="{StaticResource MutedTextBlock}"/>
+        <Border Grid.Row="4" Style="{StaticResource ToolbarCard}" Margin="0,12,0,0" Padding="10,7">
+            <TextBlock Text="Mapping choices are applied only after OK is selected." Style="{StaticResource CaptionTextBlock}"/>
         </Border>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/InfoDialogWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/InfoDialogWindow.xaml
@@ -15,7 +15,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Style="{StaticResource PageHeaderCard}" Padding="16,14">
+        <Border Style="{StaticResource ToolbarCard}" Padding="16,14">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -24,14 +24,11 @@
                 <StackPanel>
                     <TextBlock Text="Information Notice" Style="{StaticResource HeadingTextBlock}"/>
                     <TextBlock Text="Review the message before returning to the current workflow."
-                               Style="{StaticResource MutedTextBlock}"
+                               Style="{StaticResource CaptionTextBlock}"
                                Margin="0,4,0,0"/>
                 </StackPanel>
-                <Border Grid.Column="1"
-                        Style="{StaticResource SummaryStatCard}"
-                        Padding="12,8"
-                        VerticalAlignment="Center">
-                    <TextBlock Text="Ready" Style="{StaticResource SummaryStatLabel}"/>
+                <Border Grid.Column="1" Style="{StaticResource Card}" Padding="12,8" VerticalAlignment="Center">
+                    <TextBlock Text="Ready" Style="{StaticResource LabelTextBlock}"/>
                 </Border>
             </Grid>
         </Border>
@@ -42,7 +39,7 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
-                <Border Width="44" Height="44" CornerRadius="8" Background="{DynamicResource AccentSoftBrush}" VerticalAlignment="Top">
+                <Border Width="44" Height="44" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource AccentBrush}" BorderThickness="1" VerticalAlignment="Top">
                     <TextBlock Text="i" FontSize="24" FontWeight="SemiBold" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                 </Border>
                 <TextBlock Grid.Column="1"
@@ -59,8 +56,8 @@
                     MinWidth="112"/>
         </StackPanel>
 
-        <Border Grid.Row="3" Style="{StaticResource StatusFooterBar}" Margin="0,12,0,0">
-            <TextBlock Text="Message reviewed when OK is selected." Style="{StaticResource MutedTextBlock}"/>
+        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,12,0,0" Padding="10,7">
+            <TextBlock Text="Message reviewed when OK is selected." Style="{StaticResource CaptionTextBlock}"/>
         </Border>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/InfoDialogWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/InfoDialogWindow.xaml
@@ -3,19 +3,64 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Information"
-        Width="480" Height="220"
-        WindowStartupLocation="CenterScreen"
+        Width="520" Height="280"
+        MinWidth="500" MinHeight="260"
+        WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="14">
+    <Grid Margin="16">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <Border Style="{StaticResource Card}">
-            <TextBlock Text="{Binding Message}" Style="{StaticResource DialogMessageTextBlock}"/>
+
+        <Border Style="{StaticResource PageHeaderCard}" Padding="16,14">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel>
+                    <TextBlock Text="Information Notice" Style="{StaticResource HeadingTextBlock}"/>
+                    <TextBlock Text="Review the message before returning to the current workflow."
+                               Style="{StaticResource MutedTextBlock}"
+                               Margin="0,4,0,0"/>
+                </StackPanel>
+                <Border Grid.Column="1"
+                        Style="{StaticResource SummaryStatCard}"
+                        Padding="12,8"
+                        VerticalAlignment="Center">
+                    <TextBlock Text="Ready" Style="{StaticResource SummaryStatLabel}"/>
+                </Border>
+            </Grid>
         </Border>
-        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Style="{StaticResource PrimaryButton}" Content="OK" Command="{Binding OkCommand}"/>
+
+        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,12,0,12" Padding="18">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Border Width="44" Height="44" CornerRadius="8" Background="{DynamicResource AccentSoftBrush}" VerticalAlignment="Top">
+                    <TextBlock Text="i" FontSize="24" FontWeight="SemiBold" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                </Border>
+                <TextBlock Grid.Column="1"
+                           Text="{Binding Message}"
+                           Style="{StaticResource DialogMessageTextBlock}"
+                           Margin="14,0,0,0"/>
+            </Grid>
+        </Border>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Style="{StaticResource PrimaryButton}"
+                    Content="OK"
+                    Command="{Binding OkCommand}"
+                    MinWidth="112"/>
         </StackPanel>
+
+        <Border Grid.Row="3" Style="{StaticResource StatusFooterBar}" Margin="0,12,0,0">
+            <TextBlock Text="Message reviewed when OK is selected." Style="{StaticResource MutedTextBlock}"/>
+        </Border>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/InputDialogWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/InputDialogWindow.xaml
@@ -17,11 +17,11 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Style="{StaticResource PageHeaderCard}" Padding="16,14">
+        <Border Style="{StaticResource ToolbarCard}" Padding="16,14">
             <StackPanel>
                 <TextBlock Text="Input Required" Style="{StaticResource HeadingTextBlock}"/>
                 <TextBlock Text="Enter the requested value, then confirm to continue."
-                           Style="{StaticResource MutedTextBlock}"
+                           Style="{StaticResource CaptionTextBlock}"
                            Margin="0,4,0,0"/>
             </StackPanel>
         </Border>
@@ -51,8 +51,8 @@
                                   RightButtonText="OK"
                                   RightCommand="{Binding OkCommand}"/>
 
-        <Border Grid.Row="3" Style="{StaticResource StatusFooterBar}" Margin="0,12,0,0">
-            <TextBlock Text="Input is applied only after OK is selected." Style="{StaticResource MutedTextBlock}"/>
+        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,12,0,0" Padding="10,7">
+            <TextBlock Text="Input is applied only after OK is selected." Style="{StaticResource CaptionTextBlock}"/>
         </Border>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/InputDialogWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/InputDialogWindow.xaml
@@ -1,9 +1,12 @@
 <Window x:Class="InventoryManagementApp.Views.Windows.InputDialogWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         Title="Input"
-        Width="420"
-        Height="220"
+        Width="540"
+        Height="320"
+        MinWidth="520"
+        MinHeight="300"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
     <Grid Margin="16">
@@ -11,24 +14,45 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <TextBlock Text="{Binding Message}"
-                   TextWrapping="Wrap"
-                   FontSize="14"/>
+        <Border Style="{StaticResource PageHeaderCard}" Padding="16,14">
+            <StackPanel>
+                <TextBlock Text="Input Required" Style="{StaticResource HeadingTextBlock}"/>
+                <TextBlock Text="Enter the requested value, then confirm to continue."
+                           Style="{StaticResource MutedTextBlock}"
+                           Margin="0,4,0,0"/>
+            </StackPanel>
+        </Border>
 
-        <TextBox Grid.Row="1"
-                 Margin="0,12,0,0"
-                 Text="{Binding InputText, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,12,0,12" Padding="18">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <TextBlock Text="Request" Style="{StaticResource SectionHeader}"/>
+                <TextBlock Grid.Row="1"
+                           Text="{Binding Message}"
+                           TextWrapping="Wrap"
+                           Style="{StaticResource DialogMessageTextBlock}"
+                           Margin="0,6,0,12"/>
+                <TextBox Grid.Row="2"
+                         MinHeight="36"
+                         Text="{Binding InputText, UpdateSourceTrigger=PropertyChanged}"/>
+            </Grid>
+        </Border>
 
-        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
-            <Button Style="{StaticResource PrimaryButton}"
-                    Content="OK"
-                    Command="{Binding OkCommand}"
-                    Margin="0,0,8,0"/>
-            <Button Style="{StaticResource PrimaryButton}"
-                    Content="Cancel"
-                    Command="{Binding CancelCommand}"/>
-        </StackPanel>
+        <controls:DialogButtonBar Grid.Row="2"
+                                  LeftButtonText="Cancel"
+                                  LeftCommand="{Binding CancelCommand}"
+                                  RightButtonText="OK"
+                                  RightCommand="{Binding OkCommand}"/>
+
+        <Border Grid.Row="3" Style="{StaticResource StatusFooterBar}" Margin="0,12,0,0">
+            <TextBlock Text="Input is applied only after OK is selected." Style="{StaticResource MutedTextBlock}"/>
+        </Border>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml
@@ -21,7 +21,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Style="{StaticResource PageHeaderCard}" Padding="16,14">
+        <Border Style="{StaticResource ToolbarCard}" Padding="16,14">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -30,13 +30,13 @@
                 <StackPanel>
                     <TextBlock Text="Label Output Workbench" Style="{StaticResource HeadingTextBlock}"/>
                     <TextBlock Text="Select the label format, review the queued items, then preview or print."
-                               Style="{StaticResource MutedTextBlock}"
+                               Style="{StaticResource CaptionTextBlock}"
                                Margin="0,4,0,0"/>
                 </StackPanel>
-                <Border Grid.Column="1" Style="{StaticResource SummaryStatCard}" Padding="12,8" VerticalAlignment="Center">
+                <Border Grid.Column="1" Style="{StaticResource Card}" Padding="12,8" VerticalAlignment="Center">
                     <StackPanel>
-                        <TextBlock Text="Queue" Style="{StaticResource SummaryStatLabel}"/>
-                        <TextBlock Text="Ready to review" Style="{StaticResource MutedTextBlock}" Margin="0,2,0,0"/>
+                        <TextBlock Text="Queue" Style="{StaticResource LabelTextBlock}"/>
+                        <TextBlock Text="Ready to review" Style="{StaticResource CaptionTextBlock}" Margin="0,2,0,0"/>
                     </StackPanel>
                 </Border>
             </Grid>
@@ -62,7 +62,7 @@
                           VerticalAlignment="Center"/>
                 <TextBlock Grid.Column="3"
                            Text="Preview first when labels include item photos, QR codes, or updated location text."
-                           Style="{StaticResource MutedTextBlock}"
+                           Style="{StaticResource CaptionTextBlock}"
                            TextWrapping="Wrap"
                            Margin="18,0,0,0"
                            VerticalAlignment="Center"/>
@@ -75,14 +75,14 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                <Border Style="{StaticResource PaneHeaderBar}" Padding="12,10">
+                <Border Style="{StaticResource ToolbarCard}" Padding="12,10" Margin="0">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <TextBlock Text="Queued Label Items" Style="{StaticResource SectionHeader}"/>
-                        <TextBlock Grid.Column="1" Text="Item number, name, and location" Style="{StaticResource MutedTextBlock}"/>
+                        <TextBlock Grid.Column="1" Text="Item number, name, and location" Style="{StaticResource CaptionTextBlock}"/>
                     </Grid>
                 </Border>
                 <DataGrid Grid.Row="1"
@@ -102,14 +102,14 @@
 
         <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,12,0,0" Padding="12">
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button Style="{StaticResource SecondaryButton}" Content="Preview" Command="{Binding PreviewCommand}" MinWidth="112"/>
+                <Button Style="{StaticResource GhostButton}" Content="Preview" Command="{Binding PreviewCommand}" MinWidth="112"/>
                 <Button Style="{StaticResource PrimaryButton}" Content="Print" Command="{Binding PrintCommand}" MinWidth="112" Margin="8,0,0,0"/>
-                <Button Style="{StaticResource SecondaryButton}" Content="Close" Command="{Binding CloseCommand}" MinWidth="112" Margin="8,0,0,0"/>
+                <Button Style="{StaticResource GhostButton}" Content="Close" Command="{Binding CloseCommand}" MinWidth="112" Margin="8,0,0,0"/>
             </StackPanel>
         </Border>
 
-        <Border Grid.Row="4" Style="{StaticResource StatusFooterBar}" Margin="0,12,0,0">
-            <TextBlock Text="Label output ready; preview verifies the final sheet before printing." Style="{StaticResource MutedTextBlock}"/>
+        <Border Grid.Row="4" Style="{StaticResource ToolbarCard}" Margin="0,12,0,0" Padding="10,7">
+            <TextBlock Text="Label output ready; preview verifies the final sheet before printing." Style="{StaticResource CaptionTextBlock}"/>
         </Border>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Views/PrintLabelWindow.xaml -->
+<!-- Views/PrintLabelWindow.xaml -->
 <Window x:Class="InventoryManagementApp.Views.Windows.PrintLabelWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -8,47 +8,108 @@
         xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
         mc:Ignorable="d"
         Title="Print Labels"
-        Width="720" Height="420"
-        WindowStartupLocation="CenterScreen"
+        Width="860" Height="560"
+        MinWidth="780" MinHeight="500"
+        WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="12">
+    <Grid Margin="16">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Style="{StaticResource Card}">
+        <Border Style="{StaticResource PageHeaderCard}" Padding="16,14">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="200"/>
                     <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Text="Label Template" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                <ComboBox Grid.Column="1" ItemsSource="{Binding Templates}" SelectedItem="{Binding SelectedTemplate}" Margin="8,0,0,0" ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
-                <CheckBox Grid.Column="2" Content="Include QR" IsChecked="{Binding IncludeQr}" HorizontalAlignment="Left" Margin="8,4,0,0"/>
+                <StackPanel>
+                    <TextBlock Text="Label Output Workbench" Style="{StaticResource HeadingTextBlock}"/>
+                    <TextBlock Text="Select the label format, review the queued items, then preview or print."
+                               Style="{StaticResource MutedTextBlock}"
+                               Margin="0,4,0,0"/>
+                </StackPanel>
+                <Border Grid.Column="1" Style="{StaticResource SummaryStatCard}" Padding="12,8" VerticalAlignment="Center">
+                    <StackPanel>
+                        <TextBlock Text="Queue" Style="{StaticResource SummaryStatLabel}"/>
+                        <TextBlock Text="Ready to review" Style="{StaticResource MutedTextBlock}" Margin="0,2,0,0"/>
+                    </StackPanel>
+                </Border>
             </Grid>
         </Border>
 
-        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0" Margin="0,8,0,8">
-            <DataGrid ItemsSource="{Binding Items}"
-                      AutoGenerateColumns="False"
-                      IsReadOnly="True"
-                      Style="{StaticResource VirtualizedDataGridStyle}"
-                      ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
-                <DataGrid.Columns>
-                    <DataGridTextColumn Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} #'}" Binding="{Binding ItemNumber}" Width="120"/>
-                    <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
-                    <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="180"/>
-                </DataGrid.Columns>
-            </DataGrid>
+        <Border Grid.Row="1" Style="{StaticResource ToolbarCard}" Margin="0,12,0,10" Padding="12">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="260"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="Label Template" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                <ComboBox Grid.Column="1"
+                          ItemsSource="{Binding Templates}"
+                          SelectedItem="{Binding SelectedTemplate}"
+                          Margin="10,0,18,0"
+                          ItemContainerStyle="{StaticResource DropdownItemStyle}"/>
+                <CheckBox Grid.Column="2"
+                          Content="Include QR"
+                          IsChecked="{Binding IncludeQr}"
+                          VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="3"
+                           Text="Preview first when labels include item photos, QR codes, or updated location text."
+                           Style="{StaticResource MutedTextBlock}"
+                           TextWrapping="Wrap"
+                           Margin="18,0,0,0"
+                           VerticalAlignment="Center"/>
+            </Grid>
         </Border>
 
-        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Style="{StaticResource PrimaryButton}" Content="Preview" Command="{Binding PreviewCommand}"/>
-            <Button Style="{StaticResource PrimaryButton}" Content="Print" Command="{Binding PrintCommand}" Margin="8,0,0,0"/>
-            <Button Style="{StaticResource PrimaryButton}" Content="Close" Command="{Binding CloseCommand}" Margin="8,0,0,0"/>
-        </StackPanel>
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Border Style="{StaticResource PaneHeaderBar}" Padding="12,10">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Queued Label Items" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Grid.Column="1" Text="Item number, name, and location" Style="{StaticResource MutedTextBlock}"/>
+                    </Grid>
+                </Border>
+                <DataGrid Grid.Row="1"
+                          ItemsSource="{Binding Items}"
+                          AutoGenerateColumns="False"
+                          IsReadOnly="True"
+                          Style="{StaticResource VirtualizedDataGridStyle}"
+                          ColumnHeaderStyle="{StaticResource {x:Type DataGridColumnHeader}}">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} #'}" Binding="{Binding ItemNumber}" Width="140"/>
+                        <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*"/>
+                        <DataGridTextColumn Header="Location" Binding="{Binding Location}" Width="220"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Grid>
+        </Border>
+
+        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,12,0,0" Padding="12">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Style="{StaticResource SecondaryButton}" Content="Preview" Command="{Binding PreviewCommand}" MinWidth="112"/>
+                <Button Style="{StaticResource PrimaryButton}" Content="Print" Command="{Binding PrintCommand}" MinWidth="112" Margin="8,0,0,0"/>
+                <Button Style="{StaticResource SecondaryButton}" Content="Close" Command="{Binding CloseCommand}" MinWidth="112" Margin="8,0,0,0"/>
+            </StackPanel>
+        </Border>
+
+        <Border Grid.Row="4" Style="{StaticResource StatusFooterBar}" Margin="0,12,0,0">
+            <TextBlock Text="Label output ready; preview verifies the final sheet before printing." Style="{StaticResource MutedTextBlock}"/>
+        </Border>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary

- Polishes the simple information, confirmation, and input dialogs with consistent headers, clearer message bodies, aligned action areas, and footer cues.
- Polishes label output, CSV import mapping, and image import mapping windows with workbench-style framing, better guidance, and stable footer status.
- Adds `DialogOutputWindowXamlTests` to guard the visible polish markers and preserve existing command/binding paths.
- Records the completed pass in `InventoryManagementApp/ProgressNotes/2026-06-18-dialog-output-window-polish.md`.

## Validation

- Read the changed branch files back through the GitHub connector.
- Compared branch against `master`; only the intended dialog, test, and progress-note files changed.
- Local `dotnet`, WPF screenshots, local XAML parsing, and local banned-word checks remain unavailable in this scheduled Linux container because clone/raw access and the Windows/.NET runtime are blocked.