### PR TITLE
[codex] expand shared theme resource coverage

### DIFF
--- a/InventoryManagementApp.Tests/Resources/DesktopThemeResourceContractTests.cs
+++ b/InventoryManagementApp.Tests/Resources/DesktopThemeResourceContractTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Resources
+{
+    public class DesktopThemeResourceContractTests
+    {
+        [Fact]
+        public void DesktopShell_UsesAdminThemeTokensForCommonChrome()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "DesktopShell.xaml");
+
+            Assert.Contains("{DynamicResource ThemeBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeButtonCornerRadius}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlMinHeight}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBodyFontSize}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeDisabledOpacity}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeDataGridRowHeight}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeDataGridHeaderHeight}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeGridLineBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource CardPadding}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ControlPadding}", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DesktopPageShell_UsesAdminThemeTokensForSectionRailsAndActionStrips()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "DesktopPageShellResources.xaml");
+
+            Assert.Contains("{DynamicResource ThemeBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemePanelCornerRadius}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeSurfaceShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlMinHeight}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBodyFontSize}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource CardPadding}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeSubtleBorderThickness}", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-19-theme-shared-shell-resource-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-19-theme-shared-shell-resource-coverage.md
@@ -1,0 +1,8 @@
+# Theme Shared Shell Resource Coverage - 2026-06-19
+
+- Broadened shared desktop shell styles so Admin Settings theme controls reach more of the app chrome.
+- Updated `DesktopShell.xaml` to consume dynamic theme tokens for common control borders, corner radius, padding, control height, body typography, disabled opacity, shadows, data-grid row/header density, and grid-line strength.
+- Updated `DesktopPageShellResources.xaml` so section rails, action strips, pane headers, summary cards, settings forms, and inset cards consume theme padding, borders, panel radius, and shadow tokens.
+- Added `DesktopThemeResourceContractTests` to guard the expanded dynamic resource coverage.
+
+Validation note: this scheduled Linux container still cannot run `dotnet`, WPF screenshots, or local banned-word checks because the .NET SDK/Windows WPF runtime and local clone/raw access remain blocked. Connector readback/compare was used for repository validation.

--- a/InventoryManagementApp/Resources/DesktopPageShellResources.xaml
+++ b/InventoryManagementApp/Resources/DesktopPageShellResources.xaml
@@ -21,8 +21,10 @@
                         <Border Grid.Column="0"
                                 Background="{DynamicResource SurfaceBrush}"
                                 BorderBrush="{DynamicResource BorderBrushBase}"
-                                BorderThickness="1"
-                                Padding="6">
+                                BorderThickness="{DynamicResource ThemeBorderThickness}"
+                                CornerRadius="{DynamicResource ThemePanelCornerRadius}"
+                                Padding="{DynamicResource CardPadding}"
+                                Effect="{DynamicResource ThemeSurfaceShadow}">
                             <TabPanel Grid.Column="0"
                                       IsItemsHost="True"
                                       Margin="0"
@@ -44,12 +46,12 @@
 
     <Style x:Key="DesktopSectionListTabItem" TargetType="TabItem" BasedOn="{StaticResource {x:Type TabItem}}">
         <Setter Property="Width" Value="184"/>
-        <Setter Property="MinHeight" Value="30"/>
-        <Setter Property="Padding" Value="10,4"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
         <Setter Property="Margin" Value="0,0,0,4"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
         <Setter Property="VerticalContentAlignment" Value="Stretch"/>
-        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
     </Style>
 
     <Style x:Key="DesktopContentPane" TargetType="Border" BasedOn="{StaticResource Card}">
@@ -60,40 +62,43 @@
     <Style x:Key="DesktopSectionActionStrip" TargetType="Border">
         <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="0,0,0,1"/>
-        <Setter Property="Padding" Value="8,6"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
     </Style>
 
     <Style x:Key="DesktopSettingsForm" TargetType="Grid">
-        <Setter Property="Margin" Value="10"/>
+        <Setter Property="Margin" Value="{DynamicResource CardPadding}"/>
     </Style>
 
     <Style x:Key="DesktopSettingsCheckList" TargetType="ItemsControl">
-        <Setter Property="Margin" Value="10"/>
+        <Setter Property="Margin" Value="{DynamicResource CardPadding}"/>
     </Style>
 
     <Style x:Key="DesktopSummaryCard" TargetType="Border" BasedOn="{StaticResource Card}">
         <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="Padding" Value="10"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
     </Style>
 
     <Style x:Key="DesktopInsetCard" TargetType="Border" BasedOn="{StaticResource Card}">
-        <Setter Property="Padding" Value="10"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
     </Style>
 
     <Style x:Key="DesktopPaneHeader" TargetType="Border">
         <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="0,0,0,1"/>
-        <Setter Property="Padding" Value="7,5"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
     </Style>
 
     <Style x:Key="DesktopPaneSubheader" TargetType="Border">
         <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="0,0,0,1"/>
-        <Setter Property="Padding" Value="7,5"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
     </Style>
 
     <Style x:Key="DesktopNoteCard" TargetType="Border" BasedOn="{StaticResource DesktopInsetCard}">

--- a/InventoryManagementApp/Resources/DesktopShell.xaml
+++ b/InventoryManagementApp/Resources/DesktopShell.xaml
@@ -7,21 +7,21 @@
     <Thickness x:Key="ControlPadding">5,1</Thickness>
 
     <Style x:Key="PageTitleTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
-        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeSectionFontSize}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="TextWrapping" Value="NoWrap"/>
         <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
     </Style>
 
     <Style x:Key="HeadingTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
-        <Setter Property="FontSize" Value="16"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeTitleFontSize}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="TextWrapping" Value="NoWrap"/>
         <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
     </Style>
 
     <Style x:Key="SectionHeader" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
-        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="Margin" Value="0,0,0,3"/>
         <Setter Property="TextWrapping" Value="NoWrap"/>
@@ -30,34 +30,37 @@
     <Style TargetType="Border" x:Key="Card">
         <Setter Property="Background" Value="{DynamicResource SurfaceBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="{StaticResource ThemeBorderThickness}"/>
-        <Setter Property="CornerRadius" Value="{StaticResource ThemeCardCornerRadius}"/>
-        <Setter Property="Padding" Value="{StaticResource CardPadding}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemeCardCornerRadius}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
         <Setter Property="Margin" Value="0"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
     </Style>
 
     <Style x:Key="ToolbarCard" TargetType="Border">
         <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="{StaticResource ThemeSubtleBorderThickness}"/>
-        <Setter Property="CornerRadius" Value="{StaticResource ThemePanelCornerRadius}"/>
-        <Setter Property="Padding" Value="{StaticResource ToolbarPadding}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemePanelCornerRadius}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
         <Setter Property="Margin" Value="0,0,0,4"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
     </Style>
 
     <Style TargetType="Button">
         <Setter Property="Foreground" Value="{DynamicResource BtnFg}"/>
         <Setter Property="Background" Value="{DynamicResource BtnBg}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BtnBorder}"/>
-        <Setter Property="BorderThickness" Value="{StaticResource ThemeControlBorderThickness}"/>
-        <Setter Property="Padding" Value="4,1"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
         <Setter Property="FontWeight" Value="Normal"/>
         <Setter Property="Cursor" Value="Hand"/>
         <Setter Property="HorizontalContentAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
-        <Setter Property="MinHeight" Value="21"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
         <Setter Property="MinWidth" Value="52"/>
-        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
         <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -66,7 +69,7 @@
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="{StaticResource ThemeButtonCornerRadius}">
+                            CornerRadius="{DynamicResource ThemeButtonCornerRadius}">
                         <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                           Margin="{TemplateBinding Padding}"
@@ -85,7 +88,7 @@
                             <Setter TargetName="Root" Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value="0.55"/>
+                            <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -96,9 +99,9 @@
     <Style x:Key="PrimaryButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
         <Setter Property="MinWidth" Value="58"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
-        <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource OnAccentForegroundBrush}"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
     </Style>
 
@@ -111,14 +114,14 @@
 
     <Style x:Key="NavButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
         <Setter Property="Margin" Value="0,0,0,2"/>
-        <Setter Property="MinHeight" Value="24"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
         <Setter Property="HorizontalAlignment" Value="Stretch"/>
-        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="Background" Value="{DynamicResource BtnBg}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BtnBorder}"/>
-        <Setter Property="BorderThickness" Value="{StaticResource ThemeControlBorderThickness}"/>
-        <Setter Property="Padding" Value="7,2"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
     </Style>
@@ -127,10 +130,11 @@
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="Background" Value="{DynamicResource BtnBg}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BtnBorder}"/>
-        <Setter Property="BorderThickness" Value="{StaticResource ThemeControlBorderThickness}"/>
-        <Setter Property="Padding" Value="9,2"/>
-        <Setter Property="MinHeight" Value="24"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
         <Setter Property="Margin" Value="0,0,2,0"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToggleButton">
@@ -138,7 +142,7 @@
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="{StaticResource ThemeButtonCornerRadius}">
+                            CornerRadius="{DynamicResource ThemeButtonCornerRadius}">
                         <ContentPresenter Margin="{TemplateBinding Padding}"
                                           HorizontalAlignment="Center"
                                           VerticalAlignment="Center"/>
@@ -153,7 +157,7 @@
                             <Setter Property="FontWeight" Value="SemiBold"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value="0.6"/>
+                            <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -165,9 +169,11 @@
         <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="{StaticResource ThemeControlBorderThickness}"/>
-        <Setter Property="Padding" Value="{StaticResource ControlPadding}"/>
-        <Setter Property="MinHeight" Value="24"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
     </Style>
@@ -176,9 +182,11 @@
         <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="{StaticResource ThemeControlBorderThickness}"/>
-        <Setter Property="Padding" Value="{StaticResource ControlPadding}"/>
-        <Setter Property="MinHeight" Value="24"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
@@ -186,8 +194,8 @@
     </Style>
 
     <Style TargetType="DatePicker">
-        <Setter Property="MinHeight" Value="24"/>
-        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
     </Style>
 
     <Style TargetType="DataGrid">
@@ -195,15 +203,15 @@
         <Setter Property="RowBackground" Value="{DynamicResource DataGridRowBackgroundBrush}"/>
         <Setter Property="AlternatingRowBackground" Value="{DynamicResource DataGridAlternatingRowBackgroundBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="{StaticResource ThemeBorderThickness}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="GridLinesVisibility" Value="All"/>
-        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource BorderBrushBase}"/>
-        <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource BorderBrushBase}"/>
+        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource ThemeGridLineBrush}"/>
+        <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource ThemeGridLineBrush}"/>
         <Setter Property="HeadersVisibility" Value="Column"/>
-        <Setter Property="RowHeight" Value="26"/>
-        <Setter Property="ColumnHeaderHeight" Value="26"/>
-        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="RowHeight" Value="{DynamicResource ThemeDataGridRowHeight}"/>
+        <Setter Property="ColumnHeaderHeight" Value="{DynamicResource ThemeDataGridHeaderHeight}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
         <Setter Property="CanUserAddRows" Value="False"/>
         <Setter Property="CanUserDeleteRows" Value="False"/>
         <Setter Property="CanUserReorderColumns" Value="True"/>
@@ -217,7 +225,7 @@
     <Style TargetType="DataGridRow">
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="MinHeight" Value="26"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeDataGridRowHeight}"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
@@ -233,8 +241,8 @@
 
     <Style TargetType="DataGridCell">
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
-        <Setter Property="Padding" Value="4,1"/>
-        <Setter Property="BorderThickness" Value="{StaticResource ThemeBorderlessThickness}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
         <Setter Property="TextBlock.TextTrimming" Value="CharacterEllipsis"/>
         <Setter Property="TextBlock.TextWrapping" Value="NoWrap"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
@@ -253,10 +261,10 @@
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="0,0,1,1"/>
-        <Setter Property="Padding" Value="3,2"/>
-        <Setter Property="Height" Value="26"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeGridLineBrush}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="Height" Value="{DynamicResource ThemeDataGridHeaderHeight}"/>
         <Setter Property="TextBlock.TextTrimming" Value="CharacterEllipsis"/>
         <Setter Property="TextBlock.TextWrapping" Value="NoWrap"/>
     </Style>
@@ -272,7 +280,7 @@
     <Style TargetType="TabControl">
         <Setter Property="Background" Value="{DynamicResource SurfaceBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="{StaticResource ThemeBorderThickness}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
         <Setter Property="Padding" Value="0"/>
     </Style>
 
@@ -280,9 +288,10 @@
         <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
-        <Setter Property="BorderThickness" Value="1,1,1,0"/>
-        <Setter Property="Padding" Value="8,2"/>
-        <Setter Property="MinHeight" Value="24"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
         <Setter Property="Margin" Value="0,0,2,0"/>
         <Style.Triggers>
             <Trigger Property="IsSelected" Value="True">


### PR DESCRIPTION
## Summary
- broaden shared desktop shell styles so Admin Settings theme controls affect more app chrome without adding another settings model surface
- update common cards, toolbars, buttons, toggles, inputs, tabs, and data grids to consume dynamic theme tokens for borders, corners, padding, control height, typography, disabled opacity, shadows, grid density, and grid-line strength
- update desktop page section rails/action strips/pane headers/cards to use theme padding, border, radius, and shadow resources
- add focused contract tests guarding the expanded shared theme resource coverage

## Validation
- GitHub connector compare/readback confirmed the focused four-file diff and branch alignment with `master`
- Added `DesktopThemeResourceContractTests` for the shared desktop resource contract
- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks could not be run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel
