### PR TITLE
[codex] theme print preview document canvas

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemeWindowChromeContractTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeWindowChromeContractTests.cs
@@ -28,11 +28,15 @@ namespace InventoryManagementApp.Tests.Resources
             Assert.Contains("ThemedWindowHeader", xaml, StringComparison.Ordinal);
             Assert.Contains("ThemedWindowPane", xaml, StringComparison.Ordinal);
             Assert.Contains("ThemedDocumentCanvasFrame", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemedDocumentPreviewViewer", xaml, StringComparison.Ordinal);
             Assert.Contains("ThemedWindowFooter", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource BackgroundBrush}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeAppBackgroundOverlayBrush}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeShellHeaderBrush}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeDialogSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ForegroundBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeFontFamily}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBodyFontSize}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeCardCornerRadius}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemePanelCornerRadius}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeInputCornerRadius}", xaml, StringComparison.Ordinal);
@@ -41,6 +45,7 @@ namespace InventoryManagementApp.Tests.Resources
             Assert.Contains("{DynamicResource ThemeSurfaceShadow}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeRaisedShadow}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeControlShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("DefaultFocusVisual", xaml, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -53,10 +58,12 @@ namespace InventoryManagementApp.Tests.Resources
             Assert.Contains("Style=\"{StaticResource ThemedWindowHeader}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Style=\"{StaticResource ThemedWindowPane}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Style=\"{StaticResource ThemedDocumentCanvasFrame}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Style=\"{StaticResource ThemedDocumentPreviewViewer}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Style=\"{StaticResource ThemedWindowFooter}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("FontFamily=\"{DynamicResource ThemeFontFamily}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("BorderThickness=\"{DynamicResource ThemeControlBorderThickness}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("CornerRadius=\"{DynamicResource ThemePanelCornerRadius}\"", xaml, StringComparison.Ordinal);
+            Assert.DoesNotContain("Background=\"White\"", xaml, StringComparison.Ordinal);
         }
 
         private static string ReadRepositoryFile(params string[] relativePathParts)

--- a/InventoryManagementApp/ProgressNotes/2026-06-20-theme-print-preview-document-canvas.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-20-theme-print-preview-document-canvas.md
@@ -1,0 +1,14 @@
+# Theme Print Preview Document Canvas Pass - 2026-06-20
+
+## Completed
+- Added a shared `ThemedDocumentPreviewViewer` style to the admin theme window chrome resources.
+- Routed the print preview `FlowDocumentScrollViewer` through that style instead of pinning the viewer background to white.
+- Guarded the contract with `ThemeWindowChromeContractTests` so print preview document chrome keeps using admin theme resources for background, foreground, typography, borders, focus visuals, and shadow depth.
+
+## Validation
+- GitHub connector readback/compare should confirm the focused resource, window, test, and progress-note diff.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, Windows WPF runtime checks, and local banned-word checks were not run because this scheduled Linux container lacks the required .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel.
+
+## Follow-up
+- Run a Windows visual QA pass for print previews using transparent, borderless, and deep-shadow theme profiles.
+- Continue scanning individual pages/windows for inline colors or border values that bypass shared admin theme resources.

--- a/InventoryManagementApp/Resources/Theme.WindowChrome.xaml
+++ b/InventoryManagementApp/Resources/Theme.WindowChrome.xaml
@@ -39,6 +39,18 @@
         <Setter Property="SnapsToDevicePixels" Value="True"/>
     </Style>
 
+    <Style x:Key="ThemedDocumentPreviewViewer" TargetType="FlowDocumentScrollViewer">
+        <Setter Property="Background" Value="{DynamicResource ThemeDialogSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
     <Style x:Key="ThemedWindowFooter" TargetType="Border" BasedOn="{StaticResource DesktopStatusFooter}">
         <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
         <Setter Property="CornerRadius" Value="{DynamicResource ThemeFooterCornerRadius}"/>

--- a/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml
@@ -88,7 +88,7 @@
 
                     <Border Grid.Row="1" Style="{StaticResource ThemedDocumentCanvasFrame}">
                         <FlowDocumentScrollViewer x:Name="DocViewer"
-                                                  Background="White"
+                                                  Style="{StaticResource ThemedDocumentPreviewViewer}"
                                                   IsToolBarVisible="False"
                                                   VerticalScrollBarVisibility="Auto"/>
                     </Border>


### PR DESCRIPTION
## Summary
- Add a shared `ThemedDocumentPreviewViewer` style so print preview document chrome consumes admin theme background, foreground, typography, border, focus, and shadow resources.
- Route `PrintPreviewWindow` through the themed viewer style instead of hard-coding the document viewer background to white.
- Extend `ThemeWindowChromeContractTests` to guard the new document viewer style and prevent the fixed white background from returning.
- Record the scheduled theme pass in progress notes.

## Validation
- GitHub connector compare/readback confirmed the branch is 4 commits ahead of `master`, 0 behind, with the intended focused files.
- Not run locally: this scheduled Linux container does not have the .NET SDK or Windows WPF runtime, and local clone/raw access remains blocked by the network tunnel.