### PR TITLE
[codex] expand admin theme designer preview lab

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/SettingsPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/SettingsPageXamlTests.cs
@@ -116,6 +116,23 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void ThemeDesignerControl_ExposesPreviewLabForFullAppThemeCoverage()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ThemeDesignerControl.xaml");
+
+            Assert.Contains("Theme coverage preview lab", xaml, StringComparison.Ordinal);
+            Assert.Contains("Shell and card depth", xaml, StringComparison.Ordinal);
+            Assert.Contains("Themed control matrix", xaml, StringComparison.Ordinal);
+            Assert.Contains("Table density and selection", xaml, StringComparison.Ordinal);
+            Assert.Contains("Transparent background lane", xaml, StringComparison.Ordinal);
+            Assert.Contains("Print and document preview", xaml, StringComparison.Ordinal);
+            Assert.Contains("Coverage board for controls, tables, transparent backgrounds, semantic states, and document preview surfaces.", xaml, StringComparison.Ordinal);
+            Assert.Contains("<ComboBoxItem Content=\"Dropdown preview\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<DataGrid AutoGenerateColumns=\"False\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("<CheckBox Content=\"Checked\" IsChecked=\"True\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ThemeControlCustomizationOverrides_AreLoadedAfterFullCustomizationLayer()
         {
             var appXaml = ReadRepositoryFile("InventoryManagementApp", "App.xaml");

--- a/InventoryManagementApp/ProgressNotes/2026-06-20-theme-designer-preview-lab.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-20-theme-designer-preview-lab.md
@@ -1,0 +1,15 @@
+# Theme Designer Preview Lab Pass - 2026-06-20
+
+## Completed
+- Expanded the Admin Settings Theme Designer live preview into a broader `Theme coverage preview lab`.
+- Added preview coverage for shell/card depth, themed controls, disabled states, dropdowns, sliders, progress bars, table density/selection, semantic states, transparent background readability, and print/document preview surfaces.
+- Preserved the existing theme settings model, profile import/export commands, presets, and live preview behavior while making it easier for admins to judge a full-app redesign before saving.
+- Added XAML contract coverage so the preview lab markers and representative controls stay visible in the designer.
+
+## Validation
+- GitHub connector readback/compare should confirm the focused designer XAML, XAML contract test, and progress-note diff.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, Windows WPF runtime checks, and local banned-word checks were not run because this scheduled Linux container lacks the required .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel.
+
+## Follow-up
+- Run a Windows visual QA pass with transparent, borderless, deep-shadow, and high-contrast theme profiles.
+- Continue scanning individual pages/windows for inline colors, fixed shadows, or hard-coded border values that bypass shared admin theme resources.

--- a/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml
+++ b/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml
@@ -51,7 +51,7 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="1.35*" MinWidth="520"/>
                         <ColumnDefinition Width="12"/>
-                        <ColumnDefinition Width="1.0*" MinWidth="340"/>
+                        <ColumnDefinition Width="1.0*" MinWidth="360"/>
                     </Grid.ColumnDefinitions>
 
                     <TabControl Grid.Column="0" x:Name="ThemeDesignerTabs">
@@ -161,20 +161,90 @@
                     <StackPanel Grid.Column="2">
                         <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,12">
                             <StackPanel>
-                                <TextBlock Text="Live preview" Style="{StaticResource PageTitleTextBlock}"/>
-                                <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,8,0,8">
+                                <TextBlock Text="Theme coverage preview lab" Style="{StaticResource PageTitleTextBlock}"/>
+                                <TextBlock Text="Use this board to inspect how the current redesign affects the everyday app surfaces before saving it." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,10"/>
+
+                                <Border Style="{StaticResource DesktopSummaryCard}" Margin="0,0,0,8">
                                     <StackPanel>
-                                        <TextBlock Text="Inventory desk card" Style="{StaticResource SectionHeader}"/>
-                                        <TextBlock Text="Surface, text, border width, divider strength, corners, padding, shadows, disabled states, grid lines, and interaction feedback update as you tune the theme." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
-                                        <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                                            <Button Style="{StaticResource PrimaryButton}" Content="Primary" Margin="0,0,6,0"/>
-                                            <Button Style="{StaticResource GhostButton}" Content="Disabled" IsEnabled="False"/>
-                                        </StackPanel>
+                                        <TextBlock Text="Shell and card depth" Style="{StaticResource SectionHeader}"/>
+                                        <TextBlock Text="Surface opacity, border removal, card corners, padding, divider strength, and shadow depth update here as you tune the theme." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                        <Border Style="{StaticResource DesktopInsetCard}" Margin="0,8,0,0">
+                                            <DockPanel>
+                                                <TextBlock DockPanel.Dock="Right" Text="Footer chrome" Style="{StaticResource CaptionTextBlock}"/>
+                                                <TextBlock Text="Navigation / header / dialog preview" Style="{StaticResource LabelTextBlock}"/>
+                                            </DockPanel>
+                                        </Border>
                                     </StackPanel>
                                 </Border>
-                                <TextBox Text="Input preview" Margin="0,0,0,8"/>
-                                <ProgressBar Value="65" Maximum="100"/>
-                                <TextBlock Text="{Binding Status}" Style="{StaticResource CaptionTextBlock}" Margin="0,8,0,0"/>
+
+                                <Border Style="{StaticResource DesktopInsetCard}" Margin="0,0,0,8">
+                                    <StackPanel>
+                                        <TextBlock Text="Themed control matrix" Style="{StaticResource SectionHeader}"/>
+                                        <WrapPanel Margin="0,8,0,0">
+                                            <Button Style="{StaticResource PrimaryButton}" Content="Primary" Margin="0,0,6,6"/>
+                                            <Button Style="{StaticResource GhostButton}" Content="Ghost" Margin="0,0,6,6"/>
+                                            <Button Style="{StaticResource GhostButton}" Content="Disabled" IsEnabled="False" Margin="0,0,6,6"/>
+                                            <CheckBox Content="Checked" IsChecked="True" Margin="0,0,10,6"/>
+                                            <CheckBox Content="Disabled" IsEnabled="False" Margin="0,0,10,6"/>
+                                        </WrapPanel>
+                                        <TextBox Text="Input preview" Margin="0,2,0,8"/>
+                                        <ComboBox SelectedIndex="0" Margin="0,0,0,8">
+                                            <ComboBoxItem Content="Dropdown preview"/>
+                                            <ComboBoxItem Content="Menu selection"/>
+                                        </ComboBox>
+                                        <Slider Value="65" Maximum="100" Margin="0,0,0,8"/>
+                                        <ProgressBar Value="65" Maximum="100"/>
+                                    </StackPanel>
+                                </Border>
+
+                                <Border Style="{StaticResource DesktopInsetCard}" Margin="0,0,0,8">
+                                    <StackPanel>
+                                        <TextBlock Text="Table density and selection" Style="{StaticResource SectionHeader}"/>
+                                        <DataGrid AutoGenerateColumns="False" IsReadOnly="True" HeadersVisibility="Column" Height="116" Margin="0,8,0,0">
+                                            <DataGrid.Columns>
+                                                <DataGridTextColumn Header="Area" Binding="{Binding}" Width="*"/>
+                                                <DataGridTextColumn Header="Status" Binding="{Binding}" Width="90"/>
+                                            </DataGrid.Columns>
+                                            <TextBlock Text="Grid row/header density, grid-line strength, and selection contrast preview." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                        </DataGrid>
+                                    </StackPanel>
+                                </Border>
+
+                                <UniformGrid Columns="3" Margin="0,0,0,8">
+                                    <Border Style="{StaticResource DesktopInsetCard}" Margin="0,0,6,0">
+                                        <StackPanel>
+                                            <TextBlock Text="Success" Style="{StaticResource LabelTextBlock}"/>
+                                            <TextBlock Text="Semantic color" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Style="{StaticResource DesktopInsetCard}" Margin="0,0,6,0">
+                                        <StackPanel>
+                                            <TextBlock Text="Warning" Style="{StaticResource LabelTextBlock}"/>
+                                            <TextBlock Text="Semantic color" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Style="{StaticResource DesktopInsetCard}">
+                                        <StackPanel>
+                                            <TextBlock Text="Error" Style="{StaticResource LabelTextBlock}"/>
+                                            <TextBlock Text="Semantic color" Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                    </Border>
+                                </UniformGrid>
+
+                                <Border Style="{StaticResource DesktopInsetCard}" Margin="0,0,0,8">
+                                    <StackPanel>
+                                        <TextBlock Text="Transparent background lane" Style="{StaticResource SectionHeader}"/>
+                                        <TextBlock Text="Background images, overlay tint, glass surfaces, shell opacity, menu opacity, and borderless presets should leave the canvas visible without losing readable text." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                    </StackPanel>
+                                </Border>
+
+                                <Border Style="{StaticResource DesktopInsetCard}">
+                                    <StackPanel>
+                                        <TextBlock Text="Print and document preview" Style="{StaticResource SectionHeader}"/>
+                                        <TextBlock Text="Document viewers, rich text blocks, media frames, and print-preview chrome use the same theme resources as the rest of the app." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
+                                        <TextBlock Text="{Binding Status}" Style="{StaticResource CaptionTextBlock}" Margin="0,8,0,0"/>
+                                    </StackPanel>
+                                </Border>
                             </StackPanel>
                         </Border>
 
@@ -200,6 +270,8 @@
                                 <TextBlock Text="Border removal, divider strength, corners, glass surfaces, shadow depth, and preset starting points for transparent or dramatic-depth redesigns." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,8"/>
                                 <TextBlock Text="04 Density and interaction" Style="{StaticResource LabelTextBlock}"/>
                                 <TextBlock Text="Spacing, typography scale, table density, focus rings, hover strength, grid lines, and motion." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,8"/>
+                                <TextBlock Text="Preview lab" Style="{StaticResource LabelTextBlock}"/>
+                                <TextBlock Text="Coverage board for controls, tables, transparent backgrounds, semantic states, and document preview surfaces." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap" Margin="0,0,0,8"/>
                                 <TextBlock Text="Profiles" Style="{StaticResource LabelTextBlock}"/>
                                 <TextBlock Text="Portable JSON backups for full-app redesigns." Style="{StaticResource CaptionTextBlock}" TextWrapping="Wrap"/>
                             </StackPanel>


### PR DESCRIPTION
## Summary
- Expand the Admin Settings Theme Designer live preview into a broader theme coverage lab.
- Add preview coverage for shell/card depth, themed controls, disabled states, dropdowns, sliders, progress bars, table density/selection, semantic states, transparent background readability, and print/document preview surfaces.
- Add XAML contract coverage so the preview lab markers and representative controls stay visible.
- Record the scheduled theme pass in progress notes.

## Validation
- GitHub connector compare/readback confirmed the branch is 3 commits ahead of `master`, 0 behind, with the intended focused files.
- Not run locally: this scheduled Linux container does not have the .NET SDK or Windows WPF runtime, and local clone/raw access remains blocked by the network tunnel.