### PR TITLE
[codex] Route insights print actions through preview

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
@@ -75,6 +75,20 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("SelectedLogOperatorPath", xaml, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void InsightPrintActions_RouteThroughSharedPrintPreview()
+        {
+            var reportsCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs");
+            var activityCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml.cs");
+
+            Assert.Contains("new PrintPreviewWindow().ShowPreview(document, vm.ReportTitle, null)", reportsCode, StringComparison.Ordinal);
+            Assert.Contains("new PrintPreviewWindow().ShowPreview(document, \"Activity Logs\", null)", activityCode, StringComparison.Ordinal);
+            Assert.DoesNotContain("WpfPrintDialog", reportsCode, StringComparison.Ordinal);
+            Assert.DoesNotContain("WpfPrintDialog", activityCode, StringComparison.Ordinal);
+            Assert.DoesNotContain("PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator", reportsCode, StringComparison.Ordinal);
+            Assert.DoesNotContain("PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator", activityCode, StringComparison.Ordinal);
+        }
+
         static string ReadRepositoryFile(params string[] relativePathParts)
         {
             var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/InventoryManagementApp/ProgressNotes/2026-06-19-insights-print-preview-routing.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-19-insights-print-preview-routing.md
@@ -1,0 +1,18 @@
+# Insights Print Preview Routing - 2026-06-19 07:11 NZST
+
+## Completed
+
+- Routed `ReportsPage` print output through `PrintPreviewWindow` instead of opening the raw system print dialog immediately.
+- Routed `ActivityLogsPage` print output through `PrintPreviewWindow` so audit staff can review the generated log package before printing.
+- Preserved the existing report/activity document builders, empty-state messages, copy/detail actions, row context behavior, and the preview window's Page Setup / Print / Close flow.
+- Extended `InsightsPagesXamlTests` to guard that Reports and Activity Logs print actions call the shared preview surface and no longer directly invoke `WpfPrintDialog` / `PrintDocument` from the page handlers.
+
+## User Flow
+
+- Reports: run a report, press `Print`, review the branded preview package, adjust page setup if needed, then print from the preview workstation.
+- Activity Logs: filter/load audit rows, press `Print`, review the branded audit log preview, then print from the preview workstation.
+
+## Validation
+
+- GitHub connector read/write was used because local clone/raw access is blocked by the scheduled environment network tunnel.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks could not be run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct clone/raw access is blocked.

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
@@ -9,7 +9,6 @@ using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
 using InventoryManagementApp.Views.Windows;
 using WpfMessageBox = System.Windows.MessageBox;
-using WpfPrintDialog = System.Windows.Controls.PrintDialog;
 
 namespace InventoryManagementApp.Views.Pages
 {
@@ -137,16 +136,8 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            var printDialog = new WpfPrintDialog();
-            if (printDialog.ShowDialog() != true)
-                return;
-
             var document = BuildPrintDocument(vm.FilteredLogs.ToList(), vm.StatusMessage, vm.ActivitySummary);
-            document.PageWidth = printDialog.PrintableAreaWidth;
-            document.PageHeight = printDialog.PrintableAreaHeight;
-            document.PagePadding = new Thickness(36);
-            document.ColumnWidth = printDialog.PrintableAreaWidth;
-            printDialog.PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator, "Activity Logs");
+            new PrintPreviewWindow().ShowPreview(document, "Activity Logs", null);
         }
 
         private static string FormatLogDetail(ActivityLog log)

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
@@ -7,8 +7,8 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Documents;
 using System.Windows.Input;
 using InventoryManagementApp.ViewModels;
+using InventoryManagementApp.Views.Windows;
 using WpfMessageBox = System.Windows.MessageBox;
-using WpfPrintDialog = System.Windows.Controls.PrintDialog;
 
 namespace InventoryManagementApp.Views.Pages
 {
@@ -55,16 +55,8 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            var printDialog = new WpfPrintDialog();
-            if (printDialog.ShowDialog() != true)
-                return;
-
             var document = BuildReportDocument(vm.ReportTitle, vm.ReportSummary, vm.LastRunText, vm.ReportLines.ToList());
-            document.PageWidth = printDialog.PrintableAreaWidth;
-            document.PageHeight = printDialog.PrintableAreaHeight;
-            document.PagePadding = new Thickness(36);
-            document.ColumnWidth = printDialog.PrintableAreaWidth;
-            printDialog.PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator, vm.ReportTitle);
+            new PrintPreviewWindow().ShowPreview(document, vm.ReportTitle, null);
         }
 
         private void OpenSelectedDestination()


### PR DESCRIPTION
## Summary

- Routes Reports page printing through the shared `PrintPreviewWindow` instead of opening the raw system print dialog immediately.
- Routes Activity Logs printing through the same preview path so audit output can be reviewed before printing.
- Preserves the existing FlowDocument builders, empty-state messaging, row/detail/copy behavior, and the preview window's Page Setup / Print / Close flow.
- Extends `InsightsPagesXamlTests` to guard preview routing and prevent direct page-level `WpfPrintDialog` / `PrintDocument` regression.
- Records this scheduled pass in `InventoryManagementApp/ProgressNotes/2026-06-19-insights-print-preview-routing.md`.

## Validation

- GitHub connector compare confirmed this branch is 4 commits ahead of `master` and 0 behind with a focused four-file diff.
- GitHub connector readback confirmed the Reports, Activity Logs, test, and progress-note changes on the branch.
- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks could not be run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct clone/raw access is blocked by the network tunnel.