### PR TITLE
[codex] theme navigation and text chrome coverage

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemeAdminDesignerCoverageOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeAdminDesignerCoverageOverrideTests.cs
@@ -15,13 +15,15 @@ namespace InventoryManagementApp.Tests.Resources
             var controlCustomizationIndex = xaml.IndexOf("Resources/Theme.ControlCustomizationOverrides.xaml", StringComparison.Ordinal);
             var formMediaIndex = xaml.IndexOf("Resources/Theme.FormMediaPreviewOverrides.xaml", StringComparison.Ordinal);
             var adminCoverageIndex = xaml.IndexOf("Resources/Theme.AdminDesignerCoverageOverrides.xaml", StringComparison.Ordinal);
+            var navigationChromeIndex = xaml.IndexOf("Resources/Theme.NavigationChromeOverrides.xaml", StringComparison.Ordinal);
             var convertersIndex = xaml.IndexOf("Resources/Converters.xaml", StringComparison.Ordinal);
 
             Assert.True(fullCustomizationIndex >= 0, "Full customization overrides should remain loaded.");
             Assert.True(controlCustomizationIndex > fullCustomizationIndex, "Control overrides should load after full customization resources.");
             Assert.True(formMediaIndex > controlCustomizationIndex, "Form/media overrides should load after control overrides.");
-            Assert.True(adminCoverageIndex > formMediaIndex, "Admin coverage overrides should remain the final theme layer.");
-            Assert.True(convertersIndex > adminCoverageIndex, "Converters should remain after visual resources.");
+            Assert.True(adminCoverageIndex > formMediaIndex, "Admin coverage overrides should remain after form/media resources.");
+            Assert.True(navigationChromeIndex > adminCoverageIndex, "Navigation chrome overrides should load after the broad admin coverage layer.");
+            Assert.True(convertersIndex > navigationChromeIndex, "Converters should remain after visual resources.");
         }
 
         [Fact]
@@ -77,6 +79,39 @@ namespace InventoryManagementApp.Tests.Resources
             Assert.Contains("Property=\"IsChecked\" Value=\"True\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Property=\"IsKeyboardFocusWithin\" Value=\"True\"", xaml, StringComparison.Ordinal);
             Assert.Contains("Property=\"IsBlackedOut\" Value=\"True\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void NavigationChromeOverrides_ExtendAdminThemesToNavigationAndTextChrome()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.NavigationChromeOverrides.xaml");
+
+            Assert.Contains("TargetType=\"Frame\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"NavigationWindow\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Label\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"AccessText\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"BulletDecorator\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"documents:AdornerDecorator\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Viewbox\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("NavigationUIVisibility\" Value=\"Hidden\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ShowsNavigationUI\" Value=\"False\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void NavigationChromeOverrides_UseAdminThemeTokensForBackgroundsTypographyAndBorders()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.NavigationChromeOverrides.xaml");
+
+            Assert.Contains("{DynamicResource BackgroundBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource TransparentSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ForegroundBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource BorderBrushAlt}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBorderlessThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeFontFamily}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBodyFontSize}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeDisabledOpacity}", xaml, StringComparison.Ordinal);
+            Assert.Contains("FocusVisualStyle\" Value=\"{StaticResource DefaultFocusVisual}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextOptions.TextRenderingMode\" Value=\"ClearType\"", xaml, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -19,6 +19,7 @@
                 <ResourceDictionary Source="Resources/Theme.ControlCustomizationOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.FormMediaPreviewOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.AdminDesignerCoverageOverrides.xaml"/>
+                <ResourceDictionary Source="Resources/Theme.NavigationChromeOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
                 <ResourceDictionary Source="Resources/Templates.xaml"/>
             </ResourceDictionary.MergedDictionaries>

--- a/InventoryManagementApp/ProgressNotes/2026-06-20-theme-navigation-text-chrome-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-20-theme-navigation-text-chrome-coverage.md
@@ -1,0 +1,14 @@
+# Admin Theme Navigation and Text Chrome Coverage - 2026-06-20
+
+## Completed
+
+- Added a late-loaded admin theme resource dictionary for navigation and small text chrome that can sit outside page-specific styling.
+- Routed `Frame` and `NavigationWindow` through admin-selected background, foreground, typography, app icon, layout rounding, and hidden navigation chrome settings so embedded page hosts do not keep default WPF visuals.
+- Routed `Label`, `AccessText`, `BulletDecorator`, `AdornerDecorator`, and `Viewbox` through admin theme tokens for transparent surfaces, foreground color, typography, focus styling, disabled opacity, and pixel-snapped rendering where applicable.
+- Wired the new dictionary after the broad admin designer coverage layer in `App.xaml` so it remains part of the final visual override pass.
+- Added focused XAML contract tests for load order, covered controls, and the admin theme resources used by the new layer.
+
+## Validation Notes
+
+- Changes were made through the GitHub connector because the scheduled Linux container still cannot clone the repository through the network tunnel.
+- Local `dotnet test`, WPF screenshots, and local banned-word checks were not run because this container lacks the .NET SDK and Windows WPF runtime.

--- a/InventoryManagementApp/Resources/Theme.NavigationChromeOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.NavigationChromeOverrides.xaml
@@ -1,0 +1,79 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:documents="clr-namespace:System.Windows.Documents;assembly=PresentationFramework">
+    <!--
+        Late admin theme coverage for navigation and text chrome.
+        These host controls often sit around page content instead of inside it, so route their
+        backgrounds, typography, borders, shadows, and disabled opacity through the same admin
+        theme tokens used by the rest of Settings > Themes.
+    -->
+
+    <Style TargetType="Frame">
+        <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="NavigationUIVisibility" Value="Hidden"/>
+        <Setter Property="JournalOwnership" Value="OwnsJournal"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="NavigationWindow">
+        <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Icon" Value="{DynamicResource WindowIcon}"/>
+        <Setter Property="ShowsNavigationUI" Value="False"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="TextOptions.TextFormattingMode" Value="Display"/>
+        <Setter Property="TextOptions.TextRenderingMode" Value="ClearType"/>
+        <Setter Property="TextOptions.TextHintingMode" Value="Fixed"/>
+    </Style>
+
+    <Style TargetType="Label">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="2,0"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="AccessText">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="TextOptions.TextFormattingMode" Value="Display"/>
+        <Setter Property="TextOptions.TextRenderingMode" Value="ClearType"/>
+        <Setter Property="TextOptions.TextHintingMode" Value="Fixed"/>
+    </Style>
+
+    <Style TargetType="BulletDecorator">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="documents:AdornerDecorator">
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="Viewbox">
+        <Setter Property="Stretch" Value="Uniform"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+</ResourceDictionary>


### PR DESCRIPTION
## Summary
- Add a late-loaded Admin Settings theme override layer for navigation hosts and small text chrome.
- Route `Frame`, `NavigationWindow`, `Label`, `AccessText`, `BulletDecorator`, `AdornerDecorator`, and `Viewbox` through admin-selected background, transparent surface, foreground, typography, border, focus, disabled opacity, and layout rendering resources where applicable.
- Load the new dictionary after the broad admin designer coverage dictionary so it participates in the final app-wide theme pass.
- Add XAML contract tests for load order, covered controls, and required admin theme token usage.
- Record the scheduled theme coverage pass in progress notes.

## Validation
- GitHub connector compare/readback confirmed the branch is 4 commits ahead of `master`, 0 behind, with only the intended files changed.
- Not run locally: this scheduled Linux container does not have the .NET SDK or Windows WPF runtime, and local clone/raw access remains blocked by the network tunnel.