### PR TITLE
[codex] expand theme typography and overlay controls

### DIFF
--- a/InventoryManagementApp.Tests/Models/AppThemeSettingsTests.cs
+++ b/InventoryManagementApp.Tests/Models/AppThemeSettingsTests.cs
@@ -17,6 +17,7 @@ namespace InventoryManagementApp.Tests.Models
             {
                 BaseTheme = "Unexpected",
                 BackgroundColor = "123456",
+                BackgroundOverlayColor = "#GGGGGG",
                 SurfaceColor = "bad",
                 NavigationColor = "445566",
                 InputColor = "not-a-color",
@@ -24,8 +25,11 @@ namespace InventoryManagementApp.Tests.Models
                 BorderColor = "abcdef",
                 ShadowColor = "112233",
                 BackgroundImageStretch = "Tile",
+                FontFamily = "  Aptos  ",
                 BackgroundOpacity = 2,
+                BackgroundOverlayOpacity = 3,
                 SurfaceOpacity = -1,
+                DisabledOpacity = 0,
                 ButtonCornerRadius = 99,
                 ShadowDepth = -5,
                 ShadowOpacity = 5,
@@ -33,6 +37,7 @@ namespace InventoryManagementApp.Tests.Models
                 PagePadding = 100,
                 NavigationOpacity = 4,
                 FontScale = 3,
+                HeadingFontScale = 4,
                 ControlHeight = 99,
                 DataGridRowHeight = 2,
                 DataGridHeaderHeight = 99,
@@ -46,6 +51,7 @@ namespace InventoryManagementApp.Tests.Models
 
             Assert.Equal("Light", settings.BaseTheme);
             Assert.Equal("#123456", settings.BackgroundColor);
+            Assert.Equal(AppThemeSettings.CreateDefault("Light").BackgroundOverlayColor, settings.BackgroundOverlayColor);
             Assert.Equal(AppThemeSettings.CreateDefault("Light").SurfaceColor, settings.SurfaceColor);
             Assert.Equal("#445566", settings.NavigationColor);
             Assert.Equal(AppThemeSettings.CreateDefault("Light").InputColor, settings.InputColor);
@@ -53,8 +59,11 @@ namespace InventoryManagementApp.Tests.Models
             Assert.Equal("#ABCDEF", settings.BorderColor);
             Assert.Equal("#112233", settings.ShadowColor);
             Assert.Equal("UniformToFill", settings.BackgroundImageStretch);
+            Assert.Equal("Aptos", settings.FontFamily);
             Assert.Equal(1, settings.BackgroundOpacity);
+            Assert.Equal(1, settings.BackgroundOverlayOpacity);
             Assert.Equal(0, settings.SurfaceOpacity);
+            Assert.Equal(0.15, settings.DisabledOpacity);
             Assert.Equal(32, settings.ButtonCornerRadius);
             Assert.Equal(0, settings.ShadowDepth);
             Assert.Equal(1, settings.ShadowOpacity);
@@ -62,6 +71,7 @@ namespace InventoryManagementApp.Tests.Models
             Assert.Equal(28, settings.PagePadding);
             Assert.Equal(1, settings.NavigationOpacity);
             Assert.Equal(1.4, settings.FontScale);
+            Assert.Equal(1.6, settings.HeadingFontScale);
             Assert.Equal(44, settings.ControlHeight);
             Assert.Equal(22, settings.DataGridRowHeight);
             Assert.Equal(56, settings.DataGridHeaderHeight);
@@ -78,6 +88,7 @@ namespace InventoryManagementApp.Tests.Models
 
             Assert.Equal("Dark", settings.BaseTheme);
             Assert.Equal("#FF101418", settings.BackgroundColor);
+            Assert.Equal("#CC101418", settings.BackgroundOverlayColor);
             Assert.Equal("#FF252D36", settings.NavigationColor);
             Assert.Equal("#FF1B222A", settings.InputColor);
             Assert.Equal("#FF252D36", settings.ButtonColor);
@@ -103,14 +114,19 @@ namespace InventoryManagementApp.Tests.Models
         {
             ISettingsService service = new FakeSettingsService();
             var settings = AppThemeSettings.CreateDefault("Dark");
+            settings.BackgroundOverlayColor = "#AA223344";
+            settings.BackgroundOverlayOpacity = 0.28;
             settings.NavigationColor = "#FF111111";
             settings.InputColor = "#FF222222";
             settings.ButtonColor = "#FF333333";
             settings.BorderColor = "#FF444444";
             settings.ShadowColor = "#AA000000";
+            settings.FontFamily = "Aptos";
             settings.ButtonCornerRadius = 18;
             settings.BordersVisible = false;
+            settings.DisabledOpacity = 0.34;
             settings.FontScale = 1.15;
+            settings.HeadingFontScale = 1.2;
             settings.DataGridRowHeight = 38;
             settings.BackgroundImageStretch = "Uniform";
             settings.InteractionIntensity = 1.6;
@@ -123,14 +139,19 @@ namespace InventoryManagementApp.Tests.Models
             var loaded = await service.GetAppThemeSettingsAsync();
 
             Assert.Equal("Dark", loaded.BaseTheme);
+            Assert.Equal("#AA223344", loaded.BackgroundOverlayColor);
+            Assert.Equal(0.28, loaded.BackgroundOverlayOpacity);
             Assert.Equal("#FF111111", loaded.NavigationColor);
             Assert.Equal("#FF222222", loaded.InputColor);
             Assert.Equal("#FF333333", loaded.ButtonColor);
             Assert.Equal("#FF444444", loaded.BorderColor);
             Assert.Equal("#AA000000", loaded.ShadowColor);
+            Assert.Equal("Aptos", loaded.FontFamily);
             Assert.Equal(18, loaded.ButtonCornerRadius);
             Assert.False(loaded.BordersVisible);
+            Assert.Equal(0.34, loaded.DisabledOpacity);
             Assert.Equal(1.15, loaded.FontScale);
+            Assert.Equal(1.2, loaded.HeadingFontScale);
             Assert.Equal(38, loaded.DataGridRowHeight);
             Assert.Equal("Uniform", loaded.BackgroundImageStretch);
             Assert.Equal(1.6, loaded.InteractionIntensity);

--- a/InventoryManagementApp.Tests/ViewModels/PolishedVisualHierarchyResourceTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/PolishedVisualHierarchyResourceTests.cs
@@ -68,6 +68,23 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("VerticalGridLinesBrush\" Value=\"{DynamicResource ThemeGridLineBrush}\"", hierarchy, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void ThemeResources_DefineAdminControlledTypographyAndOverlayTokens()
+        {
+            var customization = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.Customization.xaml");
+            var hierarchy = ReadRepositoryFile("InventoryManagementApp", "Resources", "PolishedVisualHierarchy.xaml");
+            var mainWindow = ReadRepositoryFile("InventoryManagementApp", "MainWindow.xaml");
+
+            Assert.Contains("ThemeFontFamily", customization, StringComparison.Ordinal);
+            Assert.Contains("ThemeHeadingFontScale", customization, StringComparison.Ordinal);
+            Assert.Contains("ThemeDisabledOpacity", customization, StringComparison.Ordinal);
+            Assert.Contains("ThemeAppBackgroundOverlayBrush", customization, StringComparison.Ordinal);
+            Assert.Contains("FontFamily\" Value=\"{DynamicResource ThemeFontFamily}\"", hierarchy, StringComparison.Ordinal);
+            Assert.Contains("ThemeDisabledOpacity", hierarchy, StringComparison.Ordinal);
+            Assert.Contains("FontFamily=\"{DynamicResource ThemeFontFamily}\"", mainWindow, StringComparison.Ordinal);
+            Assert.Contains("Background=\"{DynamicResource ThemeAppBackgroundOverlayBrush}\"", mainWindow, StringComparison.Ordinal);
+        }
+
         static string ReadRepositoryFile(params string[] relativePathParts)
         {
             var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/InventoryManagementApp.Tests/ViewModels/SettingsPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/SettingsPageXamlTests.cs
@@ -59,6 +59,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ThemeDesignerControl.xaml");
 
             Assert.Contains("ItemsSource=\"{Binding ThemeOptions}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("BackgroundOverlayColor", xaml, StringComparison.Ordinal);
             Assert.Contains("SuccessColor", xaml, StringComparison.Ordinal);
             Assert.Contains("WarningColor", xaml, StringComparison.Ordinal);
             Assert.Contains("ErrorColor", xaml, StringComparison.Ordinal);
@@ -67,7 +68,9 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("ButtonColor", xaml, StringComparison.Ordinal);
             Assert.Contains("BorderColor", xaml, StringComparison.Ordinal);
             Assert.Contains("ShadowColor", xaml, StringComparison.Ordinal);
+            Assert.Contains("FontFamily", xaml, StringComparison.Ordinal);
             Assert.Contains("SurfaceAltOpacity", xaml, StringComparison.Ordinal);
+            Assert.Contains("BackgroundOverlayOpacity", xaml, StringComparison.Ordinal);
             Assert.Contains("NavigationOpacity", xaml, StringComparison.Ordinal);
             Assert.Contains("PanelCornerRadius", xaml, StringComparison.Ordinal);
             Assert.Contains("BackgroundImagePath", xaml, StringComparison.Ordinal);
@@ -80,6 +83,8 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("PagePadding", xaml, StringComparison.Ordinal);
             Assert.Contains("CardPadding", xaml, StringComparison.Ordinal);
             Assert.Contains("FontScale", xaml, StringComparison.Ordinal);
+            Assert.Contains("HeadingFontScale", xaml, StringComparison.Ordinal);
+            Assert.Contains("DisabledOpacity", xaml, StringComparison.Ordinal);
             Assert.Contains("ControlHeight", xaml, StringComparison.Ordinal);
             Assert.Contains("DataGridRowHeight", xaml, StringComparison.Ordinal);
             Assert.Contains("DataGridHeaderHeight", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp/MainWindow.xaml
+++ b/InventoryManagementApp/MainWindow.xaml
@@ -5,7 +5,8 @@
         xmlns:controls="clr-namespace:InventoryManagementApp.Controls"
         xmlns:pages="clr-namespace:InventoryManagementApp.Views.Pages"
         Title="{Binding WindowTitle}" Width="1280" Height="800" MinWidth="1040" MinHeight="620" WindowStartupLocation="CenterScreen"
-        Background="{DynamicResource BackgroundBrush}">
+        Background="{DynamicResource BackgroundBrush}"
+        FontFamily="{DynamicResource ThemeFontFamily}">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -14,6 +15,10 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
+
+        <Border Grid.RowSpan="5"
+                Background="{DynamicResource ThemeAppBackgroundOverlayBrush}"
+                IsHitTestVisible="False"/>
 
         <Border Grid.Row="0"
                 Background="{DynamicResource ThemeShellHeaderBrush}"

--- a/InventoryManagementApp/Models/AppThemeSettings.cs
+++ b/InventoryManagementApp/Models/AppThemeSettings.cs
@@ -6,6 +6,7 @@ namespace InventoryManagementApp.Models
     {
         public string BaseTheme { get; set; } = "Light";
         public string BackgroundColor { get; set; } = "#F4F6F8";
+        public string BackgroundOverlayColor { get; set; } = "#00FFFFFF";
         public string SurfaceColor { get; set; } = "#FFFFFFFF";
         public string SurfaceAltColor { get; set; } = "#FFE8EDF3";
         public string NavigationColor { get; set; } = "#FFE8EDF3";
@@ -21,7 +22,9 @@ namespace InventoryManagementApp.Models
         public string ShadowColor { get; set; } = "#66000000";
         public string BackgroundImagePath { get; set; } = string.Empty;
         public string BackgroundImageStretch { get; set; } = "UniformToFill";
+        public string FontFamily { get; set; } = "Segoe UI";
         public double BackgroundOpacity { get; set; } = 1.0;
+        public double BackgroundOverlayOpacity { get; set; }
         public double SurfaceOpacity { get; set; } = 1.0;
         public double SurfaceAltOpacity { get; set; } = 1.0;
         public double InputOpacity { get; set; } = 1.0;
@@ -31,6 +34,7 @@ namespace InventoryManagementApp.Models
         public double MenuOpacity { get; set; } = 1.0;
         public double FooterOpacity { get; set; } = 1.0;
         public double DialogOpacity { get; set; } = 1.0;
+        public double DisabledOpacity { get; set; } = 0.55;
         public bool BordersVisible { get; set; } = true;
         public double BorderOpacity { get; set; } = 1.0;
         public double CardCornerRadius { get; set; } = 6.0;
@@ -44,6 +48,7 @@ namespace InventoryManagementApp.Models
         public double PagePadding { get; set; } = 6.0;
         public double CardPadding { get; set; } = 8.0;
         public double FontScale { get; set; } = 1.0;
+        public double HeadingFontScale { get; set; } = 1.0;
         public double ControlHeight { get; set; } = 28.0;
         public double DataGridRowHeight { get; set; } = 30.0;
         public double DataGridHeaderHeight { get; set; } = 30.0;
@@ -64,6 +69,7 @@ namespace InventoryManagementApp.Models
             if (string.Equals(settings.BaseTheme, "Dark", StringComparison.OrdinalIgnoreCase))
             {
                 settings.BackgroundColor = "#FF101418";
+                settings.BackgroundOverlayColor = "#CC101418";
                 settings.SurfaceColor = "#FF1B222A";
                 settings.SurfaceAltColor = "#FF252D36";
                 settings.NavigationColor = "#FF252D36";
@@ -89,6 +95,7 @@ namespace InventoryManagementApp.Models
             BaseTheme = NormalizeBaseTheme(BaseTheme);
             var defaults = CreateDefault(BaseTheme);
             BackgroundColor = NormalizeColor(BackgroundColor, defaults.BackgroundColor);
+            BackgroundOverlayColor = NormalizeColor(BackgroundOverlayColor, defaults.BackgroundOverlayColor);
             SurfaceColor = NormalizeColor(SurfaceColor, defaults.SurfaceColor);
             SurfaceAltColor = NormalizeColor(SurfaceAltColor, defaults.SurfaceAltColor);
             NavigationColor = NormalizeColor(NavigationColor, defaults.NavigationColor);
@@ -103,7 +110,9 @@ namespace InventoryManagementApp.Models
             ErrorColor = NormalizeColor(ErrorColor, defaults.ErrorColor);
             ShadowColor = NormalizeColor(ShadowColor, defaults.ShadowColor);
             BackgroundImageStretch = NormalizeBackgroundStretch(BackgroundImageStretch);
+            FontFamily = NormalizeFontFamily(FontFamily, defaults.FontFamily);
             BackgroundOpacity = Clamp01(BackgroundOpacity);
+            BackgroundOverlayOpacity = Clamp01(BackgroundOverlayOpacity);
             SurfaceOpacity = Clamp01(SurfaceOpacity);
             SurfaceAltOpacity = Clamp01(SurfaceAltOpacity);
             InputOpacity = Clamp01(InputOpacity);
@@ -113,6 +122,7 @@ namespace InventoryManagementApp.Models
             MenuOpacity = Clamp01(MenuOpacity);
             FooterOpacity = Clamp01(FooterOpacity);
             DialogOpacity = Clamp01(DialogOpacity);
+            DisabledOpacity = Clamp(DisabledOpacity, 0.15, 1);
             BorderOpacity = Clamp01(BorderOpacity);
             CardCornerRadius = Clamp(CardCornerRadius, 0, 32);
             PanelCornerRadius = Clamp(PanelCornerRadius, 0, 32);
@@ -125,6 +135,7 @@ namespace InventoryManagementApp.Models
             PagePadding = Clamp(PagePadding, 0, 28);
             CardPadding = Clamp(CardPadding, 0, 32);
             FontScale = Clamp(FontScale, 0.75, 1.4);
+            HeadingFontScale = Clamp(HeadingFontScale, 0.75, 1.6);
             ControlHeight = Clamp(ControlHeight, 22, 44);
             DataGridRowHeight = Clamp(DataGridRowHeight, 22, 52);
             DataGridHeaderHeight = Clamp(DataGridHeaderHeight, 24, 56);
@@ -155,6 +166,15 @@ namespace InventoryManagementApp.Models
             if (double.IsNaN(value) || double.IsInfinity(value))
                 return min;
             return Math.Min(max, Math.Max(min, value));
+        }
+
+        private static string NormalizeFontFamily(string? value, string fallback)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return fallback;
+
+            var trimmed = value.Trim();
+            return trimmed.Length > 80 ? trimmed[..80] : trimmed;
         }
 
         private static string NormalizeColor(string? value, string fallback)

--- a/InventoryManagementApp/ProgressNotes/2026-06-19-theme-typography-overlay-controls.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-19-theme-typography-overlay-controls.md
@@ -1,0 +1,12 @@
+# Theme Typography and Background Overlay Controls - 2026-06-19
+
+## Completed
+- Expanded `AppThemeSettings` with admin-controlled background overlay color/opacity, app font family, heading scale, and disabled-control opacity.
+- Applied the new values through `ThemeService` resources so saved themes can tint busy backgrounds, change app typography, scale headings separately from body text, and tune disabled-state visibility.
+- Added a shell-level background overlay layer and app font binding in `MainWindow.xaml`.
+- Exposed the new settings in the Admin Settings theme designer with live preview behavior and preset support.
+- Added focused model, XAML, and resource contract coverage for the expanded customization surface.
+
+## Validation
+- Connector readback/compare was used for this scheduled pass because the Linux container still cannot clone the repository or run .NET/WPF locally.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks remain blocked by the scheduled container limitations.

--- a/InventoryManagementApp/Resources/PolishedVisualHierarchy.xaml
+++ b/InventoryManagementApp/Resources/PolishedVisualHierarchy.xaml
@@ -48,10 +48,16 @@
         <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
         <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
         <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
         <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
         <Setter Property="Padding" Value="10,3"/>
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style x:Key="GhostButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
@@ -59,6 +65,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
         <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
         <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
         <Setter Property="MinWidth" Value="62"/>
         <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
@@ -67,6 +74,11 @@
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
         <Setter Property="Padding" Value="9,3"/>
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style TargetType="DataGrid">
@@ -82,6 +94,7 @@
         <Setter Property="HeadersVisibility" Value="Column"/>
         <Setter Property="RowHeight" Value="{DynamicResource ThemeDataGridRowHeight}"/>
         <Setter Property="ColumnHeaderHeight" Value="{DynamicResource ThemeDataGridHeaderHeight}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
         <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
         <Setter Property="CanUserAddRows" Value="False"/>
         <Setter Property="CanUserDeleteRows" Value="False"/>
@@ -114,6 +127,7 @@
     <Style TargetType="DataGridColumnHeader">
         <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
         <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>

--- a/InventoryManagementApp/Resources/Theme.Customization.xaml
+++ b/InventoryManagementApp/Resources/Theme.Customization.xaml
@@ -6,7 +6,8 @@
         The Settings theme selector chooses the active color dictionary. These shared resources are
         the app-wide knobs for the visual redesign layer: border removal, glass surfaces,
         rounded controls, shadow color/direction/depth, navigation transparency, typography scale,
-        grid density, interaction intensity, focus visibility, background image fit, and grid line strength.
+        font family, heading scale, disabled opacity, background overlay tint, grid density,
+        interaction intensity, focus visibility, background image fit, and grid line strength.
     -->
 
     <Thickness x:Key="ThemeBorderThickness">1</Thickness>
@@ -20,7 +21,9 @@
     <CornerRadius x:Key="ThemeInputCornerRadius">4</CornerRadius>
     <CornerRadius x:Key="ThemeFooterCornerRadius">0,0,6,6</CornerRadius>
 
+    <FontFamily x:Key="ThemeFontFamily">Segoe UI</FontFamily>
     <sys:Double x:Key="ThemeFontScale">1</sys:Double>
+    <sys:Double x:Key="ThemeHeadingFontScale">1</sys:Double>
     <sys:Double x:Key="ThemeCaptionFontSize">11</sys:Double>
     <sys:Double x:Key="ThemeBodyFontSize">13</sys:Double>
     <sys:Double x:Key="ThemeSectionFontSize">14</sys:Double>
@@ -32,6 +35,7 @@
     <sys:Double x:Key="ThemeMotionIntensity">1</sys:Double>
     <sys:Double x:Key="ThemeFocusVisualStrokeThickness">2</sys:Double>
     <sys:Double x:Key="ThemeShadowDirection">270</sys:Double>
+    <sys:Double x:Key="ThemeDisabledOpacity">0.55</sys:Double>
 
     <SolidColorBrush x:Key="ThemeTransparentBrush" Color="#00000000"/>
     <SolidColorBrush x:Key="ThemeGlassSurfaceBrush" Color="#DFFFFFFF"/>

--- a/InventoryManagementApp/Services/ThemeService.cs
+++ b/InventoryManagementApp/Services/ThemeService.cs
@@ -89,10 +89,11 @@ namespace InventoryManagementApp.Services
                 var pressedOpacity = Math.Clamp(0.18 + (settings.InteractionIntensity * 0.12), 0, 0.48);
                 var bodyFontSize = Math.Round(13 * settings.FontScale, 1);
                 var captionFontSize = Math.Round(11 * settings.FontScale, 1);
-                var sectionFontSize = Math.Round(14 * settings.FontScale, 1);
-                var titleFontSize = Math.Round(18 * settings.FontScale, 1);
+                var sectionFontSize = Math.Round(14 * settings.FontScale * settings.HeadingFontScale, 1);
+                var titleFontSize = Math.Round(18 * settings.FontScale * settings.HeadingFontScale, 1);
 
                 Set(resources, "BackgroundBrush", CreateBackgroundBrush(settings));
+                Set(resources, "ThemeAppBackgroundOverlayBrush", CreateBrush(settings.BackgroundOverlayColor, settings.BackgroundOverlayOpacity));
                 Set(resources, "SurfaceBrush", surfaceBrush);
                 Set(resources, "SurfaceAltBrush", surfaceAltBrush);
                 Set(resources, "NavigationSurfaceBrush", navigationBrush);
@@ -145,11 +146,14 @@ namespace InventoryManagementApp.Services
                 Set(resources, "RadiusLarge", new CornerRadius(settings.CardCornerRadius));
                 Set(resources, "PagePadding", new Thickness(settings.PagePadding));
                 Set(resources, "CardPadding", new Thickness(settings.CardPadding));
+                Set(resources, "ThemeFontFamily", new FontFamily(settings.FontFamily));
                 Set(resources, "ThemeFontScale", settings.FontScale);
+                Set(resources, "ThemeHeadingFontScale", settings.HeadingFontScale);
                 Set(resources, "ThemeCaptionFontSize", captionFontSize);
                 Set(resources, "ThemeBodyFontSize", bodyFontSize);
                 Set(resources, "ThemeSectionFontSize", sectionFontSize);
                 Set(resources, "ThemeTitleFontSize", titleFontSize);
+                Set(resources, "ThemeDisabledOpacity", settings.DisabledOpacity);
                 Set(resources, "ThemeControlMinHeight", settings.ControlHeight);
                 Set(resources, "ThemeDataGridRowHeight", settings.DataGridRowHeight);
                 Set(resources, "ThemeDataGridHeaderHeight", settings.DataGridHeaderHeight);

--- a/InventoryManagementApp/ViewModels/ThemeDesignerViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ThemeDesignerViewModel.cs
@@ -73,6 +73,12 @@ namespace InventoryManagementApp.ViewModels
             set => SetString(value, (settings, newValue) => settings.BackgroundColor = newValue, nameof(BackgroundColor));
         }
 
+        public string BackgroundOverlayColor
+        {
+            get => _settings.BackgroundOverlayColor;
+            set => SetString(value, (settings, newValue) => settings.BackgroundOverlayColor = newValue, nameof(BackgroundOverlayColor));
+        }
+
         public string SurfaceColor
         {
             get => _settings.SurfaceColor;
@@ -163,10 +169,22 @@ namespace InventoryManagementApp.ViewModels
             set => SetString(value, (settings, newValue) => settings.BackgroundImageStretch = newValue, nameof(BackgroundImageStretch));
         }
 
+        public string FontFamily
+        {
+            get => _settings.FontFamily;
+            set => SetString(value, (settings, newValue) => settings.FontFamily = newValue, nameof(FontFamily));
+        }
+
         public double BackgroundOpacity
         {
             get => _settings.BackgroundOpacity;
             set => SetDouble(value, (settings, newValue) => settings.BackgroundOpacity = newValue, nameof(BackgroundOpacity));
+        }
+
+        public double BackgroundOverlayOpacity
+        {
+            get => _settings.BackgroundOverlayOpacity;
+            set => SetDouble(value, (settings, newValue) => settings.BackgroundOverlayOpacity = newValue, nameof(BackgroundOverlayOpacity));
         }
 
         public double SurfaceOpacity
@@ -221,6 +239,12 @@ namespace InventoryManagementApp.ViewModels
         {
             get => _settings.DialogOpacity;
             set => SetDouble(value, (settings, newValue) => settings.DialogOpacity = newValue, nameof(DialogOpacity));
+        }
+
+        public double DisabledOpacity
+        {
+            get => _settings.DisabledOpacity;
+            set => SetDouble(value, (settings, newValue) => settings.DisabledOpacity = newValue, nameof(DisabledOpacity));
         }
 
         public bool BordersVisible
@@ -317,6 +341,12 @@ namespace InventoryManagementApp.ViewModels
         {
             get => _settings.FontScale;
             set => SetDouble(value, (settings, newValue) => settings.FontScale = newValue, nameof(FontScale));
+        }
+
+        public double HeadingFontScale
+        {
+            get => _settings.HeadingFontScale;
+            set => SetDouble(value, (settings, newValue) => settings.HeadingFontScale = newValue, nameof(HeadingFontScale));
         }
 
         public double ControlHeight
@@ -425,11 +455,15 @@ namespace InventoryManagementApp.ViewModels
             MenuOpacity = 0.62;
             FooterOpacity = 0.58;
             DialogOpacity = 0.82;
+            DisabledOpacity = 0.48;
+            BackgroundOverlayColor = "#FFFFFFFF";
+            BackgroundOverlayOpacity = 0.16;
             NavigationColor = SurfaceAltColor;
             InputColor = SurfaceColor;
             ButtonColor = SurfaceAltColor;
             BorderColor = AccentColor;
             ShadowColor = "#88000000";
+            FontFamily = "Segoe UI";
             BordersVisible = true;
             BorderOpacity = 0.42;
             EnableSurfaceShadows = true;
@@ -443,6 +477,7 @@ namespace InventoryManagementApp.ViewModels
             ShadowOpacity = 0.24;
             ShadowDirection = 270;
             FontScale = 1.02;
+            HeadingFontScale = 1.06;
             ControlHeight = 30;
             DataGridRowHeight = 34;
             DataGridHeaderHeight = 34;
@@ -471,6 +506,8 @@ namespace InventoryManagementApp.ViewModels
             MenuOpacity = 0.92;
             FooterOpacity = 0.9;
             DialogOpacity = 0.98;
+            DisabledOpacity = 0.42;
+            BackgroundOverlayOpacity = 0;
             EnableSurfaceShadows = false;
             EnableControlShadows = false;
             NavigationOpacity = 0.92;
@@ -479,6 +516,8 @@ namespace InventoryManagementApp.ViewModels
             ButtonColor = SurfaceAltColor;
             BorderColor = SurfaceColor;
             ShadowColor = "#00000000";
+            FontFamily = "Segoe UI";
+            HeadingFontScale = 0.96;
             ControlHeight = 26;
             DataGridRowHeight = 28;
             DataGridHeaderHeight = 28;
@@ -493,6 +532,8 @@ namespace InventoryManagementApp.ViewModels
         {
             _settings = AppThemeSettings.CreateDefault("Dark");
             _settings.BackgroundColor = "#FF000000";
+            _settings.BackgroundOverlayColor = "#FF000000";
+            _settings.BackgroundOverlayOpacity = 0.2;
             _settings.SurfaceColor = "#FF111111";
             _settings.SurfaceAltColor = "#FF1F1F1F";
             _settings.NavigationColor = "#FF000000";
@@ -506,11 +547,15 @@ namespace InventoryManagementApp.ViewModels
             _settings.WarningColor = "#FFFFFF00";
             _settings.ErrorColor = "#FFFF4D4D";
             _settings.ShadowColor = "#FFFFFFFF";
+            _settings.FontFamily = "Segoe UI";
             _settings.NavigationOpacity = 1;
             _settings.HeaderOpacity = 1;
             _settings.MenuOpacity = 1;
             _settings.FooterOpacity = 1;
             _settings.DialogOpacity = 1;
+            _settings.DisabledOpacity = 0.72;
+            _settings.FontScale = 1.08;
+            _settings.HeadingFontScale = 1.12;
             _settings.ControlHeight = 32;
             _settings.DataGridRowHeight = 36;
             _settings.DataGridHeaderHeight = 36;
@@ -568,6 +613,7 @@ namespace InventoryManagementApp.ViewModels
         {
             OnPropertyChanged(nameof(BaseTheme));
             OnPropertyChanged(nameof(BackgroundColor));
+            OnPropertyChanged(nameof(BackgroundOverlayColor));
             OnPropertyChanged(nameof(SurfaceColor));
             OnPropertyChanged(nameof(SurfaceAltColor));
             OnPropertyChanged(nameof(NavigationColor));
@@ -583,7 +629,9 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(ShadowColor));
             OnPropertyChanged(nameof(BackgroundImagePath));
             OnPropertyChanged(nameof(BackgroundImageStretch));
+            OnPropertyChanged(nameof(FontFamily));
             OnPropertyChanged(nameof(BackgroundOpacity));
+            OnPropertyChanged(nameof(BackgroundOverlayOpacity));
             OnPropertyChanged(nameof(SurfaceOpacity));
             OnPropertyChanged(nameof(SurfaceAltOpacity));
             OnPropertyChanged(nameof(InputOpacity));
@@ -593,6 +641,7 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(MenuOpacity));
             OnPropertyChanged(nameof(FooterOpacity));
             OnPropertyChanged(nameof(DialogOpacity));
+            OnPropertyChanged(nameof(DisabledOpacity));
             OnPropertyChanged(nameof(BordersVisible));
             OnPropertyChanged(nameof(UseGlassSurfaces));
             OnPropertyChanged(nameof(EnableSurfaceShadows));
@@ -609,6 +658,7 @@ namespace InventoryManagementApp.ViewModels
             OnPropertyChanged(nameof(PagePadding));
             OnPropertyChanged(nameof(CardPadding));
             OnPropertyChanged(nameof(FontScale));
+            OnPropertyChanged(nameof(HeadingFontScale));
             OnPropertyChanged(nameof(ControlHeight));
             OnPropertyChanged(nameof(DataGridRowHeight));
             OnPropertyChanged(nameof(DataGridHeaderHeight));

--- a/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml
+++ b/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml
@@ -4,7 +4,7 @@
     <UserControl.Resources>
         <Style x:Key="ThemeFieldLabel" TargetType="TextBlock" BasedOn="{StaticResource LabelTextBlock}">
             <Setter Property="VerticalAlignment" Value="Center"/>
-            <Setter Property="Margin" Value="0,0,8,8"/>
+            <Setter Property="Margin" Value="0,0,8,4"/>
         </Style>
         <Style x:Key="ThemeValueBox" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
             <Setter Property="Margin" Value="0,0,0,8"/>
@@ -14,7 +14,10 @@
             <Setter Property="Minimum" Value="0"/>
             <Setter Property="Maximum" Value="1"/>
             <Setter Property="TickFrequency" Value="0.05"/>
-            <Setter Property="Margin" Value="0,0,8,8"/>
+            <Setter Property="Margin" Value="0,0,8,2"/>
+        </Style>
+        <Style x:Key="ThemeFieldPanel" TargetType="StackPanel">
+            <Setter Property="Margin" Value="0,0,0,8"/>
         </Style>
     </UserControl.Resources>
 
@@ -24,7 +27,7 @@
                 <DockPanel LastChildFill="False">
                     <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
                         <TextBlock Text="App Theme Designer" Style="{StaticResource SubheadingTextBlock}"/>
-                        <TextBlock Text="Redesign the full app shell with colors, backgrounds, transparency, borders, corners, spacing, typography, table density, focus rings, interaction feedback, shadow color/direction, and shadow depth." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        <TextBlock Text="Redesign the full app shell with colors, backgrounds, transparency, borders, corners, spacing, typography, disabled states, table density, focus rings, interaction feedback, shadow color/direction, and shadow depth." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                     </StackPanel>
                     <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
                         <Button Style="{StaticResource GhostButton}" Content="Glass" Command="{Binding GlassPresetCommand}" Margin="0,0,4,0"/>
@@ -46,126 +49,68 @@
 
                     <StackPanel Grid.Column="0">
                         <Border Style="{StaticResource DesktopInsetCard}" Margin="0,0,0,12">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="170"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                </Grid.RowDefinitions>
-                                <TextBlock Grid.ColumnSpan="2" Text="Color system" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
-                                <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Text="Use #RRGGBB or #AARRGGBB values. Changes preview immediately and are saved when you choose Save Theme." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,12"/>
-                                <TextBlock Grid.Row="2" Text="Base theme" Style="{StaticResource ThemeFieldLabel}"/>
-                                <ComboBox Grid.Row="2" Grid.Column="1" SelectedItem="{Binding BaseTheme}" ItemsSource="{Binding ThemeOptions}" Margin="0,0,0,8"/>
-                                <TextBlock Grid.Row="3" Text="Background" Style="{StaticResource ThemeFieldLabel}"/>
-                                <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding BackgroundColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
-                                <TextBlock Grid.Row="4" Text="Main surface" Style="{StaticResource ThemeFieldLabel}"/>
-                                <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding SurfaceColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
-                                <TextBlock Grid.Row="5" Text="Alt surface" Style="{StaticResource ThemeFieldLabel}"/>
-                                <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding SurfaceAltColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
-                                <TextBlock Grid.Row="6" Text="Navigation" Style="{StaticResource ThemeFieldLabel}"/>
-                                <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding NavigationColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
-                                <TextBlock Grid.Row="7" Text="Inputs" Style="{StaticResource ThemeFieldLabel}"/>
-                                <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding InputColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
-                                <TextBlock Grid.Row="8" Text="Buttons" Style="{StaticResource ThemeFieldLabel}"/>
-                                <TextBox Grid.Row="8" Grid.Column="1" Text="{Binding ButtonColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
-                                <TextBlock Grid.Row="9" Text="Borders" Style="{StaticResource ThemeFieldLabel}"/>
-                                <TextBox Grid.Row="9" Grid.Column="1" Text="{Binding BorderColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
-                                <TextBlock Grid.Row="10" Text="Text" Style="{StaticResource ThemeFieldLabel}"/>
-                                <TextBox Grid.Row="10" Grid.Column="1" Text="{Binding TextColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
-                                <TextBlock Grid.Row="11" Text="Muted text" Style="{StaticResource ThemeFieldLabel}"/>
-                                <TextBox Grid.Row="11" Grid.Column="1" Text="{Binding MutedTextColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
-                                <TextBlock Grid.Row="12" Text="Accent" Style="{StaticResource ThemeFieldLabel}"/>
-                                <TextBox Grid.Row="12" Grid.Column="1" Text="{Binding AccentColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
-                                <TextBlock Grid.Row="13" Text="Success" Style="{StaticResource ThemeFieldLabel}"/>
-                                <TextBox Grid.Row="13" Grid.Column="1" Text="{Binding SuccessColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
-                                <TextBlock Grid.Row="14" Text="Warning" Style="{StaticResource ThemeFieldLabel}"/>
-                                <TextBox Grid.Row="14" Grid.Column="1" Text="{Binding WarningColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
-                                <TextBlock Grid.Row="15" Text="Error" Style="{StaticResource ThemeFieldLabel}"/>
-                                <TextBox Grid.Row="15" Grid.Column="1" Text="{Binding ErrorColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
-                                <TextBlock Grid.Row="16" Text="Shadow" Style="{StaticResource ThemeFieldLabel}"/>
-                                <TextBox Grid.Row="16" Grid.Column="1" Text="{Binding ShadowColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
-                                <TextBlock Grid.Row="17" Text="Background fit" Style="{StaticResource ThemeFieldLabel}"/>
-                                <ComboBox Grid.Row="17" Grid.Column="1" SelectedItem="{Binding BackgroundImageStretch}" ItemsSource="{Binding BackgroundStretchOptions}" Margin="0,0,0,8"/>
-                                <DockPanel Grid.Row="18" Grid.ColumnSpan="2" LastChildFill="True">
+                            <StackPanel>
+                                <TextBlock Text="Color system" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
+                                <TextBlock Text="Use #RRGGBB or #AARRGGBB values. Changes preview immediately and are saved when you choose Save Theme." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,12"/>
+                                <TextBlock Text="Base theme" Style="{StaticResource ThemeFieldLabel}"/>
+                                <ComboBox SelectedItem="{Binding BaseTheme}" ItemsSource="{Binding ThemeOptions}" Margin="0,0,0,8"/>
+                                <TextBlock Text="Background" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Text="{Binding BackgroundColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Text="Background overlay" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Text="{Binding BackgroundOverlayColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Text="Main surface" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Text="{Binding SurfaceColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Text="Alt surface" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Text="{Binding SurfaceAltColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Text="Navigation" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Text="{Binding NavigationColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Text="Inputs" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Text="{Binding InputColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Text="Buttons" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Text="{Binding ButtonColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Text="Borders" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Text="{Binding BorderColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Text="Text" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Text="{Binding TextColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Text="Muted text" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Text="{Binding MutedTextColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Text="Accent" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Text="{Binding AccentColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Text="Success" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Text="{Binding SuccessColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Text="Warning" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Text="{Binding WarningColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Text="Error" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Text="{Binding ErrorColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Text="Shadow" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Text="{Binding ShadowColor, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Text="Font family" Style="{StaticResource ThemeFieldLabel}"/>
+                                <TextBox Text="{Binding FontFamily, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
+                                <TextBlock Text="Background fit" Style="{StaticResource ThemeFieldLabel}"/>
+                                <ComboBox SelectedItem="{Binding BackgroundImageStretch}" ItemsSource="{Binding BackgroundStretchOptions}" Margin="0,0,0,8"/>
+                                <DockPanel LastChildFill="True">
                                     <Button DockPanel.Dock="Right" Style="{StaticResource GhostButton}" Content="Clear" Command="{Binding ClearBackgroundCommand}" Margin="6,0,0,8"/>
                                     <Button DockPanel.Dock="Right" Style="{StaticResource GhostButton}" Content="Browse" Command="{Binding BrowseBackgroundCommand}" Margin="6,0,0,8"/>
                                     <TextBox Text="{Binding BackgroundImagePath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeValueBox}"/>
                                 </DockPanel>
-                            </Grid>
+                            </StackPanel>
                         </Border>
 
                         <Border Style="{StaticResource DesktopInsetCard}">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="170"/>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="64"/>
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                </Grid.RowDefinitions>
-                                <TextBlock Grid.ColumnSpan="3" Text="Transparency" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
-                                <TextBlock Grid.Row="1" Text="Background" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="1" Grid.Column="1" Value="{Binding BackgroundOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding BackgroundOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="2" Text="Main surfaces" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="2" Grid.Column="1" Value="{Binding SurfaceOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="2" Grid.Column="2" Text="{Binding SurfaceOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="3" Text="Alt surfaces" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="3" Grid.Column="1" Value="{Binding SurfaceAltOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="3" Grid.Column="2" Text="{Binding SurfaceAltOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="4" Text="Inputs" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="4" Grid.Column="1" Value="{Binding InputOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="4" Grid.Column="2" Text="{Binding InputOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="5" Text="Buttons" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="5" Grid.Column="1" Value="{Binding ButtonOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="5" Grid.Column="2" Text="{Binding ButtonOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="6" Text="Navigation bars" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="6" Grid.Column="1" Value="{Binding NavigationOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="6" Grid.Column="2" Text="{Binding NavigationOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="7" Text="Header shell" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="7" Grid.Column="1" Value="{Binding HeaderOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="7" Grid.Column="2" Text="{Binding HeaderOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="8" Text="Menu shell" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="8" Grid.Column="1" Value="{Binding MenuOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="8" Grid.Column="2" Text="{Binding MenuOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="9" Text="Footer shell" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="9" Grid.Column="1" Value="{Binding FooterOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="9" Grid.Column="2" Text="{Binding FooterOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="10" Text="Dialogs" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="10" Grid.Column="1" Value="{Binding DialogOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="10" Grid.Column="2" Text="{Binding DialogOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                            </Grid>
+                            <StackPanel>
+                                <TextBlock Text="Transparency" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Background" Style="{StaticResource ThemeFieldLabel}"/><Slider Value="{Binding BackgroundOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding BackgroundOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Background overlay" Style="{StaticResource ThemeFieldLabel}"/><Slider Value="{Binding BackgroundOverlayOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding BackgroundOverlayOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Main surfaces" Style="{StaticResource ThemeFieldLabel}"/><Slider Value="{Binding SurfaceOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding SurfaceOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Alt surfaces" Style="{StaticResource ThemeFieldLabel}"/><Slider Value="{Binding SurfaceAltOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding SurfaceAltOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Inputs" Style="{StaticResource ThemeFieldLabel}"/><Slider Value="{Binding InputOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding InputOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Buttons" Style="{StaticResource ThemeFieldLabel}"/><Slider Value="{Binding ButtonOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding ButtonOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Navigation bars" Style="{StaticResource ThemeFieldLabel}"/><Slider Value="{Binding NavigationOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding NavigationOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Header shell" Style="{StaticResource ThemeFieldLabel}"/><Slider Value="{Binding HeaderOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding HeaderOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Menu shell" Style="{StaticResource ThemeFieldLabel}"/><Slider Value="{Binding MenuOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding MenuOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Footer shell" Style="{StaticResource ThemeFieldLabel}"/><Slider Value="{Binding FooterOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding FooterOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Dialogs" Style="{StaticResource ThemeFieldLabel}"/><Slider Value="{Binding DialogOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding DialogOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                            </StackPanel>
                         </Border>
                     </StackPanel>
 
@@ -176,10 +121,10 @@
                                 <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,8,0,8">
                                     <StackPanel>
                                         <TextBlock Text="Inventory desk card" Style="{StaticResource SectionHeader}"/>
-                                        <TextBlock Text="Surface, text, borders, corners, padding, shadows, grid lines, and interaction feedback update as you tune the theme." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                        <TextBlock Text="Surface, text, borders, corners, padding, shadows, disabled states, grid lines, and interaction feedback update as you tune the theme." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                                         <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                                             <Button Style="{StaticResource PrimaryButton}" Content="Primary" Margin="0,0,6,0"/>
-                                            <Button Style="{StaticResource GhostButton}" Content="Ghost"/>
+                                            <Button Style="{StaticResource GhostButton}" Content="Disabled" IsEnabled="False"/>
                                         </StackPanel>
                                     </StackPanel>
                                 </Border>
@@ -190,133 +135,46 @@
                         </Border>
 
                         <Border Style="{StaticResource DesktopInsetCard}" Margin="0,0,0,12">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="170"/>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="64"/>
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                </Grid.RowDefinitions>
-                                <TextBlock Grid.ColumnSpan="3" Text="Shape and borders" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
-                                <TextBlock Grid.Row="1" Text="Show borders" Style="{StaticResource ThemeFieldLabel}"/>
-                                <CheckBox Grid.Row="1" Grid.Column="1" IsChecked="{Binding BordersVisible}" Margin="0,0,0,8"/>
-                                <TextBlock Grid.Row="2" Text="Glass surfaces" Style="{StaticResource ThemeFieldLabel}"/>
-                                <CheckBox Grid.Row="2" Grid.Column="1" IsChecked="{Binding UseGlassSurfaces}" Margin="0,0,0,8"/>
-                                <TextBlock Grid.Row="3" Text="Border opacity" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="3" Grid.Column="1" Value="{Binding BorderOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="3" Grid.Column="2" Text="{Binding BorderOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="4" Text="Card corners" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding CardCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="4" Grid.Column="2" Text="{Binding CardCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="5" Text="Panel corners" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="5" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding PanelCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="5" Grid.Column="2" Text="{Binding PanelCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="6" Text="Button corners" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="6" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding ButtonCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="6" Grid.Column="2" Text="{Binding ButtonCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="7" Text="Input corners" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="7" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding InputCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="7" Grid.Column="2" Text="{Binding InputCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
-                            </Grid>
+                            <StackPanel>
+                                <TextBlock Text="Shape and borders" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
+                                <CheckBox Content="Show borders" IsChecked="{Binding BordersVisible}" Margin="0,0,0,8"/>
+                                <CheckBox Content="Glass surfaces" IsChecked="{Binding UseGlassSurfaces}" Margin="0,0,0,8"/>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Border opacity" Style="{StaticResource ThemeFieldLabel}"/><Slider Value="{Binding BorderOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding BorderOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Card corners" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="0" Maximum="32" Value="{Binding CardCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding CardCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Panel corners" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="0" Maximum="32" Value="{Binding PanelCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding PanelCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Button corners" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="0" Maximum="32" Value="{Binding ButtonCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding ButtonCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Input corners" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="0" Maximum="32" Value="{Binding InputCornerRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding InputCornerRadius, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                            </StackPanel>
                         </Border>
 
                         <Border Style="{StaticResource DesktopInsetCard}" Margin="0,0,0,12">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="170"/>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="64"/>
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                </Grid.RowDefinitions>
-                                <TextBlock Grid.ColumnSpan="3" Text="Depth, spacing, and density" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
-                                <TextBlock Grid.Row="1" Text="Surface shadows" Style="{StaticResource ThemeFieldLabel}"/>
-                                <CheckBox Grid.Row="1" Grid.Column="1" IsChecked="{Binding EnableSurfaceShadows}" Margin="0,0,0,8"/>
-                                <TextBlock Grid.Row="2" Text="Control shadows" Style="{StaticResource ThemeFieldLabel}"/>
-                                <CheckBox Grid.Row="2" Grid.Column="1" IsChecked="{Binding EnableControlShadows}" Margin="0,0,0,8"/>
-                                <TextBlock Grid.Row="3" Text="Shadow blur" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="3" Grid.Column="1" Minimum="0" Maximum="48" Value="{Binding ShadowBlurRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="3" Grid.Column="2" Text="{Binding ShadowBlurRadius, StringFormat={}{0:0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="4" Text="Shadow depth" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="16" Value="{Binding ShadowDepth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="4" Grid.Column="2" Text="{Binding ShadowDepth, StringFormat={}{0:0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="5" Text="Shadow opacity" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="5" Grid.Column="1" Value="{Binding ShadowOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="5" Grid.Column="2" Text="{Binding ShadowOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="6" Text="Shadow direction" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="6" Grid.Column="1" Minimum="0" Maximum="360" TickFrequency="15" Value="{Binding ShadowDirection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="6" Grid.Column="2" Text="{Binding ShadowDirection, StringFormat={}{0:0} deg}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="7" Text="Page padding" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="7" Grid.Column="1" Minimum="0" Maximum="28" Value="{Binding PagePadding, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="7" Grid.Column="2" Text="{Binding PagePadding, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="8" Text="Card padding" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="8" Grid.Column="1" Minimum="0" Maximum="32" Value="{Binding CardPadding, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="8" Grid.Column="2" Text="{Binding CardPadding, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="9" Text="Font scale" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="9" Grid.Column="1" Minimum="0.75" Maximum="1.4" TickFrequency="0.05" Value="{Binding FontScale, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="9" Grid.Column="2" Text="{Binding FontScale, StringFormat={}{0:0.00}x}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="10" Text="Control height" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="10" Grid.Column="1" Minimum="22" Maximum="44" Value="{Binding ControlHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="10" Grid.Column="2" Text="{Binding ControlHeight, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="11" Text="Grid rows" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="11" Grid.Column="1" Minimum="22" Maximum="52" Value="{Binding DataGridRowHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="11" Grid.Column="2" Text="{Binding DataGridRowHeight, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="12" Text="Grid headers" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="12" Grid.Column="1" Minimum="24" Maximum="56" Value="{Binding DataGridHeaderHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="12" Grid.Column="2" Text="{Binding DataGridHeaderHeight, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/>
-                            </Grid>
+                            <StackPanel>
+                                <TextBlock Text="Depth, spacing, and density" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
+                                <CheckBox Content="Surface shadows" IsChecked="{Binding EnableSurfaceShadows}" Margin="0,0,0,8"/>
+                                <CheckBox Content="Control shadows" IsChecked="{Binding EnableControlShadows}" Margin="0,0,0,8"/>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Shadow blur" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="0" Maximum="48" Value="{Binding ShadowBlurRadius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding ShadowBlurRadius, StringFormat={}{0:0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Shadow depth" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="0" Maximum="16" Value="{Binding ShadowDepth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding ShadowDepth, StringFormat={}{0:0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Shadow opacity" Style="{StaticResource ThemeFieldLabel}"/><Slider Value="{Binding ShadowOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding ShadowOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Shadow direction" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="0" Maximum="360" TickFrequency="15" Value="{Binding ShadowDirection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding ShadowDirection, StringFormat={}{0:0} deg}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Page padding" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="0" Maximum="28" Value="{Binding PagePadding, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding PagePadding, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Card padding" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="0" Maximum="32" Value="{Binding CardPadding, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding CardPadding, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Font scale" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="0.75" Maximum="1.4" TickFrequency="0.05" Value="{Binding FontScale, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding FontScale, StringFormat={}{0:0.00}x}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Heading scale" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="0.75" Maximum="1.6" TickFrequency="0.05" Value="{Binding HeadingFontScale, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding HeadingFontScale, StringFormat={}{0:0.00}x}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Control height" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="22" Maximum="44" Value="{Binding ControlHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding ControlHeight, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Grid rows" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="22" Maximum="52" Value="{Binding DataGridRowHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding DataGridRowHeight, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Grid headers" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="24" Maximum="56" Value="{Binding DataGridHeaderHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding DataGridHeaderHeight, StringFormat={}{0:0}px}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                            </StackPanel>
                         </Border>
 
                         <Border Style="{StaticResource DesktopInsetCard}">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="170"/>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="64"/>
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                </Grid.RowDefinitions>
-                                <TextBlock Grid.ColumnSpan="3" Text="Interaction feel" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
-                                <TextBlock Grid.Row="1" Text="Hover/selection" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="1" Grid.Column="1" Minimum="0" Maximum="2" TickFrequency="0.1" Value="{Binding InteractionIntensity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding InteractionIntensity, StringFormat={}{0:0.0}x}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="2" Text="Focus rings" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="2" Grid.Column="1" Value="{Binding FocusRingOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="2" Grid.Column="2" Text="{Binding FocusRingOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="3" Text="Grid lines" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="3" Grid.Column="1" Value="{Binding GridLineOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="3" Grid.Column="2" Text="{Binding GridLineOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/>
-                                <TextBlock Grid.Row="4" Text="Motion" Style="{StaticResource ThemeFieldLabel}"/>
-                                <Slider Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="2" TickFrequency="0.1" Value="{Binding MotionIntensity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/>
-                                <TextBlock Grid.Row="4" Grid.Column="2" Text="{Binding MotionIntensity, StringFormat={}{0:0.0}x}" Style="{StaticResource CaptionTextBlock}"/>
-                            </Grid>
+                            <StackPanel>
+                                <TextBlock Text="Interaction feel" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Hover/selection" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="0" Maximum="2" TickFrequency="0.1" Value="{Binding InteractionIntensity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding InteractionIntensity, StringFormat={}{0:0.0}x}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Focus rings" Style="{StaticResource ThemeFieldLabel}"/><Slider Value="{Binding FocusRingOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding FocusRingOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Disabled controls" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="0.15" Maximum="1" Value="{Binding DisabledOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding DisabledOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Grid lines" Style="{StaticResource ThemeFieldLabel}"/><Slider Value="{Binding GridLineOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding GridLineOpacity, StringFormat={}{0:P0}}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                                <StackPanel Style="{StaticResource ThemeFieldPanel}"><TextBlock Text="Motion" Style="{StaticResource ThemeFieldLabel}"/><Slider Minimum="0" Maximum="2" TickFrequency="0.1" Value="{Binding MotionIntensity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource ThemeSlider}"/><TextBlock Text="{Binding MotionIntensity, StringFormat={}{0:0.0}x}" Style="{StaticResource CaptionTextBlock}"/></StackPanel>
+                            </StackPanel>
                         </Border>
                     </StackPanel>
                 </Grid>


### PR DESCRIPTION
## Summary
- adds admin-controlled background overlay color/opacity, app font family, heading scale, and disabled-control opacity to the persisted theme profile
- applies the new settings through `ThemeService`, shell background overlay resources, app font binding, shared button/grid styles, and the live Admin Settings theme designer
- updates model, XAML, and resource contract tests plus a progress note for this scheduled pass

## Validation
- GitHub connector compare/readback confirmed the branch is current with `master` and contains the focused theme-designer diff
- Added/updated tests for theme model normalization/persistence, Settings designer bindings, and theme resource contracts
- Local clone/raw access, `dotnet`, Windows/WPF screenshots, and local banned-word checks remain blocked in this scheduled Linux container
