### PR TITLE
[codex] theme print preview window chrome

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemeWindowChromeContractTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeWindowChromeContractTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Resources
+{
+    public class ThemeWindowChromeContractTests
+    {
+        [Fact]
+        public void App_LoadsThemeWindowChromeAfterSharedHierarchyResources()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "App.xaml");
+
+            var hierarchyIndex = xaml.IndexOf("Resources/PolishedVisualHierarchy.xaml", StringComparison.Ordinal);
+            var windowChromeIndex = xaml.IndexOf("Resources/Theme.WindowChrome.xaml", StringComparison.Ordinal);
+
+            Assert.True(hierarchyIndex >= 0, "App.xaml should load the shared polished visual hierarchy resources.");
+            Assert.True(windowChromeIndex > hierarchyIndex, "Window chrome resources depend on shared hierarchy styles and should load after them.");
+        }
+
+        [Fact]
+        public void ThemeWindowChrome_UsesAdminThemeTokensForWholeWindowFrames()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.WindowChrome.xaml");
+
+            Assert.Contains("ThemedWindowRoot", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemedWindowOverlay", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemedWindowHeader", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemedWindowPane", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemedDocumentCanvasFrame", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemedWindowFooter", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource BackgroundBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeAppBackgroundOverlayBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeShellHeaderBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeDialogSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeCardCornerRadius}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemePanelCornerRadius}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeInputCornerRadius}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeSurfaceShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeRaisedShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlShadow}", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PrintPreviewWindow_ConsumesThemedWindowChromeStyles()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Windows", "PrintPreviewWindow.xaml");
+
+            Assert.Contains("Style=\"{StaticResource ThemedWindowRoot}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Style=\"{StaticResource ThemedWindowOverlay}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Style=\"{StaticResource ThemedWindowHeader}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Style=\"{StaticResource ThemedWindowPane}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Style=\"{StaticResource ThemedDocumentCanvasFrame}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Style=\"{StaticResource ThemedWindowFooter}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("FontFamily=\"{DynamicResource ThemeFontFamily}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("BorderThickness=\"{DynamicResource ThemeControlBorderThickness}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("CornerRadius=\"{DynamicResource ThemePanelCornerRadius}\"", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -13,8 +13,8 @@
                 <ResourceDictionary Source="Resources/Styles.xaml"/>
                 <ResourceDictionary Source="Resources/DesktopShell.xaml"/>
                 <ResourceDictionary Source="Resources/DesktopPageShellResources.xaml"/>
-                <ResourceDictionary Source="Resources/Theme.WindowChrome.xaml"/>
                 <ResourceDictionary Source="Resources/PolishedVisualHierarchy.xaml"/>
+                <ResourceDictionary Source="Resources/Theme.WindowChrome.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
                 <ResourceDictionary Source="Resources/Templates.xaml"/>
             </ResourceDictionary.MergedDictionaries>

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -13,6 +13,7 @@
                 <ResourceDictionary Source="Resources/Styles.xaml"/>
                 <ResourceDictionary Source="Resources/DesktopShell.xaml"/>
                 <ResourceDictionary Source="Resources/DesktopPageShellResources.xaml"/>
+                <ResourceDictionary Source="Resources/Theme.WindowChrome.xaml"/>
                 <ResourceDictionary Source="Resources/PolishedVisualHierarchy.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
                 <ResourceDictionary Source="Resources/Templates.xaml"/>

--- a/InventoryManagementApp/ProgressNotes/2026-06-19-theme-window-preview-chrome.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-19-theme-window-preview-chrome.md
@@ -1,0 +1,11 @@
+# Theme window and print-preview chrome pass - 2026-06-19
+
+## Completed
+- Added `Resources/Theme.WindowChrome.xaml` as a reusable app-window chrome resource layer for themed window roots, background overlays, headers, panes, document canvas frames, and footers.
+- Loaded the window chrome dictionary after the shared polished visual hierarchy resources so it can reuse the same admin theme tokens and shared styles.
+- Updated `PrintPreviewWindow.xaml` to consume the new window chrome resources, including admin-controlled background overlay, dialog surface opacity, border thickness, corner radii, font family, and shadow resources.
+- Added `ThemeWindowChromeContractTests` to guard app resource ordering, window chrome resource coverage, and print-preview usage.
+
+## Validation
+- GitHub connector read/write and later compare/readback were used for this scheduled pass.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks could not be run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel.

--- a/InventoryManagementApp/Resources/Theme.WindowChrome.xaml
+++ b/InventoryManagementApp/Resources/Theme.WindowChrome.xaml
@@ -1,0 +1,47 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style x:Key="ThemedWindowRoot" TargetType="Grid">
+        <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+        <Setter Property="Margin" Value="{DynamicResource PagePadding}"/>
+    </Style>
+
+    <Style x:Key="ThemedWindowOverlay" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource ThemeAppBackgroundOverlayBrush}"/>
+        <Setter Property="IsHitTestVisible" Value="False"/>
+    </Style>
+
+    <Style x:Key="ThemedWindowHeader" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellHeaderBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="BorderThickness" Value="0,0,0,2"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemePanelCornerRadius}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style x:Key="ThemedWindowPane" TargetType="Border" BasedOn="{StaticResource Card}">
+        <Setter Property="Background" Value="{DynamicResource ThemeDialogSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemeCardCornerRadius}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+    </Style>
+
+    <Style x:Key="ThemedDocumentCanvasFrame" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeGridLineBrush}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemeInputCornerRadius}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style x:Key="ThemedWindowFooter" TargetType="Border" BasedOn="{StaticResource DesktopStatusFooter}">
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemeFooterCornerRadius}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+    </Style>
+</ResourceDictionary>

--- a/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml
@@ -6,27 +6,26 @@
         Width="1220" Height="820"
         MinWidth="980" MinHeight="680"
         WindowStartupLocation="CenterScreen"
-        Background="{DynamicResource BackgroundBrush}">
-    <Grid Margin="12">
+        Background="{DynamicResource BackgroundBrush}"
+        FontFamily="{DynamicResource ThemeFontFamily}">
+    <Grid Style="{StaticResource ThemedWindowRoot}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0"
-                Background="{DynamicResource SurfaceAltBrush}"
-                BorderBrush="{DynamicResource AccentBrush}"
-                BorderThickness="1,1,1,3"
-                Padding="14"
-                CornerRadius="8">
+        <Border Grid.RowSpan="3" Style="{StaticResource ThemedWindowOverlay}"/>
+
+        <Border Grid.Row="0" Style="{StaticResource ThemedWindowHeader}">
             <DockPanel LastChildFill="False">
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center" Margin="0,0,16,0">
                     <Border Width="48" Height="48"
                             Background="{DynamicResource SurfaceBrush}"
                             BorderBrush="{DynamicResource BorderBrushAlt}"
-                            BorderThickness="1"
-                            CornerRadius="6"
+                            BorderThickness="{DynamicResource ThemeControlBorderThickness}"
+                            CornerRadius="{DynamicResource ThemePanelCornerRadius}"
+                            Effect="{DynamicResource ThemeControlShadow}"
                             Margin="0,0,12,0">
                         <Image x:Name="PreviewLogo"
                                Width="34" Height="34"
@@ -73,12 +72,7 @@
                 <ColumnDefinition Width="280"/>
             </Grid.ColumnDefinitions>
 
-            <Border Grid.Column="0"
-                    Background="{DynamicResource SurfaceBrush}"
-                    BorderBrush="{DynamicResource BorderBrushAlt}"
-                    BorderThickness="1"
-                    CornerRadius="8"
-                    Padding="12">
+            <Border Grid.Column="0" Style="{StaticResource ThemedWindowPane}">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -92,12 +86,7 @@
                         <TextBlock DockPanel.Dock="Right" Text="Output Review" Style="{StaticResource CaptionTextBlock}" VerticalAlignment="Center"/>
                     </DockPanel>
 
-                    <Border Grid.Row="1"
-                            Background="White"
-                            BorderBrush="#D4D9E2"
-                            BorderThickness="1"
-                            Padding="8"
-                            CornerRadius="4">
+                    <Border Grid.Row="1" Style="{StaticResource ThemedDocumentCanvasFrame}">
                         <FlowDocumentScrollViewer x:Name="DocViewer"
                                                   Background="White"
                                                   IsToolBarVisible="False"
@@ -132,12 +121,7 @@
             </StackPanel>
         </Grid>
 
-        <Border Grid.Row="2"
-                Background="{DynamicResource SurfaceAltBrush}"
-                BorderBrush="{DynamicResource BorderBrushAlt}"
-                BorderThickness="1"
-                CornerRadius="6"
-                Padding="10,7">
+        <Border Grid.Row="2" Style="{StaticResource ThemedWindowFooter}">
             <DockPanel LastChildFill="False">
                 <TextBlock DockPanel.Dock="Left"
                            Text="Ready for final print review"


### PR DESCRIPTION
## Summary
- add `Theme.WindowChrome.xaml` as a reusable admin-theme-aware window chrome layer for window roots, overlays, headers, panes, document canvas frames, and footers
- load the new dictionary after the shared polished hierarchy resources so it can reuse existing theme tokens and shared styles
- update the print preview workstation to consume admin-controlled background overlay, dialog surface opacity, borders, corners, font family, and shadow resources
- add contract tests covering app resource ordering, window chrome token usage, and print-preview adoption

## Validation
- GitHub connector compare/readback confirmed the focused five-file branch diff and branch alignment with `master`
- Added `ThemeWindowChromeContractTests` for the window chrome and print-preview resource contract
- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks could not be run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel
