### PR TITLE
Polish final form media theme overrides

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemeFormMediaPreviewOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeFormMediaPreviewOverrideTests.cs
@@ -61,6 +61,20 @@ namespace InventoryManagementApp.Tests.Resources
             Assert.Contains("{DynamicResource ItemSelectedBrush}", xaml, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void FormMediaPreviewOverrides_PreserveFinalInteractionAndReadabilityChrome()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.FormMediaPreviewOverrides.xaml");
+
+            Assert.Contains("DefaultFocusVisual", xaml, StringComparison.Ordinal);
+            Assert.Contains("AutoToolTipPlacement", xaml, StringComparison.Ordinal);
+            Assert.Contains("AutoToolTipPrecision", xaml, StringComparison.Ordinal);
+            Assert.Contains("IsMoveToPointEnabled", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextBlock.TextTrimming", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextBlock.TextWrapping", xaml, StringComparison.Ordinal);
+            Assert.Contains("SnapsToDevicePixels", xaml, StringComparison.Ordinal);
+        }
+
         private static string ReadRepositoryFile(params string[] relativePathParts)
         {
             var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/InventoryManagementApp/ProgressNotes/2026-06-20-theme-form-media-final-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-20-theme-form-media-final-polish.md
@@ -1,0 +1,19 @@
+# Admin Theme Form and Media Final Polish
+
+Date: 2026-06-20
+
+## Completed
+
+- Tightened the final `Theme.FormMediaPreviewOverrides.xaml` resource layer so last-loaded form, media, and document-preview controls keep admin theme customization for transparency, borders, depth, typography, disabled opacity, and background visibility.
+- Preserved keyboard focus visuals for check boxes, sliders, progress bars, document preview surfaces, and rich text fields after the late override dictionary wins over earlier control styles.
+- Restored slider interaction polish in the final override layer with move-to-click behavior and value tooltips, so theme density changes do not remove expected admin tuning feedback.
+- Added label text trimming/wrapping and preview snapping hints to keep customized transparent surfaces readable when admins use strong background imagery or borderless themes.
+
+## Tests
+
+- Extended `ThemeFormMediaPreviewOverrideTests` to guard the final form/media resource layer, admin theme tokens, focus visuals, slider tooltip behavior, text readability markers, and pixel snapping markers.
+
+## Validation notes
+
+- GitHub connector branch updates and readback were used for validation in this scheduled Linux container.
+- Local `.NET` build/test, WPF screenshots, and local banned-word checks were not run because this container does not include the .NET SDK or Windows WPF runtime, and direct local clone/raw access remains blocked by the network tunnel.

--- a/InventoryManagementApp/Resources/Theme.FormMediaPreviewOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.FormMediaPreviewOverrides.xaml
@@ -44,6 +44,7 @@
         <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
         <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
         <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
@@ -66,6 +67,12 @@
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
         <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
         <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Setter Property="IsMoveToPointEnabled" Value="True"/>
+        <Setter Property="AutoToolTipPlacement" Value="TopLeft"/>
+        <Setter Property="AutoToolTipPrecision" Value="2"/>
         <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
         <Style.Triggers>
             <Trigger Property="IsEnabled" Value="False">
@@ -81,6 +88,7 @@
         <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
         <Setter Property="Height" Value="{DynamicResource ThemeControlMinHeight}"/>
         <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
     </Style>
 
     <Style TargetType="Label">
@@ -92,6 +100,8 @@
         <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
         <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="TextBlock.TextTrimming" Value="CharacterEllipsis"/>
+        <Setter Property="TextBlock.TextWrapping" Value="Wrap"/>
         <Style.Triggers>
             <Trigger Property="IsEnabled" Value="False">
                 <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
@@ -113,6 +123,8 @@
         <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
         <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
         <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
     </Style>
 
     <Style TargetType="FlowDocumentScrollViewer">
@@ -123,6 +135,8 @@
         <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
         <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
         <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
     </Style>
 
     <Style TargetType="RichTextBox">
@@ -135,5 +149,10 @@
         <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
         <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
         <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 </ResourceDictionary>


### PR DESCRIPTION
## Summary
- Tighten the final form/media theme override layer so last-loaded controls keep admin theme focus, typography, transparency, border, depth, and preview-surface customization.
- Preserve slider move-to-click and value tooltip behavior in the last-loaded resource layer.
- Add contract coverage for focus visuals, slider tooltip behavior, label readability, and preview pixel snapping markers.

## Validation
- GitHub connector compare/readback confirmed the focused resource, test, and progress-note diff.
- Not run locally: this scheduled Linux container does not have the .NET SDK or Windows WPF runtime, and local clone/raw access remains blocked.