### PR TITLE
[codex] theme popup menu items and tooltips

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ThemePopupSurfaceContractTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ThemePopupSurfaceContractTests.cs
@@ -30,6 +30,20 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("Effect\" Value=\"{DynamicResource ThemeRaisedShadow}\"", controlOverrides, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void ThemeResources_RoutePopupItemsAndTooltipsThroughAdminThemeTokens()
+        {
+            var controlOverrides = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.ControlCustomizationOverrides.xaml");
+
+            Assert.Contains("<Style TargetType=\"MenuItem\">", controlOverrides, StringComparison.Ordinal);
+            Assert.Contains("<Style TargetType=\"ToolTip\">", controlOverrides, StringComparison.Ordinal);
+            Assert.Contains("Background\" Value=\"{DynamicResource ThemePopupSurfaceBrush}\"", controlOverrides, StringComparison.Ordinal);
+            Assert.Contains("BorderThickness\" Value=\"{DynamicResource ThemeControlBorderThickness}\"", controlOverrides, StringComparison.Ordinal);
+            Assert.Contains("Opacity\" Value=\"{DynamicResource ThemeDisabledOpacity}\"", controlOverrides, StringComparison.Ordinal);
+            Assert.Contains("HasDropShadow\" Value=\"False\"", controlOverrides, StringComparison.Ordinal);
+            Assert.Contains("Effect\" Value=\"{DynamicResource ThemeRaisedShadow}\"", controlOverrides, StringComparison.Ordinal);
+        }
+
         private static string ReadRepositoryFile(params string[] relativePathParts)
         {
             var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/InventoryManagementApp/ProgressNotes/2026-06-20-theme-popup-item-tooltip-overrides.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-20-theme-popup-item-tooltip-overrides.md
@@ -1,0 +1,14 @@
+# Theme Popup Item and Tooltip Pass - 2026-06-20
+
+## Completed
+- Extended the late-loaded admin theme override layer to menu items so context menu rows honor the popup surface brush, transparent/borderless settings, themed typography, disabled opacity, hover color, and control shadow depth.
+- Added a themed tooltip override so inline help surfaces use the same admin-controlled popup background, border thickness, font settings, and raised shadow resource instead of platform drop shadow defaults.
+- Added focused contract coverage for the menu item and tooltip theme routing.
+
+## Validation
+- GitHub connector readback/compare should confirm the focused resource, test, and progress-note diff.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, Windows WPF runtime checks, and local banned-word checks were not run because this scheduled Linux container lacks the required .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel.
+
+## Follow-up
+- Run Windows visual QA against context menu rows and tooltips with Transparent Canvas, Borderless, Glass, and Deep Shadow presets.
+- Continue checking less common popup/flyout surfaces for hard-coded chrome that bypasses admin theme tokens.

--- a/InventoryManagementApp/Resources/Theme.ControlCustomizationOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.ControlCustomizationOverrides.xaml
@@ -106,4 +106,38 @@
         <Setter Property="Padding" Value="4"/>
         <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
     </Style>
+
+    <Style TargetType="MenuItem">
+        <Setter Property="Background" Value="{DynamicResource ThemePopupSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Style.Triggers>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemHoverForegroundBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="ToolTip">
+        <Setter Property="Background" Value="{DynamicResource ThemePopupSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="HasDropShadow" Value="False"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+    </Style>
 </ResourceDictionary>


### PR DESCRIPTION
## Summary
- Extend the late-loaded admin theme override layer to `MenuItem` rows so context menu content honors popup surface transparency, border removal, typography, disabled opacity, hover color, and control shadow settings.
- Add a themed `ToolTip` override so tooltip chrome uses the admin popup surface, border thickness, font settings, and raised shadow resource instead of platform drop shadow defaults.
- Add focused contract coverage for popup item and tooltip theme routing.

## Validation
- GitHub connector readback/compare confirmed the branch is 3 commits ahead of `master`, 0 behind, with the intended focused files.
- GitHub connector reported no commit statuses for the head commit.
- Not run locally: this scheduled Linux container does not have the .NET SDK or Windows WPF runtime, and local clone/raw access remains blocked by the network tunnel.