### PR TITLE
[codex] extend admin themes to overlay and document chrome

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemeOverlayDocumentOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeOverlayDocumentOverrideTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Resources
+{
+    public class ThemeOverlayDocumentOverrideTests
+    {
+        [Fact]
+        public void App_LoadsOverlayDocumentOverridesAfterSpecialSurfaces()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "App.xaml");
+
+            var specialSurfaceIndex = xaml.IndexOf("Resources/Theme.SpecialSurfaceOverrides.xaml", StringComparison.Ordinal);
+            var overlayDocumentIndex = xaml.IndexOf("Resources/Theme.OverlayDocumentOverrides.xaml", StringComparison.Ordinal);
+            var convertersIndex = xaml.IndexOf("Resources/Converters.xaml", StringComparison.Ordinal);
+
+            Assert.True(specialSurfaceIndex >= 0, "Special surface overrides should remain loaded.");
+            Assert.True(overlayDocumentIndex > specialSurfaceIndex, "Overlay/document overrides should be the final theme coverage layer.");
+            Assert.True(convertersIndex > overlayDocumentIndex, "Converters should remain after visual resources.");
+        }
+
+        [Fact]
+        public void OverlayDocumentOverrides_ExtendAdminThemesToPopupMenuAndDisclosureChrome()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.OverlayDocumentOverrides.xaml");
+
+            Assert.Contains("TargetType=\"Menu\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ContextMenu\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"MenuItem\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ToolTip\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"GroupBox\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Expander\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Separator\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Property=\"IsHighlighted\" Value=\"True\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("Property=\"IsChecked\" Value=\"True\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OverlayDocumentOverrides_ExtendAdminThemesToDocumentTextAndAdorners()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.OverlayDocumentOverrides.xaml");
+
+            Assert.Contains("TargetType=\"FlowDocument\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Paragraph\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Run\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Span\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"documents:AdornerDecorator\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"documents:AdornerLayer\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OverlayDocumentOverrides_UseAdminThemeTokensForTransparencyTypographyBordersAndDepth()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.OverlayDocumentOverrides.xaml");
+
+            Assert.Contains("{DynamicResource TransparentSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource BackgroundBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemePopupSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeDialogSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource GlassSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ForegroundBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource BorderBrushAlt}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeSubtleBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeGridLineBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeFontFamily}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBodyFontSize}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlMinHeight}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource CardPadding}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeSurfaceShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeRaisedShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ItemHoverBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ItemSelectedBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeDisabledOpacity}", xaml, StringComparison.Ordinal);
+            Assert.Contains("FocusVisualStyle\" Value=\"{StaticResource DefaultFocusVisual}\"", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -22,6 +22,7 @@
                 <ResourceDictionary Source="Resources/Theme.NavigationChromeOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.LayoutPresenterOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.SpecialSurfaceOverrides.xaml"/>
+                <ResourceDictionary Source="Resources/Theme.OverlayDocumentOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
                 <ResourceDictionary Source="Resources/Templates.xaml"/>
             </ResourceDictionary.MergedDictionaries>

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-theme-overlay-document-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-theme-overlay-document-coverage.md
@@ -1,0 +1,7 @@
+# Theme Overlay and Document Coverage
+
+- Added a late-loaded Admin Settings theme override layer for popup, menu, disclosure, tooltip, document text, and adorner chrome.
+- Routed these remaining surfaces through admin-selected background transparency, popup/dialog surface colors, typography, borders, disabled opacity, hover/selection brushes, and shadow depth resources.
+- Added source-contract tests for app resource load order, overlay/control coverage, document text coverage, and required theme token usage.
+
+Validation note: local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run in this scheduled Linux container because the .NET SDK/Windows WPF runtime are unavailable and local clone/raw access is blocked by the network tunnel.

--- a/InventoryManagementApp/Resources/Theme.OverlayDocumentOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.OverlayDocumentOverrides.xaml
@@ -1,0 +1,134 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:documents="clr-namespace:System.Windows.Documents;assembly=PresentationFramework">
+    <!--
+        Final overlay and document text coverage for Admin Settings theme customization.
+        Menus, context popups, tooltips, adorners, and FlowDocument content can otherwise keep
+        opaque platform defaults after an admin makes the rest of the app transparent, borderless,
+        rounded, or heavily shadowed.
+    -->
+
+    <Style TargetType="Menu">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="ContextMenu">
+        <Setter Property="Background" Value="{DynamicResource ThemePopupSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="2"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="MenuItem">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Style.Triggers>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemHoverForegroundBrush}"/>
+            </Trigger>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemSelectedForegroundBrush}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="ToolTip">
+        <Setter Property="Background" Value="{DynamicResource ThemeDialogSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeRaisedShadow}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="GroupBox">
+        <Setter Property="Background" Value="{DynamicResource GlassSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+    </Style>
+
+    <Style TargetType="Expander">
+        <Setter Property="Background" Value="{DynamicResource GlassSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="{DynamicResource CardPadding}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+    </Style>
+
+    <Style TargetType="Separator">
+        <Setter Property="Background" Value="{DynamicResource ThemeGridLineBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="Margin" Value="2"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="FlowDocument">
+        <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="PagePadding" Value="{DynamicResource CardPadding}"/>
+    </Style>
+
+    <Style TargetType="Paragraph">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Margin" Value="0,0,0,8"/>
+    </Style>
+
+    <Style TargetType="Run">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+    </Style>
+
+    <Style TargetType="Span">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+    </Style>
+
+    <Style TargetType="documents:AdornerDecorator">
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="documents:AdornerLayer">
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+</ResourceDictionary>


### PR DESCRIPTION
## Summary
- Add a late-loaded Admin Settings theme override layer for menus, context menus, menu items, tooltips, group boxes, expanders, separators, FlowDocument text, and adorner chrome.
- Route these remaining overlay/document surfaces through admin-selected transparency, popup/dialog colors, typography, border visibility, hover/selection brushes, disabled opacity, and shadow depth resources.
- Load the new dictionary after special-surface overrides so it acts as the final visual coverage layer before converters/templates.
- Add source-contract tests for load order, overlay/disclosure coverage, document/adorner coverage, and required admin theme token usage.

## Validation
- Verified the branch through the GitHub connector: 4 commits ahead of `master`, 0 behind, with only the intended theme resource, App.xaml load order, tests, and progress note changed.
- Read back the updated App.xaml, new override dictionary, and new tests through the GitHub connector.
- GitHub reported no commit statuses for the head commit.
- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks could not run because this scheduled Linux container still lacks the .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel.