### PR TITLE
Refine admin theme designer coverage

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/SettingsPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/SettingsPageXamlTests.cs
@@ -53,6 +53,25 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("AutoLogoutMinutesBox_PreviewTextInput", xaml, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void ThemeDesignerControl_ExposesFullAppThemeCustomizationControls()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ThemeDesignerControl.xaml");
+
+            Assert.Contains("ItemsSource=\"{Binding ThemeOptions}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("SuccessColor", xaml, StringComparison.Ordinal);
+            Assert.Contains("WarningColor", xaml, StringComparison.Ordinal);
+            Assert.Contains("ErrorColor", xaml, StringComparison.Ordinal);
+            Assert.Contains("SurfaceAltOpacity", xaml, StringComparison.Ordinal);
+            Assert.Contains("PanelCornerRadius", xaml, StringComparison.Ordinal);
+            Assert.Contains("BackgroundImagePath", xaml, StringComparison.Ordinal);
+            Assert.Contains("BorderOpacity", xaml, StringComparison.Ordinal);
+            Assert.Contains("ShadowBlurRadius", xaml, StringComparison.Ordinal);
+            Assert.Contains("ShadowDepth", xaml, StringComparison.Ordinal);
+            Assert.Contains("PagePadding", xaml, StringComparison.Ordinal);
+            Assert.Contains("CardPadding", xaml, StringComparison.Ordinal);
+        }
+
         static string ReadRepositoryFile(params string[] relativePathParts)
         {
             var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/InventoryManagementApp/ViewModels/ThemeDesignerViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ThemeDesignerViewModel.cs
@@ -5,6 +5,7 @@ using InventoryManagementApp.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
+using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -33,6 +34,7 @@ namespace InventoryManagementApp.ViewModels
             _dialogService = dialogService;
             _logger = logger ?? NullLogger<ThemeDesignerViewModel>.Instance;
 
+            ThemeOptions = new ObservableCollection<string> { "Light", "Dark" };
             SaveCommand = new AsyncRelayCommand(SaveAsync);
             ResetCommand = new RelayCommand(Reset);
             BrowseBackgroundCommand = new RelayCommand(BrowseBackground);
@@ -42,6 +44,7 @@ namespace InventoryManagementApp.ViewModels
             HighContrastPresetCommand = new RelayCommand(ApplyHighContrastPreset);
         }
 
+        public ObservableCollection<string> ThemeOptions { get; }
         public IAsyncRelayCommand SaveCommand { get; }
         public IRelayCommand ResetCommand { get; }
         public IRelayCommand BrowseBackgroundCommand { get; }
@@ -134,6 +137,12 @@ namespace InventoryManagementApp.ViewModels
             set => SetDouble(value, (settings, newValue) => settings.SurfaceOpacity = newValue, nameof(SurfaceOpacity));
         }
 
+        public double SurfaceAltOpacity
+        {
+            get => _settings.SurfaceAltOpacity;
+            set => SetDouble(value, (settings, newValue) => settings.SurfaceAltOpacity = newValue, nameof(SurfaceAltOpacity));
+        }
+
         public double InputOpacity
         {
             get => _settings.InputOpacity;
@@ -168,6 +177,12 @@ namespace InventoryManagementApp.ViewModels
         {
             get => _settings.CardCornerRadius;
             set => SetDouble(value, (settings, newValue) => settings.CardCornerRadius = newValue, nameof(CardCornerRadius));
+        }
+
+        public double PanelCornerRadius
+        {
+            get => _settings.PanelCornerRadius;
+            set => SetDouble(value, (settings, newValue) => settings.PanelCornerRadius = newValue, nameof(PanelCornerRadius));
         }
 
         public double ButtonCornerRadius
@@ -268,11 +283,13 @@ namespace InventoryManagementApp.ViewModels
         {
             UseGlassSurfaces = true;
             SurfaceOpacity = 0.68;
+            SurfaceAltOpacity = 0.58;
             InputOpacity = 0.72;
             ButtonOpacity = 0.72;
             BordersVisible = true;
             BorderOpacity = 0.42;
             CardCornerRadius = 14;
+            PanelCornerRadius = 12;
             ButtonCornerRadius = 12;
             InputCornerRadius = 10;
             ShadowBlurRadius = 18;
@@ -287,6 +304,7 @@ namespace InventoryManagementApp.ViewModels
             BordersVisible = false;
             BorderOpacity = 0;
             CardCornerRadius = 0;
+            PanelCornerRadius = 0;
             ButtonCornerRadius = 0;
             InputCornerRadius = 0;
             ShadowBlurRadius = 0;
@@ -304,6 +322,9 @@ namespace InventoryManagementApp.ViewModels
             _settings.TextColor = "#FFFFFFFF";
             _settings.MutedTextColor = "#FFE5E7EB";
             _settings.AccentColor = "#FFFFFF00";
+            _settings.SuccessColor = "#FF00FF66";
+            _settings.WarningColor = "#FFFFFF00";
+            _settings.ErrorColor = "#FFFF4D4D";
             _settings.BordersVisible = true;
             _settings.BorderOpacity = 1;
             Preview();
@@ -362,12 +383,14 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(BackgroundImagePath));
             OnPropertyChanged(nameof(BackgroundOpacity));
             OnPropertyChanged(nameof(SurfaceOpacity));
+            OnPropertyChanged(nameof(SurfaceAltOpacity));
             OnPropertyChanged(nameof(InputOpacity));
             OnPropertyChanged(nameof(ButtonOpacity));
             OnPropertyChanged(nameof(BordersVisible));
             OnPropertyChanged(nameof(UseGlassSurfaces));
             OnPropertyChanged(nameof(BorderOpacity));
             OnPropertyChanged(nameof(CardCornerRadius));
+            OnPropertyChanged(nameof(PanelCornerRadius));
             OnPropertyChanged(nameof(ButtonCornerRadius));
             OnPropertyChanged(nameof(InputCornerRadius));
             OnPropertyChanged(nameof(ShadowBlurRadius));

--- a/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml
+++ b/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml
@@ -62,14 +62,14 @@
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
                                 <TextBlock Grid.ColumnSpan="2" Text="Color system" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
                                 <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="Use #RRGGBB or #AARRGGBB values. Changes preview immediately and are saved when you choose Save Theme." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,12"/>
                                 <TextBlock Grid.Row="2" Text="Base theme" Style="{StaticResource ThemeFieldLabel}"/>
-                                <ComboBox Grid.Row="2" Grid.Column="1" SelectedItem="{Binding BaseTheme}" Margin="0,0,0,8">
-                                    <ComboBoxItem Content="Light"/>
-                                    <ComboBoxItem Content="Dark"/>
-                                </ComboBox>
+                                <ComboBox Grid.Row="2" Grid.Column="1" SelectedItem="{Binding BaseTheme}" ItemsSource="{Binding ThemeOptions}" Margin="0,0,0,8"/>
                                 <TextBlock Grid.Row="3" Text="Background" Style="{StaticResource ThemeFieldLabel}"/>
                                 <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding BackgroundColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
                                 <TextBlock Grid.Row="4" Text="Main surface" Style="{StaticResource ThemeFieldLabel}"/>
@@ -82,7 +82,13 @@
                                 <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding MutedTextColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
                                 <TextBlock Grid.Row="8" Text="Accent" Style="{StaticResource ThemeFieldLabel}"/>
                                 <TextBox Grid.Row="8" Grid.Column="1" Text="{Binding AccentColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
-                                <DockPanel Grid.Row="9" Grid.ColumnSpan="2" LastChildFill="True">
+                                <TextBlock Grid.Row="9" Text="Success" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Grid.Row="9" Grid.Column="1" Text="{Binding SuccessColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Grid.Row="10" Text="Warning" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Grid.Row="10" Grid.Column="1" Text="{Binding WarningColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Grid.Row="11" Text="Error" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Grid.Row="11" Grid.Column="1" Text="{Binding ErrorColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <DockPanel Grid.Row="12" Grid.ColumnSpan="2" LastChildFill="True">
                                     <Button DockPanel.Dock="Right" Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearBackgroundCommand}" Margin="6,0,0,8"/>
                                     <Button DockPanel.Dock="Right" Style="{StaticResource GhostButton}" Content="Browse" Command="{Binding BrowseBackgroundCommand}" Margin="6,0,0,8"/>
                                     <TextBox Text="{Binding BackgroundImagePath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
@@ -103,20 +109,24 @@
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
                                 <TextBlock Grid.ColumnSpan="3" Text="Transparency" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
                                 <TextBlock Grid.Row="1" Text="Background" Style="{StaticResource ThemeFieldLabel}"/>
                                 <Slider Grid.Row="1" Grid.Column="1" Value="{Binding BackgroundOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
                                 <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding BackgroundOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="2" Text="Surfaces" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBlock Grid.Row="2" Text="Main surfaces" Style="{StaticResource ThemeFieldLabel}"/>
                                 <Slider Grid.Row="2" Grid.Column="1" Value="{Binding SurfaceOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
                                 <TextBlock Grid.Row="2" Grid.Column="2" Text="{Binding SurfaceOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="3" Text="Inputs" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="3" Grid.Column="1" Value="{Binding InputOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="3" Grid.Column="2" Text="{Binding InputOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="4" Text="Buttons" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="4" Grid.Column="1" Value="{Binding ButtonOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="4" Grid.Column="2" Text="{Binding ButtonOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="3" Text="Alt surfaces" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="3" Grid.Column="1" Value="{Binding SurfaceAltOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="3" Grid.Column="2" Text="{Binding SurfaceAltOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="4" Text="Inputs" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="4" Grid.Column="1" Value="{Binding InputOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="4" Grid.Column="2" Text="{Binding InputOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="5" Text="Buttons" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="5" Grid.Column="1" Value="{Binding ButtonOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="5" Grid.Column="2" Text="{Binding ButtonOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
                             </Grid>
                         </Border>
                     </StackPanel>
@@ -156,6 +166,7 @@
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
                                 <TextBlock Grid.ColumnSpan="3" Text="Shape and borders" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
                                 <TextBlock Grid.Row="1" Text="Show borders" Style="{StaticResource ThemeFieldLabel}"/>
@@ -168,12 +179,15 @@
                                 <TextBlock Grid.Row="4" Text="Card corners" Style="{StaticResource ThemeFieldLabel}"/>
                                 <Slider Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding CardCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
                                 <TextBlock Grid.Row="4" Grid.Column="2" Text="{Binding CardCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="5" Text="Button corners" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="5" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding ButtonCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="5" Grid.Column="2" Text="{Binding ButtonCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="6" Text="Input corners" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="6" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding InputCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="6" Grid.Column="2" Text="{Binding InputCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="5" Text="Panel corners" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="5" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding PanelCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="5" Grid.Column="2" Text="{Binding PanelCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="6" Text="Button corners" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="6" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding ButtonCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="6" Grid.Column="2" Text="{Binding ButtonCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="7" Text="Input corners" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="7" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding InputCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="7" Grid.Column="2" Text="{Binding InputCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
                             </Grid>
                         </Border>
 


### PR DESCRIPTION
## Summary
- Expose the remaining app theme settings already supported by the model: semantic colors, alternate surface transparency, and panel corner radius.
- Change the theme selector to bind against string `ThemeOptions` instead of inline ComboBoxItem objects.
- Extend XAML contract tests so the admin theme designer keeps the full customization surface visible.

## Validation
- Verified changed files by GitHub connector readback and compare.
- Added/updated tests for the theme designer customization surface.
- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks could not be run in this scheduled Linux container because the .NET SDK/Windows WPF runtime and local clone/raw access are unavailable.