### PR TITLE
[codex] add admin theme design readiness panel

### DIFF
--- a/InventoryManagementApp.Tests/Views/ThemeDesignerReadinessPanelTests.cs
+++ b/InventoryManagementApp.Tests/Views/ThemeDesignerReadinessPanelTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Views
+{
+    public class ThemeDesignerReadinessPanelTests
+    {
+        [Fact]
+        public void ThemeDesignerControl_AddsDesignReadinessPanelFromCodeBehind()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ThemeDesignerControl.xaml.cs");
+
+            Assert.Contains("AddDesignReadinessPanel();", source, StringComparison.Ordinal);
+            Assert.Contains("private void AddDesignReadinessPanel()", source, StringComparison.Ordinal);
+            Assert.Contains("Design readiness", source, StringComparison.Ordinal);
+            Assert.Contains("Before saving a full-app redesign", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ThemeDesignerReadinessPanel_UsesSharedStylesAndLiveStatusBinding()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ThemeDesignerControl.xaml.cs");
+
+            Assert.Contains("DesktopInsetCard", source, StringComparison.Ordinal);
+            Assert.Contains("PageTitleTextBlock", source, StringComparison.Ordinal);
+            Assert.Contains("CaptionTextBlock", source, StringComparison.Ordinal);
+            Assert.Contains("LabelTextBlock", source, StringComparison.Ordinal);
+            Assert.Contains("nameof(ThemeDesignerViewModel.Status)", source, StringComparison.Ordinal);
+            Assert.Contains("FallbackValue = \"Theme designer ready.\"", source, StringComparison.Ordinal);
+            Assert.Contains("DockPanel.SetDock(panel, Dock.Bottom)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ThemeDesignerReadinessPanel_CallsOutFullCustomizationRisks()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ThemeDesignerControl.xaml.cs");
+
+            Assert.Contains("text contrast", source, StringComparison.Ordinal);
+            Assert.Contains("transparent surface readability", source, StringComparison.Ordinal);
+            Assert.Contains("focus-ring visibility", source, StringComparison.Ordinal);
+            Assert.Contains("disabled-control clarity", source, StringComparison.Ordinal);
+            Assert.Contains("table density", source, StringComparison.Ordinal);
+            Assert.Contains("borderless affordances", source, StringComparison.Ordinal);
+            Assert.Contains("shadow depth", source, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-theme-design-readiness-panel.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-theme-design-readiness-panel.md
@@ -1,0 +1,13 @@
+# Admin Theme Design Readiness Panel - 2026-06-21
+
+## Completed
+
+- Added a bottom design-readiness panel to the Admin Settings theme designer.
+- The panel gives admins a pre-save checklist for full-app redesign risks: text contrast, transparent surface readability, focus-ring visibility, disabled-control clarity, table density, borderless affordances, and shadow depth.
+- The panel uses the app's shared desktop card/text styles and binds to the live theme designer status so save/import/preset outcomes remain visible while redesigning the app.
+- Added source-contract tests for the readiness panel creation, shared style usage, live status binding, and checklist coverage.
+
+## Validation Notes
+
+- Changes were made through the GitHub connector because the scheduled Linux container still cannot clone the repository through the network tunnel.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run because this container lacks the .NET SDK and Windows WPF runtime.

--- a/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml.cs
@@ -2,7 +2,9 @@ using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 
 namespace InventoryManagementApp.Views.Pages
 {
@@ -13,6 +15,7 @@ namespace InventoryManagementApp.Views.Pages
         public ThemeDesignerControl()
         {
             InitializeComponent();
+            AddDesignReadinessPanel();
             Loaded += ThemeDesignerControl_Loaded;
         }
 
@@ -35,6 +38,53 @@ namespace InventoryManagementApp.Views.Pages
             DataContext = viewModel;
             await viewModel.InitializeAsync();
             _initialized = true;
+        }
+
+        private void AddDesignReadinessPanel()
+        {
+            if (Content is not Border { Child: DockPanel dockPanel })
+                return;
+
+            var panel = new Border
+            {
+                Margin = new Thickness(14, 0, 14, 14)
+            };
+            panel.SetResourceReference(StyleProperty, "DesktopInsetCard");
+
+            var stack = new StackPanel();
+
+            var heading = new TextBlock
+            {
+                Text = "Design readiness",
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 4)
+            };
+            heading.SetResourceReference(StyleProperty, "PageTitleTextBlock");
+            stack.Children.Add(heading);
+
+            var checklist = new TextBlock
+            {
+                Text = "Before saving a full-app redesign, review text contrast, transparent surface readability, focus-ring visibility, disabled-control clarity, table density, borderless affordances, and shadow depth in the preview lab.",
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+            checklist.SetResourceReference(StyleProperty, "CaptionTextBlock");
+            stack.Children.Add(checklist);
+
+            var status = new TextBlock
+            {
+                TextWrapping = TextWrapping.Wrap
+            };
+            status.SetResourceReference(StyleProperty, "LabelTextBlock");
+            status.SetBinding(TextBlock.TextProperty, new Binding(nameof(ThemeDesignerViewModel.Status))
+            {
+                FallbackValue = "Theme designer ready."
+            });
+            stack.Children.Add(status);
+
+            panel.Child = stack;
+            DockPanel.SetDock(panel, Dock.Bottom);
+            dockPanel.Children.Add(panel);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add a bottom design-readiness panel to the Admin Settings theme designer.
- Surface a pre-save checklist for full-app redesign risks: text contrast, transparent surface readability, focus-ring visibility, disabled-control clarity, table density, borderless affordances, and shadow depth.
- Bind the panel to the live theme designer status so preset/import/save outcomes remain visible while admins customize the app.
- Add source-contract coverage for the panel creation, shared style usage, live status binding, and checklist text.

## Validation
- Reviewed the connector compare diff against `master`.
- Read back changed files through the GitHub connector.
- GitHub reported no attached status checks for the head commit.
- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and local clone/raw access remains blocked.