### PR TITLE
Polish selected-row detail dialogs

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/DialogOutputWindowXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/DialogOutputWindowXamlTests.cs
@@ -57,6 +57,44 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("OkCommand", imageMapping, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void DetailDialog_UsesPolishedHandoffStructureAndCloseAction()
+        {
+            var detail = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "DetailDialogWindow.xaml");
+            var codeBehind = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "DetailDialogWindow.xaml.cs");
+
+            Assert.Contains("Workflow Detail", detail, StringComparison.Ordinal);
+            Assert.Contains("Selected Row Handoff", detail, StringComparison.Ordinal);
+            Assert.Contains("Close returns to the current screen with the same row context.", detail, StringComparison.Ordinal);
+            Assert.Contains("Close_Click", detail, StringComparison.Ordinal);
+            Assert.Contains("ShowDialogFor", codeBehind, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SelectedRowDetailActions_RouteThroughPolishedDetailDialog()
+        {
+            var activity = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml.cs");
+            var categories = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs");
+            var importExport = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml.cs");
+            var users = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml.cs");
+
+            Assert.Contains("DetailDialogWindow.ShowDialogFor", activity, StringComparison.Ordinal);
+            Assert.Contains("Activity Detail", activity, StringComparison.Ordinal);
+            Assert.DoesNotContain("WpfMessageBox.Show(FormatLogDetail", activity, StringComparison.Ordinal);
+
+            Assert.Contains("DetailDialogWindow.ShowDialogFor", categories, StringComparison.Ordinal);
+            Assert.Contains("Category Detail", categories, StringComparison.Ordinal);
+            Assert.DoesNotContain("WpfMessageBox.Show(FormatCategoryDetail", categories, StringComparison.Ordinal);
+
+            Assert.Contains("DetailDialogWindow.ShowDialogFor", importExport, StringComparison.Ordinal);
+            Assert.Contains("Import / Export Result", importExport, StringComparison.Ordinal);
+            Assert.DoesNotContain("WpfMessageBox.Show(log,", importExport, StringComparison.Ordinal);
+
+            Assert.Contains("DetailDialogWindow.ShowDialogFor", users, StringComparison.Ordinal);
+            Assert.Contains("User Detail", users, StringComparison.Ordinal);
+            Assert.DoesNotContain("WpfMessageBox.Show(FormatUserDetail", users, StringComparison.Ordinal);
+        }
+
         static string ReadRepositoryFile(params string[] relativePathParts)
         {
             var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/InventoryManagementApp/ProgressNotes/2026-06-18-detail-dialog-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-18-detail-dialog-polish.md
@@ -1,0 +1,14 @@
+# Detail Dialog Polish - 2026-06-18
+
+## Completed
+
+- Added `DetailDialogWindow` as a reusable polished selected-row detail surface.
+- Replaced plain detail/result `MessageBox` output for Activity Logs, Categories, Import / Export run-log rows, and Users with the new detail dialog.
+- Kept lightweight no-selection and empty-print warnings on their existing message-box paths so the change stays focused on screenshot-noted detail/result surfaces.
+- Preserved existing row double-click handlers, context-menu commands, copy paths, print paths, and page selection behavior.
+- Extended `DialogOutputWindowXamlTests` to guard the detail dialog shell and the four routed detail call paths.
+
+## Validation
+
+- Read and updated files through the GitHub connector because local clone/raw access is blocked by the scheduled container network tunnel.
+- Could not run `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, or local banned-word checks because this Linux container lacks the .NET SDK/Windows WPF runtime and local repository access remains blocked.

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
+using InventoryManagementApp.Views.Windows;
 using WpfMessageBox = System.Windows.MessageBox;
 using WpfPrintDialog = System.Windows.Controls.PrintDialog;
 
@@ -58,7 +59,14 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            WpfMessageBox.Show(FormatLogDetail(log), "Activity Detail", MessageBoxButton.OK, MessageBoxImage.Information);
+            DetailDialogWindow.ShowDialogFor(
+                Window.GetWindow(this),
+                "Activity Detail",
+                "Activity Detail",
+                FormatLogDetail(log),
+                "Review the selected audit trail, destination, and next action without losing row context.",
+                ActivityLogsViewModel.ClassifyAction(log.Action),
+                "Close returns to Activity Logs with the selected audit row still available for copy, print, or related-page routing.");
         }
 
         private void OpenRelatedPage_Click(object sender, RoutedEventArgs e)

--- a/InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Documents;
 using System.Windows.Input;
 using InventoryManagementApp.ViewModels;
+using InventoryManagementApp.Views.Windows;
 using Microsoft.Extensions.DependencyInjection;
 using WpfMessageBox = System.Windows.MessageBox;
 using WpfPrintDialog = System.Windows.Controls.PrintDialog;
@@ -110,7 +111,14 @@ namespace InventoryManagementApp.Views.Pages
             if (!TryGetSelectedCategory(out var category))
                 return;
 
-            WpfMessageBox.Show(FormatCategoryDetail(category), $"Category Detail - {category.Name}", MessageBoxButton.OK, MessageBoxImage.Information);
+            DetailDialogWindow.ShowDialogFor(
+                Window.GetWindow(this),
+                $"Category Detail - {category.Name}",
+                "Category Detail",
+                FormatCategoryDetail(category),
+                "Review naming, directory labeling, and setup handoff guidance before changing category structure.",
+                $"Category #{category.CategoryID}",
+                "Close returns to Categories with the selected category ready for copy, print, rename, or refresh actions.");
         }
 
         private void CopyCategory_Click(object sender, RoutedEventArgs e)

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;
 using InventoryManagementApp.ViewModels;
+using InventoryManagementApp.Views.Windows;
 using WpfMessageBox = System.Windows.MessageBox;
 using WpfPrintDialog = System.Windows.Controls.PrintDialog;
 
@@ -40,7 +41,14 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            WpfMessageBox.Show(log, "Import / Export Result", MessageBoxButton.OK, MessageBoxImage.Information);
+            DetailDialogWindow.ShowDialogFor(
+                Window.GetWindow(this),
+                "Import / Export Result",
+                "Import / Export Result",
+                log,
+                "Review the selected operation result before copying, printing, or continuing the data workflow.",
+                "Run Log",
+                "Close returns to the run log with the selected result still available for copy, print, or review.");
         }
 
         private void CopySelectedLog_Click(object sender, RoutedEventArgs e)

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
+using InventoryManagementApp.Views.Windows;
 using WpfMessageBox = System.Windows.MessageBox;
 using WpfPrintDialog = System.Windows.Controls.PrintDialog;
 
@@ -49,7 +50,14 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            WpfMessageBox.Show(FormatUserDetail(user), $"User Detail - {user.UserName}", MessageBoxButton.OK, MessageBoxImage.Information);
+            DetailDialogWindow.ShowDialogFor(
+                Window.GetWindow(this),
+                $"User Detail - {user.UserName}",
+                "User Detail",
+                FormatUserDetail(user),
+                "Review identity, access, lockout, and contact context before changing account settings.",
+                ResolveRole(user),
+                "Close returns to Users with the selected account ready for edit, reset, copy, print, or access review.");
         }
 
         private void CopySelectedUser_Click(object sender, RoutedEventArgs e)

--- a/InventoryManagementApp/Views/Windows/DetailDialogWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/DetailDialogWindow.xaml
@@ -1,0 +1,78 @@
+<!-- Views/Windows/DetailDialogWindow.xaml -->
+<Window x:Class="InventoryManagementApp.Views.Windows.DetailDialogWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Detail"
+        Width="660" Height="460"
+        MinWidth="560" MinHeight="380"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <Border Style="{StaticResource ToolbarCard}" Padding="16,14">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel>
+                    <TextBlock x:Name="HeaderText" Text="Workflow Detail" Style="{StaticResource HeadingTextBlock}" TextWrapping="Wrap"/>
+                    <TextBlock x:Name="SubheadText"
+                               Text="Review the selected row context before returning to the current workflow."
+                               Style="{StaticResource CaptionTextBlock}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,0"/>
+                </StackPanel>
+                <Border Grid.Column="1" Style="{StaticResource Card}" Padding="12,8" VerticalAlignment="Center" Margin="12,0,0,0">
+                    <TextBlock x:Name="EyebrowText" Text="Detail" Style="{StaticResource LabelTextBlock}"/>
+                </Border>
+            </Grid>
+        </Border>
+
+        <Border Grid.Row="1" Style="{StaticResource Card}" Margin="0,12,0,12" Padding="0">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Border Style="{StaticResource DesktopPaneHeader}">
+                    <DockPanel LastChildFill="True">
+                        <TextBlock Text="Selected Row Handoff" Style="{StaticResource SectionHeader}" Margin="0"/>
+                        <TextBlock Text="Ready for copy, review, or follow-up" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                    </DockPanel>
+                </Border>
+                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                    <TextBox x:Name="MessageText"
+                             IsReadOnly="True"
+                             TextWrapping="Wrap"
+                             AcceptsReturn="True"
+                             BorderThickness="0"
+                             Background="Transparent"
+                             Padding="16"
+                             FontSize="13"
+                             FontFamily="Segoe UI"/>
+                </ScrollViewer>
+            </Grid>
+        </Border>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Style="{StaticResource PrimaryButton}"
+                    Content="Close"
+                    MinWidth="112"
+                    Click="Close_Click"/>
+        </StackPanel>
+
+        <Border Grid.Row="3" Style="{StaticResource ToolbarCard}" Margin="0,12,0,0" Padding="10,7">
+            <TextBlock x:Name="FooterText"
+                       Text="Close returns to the current screen with the same row context."
+                       Style="{StaticResource CaptionTextBlock}"
+                       TextWrapping="Wrap"/>
+        </Border>
+    </Grid>
+</Window>

--- a/InventoryManagementApp/Views/Windows/DetailDialogWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/DetailDialogWindow.xaml.cs
@@ -1,0 +1,40 @@
+using System.Windows;
+
+namespace InventoryManagementApp.Views.Windows
+{
+    /// <summary>
+    /// Polished read-only detail surface for selected-row handoffs.
+    /// </summary>
+    public partial class DetailDialogWindow : Window
+    {
+        public DetailDialogWindow(string windowTitle, string header, string message, string? subhead = null, string? eyebrow = null, string? footer = null)
+        {
+            InitializeComponent();
+
+            Title = string.IsNullOrWhiteSpace(windowTitle) ? "Detail" : windowTitle;
+            HeaderText.Text = string.IsNullOrWhiteSpace(header) ? Title : header;
+            MessageText.Text = message ?? string.Empty;
+            SubheadText.Text = string.IsNullOrWhiteSpace(subhead)
+                ? "Review the selected row context before returning to the current workflow."
+                : subhead;
+            EyebrowText.Text = string.IsNullOrWhiteSpace(eyebrow) ? "Detail" : eyebrow;
+            FooterText.Text = string.IsNullOrWhiteSpace(footer)
+                ? "Close returns to the current screen with the same row context."
+                : footer;
+        }
+
+        public static void ShowDialogFor(Window? owner, string windowTitle, string header, string message, string? subhead = null, string? eyebrow = null, string? footer = null)
+        {
+            var dialog = new DetailDialogWindow(windowTitle, header, message, subhead, eyebrow, footer);
+            if (owner != null)
+                dialog.Owner = owner;
+
+            dialog.ShowDialog();
+        }
+
+        private void Close_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a reusable `DetailDialogWindow` for polished selected-row handoff/details.
- Routes Activity Logs, Categories, Import / Export run-log results, and Users detail actions through the polished dialog instead of plain system detail message boxes.
- Preserves existing no-selection warnings, row double-click handlers, context menu actions, copy paths, print paths, and selected-row behavior.
- Extends `DialogOutputWindowXamlTests` to guard the new dialog shell and the four routed detail call paths.
- Records the scheduled UI polish pass in `InventoryManagementApp/ProgressNotes/2026-06-18-detail-dialog-polish.md`.

## Validation

- GitHub connector compare/readback confirmed the focused branch diff and changed file contents.
- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel.
