### PR TITLE
[codex] theme form media and preview chrome

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemeFormMediaPreviewOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeFormMediaPreviewOverrideTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Resources
+{
+    public class ThemeFormMediaPreviewOverrideTests
+    {
+        [Fact]
+        public void App_LoadsFormMediaPreviewOverridesAfterFullCustomizationOverrides()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "App.xaml");
+
+            var fullCustomizationIndex = xaml.IndexOf("Resources/Theme.FullCustomizationOverrides.xaml", StringComparison.Ordinal);
+            var formMediaIndex = xaml.IndexOf("Resources/Theme.FormMediaPreviewOverrides.xaml", StringComparison.Ordinal);
+            var convertersIndex = xaml.IndexOf("Resources/Converters.xaml", StringComparison.Ordinal);
+
+            Assert.True(fullCustomizationIndex >= 0, "Full customization overrides should remain loaded.");
+            Assert.True(formMediaIndex > fullCustomizationIndex, "Form/media preview overrides must load after full customization overrides.");
+            Assert.True(convertersIndex > formMediaIndex, "Converters should remain after visual resources.");
+        }
+
+        [Fact]
+        public void FormMediaPreviewOverrides_ThemeRemainingFormMediaAndPreviewChrome()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.FormMediaPreviewOverrides.xaml");
+
+            Assert.Contains("x:Key=\"ThemeMediaPreviewFrame\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"PasswordBox\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"CheckBox\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Slider\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ProgressBar\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Label\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Image\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"DocumentViewer\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"FlowDocumentScrollViewer\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"RichTextBox\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void FormMediaPreviewOverrides_UseAdminThemeTokensForTransparencyBordersAndDepth()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.FormMediaPreviewOverrides.xaml");
+
+            Assert.Contains("{DynamicResource TransparentSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource TextBoxBackgroundBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeDialogSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ProgressBarBackgroundBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource AccentBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource BorderBrushAlt}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBorderlessThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeCardCornerRadius}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeRaisedShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeDisabledOpacity}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlMinHeight}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeFontFamily}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ItemHoverBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ItemSelectedBrush}", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -16,6 +16,7 @@
                 <ResourceDictionary Source="Resources/PolishedVisualHierarchy.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.WindowChrome.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.FullCustomizationOverrides.xaml"/>
+                <ResourceDictionary Source="Resources/Theme.FormMediaPreviewOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
                 <ResourceDictionary Source="Resources/Templates.xaml"/>
             </ResourceDictionary.MergedDictionaries>

--- a/InventoryManagementApp/ProgressNotes/2026-06-19-theme-form-media-preview-overrides.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-19-theme-form-media-preview-overrides.md
@@ -1,0 +1,10 @@
+# Theme Form, Media, and Preview Override Pass - 2026-06-19
+
+## Completed
+- Added a late-loaded admin theme override dictionary for remaining form, media, and document preview chrome.
+- Routed password boxes, check boxes, sliders, progress bars, labels, images, rich text boxes, document viewers, flow-document viewers, and reusable media preview frames through existing admin theme tokens.
+- Extended resource contract tests so future theme work keeps these controls tied to transparency, border visibility, corner radius, font, disabled opacity, hover/selection, and shadow-depth settings.
+
+## Validation
+- GitHub connector readback/compare was used for the branch because local clone/raw access is blocked by the network tunnel.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks could not run in this scheduled Linux container because the .NET SDK and Windows WPF runtime are unavailable.

--- a/InventoryManagementApp/Resources/Theme.FormMediaPreviewOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.FormMediaPreviewOverrides.xaml
@@ -1,0 +1,139 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!--
+        Late admin theme override layer for form fields, media previews, and document preview chrome.
+        This keeps less-common WPF controls aligned with the Settings theme designer after the shared
+        shell, common-control, list, menu, and scrollbar overrides have loaded.
+    -->
+
+    <Style x:Key="ThemeMediaPreviewFrame" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemeCardCornerRadius}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="PasswordBox">
+        <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="CheckBox">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+            </Trigger>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemSelectedForegroundBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="Slider">
+        <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="ProgressBar">
+        <Setter Property="Background" Value="{DynamicResource ProgressBarBackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Height" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+    </Style>
+
+    <Style TargetType="Label">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="Image">
+        <Setter Property="Opacity" Value="1"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="DocumentViewer">
+        <Setter Property="Background" Value="{DynamicResource ThemeDialogSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+    </Style>
+
+    <Style TargetType="FlowDocumentScrollViewer">
+        <Setter Property="Background" Value="{DynamicResource ThemeDialogSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+    </Style>
+
+    <Style TargetType="RichTextBox">
+        <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+    </Style>
+</ResourceDictionary>


### PR DESCRIPTION
## Summary
- add a late-loaded `Theme.FormMediaPreviewOverrides.xaml` resource dictionary after the full customization override layer
- route password boxes, check boxes, sliders, progress bars, labels, images, rich text boxes, document viewers, flow-document viewers, and reusable media preview frames through existing admin theme tokens
- extend resource contract tests and progress notes for the form/media/preview chrome theme pass

## Validation
- GitHub connector compare/readback confirmed the branch is 4 commits ahead of `master` with only the intended App.xaml, resource, test, and progress-note files
- Added `ThemeFormMediaPreviewOverrideTests` for resource ordering and theme token coverage
- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks could not run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel
