### PR TITLE
[codex] Polish shared admin status hierarchy

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/PolishedVisualHierarchyResourceTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/PolishedVisualHierarchyResourceTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.ViewModels
+{
+    public class PolishedVisualHierarchyResourceTests
+    {
+        [Fact]
+        public void PolishedVisualHierarchy_DefinesStableActionAndFooterSizing()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "PolishedVisualHierarchy.xaml");
+
+            Assert.Contains("RaisedSurfaceShadow", xaml, StringComparison.Ordinal);
+            Assert.Contains("DesktopStatusFooter", xaml, StringComparison.Ordinal);
+            Assert.Contains("AdminHandoffCard", xaml, StringComparison.Ordinal);
+            Assert.Contains("MinHeight\" Value=\"28\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("HorizontalContentAlignment\" Value=\"Center\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("VerticalContentAlignment\" Value=\"Center\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PolishedVisualHierarchy_PreservesExistingWorkbenchStyleContracts()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "PolishedVisualHierarchy.xaml");
+
+            Assert.Contains("ToolbarCard", xaml, StringComparison.Ordinal);
+            Assert.Contains("PrimaryButton", xaml, StringComparison.Ordinal);
+            Assert.Contains("GhostButton", xaml, StringComparison.Ordinal);
+            Assert.Contains("DesktopSummaryCard", xaml, StringComparison.Ordinal);
+            Assert.Contains("DesktopPaneHeader", xaml, StringComparison.Ordinal);
+            Assert.Contains("DesktopPaneSubheader", xaml, StringComparison.Ordinal);
+            Assert.Contains("DesktopSectionActionStrip", xaml, StringComparison.Ordinal);
+            Assert.Contains("DesktopNoteCard", xaml, StringComparison.Ordinal);
+            Assert.Contains("DataRunLogCard", xaml, StringComparison.Ordinal);
+        }
+
+        static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-18-shared-admin-status-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-18-shared-admin-status-polish.md
@@ -1,0 +1,19 @@
+# Shared Admin Status Polish - 2026-06-18 23:11 NZST
+
+## Completed
+
+- Tightened the shared visual hierarchy resource layer that sits under the repeated WPF workbench screens.
+- Added a slightly stronger raised surface shadow for summary cards so stat and handoff cards read with more weight.
+- Stabilized toolbar/action button sizing by giving `PrimaryButton` and `GhostButton` consistent minimum height, centered content alignment, and roomier padding.
+- Gave common toolbar, pane header, pane subheader, and section action strip styles stable minimum heights so action rows shift less between screens.
+- Added a reusable `DesktopStatusFooter` style for fixed-height page footer/status bars and a reusable `AdminHandoffCard` style for stronger admin-side detail panels.
+- Added `PolishedVisualHierarchyResourceTests` to guard the new resource markers and preserve existing shared workbench style contracts.
+
+## Why it matters
+
+The current screenshot feedback repeatedly calls out button movement, thin visual hierarchy, and footer/status consistency across pages. This pass improves those common primitives once, so existing pages get steadier action rows and future page-specific polish has a stronger shared base to use.
+
+## Validation
+
+- GitHub connector write/readback should be used to verify the changed resource dictionary, new test file, and this progress note.
+- Local `dotnet build`, `dotnet test`, WPF screenshot review, XAML parsing, and local banned-word checks were not run because this scheduled Linux container still lacks the .NET SDK/Windows WPF runtime and direct clone/raw repository access is blocked by the network tunnel.

--- a/InventoryManagementApp/Resources/PolishedVisualHierarchy.xaml
+++ b/InventoryManagementApp/Resources/PolishedVisualHierarchy.xaml
@@ -7,6 +7,13 @@
                       Opacity="0.12"
                       Color="#55000000"/>
 
+    <DropShadowEffect x:Key="RaisedSurfaceShadow"
+                      BlurRadius="8"
+                      ShadowDepth="1"
+                      Direction="270"
+                      Opacity="0.16"
+                      Color="#44000000"/>
+
     <Style TargetType="Border" x:Key="Card">
         <Setter Property="Background" Value="{DynamicResource SurfaceBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushBase}"/>
@@ -23,27 +30,36 @@
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="CornerRadius" Value="4"/>
-        <Setter Property="Padding" Value="8,6"/>
+        <Setter Property="Padding" Value="10,8"/>
         <Setter Property="Margin" Value="0,0,0,6"/>
+        <Setter Property="MinHeight" Value="38"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
     </Style>
 
     <Style x:Key="PrimaryButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
-        <Setter Property="MinWidth" Value="68"/>
+        <Setter Property="MinWidth" Value="72"/>
+        <Setter Property="MinHeight" Value="28"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
-        <Setter Property="Padding" Value="8,2"/>
+        <Setter Property="Padding" Value="10,3"/>
     </Style>
 
     <Style x:Key="GhostButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
-        <Setter Property="MinWidth" Value="58"/>
-        <Setter Property="Padding" Value="7,2"/>
+        <Setter Property="MinWidth" Value="62"/>
+        <Setter Property="MinHeight" Value="28"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Padding" Value="9,3"/>
     </Style>
 
     <Style TargetType="DataGridColumnHeader">
@@ -54,8 +70,8 @@
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
         <Setter Property="BorderThickness" Value="0,0,1,2"/>
-        <Setter Property="Padding" Value="5,3"/>
-        <Setter Property="Height" Value="28"/>
+        <Setter Property="Padding" Value="6,4"/>
+        <Setter Property="MinHeight" Value="30"/>
         <Setter Property="TextBlock.TextTrimming" Value="CharacterEllipsis"/>
         <Setter Property="TextBlock.TextWrapping" Value="NoWrap"/>
     </Style>
@@ -65,6 +81,8 @@
         <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
         <Setter Property="BorderThickness" Value="1,1,1,2"/>
         <Setter Property="Padding" Value="12"/>
+        <Setter Property="MinHeight" Value="72"/>
+        <Setter Property="Effect" Value="{StaticResource RaisedSurfaceShadow}"/>
     </Style>
 
     <Style x:Key="DesktopInsetCard" TargetType="Border" BasedOn="{StaticResource Card}">
@@ -76,21 +94,42 @@
         <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
         <Setter Property="BorderThickness" Value="0,0,0,2"/>
-        <Setter Property="Padding" Value="9,6"/>
+        <Setter Property="Padding" Value="10,7"/>
+        <Setter Property="MinHeight" Value="42"/>
     </Style>
 
     <Style x:Key="DesktopPaneSubheader" TargetType="Border">
         <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
         <Setter Property="BorderThickness" Value="0,0,0,1"/>
-        <Setter Property="Padding" Value="9,6"/>
+        <Setter Property="Padding" Value="10,7"/>
+        <Setter Property="MinHeight" Value="36"/>
     </Style>
 
     <Style x:Key="DesktopSectionActionStrip" TargetType="Border">
         <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
-        <Setter Property="BorderThickness" Value="0,0,0,2"/>
+        <Setter Property="BorderThickness" Value="0,1,0,2"/>
         <Setter Property="Padding" Value="10,7"/>
+        <Setter Property="MinHeight" Value="42"/>
+    </Style>
+
+    <Style x:Key="DesktopStatusFooter" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="1,0,1,1"/>
+        <Setter Property="CornerRadius" Value="0,0,4,4"/>
+        <Setter Property="Padding" Value="10,5"/>
+        <Setter Property="MinHeight" Value="34"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style x:Key="AdminHandoffCard" TargetType="Border" BasedOn="{StaticResource DesktopInsetCard}">
+        <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="BorderThickness" Value="1,1,1,2"/>
+        <Setter Property="Padding" Value="12"/>
+        <Setter Property="Margin" Value="0,0,0,8"/>
     </Style>
 
     <Style x:Key="DesktopNoteCard" TargetType="Border" BasedOn="{StaticResource DesktopInsetCard}">


### PR DESCRIPTION
## Summary

- Tightens the shared `PolishedVisualHierarchy.xaml` resource layer used by repeated WPF workbench surfaces.
- Gives primary/ghost buttons stable minimum height, centered content alignment, and slightly roomier padding so action rows shift less across pages.
- Adds stronger shared summary-card depth plus reusable `DesktopStatusFooter` and `AdminHandoffCard` styles for upcoming footer/detail-panel adoption.
- Adds `PolishedVisualHierarchyResourceTests` to guard the shared style markers and preserve existing workbench style contracts.
- Records this scheduled polish pass in `InventoryManagementApp/ProgressNotes/2026-06-18-shared-admin-status-polish.md`.

## Validation

- GitHub connector compare confirmed the branch is 3 commits ahead of `master` and 0 behind.
- GitHub connector readback confirmed the changed resource dictionary, new test file, and progress note on the branch.
- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks could not be run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct clone/raw access is blocked by the network tunnel.