### PR TITLE
[codex] Add main shell workflow footer

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/MainWindowShellXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/MainWindowShellXamlTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.ViewModels
+{
+    public class MainWindowShellXamlTests
+    {
+        [Fact]
+        public void MainWindow_UsesPersistentWorkflowStatusFooter()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "MainWindow.xaml");
+
+            Assert.Contains("DesktopStatusFooter", xaml, StringComparison.Ordinal);
+            Assert.Contains("Workflow status", xaml, StringComparison.Ordinal);
+            Assert.Contains("ShellWorkflowTicker", xaml, StringComparison.Ordinal);
+            Assert.Contains("CurrentWorkflowGuide", xaml, StringComparison.Ordinal);
+            Assert.Contains("RepeatBehavior=\"Forever\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Storyboard.TargetProperty=\"(TextBlock.RenderTransform).(TranslateTransform.X)\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MainWindowFooter_ExplainsCurrentLocationAndNextButtonDestinations()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "MainWindow.xaml");
+
+            Assert.Contains("CurrentNavSectionTitle", xaml, StringComparison.Ordinal);
+            Assert.Contains("CurrentPageTitle", xaml, StringComparison.Ordinal);
+            Assert.Contains("Primary: ", xaml, StringComparison.Ordinal);
+            Assert.Contains("CurrentWorkflowPrimaryActionText", xaml, StringComparison.Ordinal);
+            Assert.Contains("Next: ", xaml, StringComparison.Ordinal);
+            Assert.Contains("CurrentWorkflowSecondaryActionText", xaml, StringComparison.Ordinal);
+            Assert.Contains("CurrentUserRole", xaml, StringComparison.Ordinal);
+        }
+
+        static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -12,6 +12,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0"
@@ -133,5 +134,71 @@
                Background="{DynamicResource BackgroundBrush}"
                Content="{Binding CurrentPage}"
                Margin="{StaticResource PagePadding}"/>
+
+        <Border Grid.Row="4"
+                Style="{StaticResource DesktopStatusFooter}"
+                Margin="8,0,8,6"
+                MinHeight="40"
+                ToolTip="{Binding CurrentWorkflowGuide}">
+            <Grid ClipToBounds="True">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,14,0">
+                    <TextBlock Text="Section" Style="{StaticResource LabelTextBlock}" Margin="0,0,5,0"/>
+                    <TextBlock Text="{Binding CurrentNavSectionTitle}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock Text=" | " Style="{StaticResource CaptionTextBlock}" Margin="8,0"/>
+                    <TextBlock Text="{Binding CurrentPageTitle}" Style="{StaticResource CaptionTextBlock}" TextTrimming="CharacterEllipsis"/>
+                </StackPanel>
+
+                <Border Grid.Column="1"
+                        Background="{DynamicResource TextBoxBackgroundBrush}"
+                        BorderBrush="{DynamicResource BorderBrushAlt}"
+                        BorderThickness="1"
+                        Padding="8,3"
+                        Margin="0,0,12,0"
+                        VerticalAlignment="Center">
+                    <TextBlock Text="Workflow status" Style="{StaticResource LabelTextBlock}"/>
+                </Border>
+
+                <Grid Grid.Column="2" ClipToBounds="True" VerticalAlignment="Center">
+                    <TextBlock x:Name="ShellWorkflowTicker"
+                               Text="{Binding CurrentWorkflowGuide}"
+                               Style="{StaticResource CaptionTextBlock}"
+                               TextWrapping="NoWrap"
+                               TextTrimming="CharacterEllipsis"
+                               RenderTransformOrigin="0,0">
+                        <TextBlock.RenderTransform>
+                            <TranslateTransform X="0"/>
+                        </TextBlock.RenderTransform>
+                        <TextBlock.Triggers>
+                            <EventTrigger RoutedEvent="FrameworkElement.Loaded">
+                                <BeginStoryboard>
+                                    <Storyboard RepeatBehavior="Forever">
+                                        <DoubleAnimation Storyboard.TargetProperty="(TextBlock.RenderTransform).(TranslateTransform.X)"
+                                                         From="720"
+                                                         To="-720"
+                                                         Duration="0:0:26"/>
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </EventTrigger>
+                        </TextBlock.Triggers>
+                    </TextBlock>
+                </Grid>
+
+                <StackPanel Grid.Column="3" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="12,0,0,0">
+                    <TextBlock Text="Primary: " Style="{StaticResource LabelTextBlock}" Visibility="{Binding HasCurrentWorkflowPrimaryAction, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding CurrentWorkflowPrimaryActionText}" Style="{StaticResource CaptionTextBlock}" FontWeight="SemiBold" Visibility="{Binding HasCurrentWorkflowPrimaryAction, Converter={StaticResource BoolToVis}}" Margin="0,0,10,0"/>
+                    <TextBlock Text="Next: " Style="{StaticResource LabelTextBlock}" Visibility="{Binding HasCurrentWorkflowSecondaryAction, Converter={StaticResource BoolToVis}}"/>
+                    <TextBlock Text="{Binding CurrentWorkflowSecondaryActionText}" Style="{StaticResource CaptionTextBlock}" FontWeight="SemiBold" Visibility="{Binding HasCurrentWorkflowSecondaryAction, Converter={StaticResource BoolToVis}}" Margin="0,0,10,0"/>
+                    <TextBlock Text="Signed in: " Style="{StaticResource LabelTextBlock}"/>
+                    <TextBlock Text="{Binding CurrentUserRole}" Style="{StaticResource CaptionTextBlock}" FontWeight="SemiBold"/>
+                </StackPanel>
+            </Grid>
+        </Border>
     </Grid>
 </Window>

--- a/InventoryManagementApp/ProgressNotes/2026-06-19-main-shell-workflow-footer.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-19-main-shell-workflow-footer.md
@@ -1,0 +1,20 @@
+# Main Shell Workflow Footer - 2026-06-19 08:11 NZST
+
+## Completed
+
+- Added a persistent main-window status footer under the page frame so every screen keeps a stable "where am I and what happens next" anchor.
+- Bound the footer to the existing shell workflow state: current section, current page, workflow guidance, primary next action, secondary next action, and signed-in role.
+- Added a lightweight workflow ticker that scrolls the current page guidance across the footer for glanceable handoff context.
+- Preserved the existing menu, top workflow buttons, frame navigation, global search, switch-user entry point, and page content bindings.
+- Added `MainWindowShellXamlTests` coverage to guard the footer, ticker, current-location bindings, and primary/secondary action destination labels.
+
+## User Flow
+
+- When a staff member opens a section or presses a shell action, the top of the window still changes page as before.
+- The new footer remains fixed at the bottom and confirms the current section/page plus the primary and next related destinations.
+- The scrolling workflow guidance gives operators a constant reminder of what to do next from the current screen.
+
+## Validation
+
+- GitHub connector read/write was used because local clone/raw access is blocked by the scheduled environment network tunnel.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks could not be run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct clone/raw access is blocked.


### PR DESCRIPTION
## Summary

- Adds a persistent app-wide workflow footer to `MainWindow.xaml` below the page frame.
- Shows the current section, current page, signed-in role, and visible primary/secondary workflow destinations so staff can understand what pressing the shell buttons will do next.
- Adds a lightweight scrolling workflow-status ticker bound to `CurrentWorkflowGuide` for continuous page handoff context.
- Adds `MainWindowShellXamlTests` to guard the footer, ticker, location bindings, and next-action labels.
- Records this scheduled pass in `InventoryManagementApp/ProgressNotes/2026-06-19-main-shell-workflow-footer.md`.

## Validation

- GitHub connector compare confirmed this branch is 3 commits ahead of `master` and 0 behind with the expected three-file diff.
- GitHub connector readback confirmed the footer XAML and new tests on the branch.
- GitHub reported no commit status checks yet for the branch head at review time.
- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks could not be run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct clone/raw access is blocked by the network tunnel.