### PR TITLE
[codex] extend admin themes to popup chrome

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemePopupChromeOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemePopupChromeOverrideTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Resources
+{
+    public class ThemePopupChromeOverrideTests
+    {
+        [Fact]
+        public void App_LoadsPopupChromeOverridesAfterRangeScrollLayer()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "App.xaml");
+
+            var rangeScrollIndex = xaml.IndexOf("Resources/Theme.RangeScrollChromeOverrides.xaml", StringComparison.Ordinal);
+            var popupIndex = xaml.IndexOf("Resources/Theme.PopupChromeOverrides.xaml", StringComparison.Ordinal);
+            var convertersIndex = xaml.IndexOf("Resources/Converters.xaml", StringComparison.Ordinal);
+
+            Assert.True(rangeScrollIndex >= 0, "Range and scroll chrome overrides should remain loaded.");
+            Assert.True(popupIndex > rangeScrollIndex, "Popup chrome overrides should load after the range/scroll layer.");
+            Assert.True(convertersIndex > popupIndex, "Converters should remain after the final visual override layer.");
+        }
+
+        [Fact]
+        public void PopupChromeOverrides_ExtendAdminThemesToPopupAndMenuSurfaces()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.PopupChromeOverrides.xaml");
+
+            Assert.Contains("TargetType=\"ContextMenu\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Menu\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"MenuItem\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"ToolTip\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"StatusBar\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"StatusBarItem\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Separator\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemePopupMenuItemStyle", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemePopupSeparatorStyle", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void PopupChromeOverrides_UseAdminThemeTokensForTransparencyDepthAndInteraction()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.PopupChromeOverrides.xaml");
+
+            Assert.Contains("{DynamicResource ThemePopupSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeShellMenuBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeShellFooterBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource TransparentSurfaceBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeTransparentBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource BorderBrushAlt}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBorderlessThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeSubtleBorderThickness}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeFontFamily}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBodyFontSize}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeCaptionFontSize}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeControlMinHeight}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeSurfaceShadow}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ItemHoverBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ItemSelectedBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeDisabledOpacity}", xaml, StringComparison.Ordinal);
+            Assert.Contains("FocusVisualStyle\" Value=\"{StaticResource DefaultFocusVisual}\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("HasDropShadow\" Value=\"False\"", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -25,6 +25,7 @@
                 <ResourceDictionary Source="Resources/Theme.OverlayDocumentOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.FinalContentInputOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.RangeScrollChromeOverrides.xaml"/>
+                <ResourceDictionary Source="Resources/Theme.PopupChromeOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
                 <ResourceDictionary Source="Resources/Templates.xaml"/>
             </ResourceDictionary.MergedDictionaries>

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-theme-popup-chrome.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-theme-popup-chrome.md
@@ -1,0 +1,13 @@
+# Theme Popup Chrome Pass - 2026-06-21
+
+## Completed
+
+- Added a late-loaded Admin Settings theme override layer for popup-adjacent chrome.
+- Extended admin-selected colors, transparency, border removal, font scale, disabled opacity, hover/selected feedback, and shadow depth to context menus, menu items, top-level menus, tooltips, status bars, status bar items, and separators.
+- Kept native drop shadows disabled for context menus and tooltips so admin-controlled shadow resources define popup depth consistently.
+- Added source-contract tests for the new resource dictionary, load order, covered WPF control surfaces, and required admin theme token usage.
+
+## Validation Notes
+
+- Changes were made through the GitHub connector because local clone/raw access is blocked by the network tunnel.
+- Local `dotnet test`, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows WPF runtime.

--- a/InventoryManagementApp/Resources/Theme.PopupChromeOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.PopupChromeOverrides.xaml
@@ -1,0 +1,107 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!--
+        Late popup chrome pass for Admin Settings theme customization.
+        Context menus, menus, tooltips, status bars, and separators can otherwise keep opaque default
+        styling even when the rest of the app is transparent, borderless, rounded, or deeply shadowed.
+    -->
+
+    <Style x:Key="ThemePopupSeparatorStyle" TargetType="Separator">
+        <Setter Property="Margin" Value="4,4"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Separator">
+                    <Border Height="1"
+                            Background="{DynamicResource BorderBrushAlt}"
+                            Opacity="{DynamicResource ThemeDividerOpacity}"
+                            SnapsToDevicePixels="True"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ThemePopupMenuItemStyle" TargetType="MenuItem">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeTransparentBrush}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderlessThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Padding" Value="10,5"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+        <Style.Triggers>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemHoverBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemHoverForegroundBrush}"/>
+            </Trigger>
+            <Trigger Property="IsSubmenuOpen" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ItemSelectedBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ItemSelectedForegroundBrush}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="ContextMenu">
+        <Setter Property="Background" Value="{DynamicResource ThemePopupSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="HasDropShadow" Value="False"/>
+        <Setter Property="ItemContainerStyle" Value="{StaticResource ThemePopupMenuItemStyle}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+    </Style>
+
+    <Style TargetType="Menu">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="ItemContainerStyle" Value="{StaticResource ThemePopupMenuItemStyle}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="MenuItem" BasedOn="{StaticResource ThemePopupMenuItemStyle}"/>
+
+    <Style TargetType="ToolTip">
+        <Setter Property="Background" Value="{DynamicResource ThemePopupSurfaceBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeCaptionFontSize}"/>
+        <Setter Property="Padding" Value="8,5"/>
+        <Setter Property="HasDropShadow" Value="False"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+    </Style>
+
+    <Style TargetType="StatusBar">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellFooterBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushAlt}"/>
+        <Setter Property="BorderThickness" Value="{DynamicResource ThemeSubtleBorderThickness}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeCaptionFontSize}"/>
+        <Setter Property="MinHeight" Value="{DynamicResource ThemeControlMinHeight}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+    </Style>
+
+    <Style TargetType="StatusBarItem">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeCaptionFontSize}"/>
+        <Setter Property="Padding" Value="8,2"/>
+    </Style>
+
+    <Style TargetType="Separator" BasedOn="{StaticResource ThemePopupSeparatorStyle}"/>
+</ResourceDictionary>


### PR DESCRIPTION
## Summary
- Adds a late-loaded Admin Settings theme override dictionary for popup-adjacent chrome.
- Extends admin-controlled colors, transparency, border removal, typography, hover/selected feedback, disabled opacity, and shadow depth to context menus, menu items, top-level menus, tooltips, status bars, status bar items, and separators.
- Adds source-contract tests for the new resource load order, WPF surfaces covered, and required admin theme tokens.
- Documents the popup chrome theming pass in progress notes.

## Validation
- GitHub connector compare shows a focused 4-file diff against `master`, 4 commits ahead and 0 behind.
- Read back the new popup resource dictionary and tests through the GitHub connector.
- GitHub reports no attached status checks for the head commit.
- Local `dotnet test`, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and local clone/raw access is blocked by the network tunnel.