### PR TITLE
[codex] extend admin themes to range and scroll chrome

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemeRangeScrollChromeOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeRangeScrollChromeOverrideTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Resources
+{
+    public class ThemeRangeScrollChromeOverrideTests
+    {
+        [Fact]
+        public void App_LoadsRangeScrollChromeOverridesAfterFinalInputLayer()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "App.xaml");
+
+            var finalInputIndex = xaml.IndexOf("Resources/Theme.FinalContentInputOverrides.xaml", StringComparison.Ordinal);
+            var rangeScrollIndex = xaml.IndexOf("Resources/Theme.RangeScrollChromeOverrides.xaml", StringComparison.Ordinal);
+            var convertersIndex = xaml.IndexOf("Resources/Converters.xaml", StringComparison.Ordinal);
+
+            Assert.True(finalInputIndex >= 0, "Final content/input overrides should remain loaded.");
+            Assert.True(rangeScrollIndex > finalInputIndex, "Range and scroll chrome overrides should load after final input coverage.");
+            Assert.True(convertersIndex > rangeScrollIndex, "Converters should remain after the final visual override layer.");
+        }
+
+        [Fact]
+        public void RangeScrollChromeOverrides_ExtendAdminThemesToRangeScrollAndDragPrimitives()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.RangeScrollChromeOverrides.xaml");
+
+            Assert.Contains("TargetType=\"ScrollViewer\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ScrollBar\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Slider\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ProgressBar\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"GridSplitter\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"primitives:Thumb\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"primitives:RepeatButton\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeRangeTrackBorder", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeRangeFillBorder", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeRangeThumbStyle", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeScrollLineButtonStyle", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeScrollPageButtonStyle", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RangeScrollChromeOverrides_UseAdminThemeTokensForTransparencyDepthShapeAndInteraction()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.RangeScrollChromeOverrides.xaml");
+
+            Assert.Contains("{DynamicResource TransparentSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ProgressBarBackgroundBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource AccentBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource BorderBrushAlt}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource BtnBg}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource BtnBgHover}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource BtnBorder}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource BtnFg}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBorderlessThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeButtonCornerRadius}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeInputCornerRadius}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlMinHeight}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ItemHoverBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ItemSelectedBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource NavButtonPressedBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeDisabledOpacity}", xaml, StringComparison.Ordinal);
+            Assert.Contains("FocusVisualStyle\" Value=\"{StaticResource DefaultFocusVisual}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("RecognizesAccessKey=\"True\"", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -24,6 +24,7 @@
                 <ResourceDictionary Source="Resources/Theme.SpecialSurfaceOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.OverlayDocumentOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.FinalContentInputOverrides.xaml"/>
+                <ResourceDictionary Source="Resources/Theme.RangeScrollChromeOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
                 <ResourceDictionary Source="Resources/Templates.xaml"/>
             </ResourceDictionary.MergedDictionaries>

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-theme-range-scroll-chrome.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-theme-range-scroll-chrome.md
@@ -1,0 +1,13 @@
+# Admin Theme Range and Scroll Chrome - 2026-06-21
+
+## Completed
+
+- Added a late-loaded Admin Settings theme override layer for range and scrolling chrome.
+- Routed scroll viewers, scroll bars, slider/progress surfaces, thumb drag handles, repeat buttons, and grid splitters through admin-controlled transparency, colors, border visibility, rounded corners, focus visuals, interaction states, density, and shadow depth.
+- Preserved repeat-button content in the final default template so non-scroll repeat buttons keep their labels while still honoring the app theme.
+- Added source-contract tests for resource load order, range/scroll primitive coverage, and required admin theme token usage.
+
+## Validation Notes
+
+- Changes were made through the GitHub connector because the scheduled Linux container still cannot clone the repository through the network tunnel.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run because this container lacks the .NET SDK and Windows WPF runtime.

--- a/InventoryManagementApp/Resources/Theme.RangeScrollChromeOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.RangeScrollChromeOverrides.xaml
@@ -1,0 +1,223 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework">
+    <!--
+        Final range and scroll chrome for Admin Settings theme customization.
+        Scroll bars, sliders, progress indicators, drag handles, and splitters are small but visible
+        on nearly every dense page. Keep them aligned with admin-selected transparency, borderless
+        mode, rounded corners, interaction colors, focus visibility, density, and shadow depth.
+    -->
+
+    <Style x:Key="ThemeRangeTrackBorder" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource ProgressBarBackgroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemeInputCornerRadius}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style x:Key="ThemeRangeFillBorder" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
+        <Setter Property="CornerRadius" Value="{DynamicResource ThemeInputCornerRadius}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style x:Key="ThemeScrollLineButtonStyle" TargetType="primitives:RepeatButton">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="MinWidth" Value="12"/>
+        <Setter Property="MinHeight" Value="12"/>
+        <Setter Property="Focusable" Value="False"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="primitives:RepeatButton">
+                    <Border x:Name="Chrome"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{DynamicResource ThemeInputCornerRadius}"
+                            SnapsToDevicePixels="True">
+                        <Path Width="6"
+                              Height="6"
+                              Stretch="Uniform"
+                              Fill="{TemplateBinding Foreground}"
+                              Data="M 0 0 L 6 3 L 0 6 Z"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Chrome" Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource ItemHoverForegroundBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Chrome" Property="Background" Value="{DynamicResource NavButtonPressedBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="Chrome" Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ThemeScrollPageButtonStyle" TargetType="primitives:RepeatButton">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
+        <Setter Property="Focusable" Value="False"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="primitives:RepeatButton">
+                    <Border x:Name="Chrome"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{DynamicResource ThemeInputCornerRadius}"
+                            SnapsToDevicePixels="True"/>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Chrome" Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ThemeRangeThumbStyle" TargetType="primitives:Thumb">
+        <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="MinWidth" Value="12"/>
+        <Setter Property="MinHeight" Value="12"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="primitives:Thumb">
+                    <Border x:Name="Chrome"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{DynamicResource ThemeInputCornerRadius}"
+                            Effect="{TemplateBinding Effect}"
+                            SnapsToDevicePixels="True"/>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Chrome" Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsDragging" Value="True">
+                            <Setter TargetName="Chrome" Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="Chrome" Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="ScrollViewer">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="CanContentScroll" Value="True"/>
+        <Setter Property="PanningMode" Value="Both"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="ScrollBar">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="MinWidth" Value="12"/>
+        <Setter Property="MinHeight" Value="12"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Style.Triggers>
+            <Trigger Property="Orientation" Value="Horizontal">
+                <Setter Property="Height" Value="12"/>
+            </Trigger>
+            <Trigger Property="Orientation" Value="Vertical">
+                <Setter Property="Width" Value="12"/>
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="Slider">
+        <Setter Property="Background" Value="{DynamicResource ProgressBarBackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Setter Property="IsMoveToPointEnabled" Value="True"/>
+        <Setter Property="AutoToolTipPlacement" Value="TopLeft"/>
+        <Setter Property="AutoToolTipPrecision" Value="2"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="ProgressBar">
+        <Setter Property="Background" Value="{DynamicResource ProgressBarBackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Height" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="MinHeight" Value="4"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+    </Style>
+
+    <Style TargetType="GridSplitter">
+        <Setter Property="Background" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
+        <Setter Property="MinWidth" Value="4"/>
+        <Setter Property="MinHeight" Value="4"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
+            </Trigger>
+            <Trigger Property="IsKeyboardFocusWithin" Value="True">
+                <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="primitives:Thumb" BasedOn="{StaticResource ThemeRangeThumbStyle}"/>
+
+    <Style TargetType="primitives:RepeatButton" BasedOn="{StaticResource ThemeScrollLineButtonStyle}"/>
+</ResourceDictionary>

--- a/InventoryManagementApp/Resources/Theme.RangeScrollChromeOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.RangeScrollChromeOverrides.xaml
@@ -219,5 +219,44 @@
 
     <Style TargetType="primitives:Thumb" BasedOn="{StaticResource ThemeRangeThumbStyle}"/>
 
-    <Style TargetType="primitives:RepeatButton" BasedOn="{StaticResource ThemeScrollLineButtonStyle}"/>
+    <Style TargetType="primitives:RepeatButton">
+        <Setter Property="Background" Value="{DynamicResource BtnBg}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BtnBorder}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeControlBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource BtnFg}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Padding" Value="{DynamicResource ControlPadding}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeControlShadow}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="primitives:RepeatButton">
+                    <Border x:Name="Chrome"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{DynamicResource ThemeButtonCornerRadius}"
+                            Effect="{TemplateBinding Effect}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter Margin="{TemplateBinding Padding}"
+                                          HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          RecognizesAccessKey="True"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Chrome" Property="Background" Value="{DynamicResource BtnBgHover}"/>
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Chrome" Property="Background" Value="{DynamicResource NavButtonPressedBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="Chrome" Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>


### PR DESCRIPTION
## Summary
- Add a late-loaded Admin Settings theme override layer for range and scrolling chrome.
- Route ScrollViewer, ScrollBar, Slider, ProgressBar, Thumb, RepeatButton, and GridSplitter surfaces through admin-controlled transparency, colors, borderless mode, corner radius, focus styling, interaction states, density, and shadow depth.
- Preserve repeat-button content in the final default template so non-scroll repeat buttons keep their labels while honoring admin-selected button styling.
- Add source-contract tests for resource load order, range/scroll primitive coverage, and required admin theme token usage.

## Validation
- Verified the branch through the GitHub connector: 5 commits ahead of `master`, 0 behind, with only the intended theme resource, App.xaml load order, tests, and progress note changed.
- Read back the updated App.xaml, new range/scroll override dictionary, and new tests through the GitHub connector.
- GitHub reported no attached status checks or workflow runs for the head commit.
- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel.