### PR TITLE
[codex] Expand admin theme customization coverage

### DIFF
--- a/InventoryManagementApp.Tests/ThemeServiceTests.cs
+++ b/InventoryManagementApp.Tests/ThemeServiceTests.cs
@@ -3,6 +3,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
+using System.Windows.Media.Effects;
+using InventoryManagementApp.Models;
 using InventoryManagementApp.Services;
 using Xunit;
 
@@ -100,6 +102,70 @@ namespace InventoryManagementApp.Tests
                 service.ApplyTheme("Light");
                 var lightHover = (SolidColorBrush)app.Resources["NavButtonHoverBrush"];
                 Assert.NotEqual(darkHover.Color, lightHover.Color);
+                WpfTestHelper.ShutdownApplication();
+                await Task.CompletedTask;
+            });
+        }
+
+        [Fact]
+        public async Task ApplyCustomTheme_UpdatesBorderlessTransparentAndTypographyResources()
+        {
+            await RunOnStaThread(async () =>
+            {
+                var app = WpfTestHelper.CreateApplication();
+                var service = new ThemeService();
+                var settings = AppThemeSettings.CreateDefault("Dark");
+                settings.BordersVisible = false;
+                settings.SurfaceOpacity = 0.25;
+                settings.SurfaceAltOpacity = 0.2;
+                settings.InputOpacity = 0.3;
+                settings.ButtonOpacity = 0.35;
+                settings.NavigationOpacity = 0.22;
+                settings.FontFamily = "Aptos";
+                settings.FontScale = 1.2;
+                settings.HeadingFontScale = 1.1;
+
+                service.ApplyCustomTheme(settings);
+
+                Assert.Equal(new Thickness(0), (Thickness)app.Resources["ThemeBorderThickness"]);
+                Assert.Equal(new Thickness(0), (Thickness)app.Resources["ThemeControlBorderThickness"]);
+                Assert.Equal("Aptos", ((FontFamily)app.Resources["ThemeFontFamily"]).Source);
+                Assert.Equal(15.6, (double)app.Resources["ThemeBodyFontSize"]);
+                Assert.Equal(23.8, (double)app.Resources["ThemeTitleFontSize"]);
+                Assert.Equal(0x40, ((SolidColorBrush)app.Resources["SurfaceBrush"]).Color.A);
+                Assert.Equal(0x59, ((SolidColorBrush)app.Resources["BtnBg"]).Color.A);
+                Assert.Same(Brushes.Transparent, app.Resources["BtnBorder"]);
+                WpfTestHelper.ShutdownApplication();
+                await Task.CompletedTask;
+            });
+        }
+
+        [Fact]
+        public async Task ApplyCustomTheme_SeparatesSurfaceAndControlShadowDepth()
+        {
+            await RunOnStaThread(async () =>
+            {
+                var app = WpfTestHelper.CreateApplication();
+                var service = new ThemeService();
+                var settings = AppThemeSettings.CreateDefault();
+                settings.EnableSurfaceShadows = true;
+                settings.EnableControlShadows = true;
+                settings.ShadowBlurRadius = 10;
+                settings.ShadowDepth = 4;
+                settings.ShadowOpacity = 0.2;
+                settings.SurfaceShadowScale = 2;
+                settings.ControlShadowScale = 0.5;
+
+                service.ApplyCustomTheme(settings);
+
+                var surfaceShadow = (DropShadowEffect)app.Resources["ThemeSurfaceShadow"];
+                var controlShadow = (DropShadowEffect)app.Resources["ThemeControlShadow"];
+
+                Assert.Equal(20, surfaceShadow.BlurRadius);
+                Assert.Equal(8, surfaceShadow.ShadowDepth);
+                Assert.Equal(2.5, controlShadow.BlurRadius);
+                Assert.Equal(1, controlShadow.ShadowDepth);
+                Assert.True(surfaceShadow.Opacity > controlShadow.Opacity);
                 WpfTestHelper.ShutdownApplication();
                 await Task.CompletedTask;
             });

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -18,6 +18,7 @@
                 <ResourceDictionary Source="Resources/Theme.FullCustomizationOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.ControlCustomizationOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.FormMediaPreviewOverrides.xaml"/>
+                <ResourceDictionary Source="Resources/Theme.AdminDesignerCoverageOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
                 <ResourceDictionary Source="Resources/Templates.xaml"/>
             </ResourceDictionary.MergedDictionaries>

--- a/InventoryManagementApp/Resources/Theme.AdminDesignerCoverageOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.AdminDesignerCoverageOverrides.xaml
@@ -1,0 +1,162 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework">
+    <!--
+        Last-loaded admin theme coverage layer.
+        Earlier dictionaries define the main visual system. This file catches base WPF controls and
+        generic surfaces that can otherwise keep older hard-coded fonts, backgrounds, borders, or
+        shadows after an admin redesigns the app from Settings > Themes.
+    -->
+
+    <Style TargetType="Window">
+        <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Icon" Value="{DynamicResource WindowIcon}"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="TextOptions.TextFormattingMode" Value="Display"/>
+        <Setter Property="TextOptions.TextRenderingMode" Value="ClearType"/>
+        <Setter Property="TextOptions.TextHintingMode" Value="Fixed"/>
+    </Style>
+
+    <Style TargetType="Page">
+        <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="TextOptions.TextFormattingMode" Value="Display"/>
+        <Setter Property="TextOptions.TextRenderingMode" Value="ClearType"/>
+        <Setter Property="TextOptions.TextHintingMode" Value="Fixed"/>
+    </Style>
+
+    <Style TargetType="TextBlock">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="TextOptions.TextFormattingMode" Value="Display"/>
+        <Setter Property="TextOptions.TextRenderingMode" Value="ClearType"/>
+        <Setter Property="TextOptions.TextHintingMode" Value="Fixed"/>
+    </Style>
+
+    <Style TargetType="TextElement">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+    </Style>
+
+    <Style TargetType="ContentControl">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+    </Style>
+
+    <Style TargetType="HeaderedContentControl">
+        <Setter Property="Background" Value="{DynamicResource GlassSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+    </Style>
+
+    <Style TargetType="ItemsControl">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+    </Style>
+
+    <Style TargetType="Control">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="primitives:ToggleButton">
+        <Setter Property="Background" Value="{DynamicResource BtnBg}"/>
+        <Setter Property="Foreground" Value="{DynamicResource BtnFg}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BtnBorder}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource BtnBgHover}"/>
+            </Trigger>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemSelectedForegroundBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="primitives:RepeatButton">
+        <Setter Property="Background" Value="{DynamicResource BtnBg}"/>
+        <Setter Property="Foreground" Value="{DynamicResource BtnFg}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BtnBorder}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource BtnBgHover}"/>
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter Property="Background" Value="{DynamicResource NavButtonPressedBrush}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="Menu">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+    </Style>
+
+    <Style TargetType="ToolBarTray">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+    </Style>
+
+    <Style TargetType="GridSplitter">
+        <Setter Property="Background" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
+        <Setter Property="MinWidth" Value="4"/>
+        <Setter Property="MinHeight" Value="4"/>
+    </Style>
+</ResourceDictionary>


### PR DESCRIPTION
## Summary

- Added a final admin theme coverage resource dictionary so Settings > Themes controls apply to more base WPF surfaces.
- Wired the new dictionary into App.xaml after the existing theme customization layers so admin-selected colors, transparency, fonts, borders, and shadows win late in resource resolution.
- Added ThemeService tests for borderless transparent styling, custom typography resources, and separate surface/control shadow depth.

## Validation

- Added focused WPF unit coverage in `InventoryManagementApp.Tests/ThemeServiceTests.cs`.
- Could not run `dotnet test` in this scheduled Linux container because it lacks the .NET SDK and Windows WPF runtime, and local clone/raw access remains blocked by the network tunnel.