### PR TITLE
[codex] let theme designer override polished shell chrome

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemeFullCustomizationOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeFullCustomizationOverrideTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Resources
+{
+    public class ThemeFullCustomizationOverrideTests
+    {
+        [Fact]
+        public void App_LoadsFullCustomizationOverridesAfterPolishedChrome()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "App.xaml");
+
+            var polishedIndex = xaml.IndexOf("Resources/PolishedVisualHierarchy.xaml", StringComparison.Ordinal);
+            var chromeIndex = xaml.IndexOf("Resources/Theme.WindowChrome.xaml", StringComparison.Ordinal);
+            var overridesIndex = xaml.IndexOf("Resources/Theme.FullCustomizationOverrides.xaml", StringComparison.Ordinal);
+            var convertersIndex = xaml.IndexOf("Resources/Converters.xaml", StringComparison.Ordinal);
+
+            Assert.True(polishedIndex >= 0, "Polished theme hierarchy should still be loaded.");
+            Assert.True(chromeIndex > polishedIndex, "Window chrome should load after polished hierarchy.");
+            Assert.True(overridesIndex > chromeIndex, "Full customization overrides must load after polished chrome resources.");
+            Assert.True(convertersIndex > overridesIndex, "Converters should remain after visual resources.");
+        }
+
+        [Fact]
+        public void FullCustomizationOverrides_GiveAdminTokensFinalSayOverPolishedSurfaces()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.FullCustomizationOverrides.xaml");
+
+            Assert.Contains("x:Key=\"ToolbarCard\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"DataGridColumnHeader\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"DesktopSummaryCard\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"DesktopInsetCard\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"DesktopPaneHeader\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"DesktopPaneSubheader\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"DesktopSectionActionStrip\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"DesktopStatusFooter\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"AdminHandoffCard\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"DesktopNoteCard\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"DataRunLogCard\"", xaml, StringComparison.Ordinal);
+
+            Assert.Contains("{DynamicResource ThemeBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeSubtleBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeCardCornerRadius}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemePanelCornerRadius}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeFooterCornerRadius}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource CardPadding}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ControlPadding}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeSurfaceShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeRaisedShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeGridLineBrush}", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void FullCustomizationOverrides_RemoveHardCodedAccentBordersFromFinalSharedChrome()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.FullCustomizationOverrides.xaml");
+
+            Assert.DoesNotContain("BorderThickness\" Value=\"0,1,0,2\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("BorderThickness\" Value=\"1,1,1,2\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("BorderThickness\" Value=\"0,0,0,2\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("BorderBrush\" Value=\"{DynamicResource AccentBrush}\"", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -15,6 +15,7 @@
                 <ResourceDictionary Source="Resources/DesktopPageShellResources.xaml"/>
                 <ResourceDictionary Source="Resources/PolishedVisualHierarchy.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.WindowChrome.xaml"/>
+                <ResourceDictionary Source="Resources/Theme.FullCustomizationOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
                 <ResourceDictionary Source="Resources/Templates.xaml"/>
             </ResourceDictionary.MergedDictionaries>

--- a/InventoryManagementApp/ProgressNotes/2026-06-19-theme-full-customization-overrides.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-19-theme-full-customization-overrides.md
@@ -1,0 +1,11 @@
+# Theme Full Customization Overrides - 2026-06-19
+
+## Completed
+- Added a final theme override dictionary that loads after the polished hierarchy and window chrome resources.
+- Re-declared the remaining shared shell/card/header/footer/grid-header styles that still had hard-coded accent borders or fixed border thicknesses.
+- Routed those final shared styles through admin-controlled theme tokens for border thickness, subtle divider thickness, control border thickness, corners, padding, shadows, grid header density, and transparent/glass surfaces.
+- Added contract tests to keep the override dictionary in the correct app resource order and ensure the final shared chrome uses admin theme resources instead of fixed polished borders.
+
+## Validation
+- GitHub connector read/write and branch compare were used in this scheduled environment.
+- Local dotnet build/test, WPF screenshots, and local banned-word checks remain unavailable because the scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct local clone/raw repository access is blocked.

--- a/InventoryManagementApp/Resources/Theme.FullCustomizationOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.FullCustomizationOverrides.xaml
@@ -1,0 +1,125 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!--
+        Final admin theme override layer.
+        PolishedVisualHierarchy gives the app its richer default look, but several of those styles
+        intentionally used stronger accent borders and fixed thicknesses. These late-loaded styles
+        give the Admin Settings theme designer the final say over borders, transparency, corners,
+        padding, shadows, and grid density for the remaining shared shell surfaces.
+    -->
+
+    <Style x:Key="ToolbarCard" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemePanelCornerRadius}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Margin" Value="0,0,0,6"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="DataGridColumnHeader">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeGridLineBrush}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeDataGridHeaderHeight}"/>
+        <Setter Property="Height" Value="{DynamicResource ThemeDataGridHeaderHeight}"/>
+        <Setter Property="TextBlock.TextTrimming" Value="CharacterEllipsis"/>
+        <Setter Property="TextBlock.TextWrapping" Value="NoWrap"/>
+    </Style>
+
+    <Style x:Key="DesktopSummaryCard" TargetType="Border" BasedOn="{StaticResource Card}">
+        <Setter Property="Background" Value="{DynamicResource GlassSurfaceAltBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemeCardCornerRadius}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+        <Setter Property="MinHeight" Value="72"/>
+    </Style>
+
+    <Style x:Key="DesktopInsetCard" TargetType="Border" BasedOn="{StaticResource Card}">
+        <Setter Property="Background" Value="{DynamicResource GlassSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushBase}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemeCardCornerRadius}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+    </Style>
+
+    <Style x:Key="DesktopPaneHeader" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellHeaderBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemePanelCornerRadius}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+    </Style>
+
+    <Style x:Key="DesktopPaneSubheader" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemePanelCornerRadius}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+    </Style>
+
+    <Style x:Key="DesktopSectionActionStrip" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemePanelCornerRadius}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+    </Style>
+
+    <Style x:Key="DesktopStatusFooter" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellFooterBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemeFooterCornerRadius}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style x:Key="AdminHandoffCard" TargetType="Border" BasedOn="{StaticResource DesktopInsetCard}">
+        <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemeCardCornerRadius}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Margin" Value="0,0,0,8"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+    </Style>
+
+    <Style x:Key="DesktopNoteCard" TargetType="Border" BasedOn="{StaticResource DesktopInsetCard}">
+        <Setter Property="Background" Value="{DynamicResource GlassSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemeCardCornerRadius}"/>
+    </Style>
+
+    <Style x:Key="DataRunLogCard" TargetType="Border" BasedOn="{StaticResource DesktopNoteCard}">
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Margin" Value="0,0,0,8"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemeCardCornerRadius}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+    </Style>
+</ResourceDictionary>


### PR DESCRIPTION
## Summary
- add a final `Theme.FullCustomizationOverrides.xaml` resource layer after the polished hierarchy/window chrome dictionaries
- re-route remaining polished shared shell surfaces, cards, headers, footers, handoff cards, log cards, and grid headers through admin-controlled theme tokens
- ensure borderless themes, transparent/glass surfaces, custom corners, padding, shadows, and grid density can win over the prior fixed accent border polish
- add contract tests for resource ordering and final shared chrome token usage

## Validation
- GitHub connector compare/readback confirmed the branch is 4 commits ahead of `master` and only changes the focused theme override files
- Added `ThemeFullCustomizationOverrideTests` for app resource order and final full-customization style contracts
- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks could not be run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel
