### PR TITLE
[codex] add transparent and deep shadow theme presets

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ThemeDesignerProfileTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ThemeDesignerProfileTests.cs
@@ -77,6 +77,18 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("Portable JSON backups", xaml, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void ThemeDesignerControl_ExposesPresetToolbarWithoutHorizontalClipping()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ThemeDesignerControl.xaml");
+
+            Assert.Contains("<WrapPanel DockPanel.Dock=\"Right\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TransparentCanvasPresetCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("DeepShadowPresetCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("Transparent Canvas", xaml, StringComparison.Ordinal);
+            Assert.Contains("Deep Shadow", xaml, StringComparison.Ordinal);
+        }
+
         private static ThemeDesignerViewModel CreateViewModel(
             FakeSettingsService? settingsService = null,
             FakeThemeService? themeService = null,

--- a/InventoryManagementApp.Tests/ViewModels/ThemeDesignerViewModelTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ThemeDesignerViewModelTests.cs
@@ -75,6 +75,36 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public async Task TransparentCanvasPreset_PreviewsBackgroundFirstRedesign()
+        {
+            var settingsService = new FakeSettingsService();
+            var themeService = new RecordingThemeService();
+            var viewModel = CreateViewModel(settingsService, themeService);
+            await viewModel.InitializeAsync();
+
+            viewModel.TransparentCanvasPresetCommand.Execute(null);
+
+            Assert.True(viewModel.UseGlassSurfaces);
+            Assert.False(viewModel.BordersVisible);
+            Assert.False(viewModel.EnableSurfaceShadows);
+            Assert.False(viewModel.EnableControlShadows);
+            Assert.Equal(0, viewModel.BackgroundOverlayOpacity);
+            Assert.Equal(0.18, viewModel.SurfaceOpacity);
+            Assert.Equal(0.12, viewModel.SurfaceAltOpacity);
+            Assert.Equal(0.24, viewModel.InputOpacity);
+            Assert.Equal(0.22, viewModel.ButtonOpacity);
+            Assert.Equal(0.18, viewModel.NavigationOpacity);
+            Assert.Equal(0.16, viewModel.HeaderOpacity);
+            Assert.Equal(0, viewModel.BorderThickness);
+            Assert.Equal(0, viewModel.ControlBorderThickness);
+            Assert.Equal(0, viewModel.ShadowDepth);
+            Assert.Equal(0.06, viewModel.GridLineOpacity);
+            Assert.NotNull(themeService.LastCustomTheme);
+            Assert.Equal(0.18, themeService.LastCustomTheme!.SurfaceOpacity);
+            Assert.Equal("Transparent canvas preset previewed. Save to keep it.", viewModel.Status);
+        }
+
+        [Fact]
         public async Task BorderlessPreset_PreviewsCompleteBorderAndShadowRemoval()
         {
             var settingsService = new FakeSettingsService();
@@ -98,6 +128,33 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.NotNull(themeService.LastCustomTheme);
             Assert.False(themeService.LastCustomTheme!.BordersVisible);
             Assert.Equal("Borderless preset previewed. Save to keep it.", viewModel.Status);
+        }
+
+        [Fact]
+        public async Task DeepShadowPreset_PreviewsRaisedSurfaceAndControlDepth()
+        {
+            var settingsService = new FakeSettingsService();
+            var themeService = new RecordingThemeService();
+            var viewModel = CreateViewModel(settingsService, themeService);
+            await viewModel.InitializeAsync();
+
+            viewModel.DeepShadowPresetCommand.Execute(null);
+
+            Assert.True(viewModel.BordersVisible);
+            Assert.True(viewModel.EnableSurfaceShadows);
+            Assert.True(viewModel.EnableControlShadows);
+            Assert.Equal(36, viewModel.ShadowBlurRadius);
+            Assert.Equal(12, viewModel.ShadowDepth);
+            Assert.Equal(0.45, viewModel.ShadowOpacity);
+            Assert.Equal(2.2, viewModel.SurfaceShadowScale);
+            Assert.Equal(1.6, viewModel.ControlShadowScale);
+            Assert.Equal(12, viewModel.CardCornerRadius);
+            Assert.Equal(8, viewModel.ButtonCornerRadius);
+            Assert.Equal(1.25, viewModel.InteractionIntensity);
+            Assert.NotNull(themeService.LastCustomTheme);
+            Assert.True(themeService.LastCustomTheme!.EnableControlShadows);
+            Assert.Equal(1.6, themeService.LastCustomTheme.ControlShadowScale);
+            Assert.Equal("Deep shadow preset previewed. Save to keep it.", viewModel.Status);
         }
 
         private static ThemeDesignerViewModel CreateViewModel(FakeSettingsService settingsService, RecordingThemeService themeService)

--- a/InventoryManagementApp/ProgressNotes/2026-06-20-theme-transparent-depth-presets.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-20-theme-transparent-depth-presets.md
@@ -1,0 +1,8 @@
+# Theme Designer Transparent and Depth Presets
+
+- Added a Transparent Canvas preset for background-led redesigns with glass surfaces, low surface opacity, hidden borders, and no shadows so app backgrounds can show through the shell.
+- Added a Deep Shadow preset for admins who want stronger app-wide depth, with high surface/control shadow scales, deeper blur, visible borders, and raised chrome defaults.
+- Updated the Admin Theme Designer toolbar to wrap preset actions instead of clipping as more customization controls are added.
+- Added view-model and XAML contract coverage for the new preset commands and toolbar layout.
+
+Validation note: local dotnet tests, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and local clone/raw access is blocked by the network tunnel.

--- a/InventoryManagementApp/ViewModels/ThemeDesignerViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ThemeDesignerViewModel.cs
@@ -48,7 +48,9 @@ namespace InventoryManagementApp.ViewModels
             ImportThemeProfileCommand = new RelayCommand(ImportThemeProfile);
             ExportThemeProfileCommand = new RelayCommand(ExportThemeProfile);
             GlassPresetCommand = new RelayCommand(ApplyGlassPreset);
+            TransparentCanvasPresetCommand = new RelayCommand(ApplyTransparentCanvasPreset);
             BorderlessPresetCommand = new RelayCommand(ApplyBorderlessPreset);
+            DeepShadowPresetCommand = new RelayCommand(ApplyDeepShadowPreset);
             HighContrastPresetCommand = new RelayCommand(ApplyHighContrastPreset);
         }
 
@@ -61,7 +63,9 @@ namespace InventoryManagementApp.ViewModels
         public IRelayCommand ImportThemeProfileCommand { get; }
         public IRelayCommand ExportThemeProfileCommand { get; }
         public IRelayCommand GlassPresetCommand { get; }
+        public IRelayCommand TransparentCanvasPresetCommand { get; }
         public IRelayCommand BorderlessPresetCommand { get; }
+        public IRelayCommand DeepShadowPresetCommand { get; }
         public IRelayCommand HighContrastPresetCommand { get; }
 
         public string Status
@@ -579,6 +583,47 @@ namespace InventoryManagementApp.ViewModels
             Status = "Glass preset previewed. Save to keep it.";
         }
 
+        private void ApplyTransparentCanvasPreset()
+        {
+            UseGlassSurfaces = true;
+            BackgroundOpacity = 1;
+            BackgroundOverlayOpacity = 0;
+            SurfaceOpacity = 0.18;
+            SurfaceAltOpacity = 0.12;
+            InputOpacity = 0.24;
+            ButtonOpacity = 0.22;
+            NavigationOpacity = 0.18;
+            HeaderOpacity = 0.16;
+            MenuOpacity = 0.16;
+            FooterOpacity = 0.14;
+            DialogOpacity = 0.34;
+            DisabledOpacity = 0.36;
+            BordersVisible = false;
+            BorderOpacity = 0;
+            BorderThickness = 0;
+            ControlBorderThickness = 0;
+            DividerOpacity = 0.08;
+            EnableSurfaceShadows = false;
+            EnableControlShadows = false;
+            ShadowBlurRadius = 0;
+            ShadowDepth = 0;
+            ShadowOpacity = 0;
+            SurfaceShadowScale = 0;
+            ControlShadowScale = 0;
+            CardCornerRadius = 10;
+            PanelCornerRadius = 10;
+            ButtonCornerRadius = 10;
+            InputCornerRadius = 8;
+            PagePadding = 8;
+            CardPadding = 10;
+            InteractionIntensity = 0.75;
+            FocusRingOpacity = 0.5;
+            GridLineOpacity = 0.06;
+            MotionIntensity = 0.9;
+            BackgroundImageStretch = "UniformToFill";
+            Status = "Transparent canvas preset previewed. Save to keep it.";
+        }
+
         private void ApplyBorderlessPreset()
         {
             UseGlassSurfaces = false;
@@ -621,6 +666,44 @@ namespace InventoryManagementApp.ViewModels
             GridLineOpacity = 0;
             MotionIntensity = 0.75;
             Status = "Borderless preset previewed. Save to keep it.";
+        }
+
+        private void ApplyDeepShadowPreset()
+        {
+            UseGlassSurfaces = false;
+            SurfaceOpacity = 0.96;
+            SurfaceAltOpacity = 0.92;
+            InputOpacity = 0.96;
+            ButtonOpacity = 0.94;
+            NavigationOpacity = 0.96;
+            HeaderOpacity = 0.96;
+            MenuOpacity = 0.94;
+            FooterOpacity = 0.92;
+            DialogOpacity = 0.98;
+            BordersVisible = true;
+            BorderOpacity = 0.55;
+            BorderThickness = 1;
+            ControlBorderThickness = 1;
+            DividerOpacity = 0.5;
+            EnableSurfaceShadows = true;
+            EnableControlShadows = true;
+            ShadowBlurRadius = 36;
+            ShadowDepth = 12;
+            ShadowOpacity = 0.45;
+            ShadowDirection = 270;
+            SurfaceShadowScale = 2.2;
+            ControlShadowScale = 1.6;
+            CardCornerRadius = 12;
+            PanelCornerRadius = 10;
+            ButtonCornerRadius = 8;
+            InputCornerRadius = 6;
+            PagePadding = 10;
+            CardPadding = 12;
+            InteractionIntensity = 1.25;
+            FocusRingOpacity = 0.65;
+            GridLineOpacity = 0.32;
+            MotionIntensity = 1.15;
+            Status = "Deep shadow preset previewed. Save to keep it.";
         }
 
         private void ApplyHighContrastPreset()

--- a/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml
+++ b/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml
@@ -32,15 +32,17 @@
                         <TextBlock Text="App Theme Designer" Style="{StaticResource SubheadingTextBlock}"/>
                         <TextBlock Text="Redesign the full app shell with colors, backgrounds, transparency, border width, divider strength, corners, spacing, typography, disabled states, table density, focus rings, interaction feedback, shadow color/direction, separate surface/control shadow strength, and portable theme profiles." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                     </StackPanel>
-                    <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
-                        <Button Style="{StaticResource GhostButton}" Content="Import" Command="{Binding ImportThemeProfileCommand}" Margin="0,0,4,0"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Export" Command="{Binding ExportThemeProfileCommand}" Margin="0,0,4,0"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Glass" Command="{Binding GlassPresetCommand}" Margin="0,0,4,0"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Borderless" Command="{Binding BorderlessPresetCommand}" Margin="0,0,4,0"/>
-                        <Button Style="{StaticResource GhostButton}" Content="High Contrast" Command="{Binding HighContrastPresetCommand}" Margin="0,0,4,0"/>
-                        <Button Style="{StaticResource GhostButton}" Content="Reset" Command="{Binding ResetCommand}" Margin="0,0,4,0"/>
-                        <Button Style="{StaticResource PrimaryButton}" Content="Save Theme" Command="{Binding SaveCommand}"/>
-                    </StackPanel>
+                    <WrapPanel DockPanel.Dock="Right" HorizontalAlignment="Right" VerticalAlignment="Center">
+                        <Button Style="{StaticResource GhostButton}" Content="Import" Command="{Binding ImportThemeProfileCommand}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Export" Command="{Binding ExportThemeProfileCommand}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Glass" Command="{Binding GlassPresetCommand}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Transparent Canvas" Command="{Binding TransparentCanvasPresetCommand}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Borderless" Command="{Binding BorderlessPresetCommand}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Deep Shadow" Command="{Binding DeepShadowPresetCommand}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="High Contrast" Command="{Binding HighContrastPresetCommand}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource GhostButton}" Content="Reset" Command="{Binding ResetCommand}" Margin="0,0,4,4"/>
+                        <Button Style="{StaticResource PrimaryButton}" Content="Save Theme" Command="{Binding SaveCommand}" Margin="0,0,0,4"/>
+                    </WrapPanel>
                 </DockPanel>
             </Border>
 
@@ -195,7 +197,7 @@
                                 <TextBlock Text="02 Backgrounds and transparency" Style="{StaticResource LabelTextBlock}"/>
                                 <TextBlock Text="Background image, image fit, overlay tint, and transparent shell controls." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,8"/>
                                 <TextBlock Text="03 Shape and depth" Style="{StaticResource LabelTextBlock}"/>
-                                <TextBlock Text="Border removal, divider strength, corners, glass surfaces, and shadow depth." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,8"/>
+                                <TextBlock Text="Border removal, divider strength, corners, glass surfaces, shadow depth, and preset starting points for transparent or dramatic-depth redesigns." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,8"/>
                                 <TextBlock Text="04 Density and interaction" Style="{StaticResource LabelTextBlock}"/>
                                 <TextBlock Text="Spacing, typography scale, table density, focus rings, hover strength, grid lines, and motion." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,8"/>
                                 <TextBlock Text="Profiles" Style="{StaticResource LabelTextBlock}"/>


### PR DESCRIPTION
## Summary
- Add a Transparent Canvas preset to the Admin Theme Designer for background-led redesigns with glass surfaces, low-opacity shell chrome, hidden borders, and no shadows.
- Add a Deep Shadow preset for stronger app-wide depth across surfaces and controls.
- Change the theme designer toolbar from a fixed horizontal stack to a wrapping toolbar so additional preset/customization actions do not clip.
- Add view-model and XAML contract tests for the new preset commands and toolbar exposure.

## Validation
- GitHub connector compare/readback confirmed the branch is 5 commits ahead of `master`, 0 behind, with the intended focused files.
- Not run locally: this scheduled Linux container does not have the .NET SDK or Windows WPF runtime, and local clone/raw access remains blocked by the network tunnel.