### PR TITLE
[codex] Polish shared print preview documents

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/PrintPreviewWindowXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/PrintPreviewWindowXamlTests.cs
@@ -43,7 +43,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("Prepared {DateTime.Now:g}", codeBehind, StringComparison.Ordinal);
             Assert.Contains("PrintPolishFooter", codeBehind, StringComparison.Ordinal);
             Assert.Contains("ApplyTablePolish", codeBehind, StringComparison.Ordinal);
-            Assert.Contains("TableRowGroup", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("foreach (var rowGroup in table.RowGroups)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("Generated from InventoryManagementApp print preview", codeBehind, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp.Tests/ViewModels/PrintPreviewWindowXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/PrintPreviewWindowXamlTests.cs
@@ -32,6 +32,21 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("CloseCommand", xaml, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void PrintPreviewWindow_AppliesSharedDocumentPolishToEveryPreview()
+        {
+            var codeBehind = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "PrintPreviewWindow.xaml.cs");
+
+            Assert.Contains("ApplyDocumentPolish(_document, _title)", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("PrintPolishHeader", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Inventory Print Package", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Prepared {DateTime.Now:g}", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("PrintPolishFooter", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("ApplyTablePolish", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("TableRowGroup", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("Generated from InventoryManagementApp print preview", codeBehind, StringComparison.Ordinal);
+        }
+
         static string ReadRepositoryFile(params string[] relativePathParts)
         {
             var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/InventoryManagementApp/ProgressNotes/2026-06-19-print-preview-document-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-19-print-preview-document-polish.md
@@ -1,0 +1,22 @@
+# Print Preview Document Polish - 2026-06-19 06:11 NZST
+
+## Completed
+
+- Added shared FlowDocument polish in `PrintPreviewWindow.xaml.cs` so every preview routed through the app print preview receives a stronger document treatment before staff print it.
+- Added a branded print-package header with title, prepared timestamp, and workflow filing guidance.
+- Added a consistent footer reminding staff to confirm customer, audit, or shelf-handoff details before printing.
+- Normalized preview document typography, page padding, column spacing, foreground color, and white page background.
+- Added shared table polishing for printed directories, invoices, logs, reports, and handoff sheets: stronger header rows, alternating row backgrounds, consistent cell padding, and lighter grid lines.
+- Hardened the formatter so empty generated documents can still receive the print header/footer safely.
+- Extended `PrintPreviewWindowXamlTests` to guard the shared document-polish call, header/footer markers, table-polish loop, and existing print-preview commands.
+
+## Preserved
+
+- Existing `PrintPreviewWindow` commands: Page Setup, Print, and Close.
+- Existing preview logo/title wiring and FlowDocument viewer.
+- Existing printer dialog behavior.
+
+## Validation
+
+- GitHub connector read/write confirmed the changed files on the branch.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks could not be run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct clone/raw access is blocked by the network tunnel.

--- a/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml.cs
@@ -79,8 +79,15 @@ namespace InventoryManagementApp.Views.Windows
             document.ColumnGap = 0;
             document.TextAlignment = TextAlignment.Left;
 
-            if (document.Blocks.FirstBlock is not Section { Tag: "PrintPolishHeader" })
-                document.Blocks.InsertBefore(document.Blocks.FirstBlock, BuildDocumentHeader(title));
+            var firstBlock = document.Blocks.FirstBlock;
+            if (firstBlock is not Section { Tag: "PrintPolishHeader" })
+            {
+                var header = BuildDocumentHeader(title);
+                if (firstBlock == null)
+                    document.Blocks.Add(header);
+                else
+                    document.Blocks.InsertBefore(firstBlock, header);
+            }
 
             if (document.Blocks.LastBlock is not Paragraph { Tag: "PrintPolishFooter" })
                 document.Blocks.Add(BuildDocumentFooter());

--- a/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml.cs
@@ -1,7 +1,9 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Windows;
 using System.Windows.Documents;
+using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Controls; // WPF PrintDialog
 using InventoryManagementApp.ViewModels;
@@ -42,6 +44,7 @@ namespace InventoryManagementApp.Views.Windows
             bmp.Freeze();
             PreviewLogo.Source = bmp;
 
+            ApplyDocumentPolish(_document, _title);
             DocViewer.Document = _document;
             Owner = System.Windows.Application.Current.MainWindow;
             ShowDialog();
@@ -65,6 +68,108 @@ namespace InventoryManagementApp.Views.Windows
             }
             return new Uri("pack://application:,,,/Resources/DefaultLogo.png");
         }
+
+        private static void ApplyDocumentPolish(FlowDocument document, string title)
+        {
+            document.FontFamily = new FontFamily("Segoe UI");
+            document.FontSize = Math.Max(document.FontSize, 10.5);
+            document.Foreground = new SolidColorBrush(Color.FromRgb(31, 41, 55));
+            document.Background = Brushes.White;
+            document.PagePadding = new Thickness(44, 40, 44, 42);
+            document.ColumnGap = 0;
+            document.TextAlignment = TextAlignment.Left;
+
+            if (document.Blocks.FirstBlock is not Section { Tag: "PrintPolishHeader" })
+                document.Blocks.InsertBefore(document.Blocks.FirstBlock, BuildDocumentHeader(title));
+
+            if (document.Blocks.LastBlock is not Paragraph { Tag: "PrintPolishFooter" })
+                document.Blocks.Add(BuildDocumentFooter());
+
+            foreach (var table in document.Blocks.OfType<Table>())
+                ApplyTablePolish(table);
+        }
+
+        private static Section BuildDocumentHeader(string title)
+        {
+            var header = new Section
+            {
+                Tag = "PrintPolishHeader",
+                Background = new SolidColorBrush(Color.FromRgb(244, 247, 251)),
+                BorderBrush = new SolidColorBrush(Color.FromRgb(49, 130, 206)),
+                BorderThickness = new Thickness(0, 0, 0, 2),
+                Padding = new Thickness(12, 10, 12, 10),
+                Margin = new Thickness(0, 0, 0, 14)
+            };
+
+            header.Blocks.Add(new Paragraph(new Run(SafeText(title, "Inventory Print Package")))
+            {
+                FontSize = 20,
+                FontWeight = FontWeights.SemiBold,
+                Foreground = new SolidColorBrush(Color.FromRgb(17, 24, 39)),
+                Margin = new Thickness(0, 0, 0, 3)
+            });
+            header.Blocks.Add(new Paragraph(new Run($"Prepared {DateTime.Now:g} | Review, sign off, and file with the matching workflow."))
+            {
+                FontSize = 10.5,
+                Foreground = new SolidColorBrush(Color.FromRgb(75, 85, 99)),
+                Margin = new Thickness(0)
+            });
+
+            return header;
+        }
+
+        private static Paragraph BuildDocumentFooter()
+        {
+            return new Paragraph(new Run("Generated from InventoryManagementApp print preview | Confirm details before customer, audit, or shelf handoff."))
+            {
+                Tag = "PrintPolishFooter",
+                FontSize = 9.5,
+                Foreground = new SolidColorBrush(Color.FromRgb(75, 85, 99)),
+                BorderBrush = new SolidColorBrush(Color.FromRgb(209, 213, 219)),
+                BorderThickness = new Thickness(0, 1, 0, 0),
+                Padding = new Thickness(0, 8, 0, 0),
+                Margin = new Thickness(0, 14, 0, 0)
+            };
+        }
+
+        private static void ApplyTablePolish(Table table)
+        {
+            table.CellSpacing = 0;
+            table.Margin = new Thickness(0, 4, 0, 12);
+
+            foreach (var rowGroup in table.RowGroups)
+            {
+                for (var rowIndex = 0; rowIndex < rowGroup.Rows.Count; rowIndex++)
+                {
+                    var row = rowGroup.Rows[rowIndex];
+                    row.FontSize = rowIndex == 0 ? 10.5 : 10;
+
+                    if (rowIndex == 0)
+                    {
+                        row.Background = new SolidColorBrush(Color.FromRgb(230, 236, 246));
+                        row.Foreground = new SolidColorBrush(Color.FromRgb(17, 24, 39));
+                        row.FontWeight = FontWeights.SemiBold;
+                    }
+                    else if (rowIndex % 2 == 0)
+                    {
+                        row.Background = new SolidColorBrush(Color.FromRgb(249, 250, 252));
+                    }
+
+                    foreach (var cell in row.Cells)
+                    {
+                        cell.BorderBrush = new SolidColorBrush(Color.FromRgb(209, 213, 219));
+                        cell.BorderThickness = new Thickness(0, 0, 0, 0.6);
+                        cell.Padding = new Thickness(6, 4, 6, 4);
+
+                        foreach (var paragraph in cell.Blocks.OfType<Paragraph>())
+                            paragraph.Margin = new Thickness(0);
+                    }
+                }
+            }
+        }
+
+        private static string SafeText(string? text, string fallback)
+            => string.IsNullOrWhiteSpace(text) ? fallback : text.Trim();
 
         private void OnPageSetup()
         {


### PR DESCRIPTION
## Summary

- Adds shared `FlowDocument` polish inside `PrintPreviewWindow.xaml.cs` so every app print preview receives stronger document styling before staff print it.
- Adds a branded print-package header/footer, normalized typography/page spacing, and safer handling for empty generated documents.
- Adds shared table treatment for directory, invoice, log, report, and handoff previews with stronger header rows, alternating row backgrounds, consistent cell padding, and lighter grid lines.
- Extends `PrintPreviewWindowXamlTests` and records the pass in `InventoryManagementApp/ProgressNotes/2026-06-19-print-preview-document-polish.md`.

## Validation

- GitHub connector compare confirmed this branch is 5 commits ahead of `master` and 0 behind with a focused three-file diff.
- GitHub connector readback confirmed the changed print preview code, XAML contract test, and progress note on the branch.
- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks could not be run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct clone/raw access is blocked by the network tunnel.