### PR TITLE
Harden Admin Settings theme designer route

### DIFF
--- a/InventoryManagementApp.Tests/Views/SettingsThemeDesignerRouteTests.cs
+++ b/InventoryManagementApp.Tests/Views/SettingsThemeDesignerRouteTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Views
+{
+    public class SettingsThemeDesignerRouteTests
+    {
+        [Fact]
+        public void SettingsPageCodeBehind_RoutesAdminSettingsToThemeDesignerReliably()
+        {
+            var code = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "SettingsPage.xaml.cs");
+
+            Assert.Contains("AddThemeDesignerTab();", code, StringComparison.Ordinal);
+            Assert.Contains("Header = \"06 Themes\"", code, StringComparison.Ordinal);
+            Assert.Contains("Content = new ThemeDesignerControl()", code, StringComparison.Ordinal);
+            Assert.Contains("QueueThemeDesignerTabRetry", code, StringComparison.Ordinal);
+            Assert.Contains("Dispatcher.BeginInvoke(AddThemeDesignerTab, DispatcherPriority.Loaded)", code, StringComparison.Ordinal);
+            Assert.Contains("RenumberTabs(tabControl)", code, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ThemeDesignerControl_ExposesFullAppCustomizationSurface()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ThemeDesignerControl.xaml");
+
+            Assert.Contains("App Theme Designer", xaml, StringComparison.Ordinal);
+            Assert.Contains("ImportThemeProfileCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("ExportThemeProfileCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("GlassPresetCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("TransparentCanvasPresetCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("BorderlessPresetCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("DeepShadowPresetCommand", xaml, StringComparison.Ordinal);
+            Assert.Contains("BackgroundImagePath", xaml, StringComparison.Ordinal);
+            Assert.Contains("BackgroundOverlayOpacity", xaml, StringComparison.Ordinal);
+            Assert.Contains("SurfaceOpacity", xaml, StringComparison.Ordinal);
+            Assert.Contains("ButtonOpacity", xaml, StringComparison.Ordinal);
+            Assert.Contains("BordersVisible", xaml, StringComparison.Ordinal);
+            Assert.Contains("BorderThickness", xaml, StringComparison.Ordinal);
+            Assert.Contains("ControlBorderThickness", xaml, StringComparison.Ordinal);
+            Assert.Contains("ButtonCornerRadius", xaml, StringComparison.Ordinal);
+            Assert.Contains("ShadowDepth", xaml, StringComparison.Ordinal);
+            Assert.Contains("SurfaceShadowScale", xaml, StringComparison.Ordinal);
+            Assert.Contains("ControlShadowScale", xaml, StringComparison.Ordinal);
+            Assert.Contains("Theme coverage preview lab", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePath)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null)
+            {
+                var candidate = Path.Combine(directory.FullName, Path.Combine(relativePath));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                directory = directory.Parent;
+            }
+
+            throw new FileNotFoundException("Could not locate repository file.", Path.Combine(relativePath));
+        }
+    }
+}

--- a/InventoryManagementApp/Views/Pages/SettingsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/SettingsPage.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 using InventoryManagementApp.ViewModels;
 using TextBox = System.Windows.Controls.TextBox;
 
@@ -11,6 +12,7 @@ namespace InventoryManagementApp.Views.Pages
     {
         private SettingsViewModel? _settingsViewModel;
         private bool _themeDesignerTabAdded;
+        private bool _themeDesignerTabRetryQueued;
 
         public SettingsPage()
         {
@@ -45,8 +47,12 @@ namespace InventoryManagementApp.Views.Pages
 
             var tabControl = FindVisualChild<TabControl>(this);
             if (tabControl == null)
+            {
+                QueueThemeDesignerTabRetry();
                 return;
+            }
 
+            _themeDesignerTabRetryQueued = false;
             var tab = new TabItem
             {
                 Header = "06 Themes",
@@ -57,6 +63,15 @@ namespace InventoryManagementApp.Views.Pages
             tabControl.Items.Insert(System.Math.Min(5, tabControl.Items.Count), tab);
             RenumberTabs(tabControl);
             _themeDesignerTabAdded = true;
+        }
+
+        private void QueueThemeDesignerTabRetry()
+        {
+            if (_themeDesignerTabRetryQueued)
+                return;
+
+            _themeDesignerTabRetryQueued = true;
+            Dispatcher.BeginInvoke(AddThemeDesignerTab, DispatcherPriority.Loaded);
         }
 
         private static void RenumberTabs(TabControl tabControl)


### PR DESCRIPTION
## Summary
- Makes the Admin Settings theme designer tab retry loading if WPF has not exposed the Settings tab control yet.
- Keeps the existing split full-app theme designer reachable from Admin Settings without silently disappearing on a load timing edge.
- Adds source-contract tests for the Settings theme route and the theme designer customization surface.

## Validation
- Reviewed branch diff through the GitHub connector.
- GitHub reported the branch is 2 commits ahead of master and 0 behind.
- Local dotnet build/test and WPF runtime validation could not run in this scheduled Linux container because the .NET SDK/Windows WPF runtime and local clone/raw access are unavailable.