### PR TITLE
[codex] Add saved theme reload action

### DIFF
--- a/InventoryManagementApp.Tests/Views/ThemeDesignerReadinessPanelTests.cs
+++ b/InventoryManagementApp.Tests/Views/ThemeDesignerReadinessPanelTests.cs
@@ -45,6 +45,19 @@ namespace InventoryManagementApp.Tests.Views
             Assert.Contains("shadow depth", source, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void ThemeDesignerReadinessPanel_ExposesSavedThemeRecoveryAction()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ThemeDesignerControl.xaml.cs");
+
+            Assert.Contains("ReloadSavedTheme_Click", source, StringComparison.Ordinal);
+            Assert.Contains("Reload Saved Theme", source, StringComparison.Ordinal);
+            Assert.Contains("Discard the current preview and restore the last saved app theme.", source, StringComparison.Ordinal);
+            Assert.Contains("experimental preview makes the workspace hard to read", source, StringComparison.Ordinal);
+            Assert.Contains("await viewModel.InitializeAsync();", source, StringComparison.Ordinal);
+            Assert.Contains("EnsureThemeDesignerViewModelAsync", source, StringComparison.Ordinal);
+        }
+
         private static string ReadRepositoryFile(params string[] relativePathParts)
         {
             var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-theme-designer-saved-reload.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-theme-designer-saved-reload.md
@@ -1,0 +1,18 @@
+# Theme Designer Saved Reload
+
+Completed: 2026-06-21
+
+## What changed
+
+- Added a visible **Reload Saved Theme** action to the Admin Settings theme designer readiness panel.
+- The action discards the current live preview and reloads the persisted app theme through the existing `ThemeDesignerViewModel.InitializeAsync()` path.
+- Expanded the readiness copy so admins know how to recover if experimental transparency, borderless, or shadow-heavy previews make the workspace difficult to read.
+
+## Why it matters
+
+The theme designer intentionally lets admins make aggressive full-app visual changes. A one-click saved-theme reload makes experimentation safer because admins can recover the last saved design without needing to close the app, reset defaults, or manually reverse individual sliders.
+
+## Validation
+
+- Added source-contract coverage in `ThemeDesignerReadinessPanelTests` for the saved-theme recovery button, explanatory copy, and reload path.
+- Local `dotnet test`, WPF screenshots, and local banned-word checks remain unavailable in the scheduled Linux container because the .NET SDK/Windows WPF runtime and local clone/raw access are blocked.

--- a/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ThemeDesignerControl.xaml.cs
@@ -2,6 +2,7 @@ using InventoryManagementApp.Interfaces;
 using InventoryManagementApp.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -21,6 +22,11 @@ namespace InventoryManagementApp.Views.Pages
 
         private async void ThemeDesignerControl_Loaded(object sender, System.Windows.RoutedEventArgs e)
         {
+            await EnsureThemeDesignerViewModelAsync();
+        }
+
+        private async Task EnsureThemeDesignerViewModelAsync()
+        {
             if (_initialized || DataContext is ThemeDesignerViewModel)
                 return;
 
@@ -38,6 +44,19 @@ namespace InventoryManagementApp.Views.Pages
             DataContext = viewModel;
             await viewModel.InitializeAsync();
             _initialized = true;
+        }
+
+        private async void ReloadSavedTheme_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ThemeDesignerViewModel viewModel)
+            {
+                await viewModel.InitializeAsync();
+                _initialized = true;
+                return;
+            }
+
+            _initialized = false;
+            await EnsureThemeDesignerViewModelAsync();
         }
 
         private void AddDesignReadinessPanel()
@@ -64,12 +83,30 @@ namespace InventoryManagementApp.Views.Pages
 
             var checklist = new TextBlock
             {
-                Text = "Before saving a full-app redesign, review text contrast, transparent surface readability, focus-ring visibility, disabled-control clarity, table density, borderless affordances, and shadow depth in the preview lab.",
+                Text = "Before saving a full-app redesign, review text contrast, transparent surface readability, focus-ring visibility, disabled-control clarity, table density, borderless affordances, and shadow depth in the preview lab. Reload the saved theme if an experimental preview makes the workspace hard to read.",
                 TextWrapping = TextWrapping.Wrap,
                 Margin = new Thickness(0, 0, 0, 8)
             };
             checklist.SetResourceReference(StyleProperty, "CaptionTextBlock");
             stack.Children.Add(checklist);
+
+            var actionRow = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+
+            var reloadButton = new Button
+            {
+                Content = "Reload Saved Theme",
+                ToolTip = "Discard the current preview and restore the last saved app theme.",
+                Margin = new Thickness(0, 0, 8, 0)
+            };
+            reloadButton.SetResourceReference(StyleProperty, "GhostButton");
+            reloadButton.Click += ReloadSavedTheme_Click;
+            actionRow.Children.Add(reloadButton);
+
+            stack.Children.Add(actionRow);
 
             var status = new TextBlock
             {


### PR DESCRIPTION
## Summary

- Adds a visible **Reload Saved Theme** action to the Admin Settings theme designer readiness panel.
- Reloads the persisted theme through the existing `ThemeDesignerViewModel.InitializeAsync()` flow so admins can recover from hard-to-read live previews without manually reversing every setting.
- Expands source-contract coverage for the readiness panel recovery action and adds a progress note.

## Validation

- GitHub connector compare shows a focused three-file diff against `master`.
- No GitHub status checks or workflow runs are attached to the branch commit.
- Local `dotnet test`, WPF screenshots, and local banned-word checks could not be run in this scheduled Linux container because the .NET SDK/Windows WPF runtime and local clone/raw access are blocked.