### PR TITLE
Polish customer and kit edit dialogs

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/DialogOutputWindowXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/DialogOutputWindowXamlTests.cs
@@ -71,6 +71,38 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void EditDialogs_UsePolishedFormStructureAndPreserveBindings()
+        {
+            var customer = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "CustomerEditWindow.xaml");
+            var kit = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "KitEditWindow.xaml");
+            var kitItem = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "KitItemEditWindow.xaml");
+            var saveCancel = ReadRepositoryFile("InventoryManagementApp", "Views", "Controls", "SaveCancelBar.xaml");
+
+            Assert.Contains("Customer Profile", customer, StringComparison.Ordinal);
+            Assert.Contains("Account Identity", customer, StringComparison.Ordinal);
+            Assert.Contains("Communication", customer, StringComparison.Ordinal);
+            Assert.Contains("Customer.Company, UpdateSourceTrigger=PropertyChanged", customer, StringComparison.Ordinal);
+            Assert.Contains("Customer.Address, UpdateSourceTrigger=PropertyChanged", customer, StringComparison.Ordinal);
+
+            Assert.Contains("Kit Setup", kit, StringComparison.Ordinal);
+            Assert.Contains("Kit Identity", kit, StringComparison.Ordinal);
+            Assert.Contains("Release State", kit, StringComparison.Ordinal);
+            Assert.Contains("Kit.KitNumber, UpdateSourceTrigger=PropertyChanged", kit, StringComparison.Ordinal);
+            Assert.Contains("Kit.Description, UpdateSourceTrigger=PropertyChanged", kit, StringComparison.Ordinal);
+
+            Assert.Contains("Kit Item Membership", kitItem, StringComparison.Ordinal);
+            Assert.Contains("Membership Details", kitItem, StringComparison.Ordinal);
+            Assert.Contains("KitItem.ItemNumber, UpdateSourceTrigger=PropertyChanged", kitItem, StringComparison.Ordinal);
+            Assert.Contains("KitItem.Quantity, UpdateSourceTrigger=PropertyChanged", kitItem, StringComparison.Ordinal);
+            Assert.Contains("KitItem.IsOptional", kitItem, StringComparison.Ordinal);
+
+            Assert.Contains("Review changes, then save or cancel", saveCancel, StringComparison.Ordinal);
+            Assert.Contains("SaveCommand", saveCancel, StringComparison.Ordinal);
+            Assert.Contains("CancelCommand", saveCancel, StringComparison.Ordinal);
+            Assert.Contains("Width=\"104\"", saveCancel, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void SelectedRowDetailActions_RouteThroughPolishedDetailDialog()
         {
             var activity = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-18-customer-kit-edit-dialog-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-18-customer-kit-edit-dialog-polish.md
@@ -1,0 +1,14 @@
+# Customer and Kit Edit Dialog Polish - 2026-06-18
+
+## Completed
+
+- Polished `CustomerEditWindow` into a deliberate customer-profile form with a stronger header, account identity card, communication card, service-address note area, and preserved customer bindings.
+- Polished `KitEditWindow` into a structured kit setup form with identity, release-state, and description sections while preserving kit number, name, category, active, and description bindings.
+- Polished `KitItemEditWindow` into a clearer kit membership form with quantity and optional-state guidance while preserving existing kit-item bindings.
+- Upgraded the shared `SaveCancelBar` so edit dialogs get aligned fixed-width Save/Cancel actions plus a stable footer cue without changing `SaveCommand` or `CancelCommand`.
+- Extended `DialogOutputWindowXamlTests` to guard the edit-dialog polish markers, preserved bindings, and shared save/cancel action contract.
+
+## Validation
+
+- Read and updated files through the GitHub connector because local clone/raw access is blocked by the scheduled container network tunnel.
+- Could not run `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, or local banned-word checks because this Linux container lacks the .NET SDK/Windows WPF runtime and local repository access remains blocked.

--- a/InventoryManagementApp/Views/Controls/SaveCancelBar.xaml
+++ b/InventoryManagementApp/Views/Controls/SaveCancelBar.xaml
@@ -1,8 +1,31 @@
 <UserControl x:Class="InventoryManagementApp.Views.Controls.SaveCancelBar"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
-        <Button Style="{StaticResource PrimaryButton}" Width="82" Content="Save" Command="{Binding SaveCommand}" Margin="0,0,6,0"/>
-        <Button Style="{StaticResource GhostButton}" Width="82" Content="Cancel" Command="{Binding CancelCommand}"/>
-    </StackPanel>
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             MinHeight="56">
+    <Border Style="{StaticResource ToolbarCard}" Margin="0,10,0,0" Padding="10,8">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Text="Review changes, then save or cancel to return to the current workflow."
+                       Style="{StaticResource CaptionTextBlock}"
+                       VerticalAlignment="Center"
+                       TextWrapping="Wrap"
+                       Margin="0,0,12,0"/>
+
+            <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Style="{StaticResource PrimaryButton}"
+                        Width="104"
+                        Content="Save"
+                        Command="{Binding SaveCommand}"
+                        Margin="0,0,8,0"/>
+                <Button Style="{StaticResource GhostButton}"
+                        Width="104"
+                        Content="Cancel"
+                        Command="{Binding CancelCommand}"/>
+            </StackPanel>
+        </Grid>
+    </Border>
 </UserControl>

--- a/InventoryManagementApp/Views/Windows/CustomerEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/CustomerEditWindow.xaml
@@ -3,47 +3,96 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
-        Title="Customer" Width="520" Height="420" WindowStartupLocation="CenterOwner"
+        Title="Customer" Width="620" Height="520" MinWidth="560" MinHeight="460" WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="12">
+    <Grid Margin="16">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="120"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
+        <Border Style="{StaticResource ToolbarCard}" Padding="16,14">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel>
+                    <TextBlock Text="Customer Profile" Style="{StaticResource HeadingTextBlock}"/>
+                    <TextBlock Text="Keep account, contact, and delivery details ready for rentals, reservations, and service handoffs."
+                               Style="{StaticResource CaptionTextBlock}"
+                               Margin="0,4,0,0"/>
+                </StackPanel>
+                <Border Grid.Column="1" Style="{StaticResource Card}" Padding="12,8" VerticalAlignment="Center" Margin="12,0,0,0">
+                    <TextBlock Text="Directory Record" Style="{StaticResource LabelTextBlock}"/>
+                </Border>
+            </Grid>
+        </Border>
 
-            <TextBlock Grid.Row="0" Grid.Column="0" Text="Company" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Customer.Company, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="0,10,0,0">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="1.2*"/>
+                    <ColumnDefinition Width="12"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Contact" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Customer.Contact, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                <Border Grid.Column="0" Style="{StaticResource Card}" Padding="14">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="118"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Email" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Customer.Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                        <TextBlock Grid.Row="0" Grid.ColumnSpan="2" Text="Account Identity" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="The company and primary contact appear in customer lookup, printouts, and selected-customer handoffs."
+                                   Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,12"/>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="Phone" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Customer.Phone, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Company" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Customer.Company, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Text="Mobile" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Customer.Mobile, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Contact" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Customer.Contact, UpdateSourceTrigger=PropertyChanged}"/>
+                    </Grid>
+                </Border>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Address" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,0"/>
-            <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Customer.Address, UpdateSourceTrigger=PropertyChanged}"/>
-        </Grid>
+                <StackPanel Grid.Column="2">
+                    <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10">
+                        <StackPanel>
+                            <TextBlock Text="Communication" Style="{StaticResource SectionHeader}"/>
+                            <TextBlock Text="Email, phone, and mobile are used for customer follow-up and printed contact sheets."
+                                       Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,10"/>
+                            <TextBlock Text="Email" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBox Text="{Binding Customer.Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,2,0,8"/>
+                            <TextBlock Text="Phone" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBox Text="{Binding Customer.Phone, UpdateSourceTrigger=PropertyChanged}" Margin="0,2,0,8"/>
+                            <TextBlock Text="Mobile" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBox Text="{Binding Customer.Mobile, UpdateSourceTrigger=PropertyChanged}" Margin="0,2,0,0"/>
+                        </StackPanel>
+                    </Border>
 
-        <controls:SaveCancelBar Grid.Row="1"/>
+                    <Border Style="{StaticResource DesktopNoteCard}">
+                        <StackPanel>
+                            <TextBlock Text="Service Address" Style="{StaticResource SectionHeader}"/>
+                            <TextBlock Text="Keep this concise enough for directory rows, handoff sheets, and delivery notes."
+                                       Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,8"/>
+                            <TextBox Text="{Binding Customer.Address, UpdateSourceTrigger=PropertyChanged}"
+                                     Height="82"
+                                     AcceptsReturn="True"
+                                     VerticalScrollBarVisibility="Auto"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+            </Grid>
+        </ScrollViewer>
+
+        <controls:SaveCancelBar Grid.Row="2"/>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/KitEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/KitEditWindow.xaml
@@ -3,47 +3,99 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
         Title="Kit"
-        Width="560"
-        Height="480"
+        Width="660"
+        Height="560"
+        MinWidth="600"
+        MinHeight="500"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
     <Grid Margin="16">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Grid>
+        <Border Style="{StaticResource ToolbarCard}" Padding="16,14">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel>
+                    <TextBlock Text="Kit Setup" Style="{StaticResource HeadingTextBlock}"/>
+                    <TextBlock Text="Define the kit identity, category, description, and active state used by the kit operations workbench."
+                               Style="{StaticResource CaptionTextBlock}"
+                               Margin="0,4,0,0"/>
+                </StackPanel>
+                <Border Grid.Column="1" Style="{StaticResource Card}" Padding="12,8" VerticalAlignment="Center" Margin="12,0,0,0">
+                    <TextBlock Text="Kit Record" Style="{StaticResource LabelTextBlock}"/>
+                </Border>
+            </Grid>
+        </Border>
+
+        <Grid Grid.Row="1" Margin="0,10,0,0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="140"/>
+                <ColumnDefinition Width="1.25*"/>
+                <ColumnDefinition Width="12"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="0" Grid.Column="0" Text="Kit Number" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Kit.KitNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+            <Border Grid.Column="0" Style="{StaticResource Card}" Padding="14">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="126"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Name" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Kit.Name, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                    <TextBlock Grid.Row="0" Grid.ColumnSpan="2" Text="Kit Identity" Style="{StaticResource SectionHeader}"/>
+                    <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="These fields drive the kit directory, membership handoff, and printed kit sheets."
+                               Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,12"/>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Category" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Kit.Category, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Kit Number" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Kit.KitNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="Description" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Kit.Description, UpdateSourceTrigger=PropertyChanged}" AcceptsReturn="True" Height="120"/>
+                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Name" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Kit.Name, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <CheckBox Grid.Row="4"
-                      Grid.Column="1"
-                      Content="Active"
-                      IsChecked="{Binding Kit.IsActive}"/>
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Category" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Kit.Category, UpdateSourceTrigger=PropertyChanged}"/>
+                </Grid>
+            </Border>
+
+            <StackPanel Grid.Column="2">
+                <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,10">
+                    <StackPanel>
+                        <TextBlock Text="Release State" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="Active kits remain available to the operations workbench and printed pick sheets."
+                                   Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,10"/>
+                        <CheckBox Content="Active"
+                                  IsChecked="{Binding Kit.IsActive}"
+                                  FontWeight="SemiBold"/>
+                    </StackPanel>
+                </Border>
+
+                <Border Style="{StaticResource DesktopNoteCard}">
+                    <StackPanel>
+                        <TextBlock Text="Kit Description" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="Summarize included use cases, shelf notes, or inspection expectations for the selected kit."
+                                   Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,8"/>
+                        <TextBox Text="{Binding Kit.Description, UpdateSourceTrigger=PropertyChanged}"
+                                 AcceptsReturn="True"
+                                 Height="166"
+                                 VerticalScrollBarVisibility="Auto"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
         </Grid>
 
-        <controls:SaveCancelBar Grid.Row="1"/>
+        <controls:SaveCancelBar Grid.Row="2"/>
     </Grid>
 </Window>

--- a/InventoryManagementApp/Views/Windows/KitItemEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/KitItemEditWindow.xaml
@@ -3,40 +3,67 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
         Title="Kit Item"
-        Width="520"
-        Height="360"
+        Width="560"
+        Height="430"
+        MinWidth="520"
+        MinHeight="390"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
     <Grid Margin="16">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="140"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
+        <Border Style="{StaticResource ToolbarCard}" Padding="16,14">
+            <StackPanel>
+                <TextBlock Text="Kit Item Membership" Style="{StaticResource HeadingTextBlock}"/>
+                <TextBlock Text="Set the item reference, display name, required quantity, and whether this item is optional for the kit."
+                           Style="{StaticResource CaptionTextBlock}"
+                           Margin="0,4,0,0"/>
+            </StackPanel>
+        </Border>
 
-            <TextBlock Grid.Row="0" Grid.Column="0" Text="Item #" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding KitItem.ItemNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="14" Margin="0,10,0,0">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="138"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Item Name" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding KitItem.ItemName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                <TextBlock Grid.Row="0" Grid.ColumnSpan="2" Text="Membership Details" Style="{StaticResource SectionHeader}"/>
+                <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="These fields control the kit membership list and printed pick sheet requirements."
+                           Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,12"/>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Quantity" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8"/>
-            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding KitItem.Quantity, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                <TextBlock Grid.Row="2" Grid.Column="0" Text="Item #" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8" VerticalAlignment="Center"/>
+                <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding KitItem.ItemNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-            <CheckBox Grid.Row="3" Grid.Column="1" Content="Optional" IsChecked="{Binding KitItem.IsOptional}"/>
-        </Grid>
+                <TextBlock Grid.Row="3" Grid.Column="0" Text="Item Name" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8" VerticalAlignment="Center"/>
+                <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding KitItem.ItemName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
 
-        <controls:SaveCancelBar Grid.Row="1"/>
+                <TextBlock Grid.Row="4" Grid.Column="0" Text="Quantity" Style="{StaticResource LabelTextBlock}" Margin="0,0,8,8" VerticalAlignment="Center"/>
+                <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding KitItem.Quantity, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+
+                <Border Grid.Row="5" Grid.ColumnSpan="2" Style="{StaticResource DesktopNoteCard}" Margin="0,4,0,0" Padding="12">
+                    <DockPanel LastChildFill="True">
+                        <CheckBox DockPanel.Dock="Left" Content="Optional" IsChecked="{Binding KitItem.IsOptional}" FontWeight="SemiBold" Margin="0,0,12,0"/>
+                        <TextBlock Text="Optional items stay visible in membership review without blocking the core pick list."
+                                   Style="{StaticResource CaptionTextBlock}"
+                                   VerticalAlignment="Center"/>
+                    </DockPanel>
+                </Border>
+            </Grid>
+        </Border>
+
+        <controls:SaveCancelBar Grid.Row="2"/>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary

- Polishes `CustomerEditWindow` into a stronger customer-profile form with a header, account identity, communication, and service-address sections.
- Polishes `KitEditWindow` and `KitItemEditWindow` with structured setup/membership sections, clearer guidance, and preserved bindings.
- Upgrades the shared `SaveCancelBar` so edit dialogs get aligned fixed-width Save/Cancel actions plus a stable footer cue while preserving `SaveCommand` and `CancelCommand`.
- Extends `DialogOutputWindowXamlTests` to guard the edit-dialog polish markers, preserved bindings, and shared action-bar contract.
- Records the scheduled UI polish pass in `InventoryManagementApp/ProgressNotes/2026-06-18-customer-kit-edit-dialog-polish.md`.

## Validation

- GitHub connector compare/readback confirmed the focused branch diff and changed file contents.
- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel.
