### PR TITLE
[codex] expand admin theme layout presenter coverage

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemeAdminDesignerCoverageOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeAdminDesignerCoverageOverrideTests.cs
@@ -126,10 +126,9 @@ namespace InventoryManagementApp.Tests.Resources
             Assert.Contains("TargetType=\"StackPanel\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"WrapPanel\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"Canvas\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("TargetType=\"UniformGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"primitives:UniformGrid\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"ContentPresenter\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"ItemsPresenter\"", xaml, StringComparison.Ordinal);
-            Assert.Contains("TargetType=\"HeaderedItemsControl\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"primitives:Popup\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"GridViewColumnHeader\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"DocumentViewer\"", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/Resources/ThemeAdminDesignerCoverageOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeAdminDesignerCoverageOverrideTests.cs
@@ -16,6 +16,7 @@ namespace InventoryManagementApp.Tests.Resources
             var formMediaIndex = xaml.IndexOf("Resources/Theme.FormMediaPreviewOverrides.xaml", StringComparison.Ordinal);
             var adminCoverageIndex = xaml.IndexOf("Resources/Theme.AdminDesignerCoverageOverrides.xaml", StringComparison.Ordinal);
             var navigationChromeIndex = xaml.IndexOf("Resources/Theme.NavigationChromeOverrides.xaml", StringComparison.Ordinal);
+            var layoutPresenterIndex = xaml.IndexOf("Resources/Theme.LayoutPresenterOverrides.xaml", StringComparison.Ordinal);
             var convertersIndex = xaml.IndexOf("Resources/Converters.xaml", StringComparison.Ordinal);
 
             Assert.True(fullCustomizationIndex >= 0, "Full customization overrides should remain loaded.");
@@ -23,7 +24,8 @@ namespace InventoryManagementApp.Tests.Resources
             Assert.True(formMediaIndex > controlCustomizationIndex, "Form/media overrides should load after control overrides.");
             Assert.True(adminCoverageIndex > formMediaIndex, "Admin coverage overrides should remain after form/media resources.");
             Assert.True(navigationChromeIndex > adminCoverageIndex, "Navigation chrome overrides should load after the broad admin coverage layer.");
-            Assert.True(convertersIndex > navigationChromeIndex, "Converters should remain after visual resources.");
+            Assert.True(layoutPresenterIndex > navigationChromeIndex, "Layout presenter overrides should load after navigation chrome resources.");
+            Assert.True(convertersIndex > layoutPresenterIndex, "Converters should remain after visual resources.");
         }
 
         [Fact]
@@ -111,6 +113,46 @@ namespace InventoryManagementApp.Tests.Resources
             Assert.Contains("{DynamicResource ThemeBodyFontSize}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeDisabledOpacity}", xaml, StringComparison.Ordinal);
             Assert.Contains("FocusVisualStyle\" Value=\"{StaticResource DefaultFocusVisual}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextOptions.TextRenderingMode\" Value=\"ClearType\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void LayoutPresenterOverrides_ExtendAdminThemesToStructuralLayoutChrome()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.LayoutPresenterOverrides.xaml");
+
+            Assert.Contains("TargetType=\"Grid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"DockPanel\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"StackPanel\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"WrapPanel\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Canvas\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"UniformGrid\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ContentPresenter\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ItemsPresenter\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"HeaderedItemsControl\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"primitives:Popup\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"GridViewColumnHeader\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"DocumentViewer\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"FlowDocumentReader\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"FlowDocumentScrollViewer\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void LayoutPresenterOverrides_UseAdminThemeTokensForTransparentBackgroundsAndTypography()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.LayoutPresenterOverrides.xaml");
+
+            Assert.Contains("{DynamicResource TransparentSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource BackgroundBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ForegroundBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource BorderBrushAlt}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeGridLineBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeFontFamily}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBodyFontSize}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeDataGridHeaderHeight}", xaml, StringComparison.Ordinal);
+            Assert.Contains("AllowsTransparency\" Value=\"True\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TextOptions.TextRenderingMode\" Value=\"ClearType\"", xaml, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -20,6 +20,7 @@
                 <ResourceDictionary Source="Resources/Theme.FormMediaPreviewOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.AdminDesignerCoverageOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.NavigationChromeOverrides.xaml"/>
+                <ResourceDictionary Source="Resources/Theme.LayoutPresenterOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
                 <ResourceDictionary Source="Resources/Templates.xaml"/>
             </ResourceDictionary.MergedDictionaries>

--- a/InventoryManagementApp/ProgressNotes/2026-06-20-theme-layout-presenter-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-20-theme-layout-presenter-coverage.md
@@ -1,0 +1,14 @@
+# Admin Theme Layout and Presenter Coverage - 2026-06-20
+
+## Completed
+
+- Added a late-loaded admin theme resource dictionary for structural layout and presenter chrome that can sit between visible controls.
+- Routed `Grid`, `DockPanel`, `StackPanel`, `WrapPanel`, `Canvas`, and `UniformGrid` through transparent admin theme surfaces so app background images and colors can show through more consistently.
+- Routed `ContentPresenter`, `ItemsPresenter`, `Popup`, `GridViewColumnHeader`, `DocumentViewer`, `FlowDocumentReader`, and `FlowDocumentScrollViewer` through admin theme layout, typography, popup transparency, border, and document background tokens where applicable.
+- Loaded the new dictionary after navigation chrome overrides so it participates in the final Admin Settings visual override pass.
+- Added focused XAML contract tests for load order, covered structural controls, transparent background tokens, typography tokens, popup transparency, and document/presenter coverage.
+
+## Validation Notes
+
+- Changes were made through the GitHub connector because the scheduled Linux container still cannot clone the repository through the network tunnel.
+- Local `dotnet test`, WPF screenshots, and local banned-word checks were not run because this container lacks the .NET SDK and Windows WPF runtime.

--- a/InventoryManagementApp/Resources/Theme.LayoutPresenterOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.LayoutPresenterOverrides.xaml
@@ -1,0 +1,111 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework">
+    <!--
+        Last-mile layout and presenter chrome for Admin Settings theme customization.
+        These elements often sit between styled controls, so they should stay transparent,
+        pick up admin-selected typography, and allow the app background to show through.
+    -->
+
+    <Style TargetType="Grid">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="DockPanel">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="StackPanel">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="WrapPanel">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="Canvas">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="UniformGrid">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="ContentPresenter">
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+        <Setter Property="TextOptions.TextFormattingMode" Value="Display"/>
+        <Setter Property="TextOptions.TextRenderingMode" Value="ClearType"/>
+        <Setter Property="TextOptions.TextHintingMode" Value="Fixed"/>
+    </Style>
+
+    <Style TargetType="ItemsPresenter">
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="HeaderedItemsControl">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+    </Style>
+
+    <Style TargetType="primitives:Popup">
+        <Setter Property="AllowsTransparency" Value="True"/>
+        <Setter Property="PopupAnimation" Value="Fade"/>
+    </Style>
+
+    <Style TargetType="GridViewColumnHeader">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeGridLineBrush}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeDataGridHeaderHeight}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+    </Style>
+
+    <Style TargetType="DocumentViewer">
+        <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+    </Style>
+
+    <Style TargetType="FlowDocumentReader">
+        <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+    </Style>
+
+    <Style TargetType="FlowDocumentScrollViewer">
+        <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+    </Style>
+</ResourceDictionary>

--- a/InventoryManagementApp/Resources/Theme.LayoutPresenterOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.LayoutPresenterOverrides.xaml
@@ -37,7 +37,7 @@
         <Setter Property="UseLayoutRounding" Value="True"/>
     </Style>
 
-    <Style TargetType="UniformGrid">
+    <Style TargetType="primitives:UniformGrid">
         <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="UseLayoutRounding" Value="True"/>
@@ -54,14 +54,6 @@
     <Style TargetType="ItemsPresenter">
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="UseLayoutRounding" Value="True"/>
-    </Style>
-
-    <Style TargetType="HeaderedItemsControl">
-        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
-        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
-        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
-        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
     </Style>
 
     <Style TargetType="primitives:Popup">


### PR DESCRIPTION
## Summary
- Add a late-loaded Admin Settings theme override layer for structural layout and presenter chrome.
- Route layout panels, presenters, popups, GridView headers, and document viewers through admin-selected transparent backgrounds, typography, borders, popup transparency, and document background tokens where applicable.
- Load the new dictionary after navigation chrome overrides so it participates in the final app-wide theme pass.
- Add focused XAML contract tests for load order, structural coverage, and required admin theme token usage.
- Record the scheduled theme coverage pass in progress notes.

## Validation
- GitHub connector compare/readback confirmed the branch is 6 commits ahead of `master`, 0 behind, with only the intended files changed.
- Not run locally: this scheduled Linux container does not have the .NET SDK or Windows WPF runtime, and local clone/raw access remains blocked by the network tunnel.