### PR TITLE
[codex] Polish rent checkout dialog

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/DialogOutputWindowXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/DialogOutputWindowXamlTests.cs
@@ -113,6 +113,26 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void RentCheckoutDialog_UsesPolishedHandoffStructureAndPreservesCommands()
+        {
+            var rent = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "RentItemPopupWindow.xaml");
+
+            Assert.Contains("Rental Checkout", rent, StringComparison.Ordinal);
+            Assert.Contains("01 Customer directory", rent, StringComparison.Ordinal);
+            Assert.Contains("Selected Customer Handoff", rent, StringComparison.Ordinal);
+            Assert.Contains("Checkout Readiness", rent, StringComparison.Ordinal);
+            Assert.Contains("DesktopStatusFooter", rent, StringComparison.Ordinal);
+            Assert.Contains("CustomerSearchText, UpdateSourceTrigger=PropertyChanged", rent, StringComparison.Ordinal);
+            Assert.Contains("ClearCustomerSearchCommand", rent, StringComparison.Ordinal);
+            Assert.Contains("AddCustomerCommand", rent, StringComparison.Ordinal);
+            Assert.Contains("SetRentalDaysCommand", rent, StringComparison.Ordinal);
+            Assert.Contains("SelectedDueDate, Mode=TwoWay", rent, StringComparison.Ordinal);
+            Assert.Contains("RentalDays, UpdateSourceTrigger=PropertyChanged", rent, StringComparison.Ordinal);
+            Assert.Contains("CheckOutCommand", rent, StringComparison.Ordinal);
+            Assert.Contains("CancelCommand", rent, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void SelectedRowDetailActions_RouteThroughPolishedDetailDialog()
         {
             var activity = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-19-rent-checkout-dialog-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-19-rent-checkout-dialog-polish.md
@@ -1,0 +1,18 @@
+# Rent Checkout Dialog Polish - 2026-06-19 01:11 NZST
+
+## Completed
+
+- Polished `RentItemPopupWindow.xaml` into a stronger rental checkout surface with a deliberate header, top action affordances, customer/due-date summary cards, and a stable footer status/action bar.
+- Reworked the customer selection area into a clearer checkout workbench with a pane header, aligned search/add controls, richer customer list rows, and a selected-customer handoff panel.
+- Kept the existing checkout behavior intact: customer search, clear search, add customer, selected customer binding, due-date binding, quick rental-day buttons, rental-day text entry, confirm checkout, and cancel all still use the same bindings/commands.
+- Added `DialogOutputWindowXamlTests` coverage for the rental checkout dialog markers and preserved command/binding paths.
+
+## Validation
+
+- GitHub connector readback should be used to confirm this branch's changed XAML, XAML test, and progress note before merge.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and local clone/raw access is blocked by the network tunnel.
+
+## Next Useful Targets
+
+- Continue dialog polish on rental filter/history output surfaces and the remaining print preview document styles.
+- Run the Windows QA screenshot capture once a Windows/.NET workstation is available so the new rental checkout layout can be reviewed at runtime.

--- a/InventoryManagementApp/Views/Windows/RentItemPopupWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/RentItemPopupWindow.xaml
@@ -4,11 +4,24 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:helpers="clr-namespace:InventoryManagementApp.Utilities.Helpers"
         Title="{Binding ItemLabelSingular, Source={x:Static helpers:LabelProvider.Instance}, StringFormat='Rent {0}'}"
-        Width="860" Height="520" MinWidth="780" MinHeight="460"
+        Width="940" Height="620" MinWidth="820" MinHeight="540"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="8">
+    <Window.Resources>
+        <Style x:Key="CheckoutSummaryLabel" TargetType="TextBlock" BasedOn="{StaticResource LabelTextBlock}">
+            <Setter Property="TextWrapping" Value="NoWrap"/>
+            <Setter Property="Margin" Value="0,0,0,3"/>
+        </Style>
+        <Style x:Key="CheckoutSummaryValue" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+        </Style>
+    </Window.Resources>
+
+    <Grid Margin="10">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
@@ -16,46 +29,83 @@
 
         <Border Grid.Row="0" Style="{StaticResource ToolbarCard}">
             <DockPanel LastChildFill="True">
-                <TextBlock Text="Rent Item" Style="{StaticResource PageTitleTextBlock}" DockPanel.Dock="Left" Margin="0,0,12,0"/>
-                <TextBlock Text="Search the customer directory, confirm the collector, then set the due-back date." Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center"/>
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center" Margin="12,0,0,0">
+                    <Button Style="{StaticResource GhostButton}" Width="92" Content="Cancel" Command="{Binding CancelCommand}" Margin="0,0,6,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Width="132" Content="Confirm Rental" Command="{Binding CheckOutCommand}"/>
+                </StackPanel>
+                <StackPanel>
+                    <TextBlock Text="Rental Checkout" Style="{StaticResource PageTitleTextBlock}"/>
+                    <TextBlock Text="Pick the customer, confirm contact details, then set the due-back date before checkout." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                </StackPanel>
             </DockPanel>
         </Border>
 
-        <Border Grid.Row="1" Style="{StaticResource Card}" Padding="0" Margin="0,0,0,8">
-            <DockPanel LastChildFill="True">
-                <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="0,0,0,1" Padding="5,3">
+        <UniformGrid Grid.Row="1" Columns="3" Margin="0,0,0,8">
+            <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,6,0">
+                <StackPanel>
+                    <TextBlock Text="01 Customer directory" Style="{StaticResource CheckoutSummaryLabel}"/>
+                    <TextBlock Text="{Binding CustomerCountSummary}" Style="{StaticResource CheckoutSummaryValue}"/>
+                    <TextBlock Text="Search narrows the pickup contact list before checkout." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,4,0,0"/>
+                </StackPanel>
+            </Border>
+            <Border Style="{StaticResource DesktopSummaryCard}" Margin="3,0,3,0">
+                <StackPanel>
+                    <TextBlock Text="02 Selected pickup" Style="{StaticResource CheckoutSummaryLabel}"/>
+                    <TextBlock Text="{Binding SelectedCustomerSummary}" Style="{StaticResource CheckoutSummaryValue}"/>
+                    <TextBlock Text="{Binding SelectedCustomerContactLine}" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,4,0,0"/>
+                </StackPanel>
+            </Border>
+            <Border Style="{StaticResource DesktopSummaryCard}" Margin="6,0,0,0">
+                <StackPanel>
+                    <TextBlock Text="03 Return timing" Style="{StaticResource CheckoutSummaryLabel}"/>
+                    <TextBlock Text="Due date and rental days" Style="{StaticResource CheckoutSummaryValue}"/>
+                    <TextBlock Text="Quick day buttons keep common checkout periods aligned." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,4,0,0"/>
+                </StackPanel>
+            </Border>
+        </UniformGrid>
+
+        <Border Grid.Row="2" Style="{StaticResource Card}" Padding="0" Margin="0,0,0,8">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <Border Grid.Row="0" Style="{StaticResource DesktopPaneHeader}">
                     <DockPanel LastChildFill="True">
-                        <TextBlock Text="01 Customer And Rental Details" Style="{StaticResource SectionHeader}" Margin="0" DockPanel.Dock="Left"/>
-                        <TextBlock Text="{Binding CustomerCountSummary}" Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
+                        <TextBlock Text="Customer And Rental Details" Style="{StaticResource SectionHeader}" DockPanel.Dock="Left" Margin="0"/>
+                        <TextBlock Text="Select a row to load the pickup handoff panel." Style="{StaticResource CaptionTextBlock}" HorizontalAlignment="Right"/>
                     </DockPanel>
                 </Border>
 
-                <Grid Margin="8">
+                <Grid Grid.Row="1" Margin="10">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*" MinWidth="420"/>
                         <ColumnDefinition Width="8"/>
-                        <ColumnDefinition Width="300"/>
+                        <ColumnDefinition Width="320" MinWidth="300"/>
                     </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
 
-                    <Grid Grid.Row="0" Grid.Column="0" Margin="0,0,0,6">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="110"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" Text="Find customer" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Column="1"
-                                 Text="{Binding CustomerSearchText, UpdateSourceTrigger=PropertyChanged}"
-                                 Margin="8,0"
-                                 MinWidth="260"/>
-                        <Button Grid.Column="2" Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearCustomerSearchCommand}" Margin="0,0,6,0"/>
-                        <Button Grid.Column="3" Style="{StaticResource PrimaryButton}" Content="Add Customer" Command="{Binding AddCustomerCommand}"/>
-                    </Grid>
+                    <Border Grid.Row="0" Grid.Column="0" Style="{StaticResource DesktopSectionActionStrip}" Padding="8" Margin="0,0,0,8">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="110"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="Find customer" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
+                            <TextBox Grid.Column="1"
+                                     Text="{Binding CustomerSearchText, UpdateSourceTrigger=PropertyChanged}"
+                                     Margin="8,0"
+                                     MinWidth="260"/>
+                            <Button Grid.Column="2" Style="{StaticResource GhostButton}" Width="76" Content="Clear" Command="{Binding ClearCustomerSearchCommand}" Margin="0,0,6,0"/>
+                            <Button Grid.Column="3" Style="{StaticResource PrimaryButton}" Width="116" Content="Add Customer" Command="{Binding AddCustomerCommand}"/>
+                        </Grid>
+                    </Border>
 
                     <Border Grid.Row="1" Grid.Column="0" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Background="{DynamicResource ControlBackgroundBrush}">
                         <ListBox ItemsSource="{Binding FilteredCustomers}"
@@ -63,22 +113,24 @@
                                  ScrollViewer.VerticalScrollBarVisibility="Auto">
                             <ListBox.ItemTemplate>
                                 <DataTemplate>
-                                    <Grid Margin="2" MinHeight="52">
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="Auto"/>
-                                            <RowDefinition Height="Auto"/>
-                                            <RowDefinition Height="Auto"/>
-                                        </Grid.RowDefinitions>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*"/>
-                                            <ColumnDefinition Width="190"/>
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock Grid.Row="0" Grid.Column="0" Text="{Binding Company}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
-                                        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Contact}" TextTrimming="CharacterEllipsis" Margin="8,0,0,0"/>
-                                        <TextBlock Grid.Row="1" Grid.Column="0" Text="{Binding Email}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis"/>
-                                        <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Phone}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis" Margin="8,0,0,0"/>
-                                        <TextBlock Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding Address}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis"/>
-                                    </Grid>
+                                    <Border BorderBrush="{DynamicResource BorderBrushBase}" BorderThickness="0,0,0,1" Padding="6" MinHeight="62">
+                                        <Grid>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                            </Grid.RowDefinitions>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="190"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Grid.Row="0" Grid.Column="0" Text="{Binding Company}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                                            <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Contact}" TextTrimming="CharacterEllipsis" Margin="8,0,0,0"/>
+                                            <TextBlock Grid.Row="1" Grid.Column="0" Text="{Binding Email}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis"/>
+                                            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Phone}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis" Margin="8,0,0,0"/>
+                                            <TextBlock Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding Address}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis"/>
+                                        </Grid>
+                                    </Border>
                                 </DataTemplate>
                             </ListBox.ItemTemplate>
                         </ListBox>
@@ -87,16 +139,16 @@
                     <GridSplitter Grid.Row="0" Grid.RowSpan="2" Grid.Column="1" Width="8" HorizontalAlignment="Stretch" Background="{DynamicResource BorderBrushBase}"/>
 
                     <DockPanel Grid.Row="0" Grid.RowSpan="2" Grid.Column="2" LastChildFill="True">
-                        <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="8" Margin="0,0,0,8">
+                        <Border DockPanel.Dock="Top" Style="{StaticResource AdminHandoffCard}">
                             <StackPanel>
-                                <TextBlock Text="02 Selected Customer" Style="{StaticResource SectionHeader}" Margin="0,0,0,6"/>
+                                <TextBlock Text="Selected Customer Handoff" Style="{StaticResource SectionHeader}" Margin="0,0,0,6"/>
                                 <TextBlock Text="{Binding SelectedCustomerSummary}" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,0,0,6"/>
                                 <TextBlock Text="{Binding SelectedCustomerContactLine}" TextWrapping="Wrap" Margin="0,0,0,4"/>
                                 <TextBlock Text="{Binding SelectedCustomerAddressLine}" TextWrapping="Wrap" Style="{StaticResource CaptionTextBlock}"/>
                             </StackPanel>
                         </Border>
 
-                        <Border DockPanel.Dock="Top" Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="8" Margin="0,0,0,8">
+                        <Border DockPanel.Dock="Top" Style="{StaticResource DesktopInsetCard}" Margin="0,0,0,8">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="110"/>
@@ -107,30 +159,38 @@
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
-                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Due Back" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                                <DatePicker Grid.Row="0" Grid.Column="1" SelectedDate="{Binding SelectedDueDate, Mode=TwoWay}" Margin="0,0,0,6"/>
-                                <TextBlock Grid.Row="1" Grid.Column="0" Text="Quick days" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,6"/>
-                                <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal" Margin="0,0,0,6">
-                                    <Button Content="7" Command="{Binding SetRentalDaysCommand}" CommandParameter="7" Margin="0,0,4,0"/>
-                                    <Button Content="14" Command="{Binding SetRentalDaysCommand}" CommandParameter="14" Margin="0,0,4,0"/>
-                                    <Button Content="30" Command="{Binding SetRentalDaysCommand}" CommandParameter="30"/>
-                                </StackPanel>
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Due Back" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                                <DatePicker Grid.Row="0" Grid.Column="1" SelectedDate="{Binding SelectedDueDate, Mode=TwoWay}" Margin="0,0,0,8"/>
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="Quick days" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Margin="0,0,8,8"/>
+                                <UniformGrid Grid.Row="1" Grid.Column="1" Columns="3" Margin="0,0,0,8">
+                                    <Button Style="{StaticResource GhostButton}" Content="7" Command="{Binding SetRentalDaysCommand}" CommandParameter="7" Margin="0,0,4,0"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="14" Command="{Binding SetRentalDaysCommand}" CommandParameter="14" Margin="2,0"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="30" Command="{Binding SetRentalDaysCommand}" CommandParameter="30" Margin="4,0,0,0"/>
+                                </UniformGrid>
                                 <TextBlock Grid.Row="2" Grid.Column="0" Text="Rental days" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center"/>
-                                <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding RentalDays, UpdateSourceTrigger=PropertyChanged}" Width="70" HorizontalAlignment="Left"/>
+                                <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding RentalDays, UpdateSourceTrigger=PropertyChanged}" Width="78" HorizontalAlignment="Left"/>
                             </Grid>
                         </Border>
 
-                        <Border Background="{DynamicResource SurfaceAltBrush}" BorderBrush="{DynamicResource BorderBrushAlt}" BorderThickness="1" Padding="8">
-                            <TextBlock Text="{Binding SelectedCustomerActionHint}" TextWrapping="Wrap"/>
+                        <Border Style="{StaticResource DesktopNoteCard}">
+                            <StackPanel>
+                                <TextBlock Text="Checkout Readiness" Style="{StaticResource LabelTextBlock}" Margin="0,0,0,4"/>
+                                <TextBlock Text="{Binding SelectedCustomerActionHint}" TextWrapping="Wrap"/>
+                            </StackPanel>
                         </Border>
                     </DockPanel>
                 </Grid>
-            </DockPanel>
+            </Grid>
         </Border>
 
-        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Style="{StaticResource GhostButton}" Content="Cancel" Command="{Binding CancelCommand}" Margin="0,0,6,0"/>
-            <Button Style="{StaticResource PrimaryButton}" Content="Confirm Rental" Command="{Binding CheckOutCommand}"/>
-        </StackPanel>
+        <Border Grid.Row="3" Style="{StaticResource DesktopStatusFooter}">
+            <DockPanel LastChildFill="True">
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                    <Button Style="{StaticResource GhostButton}" Width="92" Content="Cancel" Command="{Binding CancelCommand}" Margin="0,0,6,0"/>
+                    <Button Style="{StaticResource PrimaryButton}" Width="132" Content="Confirm Rental" Command="{Binding CheckOutCommand}"/>
+                </StackPanel>
+                <TextBlock Text="Confirm Rental creates the checkout after customer and due-back details are reviewed." Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,12,0"/>
+            </DockPanel>
+        </Border>
     </Grid>
 </Window>

--- a/ToDo.md
+++ b/ToDo.md
@@ -4,6 +4,7 @@
 
 Progress log:
 
+- 2026-06-19 01:11 NZST: Polished the rental checkout dialog. `RentItemPopupWindow` now has a stronger Rental Checkout header, customer/due-date summary cards, aligned customer search/add controls, richer customer rows, a selected-customer handoff panel, checkout readiness guidance, and a stable footer status/action bar while preserving existing customer search, clear, add-customer, due-date, quick-day, rental-day, confirm, and cancel bindings. Added XAML contract coverage in `DialogOutputWindowXamlTests`. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-19-rent-checkout-dialog-polish.md`.
 - 2026-06-18 17:11 NZST: Polished the Import / Export data workbench. `ImportExportPage` now has a stronger data-operations header, item/customer/protection/run-log summary cards, aligned data-action and result-action rows, clearer item/customer/recovery/photo lanes, a stronger run-log empty state, selected-result handoff card, and stable footer status while preserving existing import/export/backup/image-map/cancel/clear commands and log copy/print/open/right-click/double-click handlers. Added shared `DataRunLogCard` styling and updated XAML contract tests for the data desk. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-18-import-export-data-workbench-polish.md`.
 - 2026-06-18 12:11 NZST: Polished the Insights workbenches. `ReportsPage` now has a stronger reporting header, report/row/destination/last-run summary cards, separated report-selection and output-action controls, richer report result rows, a styled empty state, and carded row-handoff sections. `ActivityLogsPage` now has a stronger audit header, visible/load/selected/destination summary cards, separated audit filters and actions, richer audit rows, a styled empty state, and carded audit-handoff sections while preserving existing commands, bindings, double-click handlers, print/copy handlers, and row-correct context menu hooks. Added XAML contract tests for both Insights pages. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-18-insights-workbench-polish.md`.
 - 2026-06-18 11:11 NZST: Polished the Categories workbench. `CategoriesPage` now has a stronger category setup header, directory/filter/selected/name-readiness summary cards, separated category actions and create/filter controls, richer category directory rows, a styled empty state, and carded setup-handoff sections while preserving existing category commands, bindings, double-click handlers, print/copy handlers, and row-correct context menu hooks. Added XAML contract tests for the updated category page. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-18-categories-workbench-polish.md`.
@@ -17,7 +18,7 @@ Progress log:
 - 2026-06-18 02:11 NZST: Polished the Dashboard KPI and activity surface. `DashboardPage` now has a stronger command-center header, more prominent stat cards, a four-part priority strip for checked-out items/rentals/issues/activity, clearer operational pane captions, and visible recent-activity destination context while preserving existing grid names, commands, bindings, context menus, and keyboard paths. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-18-dashboard-kpi-activity-polish.md`.
 - 2026-06-18 01:11 NZST: Polished the Search Tools results and intelligence surface. `ItemSearchPage` now gives the search results and checked-out panes stronger pane headers, expands the intelligence area, adds a session-pulse summary strip, clarifies repeat/open/print/clear actions, and gives recent-search and unavailable-demand tables roomier scanning while preserving existing grid names, click handlers, bindings, and keyboard paths. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-18-search-intelligence-polish.md`.
 - 2026-06-18 00:11 NZST: Polished the first-run setup wizard onboarding surface. `SetupWizardWindow` now has a stronger launch header, setup checklist, guided field descriptions, framed company-logo preview, ready-check validation area, and a `Complete Setup` action while preserving existing setup commands and password bindings. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-18-setup-wizard-onboarding-polish.md`.
-- 2026-06-17 23:11 NZST: Polished the auth entry surface and sensitive password dialogs. The login account-selection surface now has a deliberate two-panel workstation entry layout with branded company context, role/access guidance, profile count, and stronger user cards. `PasswordPromptWindow` and `ChangePasswordWindow` now use secure-access framing, clearer field guidance, wider password inputs, and stronger action labels while preserving the existing command paths. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-17-auth-entry-polish.md`.
+- 2026-06-17 23:11 NZST: Polished the auth entry surface and sensitive password dialogs. The login account-selection surface now has a deliberate two-panel workstation entry layout with branded company context, role/access guidance, profile count, and stronger user cards. `PasswordPromptWindow` and `ChangePasswordWindow` now use secure-access framing, clearer field guidance, wider inputs, and stronger action labels while preserving the existing command paths. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-17-auth-entry-polish.md`.
 - 2026-06-17 22:32 NZST: Added a shared visual hierarchy polish layer (`InventoryManagementApp/Resources/PolishedVisualHierarchy.xaml`) and loaded it in `App.xaml`. This targets the repeated flat/box-heavy feedback by improving common cards, toolbar/action strips, pane headers, summary cards, primary buttons, and dense grid headers across the app. Detailed log: `InventoryManagementApp/ProgressNotes/2026-06-17-shared-visual-hierarchy-polish.md`.
 
 Overall: the UI is operationally competent and consistent, but most screens still look like a solid internal item rather than a polished commercial product. The strongest positives are workflow clarity and consistent layout; the main weakness is flat visual hierarchy.
@@ -51,46 +52,46 @@ Overall: the UI is operationally competent and consistent, but most screens stil
 04-import-export-backup-images.png: the split between backup and image import is logical; visually it still feels like default controls arranged in boxes. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/ImportExportPage.xaml`; runtime screenshot review still needed.
 05-import-export-run-log.png: the log area is practical, but the right-side guidance panel looks too generic to add much visual confidence. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/ImportExportPage.xaml`; runtime screenshot review still needed.
 05-admin
-01-users.png: useful layout, but the user detail boxes on the right feel empty and under-styled.
-02-users-narrow.png: still works in a tighter width, which is good; however, it becomes visually cramped quickly.
+01-users.png: useful layout, but the user detail boxes on the right feel empty and under-styled. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/UsersPage.xaml`; runtime screenshot review still needed.
+02-users-narrow.png: still works in a tighter width, which is good; however, it becomes visually cramped quickly. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/UsersPage.xaml`; runtime screenshot review still needed.
 03-settings-service-status.png: this is one of the better admin screens because grouped panels create some rhythm.
 04-settings-database.png: weakest settings page visually; it looks more like an unfinished scaffold than a finished screen. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/SettingsPage.xaml`; runtime screenshot review still needed.
-05-settings-general.png: clear form layout and good explanatory notes; still needs stronger typography and contrast hierarchy.
-06-settings-item-display.png: practical bulk-edit page, but it is visually too austere for such a central configuration area.
-07-settings-email.png: functional and readable; one of the more form-complete screens, though still plain.
+05-settings-general.png: clear form layout and good explanatory notes; still needs stronger typography and contrast hierarchy. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/SettingsPage.xaml`; runtime screenshot review still needed.
+06-settings-item-display.png: practical bulk-edit page, but it is visually too austere for such a central configuration area. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/SettingsPage.xaml`; runtime screenshot review still needed.
+07-settings-email.png: functional and readable; one of the more form-complete screens, though still plain. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/SettingsPage.xaml`; runtime screenshot review still needed.
 08-settings-branding.png: ironically this branding page least conveys brand; the logo area and spacing feel temporary. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/SettingsPage.xaml`; runtime screenshot review still needed.
-09-settings-messaging.png: simple and understandable, but visually extremely minimal.
+09-settings-messaging.png: simple and understandable, but visually extremely minimal. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/SettingsPage.xaml`; runtime screenshot review still needed.
 10-settings-backups.png: backup path UI works, but the screen feels empty and not especially trustworthy-looking. Status: first-pass polish complete in `InventoryManagementApp/Views/Pages/SettingsPage.xaml`; runtime screenshot review still needed.
 06-dialogs 01-10
-01-print-labels.png: straightforward and usable, but too plain for a modal that triggers output.
-02-info-dialog.png: readable, but oversized empty space makes it feel low-polish.
-03-confirm-dialog.png: clear action choice, though the balance and spacing feel crude.
-04-input-dialog.png: same issue as above; functional, but not refined.
+01-print-labels.png: straightforward and usable, but too plain for a modal that triggers output. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/PrintLabelWindow.xaml`; runtime screenshot review still needed.
+02-info-dialog.png: readable, but oversized empty space makes it feel low-polish. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/InfoDialogWindow.xaml`; runtime screenshot review still needed.
+03-confirm-dialog.png: clear action choice, though the balance and spacing feel crude. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/ConfirmDialogWindow.xaml`; runtime screenshot review still needed.
+04-input-dialog.png: same issue as above; functional, but not refined. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/InputDialogWindow.xaml`; runtime screenshot review still needed.
 05-item-details.png: one of the better dialogs; the information is organized well and the actions make sense.
-06-item-edit.png: capable form, but long-scroll presentation feels heavy and visually monotonous.
-07-customer-edit.png: simple and readable, though almost aggressively plain.
+06-item-edit.png: capable form, but long-scroll presentation feels heavy and visually monotonous. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/ItemEditWindow.xaml`; runtime screenshot review still needed.
+07-customer-edit.png: simple and readable, though almost aggressively plain. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/CustomerEditWindow.xaml`; runtime screenshot review still needed.
 08-rental-history.png: solid data dialog with good density and clear table structure.
 09-rentals-filter.png: compact and functional, but labels and spacing need more deliberate design.
-10-import-mapping.png: clear task framing, but the oversized side buttons look awkward.
+10-import-mapping.png: clear task framing, but the oversized side buttons look awkward. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/ImportMappingWindow.xaml`; runtime screenshot review still needed.
 06-dialogs 11-20
-11-image-import-mapping.png: understandable, but visually very raw.
+11-image-import-mapping.png: understandable, but visually very raw. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/ImageImportMappingWindow.xaml`; runtime screenshot review still needed.
 12-print-preview.png: clean preview shell; one of the more professional-looking modal frames.
 13-maintenance-edit.png: compact and effective; one of the cleaner edit forms.
 14-calibration-edit.png: same as maintenance edit, with good balance and readable fields.
 15-reservation-edit.png: useful snapshot panel on the left; stronger than many other forms.
-16-kit-edit.png: clear enough, but the large blank space makes it feel underdesigned.
-17-kit-item-edit.png: efficient and readable, though minimal to the point of feeling temporary.
+16-kit-edit.png: clear enough, but the large blank space makes it feel underdesigned. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/KitEditWindow.xaml`; runtime screenshot review still needed.
+17-kit-item-edit.png: efficient and readable, though minimal to the point of feeling temporary. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/KitItemEditWindow.xaml`; runtime screenshot review still needed.
 18-users-edit.png: one of the most complete dialogs functionally; still busy and text-heavy, but convincingly useful.
-19-rent-item-popup.png: one of the better transactional dialogs; clear customer selection and next-step guidance.
+19-rent-item-popup.png: one of the better transactional dialogs; clear customer selection and next-step guidance. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/RentItemPopupWindow.xaml`; runtime screenshot review still needed.
 20-change-password.png: too bare; this should feel more intentional and trustworthy. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/ChangePasswordWindow.xaml`; runtime screenshot review still needed.
 06-dialogs 21-30
 21-password-prompt.png: clear, but visually weak for a sensitive auth step. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/PasswordPromptWindow.xaml`; runtime screenshot review still needed.
-22-password-reset-prompt.png: the reset affordance is good; the red error copy helps, but the whole screen still feels unstyled.
+22-password-reset-prompt.png: the reset affordance is good; the red error copy helps, but the whole screen still feels unstyled. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/PasswordPromptWindow.xaml`; runtime screenshot review still needed.
 23-setup-wizard.png: good structure, but it does not feel like an onboarding experience yet. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/SetupWizardWindow.xaml`; runtime screenshot review still needed.
-24-activity-detail-dialog.png: clear and simple, though very plain.
-25-category-detail-dialog.png: readable and specific; still closer to a system dialog than a polished detail sheet.
-26-import-export-result-dialog.png: good concise result summary; visually generic.
-27-user-detail-dialog.png: useful content, but the dialog lacks visual hierarchy.
+24-activity-detail-dialog.png: clear and simple, though very plain. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/DetailDialogWindow.xaml`; runtime screenshot review still needed.
+25-category-detail-dialog.png: readable and specific; still closer to a system dialog than a polished detail sheet. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/DetailDialogWindow.xaml`; runtime screenshot review still needed.
+26-import-export-result-dialog.png: good concise result summary; visually generic. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/DetailDialogWindow.xaml`; runtime screenshot review still needed.
+27-user-detail-dialog.png: useful content, but the dialog lacks visual hierarchy. Status: first-pass polish complete in `InventoryManagementApp/Views/Windows/DetailDialogWindow.xaml`; runtime screenshot review still needed.
 28-item-search-preview.png: good printable content structure, though visually sparse.
 29-dashboard-preview.png: clear snapshot summary; the printed surface is clean but not branded.
 30-customer-directory-preview.png: readable output, but very plain and under-formatted.


### PR DESCRIPTION
## Summary

- Polishes `RentItemPopupWindow.xaml` into a stronger rental checkout surface with a deliberate header, customer/due-date summary cards, aligned search/add controls, selected-customer handoff, checkout readiness guidance, and a stable footer action/status bar.
- Preserves the existing customer search, clear, add-customer, selected customer, due-date, quick-day, rental-day, confirm checkout, and cancel command/binding paths.
- Adds `DialogOutputWindowXamlTests` coverage for the rental checkout dialog markers and preserved bindings.
- Records the scheduled polish pass in `ToDo.md` and `InventoryManagementApp/ProgressNotes/2026-06-19-rent-checkout-dialog-polish.md`.

## Validation

- GitHub connector compare confirmed the branch is 4 commits ahead of `master` and 0 behind.
- GitHub connector readback confirmed the changed XAML, XAML test, and progress note on the branch.
- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks could not be run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct clone/raw access is blocked by the network tunnel.