### PR TITLE
[codex] extend admin themes to vector shape chrome

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemeAdminDesignerCoverageOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeAdminDesignerCoverageOverrideTests.cs
@@ -158,7 +158,7 @@ namespace InventoryManagementApp.Tests.Resources
         }
 
         [Fact]
-        public void SpecialSurfaceOverrides_ExtendAdminThemesToMediaDocumentAndResizeChrome()
+        public void SpecialSurfaceOverrides_ExtendAdminThemesToMediaDocumentResizeAndVectorChrome()
         {
             var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.SpecialSurfaceOverrides.xaml");
 
@@ -166,6 +166,12 @@ namespace InventoryManagementApp.Tests.Resources
             Assert.Contains("TargetType=\"MediaElement\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"InkCanvas\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"Viewport3D\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Rectangle\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Ellipse\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Line\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Path\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Polygon\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Polyline\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"FixedPage\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"FlowDocumentPageViewer\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"StatusBarItem\"", xaml, StringComparison.Ordinal);
@@ -175,7 +181,7 @@ namespace InventoryManagementApp.Tests.Resources
         }
 
         [Fact]
-        public void SpecialSurfaceOverrides_UseAdminThemeTokensForTransparencyTypographyAndDepth()
+        public void SpecialSurfaceOverrides_UseAdminThemeTokensForTransparencyTypographyDepthAndVectorStrokes()
         {
             var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.SpecialSurfaceOverrides.xaml");
 
@@ -183,9 +189,11 @@ namespace InventoryManagementApp.Tests.Resources
             Assert.Contains("{DynamicResource BackgroundBrush}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ForegroundBrush}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource BorderBrushAlt}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource AccentBrush}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeBorderThickness}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeBorderlessThickness}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeControlBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeShapeStrokeThickness}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeFontFamily}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeBodyFontSize}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeCaptionFontSize}", xaml, StringComparison.Ordinal);
@@ -196,6 +204,16 @@ namespace InventoryManagementApp.Tests.Resources
             Assert.Contains("{DynamicResource ThemeDisabledOpacity}", xaml, StringComparison.Ordinal);
             Assert.Contains("FocusVisualStyle\" Value=\"{StaticResource DefaultFocusVisual}\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TextOptions.TextRenderingMode\" Value=\"ClearType\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ThemeCustomizationAndService_ExposeShapeStrokeResourceForBorderlessVectorChrome()
+        {
+            var resources = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.Customization.xaml");
+            var service = ReadRepositoryFile("InventoryManagementApp", "Services", "ThemeService.cs");
+
+            Assert.Contains("x:Key=\"ThemeShapeStrokeThickness\"", resources, StringComparison.Ordinal);
+            Assert.Contains("Set(resources, \"ThemeShapeStrokeThickness\", settings.BordersVisible ? settings.ControlBorderThickness : 0)", service, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-theme-vector-shape-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-theme-vector-shape-coverage.md
@@ -1,0 +1,13 @@
+# Admin Theme Vector Shape Coverage - 2026-06-21
+
+## Completed
+
+- Added a shared `ThemeShapeStrokeThickness` resource so vector outlines can follow Admin Settings border visibility instead of using a fixed stroke width.
+- Updated `ThemeService` to set `ThemeShapeStrokeThickness` from `ControlBorderThickness` and collapse it to `0` when the admin turns borders off.
+- Extended the late-loaded special surface theme layer to route `Rectangle`, `Ellipse`, `Line`, `Path`, `Polygon`, and `Polyline` through admin-selected transparent surfaces, accent/border colors, stroke thickness, and control shadows where applicable.
+- Added focused source-contract coverage for vector shape styles, the shape stroke resource, and the service wiring that makes borderless themes affect vector chrome.
+
+## Validation Notes
+
+- Changes were made through the GitHub connector because the scheduled Linux container still cannot clone the repository through the network tunnel.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run because this container lacks the .NET SDK and Windows WPF runtime.

--- a/InventoryManagementApp/Resources/Theme.Customization.xaml
+++ b/InventoryManagementApp/Resources/Theme.Customization.xaml
@@ -35,6 +35,7 @@
     <sys:Double x:Key="ThemeInteractionIntensity">1</sys:Double>
     <sys:Double x:Key="ThemeMotionIntensity">1</sys:Double>
     <sys:Double x:Key="ThemeFocusVisualStrokeThickness">2</sys:Double>
+    <sys:Double x:Key="ThemeShapeStrokeThickness">1</sys:Double>
     <sys:Double x:Key="ThemeShadowDirection">270</sys:Double>
     <sys:Double x:Key="ThemeDividerOpacity">1</sys:Double>
     <sys:Double x:Key="ThemeSurfaceShadowScale">1</sys:Double>

--- a/InventoryManagementApp/Resources/Theme.SpecialSurfaceOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.SpecialSurfaceOverrides.xaml
@@ -4,8 +4,9 @@
     <!--
         Last-mile special surfaces for Admin Settings theme customization.
         These controls are less common than buttons, grids, and text inputs, but they can still
-        carry opaque platform defaults around previews, media, ink, resize handles, and document
-        pages. Keep them routed through admin-selected transparency, typography, borders, and depth.
+        carry opaque platform defaults around previews, media, ink, resize handles, vector chrome,
+        and document pages. Keep them routed through admin-selected transparency, typography,
+        borders, color, and depth.
     -->
 
     <Style TargetType="Image">
@@ -31,6 +32,50 @@
         <Setter Property="ClipToBounds" Value="True"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="Rectangle">
+        <Setter Property="Fill" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="Stroke" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="StrokeThickness" Value="{DynamicResource ThemeShapeStrokeThickness}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="Ellipse">
+        <Setter Property="Fill" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="Stroke" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="StrokeThickness" Value="{DynamicResource ThemeShapeStrokeThickness}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="Line">
+        <Setter Property="Stroke" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="StrokeThickness" Value="{DynamicResource ThemeShapeStrokeThickness}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="Path">
+        <Setter Property="Fill" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="Stroke" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="StrokeThickness" Value="{DynamicResource ThemeShapeStrokeThickness}"/>
+        <Setter Property="Stretch" Value="Uniform"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="Polygon">
+        <Setter Property="Fill" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="Stroke" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="StrokeThickness" Value="{DynamicResource ThemeShapeStrokeThickness}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="Polyline">
+        <Setter Property="Stroke" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="StrokeThickness" Value="{DynamicResource ThemeShapeStrokeThickness}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
     </Style>
 
     <Style TargetType="FixedPage">

--- a/InventoryManagementApp/Services/ThemeService.cs
+++ b/InventoryManagementApp/Services/ThemeService.cs
@@ -138,6 +138,7 @@ namespace InventoryManagementApp.Services
                 Set(resources, "ThemeBorderThickness", borderThickness);
                 Set(resources, "ThemeSubtleBorderThickness", dividerThickness);
                 Set(resources, "ThemeControlBorderThickness", controlBorderThickness);
+                Set(resources, "ThemeShapeStrokeThickness", settings.BordersVisible ? settings.ControlBorderThickness : 0);
                 Set(resources, "ThemeBorderlessThickness", new Thickness(0));
                 Set(resources, "ThemeCardCornerRadius", new CornerRadius(settings.CardCornerRadius));
                 Set(resources, "ThemePanelCornerRadius", new CornerRadius(settings.PanelCornerRadius));


### PR DESCRIPTION
## Summary
- Add a shared `ThemeShapeStrokeThickness` resource so vector outlines can follow Admin Settings border visibility.
- Update `ThemeService` so borderless themes collapse vector shape strokes while normal themes use the configured control border thickness.
- Extend the late-loaded special surface override layer to theme `Rectangle`, `Ellipse`, `Line`, `Path`, `Polygon`, and `Polyline` with admin-selected transparency, accent/border colors, strokes, and shadows where applicable.
- Add source-contract tests for vector shape coverage, the new stroke resource, and the service wiring.

## Validation
- Verified the branch through the GitHub connector: 5 commits ahead of `master`, 0 behind, with only the intended theme resources, service wiring, tests, and progress note changed.
- Read back the updated special-surface dictionary and test coverage through the GitHub connector.
- GitHub reported no commit statuses for the head commit.
- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks could not run because this scheduled Linux container still lacks the .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel.