### PR TITLE
Add theme designer workflow tests

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ThemeDesignerViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ThemeDesignerViewModelTests.cs
@@ -1,0 +1,258 @@
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models;
+using InventoryManagementApp.ViewModels;
+using Moq;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.ViewModels
+{
+    public class ThemeDesignerViewModelTests
+    {
+        [Fact]
+        public async Task InitializeAsync_LoadsSavedThemeProfileAndAppliesPreview()
+        {
+            var settingsService = new FakeSettingsService();
+            var saved = AppThemeSettings.CreateDefault("Dark");
+            saved.BackgroundColor = "#FF010203";
+            saved.SurfaceColor = "#FF111213";
+            saved.ButtonCornerRadius = 17;
+            saved.EnableControlShadows = true;
+            saved.ControlShadowScale = 1.4;
+            await settingsService.SaveAppThemeSettingsAsync(saved);
+
+            var themeService = new RecordingThemeService();
+            var viewModel = CreateViewModel(settingsService, themeService);
+
+            await viewModel.InitializeAsync();
+
+            Assert.Equal("Dark", viewModel.BaseTheme);
+            Assert.Equal("#FF010203", viewModel.BackgroundColor);
+            Assert.Equal("#FF111213", viewModel.SurfaceColor);
+            Assert.Equal(17, viewModel.ButtonCornerRadius);
+            Assert.True(viewModel.EnableControlShadows);
+            Assert.Equal(1.4, viewModel.ControlShadowScale);
+            Assert.NotNull(themeService.LastCustomTheme);
+            Assert.Equal("Dark", themeService.LastCustomTheme!.BaseTheme);
+            Assert.Equal("Loaded saved app theme.", viewModel.Status);
+        }
+
+        [Fact]
+        public async Task SaveCommand_NormalizesPersistsAndAppliesFullThemeProfile()
+        {
+            var settingsService = new FakeSettingsService();
+            var themeService = new RecordingThemeService();
+            var viewModel = CreateViewModel(settingsService, themeService);
+            await viewModel.InitializeAsync();
+
+            viewModel.BaseTheme = "Dark";
+            viewModel.BackgroundColor = "112233";
+            viewModel.ButtonColor = "445566";
+            viewModel.BordersVisible = false;
+            viewModel.ButtonCornerRadius = 21;
+            viewModel.ShadowDepth = 8;
+            viewModel.ControlShadowScale = 0.75;
+            viewModel.BackgroundImageStretch = "Uniform";
+
+            await viewModel.SaveCommand.ExecuteAsync(null);
+            var loaded = await settingsService.GetAppThemeSettingsAsync();
+
+            Assert.Equal("Dark", await settingsService.GetThemeAsync());
+            Assert.Equal("Dark", loaded.BaseTheme);
+            Assert.Equal("#112233", loaded.BackgroundColor);
+            Assert.Equal("#445566", loaded.ButtonColor);
+            Assert.False(loaded.BordersVisible);
+            Assert.Equal(21, loaded.ButtonCornerRadius);
+            Assert.Equal(8, loaded.ShadowDepth);
+            Assert.Equal(0.75, loaded.ControlShadowScale);
+            Assert.Equal("Uniform", loaded.BackgroundImageStretch);
+            Assert.Equal("Theme saved and applied.", viewModel.Status);
+            Assert.NotNull(themeService.LastCustomTheme);
+            Assert.Equal("#112233", themeService.LastCustomTheme!.BackgroundColor);
+            Assert.True(themeService.CustomApplyCount > 1);
+        }
+
+        [Fact]
+        public async Task BorderlessPreset_PreviewsCompleteBorderAndShadowRemoval()
+        {
+            var settingsService = new FakeSettingsService();
+            var themeService = new RecordingThemeService();
+            var viewModel = CreateViewModel(settingsService, themeService);
+            await viewModel.InitializeAsync();
+
+            viewModel.BorderlessPresetCommand.Execute(null);
+
+            Assert.False(viewModel.BordersVisible);
+            Assert.False(viewModel.EnableSurfaceShadows);
+            Assert.False(viewModel.EnableControlShadows);
+            Assert.Equal(0, viewModel.BorderOpacity);
+            Assert.Equal(0, viewModel.BorderThickness);
+            Assert.Equal(0, viewModel.ControlBorderThickness);
+            Assert.Equal(0, viewModel.ShadowBlurRadius);
+            Assert.Equal(0, viewModel.ShadowDepth);
+            Assert.Equal(0, viewModel.ShadowOpacity);
+            Assert.Equal(0, viewModel.SurfaceShadowScale);
+            Assert.Equal(0, viewModel.ControlShadowScale);
+            Assert.NotNull(themeService.LastCustomTheme);
+            Assert.False(themeService.LastCustomTheme!.BordersVisible);
+            Assert.Equal("Borderless preset previewed. Save to keep it.", viewModel.Status);
+        }
+
+        private static ThemeDesignerViewModel CreateViewModel(FakeSettingsService settingsService, RecordingThemeService themeService)
+        {
+            return new ThemeDesignerViewModel(
+                settingsService,
+                themeService,
+                new Mock<IFileDialogService>().Object,
+                new Mock<IDialogService>().Object);
+        }
+
+        private sealed class RecordingThemeService : IThemeService
+        {
+            public AppThemeSettings? LastCustomTheme { get; private set; }
+            public int CustomApplyCount { get; private set; }
+
+            public void ApplyTheme(string? theme)
+            {
+            }
+
+            public void ApplyCustomTheme(AppThemeSettings? settings)
+            {
+                if (settings == null)
+                {
+                    LastCustomTheme = null;
+                    return;
+                }
+
+                var copy = new AppThemeSettings
+                {
+                    BaseTheme = settings.BaseTheme,
+                    BackgroundColor = settings.BackgroundColor,
+                    BackgroundOverlayColor = settings.BackgroundOverlayColor,
+                    SurfaceColor = settings.SurfaceColor,
+                    SurfaceAltColor = settings.SurfaceAltColor,
+                    NavigationColor = settings.NavigationColor,
+                    InputColor = settings.InputColor,
+                    ButtonColor = settings.ButtonColor,
+                    BorderColor = settings.BorderColor,
+                    TextColor = settings.TextColor,
+                    MutedTextColor = settings.MutedTextColor,
+                    AccentColor = settings.AccentColor,
+                    SuccessColor = settings.SuccessColor,
+                    WarningColor = settings.WarningColor,
+                    ErrorColor = settings.ErrorColor,
+                    ShadowColor = settings.ShadowColor,
+                    BackgroundImagePath = settings.BackgroundImagePath,
+                    BackgroundImageStretch = settings.BackgroundImageStretch,
+                    FontFamily = settings.FontFamily,
+                    BackgroundOpacity = settings.BackgroundOpacity,
+                    BackgroundOverlayOpacity = settings.BackgroundOverlayOpacity,
+                    SurfaceOpacity = settings.SurfaceOpacity,
+                    SurfaceAltOpacity = settings.SurfaceAltOpacity,
+                    InputOpacity = settings.InputOpacity,
+                    ButtonOpacity = settings.ButtonOpacity,
+                    NavigationOpacity = settings.NavigationOpacity,
+                    HeaderOpacity = settings.HeaderOpacity,
+                    MenuOpacity = settings.MenuOpacity,
+                    FooterOpacity = settings.FooterOpacity,
+                    DialogOpacity = settings.DialogOpacity,
+                    DisabledOpacity = settings.DisabledOpacity,
+                    BordersVisible = settings.BordersVisible,
+                    BorderOpacity = settings.BorderOpacity,
+                    BorderThickness = settings.BorderThickness,
+                    ControlBorderThickness = settings.ControlBorderThickness,
+                    DividerOpacity = settings.DividerOpacity,
+                    CardCornerRadius = settings.CardCornerRadius,
+                    PanelCornerRadius = settings.PanelCornerRadius,
+                    ButtonCornerRadius = settings.ButtonCornerRadius,
+                    InputCornerRadius = settings.InputCornerRadius,
+                    ShadowBlurRadius = settings.ShadowBlurRadius,
+                    ShadowDepth = settings.ShadowDepth,
+                    ShadowOpacity = settings.ShadowOpacity,
+                    ShadowDirection = settings.ShadowDirection,
+                    SurfaceShadowScale = settings.SurfaceShadowScale,
+                    ControlShadowScale = settings.ControlShadowScale,
+                    PagePadding = settings.PagePadding,
+                    CardPadding = settings.CardPadding,
+                    FontScale = settings.FontScale,
+                    HeadingFontScale = settings.HeadingFontScale,
+                    ControlHeight = settings.ControlHeight,
+                    DataGridRowHeight = settings.DataGridRowHeight,
+                    DataGridHeaderHeight = settings.DataGridHeaderHeight,
+                    InteractionIntensity = settings.InteractionIntensity,
+                    FocusRingOpacity = settings.FocusRingOpacity,
+                    GridLineOpacity = settings.GridLineOpacity,
+                    MotionIntensity = settings.MotionIntensity,
+                    UseGlassSurfaces = settings.UseGlassSurfaces,
+                    EnableSurfaceShadows = settings.EnableSurfaceShadows,
+                    EnableControlShadows = settings.EnableControlShadows
+                };
+                copy.Normalize();
+                LastCustomTheme = copy;
+                CustomApplyCount++;
+            }
+        }
+
+        private sealed class FakeSettingsService : ISettingsService
+        {
+            private readonly Dictionary<string, string> _settings = new();
+
+            public event System.EventHandler<IDictionary<ItemDetailField, bool>>? ItemDetailVisibilityChanged;
+            public event System.EventHandler<double>? ItemCardSizeChanged;
+
+            public Task SaveSettingAsync(string key, string value, CancellationToken cancellationToken = default)
+            {
+                _settings[key] = value;
+                return Task.CompletedTask;
+            }
+
+            public Task<string?> GetSettingAsync(string? key, CancellationToken cancellationToken = default)
+            {
+                return Task.FromResult(key != null && _settings.TryGetValue(key, out var value) ? value : null);
+            }
+
+            public Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new Dictionary<string, string>(_settings));
+
+            public Task UpdateSettingsAsync(Dictionary<string, string> settings, CancellationToken cancellationToken = default)
+            {
+                foreach (var setting in settings)
+                    _settings[setting.Key] = setting.Value;
+                return Task.CompletedTask;
+            }
+
+            public Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
+            {
+                _settings.Remove(key);
+                return Task.CompletedTask;
+            }
+
+            public Task<string?> GetThemeAsync(CancellationToken cancellationToken = default) => GetSettingAsync("Theme", cancellationToken);
+            public Task SaveThemeAsync(string theme, CancellationToken cancellationToken = default) => SaveSettingAsync("Theme", theme, cancellationToken);
+            public Task<int> GetPasswordIterationsAsync(CancellationToken cancellationToken = default) => Task.FromResult(100000);
+            public Task SavePasswordIterationsAsync(int iterations, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<int> GetAutoLogoutMinutesAsync(CancellationToken cancellationToken = default) => Task.FromResult(1);
+            public Task SaveAutoLogoutMinutesAsync(int minutes, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelSingularAsync(CancellationToken cancellationToken = default) => Task.FromResult("Item");
+            public Task SaveItemLabelSingularAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<string> GetItemLabelPluralAsync(CancellationToken cancellationToken = default) => Task.FromResult("Items");
+            public Task SaveItemLabelPluralAsync(string label, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<IDictionary<ItemDetailField, bool>> GetItemDetailVisibilityAsync(CancellationToken cancellationToken = default) => Task.FromResult<IDictionary<ItemDetailField, bool>>(new Dictionary<ItemDetailField, bool>());
+
+            public Task SaveItemDetailVisibilityAsync(IDictionary<ItemDetailField, bool> visibility, CancellationToken cancellationToken = default)
+            {
+                ItemDetailVisibilityChanged?.Invoke(this, visibility);
+                return Task.CompletedTask;
+            }
+
+            public Task<double> GetItemCardSizeAsync(CancellationToken cancellationToken = default) => Task.FromResult(1.0);
+
+            public Task SaveItemCardSizeAsync(double size, CancellationToken cancellationToken = default)
+            {
+                ItemCardSizeChanged?.Invoke(this, size);
+                return Task.CompletedTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add view-model tests for the Admin Settings theme designer workflow.
- Cover loading saved full-app theme profiles, live preview application, saving normalized custom theme profiles, and the borderless preset that removes borders and shadows.

## Validation
- Not run locally: this scheduled Linux container does not have the .NET SDK or Windows WPF runtime, and local clone/raw access is blocked.