### PR TITLE
[codex] extend admin themes to text hierarchy

### DIFF
--- a/InventoryManagementApp.Tests/Resources/ThemeTextHierarchyOverrideTests.cs
+++ b/InventoryManagementApp.Tests/Resources/ThemeTextHierarchyOverrideTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Resources
+{
+    public class ThemeTextHierarchyOverrideTests
+    {
+        [Fact]
+        public void App_LoadsTextHierarchyOverridesAfterPopupChromeLayer()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "App.xaml");
+
+            var popupIndex = xaml.IndexOf("Resources/Theme.PopupChromeOverrides.xaml", StringComparison.Ordinal);
+            var textIndex = xaml.IndexOf("Resources/Theme.TextHierarchyOverrides.xaml", StringComparison.Ordinal);
+            var convertersIndex = xaml.IndexOf("Resources/Converters.xaml", StringComparison.Ordinal);
+
+            Assert.True(popupIndex >= 0, "Popup chrome overrides should remain loaded.");
+            Assert.True(textIndex > popupIndex, "Text hierarchy overrides should load after popup/status chrome.");
+            Assert.True(convertersIndex > textIndex, "Converters should remain after the final visual override layer.");
+        }
+
+        [Fact]
+        public void TextHierarchyOverrides_ReclaimSharedTextBlockRolesForAdminThemes()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.TextHierarchyOverrides.xaml");
+
+            Assert.Contains("TargetType=\"TextBlock\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"ErrorTextBlock\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"SectionHeader\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"HeadingTextBlock\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"SubheadingTextBlock\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"DialogMessageTextBlock\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"PageTitleTextBlock\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"CaptionTextBlock\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"LabelTextBlock\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"ListItemTitleTextBlock\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("x:Key=\"StatisticValueTextBlock\"", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void TextHierarchyOverrides_UseAdminThemeTokensForFontScaleColorAndRendering()
+        {
+            var xaml = ReadRepositoryFile("InventoryManagementApp", "Resources", "Theme.TextHierarchyOverrides.xaml");
+
+            Assert.Contains("{DynamicResource ThemeFontFamily}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeBodyFontSize}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeSectionFontSize}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeTitleFontSize}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ThemeCaptionFontSize}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ForegroundBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ForegroundMutedBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource AccentBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("{DynamicResource ErrorBrush}", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextOptions.TextFormattingMode", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextOptions.TextRenderingMode", xaml, StringComparison.Ordinal);
+            Assert.Contains("TextOptions.TextHintingMode", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -26,6 +26,7 @@
                 <ResourceDictionary Source="Resources/Theme.FinalContentInputOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.RangeScrollChromeOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.PopupChromeOverrides.xaml"/>
+                <ResourceDictionary Source="Resources/Theme.TextHierarchyOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
                 <ResourceDictionary Source="Resources/Templates.xaml"/>
             </ResourceDictionary.MergedDictionaries>

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-theme-text-hierarchy.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-theme-text-hierarchy.md
@@ -1,0 +1,13 @@
+# Admin Theme Text Hierarchy Pass - 2026-06-21
+
+## Completed
+
+- Added a late-loaded Admin Settings theme override layer for shared TextBlock hierarchy roles.
+- Routed headings, page titles, section headers, dialog body text, captions, labels, list-item titles, statistic values, and error text through admin-selected font family, body size, heading size, caption size, foreground, muted, accent, and semantic error resources.
+- Kept text wrapping, trimming, and rendering settings consistent so full-app redesigns preserve readability across dense desktop pages and transparent/background-image themes.
+- Added source-contract tests for load order, covered text roles, and required admin theme typography/color tokens.
+
+## Validation Notes
+
+- Changes were made through the GitHub connector because local clone/raw access is blocked by the network tunnel.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows WPF runtime.

--- a/InventoryManagementApp/Resources/Theme.TextHierarchyOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.TextHierarchyOverrides.xaml
@@ -1,0 +1,79 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!--
+        Final text hierarchy pass for Admin Settings theme customization.
+        The base style sheet defines many keyed TextBlock roles with fixed font sizes. This layer
+        gives the admin-selected font family, body scale, heading scale, captions, semantic colors,
+        and rendering choices final control over the app's visible text hierarchy.
+    -->
+
+    <Style TargetType="TextBlock">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="TextOptions.TextFormattingMode" Value="Display"/>
+        <Setter Property="TextOptions.TextRenderingMode" Value="ClearType"/>
+        <Setter Property="TextOptions.TextHintingMode" Value="Fixed"/>
+    </Style>
+
+    <Style x:Key="ErrorTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+    </Style>
+
+    <Style x:Key="SectionHeader" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeSectionFontSize}"/>
+        <Setter Property="Margin" Value="0,0,0,4"/>
+    </Style>
+
+    <Style x:Key="HeadingTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="{DynamicResource ThemeTitleFontSize}"/>
+        <Setter Property="FontWeight" Value="Bold"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+    </Style>
+
+    <Style x:Key="SubheadingTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="{DynamicResource ThemeSectionFontSize}"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+    </Style>
+
+    <Style x:Key="DialogMessageTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="LineHeight" Value="20"/>
+    </Style>
+
+    <Style x:Key="PageTitleTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="{DynamicResource ThemeTitleFontSize}"/>
+        <Setter Property="FontWeight" Value="Bold"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+    </Style>
+
+    <Style x:Key="CaptionTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="{DynamicResource ThemeCaptionFontSize}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundMutedBrush}"/>
+    </Style>
+
+    <Style x:Key="LabelTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="{DynamicResource ThemeCaptionFontSize}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundMutedBrush}"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+    </Style>
+
+    <Style x:Key="ListItemTitleTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="{DynamicResource ThemeSectionFontSize}"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+    </Style>
+
+    <Style x:Key="StatisticValueTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+        <Setter Property="FontSize" Value="{DynamicResource ThemeTitleFontSize}"/>
+        <Setter Property="FontWeight" Value="Bold"/>
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+    </Style>
+</ResourceDictionary>

--- a/InventoryManagementApp/Resources/Theme.TextHierarchyOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.TextHierarchyOverrides.xaml
@@ -44,7 +44,6 @@
     <Style x:Key="DialogMessageTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
         <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
         <Setter Property="TextWrapping" Value="Wrap"/>
-        <Setter Property="LineHeight" Value="20"/>
     </Style>
 
     <Style x:Key="PageTitleTextBlock" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">


### PR DESCRIPTION
## Summary
- Add a late-loaded Admin Settings theme override layer for shared TextBlock hierarchy roles.
- Route headings, page titles, section headers, dialog text, captions, labels, list item titles, statistic values, and error text through admin-controlled font family, body/title/section/caption sizes, foreground, muted, accent, and semantic error resources.
- Load the layer after popup/status chrome so saved admin typography settings get final control over visible text hierarchy.
- Add source-contract tests for load order, covered text roles, and required theme typography/color tokens.

## Validation
- Verified the branch through the GitHub connector: focused 4-file diff, 5 commits ahead of `master`, 0 behind.
- Read back updated `App.xaml`, `Theme.TextHierarchyOverrides.xaml`, and `ThemeTextHierarchyOverrideTests.cs` through the GitHub connector.
- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and local clone/raw access remains blocked by the network tunnel.