### PR TITLE
[codex] theme date and selection controls

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemeAdminDesignerCoverageOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeAdminDesignerCoverageOverrideTests.cs
@@ -62,6 +62,24 @@ namespace InventoryManagementApp.Tests.Resources
         }
 
         [Fact]
+        public void ControlCustomizationOverrides_ExtendThemeHooksToSelectionAndDateControls()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.ControlCustomizationOverrides.xaml");
+
+            Assert.Contains("xmlns:primitives=\"clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"CheckBox\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"RadioButton\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"DatePicker\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"primitives:DatePickerTextBox\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Calendar\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"primitives:CalendarButton\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"primitives:CalendarDayButton\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Property=\"IsChecked\" Value=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Property=\"IsKeyboardFocusWithin\" Value=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Property=\"IsBlackedOut\" Value=\"True\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void AdminDesignerCoverageOverrides_UseAdminTokensForSelectionTransparencyAndDepth()
         {
             var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.AdminDesignerCoverageOverrides.xaml");

--- a/InventoryManagementApp/ProgressNotes/2026-06-20-theme-date-calendar-selection-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-20-theme-date-calendar-selection-coverage.md
@@ -1,0 +1,13 @@
+# Admin Theme Date and Selection Coverage - 2026-06-20
+
+## Completed
+
+- Extended the later admin control customization dictionary to keep radio buttons aligned with the already themed checkbox behavior.
+- Added date picker and inner date picker text box theme hooks so form date inputs honor admin-selected transparent backgrounds, borders, focus color, typography, disabled opacity, and control shadow depth.
+- Added calendar, calendar navigation button, and day button theme hooks so popup calendar surfaces follow admin-selected popup backgrounds, hover/selection colors, border removal, typography, disabled opacity, and raised shadow depth.
+- Added focused XAML contract tests to preserve the selection and date control coverage.
+
+## Validation Notes
+
+- Changes were made through the GitHub connector because the scheduled Linux container still cannot clone the repository through the network tunnel.
+- Local `dotnet test`, WPF screenshots, and local banned-word checks were not run because this container lacks the .NET SDK and Windows WPF runtime.

--- a/InventoryManagementApp/Resources/Theme.ControlCustomizationOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.ControlCustomizationOverrides.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework">
     <!--
         Final control-level customization hooks for the Admin Settings theme designer.
         This dictionary is loaded after the broad full-customization override layer so tabs,
@@ -69,6 +70,31 @@
         </Style.Triggers>
     </Style>
 
+    <Style TargetType="RadioButton">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Padding" Value="4,2"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+            </Trigger>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
     <Style TargetType="Slider">
         <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
         <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
@@ -94,6 +120,102 @@
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
         <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
         <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+    </Style>
+
+    <Style TargetType="DatePicker">
+        <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+            </Trigger>
+            <Trigger Property="IsKeyboardFocusWithin" Value="True">
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="primitives:DatePickerTextBox">
+        <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="CaretBrush" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="SelectionBrush" Value="{DynamicResource ItemSelectedBrush}"/>
+        <Setter Property="SelectionTextBrush" Value="{DynamicResource ItemSelectedForegroundBrush}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+    </Style>
+
+    <Style TargetType="Calendar">
+        <Setter Property="Background" Value="{DynamicResource ThemePopupSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+    </Style>
+
+    <Style TargetType="primitives:CalendarButton">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemHoverForegroundBrush}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="primitives:CalendarDayButton">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemHoverForegroundBrush}"/>
+            </Trigger>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemSelectedForegroundBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+            </Trigger>
+            <Trigger Property="IsBlackedOut" Value="True">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style TargetType="ContextMenu">


### PR DESCRIPTION
## Summary
- Extend the later Admin Settings control customization layer to radio buttons so selection controls share the same admin-controlled transparency, border, focus, font, disabled opacity, and shadow behavior as check boxes.
- Add date picker and inner date picker text box theme hooks for admin-selected input background, border removal, focus color, typography, disabled opacity, and control shadow depth.
- Add calendar, calendar navigation button, and day button theme hooks so popup date surfaces honor admin-selected popup backgrounds, hover/selection colors, borders, typography, disabled opacity, and raised shadow depth.
- Add focused XAML contract coverage and a progress note for the scheduled theme coverage pass.

## Validation
- GitHub connector compare/readback confirmed the branch is 3 commits ahead of `master`, 0 behind, with only the intended focused files changed.
- GitHub connector reported no commit statuses for the head commit.
- Not run locally: this scheduled Linux container does not have the .NET SDK or Windows WPF runtime, and local clone/raw access remains blocked by the network tunnel.