### PR TITLE
[codex] theme list menu and scrollbar chrome

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemeScrollableChromeOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeScrollableChromeOverrideTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Resources
+{
+    public class ThemeScrollableChromeOverrideTests
+    {
+        [Fact]
+        public void FullCustomizationOverrides_ThemeListMenuAndScrollChrome()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.FullCustomizationOverrides.xaml");
+
+            Assert.Contains("TargetType=\"ListBox\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ListView\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ListBoxItem\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ListViewItem\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ContextMenu\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"MenuItem\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Separator\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ScrollBar\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"{x:Type primitives:Thumb}\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void FullCustomizationOverrides_ListMenuAndScrollChromeUseAdminThemeTokens()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.FullCustomizationOverrides.xaml");
+
+            Assert.Contains("xmlns:primitives=\"clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource SurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource GlassSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeDialogSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource TransparentSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource AccentBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource BorderBrushAlt}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeSubtleBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBorderlessThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeSurfaceShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeRaisedShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeDisabledOpacity}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlMinHeight}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeFontFamily}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ItemHoverBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ItemSelectedBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeGridLineBrush}", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void FullCustomizationOverrides_ListMenuAndScrollChromeLoadAfterCommonControls()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.FullCustomizationOverrides.xaml");
+
+            var statusBarIndex = xaml.IndexOf("TargetType=\"StatusBar\"", StringComparison.Ordinal);
+            var listBoxIndex = xaml.IndexOf("TargetType=\"ListBox\"", StringComparison.Ordinal);
+            var contextMenuIndex = xaml.IndexOf("TargetType=\"ContextMenu\"", StringComparison.Ordinal);
+            var scrollBarIndex = xaml.IndexOf("TargetType=\"ScrollBar\"", StringComparison.Ordinal);
+
+            Assert.True(statusBarIndex >= 0, "Common control overrides should remain before this extension block.");
+            Assert.True(listBoxIndex > statusBarIndex, "List chrome should extend the final override layer after common controls.");
+            Assert.True(contextMenuIndex > listBoxIndex, "Menu chrome should follow list chrome in the final override layer.");
+            Assert.True(scrollBarIndex > contextMenuIndex, "Scrollbar chrome should be part of the late final override block.");
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-19-theme-list-menu-scrollbar-overrides.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-19-theme-list-menu-scrollbar-overrides.md
@@ -1,0 +1,10 @@
+# Theme List, Menu, and Scrollbar Override Pass - 2026-06-19
+
+## Completed
+- Extended the final admin theme override layer to list, menu, separator, scrollbar, and thumb chrome that could still inherit platform/default styling.
+- Routed list containers, list rows, context menus, menu items, separators, scrollbars, and scrollbar thumbs through the existing admin theme tokens for transparent surfaces, dialog/list backgrounds, borders, grid lines, typography, disabled opacity, hover/selection feedback, and shadow depth.
+- Added contract tests to keep those list/menu/scrollbar overrides present and tied to the Settings theme designer resource model.
+
+## Validation
+- GitHub connector readback/compare was used for the branch because local clone/raw access is blocked by the network tunnel.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks could not run in this scheduled Linux container because the .NET SDK and Windows WPF runtime are unavailable.

--- a/InventoryManagementApp/Resources/Theme.FullCustomizationOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.FullCustomizationOverrides.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework">
     <!--
         Final admin theme override layer.
         PolishedVisualHierarchy gives the app its richer default look, but several of those styles
@@ -259,5 +260,107 @@
         <Setter Property="FontSize" Value="{DynamicResource ThemeCaptionFontSize}"/>
         <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
         <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+    </Style>
+
+    <Style TargetType="ListBox">
+        <Setter Property="Background" Value="{DynamicResource SurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+    </Style>
+
+    <Style TargetType="ListView" BasedOn="{StaticResource {x:Type ListBox}}">
+        <Setter Property="Background" Value="{DynamicResource GlassSurfaceBrush}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+    </Style>
+
+    <Style TargetType="ListBoxItem">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemHoverForegroundBrush}"/>
+            </Trigger>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemSelectedForegroundBrush}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Type ListBoxItem}}">
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeGridLineBrush}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+    </Style>
+
+    <Style TargetType="ContextMenu">
+        <Setter Property="Background" Value="{DynamicResource ThemeDialogSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="4"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+    </Style>
+
+    <Style TargetType="MenuItem">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Padding" Value="10,5"/>
+        <Style.Triggers>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemHoverForegroundBrush}"/>
+            </Trigger>
+            <Trigger Property="IsSubmenuOpen" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemSelectedForegroundBrush}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="Separator">
+        <Setter Property="Background" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="Margin" Value="4,3"/>
+    </Style>
+
+    <Style TargetType="ScrollBar">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="MinWidth" Value="12"/>
+        <Setter Property="MinHeight" Value="12"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+    </Style>
+
+    <Style TargetType="{x:Type primitives:Thumb}">
+        <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
     </Style>
 </ResourceDictionary>


### PR DESCRIPTION
## Summary
- extend the final admin theme override layer to list, menu, separator, scrollbar, and thumb chrome that could still inherit default platform styling
- route list containers, list rows, context menus, menu items, separators, scrollbars, and scrollbar thumbs through existing admin theme tokens for transparent surfaces, dialog/list backgrounds, borders, typography, disabled opacity, hover/selection feedback, grid lines, and shadows
- add resource contract tests and a progress note for the scheduled theme customization pass

## Validation
- GitHub connector compare/readback confirmed the branch is 3 commits ahead of `master` with only the intended theme override, test, and progress-note files
- Added `ThemeScrollableChromeOverrideTests` to guard the list/menu/scrollbar theme override contract
- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks could not run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel
