### PR TITLE
[codex] honor theme transparency for popup surfaces

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ThemePopupSurfaceContractTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ThemePopupSurfaceContractTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.ViewModels
+{
+    public class ThemePopupSurfaceContractTests
+    {
+        [Fact]
+        public void ThemeService_HonorsAdminTransparencyForPopupSurfaces()
+        {
+            var themeService = ReadRepositoryFile("InventoryManagementApp", "Services", "ThemeService.cs");
+
+            Assert.Contains("ThemePopupSurfaceBrush", themeService, StringComparison.Ordinal);
+            Assert.Contains("CreateBrush(settings.SurfaceAltColor, Math.Min(surfaceAltOpacity, settings.MenuOpacity))", themeService, StringComparison.Ordinal);
+            Assert.Contains("CreateBrush(settings.InputColor, settings.InputOpacity)", themeService, StringComparison.Ordinal);
+            Assert.DoesNotContain("Math.Max(settings.InputOpacity, 0.9)", themeService, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ThemeResources_RouteContextMenusThroughPopupSurfaceBrush()
+        {
+            var tokens = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.Customization.xaml");
+            var controlOverrides = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.ControlCustomizationOverrides.xaml");
+
+            Assert.Contains("x:Key=\"ThemePopupSurfaceBrush\"", tokens, StringComparison.Ordinal);
+            Assert.Contains("<Style TargetType=\"ContextMenu\">", controlOverrides, StringComparison.Ordinal);
+            Assert.Contains("Background\" Value=\"{DynamicResource ThemePopupSurfaceBrush}\"", controlOverrides, StringComparison.Ordinal);
+            Assert.Contains("BorderThickness\" Value=\"{DynamicResource ThemeControlBorderThickness}\"", controlOverrides, StringComparison.Ordinal);
+            Assert.Contains("Effect\" Value=\"{DynamicResource ThemeRaisedShadow}\"", controlOverrides, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-20-theme-transparent-popup-surfaces.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-20-theme-transparent-popup-surfaces.md
@@ -1,0 +1,15 @@
+# Theme Transparent Popup Surface Pass - 2026-06-20
+
+## Completed
+- Removed the near-opaque combo-box popup fallback so dropdown backgrounds now honor the admin-controlled input opacity.
+- Added a shared `ThemePopupSurfaceBrush` resource for popup/menu surfaces driven by the admin menu opacity and alternate surface color.
+- Added a late-loaded context menu override so right-click menus use the popup surface brush, themed borders, themed typography, and admin-controlled shadow depth.
+- Added focused contract tests for popup transparency resources and override routing.
+
+## Validation
+- GitHub connector readback/compare should confirm the focused service, resource, test, and progress-note diff.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, Windows WPF runtime checks, and local banned-word checks were not run because this scheduled Linux container lacks the required .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel.
+
+## Follow-up
+- Run Windows visual QA with Transparent Canvas, Borderless, Glass, and Deep Shadow presets against combo-box dropdowns and context menus.
+- Continue checking other popups and flyouts for hard-coded opacity, border thickness, or fixed shadows.

--- a/InventoryManagementApp/Resources/Theme.ControlCustomizationOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.ControlCustomizationOverrides.xaml
@@ -95,4 +95,15 @@
         <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
         <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
     </Style>
+
+    <Style TargetType="ContextMenu">
+        <Setter Property="Background" Value="{DynamicResource ThemePopupSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="4"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+    </Style>
 </ResourceDictionary>

--- a/InventoryManagementApp/Resources/Theme.Customization.xaml
+++ b/InventoryManagementApp/Resources/Theme.Customization.xaml
@@ -49,6 +49,7 @@
     <SolidColorBrush x:Key="ThemeShellMenuBrush" Color="#FFE8EDF3"/>
     <SolidColorBrush x:Key="ThemeShellFooterBrush" Color="#BFFFFFFF"/>
     <SolidColorBrush x:Key="ThemeDialogSurfaceBrush" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="ThemePopupSurfaceBrush" Color="#FFE8EDF3"/>
     <SolidColorBrush x:Key="NavigationSurfaceBrush" Color="#FFE8EDF3"/>
     <SolidColorBrush x:Key="NavigationAltSurfaceBrush" Color="#FFFFFFFF"/>
     <SolidColorBrush x:Key="ThemeGridLineBrush" Color="#6B94A3B8"/>

--- a/InventoryManagementApp/Services/ThemeService.cs
+++ b/InventoryManagementApp/Services/ThemeService.cs
@@ -104,11 +104,12 @@ namespace InventoryManagementApp.Services
                 Set(resources, "ThemeShellMenuBrush", CreateBrush(settings.NavigationColor, Math.Min(navigationOpacity, settings.MenuOpacity)));
                 Set(resources, "ThemeShellFooterBrush", CreateBrush(settings.SurfaceAltColor, Math.Min(surfaceAltOpacity, settings.FooterOpacity)));
                 Set(resources, "ThemeDialogSurfaceBrush", CreateBrush(settings.SurfaceColor, Math.Min(surfaceOpacity, settings.DialogOpacity)));
+                Set(resources, "ThemePopupSurfaceBrush", CreateBrush(settings.SurfaceAltColor, Math.Min(surfaceAltOpacity, settings.MenuOpacity)));
                 Set(resources, "GlassSurfaceBrush", CreateBrush(settings.SurfaceColor, Math.Min(settings.SurfaceOpacity, 0.78)));
                 Set(resources, "GlassSurfaceAltBrush", CreateBrush(settings.SurfaceAltColor, Math.Min(settings.SurfaceAltOpacity, 0.68)));
                 Set(resources, "TransparentSurfaceBrush", Brushes.Transparent);
                 Set(resources, "TextBoxBackgroundBrush", inputBrush);
-                Set(resources, "ComboBoxPopupBackgroundBrush", CreateBrush(settings.InputColor, Math.Max(settings.InputOpacity, 0.9)));
+                Set(resources, "ComboBoxPopupBackgroundBrush", CreateBrush(settings.InputColor, settings.InputOpacity));
                 Set(resources, "ForegroundBrush", CreateBrush(settings.TextColor, 1));
                 Set(resources, "ForegroundMutedBrush", CreateBrush(settings.MutedTextColor, 1));
                 Set(resources, "AccentBrush", CreateBrush(settings.AccentColor, 1));


### PR DESCRIPTION
## Summary
- Add a shared `ThemePopupSurfaceBrush` resource for menu and popup surfaces.
- Stop forcing combo-box dropdown backgrounds to at least 90% opacity so transparent/background-led themes can show through dropdowns.
- Route context menus through the late-loaded admin theme override layer with popup surface color, themed border thickness, typography, and shadow depth.
- Add focused contract tests covering popup transparency resource routing.

## Validation
- GitHub connector readback/compare confirmed the branch is 5 commits ahead of `master`, 0 behind, with the intended focused files.
- Not run locally: this scheduled Linux container does not have the .NET SDK or Windows WPF runtime, and local clone/raw access remains blocked by the network tunnel.