### PR TITLE
[codex] expand admin theme designer customization

### DIFF
--- a/InventoryManagementApp.Tests/AppThemeSettingsTests.cs
+++ b/InventoryManagementApp.Tests/AppThemeSettingsTests.cs
@@ -1,0 +1,97 @@
+using System.Text.Json;
+using InventoryManagementApp.Models;
+using Xunit;
+
+public class AppThemeSettingsTests
+{
+    [Fact]
+    public void Normalize_ClampsExpandedTransparencyAndShadowControls()
+    {
+        var settings = new AppThemeSettings
+        {
+            BackgroundOpacity = 1.5,
+            SurfaceOpacity = -0.5,
+            HeaderOpacity = 4,
+            MenuOpacity = double.NaN,
+            FooterOpacity = -2,
+            DialogOpacity = 1.2,
+            ShadowBlurRadius = 99,
+            ShadowDepth = -4,
+            ShadowOpacity = 2,
+            ShadowDirection = 999,
+            FontScale = 3,
+            ControlHeight = 2,
+            DataGridRowHeight = 100,
+            DataGridHeaderHeight = 1,
+            InteractionIntensity = -1,
+            MotionIntensity = 9
+        };
+
+        settings.Normalize();
+
+        Assert.Equal(1, settings.BackgroundOpacity);
+        Assert.Equal(0, settings.SurfaceOpacity);
+        Assert.Equal(1, settings.HeaderOpacity);
+        Assert.Equal(0, settings.MenuOpacity);
+        Assert.Equal(0, settings.FooterOpacity);
+        Assert.Equal(1, settings.DialogOpacity);
+        Assert.Equal(48, settings.ShadowBlurRadius);
+        Assert.Equal(0, settings.ShadowDepth);
+        Assert.Equal(1, settings.ShadowOpacity);
+        Assert.Equal(360, settings.ShadowDirection);
+        Assert.Equal(1.4, settings.FontScale);
+        Assert.Equal(22, settings.ControlHeight);
+        Assert.Equal(52, settings.DataGridRowHeight);
+        Assert.Equal(24, settings.DataGridHeaderHeight);
+        Assert.Equal(0, settings.InteractionIntensity);
+        Assert.Equal(2, settings.MotionIntensity);
+    }
+
+    [Fact]
+    public void Normalize_PreservesShadowToggleChoices()
+    {
+        var settings = AppThemeSettings.CreateDefault();
+
+        settings.EnableSurfaceShadows = false;
+        settings.EnableControlShadows = true;
+        settings.Normalize();
+
+        Assert.False(settings.EnableSurfaceShadows);
+        Assert.True(settings.EnableControlShadows);
+    }
+
+    [Fact]
+    public void Normalize_AcceptsBareHexAndRejectsMalformedColors()
+    {
+        var settings = AppThemeSettings.CreateDefault();
+        settings.AccentColor = "60a5fa";
+        settings.ErrorColor = "not-a-color";
+
+        settings.Normalize();
+
+        Assert.Equal("#60A5FA", settings.AccentColor);
+        Assert.Equal("#FFDC2626", settings.ErrorColor);
+    }
+
+    [Fact]
+    public void JsonRoundTrip_PreservesExpandedThemeSettings()
+    {
+        var settings = AppThemeSettings.CreateDefault("Dark");
+        settings.HeaderOpacity = 0.42;
+        settings.MenuOpacity = 0.37;
+        settings.FooterOpacity = 0.31;
+        settings.DialogOpacity = 0.88;
+        settings.EnableSurfaceShadows = false;
+        settings.EnableControlShadows = true;
+
+        var json = JsonSerializer.Serialize(settings);
+        var roundTripped = JsonSerializer.Deserialize<AppThemeSettings>(json)!;
+
+        Assert.Equal(0.42, roundTripped.HeaderOpacity);
+        Assert.Equal(0.37, roundTripped.MenuOpacity);
+        Assert.Equal(0.31, roundTripped.FooterOpacity);
+        Assert.Equal(0.88, roundTripped.DialogOpacity);
+        Assert.False(roundTripped.EnableSurfaceShadows);
+        Assert.True(roundTripped.EnableControlShadows);
+    }
+}

--- a/InventoryManagementApp.Tests/AppThemeSettingsTests.cs
+++ b/InventoryManagementApp.Tests/AppThemeSettingsTests.cs
@@ -66,11 +66,13 @@ public class AppThemeSettingsTests
         var settings = AppThemeSettings.CreateDefault();
         settings.AccentColor = "60a5fa";
         settings.ErrorColor = "not-a-color";
+        settings.WarningColor = "#GGGGGG";
 
         settings.Normalize();
 
         Assert.Equal("#60A5FA", settings.AccentColor);
         Assert.Equal("#FFDC2626", settings.ErrorColor);
+        Assert.Equal("#FFD97706", settings.WarningColor);
     }
 
     [Fact]

--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -16,9 +16,10 @@
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0"
-                Background="{DynamicResource SurfaceBrush}"
+                Background="{DynamicResource ThemeShellHeaderBrush}"
                 BorderBrush="{DynamicResource BorderBrushBase}"
                 BorderThickness="0,0,0,1"
+                Effect="{DynamicResource ThemeSurfaceShadow}"
                 Padding="8,5">
             <Grid VerticalAlignment="Center">
                 <Grid.ColumnDefinitions>
@@ -65,9 +66,10 @@
         </Border>
 
         <Border Grid.Row="1"
-                Background="{DynamicResource SurfaceAltBrush}"
+                Background="{DynamicResource ThemeShellMenuBrush}"
                 BorderBrush="{DynamicResource BorderBrushBase}"
                 BorderThickness="0,0,0,1"
+                Effect="{DynamicResource ThemeRaisedShadow}"
                 Padding="4,3">
             <Menu Style="{StaticResource SectionMenu}">
                 <MenuItem Header="Overview" Style="{StaticResource SectionMenuItem}" PreviewMouseLeftButtonDown="SectionMenuItem_PreviewMouseLeftButtonDown">
@@ -100,9 +102,10 @@
         </Border>
 
         <Border Grid.Row="2"
-                Background="{DynamicResource SurfaceBrush}"
+                Background="{DynamicResource ThemeShellHeaderBrush}"
                 BorderBrush="{DynamicResource BorderBrushBase}"
                 BorderThickness="0,0,0,1"
+                Effect="{DynamicResource ThemeSurfaceShadow}"
                 Padding="8,6">
             <Grid>
                 <Grid.ColumnDefinitions>

--- a/InventoryManagementApp/Models/AppThemeSettings.cs
+++ b/InventoryManagementApp/Models/AppThemeSettings.cs
@@ -27,6 +27,10 @@ namespace InventoryManagementApp.Models
         public double InputOpacity { get; set; } = 1.0;
         public double ButtonOpacity { get; set; } = 1.0;
         public double NavigationOpacity { get; set; } = 1.0;
+        public double HeaderOpacity { get; set; } = 1.0;
+        public double MenuOpacity { get; set; } = 1.0;
+        public double FooterOpacity { get; set; } = 1.0;
+        public double DialogOpacity { get; set; } = 1.0;
         public bool BordersVisible { get; set; } = true;
         public double BorderOpacity { get; set; } = 1.0;
         public double CardCornerRadius { get; set; } = 6.0;
@@ -48,6 +52,8 @@ namespace InventoryManagementApp.Models
         public double GridLineOpacity { get; set; } = 0.42;
         public double MotionIntensity { get; set; } = 1.0;
         public bool UseGlassSurfaces { get; set; }
+        public bool EnableSurfaceShadows { get; set; } = true;
+        public bool EnableControlShadows { get; set; }
 
         public static AppThemeSettings CreateDefault(string? baseTheme = null)
         {
@@ -103,6 +109,10 @@ namespace InventoryManagementApp.Models
             InputOpacity = Clamp01(InputOpacity);
             ButtonOpacity = Clamp01(ButtonOpacity);
             NavigationOpacity = Clamp01(NavigationOpacity);
+            HeaderOpacity = Clamp01(HeaderOpacity);
+            MenuOpacity = Clamp01(MenuOpacity);
+            FooterOpacity = Clamp01(FooterOpacity);
+            DialogOpacity = Clamp01(DialogOpacity);
             BorderOpacity = Clamp01(BorderOpacity);
             CardCornerRadius = Clamp(CardCornerRadius, 0, 32);
             PanelCornerRadius = Clamp(PanelCornerRadius, 0, 32);

--- a/InventoryManagementApp/Models/AppThemeSettings.cs
+++ b/InventoryManagementApp/Models/AppThemeSettings.cs
@@ -166,7 +166,16 @@ namespace InventoryManagementApp.Models
             if (!trimmed.StartsWith("#", StringComparison.Ordinal))
                 trimmed = "#" + trimmed;
 
-            return trimmed.Length is 7 or 9 ? trimmed.ToUpperInvariant() : fallback;
+            if (trimmed.Length is not (7 or 9))
+                return fallback;
+
+            for (var i = 1; i < trimmed.Length; i++)
+            {
+                if (!Uri.IsHexDigit(trimmed[i]))
+                    return fallback;
+            }
+
+            return trimmed.ToUpperInvariant();
         }
     }
 }

--- a/InventoryManagementApp/Resources/PolishedVisualHierarchy.xaml
+++ b/InventoryManagementApp/Resources/PolishedVisualHierarchy.xaml
@@ -21,17 +21,19 @@
         <Setter Property="CornerRadius" Value="{DynamicResource ThemeCardCornerRadius}"/>
         <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
         <Setter Property="Margin" Value="0"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
     </Style>
 
     <Style x:Key="ToolbarCard" TargetType="Border">
-        <Setter Property="Background" Value="{DynamicResource NavigationSurfaceBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
         <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
         <Setter Property="CornerRadius" Value="{DynamicResource ThemePanelCornerRadius}"/>
         <Setter Property="Padding" Value="10,8"/>
         <Setter Property="Margin" Value="0,0,0,6"/>
         <Setter Property="MinHeight" Value="38"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
     </Style>
 
@@ -48,6 +50,7 @@
         <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
         <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
         <Setter Property="Padding" Value="10,3"/>
     </Style>
 
@@ -62,6 +65,7 @@
         <Setter Property="VerticalAlignment" Value="Center"/>
         <Setter Property="HorizontalContentAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
         <Setter Property="Padding" Value="9,3"/>
     </Style>
 
@@ -86,6 +90,7 @@
         <Setter Property="AutoGenerateColumns" Value="False"/>
         <Setter Property="AlternationCount" Value="2"/>
         <Setter Property="SelectionUnit" Value="FullRow"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
         <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
     </Style>
 
@@ -107,7 +112,7 @@
     </Style>
 
     <Style TargetType="DataGridColumnHeader">
-        <Setter Property="Background" Value="{DynamicResource NavigationSurfaceBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
@@ -126,6 +131,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
         <Setter Property="BorderThickness" Value="1,1,1,2"/>
         <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
         <Setter Property="MinHeight" Value="72"/>
     </Style>
 
@@ -133,40 +139,45 @@
         <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushBase}"/>
         <Setter Property="Background" Value="{DynamicResource GlassSurfaceBrush}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
     </Style>
 
     <Style x:Key="DesktopPaneHeader" TargetType="Border">
-        <Setter Property="Background" Value="{DynamicResource NavigationSurfaceBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource ThemeShellHeaderBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
         <Setter Property="BorderThickness" Value="0,0,0,2"/>
         <Setter Property="CornerRadius" Value="{DynamicResource ThemePanelCornerRadius}"/>
         <Setter Property="Padding" Value="10,7"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
         <Setter Property="MinHeight" Value="42"/>
     </Style>
 
     <Style x:Key="DesktopPaneSubheader" TargetType="Border">
-        <Setter Property="Background" Value="{DynamicResource NavigationSurfaceBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
         <Setter Property="BorderThickness" Value="0,0,0,1"/>
         <Setter Property="CornerRadius" Value="{DynamicResource ThemePanelCornerRadius}"/>
         <Setter Property="Padding" Value="10,7"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
         <Setter Property="MinHeight" Value="36"/>
     </Style>
 
     <Style x:Key="DesktopSectionActionStrip" TargetType="Border">
-        <Setter Property="Background" Value="{DynamicResource NavigationSurfaceBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
         <Setter Property="BorderThickness" Value="0,1,0,2"/>
         <Setter Property="Padding" Value="10,7"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
         <Setter Property="MinHeight" Value="42"/>
     </Style>
 
     <Style x:Key="DesktopStatusFooter" TargetType="Border">
-        <Setter Property="Background" Value="{DynamicResource GlassSurfaceAltBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource ThemeShellFooterBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
         <Setter Property="BorderThickness" Value="1,0,1,1"/>
         <Setter Property="CornerRadius" Value="{DynamicResource ThemeFooterCornerRadius}"/>
         <Setter Property="Padding" Value="10,5"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
         <Setter Property="MinHeight" Value="34"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
     </Style>
@@ -177,6 +188,7 @@
         <Setter Property="BorderThickness" Value="1,1,1,2"/>
         <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
         <Setter Property="Margin" Value="0,0,0,8"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
     </Style>
 
     <Style x:Key="DesktopNoteCard" TargetType="Border" BasedOn="{StaticResource DesktopInsetCard}">
@@ -190,5 +202,6 @@
         <Setter Property="Margin" Value="0,0,0,8"/>
         <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
         <Setter Property="BorderThickness" Value="1,1,1,2"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
     </Style>
 </ResourceDictionary>

--- a/InventoryManagementApp/Resources/Theme.Customization.xaml
+++ b/InventoryManagementApp/Resources/Theme.Customization.xaml
@@ -37,12 +37,22 @@
     <SolidColorBrush x:Key="ThemeGlassSurfaceBrush" Color="#DFFFFFFF"/>
     <SolidColorBrush x:Key="ThemeGlassSurfaceAltBrush" Color="#BFFFFFFF"/>
     <SolidColorBrush x:Key="ThemeAppBackgroundOverlayBrush" Color="#00FFFFFF"/>
+    <SolidColorBrush x:Key="ThemeShellHeaderBrush" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="ThemeShellMenuBrush" Color="#FFE8EDF3"/>
+    <SolidColorBrush x:Key="ThemeShellFooterBrush" Color="#BFFFFFFF"/>
+    <SolidColorBrush x:Key="ThemeDialogSurfaceBrush" Color="#FFFFFFFF"/>
     <SolidColorBrush x:Key="NavigationSurfaceBrush" Color="#FFE8EDF3"/>
     <SolidColorBrush x:Key="NavigationAltSurfaceBrush" Color="#FFFFFFFF"/>
     <SolidColorBrush x:Key="ThemeGridLineBrush" Color="#6B94A3B8"/>
     <SolidColorBrush x:Key="ThemeShadowColorBrush" Color="#66000000"/>
 
     <DropShadowEffect x:Key="ThemeNoShadow"
+                      BlurRadius="0"
+                      ShadowDepth="0"
+                      Opacity="0"
+                      Color="#00000000"/>
+
+    <DropShadowEffect x:Key="ThemeControlShadow"
                       BlurRadius="0"
                       ShadowDepth="0"
                       Opacity="0"

--- a/InventoryManagementApp/Services/ThemeService.cs
+++ b/InventoryManagementApp/Services/ThemeService.cs
@@ -76,11 +76,14 @@ namespace InventoryManagementApp.Services
                 var borderThickness = settings.BordersVisible ? new Thickness(1) : new Thickness(0);
                 var subtleBorderThickness = settings.BordersVisible ? new Thickness(0, 0, 0, 1) : new Thickness(0);
                 var borderBrush = CreateBrush(settings.BorderColor, settings.BorderOpacity * 0.55);
-                var surfaceBrush = CreateBrush(settings.SurfaceColor, settings.UseGlassSurfaces ? Math.Min(settings.SurfaceOpacity, 0.72) : settings.SurfaceOpacity);
-                var surfaceAltBrush = CreateBrush(settings.SurfaceAltColor, settings.UseGlassSurfaces ? Math.Min(settings.SurfaceAltOpacity, 0.62) : settings.SurfaceAltOpacity);
+                var surfaceOpacity = settings.UseGlassSurfaces ? Math.Min(settings.SurfaceOpacity, 0.72) : settings.SurfaceOpacity;
+                var surfaceAltOpacity = settings.UseGlassSurfaces ? Math.Min(settings.SurfaceAltOpacity, 0.62) : settings.SurfaceAltOpacity;
+                var navigationOpacity = settings.UseGlassSurfaces ? Math.Min(settings.NavigationOpacity, 0.74) : settings.NavigationOpacity;
+                var surfaceBrush = CreateBrush(settings.SurfaceColor, surfaceOpacity);
+                var surfaceAltBrush = CreateBrush(settings.SurfaceAltColor, surfaceAltOpacity);
                 var inputBrush = CreateBrush(settings.InputColor, settings.InputOpacity);
                 var buttonBrush = CreateBrush(settings.ButtonColor, settings.ButtonOpacity);
-                var navigationBrush = CreateBrush(settings.NavigationColor, settings.UseGlassSurfaces ? Math.Min(settings.NavigationOpacity, 0.74) : settings.NavigationOpacity);
+                var navigationBrush = CreateBrush(settings.NavigationColor, navigationOpacity);
                 var hoverOpacity = Math.Clamp(0.08 + (settings.InteractionIntensity * 0.08), 0, 0.28);
                 var selectedOpacity = Math.Clamp(0.14 + (settings.InteractionIntensity * 0.13), 0, 0.42);
                 var pressedOpacity = Math.Clamp(0.18 + (settings.InteractionIntensity * 0.12), 0, 0.48);
@@ -93,7 +96,11 @@ namespace InventoryManagementApp.Services
                 Set(resources, "SurfaceBrush", surfaceBrush);
                 Set(resources, "SurfaceAltBrush", surfaceAltBrush);
                 Set(resources, "NavigationSurfaceBrush", navigationBrush);
-                Set(resources, "NavigationAltSurfaceBrush", CreateBrush(settings.NavigationColor, Math.Min(1, settings.NavigationOpacity * 0.9)));
+                Set(resources, "NavigationAltSurfaceBrush", CreateBrush(settings.NavigationColor, Math.Min(1, navigationOpacity * 0.9)));
+                Set(resources, "ThemeShellHeaderBrush", CreateBrush(settings.SurfaceColor, Math.Min(surfaceOpacity, settings.HeaderOpacity)));
+                Set(resources, "ThemeShellMenuBrush", CreateBrush(settings.NavigationColor, Math.Min(navigationOpacity, settings.MenuOpacity)));
+                Set(resources, "ThemeShellFooterBrush", CreateBrush(settings.SurfaceAltColor, Math.Min(surfaceAltOpacity, settings.FooterOpacity)));
+                Set(resources, "ThemeDialogSurfaceBrush", CreateBrush(settings.SurfaceColor, Math.Min(surfaceOpacity, settings.DialogOpacity)));
                 Set(resources, "GlassSurfaceBrush", CreateBrush(settings.SurfaceColor, Math.Min(settings.SurfaceOpacity, 0.78)));
                 Set(resources, "GlassSurfaceAltBrush", CreateBrush(settings.SurfaceAltColor, Math.Min(settings.SurfaceAltOpacity, 0.68)));
                 Set(resources, "TransparentSurfaceBrush", Brushes.Transparent);
@@ -150,11 +157,12 @@ namespace InventoryManagementApp.Services
                 Set(resources, "ThemeMotionIntensity", settings.MotionIntensity);
                 Set(resources, "ThemeShadowDirection", settings.ShadowDirection);
                 Set(resources, "ThemeShadowColorBrush", CreateBrush(settings.ShadowColor, settings.ShadowOpacity));
-                Set(resources, "ThemeSurfaceShadow", CreateShadow(settings));
-                Set(resources, "ThemeRaisedShadow", CreateShadow(settings, 1.55));
-                Set(resources, "ThemeDeepShadow", CreateShadow(settings, 2.35));
-                Set(resources, "SubtleSurfaceShadow", CreateShadow(settings));
-                Set(resources, "RaisedSurfaceShadow", CreateShadow(settings, 1.55));
+                Set(resources, "ThemeSurfaceShadow", settings.EnableSurfaceShadows ? CreateShadow(settings) : CreateNoShadow());
+                Set(resources, "ThemeRaisedShadow", settings.EnableSurfaceShadows ? CreateShadow(settings, 1.55) : CreateNoShadow());
+                Set(resources, "ThemeDeepShadow", settings.EnableSurfaceShadows ? CreateShadow(settings, 2.35) : CreateNoShadow());
+                Set(resources, "ThemeControlShadow", settings.EnableControlShadows ? CreateShadow(settings, 0.45) : CreateNoShadow());
+                Set(resources, "SubtleSurfaceShadow", settings.EnableSurfaceShadows ? CreateShadow(settings) : CreateNoShadow());
+                Set(resources, "RaisedSurfaceShadow", settings.EnableSurfaceShadows ? CreateShadow(settings, 1.55) : CreateNoShadow());
 
                 RefreshWindows(app);
             }
@@ -271,6 +279,22 @@ namespace InventoryManagementApp.Services
                 Direction = settings.ShadowDirection,
                 Opacity = Math.Clamp(settings.ShadowOpacity * multiplier, 0, 1),
                 Color = ParseColor(settings.ShadowColor)
+            };
+
+            if (effect.CanFreeze)
+                effect.Freeze();
+
+            return effect;
+        }
+
+        private static DropShadowEffect CreateNoShadow()
+        {
+            var effect = new DropShadowEffect
+            {
+                BlurRadius = 0,
+                ShadowDepth = 0,
+                Opacity = 0,
+                Color = Colors.Transparent
             };
 
             if (effect.CanFreeze)

--- a/InventoryManagementApp/ViewModels/ThemeDesignerViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ThemeDesignerViewModel.cs
@@ -199,6 +199,30 @@ namespace InventoryManagementApp.ViewModels
             set => SetDouble(value, (settings, newValue) => settings.NavigationOpacity = newValue, nameof(NavigationOpacity));
         }
 
+        public double HeaderOpacity
+        {
+            get => _settings.HeaderOpacity;
+            set => SetDouble(value, (settings, newValue) => settings.HeaderOpacity = newValue, nameof(HeaderOpacity));
+        }
+
+        public double MenuOpacity
+        {
+            get => _settings.MenuOpacity;
+            set => SetDouble(value, (settings, newValue) => settings.MenuOpacity = newValue, nameof(MenuOpacity));
+        }
+
+        public double FooterOpacity
+        {
+            get => _settings.FooterOpacity;
+            set => SetDouble(value, (settings, newValue) => settings.FooterOpacity = newValue, nameof(FooterOpacity));
+        }
+
+        public double DialogOpacity
+        {
+            get => _settings.DialogOpacity;
+            set => SetDouble(value, (settings, newValue) => settings.DialogOpacity = newValue, nameof(DialogOpacity));
+        }
+
         public bool BordersVisible
         {
             get => _settings.BordersVisible;
@@ -209,6 +233,18 @@ namespace InventoryManagementApp.ViewModels
         {
             get => _settings.UseGlassSurfaces;
             set => SetBool(value, (settings, newValue) => settings.UseGlassSurfaces = newValue, nameof(UseGlassSurfaces));
+        }
+
+        public bool EnableSurfaceShadows
+        {
+            get => _settings.EnableSurfaceShadows;
+            set => SetBool(value, (settings, newValue) => settings.EnableSurfaceShadows = newValue, nameof(EnableSurfaceShadows));
+        }
+
+        public bool EnableControlShadows
+        {
+            get => _settings.EnableControlShadows;
+            set => SetBool(value, (settings, newValue) => settings.EnableControlShadows = newValue, nameof(EnableControlShadows));
         }
 
         public double BorderOpacity
@@ -385,6 +421,10 @@ namespace InventoryManagementApp.ViewModels
             InputOpacity = 0.72;
             ButtonOpacity = 0.72;
             NavigationOpacity = 0.76;
+            HeaderOpacity = 0.68;
+            MenuOpacity = 0.62;
+            FooterOpacity = 0.58;
+            DialogOpacity = 0.82;
             NavigationColor = SurfaceAltColor;
             InputColor = SurfaceColor;
             ButtonColor = SurfaceAltColor;
@@ -392,6 +432,8 @@ namespace InventoryManagementApp.ViewModels
             ShadowColor = "#88000000";
             BordersVisible = true;
             BorderOpacity = 0.42;
+            EnableSurfaceShadows = true;
+            EnableControlShadows = true;
             CardCornerRadius = 14;
             PanelCornerRadius = 12;
             ButtonCornerRadius = 12;
@@ -425,6 +467,12 @@ namespace InventoryManagementApp.ViewModels
             ShadowDepth = 0;
             ShadowOpacity = 0;
             ShadowDirection = 270;
+            HeaderOpacity = 0.96;
+            MenuOpacity = 0.92;
+            FooterOpacity = 0.9;
+            DialogOpacity = 0.98;
+            EnableSurfaceShadows = false;
+            EnableControlShadows = false;
             NavigationOpacity = 0.92;
             NavigationColor = SurfaceColor;
             InputColor = SurfaceColor;
@@ -459,11 +507,17 @@ namespace InventoryManagementApp.ViewModels
             _settings.ErrorColor = "#FFFF4D4D";
             _settings.ShadowColor = "#FFFFFFFF";
             _settings.NavigationOpacity = 1;
+            _settings.HeaderOpacity = 1;
+            _settings.MenuOpacity = 1;
+            _settings.FooterOpacity = 1;
+            _settings.DialogOpacity = 1;
             _settings.ControlHeight = 32;
             _settings.DataGridRowHeight = 36;
             _settings.DataGridHeaderHeight = 36;
             _settings.BordersVisible = true;
             _settings.BorderOpacity = 1;
+            _settings.EnableSurfaceShadows = false;
+            _settings.EnableControlShadows = false;
             _settings.ShadowDirection = 270;
             _settings.InteractionIntensity = 1.45;
             _settings.FocusRingOpacity = 1;
@@ -535,8 +589,14 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(InputOpacity));
             OnPropertyChanged(nameof(ButtonOpacity));
             OnPropertyChanged(nameof(NavigationOpacity));
+            OnPropertyChanged(nameof(HeaderOpacity));
+            OnPropertyChanged(nameof(MenuOpacity));
+            OnPropertyChanged(nameof(FooterOpacity));
+            OnPropertyChanged(nameof(DialogOpacity));
             OnPropertyChanged(nameof(BordersVisible));
             OnPropertyChanged(nameof(UseGlassSurfaces));
+            OnPropertyChanged(nameof(EnableSurfaceShadows));
+            OnPropertyChanged(nameof(EnableControlShadows));
             OnPropertyChanged(nameof(BorderOpacity));
             OnPropertyChanged(nameof(CardCornerRadius));
             OnPropertyChanged(nameof(PanelCornerRadius));

--- a/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml
+++ b/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml
@@ -129,6 +129,10 @@
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
                                 <TextBlock Grid.ColumnSpan="3" Text="Transparency" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
                                 <TextBlock Grid.Row="1" Text="Background" Style="{StaticResource ThemeFieldLabel}"/>
@@ -149,6 +153,18 @@
                                 <TextBlock Grid.Row="6" Text="Navigation bars" Style="{StaticResource ThemeFieldLabel}"/>
                                 <Slider Grid.Row="6" Grid.Column="1" Value="{Binding NavigationOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
                                 <TextBlock Grid.Row="6" Grid.Column="2" Text="{Binding NavigationOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="7" Text="Header shell" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="7" Grid.Column="1" Value="{Binding HeaderOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="7" Grid.Column="2" Text="{Binding HeaderOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="8" Text="Menu shell" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="8" Grid.Column="1" Value="{Binding MenuOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="8" Grid.Column="2" Text="{Binding MenuOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="9" Text="Footer shell" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="9" Grid.Column="1" Value="{Binding FooterOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="9" Grid.Column="2" Text="{Binding FooterOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="10" Text="Dialogs" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="10" Grid.Column="1" Value="{Binding DialogOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="10" Grid.Column="2" Text="{Binding DialogOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
                             </Grid>
                         </Border>
                     </StackPanel>
@@ -232,38 +248,44 @@
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
                                 <TextBlock Grid.ColumnSpan="3" Text="Depth, spacing, and density" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
-                                <TextBlock Grid.Row="1" Text="Shadow blur" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="1" Grid.Column="1" Minimum="0" Maximum="48" Value="{Binding ShadowBlurRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding ShadowBlurRadius, StringFormat={}{0:0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="2" Text="Shadow depth" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="2" Grid.Column="1" Minimum="0" Maximum="16" Value="{Binding ShadowDepth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="2" Grid.Column="2" Text="{Binding ShadowDepth, StringFormat={}{0:0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="3" Text="Shadow opacity" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="3" Grid.Column="1" Value="{Binding ShadowOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="3" Grid.Column="2" Text="{Binding ShadowOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="4" Text="Shadow direction" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="360" TickFrequency="15" Value="{Binding ShadowDirection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="4" Grid.Column="2" Text="{Binding ShadowDirection, StringFormat={}{0:0} deg}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="5" Text="Page padding" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="5" Grid.Column="1" Minimum="0" Maximum="28" Value="{Binding PagePadding, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="5" Grid.Column="2" Text="{Binding PagePadding, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="6" Text="Card padding" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="6" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding CardPadding, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="6" Grid.Column="2" Text="{Binding CardPadding, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="7" Text="Font scale" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="7" Grid.Column="1" Minimum="0.75" Maximum="1.4" TickFrequency="0.05" Value="{Binding FontScale, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="7" Grid.Column="2" Text="{Binding FontScale, StringFormat={}{0:0.00}x}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="8" Text="Control height" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="8" Grid.Column="1" Minimum="22" Maximum="44" Value="{Binding ControlHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="8" Grid.Column="2" Text="{Binding ControlHeight, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="9" Text="Grid rows" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="9" Grid.Column="1" Minimum="22" Maximum="52" Value="{Binding DataGridRowHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="9" Grid.Column="2" Text="{Binding DataGridRowHeight, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="10" Text="Grid headers" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="10" Grid.Column="1" Minimum="24" Maximum="56" Value="{Binding DataGridHeaderHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="10" Grid.Column="2" Text="{Binding DataGridHeaderHeight, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="1" Text="Surface shadows" Style="{StaticResource ThemeFieldLabel}"/>
+                                <CheckBox Grid.Row="1" Grid.Column="1" IsChecked="{Binding EnableSurfaceShadows}" Margin="0,0,0,8"/>
+                                <TextBlock Grid.Row="2" Text="Control shadows" Style="{StaticResource ThemeFieldLabel}"/>
+                                <CheckBox Grid.Row="2" Grid.Column="1" IsChecked="{Binding EnableControlShadows}" Margin="0,0,0,8"/>
+                                <TextBlock Grid.Row="3" Text="Shadow blur" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="3" Grid.Column="1" Minimum="0" Maximum="48" Value="{Binding ShadowBlurRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="3" Grid.Column="2" Text="{Binding ShadowBlurRadius, StringFormat={}{0:0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="4" Text="Shadow depth" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="16" Value="{Binding ShadowDepth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="4" Grid.Column="2" Text="{Binding ShadowDepth, StringFormat={}{0:0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="5" Text="Shadow opacity" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="5" Grid.Column="1" Value="{Binding ShadowOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="5" Grid.Column="2" Text="{Binding ShadowOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="6" Text="Shadow direction" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="6" Grid.Column="1" Minimum="0" Maximum="360" TickFrequency="15" Value="{Binding ShadowDirection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="6" Grid.Column="2" Text="{Binding ShadowDirection, StringFormat={}{0:0} deg}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="7" Text="Page padding" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="7" Grid.Column="1" Minimum="0" Maximum="28" Value="{Binding PagePadding, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="7" Grid.Column="2" Text="{Binding PagePadding, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="8" Text="Card padding" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="8" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding CardPadding, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="8" Grid.Column="2" Text="{Binding CardPadding, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="9" Text="Font scale" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="9" Grid.Column="1" Minimum="0.75" Maximum="1.4" TickFrequency="0.05" Value="{Binding FontScale, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="9" Grid.Column="2" Text="{Binding FontScale, StringFormat={}{0:0.00}x}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="10" Text="Control height" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="10" Grid.Column="1" Minimum="22" Maximum="44" Value="{Binding ControlHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="10" Grid.Column="2" Text="{Binding ControlHeight, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="11" Text="Grid rows" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="11" Grid.Column="1" Minimum="22" Maximum="52" Value="{Binding DataGridRowHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="11" Grid.Column="2" Text="{Binding DataGridRowHeight, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
+                                <TextBlock Grid.Row="12" Text="Grid headers" Style="{StaticResource ThemeFieldLabel}"/>
+                                <Slider Grid.Row="12" Grid.Column="1" Minimum="24" Maximum="56" Value="{Binding DataGridHeaderHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
+                                <TextBlock Grid.Row="12" Grid.Column="2" Text="{Binding DataGridHeaderHeight, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
                             </Grid>
                         </Border>
 


### PR DESCRIPTION
## Summary
- expands the admin Settings theme designer with shell/header/menu/footer/dialog transparency controls and shadow toggles
- applies the theme shadow and shell resources across the main window, cards, toolbars, buttons, grids, headers, and footer styles
- hardens custom color normalization and adds unit coverage for the expanded theme settings model

## Validation
- Not run: this scheduled Linux container does not have the .NET SDK or Windows WPF runtime, and local clone/raw access is blocked by the network tunnel.