### PR TITLE
[codex] extend admin theme overrides to common controls

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemeCommonControlOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeCommonControlOverrideTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Resources
+{
+    public class ThemeCommonControlOverrideTests
+    {
+        [Fact]
+        public void FullCustomizationOverrides_ThemeRemainingCommonControlChrome()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.FullCustomizationOverrides.xaml");
+
+            Assert.Contains("x:Key=\"ThemeToolTipTemplate\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ToolTip\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"GroupBox\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Expander\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"RadioButton\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"DatePicker\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Calendar\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"TreeView\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"TreeViewItem\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ToolBar\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"StatusBar\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void FullCustomizationOverrides_CommonControlsUseAdminThemeTokens()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.FullCustomizationOverrides.xaml");
+
+            Assert.Contains("{DynamicResource ThemeDialogSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeShellMenuBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeShellFooterBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource GlassSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource TextBoxBackgroundBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemePanelCornerRadius}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeSubtleBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeRaisedShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeDisabledOpacity}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlMinHeight}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeFontFamily}", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void FullCustomizationOverrides_CommonControlChromeLoadsAfterExistingSurfaceOverrides()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.FullCustomizationOverrides.xaml");
+
+            var surfaceOverrideIndex = xaml.IndexOf("x:Key=\"DataRunLogCard\"", StringComparison.Ordinal);
+            var tooltipTemplateIndex = xaml.IndexOf("x:Key=\"ThemeToolTipTemplate\"", StringComparison.Ordinal);
+            var statusBarIndex = xaml.IndexOf("TargetType=\"StatusBar\"", StringComparison.Ordinal);
+
+            Assert.True(surfaceOverrideIndex >= 0, "Existing shared surface overrides should remain in the final layer.");
+            Assert.True(tooltipTemplateIndex > surfaceOverrideIndex, "Common control chrome should extend the final override layer after shared surfaces.");
+            Assert.True(statusBarIndex > tooltipTemplateIndex, "Status bar chrome should be part of the common control override block.");
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-19-theme-common-control-overrides.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-19-theme-common-control-overrides.md
@@ -1,0 +1,11 @@
+# Theme Common Control Override Pass - 2026-06-19
+
+## Completed
+- Extended the final admin theme override layer to common WPF controls that could still fall back to platform chrome.
+- Added theme-aware styling for tooltips, group boxes, expanders, radio buttons, date pickers, calendars, tree views, toolbars, and status bars.
+- Routed those controls through the existing admin theme tokens for background transparency, dialog/menu/footer surfaces, borders, corner radius, font family, control height, disabled opacity, hover/selection brushes, and shadow depth.
+- Added contract tests to keep those common-control overrides present and tied to the Settings theme designer resource model.
+
+## Validation
+- GitHub connector readback/compare was used for the branch because local clone/raw access is blocked by the network tunnel.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks could not run in this scheduled Linux container because the .NET SDK and Windows WPF runtime are unavailable.

--- a/InventoryManagementApp/Resources/Theme.FullCustomizationOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.FullCustomizationOverrides.xaml
@@ -122,4 +122,142 @@
         <Setter Property="CornerRadius" Value="{DynamicResource ThemeCardCornerRadius}"/>
         <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
     </Style>
+
+    <ControlTemplate x:Key="ThemeToolTipTemplate" TargetType="ToolTip">
+        <Border Background="{DynamicResource ThemeDialogSurfaceBrush}"
+                BorderBrush="{DynamicResource BorderBrushAlt}"
+                BorderThickness="{DynamicResource ThemeControlBorderThickness}"
+                CornerRadius="{DynamicResource ThemePanelCornerRadius}"
+                Padding="{TemplateBinding Padding}"
+                Effect="{DynamicResource ThemeRaisedShadow}"
+                SnapsToDevicePixels="True">
+            <ContentPresenter RecognizesAccessKey="True"/>
+        </Border>
+    </ControlTemplate>
+
+    <Style TargetType="ToolTip">
+        <Setter Property="Background" Value="{DynamicResource ThemeDialogSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Template" Value="{StaticResource ThemeToolTipTemplate}"/>
+    </Style>
+
+    <Style TargetType="GroupBox">
+        <Setter Property="Background" Value="{DynamicResource GlassSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+    </Style>
+
+    <Style TargetType="Expander">
+        <Setter Property="Background" Value="{DynamicResource GlassSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+    </Style>
+
+    <Style TargetType="RadioButton">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="DatePicker">
+        <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="Calendar">
+        <Setter Property="Background" Value="{DynamicResource ThemeDialogSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+    </Style>
+
+    <Style TargetType="TreeView">
+        <Setter Property="Background" Value="{DynamicResource SurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+    </Style>
+
+    <Style TargetType="TreeViewItem">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Padding" Value="6,3"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemHoverForegroundBrush}"/>
+            </Trigger>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemSelectedForegroundBrush}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="ToolBar">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+    </Style>
+
+    <Style TargetType="StatusBar">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellFooterBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeCaptionFontSize}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+    </Style>
 </ResourceDictionary>


### PR DESCRIPTION
## Summary
- extends the final admin theme override layer to common WPF controls that could still use platform/default chrome
- adds theme-aware styling for tooltips, group boxes, expanders, radio buttons, date pickers, calendars, tree views, toolbars, and status bars
- routes those controls through existing admin theme tokens for transparent/dialog/menu/footer surfaces, borders, corners, control height, fonts, disabled opacity, hover/selection feedback, and shadows
- adds resource contract tests and a progress note for the scheduled theme customization pass

## Validation
- GitHub connector compare/readback confirmed the branch is 3 commits ahead of `master` with the expected focused diff
- Added `ThemeCommonControlOverrideTests` to guard the common-control theme override contract
- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks could not run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel
