### PR TITLE
[codex] theme special media and document surfaces

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemeAdminDesignerCoverageOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeAdminDesignerCoverageOverrideTests.cs
@@ -17,6 +17,7 @@ namespace InventoryManagementApp.Tests.Resources
             var adminCoverageIndex = xaml.IndexOf("Resources/Theme.AdminDesignerCoverageOverrides.xaml", StringComparison.Ordinal);
             var navigationChromeIndex = xaml.IndexOf("Resources/Theme.NavigationChromeOverrides.xaml", StringComparison.Ordinal);
             var layoutPresenterIndex = xaml.IndexOf("Resources/Theme.LayoutPresenterOverrides.xaml", StringComparison.Ordinal);
+            var specialSurfaceIndex = xaml.IndexOf("Resources/Theme.SpecialSurfaceOverrides.xaml", StringComparison.Ordinal);
             var convertersIndex = xaml.IndexOf("Resources/Converters.xaml", StringComparison.Ordinal);
 
             Assert.True(fullCustomizationIndex >= 0, "Full customization overrides should remain loaded.");
@@ -25,7 +26,8 @@ namespace InventoryManagementApp.Tests.Resources
             Assert.True(adminCoverageIndex > formMediaIndex, "Admin coverage overrides should remain after form/media resources.");
             Assert.True(navigationChromeIndex > adminCoverageIndex, "Navigation chrome overrides should load after the broad admin coverage layer.");
             Assert.True(layoutPresenterIndex > navigationChromeIndex, "Layout presenter overrides should load after navigation chrome resources.");
-            Assert.True(convertersIndex > layoutPresenterIndex, "Converters should remain after visual resources.");
+            Assert.True(specialSurfaceIndex > layoutPresenterIndex, "Special surface overrides should load after layout presenter resources.");
+            Assert.True(convertersIndex > specialSurfaceIndex, "Converters should remain after visual resources.");
         }
 
         [Fact]
@@ -152,6 +154,47 @@ namespace InventoryManagementApp.Tests.Resources
             Assert.Contains("{DynamicResource ThemeBodyFontSize}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeDataGridHeaderHeight}", xaml, StringComparison.Ordinal);
             Assert.Contains("AllowsTransparency\" Value=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextOptions.TextRenderingMode\" Value=\"ClearType\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SpecialSurfaceOverrides_ExtendAdminThemesToMediaDocumentAndResizeChrome()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.SpecialSurfaceOverrides.xaml");
+
+            Assert.Contains("TargetType=\"Image\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"MediaElement\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"InkCanvas\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Viewport3D\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"FixedPage\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"FlowDocumentPageViewer\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"StatusBarItem\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ResizeGrip\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"primitives:Thumb\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"primitives:Track\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SpecialSurfaceOverrides_UseAdminThemeTokensForTransparencyTypographyAndDepth()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.SpecialSurfaceOverrides.xaml");
+
+            Assert.Contains("{DynamicResource TransparentSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource BackgroundBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ForegroundBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource BorderBrushAlt}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBorderlessThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeFontFamily}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBodyFontSize}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeCaptionFontSize}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeSurfaceShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ItemHoverBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ItemSelectedBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeDisabledOpacity}", xaml, StringComparison.Ordinal);
+            Assert.Contains("FocusVisualStyle\" Value=\"{StaticResource DefaultFocusVisual}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TextOptions.TextRenderingMode\" Value=\"ClearType\"", xaml, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -21,6 +21,7 @@
                 <ResourceDictionary Source="Resources/Theme.AdminDesignerCoverageOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.NavigationChromeOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.LayoutPresenterOverrides.xaml"/>
+                <ResourceDictionary Source="Resources/Theme.SpecialSurfaceOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
                 <ResourceDictionary Source="Resources/Templates.xaml"/>
             </ResourceDictionary.MergedDictionaries>

--- a/InventoryManagementApp/ProgressNotes/2026-06-20-theme-special-surface-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-20-theme-special-surface-coverage.md
@@ -1,0 +1,13 @@
+# Admin Theme Special Surface Coverage - 2026-06-20
+
+## Completed
+
+- Added a late-loaded admin theme resource dictionary for special media, document, ink, resize, and range-control surfaces that can otherwise keep platform defaults.
+- Routed `Image`, `MediaElement`, `InkCanvas`, `Viewport3D`, `FixedPage`, `FlowDocumentPageViewer`, `StatusBarItem`, `ResizeGrip`, `Thumb`, and `Track` through admin theme transparency, typography, border, focus, disabled opacity, and shadow tokens where applicable.
+- Loaded the new dictionary after layout presenter overrides so it participates in the final Admin Settings visual override pass before converters and templates.
+- Added focused XAML contract tests for load order, covered special-surface controls, and the required admin theme token usage.
+
+## Validation Notes
+
+- Changes were made through the GitHub connector because the scheduled Linux container still cannot clone the repository through the network tunnel.
+- Local `dotnet test`, WPF screenshots, and local banned-word checks were not run because this container lacks the .NET SDK and Windows WPF runtime.

--- a/InventoryManagementApp/Resources/Theme.SpecialSurfaceOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.SpecialSurfaceOverrides.xaml
@@ -1,0 +1,106 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework">
+    <!--
+        Last-mile special surfaces for Admin Settings theme customization.
+        These controls are less common than buttons, grids, and text inputs, but they can still
+        carry opaque platform defaults around previews, media, ink, resize handles, and document
+        pages. Keep them routed through admin-selected transparency, typography, borders, and depth.
+    -->
+
+    <Style TargetType="Image">
+        <Setter Property="Stretch" Value="Uniform"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+        <Setter Property="RenderOptions.BitmapScalingMode" Value="HighQuality"/>
+    </Style>
+
+    <Style TargetType="MediaElement">
+        <Setter Property="Stretch" Value="Uniform"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="InkCanvas">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="Viewport3D">
+        <Setter Property="ClipToBounds" Value="True"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="FixedPage">
+        <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+        <Setter Property="TextOptions.TextFormattingMode" Value="Display"/>
+        <Setter Property="TextOptions.TextRenderingMode" Value="ClearType"/>
+        <Setter Property="TextOptions.TextHintingMode" Value="Fixed"/>
+    </Style>
+
+    <Style TargetType="FlowDocumentPageViewer">
+        <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+    </Style>
+
+    <Style TargetType="StatusBarItem">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeCaptionFontSize}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="ResizeGrip">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+    </Style>
+
+    <Style TargetType="primitives:Thumb">
+        <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+            </Trigger>
+            <Trigger Property="IsDragging" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="primitives:Track">
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+</ResourceDictionary>


### PR DESCRIPTION
## Summary
- Add a late-loaded Admin Settings theme override layer for special media, document, ink, resize, and range-control surfaces.
- Route Image, MediaElement, InkCanvas, Viewport3D, FixedPage, FlowDocumentPageViewer, StatusBarItem, ResizeGrip, Thumb, and Track through admin-selected transparency, typography, border, focus, disabled opacity, and shadow resources where applicable.
- Load the new dictionary after layout presenter overrides so it participates in the final app-wide Admin Settings visual override pass.
- Add focused XAML contract tests and a progress note for the scheduled theme coverage pass.

## Validation
- GitHub connector compare/readback confirmed the branch is 4 commits ahead of master and 0 behind, with only the intended files changed.
- GitHub connector reported no commit statuses for the head commit.
- Not run locally: this scheduled Linux container does not have the .NET SDK or Windows WPF runtime, and local clone/raw access remains blocked by the network tunnel.