### PR TITLE
[codex] Add admin theme customization resources

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/SettingsThemeCustomizationXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/SettingsThemeCustomizationXamlTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.ViewModels
+{
+    public class SettingsThemeCustomizationXamlTests
+    {
+        [Fact]
+        public void SettingsPage_ExposesAdminThemeSelection()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "SettingsPage.xaml");
+
+            Assert.Contains("Admin Settings Workbench", xaml, StringComparison.Ordinal);
+            Assert.Contains("Text=\"Theme\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SelectedItem=\"{Binding Theme}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ItemsSource=\"{Binding ThemeOptions}\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void App_LoadsThemeCustomizationDictionaryBeforeSharedStyles()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "App.xaml");
+
+            var themeCustomizationIndex = xaml.IndexOf("Resources/Theme.Customization.xaml", StringComparison.Ordinal);
+            var stylesIndex = xaml.IndexOf("Resources/Styles.xaml", StringComparison.Ordinal);
+            var desktopShellIndex = xaml.IndexOf("Resources/DesktopShell.xaml", StringComparison.Ordinal);
+
+            Assert.True(themeCustomizationIndex > 0, "Theme customization resources should be merged into App.xaml.");
+            Assert.True(themeCustomizationIndex < stylesIndex, "Theme customization resources must load before shared styles.");
+            Assert.True(themeCustomizationIndex < desktopShellIndex, "Theme customization resources must load before shell styles.");
+        }
+
+        [Fact]
+        public void ThemeCustomizationResources_DefineFullAppVisualKnobs()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.Customization.xaml");
+
+            Assert.Contains("ThemeBorderThickness", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeBorderlessThickness", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeCardCornerRadius", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeButtonCornerRadius", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeTransparentBrush", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeGlassSurfaceBrush", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeAppBackgroundOverlayBrush", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeNoShadow", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeSurfaceShadow", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeDeepShadow", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SharedStyles_UseThemeShapeTransparencyAndShadowTokens()
+        {
+            var polishedXaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "PolishedVisualHierarchy.xaml");
+            var shellXaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "DesktopShell.xaml");
+
+            Assert.Contains("ThemeCardCornerRadius", polishedXaml, StringComparison.Ordinal);
+            Assert.Contains("ThemePanelCornerRadius", polishedXaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeSurfaceShadow", polishedXaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeRaisedShadow", polishedXaml, StringComparison.Ordinal);
+            Assert.Contains("GlassSurfaceBrush", polishedXaml, StringComparison.Ordinal);
+            Assert.Contains("GlassSurfaceAltBrush", polishedXaml, StringComparison.Ordinal);
+
+            Assert.Contains("ThemeButtonCornerRadius", shellXaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeControlBorderThickness", shellXaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeBorderlessThickness", shellXaml, StringComparison.Ordinal);
+            Assert.Contains("TransparentSurfaceBrush", shellXaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void LightAndDarkPalettes_ExposeTransparentAndGlassBrushes()
+        {
+            var lightXaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Colors.Light.xaml");
+            var darkXaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Colors.Dark.xaml");
+
+            foreach (var xaml in new[] { lightXaml, darkXaml })
+            {
+                Assert.Contains("TransparentSurfaceBrush", xaml, StringComparison.Ordinal);
+                Assert.Contains("GlassSurfaceBrush", xaml, StringComparison.Ordinal);
+                Assert.Contains("GlassSurfaceAltBrush", xaml, StringComparison.Ordinal);
+                Assert.Contains("AppBackgroundTintBrush", xaml, StringComparison.Ordinal);
+            }
+        }
+
+        static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -9,6 +9,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <!-- Theme dictionary added at runtime -->
                 <ResourceDictionary Source="Resources/Colors.Light.xaml"/>
+                <ResourceDictionary Source="Resources/Theme.Customization.xaml"/>
                 <ResourceDictionary Source="Resources/Styles.xaml"/>
                 <ResourceDictionary Source="Resources/DesktopShell.xaml"/>
                 <ResourceDictionary Source="Resources/DesktopPageShellResources.xaml"/>

--- a/InventoryManagementApp/InventoryManagementApp.csproj
+++ b/InventoryManagementApp/InventoryManagementApp.csproj
@@ -62,6 +62,7 @@
   <ItemGroup>
     <Page Remove="Resources\Colors.Dark.xaml" />
     <Page Remove="Resources\Colors.Light.xaml" />
+    <Page Remove="Resources\Theme.Customization.xaml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -105,6 +106,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Resource>
     <Resource Include="Resources\Colors.Light.xaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Generator>MSBuild:Compile</Generator>
+    </Resource>
+    <Resource Include="Resources\Theme.Customization.xaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Generator>MSBuild:Compile</Generator>
     </Resource>

--- a/InventoryManagementApp/ProgressNotes/2026-06-19-admin-theme-customization-resources.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-19-admin-theme-customization-resources.md
@@ -1,0 +1,21 @@
+# Admin Theme Customization Resources - 2026-06-19 09:11 NZST
+
+## Completed
+
+- Added `Resources/Theme.Customization.xaml` as the shared app-wide visual customization layer loaded from `App.xaml` before common styles.
+- Added centralized theme knobs for border removal, control/card/panel corner radius, transparent and glass surfaces, app background overlay support, and multiple shadow depths.
+- Extended light and dark palettes with transparent, glass, and background-tint brushes so admin-selected themes can let backgrounds show through consistently.
+- Updated shared visual hierarchy styles and desktop shell controls so common cards, panels, footers, buttons, text boxes, combo boxes, data grids, and borderless cells consume the new theme tokens.
+- Included the new resource dictionary in the WPF project build output.
+- Added XAML contract coverage in `SettingsThemeCustomizationXamlTests` to protect the Settings theme selector and the shared customization resources.
+
+## Validation
+
+- GitHub connector read/write confirmed the changed app resource, palette, style, project, test, and progress-note files on the feature branch.
+- Static XAML contract tests were added for the new theme customization hooks.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks could not be run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct clone/raw access is blocked by the network tunnel.
+
+## Follow-up
+
+- A later Windows-capable pass should add a dedicated Settings theme designer tab with persisted per-admin sliders/color pickers for these resource keys.
+- A later pass should add custom background image/color persistence once the Settings storage contract is expanded.

--- a/InventoryManagementApp/Resources/Colors.Dark.xaml
+++ b/InventoryManagementApp/Resources/Colors.Dark.xaml
@@ -31,6 +31,10 @@
     <SolidColorBrush x:Key="TextBoxBackgroundBrush" Color="#3C3C3C"/>
     <SolidColorBrush x:Key="ComboBoxPopupBackgroundBrush" Color="#252526"/>
     <SolidColorBrush x:Key="OverlayBrush" Color="#66000000"/>
+    <SolidColorBrush x:Key="TransparentSurfaceBrush" Color="#00000000"/>
+    <SolidColorBrush x:Key="GlassSurfaceBrush" Color="#D9252526"/>
+    <SolidColorBrush x:Key="GlassSurfaceAltBrush" Color="#B82D2D30"/>
+    <SolidColorBrush x:Key="AppBackgroundTintBrush" Color="#22000000"/>
     <SolidColorBrush x:Key="NavButtonHoverBrush" Color="#2A2D2E"/>
     <SolidColorBrush x:Key="NavButtonHoverBorderBrush" Color="#3F3F46"/>
     <SolidColorBrush x:Key="NavButtonPressedBrush" Color="#313136"/>

--- a/InventoryManagementApp/Resources/Colors.Light.xaml
+++ b/InventoryManagementApp/Resources/Colors.Light.xaml
@@ -31,6 +31,10 @@
     <SolidColorBrush x:Key="TextBoxBackgroundBrush" Color="#FFFFFF"/>
     <SolidColorBrush x:Key="ComboBoxPopupBackgroundBrush" Color="#FFFFFF"/>
     <SolidColorBrush x:Key="OverlayBrush" Color="#33000000"/>
+    <SolidColorBrush x:Key="TransparentSurfaceBrush" Color="#00FFFFFF"/>
+    <SolidColorBrush x:Key="GlassSurfaceBrush" Color="#E8FFFFFF"/>
+    <SolidColorBrush x:Key="GlassSurfaceAltBrush" Color="#CFFFFFFF"/>
+    <SolidColorBrush x:Key="AppBackgroundTintBrush" Color="#22FFFFFF"/>
     <SolidColorBrush x:Key="NavButtonHoverBrush" Color="#E7F3FF"/>
     <SolidColorBrush x:Key="NavButtonHoverBorderBrush" Color="#C6E2FF"/>
     <SolidColorBrush x:Key="NavButtonPressedBrush" Color="#D8ECFF"/>

--- a/InventoryManagementApp/Resources/DesktopShell.xaml
+++ b/InventoryManagementApp/Resources/DesktopShell.xaml
@@ -30,17 +30,18 @@
     <Style TargetType="Border" x:Key="Card">
         <Setter Property="Background" Value="{DynamicResource SurfaceBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="CornerRadius" Value="0"/>
+        <Setter Property="BorderThickness" Value="{StaticResource ThemeBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{StaticResource ThemeCardCornerRadius}"/>
         <Setter Property="Padding" Value="{StaticResource CardPadding}"/>
         <Setter Property="Margin" Value="0"/>
+        <Setter Property="Effect" Value="{StaticResource ThemeSurfaceShadow}"/>
     </Style>
 
     <Style x:Key="ToolbarCard" TargetType="Border">
         <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="CornerRadius" Value="0"/>
+        <Setter Property="BorderThickness" Value="{StaticResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{StaticResource ThemePanelCornerRadius}"/>
         <Setter Property="Padding" Value="{StaticResource ToolbarPadding}"/>
         <Setter Property="Margin" Value="0,0,0,4"/>
     </Style>
@@ -49,7 +50,7 @@
         <Setter Property="Foreground" Value="{DynamicResource BtnFg}"/>
         <Setter Property="Background" Value="{DynamicResource BtnBg}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BtnBorder}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderThickness" Value="{StaticResource ThemeControlBorderThickness}"/>
         <Setter Property="Padding" Value="4,1"/>
         <Setter Property="FontWeight" Value="Normal"/>
         <Setter Property="Cursor" Value="Hand"/>
@@ -65,7 +66,8 @@
                     <Border x:Name="Root"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}">
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{StaticResource ThemeButtonCornerRadius}">
                         <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                           Margin="{TemplateBinding Padding}"
@@ -102,7 +104,7 @@
     </Style>
 
     <Style x:Key="GhostButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
-        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="MinWidth" Value="54"/>
@@ -116,7 +118,7 @@
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="Background" Value="{DynamicResource BtnBg}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BtnBorder}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderThickness" Value="{StaticResource ThemeControlBorderThickness}"/>
         <Setter Property="Padding" Value="7,2"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
@@ -126,7 +128,7 @@
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="Background" Value="{DynamicResource BtnBg}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BtnBorder}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderThickness" Value="{StaticResource ThemeControlBorderThickness}"/>
         <Setter Property="Padding" Value="9,2"/>
         <Setter Property="MinHeight" Value="24"/>
         <Setter Property="Margin" Value="0,0,2,0"/>
@@ -136,7 +138,8 @@
                     <Border x:Name="Root"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}">
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{StaticResource ThemeButtonCornerRadius}">
                         <ContentPresenter Margin="{TemplateBinding Padding}"
                                           HorizontalAlignment="Center"
                                           VerticalAlignment="Center"/>
@@ -163,7 +166,7 @@
         <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderThickness" Value="{StaticResource ThemeControlBorderThickness}"/>
         <Setter Property="Padding" Value="{StaticResource ControlPadding}"/>
         <Setter Property="MinHeight" Value="24"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
@@ -174,7 +177,7 @@
         <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderThickness" Value="{StaticResource ThemeControlBorderThickness}"/>
         <Setter Property="Padding" Value="{StaticResource ControlPadding}"/>
         <Setter Property="MinHeight" Value="24"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
@@ -193,7 +196,7 @@
         <Setter Property="RowBackground" Value="{DynamicResource DataGridRowBackgroundBrush}"/>
         <Setter Property="AlternatingRowBackground" Value="{DynamicResource DataGridAlternatingRowBackgroundBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderThickness" Value="{StaticResource ThemeBorderThickness}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="GridLinesVisibility" Value="All"/>
         <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource BorderBrushBase}"/>
@@ -232,7 +235,7 @@
     <Style TargetType="DataGridCell">
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="Padding" Value="4,1"/>
-        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="BorderThickness" Value="{StaticResource ThemeBorderlessThickness}"/>
         <Setter Property="TextBlock.TextTrimming" Value="CharacterEllipsis"/>
         <Setter Property="TextBlock.TextWrapping" Value="NoWrap"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
@@ -270,7 +273,7 @@
     <Style TargetType="TabControl">
         <Setter Property="Background" Value="{DynamicResource SurfaceBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderThickness" Value="{StaticResource ThemeBorderThickness}"/>
         <Setter Property="Padding" Value="0"/>
     </Style>
 

--- a/InventoryManagementApp/Resources/PolishedVisualHierarchy.xaml
+++ b/InventoryManagementApp/Resources/PolishedVisualHierarchy.xaml
@@ -17,19 +17,19 @@
     <Style TargetType="Border" x:Key="Card">
         <Setter Property="Background" Value="{DynamicResource SurfaceBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushBase}"/>
-        <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="CornerRadius" Value="4"/>
+        <Setter Property="BorderThickness" Value="{StaticResource ThemeBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{StaticResource ThemeCardCornerRadius}"/>
         <Setter Property="Padding" Value="8"/>
         <Setter Property="Margin" Value="0"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
-        <Setter Property="Effect" Value="{StaticResource SubtleSurfaceShadow}"/>
+        <Setter Property="Effect" Value="{StaticResource ThemeSurfaceShadow}"/>
     </Style>
 
     <Style x:Key="ToolbarCard" TargetType="Border">
         <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="CornerRadius" Value="4"/>
+        <Setter Property="BorderThickness" Value="{StaticResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{StaticResource ThemePanelCornerRadius}"/>
         <Setter Property="Padding" Value="10,8"/>
         <Setter Property="Margin" Value="0,0,0,6"/>
         <Setter Property="MinHeight" Value="38"/>
@@ -45,14 +45,16 @@
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="BorderThickness" Value="{StaticResource ThemeControlBorderThickness}"/>
         <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="Padding" Value="10,3"/>
     </Style>
 
     <Style x:Key="GhostButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
-        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{StaticResource ThemeControlBorderThickness}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="MinWidth" Value="62"/>
         <Setter Property="MinHeight" Value="28"/>
@@ -77,23 +79,25 @@
     </Style>
 
     <Style x:Key="DesktopSummaryCard" TargetType="Border" BasedOn="{StaticResource Card}">
-        <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource GlassSurfaceAltBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
         <Setter Property="BorderThickness" Value="1,1,1,2"/>
         <Setter Property="Padding" Value="12"/>
         <Setter Property="MinHeight" Value="72"/>
-        <Setter Property="Effect" Value="{StaticResource RaisedSurfaceShadow}"/>
+        <Setter Property="Effect" Value="{StaticResource ThemeRaisedShadow}"/>
     </Style>
 
     <Style x:Key="DesktopInsetCard" TargetType="Border" BasedOn="{StaticResource Card}">
         <Setter Property="Padding" Value="12"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushBase}"/>
+        <Setter Property="Background" Value="{DynamicResource GlassSurfaceBrush}"/>
     </Style>
 
     <Style x:Key="DesktopPaneHeader" TargetType="Border">
         <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
         <Setter Property="BorderThickness" Value="0,0,0,2"/>
+        <Setter Property="CornerRadius" Value="{StaticResource ThemePanelCornerRadius}"/>
         <Setter Property="Padding" Value="10,7"/>
         <Setter Property="MinHeight" Value="42"/>
     </Style>
@@ -102,6 +106,7 @@
         <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
         <Setter Property="BorderThickness" Value="0,0,0,1"/>
+        <Setter Property="CornerRadius" Value="{StaticResource ThemePanelCornerRadius}"/>
         <Setter Property="Padding" Value="10,7"/>
         <Setter Property="MinHeight" Value="36"/>
     </Style>
@@ -115,13 +120,14 @@
     </Style>
 
     <Style x:Key="DesktopStatusFooter" TargetType="Border">
-        <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource GlassSurfaceAltBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
         <Setter Property="BorderThickness" Value="1,0,1,1"/>
-        <Setter Property="CornerRadius" Value="0,0,4,4"/>
+        <Setter Property="CornerRadius" Value="{StaticResource ThemeFooterCornerRadius}"/>
         <Setter Property="Padding" Value="10,5"/>
         <Setter Property="MinHeight" Value="34"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="Effect" Value="{StaticResource ThemeSurfaceShadow}"/>
     </Style>
 
     <Style x:Key="AdminHandoffCard" TargetType="Border" BasedOn="{StaticResource DesktopInsetCard}">
@@ -130,12 +136,13 @@
         <Setter Property="BorderThickness" Value="1,1,1,2"/>
         <Setter Property="Padding" Value="12"/>
         <Setter Property="Margin" Value="0,0,0,8"/>
+        <Setter Property="Effect" Value="{StaticResource ThemeRaisedShadow}"/>
     </Style>
 
     <Style x:Key="DesktopNoteCard" TargetType="Border" BasedOn="{StaticResource DesktopInsetCard}">
-        <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource GlassSurfaceBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderThickness" Value="{StaticResource ThemeSubtleBorderThickness}"/>
     </Style>
 
     <Style x:Key="DataRunLogCard" TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">

--- a/InventoryManagementApp/Resources/Theme.Customization.xaml
+++ b/InventoryManagementApp/Resources/Theme.Customization.xaml
@@ -1,0 +1,52 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!--
+        Admin theme designer tokens.
+        The Settings theme selector chooses the active color dictionary. These shared resources are
+        the app-wide knobs for the visual redesign layer: border removal, glass surfaces,
+        rounded controls, and shadow depth.
+    -->
+
+    <Thickness x:Key="ThemeBorderThickness">1</Thickness>
+    <Thickness x:Key="ThemeSubtleBorderThickness">1</Thickness>
+    <Thickness x:Key="ThemeControlBorderThickness">1</Thickness>
+    <Thickness x:Key="ThemeBorderlessThickness">0</Thickness>
+
+    <CornerRadius x:Key="ThemeCardCornerRadius">6</CornerRadius>
+    <CornerRadius x:Key="ThemePanelCornerRadius">4</CornerRadius>
+    <CornerRadius x:Key="ThemeButtonCornerRadius">5</CornerRadius>
+    <CornerRadius x:Key="ThemeInputCornerRadius">4</CornerRadius>
+    <CornerRadius x:Key="ThemeFooterCornerRadius">0,0,6,6</CornerRadius>
+
+    <SolidColorBrush x:Key="ThemeTransparentBrush" Color="#00000000"/>
+    <SolidColorBrush x:Key="ThemeGlassSurfaceBrush" Color="#DFFFFFFF"/>
+    <SolidColorBrush x:Key="ThemeGlassSurfaceAltBrush" Color="#BFFFFFFF"/>
+    <SolidColorBrush x:Key="ThemeAppBackgroundOverlayBrush" Color="#00FFFFFF"/>
+
+    <DropShadowEffect x:Key="ThemeNoShadow"
+                      BlurRadius="0"
+                      ShadowDepth="0"
+                      Opacity="0"
+                      Color="#00000000"/>
+
+    <DropShadowEffect x:Key="ThemeSurfaceShadow"
+                      BlurRadius="7"
+                      ShadowDepth="1"
+                      Direction="270"
+                      Opacity="0.14"
+                      Color="#55000000"/>
+
+    <DropShadowEffect x:Key="ThemeRaisedShadow"
+                      BlurRadius="13"
+                      ShadowDepth="2"
+                      Direction="270"
+                      Opacity="0.20"
+                      Color="#44000000"/>
+
+    <DropShadowEffect x:Key="ThemeDeepShadow"
+                      BlurRadius="22"
+                      ShadowDepth="5"
+                      Direction="270"
+                      Opacity="0.28"
+                      Color="#55000000"/>
+</ResourceDictionary>


### PR DESCRIPTION
## Summary

- Adds `Theme.Customization.xaml` as an app-wide theme customization layer loaded before shared styles.
- Adds centralized visual knobs for border removal, transparent/glass surfaces, background overlay support, button/card/panel corner roundness, and multiple shadow depths.
- Extends light and dark palettes with transparent, glass, and background-tint brushes so selected themes can let custom backgrounds show through.
- Updates shared card, toolbar, footer, button, input, data grid, and shell styles to consume the new theme tokens.
- Adds `SettingsThemeCustomizationXamlTests` to protect the Settings theme selector and the theme customization resource contract.
- Records this scheduled pass in `InventoryManagementApp/ProgressNotes/2026-06-19-admin-theme-customization-resources.md`.

## Validation

- GitHub connector compare confirmed this branch is 9 commits ahead of `master` and 0 behind with the expected 9-file diff.
- GitHub connector readback confirmed the new theme customization resource and XAML tests on the branch.
- GitHub reported no commit status checks yet for the branch head at review time.
- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks could not be run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct clone/raw access is blocked by the network tunnel.

## Follow-up

- Add a dedicated Settings theme designer tab with persisted sliders/color pickers once a Windows-capable pass can update and test the full settings view model and XAML surface.
- Add persisted custom background image/color controls after the settings storage contract is expanded.