### PR TITLE
[codex] Add admin theme profile import and export

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ThemeDesignerProfileTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ThemeDesignerProfileTests.cs
@@ -1,0 +1,213 @@
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Documents;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.ViewModels
+{
+    public class ThemeDesignerProfileTests
+    {
+        [Fact]
+        public void ExportThemeProfileCommand_WritesNormalizedThemeJson()
+        {
+            var exportPath = Path.Combine(Path.GetTempPath(), $"tool-theme-{Guid.NewGuid():N}.json");
+            var fileDialogs = new FakeFileDialogService { SavePath = exportPath };
+            var viewModel = CreateViewModel(fileDialogs: fileDialogs);
+
+            viewModel.BackgroundColor = "445566";
+            viewModel.BorderThickness = 99;
+            viewModel.ExportThemeProfileCommand.Execute(null);
+
+            var exported = JsonSerializer.Deserialize<AppThemeSettings>(File.ReadAllText(exportPath));
+
+            Assert.NotNull(exported);
+            Assert.Equal("#445566", exported!.BackgroundColor);
+            Assert.Equal(6, exported.BorderThickness);
+            Assert.Equal("Theme profile exported.", viewModel.Status);
+            Assert.Equal("Theme Profile (*.json)|*.json|All Files (*.*)|*.*", fileDialogs.LastSaveFilter);
+        }
+
+        [Fact]
+        public void ImportThemeProfileCommand_PreviewsNormalizedProfileWithoutSaving()
+        {
+            var importPath = Path.Combine(Path.GetTempPath(), $"tool-theme-{Guid.NewGuid():N}.json");
+            File.WriteAllText(importPath, JsonSerializer.Serialize(new AppThemeSettings
+            {
+                BaseTheme = "Dark",
+                BackgroundColor = "112233",
+                ButtonCornerRadius = 99,
+                SurfaceOpacity = -4,
+                ShadowDepth = 12,
+                FontFamily = "  Aptos  "
+            }));
+
+            var fileDialogs = new FakeFileDialogService { OpenPath = importPath };
+            var settingsService = new FakeSettingsService();
+            var themeService = new FakeThemeService();
+            var viewModel = CreateViewModel(settingsService, themeService, fileDialogs);
+
+            viewModel.ImportThemeProfileCommand.Execute(null);
+
+            Assert.Equal("#112233", viewModel.BackgroundColor);
+            Assert.Equal(32, viewModel.ButtonCornerRadius);
+            Assert.Equal(0, viewModel.SurfaceOpacity);
+            Assert.Equal(12, viewModel.ShadowDepth);
+            Assert.Equal("Aptos", viewModel.FontFamily);
+            Assert.Equal("Theme profile imported for preview. Save to keep it.", viewModel.Status);
+            Assert.Equal(0, settingsService.SaveThemeCalls);
+            Assert.Equal("Dark", themeService.LastAppliedCustomTheme?.BaseTheme);
+            Assert.Equal("Theme Profile (*.json)|*.json|All Files (*.*)|*.*", fileDialogs.LastOpenFilter);
+        }
+
+        [Fact]
+        public void ThemeDesignerControl_ExposesThemeProfileImportExportActions()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ThemeDesignerControl.xaml");
+
+            Assert.Contains("ImportThemeProfileCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ExportThemeProfileCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("Theme profile backup", xaml, StringComparison.Ordinal);
+            Assert.Contains("Portable JSON backups", xaml, StringComparison.Ordinal);
+        }
+
+        private static ThemeDesignerViewModel CreateViewModel(
+            FakeSettingsService? settingsService = null,
+            FakeThemeService? themeService = null,
+            FakeFileDialogService? fileDialogs = null)
+        {
+            return new ThemeDesignerViewModel(
+                settingsService ?? new FakeSettingsService(),
+                themeService ?? new FakeThemeService(),
+                fileDialogs ?? new FakeFileDialogService(),
+                new FakeDialogService());
+        }
+
+        private sealed class FakeThemeService : IThemeService
+        {
+            public AppThemeSettings? LastAppliedCustomTheme { get; private set; }
+            public void ApplyTheme(string? theme) { }
+            public void ApplyCustomTheme(AppThemeSettings? settings) => LastAppliedCustomTheme = settings;
+        }
+
+        private sealed class FakeFileDialogService : IFileDialogService
+        {
+            public string? OpenPath { get; set; }
+            public string? SavePath { get; set; }
+            public string? LastOpenFilter { get; private set; }
+            public string? LastSaveFilter { get; private set; }
+
+            public string? OpenFile(string filter, string? initialDirectory = null)
+            {
+                LastOpenFilter = filter;
+                return OpenPath;
+            }
+
+            public string? SaveFile(string filter, string? initialDirectory = null)
+            {
+                LastSaveFilter = filter;
+                return SavePath;
+            }
+
+            public string? BrowseFolder(string? initialDirectory = null) => null;
+        }
+
+        private sealed class FakeDialogService : IDialogService
+        {
+            public void ShowInfo(string message, string title) { }
+            public bool ShowConfirmation(string message, string title) => true;
+            public ItemModel? ShowEditItemDialog(ItemModel item) => item;
+            public void ShowItemDetails(ItemModel item) { }
+            public (CustomerModel customer, DateTime dueDate)? ShowRentItemDialog(ItemModel item, IEnumerable<CustomerModel> customers) => null;
+            public CustomerModel? ShowAddCustomerDialog() => null;
+            public CustomerModel? ShowEditCustomerDialog(CustomerModel customer) => customer;
+            public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
+            public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
+            public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
+            public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public void ShowPrintPreview(FlowDocument document, string title, string description) { }
+            public void ShowPrintLabelDialog() { }
+        }
+
+        private sealed class FakeSettingsService : ISettingsService
+        {
+            private readonly Dictionary<string, string> _settings = new();
+            public int SaveThemeCalls { get; private set; }
+
+            public event EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
+            public event EventHandler<double>? ItemCardSizeChanged;
+
+            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
+            {
+                _settings[key] = value;
+                return Task.CompletedTask;
+            }
+
+            public Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default)
+                => Task.FromResult(key != null && _settings.TryGetValue(key, out var value) ? value : null);
+
+            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult(new Dictionary<string, string>(_settings));
+
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
+            {
+                foreach (var setting in settings)
+                    _settings[setting.Key] = setting.Value;
+                return Task.CompletedTask;
+            }
+
+            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
+            {
+                _settings.Remove(key);
+                return Task.CompletedTask;
+            }
+
+            public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default) => Task.FromResult<string?>("Light");
+
+            public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default)
+            {
+                SaveThemeCalls++;
+                return Task.CompletedTask;
+            }
+
+            public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(100000);
+            public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(1);
+            public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default) => Task.FromResult("Item");
+            public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult("Items");
+            public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default) => Task.FromResult<IDictionary<ItemDetailField, bool>>(new Dictionary<ItemDetailField, bool>());
+            public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
+            {
+                ItemDetailVisibilityChanged?.Invoke(this, visibility);
+                return Task.CompletedTask;
+            }
+            public Task<double> GetItemCardSizeAsync(CancellationToken cancellationToken = default) => Task.FromResult(1.0);
+            public Task SaveItemCardSizeAsync(double size, CancellationToken cancellationToken = default)
+            {
+                ItemCardSizeChanged?.Invoke(this, size);
+                return Task.CompletedTask;
+            }
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-20-theme-profile-import-export.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-20-theme-profile-import-export.md
@@ -1,0 +1,13 @@
+# Theme Profile Import / Export
+
+## Completed
+
+- Added JSON theme profile export from the Admin Settings theme designer so an admin can back up a full-app redesign before experimenting.
+- Added JSON theme profile import so admins can preview a saved redesign from another workstation or backup file before choosing Save Theme.
+- Surfaced Import and Export actions in both the theme designer toolbar and the side-panel profile backup area.
+- Added focused tests for export normalization, import preview behavior, and the XAML contract for the profile controls.
+
+## Validation Notes
+
+- Local `dotnet test`, WPF screenshots, and local banned-word checks remain unavailable in this scheduled Linux container because the .NET SDK/Windows WPF runtime and direct local clone/raw access are blocked.
+- Changed files were reviewed through the GitHub connector after commit.

--- a/InventoryManagementApp/ViewModels/ThemeDesignerViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ThemeDesignerViewModel.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.ObjectModel;
+using System.IO;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,6 +15,9 @@ namespace InventoryManagementApp.ViewModels
 {
     public class ThemeDesignerViewModel : ObservableObject
     {
+        private static readonly JsonSerializerOptions ThemeProfileJsonOptions = new() { WriteIndented = true };
+        private const string ThemeProfileDialogFilter = "Theme Profile (*.json)|*.json|All Files (*.*)|*.*";
+
         private readonly ISettingsService _settingsService;
         private readonly IThemeService _themeService;
         private readonly IFileDialogService _fileDialogService;
@@ -40,6 +45,8 @@ namespace InventoryManagementApp.ViewModels
             ResetCommand = new RelayCommand(Reset);
             BrowseBackgroundCommand = new RelayCommand(BrowseBackground);
             ClearBackgroundCommand = new RelayCommand(() => BackgroundImagePath = string.Empty);
+            ImportThemeProfileCommand = new RelayCommand(ImportThemeProfile);
+            ExportThemeProfileCommand = new RelayCommand(ExportThemeProfile);
             GlassPresetCommand = new RelayCommand(ApplyGlassPreset);
             BorderlessPresetCommand = new RelayCommand(ApplyBorderlessPreset);
             HighContrastPresetCommand = new RelayCommand(ApplyHighContrastPreset);
@@ -51,6 +58,8 @@ namespace InventoryManagementApp.ViewModels
         public IRelayCommand ResetCommand { get; }
         public IRelayCommand BrowseBackgroundCommand { get; }
         public IRelayCommand ClearBackgroundCommand { get; }
+        public IRelayCommand ImportThemeProfileCommand { get; }
+        public IRelayCommand ExportThemeProfileCommand { get; }
         public IRelayCommand GlassPresetCommand { get; }
         public IRelayCommand BorderlessPresetCommand { get; }
         public IRelayCommand HighContrastPresetCommand { get; }
@@ -471,6 +480,52 @@ namespace InventoryManagementApp.ViewModels
             var path = _fileDialogService.OpenFile("Image Files|*.png;*.jpg;*.jpeg;*.bmp");
             if (!string.IsNullOrWhiteSpace(path))
                 BackgroundImagePath = path;
+        }
+
+        private void ExportThemeProfile()
+        {
+            var path = _fileDialogService.SaveFile(ThemeProfileDialogFilter);
+            if (string.IsNullOrWhiteSpace(path))
+                return;
+
+            try
+            {
+                _settings.Normalize();
+                File.WriteAllText(path, JsonSerializer.Serialize(_settings, ThemeProfileJsonOptions));
+                NotifyAllThemePropertiesChanged();
+                Status = "Theme profile exported.";
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to export app theme profile.");
+                _dialogService.ShowInfo("Theme profile could not be exported. Choose a writable location and try again.", "Theme Profile");
+                Status = "Theme profile export failed.";
+            }
+        }
+
+        private void ImportThemeProfile()
+        {
+            var path = _fileDialogService.OpenFile(ThemeProfileDialogFilter);
+            if (string.IsNullOrWhiteSpace(path))
+                return;
+
+            try
+            {
+                var imported = JsonSerializer.Deserialize<AppThemeSettings>(File.ReadAllText(path), ThemeProfileJsonOptions)
+                    ?? throw new InvalidDataException("Theme profile did not contain app theme settings.");
+
+                imported.Normalize();
+                _settings = imported;
+                Preview();
+                NotifyAllThemePropertiesChanged();
+                Status = "Theme profile imported for preview. Save to keep it.";
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to import app theme profile.");
+                _dialogService.ShowInfo("Theme profile could not be imported. Choose a valid theme JSON file and try again.", "Theme Profile");
+                Status = "Theme profile import failed.";
+            }
         }
 
         private void ApplyGlassPreset()

--- a/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml
+++ b/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml
@@ -30,9 +30,11 @@
                 <DockPanel LastChildFill="False">
                     <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
                         <TextBlock Text="App Theme Designer" Style="{StaticResource SubheadingTextBlock}"/>
-                        <TextBlock Text="Redesign the full app shell with colors, backgrounds, transparency, border width, divider strength, corners, spacing, typography, disabled states, table density, focus rings, interaction feedback, shadow color/direction, and separate surface/control shadow strength." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                        <TextBlock Text="Redesign the full app shell with colors, backgrounds, transparency, border width, divider strength, corners, spacing, typography, disabled states, table density, focus rings, interaction feedback, shadow color/direction, separate surface/control shadow strength, and portable theme profiles." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                     </StackPanel>
                     <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
+                        <Button Style="{StaticResource GhostButton}" Content="Import" Command="{Binding ImportThemeProfileCommand}" Margin="0,0,4,0"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Export" Command="{Binding ExportThemeProfileCommand}" Margin="0,0,4,0"/>
                         <Button Style="{StaticResource GhostButton}" Content="Glass" Command="{Binding GlassPresetCommand}" Margin="0,0,4,0"/>
                         <Button Style="{StaticResource GhostButton}" Content="Borderless" Command="{Binding BorderlessPresetCommand}" Margin="0,0,4,0"/>
                         <Button Style="{StaticResource GhostButton}" Content="High Contrast" Command="{Binding HighContrastPresetCommand}" Margin="0,0,4,0"/>
@@ -174,6 +176,17 @@
                             </StackPanel>
                         </Border>
 
+                        <Border Style="{StaticResource DesktopInsetCard}" Margin="0,0,0,12">
+                            <StackPanel>
+                                <TextBlock Text="Theme profile backup" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
+                                <TextBlock Text="Export a JSON theme profile before experimenting, or import a profile from another workstation. Imported profiles preview immediately; choose Save Theme to make one permanent." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,10"/>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Style="{StaticResource GhostButton}" Content="Import Profile" Command="{Binding ImportThemeProfileCommand}" Margin="0,0,6,0"/>
+                                    <Button Style="{StaticResource GhostButton}" Content="Export Profile" Command="{Binding ExportThemeProfileCommand}"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+
                         <Border Style="{StaticResource DesktopInsetCard}">
                             <StackPanel>
                                 <TextBlock Text="Theme pages" Style="{StaticResource PageTitleTextBlock}" Margin="0,0,0,4"/>
@@ -184,7 +197,9 @@
                                 <TextBlock Text="03 Shape and depth" Style="{StaticResource LabelTextBlock}"/>
                                 <TextBlock Text="Border removal, divider strength, corners, glass surfaces, and shadow depth." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,8"/>
                                 <TextBlock Text="04 Density and interaction" Style="{StaticResource LabelTextBlock}"/>
-                                <TextBlock Text="Spacing, typography scale, table density, focus rings, hover strength, grid lines, and motion." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                <TextBlock Text="Spacing, typography scale, table density, focus rings, hover strength, grid lines, and motion." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,8"/>
+                                <TextBlock Text="Profiles" Style="{StaticResource LabelTextBlock}"/>
+                                <TextBlock Text="Portable JSON backups for full-app redesigns." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                             </StackPanel>
                         </Border>
                     </StackPanel>


### PR DESCRIPTION
## Summary

- Adds JSON import/export commands to the Admin Settings theme designer so admins can back up, move, and restore full-app redesign profiles.
- Surfaces Import/Export controls in the Themes workspace toolbar and side-panel profile backup area.
- Adds focused tests for export normalization, import preview behavior, and XAML contract coverage for the profile controls.

## Validation

- Reviewed changed files and branch diff through the GitHub connector.
- Local dotnet tests, WPF screenshots, and local banned-word checks could not be run in this scheduled Linux container because the .NET SDK/Windows WPF runtime and direct clone/raw access remain blocked.