### PR TITLE
Add admin app theme designer

### DIFF
--- a/InventoryManagementApp.Tests/Models/AppThemeSettingsTests.cs
+++ b/InventoryManagementApp.Tests/Models/AppThemeSettingsTests.cs
@@ -1,0 +1,120 @@
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Models
+{
+    public class AppThemeSettingsTests
+    {
+        [Fact]
+        public void Normalize_ClampsVisualControlsAndNormalizesColors()
+        {
+            var settings = new AppThemeSettings
+            {
+                BaseTheme = "Unexpected",
+                BackgroundColor = "123456",
+                SurfaceColor = "bad",
+                BackgroundOpacity = 2,
+                SurfaceOpacity = -1,
+                ButtonCornerRadius = 99,
+                ShadowDepth = -5,
+                ShadowOpacity = 5,
+                PagePadding = 100
+            };
+
+            settings.Normalize();
+
+            Assert.Equal("Light", settings.BaseTheme);
+            Assert.Equal("#123456", settings.BackgroundColor);
+            Assert.Equal(AppThemeSettings.CreateDefault("Light").SurfaceColor, settings.SurfaceColor);
+            Assert.Equal(1, settings.BackgroundOpacity);
+            Assert.Equal(0, settings.SurfaceOpacity);
+            Assert.Equal(32, settings.ButtonCornerRadius);
+            Assert.Equal(0, settings.ShadowDepth);
+            Assert.Equal(1, settings.ShadowOpacity);
+            Assert.Equal(28, settings.PagePadding);
+        }
+
+        [Fact]
+        public void Normalize_AcceptsComboBoxItemTextForDarkTheme()
+        {
+            var settings = AppThemeSettings.CreateDefault("System.Windows.Controls.ComboBoxItem: Dark");
+
+            Assert.Equal("Dark", settings.BaseTheme);
+            Assert.Equal("#FF101418", settings.BackgroundColor);
+        }
+
+        [Fact]
+        public async Task SettingsServiceDefaults_SaveAndLoadThemeProfileAsSingleSetting()
+        {
+            ISettingsService service = new FakeSettingsService();
+            var settings = AppThemeSettings.CreateDefault("Dark");
+            settings.ButtonCornerRadius = 18;
+            settings.BordersVisible = false;
+
+            await service.SaveAppThemeSettingsAsync(settings);
+            var loaded = await service.GetAppThemeSettingsAsync();
+
+            Assert.Equal("Dark", loaded.BaseTheme);
+            Assert.Equal(18, loaded.ButtonCornerRadius);
+            Assert.False(loaded.BordersVisible);
+        }
+
+        private sealed class FakeSettingsService : ISettingsService
+        {
+            private readonly Dictionary<string, string> _settings = new();
+
+            public event System.EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
+            public event System.EventHandler<double>? ItemCardSizeChanged;
+
+            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
+            {
+                _settings[key] = value;
+                return Task.CompletedTask;
+            }
+
+            public Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default)
+            {
+                return Task.FromResult(key != null && _settings.TryGetValue(key, out var value) ? value : null);
+            }
+
+            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>(_settings));
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
+            {
+                foreach (var setting in settings)
+                    _settings[setting.Key] = setting.Value;
+                return Task.CompletedTask;
+            }
+            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
+            {
+                _settings.Remove(key);
+                return Task.CompletedTask;
+            }
+            public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default) => GetSettingAsync("Theme", cancellationToken);
+            public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default) => SaveSettingAsync("Theme", theme, cancellationToken);
+            public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(100000);
+            public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(1);
+            public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default) => Task.FromResult("Item");
+            public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult("Items");
+            public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default) => Task.FromResult<IDictionary<ItemDetailField, bool>>(new Dictionary<ItemDetailField, bool>());
+            public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
+            {
+                ItemDetailVisibilityChanged?.Invoke(this, visibility);
+                return Task.CompletedTask;
+            }
+            public Task<double> GetItemCardSizeAsync(CancellationToken cancellationToken = default) => Task.FromResult(1.0);
+            public Task SaveItemCardSizeAsync(double size, CancellationToken cancellationToken = default)
+            {
+                ItemCardSizeChanged?.Invoke(this, size);
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/InventoryManagementApp/Interfaces/ISettingsService.cs
+++ b/InventoryManagementApp/Interfaces/ISettingsService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using InventoryManagementApp.Models;
@@ -8,6 +9,8 @@ namespace InventoryManagementApp.Interfaces
 {
     public interface ISettingsService
     {
+        public const string AppThemeSettingsKey = "AppThemeSettings";
+
         event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
         event EventHandler<double>? ItemCardSizeChanged;
         Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default);
@@ -18,6 +21,35 @@ namespace InventoryManagementApp.Interfaces
         // Theme configuration
         Task<string?> GetThemeAsync(CancellationToken cancellationToken = default);
         Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default);
+
+        async Task<AppThemeSettings> GetAppThemeSettingsAsync(CancellationToken cancellationToken = default)
+        {
+            var json = await GetSettingAsync(AppThemeSettingsKey, cancellationToken).ConfigureAwait(false);
+            AppThemeSettings? settings = null;
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                try
+                {
+                    settings = JsonSerializer.Deserialize<AppThemeSettings>(json);
+                }
+                catch (JsonException)
+                {
+                    settings = null;
+                }
+            }
+
+            settings ??= AppThemeSettings.CreateDefault(await GetThemeAsync(cancellationToken).ConfigureAwait(false));
+            settings.Normalize();
+            return settings;
+        }
+
+        async Task SaveAppThemeSettingsAsync(AppThemeSettings settings, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            settings.Normalize();
+            var json = JsonSerializer.Serialize(settings);
+            await SaveSettingAsync(AppThemeSettingsKey, json, cancellationToken).ConfigureAwait(false);
+        }
 
         // Password hashing configuration
         Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default);

--- a/InventoryManagementApp/Interfaces/IThemeService.cs
+++ b/InventoryManagementApp/Interfaces/IThemeService.cs
@@ -1,9 +1,10 @@
-using System;
+using InventoryManagementApp.Models;
 
 namespace InventoryManagementApp.Interfaces
 {
     public interface IThemeService
     {
         void ApplyTheme(string? theme);
+        void ApplyCustomTheme(AppThemeSettings? settings) { }
     }
 }

--- a/InventoryManagementApp/Models/AppThemeSettings.cs
+++ b/InventoryManagementApp/Models/AppThemeSettings.cs
@@ -37,7 +37,7 @@ namespace InventoryManagementApp.Models
         {
             var settings = new AppThemeSettings();
             if (!string.IsNullOrWhiteSpace(baseTheme))
-                settings.BaseTheme = baseTheme;
+                settings.BaseTheme = NormalizeBaseTheme(baseTheme);
 
             if (string.Equals(settings.BaseTheme, "Dark", StringComparison.OrdinalIgnoreCase))
             {
@@ -58,8 +58,8 @@ namespace InventoryManagementApp.Models
 
         public void Normalize()
         {
+            BaseTheme = NormalizeBaseTheme(BaseTheme);
             var defaults = CreateDefault(BaseTheme);
-            BaseTheme = string.Equals(BaseTheme, "Dark", StringComparison.OrdinalIgnoreCase) ? "Dark" : "Light";
             BackgroundColor = NormalizeColor(BackgroundColor, defaults.BackgroundColor);
             SurfaceColor = NormalizeColor(SurfaceColor, defaults.SurfaceColor);
             SurfaceAltColor = NormalizeColor(SurfaceAltColor, defaults.SurfaceAltColor);
@@ -85,6 +85,9 @@ namespace InventoryManagementApp.Models
             PagePadding = Clamp(PagePadding, 0, 28);
             CardPadding = Clamp(CardPadding, 0, 32);
         }
+
+        private static string NormalizeBaseTheme(string? value)
+            => value?.IndexOf("Dark", StringComparison.OrdinalIgnoreCase) >= 0 ? "Dark" : "Light";
 
         private static double Clamp01(double value) => Clamp(value, 0, 1);
 

--- a/InventoryManagementApp/Models/AppThemeSettings.cs
+++ b/InventoryManagementApp/Models/AppThemeSettings.cs
@@ -1,0 +1,110 @@
+using System;
+
+namespace InventoryManagementApp.Models
+{
+    public class AppThemeSettings
+    {
+        public string BaseTheme { get; set; } = "Light";
+        public string BackgroundColor { get; set; } = "#F4F6F8";
+        public string SurfaceColor { get; set; } = "#FFFFFFFF";
+        public string SurfaceAltColor { get; set; } = "#FFE8EDF3";
+        public string TextColor { get; set; } = "#FF111827";
+        public string MutedTextColor { get; set; } = "#FF5B6472";
+        public string AccentColor { get; set; } = "#FF2563EB";
+        public string SuccessColor { get; set; } = "#FF15803D";
+        public string WarningColor { get; set; } = "#FFD97706";
+        public string ErrorColor { get; set; } = "#FFDC2626";
+        public string BackgroundImagePath { get; set; } = string.Empty;
+        public double BackgroundOpacity { get; set; } = 1.0;
+        public double SurfaceOpacity { get; set; } = 1.0;
+        public double SurfaceAltOpacity { get; set; } = 1.0;
+        public double InputOpacity { get; set; } = 1.0;
+        public double ButtonOpacity { get; set; } = 1.0;
+        public bool BordersVisible { get; set; } = true;
+        public double BorderOpacity { get; set; } = 1.0;
+        public double CardCornerRadius { get; set; } = 6.0;
+        public double PanelCornerRadius { get; set; } = 4.0;
+        public double ButtonCornerRadius { get; set; } = 5.0;
+        public double InputCornerRadius { get; set; } = 4.0;
+        public double ShadowBlurRadius { get; set; } = 7.0;
+        public double ShadowDepth { get; set; } = 1.0;
+        public double ShadowOpacity { get; set; } = 0.14;
+        public double PagePadding { get; set; } = 6.0;
+        public double CardPadding { get; set; } = 8.0;
+        public bool UseGlassSurfaces { get; set; }
+
+        public static AppThemeSettings CreateDefault(string? baseTheme = null)
+        {
+            var settings = new AppThemeSettings();
+            if (!string.IsNullOrWhiteSpace(baseTheme))
+                settings.BaseTheme = baseTheme;
+
+            if (string.Equals(settings.BaseTheme, "Dark", StringComparison.OrdinalIgnoreCase))
+            {
+                settings.BackgroundColor = "#FF101418";
+                settings.SurfaceColor = "#FF1B222A";
+                settings.SurfaceAltColor = "#FF252D36";
+                settings.TextColor = "#FFF3F4F6";
+                settings.MutedTextColor = "#FFB5BDC8";
+                settings.AccentColor = "#FF60A5FA";
+                settings.SuccessColor = "#FF4ADE80";
+                settings.WarningColor = "#FFFBBF24";
+                settings.ErrorColor = "#FFF87171";
+                settings.ShadowOpacity = 0.35;
+            }
+
+            return settings;
+        }
+
+        public void Normalize()
+        {
+            var defaults = CreateDefault(BaseTheme);
+            BaseTheme = string.Equals(BaseTheme, "Dark", StringComparison.OrdinalIgnoreCase) ? "Dark" : "Light";
+            BackgroundColor = NormalizeColor(BackgroundColor, defaults.BackgroundColor);
+            SurfaceColor = NormalizeColor(SurfaceColor, defaults.SurfaceColor);
+            SurfaceAltColor = NormalizeColor(SurfaceAltColor, defaults.SurfaceAltColor);
+            TextColor = NormalizeColor(TextColor, defaults.TextColor);
+            MutedTextColor = NormalizeColor(MutedTextColor, defaults.MutedTextColor);
+            AccentColor = NormalizeColor(AccentColor, defaults.AccentColor);
+            SuccessColor = NormalizeColor(SuccessColor, defaults.SuccessColor);
+            WarningColor = NormalizeColor(WarningColor, defaults.WarningColor);
+            ErrorColor = NormalizeColor(ErrorColor, defaults.ErrorColor);
+            BackgroundOpacity = Clamp01(BackgroundOpacity);
+            SurfaceOpacity = Clamp01(SurfaceOpacity);
+            SurfaceAltOpacity = Clamp01(SurfaceAltOpacity);
+            InputOpacity = Clamp01(InputOpacity);
+            ButtonOpacity = Clamp01(ButtonOpacity);
+            BorderOpacity = Clamp01(BorderOpacity);
+            CardCornerRadius = Clamp(CardCornerRadius, 0, 32);
+            PanelCornerRadius = Clamp(PanelCornerRadius, 0, 32);
+            ButtonCornerRadius = Clamp(ButtonCornerRadius, 0, 32);
+            InputCornerRadius = Clamp(InputCornerRadius, 0, 32);
+            ShadowBlurRadius = Clamp(ShadowBlurRadius, 0, 48);
+            ShadowDepth = Clamp(ShadowDepth, 0, 16);
+            ShadowOpacity = Clamp01(ShadowOpacity);
+            PagePadding = Clamp(PagePadding, 0, 28);
+            CardPadding = Clamp(CardPadding, 0, 32);
+        }
+
+        private static double Clamp01(double value) => Clamp(value, 0, 1);
+
+        private static double Clamp(double value, double min, double max)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value))
+                return min;
+            return Math.Min(max, Math.Max(min, value));
+        }
+
+        private static string NormalizeColor(string? value, string fallback)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return fallback;
+
+            var trimmed = value.Trim();
+            if (!trimmed.StartsWith("#", StringComparison.Ordinal))
+                trimmed = "#" + trimmed;
+
+            return trimmed.Length is 7 or 9 ? trimmed.ToUpperInvariant() : fallback;
+        }
+    }
+}

--- a/InventoryManagementApp/Services/ThemeService.cs
+++ b/InventoryManagementApp/Services/ThemeService.cs
@@ -1,23 +1,31 @@
 using System;
+using System.IO;
 using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Effects;
+using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
 using Application = System.Windows.Application;
 
 namespace InventoryManagementApp.Services
 {
     /// <summary>
-    /// Service for managing application theme (light/dark mode) by loading and applying appropriate resource dictionaries.
+    /// Service for managing application theme resources.
     /// </summary>
     public class ThemeService : IThemeService
     {
         private static readonly Uri LightThemeUri = new("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Light.xaml", UriKind.Absolute);
         private static readonly Uri DarkThemeUri = new("pack://application:,,,/InventoryManagementApp;component/Resources/Colors.Dark.xaml", UriKind.Absolute);
+        private readonly ISettingsService? _settingsService;
+        private bool _applyingCustomTheme;
 
-        /// <summary>
-        /// Applies the specified theme to the application.
-        /// </summary>
-        /// <param name="theme">The theme name ("Dark" for dark mode, any other value for light mode).</param>
+        public ThemeService(ISettingsService? settingsService = null)
+        {
+            _settingsService = settingsService;
+        }
+
         public void ApplyTheme(string? theme)
         {
             var app = Application.Current;
@@ -39,21 +47,130 @@ namespace InventoryManagementApp.Services
                 }
 
                 dictionaries.Insert(Math.Min(insertIndex, dictionaries.Count), new ResourceDictionary { Source = themeUri });
-
-                foreach (Window window in app.Windows)
-                {
-                    window.InvalidateVisual();
-                    window.UpdateLayout();
-                }
+                RefreshWindows(app);
             }
 
+            InvokeOnUi(app, ApplyOnUiThread);
+            ApplySavedCustomTheme(theme);
+        }
+
+        public void ApplyCustomTheme(AppThemeSettings? settings)
+        {
+            var app = Application.Current;
+            if (app is null || settings is null) return;
+
+            void ApplyOnUiThread()
+            {
+                settings.Normalize();
+                _applyingCustomTheme = true;
+                try
+                {
+                    ApplyTheme(settings.BaseTheme);
+                }
+                finally
+                {
+                    _applyingCustomTheme = false;
+                }
+
+                var resources = app.Resources;
+                var borderThickness = settings.BordersVisible ? new Thickness(1) : new Thickness(0);
+                var subtleBorderThickness = settings.BordersVisible ? new Thickness(0, 0, 0, 1) : new Thickness(0);
+                var borderBrush = CreateBrush(settings.AccentColor, settings.BorderOpacity * 0.55);
+                var surfaceBrush = CreateBrush(settings.SurfaceColor, settings.UseGlassSurfaces ? Math.Min(settings.SurfaceOpacity, 0.72) : settings.SurfaceOpacity);
+                var surfaceAltBrush = CreateBrush(settings.SurfaceAltColor, settings.UseGlassSurfaces ? Math.Min(settings.SurfaceAltOpacity, 0.62) : settings.SurfaceAltOpacity);
+
+                Set(resources, "BackgroundBrush", CreateBackgroundBrush(settings));
+                Set(resources, "SurfaceBrush", surfaceBrush);
+                Set(resources, "SurfaceAltBrush", surfaceAltBrush);
+                Set(resources, "GlassSurfaceBrush", CreateBrush(settings.SurfaceColor, Math.Min(settings.SurfaceOpacity, 0.78)));
+                Set(resources, "GlassSurfaceAltBrush", CreateBrush(settings.SurfaceAltColor, Math.Min(settings.SurfaceAltOpacity, 0.68)));
+                Set(resources, "TransparentSurfaceBrush", Brushes.Transparent);
+                Set(resources, "TextBoxBackgroundBrush", CreateBrush(settings.SurfaceColor, settings.InputOpacity));
+                Set(resources, "ComboBoxPopupBackgroundBrush", CreateBrush(settings.SurfaceColor, Math.Max(settings.SurfaceOpacity, 0.9)));
+                Set(resources, "ForegroundBrush", CreateBrush(settings.TextColor, 1));
+                Set(resources, "ForegroundMutedBrush", CreateBrush(settings.MutedTextColor, 1));
+                Set(resources, "AccentBrush", CreateBrush(settings.AccentColor, 1));
+                Set(resources, "OnAccentForegroundBrush", CreateOnAccentBrush(settings.AccentColor));
+                Set(resources, "SuccessBrush", CreateBrush(settings.SuccessColor, 1));
+                Set(resources, "WarningBrush", CreateBrush(settings.WarningColor, 1));
+                Set(resources, "ErrorBrush", CreateBrush(settings.ErrorColor, 1));
+                Set(resources, "BorderBrushBase", borderBrush);
+                Set(resources, "BorderBrushAlt", CreateBrush(settings.MutedTextColor, settings.BorderOpacity * 0.45));
+                Set(resources, "BtnBg", CreateBrush(settings.SurfaceAltColor, settings.ButtonOpacity));
+                Set(resources, "BtnBgHover", CreateBrush(settings.AccentColor, Math.Min(1, settings.ButtonOpacity * 0.22 + 0.12)));
+                Set(resources, "BtnBorder", settings.BordersVisible ? CreateBrush(settings.AccentColor, settings.BorderOpacity * 0.72) : Brushes.Transparent);
+                Set(resources, "BtnFg", CreateBrush(settings.TextColor, 1));
+                Set(resources, "NavButtonPressedBrush", CreateBrush(settings.AccentColor, 0.24));
+                Set(resources, "NavButtonHoverBrush", CreateBrush(settings.AccentColor, 0.16));
+                Set(resources, "ItemHoverBrush", CreateBrush(settings.AccentColor, 0.14));
+                Set(resources, "ItemSelectedBrush", CreateBrush(settings.AccentColor, 0.24));
+                Set(resources, "ItemHoverForegroundBrush", CreateBrush(settings.TextColor, 1));
+                Set(resources, "ItemSelectedForegroundBrush", CreateBrush(settings.TextColor, 1));
+                Set(resources, "DataGridRowBackgroundBrush", CreateBrush(settings.SurfaceColor, Math.Max(settings.SurfaceOpacity, 0.78)));
+                Set(resources, "DataGridAlternatingRowBackgroundBrush", CreateBrush(settings.SurfaceAltColor, Math.Max(settings.SurfaceAltOpacity, 0.72)));
+                Set(resources, "ProgressBarBackgroundBrush", CreateBrush(settings.SurfaceAltColor, Math.Max(settings.SurfaceAltOpacity, 0.65)));
+                Set(resources, "ThemeBorderThickness", borderThickness);
+                Set(resources, "ThemeSubtleBorderThickness", subtleBorderThickness);
+                Set(resources, "ThemeControlBorderThickness", borderThickness);
+                Set(resources, "ThemeBorderlessThickness", new Thickness(0));
+                Set(resources, "ThemeCardCornerRadius", new CornerRadius(settings.CardCornerRadius));
+                Set(resources, "ThemePanelCornerRadius", new CornerRadius(settings.PanelCornerRadius));
+                Set(resources, "ThemeButtonCornerRadius", new CornerRadius(settings.ButtonCornerRadius));
+                Set(resources, "ThemeInputCornerRadius", new CornerRadius(settings.InputCornerRadius));
+                Set(resources, "ThemeFooterCornerRadius", new CornerRadius(settings.PanelCornerRadius));
+                Set(resources, "RadiusSmall", new CornerRadius(settings.InputCornerRadius));
+                Set(resources, "RadiusMedium", new CornerRadius(settings.CardCornerRadius));
+                Set(resources, "RadiusLarge", new CornerRadius(settings.CardCornerRadius));
+                Set(resources, "PagePadding", new Thickness(settings.PagePadding));
+                Set(resources, "CardPadding", new Thickness(settings.CardPadding));
+                Set(resources, "ThemeSurfaceShadow", CreateShadow(settings));
+                Set(resources, "ThemeRaisedShadow", CreateShadow(settings, 1.55));
+                Set(resources, "ThemeDeepShadow", CreateShadow(settings, 2.35));
+                Set(resources, "SubtleSurfaceShadow", CreateShadow(settings));
+                Set(resources, "RaisedSurfaceShadow", CreateShadow(settings, 1.55));
+
+                RefreshWindows(app);
+            }
+
+            InvokeOnUi(app, ApplyOnUiThread);
+        }
+
+        private void ApplySavedCustomTheme(string? theme)
+        {
+            if (_applyingCustomTheme || _settingsService == null)
+                return;
+
+            try
+            {
+                var settings = _settingsService.GetAppThemeSettingsAsync().GetAwaiter().GetResult();
+                if (!string.IsNullOrWhiteSpace(theme))
+                    settings.BaseTheme = theme;
+                ApplyCustomTheme(settings);
+            }
+            catch
+            {
+                // A missing database or invalid saved profile should never prevent the base theme from loading.
+            }
+        }
+
+        private static void InvokeOnUi(Application app, Action action)
+        {
             if (app.Dispatcher.CheckAccess())
             {
-                ApplyOnUiThread();
+                action();
                 return;
             }
 
-            app.Dispatcher.Invoke(ApplyOnUiThread, DispatcherPriority.Send);
+            app.Dispatcher.Invoke(action, DispatcherPriority.Send);
+        }
+
+        private static void RefreshWindows(Application app)
+        {
+            foreach (Window window in app.Windows)
+            {
+                window.InvalidateVisual();
+                window.UpdateLayout();
+            }
         }
 
         private static bool IsThemeDictionary(ResourceDictionary dictionary)
@@ -61,6 +178,66 @@ namespace InventoryManagementApp.Services
             var source = dictionary.Source?.OriginalString.Replace('\\', '/');
             return source?.EndsWith("Resources/Colors.Light.xaml", StringComparison.OrdinalIgnoreCase) == true ||
                    source?.EndsWith("Resources/Colors.Dark.xaml", StringComparison.OrdinalIgnoreCase) == true;
+        }
+
+        private static void Set(ResourceDictionary resources, string key, object value)
+        {
+            resources[key] = value;
+        }
+
+        private static Brush CreateBackgroundBrush(AppThemeSettings settings)
+        {
+            if (!string.IsNullOrWhiteSpace(settings.BackgroundImagePath) && File.Exists(settings.BackgroundImagePath))
+            {
+                try
+                {
+                    return new ImageBrush(new BitmapImage(new Uri(settings.BackgroundImagePath, UriKind.Absolute)))
+                    {
+                        Stretch = Stretch.UniformToFill,
+                        Opacity = settings.BackgroundOpacity
+                    };
+                }
+                catch
+                {
+                    // Fall back to the configured color if the image cannot be loaded.
+                }
+            }
+
+            return CreateBrush(settings.BackgroundColor, settings.BackgroundOpacity);
+        }
+
+        private static SolidColorBrush CreateBrush(string color, double opacity)
+        {
+            var parsed = (Color)ColorConverter.ConvertFromString(color);
+            parsed.A = (byte)Math.Round(255 * Math.Clamp(opacity, 0, 1), MidpointRounding.AwayFromZero);
+            var brush = new SolidColorBrush(parsed);
+            if (brush.CanFreeze)
+                brush.Freeze();
+            return brush;
+        }
+
+        private static SolidColorBrush CreateOnAccentBrush(string accentColor)
+        {
+            var color = (Color)ColorConverter.ConvertFromString(accentColor);
+            var brightness = (color.R * 0.299) + (color.G * 0.587) + (color.B * 0.114);
+            return CreateBrush(brightness > 140 ? "#FF111827" : "#FFFFFFFF", 1);
+        }
+
+        private static DropShadowEffect CreateShadow(AppThemeSettings settings, double multiplier = 1)
+        {
+            return new DropShadowEffect
+            {
+                BlurRadius = settings.ShadowBlurRadius * multiplier,
+                ShadowDepth = settings.ShadowDepth * multiplier,
+                Direction = 270,
+                Opacity = Math.Clamp(settings.ShadowOpacity * multiplier, 0, 1),
+                Color = ParseColor("#66000000")
+            };
+        }
+
+        private static Color ParseColor(string value)
+        {
+            return (Color)ColorConverter.ConvertFromString(value)!;
         }
     }
 }

--- a/InventoryManagementApp/ViewModels/ThemeDesignerViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ThemeDesignerViewModel.cs
@@ -1,0 +1,380 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InventoryManagementApp.ViewModels
+{
+    public class ThemeDesignerViewModel : ObservableObject
+    {
+        private readonly ISettingsService _settingsService;
+        private readonly IThemeService _themeService;
+        private readonly IFileDialogService _fileDialogService;
+        private readonly IDialogService _dialogService;
+        private readonly ILogger<ThemeDesignerViewModel> _logger;
+        private AppThemeSettings _settings = AppThemeSettings.CreateDefault();
+        private string _status = "Theme designer ready.";
+
+        public ThemeDesignerViewModel(
+            ISettingsService settingsService,
+            IThemeService themeService,
+            IFileDialogService fileDialogService,
+            IDialogService dialogService,
+            ILogger<ThemeDesignerViewModel>? logger = null)
+        {
+            _settingsService = settingsService;
+            _themeService = themeService;
+            _fileDialogService = fileDialogService;
+            _dialogService = dialogService;
+            _logger = logger ?? NullLogger<ThemeDesignerViewModel>.Instance;
+
+            SaveCommand = new AsyncRelayCommand(SaveAsync);
+            ResetCommand = new RelayCommand(Reset);
+            BrowseBackgroundCommand = new RelayCommand(BrowseBackground);
+            ClearBackgroundCommand = new RelayCommand(() => BackgroundImagePath = string.Empty);
+            GlassPresetCommand = new RelayCommand(ApplyGlassPreset);
+            BorderlessPresetCommand = new RelayCommand(ApplyBorderlessPreset);
+            HighContrastPresetCommand = new RelayCommand(ApplyHighContrastPreset);
+        }
+
+        public IAsyncRelayCommand SaveCommand { get; }
+        public IRelayCommand ResetCommand { get; }
+        public IRelayCommand BrowseBackgroundCommand { get; }
+        public IRelayCommand ClearBackgroundCommand { get; }
+        public IRelayCommand GlassPresetCommand { get; }
+        public IRelayCommand BorderlessPresetCommand { get; }
+        public IRelayCommand HighContrastPresetCommand { get; }
+
+        public string Status
+        {
+            get => _status;
+            private set => SetProperty(ref _status, value);
+        }
+
+        public string BaseTheme
+        {
+            get => _settings.BaseTheme;
+            set => SetString(value, (settings, newValue) => settings.BaseTheme = newValue, nameof(BaseTheme));
+        }
+
+        public string BackgroundColor
+        {
+            get => _settings.BackgroundColor;
+            set => SetString(value, (settings, newValue) => settings.BackgroundColor = newValue, nameof(BackgroundColor));
+        }
+
+        public string SurfaceColor
+        {
+            get => _settings.SurfaceColor;
+            set => SetString(value, (settings, newValue) => settings.SurfaceColor = newValue, nameof(SurfaceColor));
+        }
+
+        public string SurfaceAltColor
+        {
+            get => _settings.SurfaceAltColor;
+            set => SetString(value, (settings, newValue) => settings.SurfaceAltColor = newValue, nameof(SurfaceAltColor));
+        }
+
+        public string TextColor
+        {
+            get => _settings.TextColor;
+            set => SetString(value, (settings, newValue) => settings.TextColor = newValue, nameof(TextColor));
+        }
+
+        public string MutedTextColor
+        {
+            get => _settings.MutedTextColor;
+            set => SetString(value, (settings, newValue) => settings.MutedTextColor = newValue, nameof(MutedTextColor));
+        }
+
+        public string AccentColor
+        {
+            get => _settings.AccentColor;
+            set => SetString(value, (settings, newValue) => settings.AccentColor = newValue, nameof(AccentColor));
+        }
+
+        public string SuccessColor
+        {
+            get => _settings.SuccessColor;
+            set => SetString(value, (settings, newValue) => settings.SuccessColor = newValue, nameof(SuccessColor));
+        }
+
+        public string WarningColor
+        {
+            get => _settings.WarningColor;
+            set => SetString(value, (settings, newValue) => settings.WarningColor = newValue, nameof(WarningColor));
+        }
+
+        public string ErrorColor
+        {
+            get => _settings.ErrorColor;
+            set => SetString(value, (settings, newValue) => settings.ErrorColor = newValue, nameof(ErrorColor));
+        }
+
+        public string BackgroundImagePath
+        {
+            get => _settings.BackgroundImagePath;
+            set => SetString(value, (settings, newValue) => settings.BackgroundImagePath = newValue, nameof(BackgroundImagePath));
+        }
+
+        public double BackgroundOpacity
+        {
+            get => _settings.BackgroundOpacity;
+            set => SetDouble(value, (settings, newValue) => settings.BackgroundOpacity = newValue, nameof(BackgroundOpacity));
+        }
+
+        public double SurfaceOpacity
+        {
+            get => _settings.SurfaceOpacity;
+            set => SetDouble(value, (settings, newValue) => settings.SurfaceOpacity = newValue, nameof(SurfaceOpacity));
+        }
+
+        public double InputOpacity
+        {
+            get => _settings.InputOpacity;
+            set => SetDouble(value, (settings, newValue) => settings.InputOpacity = newValue, nameof(InputOpacity));
+        }
+
+        public double ButtonOpacity
+        {
+            get => _settings.ButtonOpacity;
+            set => SetDouble(value, (settings, newValue) => settings.ButtonOpacity = newValue, nameof(ButtonOpacity));
+        }
+
+        public bool BordersVisible
+        {
+            get => _settings.BordersVisible;
+            set => SetBool(value, (settings, newValue) => settings.BordersVisible = newValue, nameof(BordersVisible));
+        }
+
+        public bool UseGlassSurfaces
+        {
+            get => _settings.UseGlassSurfaces;
+            set => SetBool(value, (settings, newValue) => settings.UseGlassSurfaces = newValue, nameof(UseGlassSurfaces));
+        }
+
+        public double BorderOpacity
+        {
+            get => _settings.BorderOpacity;
+            set => SetDouble(value, (settings, newValue) => settings.BorderOpacity = newValue, nameof(BorderOpacity));
+        }
+
+        public double CardCornerRadius
+        {
+            get => _settings.CardCornerRadius;
+            set => SetDouble(value, (settings, newValue) => settings.CardCornerRadius = newValue, nameof(CardCornerRadius));
+        }
+
+        public double ButtonCornerRadius
+        {
+            get => _settings.ButtonCornerRadius;
+            set => SetDouble(value, (settings, newValue) => settings.ButtonCornerRadius = newValue, nameof(ButtonCornerRadius));
+        }
+
+        public double InputCornerRadius
+        {
+            get => _settings.InputCornerRadius;
+            set => SetDouble(value, (settings, newValue) => settings.InputCornerRadius = newValue, nameof(InputCornerRadius));
+        }
+
+        public double ShadowBlurRadius
+        {
+            get => _settings.ShadowBlurRadius;
+            set => SetDouble(value, (settings, newValue) => settings.ShadowBlurRadius = newValue, nameof(ShadowBlurRadius));
+        }
+
+        public double ShadowDepth
+        {
+            get => _settings.ShadowDepth;
+            set => SetDouble(value, (settings, newValue) => settings.ShadowDepth = newValue, nameof(ShadowDepth));
+        }
+
+        public double ShadowOpacity
+        {
+            get => _settings.ShadowOpacity;
+            set => SetDouble(value, (settings, newValue) => settings.ShadowOpacity = newValue, nameof(ShadowOpacity));
+        }
+
+        public double PagePadding
+        {
+            get => _settings.PagePadding;
+            set => SetDouble(value, (settings, newValue) => settings.PagePadding = newValue, nameof(PagePadding));
+        }
+
+        public double CardPadding
+        {
+            get => _settings.CardPadding;
+            set => SetDouble(value, (settings, newValue) => settings.CardPadding = newValue, nameof(CardPadding));
+        }
+
+        public async Task InitializeAsync(CancellationToken token = default)
+        {
+            try
+            {
+                _settings = await _settingsService.GetAppThemeSettingsAsync(token).ConfigureAwait(false);
+                _themeService.ApplyCustomTheme(_settings);
+                NotifyAllThemePropertiesChanged();
+                Status = "Loaded saved app theme.";
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to load app theme settings.");
+                _settings = AppThemeSettings.CreateDefault();
+                NotifyAllThemePropertiesChanged();
+                Status = "Using default theme settings.";
+            }
+        }
+
+        private async Task SaveAsync(CancellationToken token = default)
+        {
+            try
+            {
+                _settings.Normalize();
+                await _settingsService.SaveThemeAsync(_settings.BaseTheme, token).ConfigureAwait(false);
+                await _settingsService.SaveAppThemeSettingsAsync(_settings, token).ConfigureAwait(false);
+                _themeService.ApplyCustomTheme(_settings);
+                NotifyAllThemePropertiesChanged();
+                Status = "Theme saved and applied.";
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save app theme settings.");
+                _dialogService.ShowInfo("Theme settings could not be saved. Check color values and try again.", "Theme Settings");
+                Status = "Theme save failed.";
+            }
+        }
+
+        private void Reset()
+        {
+            _settings = AppThemeSettings.CreateDefault(BaseTheme);
+            Preview();
+            NotifyAllThemePropertiesChanged();
+            Status = "Theme reset to defaults. Save to keep it.";
+        }
+
+        private void BrowseBackground()
+        {
+            var path = _fileDialogService.OpenFile("Image Files|*.png;*.jpg;*.jpeg;*.bmp");
+            if (!string.IsNullOrWhiteSpace(path))
+                BackgroundImagePath = path;
+        }
+
+        private void ApplyGlassPreset()
+        {
+            UseGlassSurfaces = true;
+            SurfaceOpacity = 0.68;
+            InputOpacity = 0.72;
+            ButtonOpacity = 0.72;
+            BordersVisible = true;
+            BorderOpacity = 0.42;
+            CardCornerRadius = 14;
+            ButtonCornerRadius = 12;
+            InputCornerRadius = 10;
+            ShadowBlurRadius = 18;
+            ShadowDepth = 4;
+            ShadowOpacity = 0.24;
+            Status = "Glass preset previewed. Save to keep it.";
+        }
+
+        private void ApplyBorderlessPreset()
+        {
+            UseGlassSurfaces = false;
+            BordersVisible = false;
+            BorderOpacity = 0;
+            CardCornerRadius = 0;
+            ButtonCornerRadius = 0;
+            InputCornerRadius = 0;
+            ShadowBlurRadius = 0;
+            ShadowDepth = 0;
+            ShadowOpacity = 0;
+            Status = "Borderless preset previewed. Save to keep it.";
+        }
+
+        private void ApplyHighContrastPreset()
+        {
+            _settings = AppThemeSettings.CreateDefault("Dark");
+            _settings.BackgroundColor = "#FF000000";
+            _settings.SurfaceColor = "#FF111111";
+            _settings.SurfaceAltColor = "#FF1F1F1F";
+            _settings.TextColor = "#FFFFFFFF";
+            _settings.MutedTextColor = "#FFE5E7EB";
+            _settings.AccentColor = "#FFFFFF00";
+            _settings.BordersVisible = true;
+            _settings.BorderOpacity = 1;
+            Preview();
+            NotifyAllThemePropertiesChanged();
+            Status = "High contrast preset previewed. Save to keep it.";
+        }
+
+        private void SetString(string value, Action<AppThemeSettings, string> update, string propertyName)
+        {
+            update(_settings, value ?? string.Empty);
+            OnPropertyChanged(propertyName);
+            Preview();
+        }
+
+        private void SetDouble(double value, Action<AppThemeSettings, double> update, string propertyName)
+        {
+            update(_settings, value);
+            OnPropertyChanged(propertyName);
+            Preview();
+        }
+
+        private void SetBool(bool value, Action<AppThemeSettings, bool> update, string propertyName)
+        {
+            update(_settings, value);
+            OnPropertyChanged(propertyName);
+            Preview();
+        }
+
+        private void Preview()
+        {
+            try
+            {
+                _settings.Normalize();
+                _themeService.ApplyCustomTheme(_settings);
+                NotifyAllThemePropertiesChanged();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to preview app theme settings.");
+                Status = "Preview failed. Check color values.";
+            }
+        }
+
+        private void NotifyAllThemePropertiesChanged()
+        {
+            OnPropertyChanged(nameof(BaseTheme));
+            OnPropertyChanged(nameof(BackgroundColor));
+            OnPropertyChanged(nameof(SurfaceColor));
+            OnPropertyChanged(nameof(SurfaceAltColor));
+            OnPropertyChanged(nameof(TextColor));
+            OnPropertyChanged(nameof(MutedTextColor));
+            OnPropertyChanged(nameof(AccentColor));
+            OnPropertyChanged(nameof(SuccessColor));
+            OnPropertyChanged(nameof(WarningColor));
+            OnPropertyChanged(nameof(ErrorColor));
+            OnPropertyChanged(nameof(BackgroundImagePath));
+            OnPropertyChanged(nameof(BackgroundOpacity));
+            OnPropertyChanged(nameof(SurfaceOpacity));
+            OnPropertyChanged(nameof(InputOpacity));
+            OnPropertyChanged(nameof(ButtonOpacity));
+            OnPropertyChanged(nameof(BordersVisible));
+            OnPropertyChanged(nameof(UseGlassSurfaces));
+            OnPropertyChanged(nameof(BorderOpacity));
+            OnPropertyChanged(nameof(CardCornerRadius));
+            OnPropertyChanged(nameof(ButtonCornerRadius));
+            OnPropertyChanged(nameof(InputCornerRadius));
+            OnPropertyChanged(nameof(ShadowBlurRadius));
+            OnPropertyChanged(nameof(ShadowDepth));
+            OnPropertyChanged(nameof(ShadowOpacity));
+            OnPropertyChanged(nameof(PagePadding));
+            OnPropertyChanged(nameof(CardPadding));
+        }
+    }
+}

--- a/InventoryManagementApp/Views/Pages/SettingsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/SettingsPage.xaml.cs
@@ -1,5 +1,7 @@
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 using InventoryManagementApp.ViewModels;
 using TextBox = System.Windows.Controls.TextBox;
 
@@ -8,6 +10,7 @@ namespace InventoryManagementApp.Views.Pages
     public partial class SettingsPage : Page
     {
         private SettingsViewModel? _settingsViewModel;
+        private bool _themeDesignerTabAdded;
 
         public SettingsPage()
         {
@@ -17,21 +20,74 @@ namespace InventoryManagementApp.Views.Pages
             DataContextChanged += SettingsPage_DataContextChanged;
         }
 
-        private void SettingsPage_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        private void SettingsPage_Loaded(object sender, RoutedEventArgs e)
         {
+            AddThemeDesignerTab();
             AttachViewModel(DataContext as SettingsViewModel);
             SyncSensitiveFieldsFromViewModel();
         }
 
-        private void SettingsPage_Unloaded(object sender, System.Windows.RoutedEventArgs e)
+        private void SettingsPage_Unloaded(object sender, RoutedEventArgs e)
         {
             AttachViewModel(null);
         }
 
-        private void SettingsPage_DataContextChanged(object sender, System.Windows.DependencyPropertyChangedEventArgs e)
+        private void SettingsPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             AttachViewModel(e.NewValue as SettingsViewModel);
             SyncSensitiveFieldsFromViewModel();
+        }
+
+        private void AddThemeDesignerTab()
+        {
+            if (_themeDesignerTabAdded)
+                return;
+
+            var tabControl = FindVisualChild<TabControl>(this);
+            if (tabControl == null)
+                return;
+
+            var tab = new TabItem
+            {
+                Header = "06 Themes",
+                Style = TryFindResource("DesktopSectionListTabItem") as Style,
+                Content = new ThemeDesignerControl()
+            };
+
+            tabControl.Items.Insert(System.Math.Min(5, tabControl.Items.Count), tab);
+            RenumberTabs(tabControl);
+            _themeDesignerTabAdded = true;
+        }
+
+        private static void RenumberTabs(TabControl tabControl)
+        {
+            for (var i = 0; i < tabControl.Items.Count; i++)
+            {
+                if (tabControl.Items[i] is not TabItem item)
+                    continue;
+
+                var header = item.Header?.ToString();
+                if (string.IsNullOrWhiteSpace(header) || header.Length < 4 || !char.IsDigit(header[0]) || !char.IsDigit(header[1]))
+                    continue;
+
+                item.Header = $"{i + 1:00}{header[2..]}";
+            }
+        }
+
+        private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+        {
+            for (var i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                if (child is T typed)
+                    return typed;
+
+                var nested = FindVisualChild<T>(child);
+                if (nested != null)
+                    return nested;
+            }
+
+            return null;
         }
 
         private void AttachViewModel(SettingsViewModel? viewModel)
@@ -79,7 +135,7 @@ namespace InventoryManagementApp.Views.Pages
             }
         }
 
-        private void SmtpPasswordBox_PasswordChanged(object sender, System.Windows.RoutedEventArgs e)
+        private void SmtpPasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
         {
             if (_settingsViewModel != null && _settingsViewModel.SmtpPassword != SmtpPasswordBox.Password)
             {
@@ -87,7 +143,7 @@ namespace InventoryManagementApp.Views.Pages
             }
         }
 
-        private void SmsApiKeyBox_PasswordChanged(object sender, System.Windows.RoutedEventArgs e)
+        private void SmsApiKeyBox_PasswordChanged(object sender, RoutedEventArgs e)
         {
             if (_settingsViewModel != null && _settingsViewModel.SmsApiKey != SmsApiKeyBox.Password)
             {

--- a/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml
+++ b/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml
@@ -1,0 +1,218 @@
+<UserControl x:Class="InventoryManagementApp.Views.Pages.ThemeDesignerControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <UserControl.Resources>
+        <Style x:Key="ThemeFieldLabel" TargetType="TextBlock" BasedOn="{StaticResource LabelTextBlock}">
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Margin" Value="0,0,8,8"/>
+        </Style>
+        <Style x:Key="ThemeValueBox" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+            <Setter Property="Margin" Value="0,0,0,8"/>
+            <Setter Property="MinWidth" Value="120"/>
+        </Style>
+        <Style x:Key="ThemeSlider" TargetType="Slider">
+            <Setter Property="Minimum" Value="0"/>
+            <Setter Property="Maximum" Value="1"/>
+            <Setter Property="TickFrequency" Value="0.05"/>
+            <Setter Property="Margin" Value="0,0,8,8"/>
+        </Style>
+    </UserControl.Resources>
+
+    <Border Style="{StaticResource DesktopContentPane}">
+        <DockPanel>
+            <Border DockPanel.Dock="Top" Style="{StaticResource DesktopSectionActionStrip}">
+                <DockPanel LastChildFill="False">
+                    <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
+                        <TextBlock Text="App Theme Designer" Style="{StaticResource SubheadingTextBlock}"/>
+                        <TextBlock Text="Redesign the full app shell with colors, backgrounds, transparency, borders, corners, spacing, and shadow depth." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                    </StackPanel>
+                    <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
+                        <Button Style="{StaticResource GhostButton}" Content="Glass" Command="{Binding GlassPresetCommand}" Margin="0,0,4,0"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Borderless" Command="{Binding BorderlessPresetCommand}" Margin="0,0,4,0"/>
+                        <Button Style="{StaticResource GhostButton}" Content="High Contrast" Command="{Binding HighContrastPresetCommand}" Margin="0,0,4,0"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Reset" Command="{Binding ResetCommand}" Margin="0,0,4,0"/>
+                        <Button Style="{StaticResource PrimaryButton}" Content="Save Theme" Command="{Binding SaveCommand}"/>
+                    </StackPanel>
+                </DockPanel>
+            </Border>
+
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <Grid Margin="14" VerticalAlignment="Top">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1.4*" MinWidth="420"/>
+                        <ColumnDefinition Width="12"/>
+                        <ColumnDefinition Width="1.1*" MinWidth="340"/>
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0">
+                        <Border Style="{StaticResource DesktopInsetCard}" Margin="0,0,0,12">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="170"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <TextBlock Grid.ColumnSpan="2" Text="Color system" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
+                                <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="Use #RRGGBB or #AARRGGBB values. Changes preview immediately and are saved when you choose Save Theme." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,12"/>
+                                <TextBlock Grid.Row="2" Text="Base theme" Style="{StaticResource ThemeFieldLabel}"/>
+                                <ComboBox Grid.Row="2" Grid.Column="1" SelectedItem="{Binding BaseTheme}" Margin="0,0,0,8">
+                                    <ComboBoxItem Content="Light"/>
+                                    <ComboBoxItem Content="Dark"/>
+                                </ComboBox>
+                                <TextBlock Grid.Row="3" Text="Background" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding BackgroundColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Grid.Row="4" Text="Main surface" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding SurfaceColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Grid.Row="5" Text="Alt surface" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding SurfaceAltColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Grid.Row="6" Text="Text" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding TextColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Grid.Row="7" Text="Muted text" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding MutedTextColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Grid.Row="8" Text="Accent" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Grid.Row="8" Grid.Column="1" Text="{Binding AccentColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <DockPanel Grid.Row="9" Grid.ColumnSpan="2" LastChildFill="True">
+                                    <Button DockPanel.Dock="Right" Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearBackgroundCommand}" Margin="6,0,0,8"/>
+                                    <Button DockPanel.Dock="Right" Style="{StaticResource GhostButton}" Content="Browse" Command="{Binding BrowseBackgroundCommand}" Margin="6,0,0,8"/>
+                                    <TextBox Text="{Binding BackgroundImagePath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                </DockPanel>
+                            </Grid>
+                        </Border>
+
+                        <Border Style="{StaticResource DesktopInsetCard}">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="170"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="64"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <TextBlock Grid.ColumnSpan="3" Text="Transparency" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
+                                <TextBlock Grid.Row="1" Text="Background" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="1" Grid.Column="1" Value="{Binding BackgroundOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding BackgroundOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="2" Text="Surfaces" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="2" Grid.Column="1" Value="{Binding SurfaceOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="2" Grid.Column="2" Text="{Binding SurfaceOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="3" Text="Inputs" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="3" Grid.Column="1" Value="{Binding InputOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="3" Grid.Column="2" Text="{Binding InputOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="4" Text="Buttons" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="4" Grid.Column="1" Value="{Binding ButtonOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="4" Grid.Column="2" Text="{Binding ButtonOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
+                            </Grid>
+                        </Border>
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="2">
+                        <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,12">
+                            <StackPanel>
+                                <TextBlock Text="Live preview" Style="{StaticResource PageTitleTextBlock}"/>
+                                <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,8,0,8">
+                                    <StackPanel>
+                                        <TextBlock Text="Inventory desk card" Style="{StaticResource SectionHeader}"/>
+                                        <TextBlock Text="Surface, text, borders, corners, padding, and shadows update as you tune the theme." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                        <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                                            <Button Style="{StaticResource PrimaryButton}" Content="Primary" Margin="0,0,6,0"/>
+                                            <Button Style="{StaticResource GhostButton}" Content="Ghost"/>
+                                        </StackPanel>
+                                    </StackPanel>
+                                </Border>
+                                <TextBox Text="Input preview" Margin="0,0,0,8"/>
+                                <ProgressBar Value="65" Maximum="100"/>
+                                <TextBlock Text="{Binding Status}" Style="{StaticResource CaptionTextBlock}" Margin="0,8,0,0"/>
+                            </StackPanel>
+                        </Border>
+
+                        <Border Style="{StaticResource DesktopInsetCard}" Margin="0,0,0,12">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="170"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="64"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <TextBlock Grid.ColumnSpan="3" Text="Shape and borders" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
+                                <TextBlock Grid.Row="1" Text="Show borders" Style="{StaticResource ThemeFieldLabel}"/>
+                                <CheckBox Grid.Row="1" Grid.Column="1" IsChecked="{Binding BordersVisible}" Margin="0,0,0,8"/>
+                                <TextBlock Grid.Row="2" Text="Glass surfaces" Style="{StaticResource ThemeFieldLabel}"/>
+                                <CheckBox Grid.Row="2" Grid.Column="1" IsChecked="{Binding UseGlassSurfaces}" Margin="0,0,0,8"/>
+                                <TextBlock Grid.Row="3" Text="Border opacity" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="3" Grid.Column="1" Value="{Binding BorderOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="3" Grid.Column="2" Text="{Binding BorderOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="4" Text="Card corners" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding CardCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="4" Grid.Column="2" Text="{Binding CardCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="5" Text="Button corners" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="5" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding ButtonCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="5" Grid.Column="2" Text="{Binding ButtonCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="6" Text="Input corners" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="6" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding InputCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="6" Grid.Column="2" Text="{Binding InputCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
+                            </Grid>
+                        </Border>
+
+                        <Border Style="{StaticResource DesktopInsetCard}">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="170"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="64"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <TextBlock Grid.ColumnSpan="3" Text="Depth and spacing" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
+                                <TextBlock Grid.Row="1" Text="Shadow blur" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="1" Grid.Column="1" Minimum="0" Maximum="48" Value="{Binding ShadowBlurRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding ShadowBlurRadius, StringFormat={}{0:0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="2" Text="Shadow depth" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="2" Grid.Column="1" Minimum="0" Maximum="16" Value="{Binding ShadowDepth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="2" Grid.Column="2" Text="{Binding ShadowDepth, StringFormat={}{0:0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="3" Text="Shadow opacity" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="3" Grid.Column="1" Value="{Binding ShadowOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="3" Grid.Column="2" Text="{Binding ShadowOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="4" Text="Page padding" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="28" Value="{Binding PagePadding, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="4" Grid.Column="2" Text="{Binding PagePadding, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="5" Text="Card padding" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="5" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding CardPadding, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="5" Grid.Column="2" Text="{Binding CardPadding, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
+                            </Grid>
+                        </Border>
+                    </StackPanel>
+                </Grid>
+            </ScrollViewer>
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml.cs
@@ -1,0 +1,40 @@
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System.Windows.Controls;
+
+namespace InventoryManagementApp.Views.Pages
+{
+    public partial class ThemeDesignerControl : UserControl
+    {
+        private bool _initialized;
+
+        public ThemeDesignerControl()
+        {
+            InitializeComponent();
+            Loaded += ThemeDesignerControl_Loaded;
+        }
+
+        private async void ThemeDesignerControl_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            if (_initialized || DataContext is ThemeDesignerViewModel)
+                return;
+
+            if (System.Windows.Application.Current is not App app)
+                return;
+
+            var services = app.Host.Services;
+            var viewModel = new ThemeDesignerViewModel(
+                services.GetRequiredService<ISettingsService>(),
+                services.GetRequiredService<IThemeService>(),
+                services.GetRequiredService<IFileDialogService>(),
+                services.GetRequiredService<IDialogService>(),
+                services.GetService<ILogger<ThemeDesignerViewModel>>());
+
+            DataContext = viewModel;
+            await viewModel.InitializeAsync();
+            _initialized = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a persisted custom app theme profile for full-app colors, background image/color, transparency, borders, corner radius, spacing, and shadow depth.
- Restores saved custom theme resources through the normal theme service so startup and the whole shell pick up the admin redesign.
- Adds a standalone Themes workspace into Admin Settings without changing the existing email/settings view model flow.
- Adds focused tests for theme defaults, normalization, selector handling, and JSON persistence through the settings contract.

## Validation
- GitHub connector compare confirmed the clean replay branch contains the intended theme-designer files and no SettingsViewModel overwrite.
- Not run locally: this scheduled Linux container does not have the .NET SDK or Windows WPF runtime, and local clone/raw access is blocked by the network tunnel.