### PR TITLE
Expand admin theme interaction controls

### DIFF
--- a/InventoryManagementApp.Tests/Models/AppThemeSettingsTests.cs
+++ b/InventoryManagementApp.Tests/Models/AppThemeSettingsTests.cs
@@ -17,6 +17,7 @@ namespace InventoryManagementApp.Tests.Models
                 BaseTheme = "Unexpected",
                 BackgroundColor = "123456",
                 SurfaceColor = "bad",
+                BackgroundImageStretch = "Tile",
                 BackgroundOpacity = 2,
                 SurfaceOpacity = -1,
                 ButtonCornerRadius = 99,
@@ -27,7 +28,11 @@ namespace InventoryManagementApp.Tests.Models
                 FontScale = 3,
                 ControlHeight = 99,
                 DataGridRowHeight = 2,
-                DataGridHeaderHeight = 99
+                DataGridHeaderHeight = 99,
+                InteractionIntensity = 5,
+                FocusRingOpacity = -2,
+                GridLineOpacity = 4,
+                MotionIntensity = double.PositiveInfinity
             };
 
             settings.Normalize();
@@ -35,6 +40,7 @@ namespace InventoryManagementApp.Tests.Models
             Assert.Equal("Light", settings.BaseTheme);
             Assert.Equal("#123456", settings.BackgroundColor);
             Assert.Equal(AppThemeSettings.CreateDefault("Light").SurfaceColor, settings.SurfaceColor);
+            Assert.Equal("UniformToFill", settings.BackgroundImageStretch);
             Assert.Equal(1, settings.BackgroundOpacity);
             Assert.Equal(0, settings.SurfaceOpacity);
             Assert.Equal(32, settings.ButtonCornerRadius);
@@ -46,6 +52,10 @@ namespace InventoryManagementApp.Tests.Models
             Assert.Equal(44, settings.ControlHeight);
             Assert.Equal(22, settings.DataGridRowHeight);
             Assert.Equal(56, settings.DataGridHeaderHeight);
+            Assert.Equal(2, settings.InteractionIntensity);
+            Assert.Equal(0, settings.FocusRingOpacity);
+            Assert.Equal(1, settings.GridLineOpacity);
+            Assert.Equal(0, settings.MotionIntensity);
         }
 
         [Fact]
@@ -57,6 +67,20 @@ namespace InventoryManagementApp.Tests.Models
             Assert.Equal("#FF101418", settings.BackgroundColor);
         }
 
+        [Theory]
+        [InlineData("None")]
+        [InlineData("Fill")]
+        [InlineData("Uniform")]
+        [InlineData("UniformToFill")]
+        public void Normalize_PreservesSupportedBackgroundStretchModes(string stretch)
+        {
+            var settings = new AppThemeSettings { BackgroundImageStretch = stretch };
+
+            settings.Normalize();
+
+            Assert.Equal(stretch, settings.BackgroundImageStretch);
+        }
+
         [Fact]
         public async Task SettingsServiceDefaults_SaveAndLoadThemeProfileAsSingleSetting()
         {
@@ -66,6 +90,11 @@ namespace InventoryManagementApp.Tests.Models
             settings.BordersVisible = false;
             settings.FontScale = 1.15;
             settings.DataGridRowHeight = 38;
+            settings.BackgroundImageStretch = "Uniform";
+            settings.InteractionIntensity = 1.6;
+            settings.FocusRingOpacity = 0.75;
+            settings.GridLineOpacity = 0.2;
+            settings.MotionIntensity = 0.35;
 
             await service.SaveAppThemeSettingsAsync(settings);
             var loaded = await service.GetAppThemeSettingsAsync();
@@ -75,6 +104,11 @@ namespace InventoryManagementApp.Tests.Models
             Assert.False(loaded.BordersVisible);
             Assert.Equal(1.15, loaded.FontScale);
             Assert.Equal(38, loaded.DataGridRowHeight);
+            Assert.Equal("Uniform", loaded.BackgroundImageStretch);
+            Assert.Equal(1.6, loaded.InteractionIntensity);
+            Assert.Equal(0.75, loaded.FocusRingOpacity);
+            Assert.Equal(0.2, loaded.GridLineOpacity);
+            Assert.Equal(0.35, loaded.MotionIntensity);
         }
 
         private sealed class FakeSettingsService : ISettingsService

--- a/InventoryManagementApp.Tests/Models/AppThemeSettingsTests.cs
+++ b/InventoryManagementApp.Tests/Models/AppThemeSettingsTests.cs
@@ -1,5 +1,6 @@
 using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.Models;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/InventoryManagementApp.Tests/ViewModels/PolishedVisualHierarchyResourceTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/PolishedVisualHierarchyResourceTests.cs
@@ -52,6 +52,20 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("ThemeDataGridHeaderHeight", hierarchy, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void ThemeResources_DefineAdminControlledInteractionTokens()
+        {
+            var customization = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.Customization.xaml");
+            var hierarchy = ReadRepositoryFile("InventoryManagementApp", "Resources", "PolishedVisualHierarchy.xaml");
+
+            Assert.Contains("ThemeInteractionIntensity", customization, StringComparison.Ordinal);
+            Assert.Contains("ThemeMotionIntensity", customization, StringComparison.Ordinal);
+            Assert.Contains("ThemeFocusVisualStrokeThickness", customization, StringComparison.Ordinal);
+            Assert.Contains("ThemeGridLineBrush", customization, StringComparison.Ordinal);
+            Assert.Contains("HorizontalGridLinesBrush\" Value=\"{DynamicResource ThemeGridLineBrush}\"", hierarchy, StringComparison.Ordinal);
+            Assert.Contains("VerticalGridLinesBrush\" Value=\"{DynamicResource ThemeGridLineBrush}\"", hierarchy, StringComparison.Ordinal);
+        }
+
         static string ReadRepositoryFile(params string[] relativePathParts)
         {
             var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/InventoryManagementApp.Tests/ViewModels/SettingsPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/SettingsPageXamlTests.cs
@@ -66,6 +66,8 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("NavigationOpacity", xaml, StringComparison.Ordinal);
             Assert.Contains("PanelCornerRadius", xaml, StringComparison.Ordinal);
             Assert.Contains("BackgroundImagePath", xaml, StringComparison.Ordinal);
+            Assert.Contains("BackgroundImageStretch", xaml, StringComparison.Ordinal);
+            Assert.Contains("BackgroundStretchOptions", xaml, StringComparison.Ordinal);
             Assert.Contains("BorderOpacity", xaml, StringComparison.Ordinal);
             Assert.Contains("ShadowBlurRadius", xaml, StringComparison.Ordinal);
             Assert.Contains("ShadowDepth", xaml, StringComparison.Ordinal);
@@ -75,7 +77,12 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("ControlHeight", xaml, StringComparison.Ordinal);
             Assert.Contains("DataGridRowHeight", xaml, StringComparison.Ordinal);
             Assert.Contains("DataGridHeaderHeight", xaml, StringComparison.Ordinal);
+            Assert.Contains("InteractionIntensity", xaml, StringComparison.Ordinal);
+            Assert.Contains("FocusRingOpacity", xaml, StringComparison.Ordinal);
+            Assert.Contains("GridLineOpacity", xaml, StringComparison.Ordinal);
+            Assert.Contains("MotionIntensity", xaml, StringComparison.Ordinal);
             Assert.Contains("Depth, spacing, and density", xaml, StringComparison.Ordinal);
+            Assert.Contains("Interaction feel", xaml, StringComparison.Ordinal);
         }
 
         static string ReadRepositoryFile(params string[] relativePathParts)

--- a/InventoryManagementApp/Models/AppThemeSettings.cs
+++ b/InventoryManagementApp/Models/AppThemeSettings.cs
@@ -15,6 +15,7 @@ namespace InventoryManagementApp.Models
         public string WarningColor { get; set; } = "#FFD97706";
         public string ErrorColor { get; set; } = "#FFDC2626";
         public string BackgroundImagePath { get; set; } = string.Empty;
+        public string BackgroundImageStretch { get; set; } = "UniformToFill";
         public double BackgroundOpacity { get; set; } = 1.0;
         public double SurfaceOpacity { get; set; } = 1.0;
         public double SurfaceAltOpacity { get; set; } = 1.0;
@@ -36,6 +37,10 @@ namespace InventoryManagementApp.Models
         public double ControlHeight { get; set; } = 28.0;
         public double DataGridRowHeight { get; set; } = 30.0;
         public double DataGridHeaderHeight { get; set; } = 30.0;
+        public double InteractionIntensity { get; set; } = 1.0;
+        public double FocusRingOpacity { get; set; } = 0.55;
+        public double GridLineOpacity { get; set; } = 0.42;
+        public double MotionIntensity { get; set; } = 1.0;
         public bool UseGlassSurfaces { get; set; }
 
         public static AppThemeSettings CreateDefault(string? baseTheme = null)
@@ -56,6 +61,7 @@ namespace InventoryManagementApp.Models
                 settings.WarningColor = "#FFFBBF24";
                 settings.ErrorColor = "#FFF87171";
                 settings.ShadowOpacity = 0.35;
+                settings.GridLineOpacity = 0.5;
             }
 
             return settings;
@@ -74,6 +80,7 @@ namespace InventoryManagementApp.Models
             SuccessColor = NormalizeColor(SuccessColor, defaults.SuccessColor);
             WarningColor = NormalizeColor(WarningColor, defaults.WarningColor);
             ErrorColor = NormalizeColor(ErrorColor, defaults.ErrorColor);
+            BackgroundImageStretch = NormalizeBackgroundStretch(BackgroundImageStretch);
             BackgroundOpacity = Clamp01(BackgroundOpacity);
             SurfaceOpacity = Clamp01(SurfaceOpacity);
             SurfaceAltOpacity = Clamp01(SurfaceAltOpacity);
@@ -94,10 +101,25 @@ namespace InventoryManagementApp.Models
             ControlHeight = Clamp(ControlHeight, 22, 44);
             DataGridRowHeight = Clamp(DataGridRowHeight, 22, 52);
             DataGridHeaderHeight = Clamp(DataGridHeaderHeight, 24, 56);
+            InteractionIntensity = Clamp(InteractionIntensity, 0, 2);
+            FocusRingOpacity = Clamp01(FocusRingOpacity);
+            GridLineOpacity = Clamp01(GridLineOpacity);
+            MotionIntensity = Clamp(MotionIntensity, 0, 2);
         }
 
         private static string NormalizeBaseTheme(string? value)
             => value?.IndexOf("Dark", StringComparison.OrdinalIgnoreCase) >= 0 ? "Dark" : "Light";
+
+        private static string NormalizeBackgroundStretch(string? value)
+        {
+            if (string.Equals(value, "None", StringComparison.OrdinalIgnoreCase))
+                return "None";
+            if (string.Equals(value, "Fill", StringComparison.OrdinalIgnoreCase))
+                return "Fill";
+            if (string.Equals(value, "Uniform", StringComparison.OrdinalIgnoreCase))
+                return "Uniform";
+            return "UniformToFill";
+        }
 
         private static double Clamp01(double value) => Clamp(value, 0, 1);
 

--- a/InventoryManagementApp/ProgressNotes/2026-06-19-theme-interaction-designer.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-19-theme-interaction-designer.md
@@ -1,0 +1,14 @@
+# Theme Interaction Designer Pass - 2026-06-19
+
+## Completed
+
+- Expanded the admin Themes workspace with background image fit selection, hover/selection intensity, focus-ring visibility, grid-line strength, and motion-intensity controls.
+- Persisted the new settings in `AppThemeSettings` with safe normalization ranges and supported background stretch modes.
+- Applied the settings through `ThemeService` so saved profiles affect background image stretch, hover/selected states, focus visuals, table/grid line strength, and shared interaction tokens across the app.
+- Updated shared visual hierarchy resources so data grids consume the admin-controlled grid-line brush.
+- Added/updated contract tests for model normalization, Settings theme designer bindings, and shared interaction resource tokens.
+
+## Validation Notes
+
+- Local clone/raw access, `dotnet`, Windows/WPF runtime screenshots, and local banned-word checks remain blocked in this scheduled Linux container.
+- Changes were made through the GitHub connector and guarded with repository tests that can run in a Windows/.NET-capable environment.

--- a/InventoryManagementApp/Resources/PolishedVisualHierarchy.xaml
+++ b/InventoryManagementApp/Resources/PolishedVisualHierarchy.xaml
@@ -73,8 +73,8 @@
         <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="GridLinesVisibility" Value="All"/>
-        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource BorderBrushBase}"/>
-        <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource BorderBrushBase}"/>
+        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource ThemeGridLineBrush}"/>
+        <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource ThemeGridLineBrush}"/>
         <Setter Property="HeadersVisibility" Value="Column"/>
         <Setter Property="RowHeight" Value="{DynamicResource ThemeDataGridRowHeight}"/>
         <Setter Property="ColumnHeaderHeight" Value="{DynamicResource ThemeDataGridHeaderHeight}"/>

--- a/InventoryManagementApp/Resources/Theme.Customization.xaml
+++ b/InventoryManagementApp/Resources/Theme.Customization.xaml
@@ -5,7 +5,8 @@
         Admin theme designer tokens.
         The Settings theme selector chooses the active color dictionary. These shared resources are
         the app-wide knobs for the visual redesign layer: border removal, glass surfaces,
-        rounded controls, shadow depth, navigation transparency, typography scale, and grid density.
+        rounded controls, shadow depth, navigation transparency, typography scale, grid density,
+        interaction intensity, focus visibility, background image fit, and grid line strength.
     -->
 
     <Thickness x:Key="ThemeBorderThickness">1</Thickness>
@@ -27,6 +28,9 @@
     <sys:Double x:Key="ThemeControlMinHeight">28</sys:Double>
     <sys:Double x:Key="ThemeDataGridRowHeight">30</sys:Double>
     <sys:Double x:Key="ThemeDataGridHeaderHeight">30</sys:Double>
+    <sys:Double x:Key="ThemeInteractionIntensity">1</sys:Double>
+    <sys:Double x:Key="ThemeMotionIntensity">1</sys:Double>
+    <sys:Double x:Key="ThemeFocusVisualStrokeThickness">2</sys:Double>
 
     <SolidColorBrush x:Key="ThemeTransparentBrush" Color="#00000000"/>
     <SolidColorBrush x:Key="ThemeGlassSurfaceBrush" Color="#DFFFFFFF"/>
@@ -34,6 +38,7 @@
     <SolidColorBrush x:Key="ThemeAppBackgroundOverlayBrush" Color="#00FFFFFF"/>
     <SolidColorBrush x:Key="NavigationSurfaceBrush" Color="#FFE8EDF3"/>
     <SolidColorBrush x:Key="NavigationAltSurfaceBrush" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="ThemeGridLineBrush" Color="#6B94A3B8"/>
 
     <DropShadowEffect x:Key="ThemeNoShadow"
                       BlurRadius="0"

--- a/InventoryManagementApp/Services/ThemeService.cs
+++ b/InventoryManagementApp/Services/ThemeService.cs
@@ -79,6 +79,9 @@ namespace InventoryManagementApp.Services
                 var surfaceBrush = CreateBrush(settings.SurfaceColor, settings.UseGlassSurfaces ? Math.Min(settings.SurfaceOpacity, 0.72) : settings.SurfaceOpacity);
                 var surfaceAltBrush = CreateBrush(settings.SurfaceAltColor, settings.UseGlassSurfaces ? Math.Min(settings.SurfaceAltOpacity, 0.62) : settings.SurfaceAltOpacity);
                 var navigationBrush = CreateBrush(settings.SurfaceAltColor, settings.UseGlassSurfaces ? Math.Min(settings.NavigationOpacity, 0.74) : settings.NavigationOpacity);
+                var hoverOpacity = Math.Clamp(0.08 + (settings.InteractionIntensity * 0.08), 0, 0.28);
+                var selectedOpacity = Math.Clamp(0.14 + (settings.InteractionIntensity * 0.13), 0, 0.42);
+                var pressedOpacity = Math.Clamp(0.18 + (settings.InteractionIntensity * 0.12), 0, 0.48);
                 var bodyFontSize = Math.Round(13 * settings.FontScale, 1);
                 var captionFontSize = Math.Round(11 * settings.FontScale, 1);
                 var sectionFontSize = Math.Round(14 * settings.FontScale, 1);
@@ -104,17 +107,20 @@ namespace InventoryManagementApp.Services
                 Set(resources, "BorderBrushBase", borderBrush);
                 Set(resources, "BorderBrushAlt", CreateBrush(settings.MutedTextColor, settings.BorderOpacity * 0.45));
                 Set(resources, "BtnBg", CreateBrush(settings.SurfaceAltColor, settings.ButtonOpacity));
-                Set(resources, "BtnBgHover", CreateBrush(settings.AccentColor, Math.Min(1, settings.ButtonOpacity * 0.22 + 0.12)));
+                Set(resources, "BtnBgHover", CreateBrush(settings.AccentColor, Math.Min(1, settings.ButtonOpacity * hoverOpacity + 0.08)));
                 Set(resources, "BtnBorder", settings.BordersVisible ? CreateBrush(settings.AccentColor, settings.BorderOpacity * 0.72) : Brushes.Transparent);
                 Set(resources, "BtnFg", CreateBrush(settings.TextColor, 1));
-                Set(resources, "NavButtonPressedBrush", CreateBrush(settings.AccentColor, 0.24));
-                Set(resources, "NavButtonHoverBrush", CreateBrush(settings.AccentColor, 0.16));
-                Set(resources, "ItemHoverBrush", CreateBrush(settings.AccentColor, 0.14));
-                Set(resources, "ItemSelectedBrush", CreateBrush(settings.AccentColor, 0.24));
+                Set(resources, "FocusVisualStrokeBrush", CreateBrush(settings.AccentColor, settings.FocusRingOpacity));
+                Set(resources, "ThemeFocusVisualStrokeThickness", Math.Clamp(1 + settings.FocusRingOpacity * 3, 1, 4));
+                Set(resources, "NavButtonPressedBrush", CreateBrush(settings.AccentColor, pressedOpacity));
+                Set(resources, "NavButtonHoverBrush", CreateBrush(settings.AccentColor, hoverOpacity));
+                Set(resources, "ItemHoverBrush", CreateBrush(settings.AccentColor, hoverOpacity));
+                Set(resources, "ItemSelectedBrush", CreateBrush(settings.AccentColor, selectedOpacity));
                 Set(resources, "ItemHoverForegroundBrush", CreateBrush(settings.TextColor, 1));
                 Set(resources, "ItemSelectedForegroundBrush", CreateBrush(settings.TextColor, 1));
                 Set(resources, "DataGridRowBackgroundBrush", CreateBrush(settings.SurfaceColor, Math.Max(settings.SurfaceOpacity, 0.78)));
                 Set(resources, "DataGridAlternatingRowBackgroundBrush", CreateBrush(settings.SurfaceAltColor, Math.Max(settings.SurfaceAltOpacity, 0.72)));
+                Set(resources, "ThemeGridLineBrush", settings.BordersVisible ? CreateBrush(settings.MutedTextColor, settings.GridLineOpacity) : Brushes.Transparent);
                 Set(resources, "ProgressBarBackgroundBrush", CreateBrush(settings.SurfaceAltColor, Math.Max(settings.SurfaceAltOpacity, 0.65)));
                 Set(resources, "ThemeBorderThickness", borderThickness);
                 Set(resources, "ThemeSubtleBorderThickness", subtleBorderThickness);
@@ -138,6 +144,8 @@ namespace InventoryManagementApp.Services
                 Set(resources, "ThemeControlMinHeight", settings.ControlHeight);
                 Set(resources, "ThemeDataGridRowHeight", settings.DataGridRowHeight);
                 Set(resources, "ThemeDataGridHeaderHeight", settings.DataGridHeaderHeight);
+                Set(resources, "ThemeInteractionIntensity", settings.InteractionIntensity);
+                Set(resources, "ThemeMotionIntensity", settings.MotionIntensity);
                 Set(resources, "ThemeSurfaceShadow", CreateShadow(settings));
                 Set(resources, "ThemeRaisedShadow", CreateShadow(settings, 1.55));
                 Set(resources, "ThemeDeepShadow", CreateShadow(settings, 2.35));
@@ -213,7 +221,7 @@ namespace InventoryManagementApp.Services
                 {
                     return new ImageBrush(new BitmapImage(new Uri(settings.BackgroundImagePath, UriKind.Absolute)))
                     {
-                        Stretch = Stretch.UniformToFill,
+                        Stretch = ParseStretch(settings.BackgroundImageStretch),
                         Opacity = settings.BackgroundOpacity
                     };
                 }
@@ -224,6 +232,13 @@ namespace InventoryManagementApp.Services
             }
 
             return CreateBrush(settings.BackgroundColor, settings.BackgroundOpacity);
+        }
+
+        private static Stretch ParseStretch(string? value)
+        {
+            if (Enum.TryParse(value, ignoreCase: true, out Stretch stretch))
+                return stretch;
+            return Stretch.UniformToFill;
         }
 
         private static SolidColorBrush CreateBrush(string color, double opacity)

--- a/InventoryManagementApp/ViewModels/ThemeDesignerViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ThemeDesignerViewModel.cs
@@ -35,6 +35,7 @@ namespace InventoryManagementApp.ViewModels
             _logger = logger ?? NullLogger<ThemeDesignerViewModel>.Instance;
 
             ThemeOptions = new ObservableCollection<string> { "Light", "Dark" };
+            BackgroundStretchOptions = new ObservableCollection<string> { "UniformToFill", "Uniform", "Fill", "None" };
             SaveCommand = new AsyncRelayCommand(SaveAsync);
             ResetCommand = new RelayCommand(Reset);
             BrowseBackgroundCommand = new RelayCommand(BrowseBackground);
@@ -45,6 +46,7 @@ namespace InventoryManagementApp.ViewModels
         }
 
         public ObservableCollection<string> ThemeOptions { get; }
+        public ObservableCollection<string> BackgroundStretchOptions { get; }
         public IAsyncRelayCommand SaveCommand { get; }
         public IRelayCommand ResetCommand { get; }
         public IRelayCommand BrowseBackgroundCommand { get; }
@@ -123,6 +125,12 @@ namespace InventoryManagementApp.ViewModels
         {
             get => _settings.BackgroundImagePath;
             set => SetString(value, (settings, newValue) => settings.BackgroundImagePath = newValue, nameof(BackgroundImagePath));
+        }
+
+        public string BackgroundImageStretch
+        {
+            get => _settings.BackgroundImageStretch;
+            set => SetString(value, (settings, newValue) => settings.BackgroundImageStretch = newValue, nameof(BackgroundImageStretch));
         }
 
         public double BackgroundOpacity
@@ -257,6 +265,30 @@ namespace InventoryManagementApp.ViewModels
             set => SetDouble(value, (settings, newValue) => settings.DataGridHeaderHeight = newValue, nameof(DataGridHeaderHeight));
         }
 
+        public double InteractionIntensity
+        {
+            get => _settings.InteractionIntensity;
+            set => SetDouble(value, (settings, newValue) => settings.InteractionIntensity = newValue, nameof(InteractionIntensity));
+        }
+
+        public double FocusRingOpacity
+        {
+            get => _settings.FocusRingOpacity;
+            set => SetDouble(value, (settings, newValue) => settings.FocusRingOpacity = newValue, nameof(FocusRingOpacity));
+        }
+
+        public double GridLineOpacity
+        {
+            get => _settings.GridLineOpacity;
+            set => SetDouble(value, (settings, newValue) => settings.GridLineOpacity = newValue, nameof(GridLineOpacity));
+        }
+
+        public double MotionIntensity
+        {
+            get => _settings.MotionIntensity;
+            set => SetDouble(value, (settings, newValue) => settings.MotionIntensity = newValue, nameof(MotionIntensity));
+        }
+
         public async Task InitializeAsync(CancellationToken token = default)
         {
             try
@@ -330,6 +362,11 @@ namespace InventoryManagementApp.ViewModels
             ControlHeight = 30;
             DataGridRowHeight = 34;
             DataGridHeaderHeight = 34;
+            InteractionIntensity = 1.1;
+            FocusRingOpacity = 0.48;
+            GridLineOpacity = 0.24;
+            MotionIntensity = 1.1;
+            BackgroundImageStretch = "UniformToFill";
             Status = "Glass preset previewed. Save to keep it.";
         }
 
@@ -349,6 +386,10 @@ namespace InventoryManagementApp.ViewModels
             ControlHeight = 26;
             DataGridRowHeight = 28;
             DataGridHeaderHeight = 28;
+            InteractionIntensity = 0.55;
+            FocusRingOpacity = 0.38;
+            GridLineOpacity = 0;
+            MotionIntensity = 0.75;
             Status = "Borderless preset previewed. Save to keep it.";
         }
 
@@ -370,6 +411,10 @@ namespace InventoryManagementApp.ViewModels
             _settings.DataGridHeaderHeight = 36;
             _settings.BordersVisible = true;
             _settings.BorderOpacity = 1;
+            _settings.InteractionIntensity = 1.45;
+            _settings.FocusRingOpacity = 1;
+            _settings.GridLineOpacity = 0.85;
+            _settings.MotionIntensity = 0.4;
             Preview();
             NotifyAllThemePropertiesChanged();
             Status = "High contrast preset previewed. Save to keep it.";
@@ -424,6 +469,7 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(WarningColor));
             OnPropertyChanged(nameof(ErrorColor));
             OnPropertyChanged(nameof(BackgroundImagePath));
+            OnPropertyChanged(nameof(BackgroundImageStretch));
             OnPropertyChanged(nameof(BackgroundOpacity));
             OnPropertyChanged(nameof(SurfaceOpacity));
             OnPropertyChanged(nameof(SurfaceAltOpacity));
@@ -446,6 +492,10 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(ControlHeight));
             OnPropertyChanged(nameof(DataGridRowHeight));
             OnPropertyChanged(nameof(DataGridHeaderHeight));
+            OnPropertyChanged(nameof(InteractionIntensity));
+            OnPropertyChanged(nameof(FocusRingOpacity));
+            OnPropertyChanged(nameof(GridLineOpacity));
+            OnPropertyChanged(nameof(MotionIntensity));
         }
     }
 }

--- a/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml
+++ b/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml
@@ -24,7 +24,7 @@
                 <DockPanel LastChildFill="False">
                     <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
                         <TextBlock Text="App Theme Designer" Style="{StaticResource SubheadingTextBlock}"/>
-                        <TextBlock Text="Redesign the full app shell with colors, backgrounds, transparency, borders, corners, spacing, typography, table density, and shadow depth." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        <TextBlock Text="Redesign the full app shell with colors, backgrounds, transparency, borders, corners, spacing, typography, table density, focus rings, interaction feedback, and shadow depth." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                     </StackPanel>
                     <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
                         <Button Style="{StaticResource GhostButton}" Content="Glass" Command="{Binding GlassPresetCommand}" Margin="0,0,4,0"/>
@@ -39,9 +39,9 @@
             <ScrollViewer VerticalScrollBarVisibility="Auto">
                 <Grid Margin="14" VerticalAlignment="Top">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="1.4*" MinWidth="420"/>
+                        <ColumnDefinition Width="1.35*" MinWidth="420"/>
                         <ColumnDefinition Width="12"/>
-                        <ColumnDefinition Width="1.1*" MinWidth="340"/>
+                        <ColumnDefinition Width="1.15*" MinWidth="360"/>
                     </Grid.ColumnDefinitions>
 
                     <StackPanel Grid.Column="0">
@@ -52,6 +52,7 @@
                                     <ColumnDefinition Width="*"/>
                                 </Grid.ColumnDefinitions>
                                 <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
@@ -88,7 +89,9 @@
                                 <TextBox Grid.Row="10" Grid.Column="1" Text="{Binding WarningColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
                                 <TextBlock Grid.Row="11" Text="Error" Style="{StaticResource ThemeFieldLabel}"/>
                                 <TextBox Grid.Row="11" Grid.Column="1" Text="{Binding ErrorColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
-                                <DockPanel Grid.Row="12" Grid.ColumnSpan="2" LastChildFill="True">
+                                <TextBlock Grid.Row="12" Text="Background fit" Style="{StaticResource ThemeFieldLabel}"/>
+                                <ComboBox Grid.Row="12" Grid.Column="1" SelectedItem="{Binding BackgroundImageStretch}" ItemsSource="{Binding BackgroundStretchOptions}" Margin="0,0,0,8"/>
+                                <DockPanel Grid.Row="13" Grid.ColumnSpan="2" LastChildFill="True">
                                     <Button DockPanel.Dock="Right" Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearBackgroundCommand}" Margin="6,0,0,8"/>
                                     <Button DockPanel.Dock="Right" Style="{StaticResource GhostButton}" Content="Browse" Command="{Binding BrowseBackgroundCommand}" Margin="6,0,0,8"/>
                                     <TextBox Text="{Binding BackgroundImagePath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
@@ -142,7 +145,7 @@
                                 <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,8,0,8">
                                     <StackPanel>
                                         <TextBlock Text="Inventory desk card" Style="{StaticResource SectionHeader}"/>
-                                        <TextBlock Text="Surface, text, borders, corners, padding, and shadows update as you tune the theme." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                        <TextBlock Text="Surface, text, borders, corners, padding, shadows, grid lines, and interaction feedback update as you tune the theme." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                                         <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                                             <Button Style="{StaticResource PrimaryButton}" Content="Primary" Margin="0,0,6,0"/>
                                             <Button Style="{StaticResource GhostButton}" Content="Ghost"/>
@@ -195,7 +198,7 @@
                             </Grid>
                         </Border>
 
-                        <Border Style="{StaticResource DesktopInsetCard}">
+                        <Border Style="{StaticResource DesktopInsetCard}" Margin="0,0,0,12">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="170"/>
@@ -242,6 +245,36 @@
                                 <TextBlock Grid.Row="9" Text="Grid headers" Style="{StaticResource ThemeFieldLabel}"/>
                                 <Slider Grid.Row="9" Grid.Column="1" Minimum="24" Maximum="56" Value="{Binding DataGridHeaderHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
                                 <TextBlock Grid.Row="9" Grid.Column="2" Text="{Binding DataGridHeaderHeight, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
+                            </Grid>
+                        </Border>
+
+                        <Border Style="{StaticResource DesktopInsetCard}">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="170"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="64"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <TextBlock Grid.ColumnSpan="3" Text="Interaction feel" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
+                                <TextBlock Grid.Row="1" Text="Hover/selection" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="1" Grid.Column="1" Minimum="0" Maximum="2" TickFrequency="0.1" Value="{Binding InteractionIntensity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding InteractionIntensity, StringFormat={}{0:0.0}x}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="2" Text="Focus rings" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="2" Grid.Column="1" Value="{Binding FocusRingOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="2" Grid.Column="2" Text="{Binding FocusRingOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="3" Text="Grid lines" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="3" Grid.Column="1" Value="{Binding GridLineOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="3" Grid.Column="2" Text="{Binding GridLineOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="4" Text="Motion" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="2" TickFrequency="0.1" Value="{Binding MotionIntensity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="4" Grid.Column="2" Text="{Binding MotionIntensity, StringFormat={}{0:0.0}x}" Style="{StaticResource CaptionTextBlock}"/>
                             </Grid>
                         </Border>
                     </StackPanel>


### PR DESCRIPTION
## Summary

- adds background image fit selection plus hover/selection, focus-ring, grid-line, and motion-intensity controls to the Admin Settings theme designer
- persists and normalizes the new customization knobs in `AppThemeSettings`
- applies the settings through `ThemeService` resources so saved themes affect background image stretch, hover/selected feedback, focus visuals, and grid line strength across the app
- updates shared visual hierarchy resources and contract tests for the new theme interaction tokens

## Validation

- GitHub connector compare/readback confirmed the focused branch diff
- Added/updated model, XAML, and resource contract tests for the new controls
- Local clone/raw access, `dotnet`, Windows/WPF screenshots, and local banned-word checks remain blocked in this scheduled Linux container
