### PR TITLE
[codex] Polish item edit dialog

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/DialogOutputWindowXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/DialogOutputWindowXamlTests.cs
@@ -73,10 +73,20 @@ namespace InventoryManagementApp.Tests.ViewModels
         [Fact]
         public void EditDialogs_UsePolishedFormStructureAndPreserveBindings()
         {
+            var item = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "ItemEditWindow.xaml");
             var customer = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "CustomerEditWindow.xaml");
             var kit = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "KitEditWindow.xaml");
             var kitItem = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "KitItemEditWindow.xaml");
             var saveCancel = ReadRepositoryFile("InventoryManagementApp", "Views", "Controls", "SaveCancelBar.xaml");
+
+            Assert.Contains("Item Edit Workbench", item, StringComparison.Ordinal);
+            Assert.Contains("Inventory Identity", item, StringComparison.Ordinal);
+            Assert.Contains("Image and Availability", item, StringComparison.Ordinal);
+            Assert.Contains("DesktopStatusFooter", item, StringComparison.Ordinal);
+            Assert.Contains("ItemModel.ItemNumber, UpdateSourceTrigger=PropertyChanged", item, StringComparison.Ordinal);
+            Assert.Contains("ItemModel.MissingComponentsNotes, UpdateSourceTrigger=PropertyChanged", item, StringComparison.Ordinal);
+            Assert.Contains("BrowseImageCommand", item, StringComparison.Ordinal);
+            Assert.Contains("RemoveImageCommand", item, StringComparison.Ordinal);
 
             Assert.Contains("Customer Profile", customer, StringComparison.Ordinal);
             Assert.Contains("Account Identity", customer, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-06-19-item-edit-dialog-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-19-item-edit-dialog-polish.md
@@ -1,0 +1,19 @@
+# 2026-06-19 Item Edit Dialog Polish
+
+## Completed
+
+- Polished `ItemEditWindow.xaml` into a stronger item edit workbench instead of a long, visually monotonous form.
+- Added a deliberate header, edit-state cue, four summary cards, a grouped identity/shelf form, a photo and availability handoff card, clearer notes/issues sections, and a dedicated incomplete-components handoff card.
+- Added a stable `DesktopStatusFooter` cue beneath the existing shared `SaveCancelBar` so this dialog follows the latest shared status-footer direction.
+- Preserved the existing `ItemModel` field bindings plus `BrowseImageCommand`, `RemoveImageCommand`, `SaveCommand`, and `CancelCommand` paths.
+- Extended `DialogOutputWindowXamlTests` so the item edit dialog polish markers and critical bindings are guarded with the other polished dialog surfaces.
+
+## Validation
+
+- GitHub connector readback/compare was used for the branch because local clone/raw access is blocked by the network tunnel.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks could not be run in this scheduled Linux container because it lacks the .NET SDK/Windows WPF runtime and local repository access remains blocked.
+
+## Follow-up Candidates
+
+- Continue adopting `DesktopStatusFooter` and `AdminHandoffCard` in remaining edit/result dialogs.
+- Start branded document-specific print styling for item search, dashboard, customer directory, rental request, invoice, activity log, import/export log, user directory, and reports previews.

--- a/InventoryManagementApp/Views/Windows/ItemEditWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/ItemEditWindow.xaml
@@ -5,25 +5,85 @@
         xmlns:controls="clr-namespace:InventoryManagementApp.Views.Controls"
         xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
         Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}}"
-        Width="760"
-        Height="820"
-        MinWidth="700"
-        MinHeight="760"
+        Width="840"
+        Height="840"
+        MinWidth="760"
+        MinHeight="780"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
     <Grid Margin="16">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}" Margin="0,0,0,10">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel>
+                    <TextBlock Text="Item Edit Workbench" Style="{StaticResource PageTitleTextBlock}"/>
+                    <TextBlock Text="Review identity, location, readiness, and image details before saving this inventory record."
+                               Style="{StaticResource CaptionTextBlock}"
+                               Margin="0,2,0,0"
+                               TextWrapping="Wrap"/>
+                </StackPanel>
+
+                <Border Grid.Column="1" Style="{StaticResource DesktopNoteCard}" Padding="10,6" Margin="14,0,0,0" VerticalAlignment="Center">
+                    <StackPanel>
+                        <TextBlock Text="Edit State" Style="{StaticResource LabelTextBlock}"/>
+                        <TextBlock Text="Unsaved changes stay in this dialog until Save is selected."
+                                   Style="{StaticResource CaptionTextBlock}"
+                                   TextWrapping="Wrap"
+                                   MaxWidth="220"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Border>
+
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
             <StackPanel>
-                <Grid Margin="0,0,0,12">
+                <UniformGrid Columns="4" Margin="0,0,0,10">
+                    <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,0">
+                        <StackPanel>
+                            <TextBlock Text="Identity" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="Number, name, brand" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                            <TextBlock Text="Required search fields stay grouped together." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,0">
+                        <StackPanel>
+                            <TextBlock Text="Shelf" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="Location and supplier" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                            <TextBlock Text="Stockroom context is checked before save." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,8,0">
+                        <StackPanel>
+                            <TextBlock Text="Readiness" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="Rental and powered flags" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                            <TextBlock Text="Availability intent remains visible while editing." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Style="{StaticResource DesktopSummaryCard}">
+                        <StackPanel>
+                            <TextBlock Text="Condition" Style="{StaticResource LabelTextBlock}"/>
+                            <TextBlock Text="Notes and issues" Style="{StaticResource SectionHeader}" TextWrapping="Wrap"/>
+                            <TextBlock Text="Incomplete records get explicit handoff notes." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                </UniformGrid>
+
+                <Grid Margin="0,0,0,10">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="2.1*"/>
-                        <ColumnDefinition Width="14"/>
-                        <ColumnDefinition Width="1.05*"/>
+                        <ColumnDefinition Width="2*"/>
+                        <ColumnDefinition Width="12"/>
+                        <ColumnDefinition Width="1*"/>
                     </Grid.ColumnDefinitions>
 
                     <Border Grid.Column="0" Style="{StaticResource Card}" Padding="14">
@@ -41,10 +101,15 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
-                            <TextBlock Grid.Row="0" Grid.ColumnSpan="2" Text="Core item details" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
-                            <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="Capture the inventory identity first, then shelf location and supplier information." Style="{StaticResource CaptionTextBlock}" Margin="0,0,0,12"/>
+                            <TextBlock Grid.Row="0" Grid.ColumnSpan="2" Text="Inventory Identity" Style="{StaticResource SectionHeader}"/>
+                            <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="Capture the record information operators use to find, shelve, and source this item."
+                                       Style="{StaticResource CaptionTextBlock}"
+                                       TextWrapping="Wrap"
+                                       Margin="0,2,0,12"/>
 
                             <TextBlock Grid.Row="2" Text="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='{}{0} Number'}" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                             <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding ItemModel.ItemNumber, UpdateSourceTrigger=PropertyChanged}" Margin="8,0,0,8"/>
@@ -55,67 +120,114 @@
                             <TextBlock Grid.Row="4" Text="Brand" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
                             <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding ItemModel.Brand, UpdateSourceTrigger=PropertyChanged}" Margin="8,0,0,8"/>
 
-                            <TextBlock Grid.Row="5" Text="Location" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                            <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding ItemModel.Location, UpdateSourceTrigger=PropertyChanged}" Margin="8,0,0,8"/>
+                            <TextBlock Grid.Row="5" Grid.ColumnSpan="2" Text="Shelf and Sourcing" Style="{StaticResource SectionHeader}" Margin="0,8,0,8"/>
 
-                            <TextBlock Grid.Row="6" Text="Part #" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                            <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding ItemModel.PartNumber, UpdateSourceTrigger=PropertyChanged}" Margin="8,0,0,8"/>
+                            <TextBlock Grid.Row="6" Text="Location" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                            <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding ItemModel.Location, UpdateSourceTrigger=PropertyChanged}" Margin="8,0,0,8"/>
 
-                            <TextBlock Grid.Row="7" Text="Supplier" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                            <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding ItemModel.Supplier, UpdateSourceTrigger=PropertyChanged}" Margin="8,0,0,0"/>
+                            <TextBlock Grid.Row="7" Text="Part #" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                            <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding ItemModel.PartNumber, UpdateSourceTrigger=PropertyChanged}" Margin="8,0,0,8"/>
+
+                            <TextBlock Grid.Row="8" Text="Supplier" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                            <TextBox Grid.Row="8" Grid.Column="1" Text="{Binding ItemModel.Supplier, UpdateSourceTrigger=PropertyChanged}" Margin="8,0,0,8"/>
+
+                            <Border Grid.Row="9" Grid.ColumnSpan="2" Style="{StaticResource DesktopNoteCard}" Padding="10,8" Margin="0,6,0,0">
+                                <TextBlock Text="Save after checking the item number, name, shelf location, and supplier details against the physical item."
+                                           Style="{StaticResource CaptionTextBlock}"
+                                           TextWrapping="Wrap"/>
+                            </Border>
                         </Grid>
                     </Border>
 
                     <StackPanel Grid.Column="2">
-                        <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,12">
+                        <Border Style="{StaticResource AdminHandoffCard}">
                             <StackPanel>
-                                <TextBlock Text="Flags" Style="{StaticResource SectionHeader}"/>
+                                <TextBlock Text="Image and Availability" Style="{StaticResource SectionHeader}"/>
+                                <TextBlock Text="Keep the visual identifier and checkout intent aligned with the shelf record."
+                                           Style="{StaticResource CaptionTextBlock}"
+                                           TextWrapping="Wrap"
+                                           Margin="0,2,0,10"/>
+
+                                <Border Width="170" Height="150" Background="{DynamicResource SurfaceBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Margin="0,0,0,10" HorizontalAlignment="Left">
+                                    <Image Stretch="Uniform"
+                                           Source="{Binding ItemModel.ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
+                                </Border>
+
+                                <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                                    <Button Content="Browse" Style="{StaticResource PrimaryButton}" Command="{Binding BrowseImageCommand}" Width="92" Margin="0,0,8,0"/>
+                                    <Button Content="Remove" Style="{StaticResource GhostButton}" Command="{Binding RemoveImageCommand}" Width="92"/>
+                                </StackPanel>
+
                                 <CheckBox Content="Powered item" IsChecked="{Binding ItemModel.IsPowered}" Margin="0,0,0,6"/>
                                 <CheckBox Content="Available for rental" IsChecked="{Binding ItemModel.IsRentalItem}"/>
                             </StackPanel>
                         </Border>
 
-                        <Border Style="{StaticResource DesktopSummaryCard}">
+                        <Border Style="{StaticResource DesktopNoteCard}" Padding="12">
                             <StackPanel>
-                                <TextBlock Text="Photo" Style="{StaticResource SectionHeader}"/>
-                                <Border Width="150" Height="150" Background="{DynamicResource SurfaceBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Margin="0,0,0,10">
-                                    <Image Stretch="Uniform"
-                                           Source="{Binding ItemModel.ImagePath, Converter={StaticResource NullToDefaultImageConverter}, ConverterParameter=item}"/>
-                                </Border>
-                                <Button Content="Browse" Style="{StaticResource PrimaryButton}" Command="{Binding BrowseImageCommand}" Margin="0,0,0,6"/>
-                                <Button Content="Remove" Style="{StaticResource GhostButton}" Command="{Binding RemoveImageCommand}"/>
+                                <TextBlock Text="Save Review" Style="{StaticResource SectionHeader}"/>
+                                <TextBlock Text="Operators see these fields across search, checkout, maintenance, calibration, and printed handoffs."
+                                           Style="{StaticResource CaptionTextBlock}"
+                                           TextWrapping="Wrap"/>
                             </StackPanel>
                         </Border>
                     </StackPanel>
                 </Grid>
 
-                <Border Style="{StaticResource Card}" Padding="14" Margin="0,0,0,12">
-                    <StackPanel>
-                        <TextBlock Text="Notes" Style="{StaticResource SectionHeader}" Margin="0,0,0,6"/>
-                        <TextBox Text="{Binding ItemModel.Notes, UpdateSourceTrigger=PropertyChanged}" Height="92" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
-                    </StackPanel>
-                </Border>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="12"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
 
-                <Border Style="{StaticResource Card}" Padding="14" Margin="0,0,0,12">
-                    <StackPanel>
-                        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                            <TextBlock Text="&#x26A0;" FontSize="16" Foreground="{DynamicResource ErrorBrush}" Margin="0,0,8,0" VerticalAlignment="Center"/>
-                            <CheckBox Content="Mark as Incomplete/Missing Components" IsChecked="{Binding ItemModel.IsIncomplete}" Foreground="{DynamicResource ErrorBrush}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                    <StackPanel Grid.Column="0">
+                        <Border Style="{StaticResource Card}" Padding="14" Margin="0,0,0,10">
+                            <StackPanel>
+                                <TextBlock Text="General Notes" Style="{StaticResource SectionHeader}" Margin="0,0,0,6"/>
+                                <TextBlock Text="Use this area for normal handling notes, storage reminders, or service context."
+                                           Style="{StaticResource CaptionTextBlock}"
+                                           TextWrapping="Wrap"
+                                           Margin="0,0,0,8"/>
+                                <TextBox Text="{Binding ItemModel.Notes, UpdateSourceTrigger=PropertyChanged}" Height="110" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+                            </StackPanel>
+                        </Border>
+
+                        <Border Style="{StaticResource Card}" Padding="14">
+                            <StackPanel>
+                                <TextBlock Text="Issues / Problems" Style="{StaticResource SectionHeader}" Margin="0,0,0,6"/>
+                                <TextBlock Text="Record known problems that should be visible before checkout or service assignment."
+                                           Style="{StaticResource CaptionTextBlock}"
+                                           TextWrapping="Wrap"
+                                           Margin="0,0,0,8"/>
+                                <TextBox Text="{Binding ItemModel.IssuesNotes, UpdateSourceTrigger=PropertyChanged}" Height="110" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" ToolTip="Describe any issues or problems with this item"/>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+
+                    <Border Grid.Column="2" Style="{StaticResource AdminHandoffCard}">
+                        <StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                <CheckBox Content="Mark as Incomplete/Missing Components" IsChecked="{Binding ItemModel.IsIncomplete}" Foreground="{DynamicResource ErrorBrush}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <TextBlock Text="Missing Components" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4" Foreground="{DynamicResource ErrorBrush}"/>
+                            <TextBlock Text="List every missing part so the record gives clear handoff guidance before the item is released."
+                                       Style="{StaticResource CaptionTextBlock}"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8"/>
+                            <TextBox Text="{Binding ItemModel.MissingComponentsNotes, UpdateSourceTrigger=PropertyChanged}" Height="260" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" ToolTip="List missing parts or components"/>
                         </StackPanel>
-                        <TextBlock Text="Missing Components" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4" Foreground="{DynamicResource ErrorBrush}"/>
-                        <TextBox Text="{Binding ItemModel.MissingComponentsNotes, UpdateSourceTrigger=PropertyChanged}" Height="84" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" ToolTip="List missing parts or components"/>
-                    </StackPanel>
-                </Border>
-
-                <Border Style="{StaticResource Card}" Padding="14">
-                    <StackPanel>
-                        <TextBlock Text="Issues / Problems" Style="{StaticResource SectionHeader}" Margin="0,0,0,6"/>
-                        <TextBox Text="{Binding ItemModel.IssuesNotes, UpdateSourceTrigger=PropertyChanged}" Height="84" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" ToolTip="Describe any issues or problems with this item"/>
-                    </StackPanel>
-                </Border>
+                    </Border>
+                </Grid>
             </StackPanel>
         </ScrollViewer>
 
-        <controls:SaveCancelBar Grid.Row="1"/>
+        <controls:SaveCancelBar Grid.Row="2"/>
+
+        <Border Grid.Row="3" Style="{StaticResource DesktopStatusFooter}" Margin="0,8,0,0">
+            <TextBlock Text="Item edit status: review identity, shelf, readiness, condition notes, then save to return to the current workflow."
+                       Style="{StaticResource CaptionTextBlock}"
+                       TextWrapping="Wrap"/>
+        </Border>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary

- Polishes `ItemEditWindow.xaml` into a stronger item edit workbench with a deliberate header, edit-state cue, summary cards, grouped identity/shelf fields, photo and availability handoff, condition sections, and a stable status footer.
- Preserves existing `ItemModel` bindings plus image, save, and cancel command paths.
- Extends `DialogOutputWindowXamlTests` to guard the item edit polish markers and critical bindings.
- Records the scheduled polish pass in `InventoryManagementApp/ProgressNotes/2026-06-19-item-edit-dialog-polish.md`.

## Validation

- GitHub connector compare confirmed the branch is 3 commits ahead of `master` and 0 behind.
- GitHub connector readback confirmed the changed XAML/test/progress-note contents on the branch.
- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks could not be run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct clone/raw access is blocked by the network tunnel.