### PR TITLE
Extend admin themes to document structure chrome

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemeOverlayDocumentOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeOverlayDocumentOverrideTests.cs
@@ -37,7 +37,7 @@ namespace InventoryManagementApp.Tests.Resources
         }
 
         [Fact]
-        public void OverlayDocumentOverrides_ExtendAdminThemesToDocumentTextAndAdorners()
+        public void OverlayDocumentOverrides_ExtendAdminThemesToDocumentTextStructureAndAdorners()
         {
             var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.OverlayDocumentOverrides.xaml");
 
@@ -45,6 +45,12 @@ namespace InventoryManagementApp.Tests.Resources
             Assert.Contains("TargetType=\"Paragraph\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"Run\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"Span\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Section\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"List\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ListItem\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Hyperlink\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Table\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"TableCell\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"documents:AdornerDecorator\"", xaml, StringComparison.Ordinal);
             Assert.Contains("TargetType=\"documents:AdornerLayer\"", xaml, StringComparison.Ordinal);
         }
@@ -60,15 +66,18 @@ namespace InventoryManagementApp.Tests.Resources
             Assert.Contains("{DynamicResource ThemeDialogSurfaceBrush}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource GlassSurfaceBrush}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ForegroundBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource AccentBrush}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource BorderBrushAlt}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeBorderThickness}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeControlBorderThickness}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeSubtleBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBorderlessThickness}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeGridLineBrush}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeFontFamily}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeBodyFontSize}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeControlMinHeight}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource CardPadding}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ControlPadding}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeSurfaceShadow}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ThemeRaisedShadow}", xaml, StringComparison.Ordinal);
             Assert.Contains("{DynamicResource ItemHoverBrush}", xaml, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-theme-document-structure-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-theme-document-structure-coverage.md
@@ -1,0 +1,12 @@
+# Admin Theme Document Structure Coverage - 2026-06-21
+
+## Completed
+
+- Extended the final Admin Settings overlay/document theme layer to cover structured FlowDocument content: sections, lists, list items, hyperlinks, tables, and table cells.
+- Routed document structure through admin-selected transparent surfaces, foreground/accent colors, borderless and subtle border resources, grid-line color, typography, and shared padding.
+- Updated source-contract coverage so future changes keep these document surfaces connected to the full-app theme customization system.
+
+## Validation Notes
+
+- Changes were made through the GitHub connector because the scheduled Linux container still cannot clone the repository through the network tunnel.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run because this container lacks the .NET SDK and Windows WPF runtime.

--- a/InventoryManagementApp/Resources/Theme.OverlayDocumentOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.OverlayDocumentOverrides.xaml
@@ -124,6 +124,56 @@
         <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
     </Style>
 
+    <Style TargetType="Section">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+    </Style>
+
+    <Style TargetType="List">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+    </Style>
+
+    <Style TargetType="ListItem">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+    </Style>
+
+    <Style TargetType="Hyperlink">
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+    </Style>
+
+    <Style TargetType="Table">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeGridLineBrush}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="CellSpacing" Value="0"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+    </Style>
+
+    <Style TargetType="TableCell">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeGridLineBrush}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+    </Style>
+
     <Style TargetType="documents:AdornerDecorator">
         <Setter Property="SnapsToDevicePixels" Value="True"/>
     </Style>


### PR DESCRIPTION
## Summary

- Extend the final Admin Settings overlay/document theme layer to FlowDocument sections, lists, list items, hyperlinks, tables, and table cells.
- Route those document structures through admin-controlled transparency, foreground/accent colors, borderless/subtle borders, grid-line color, typography, and padding tokens.
- Add source-contract tests and a progress note for the new theme coverage.

## Validation

- Reviewed the branch diff through the GitHub connector.
- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel.