### PR TITLE
Extend admin theme coverage to validation and adorner chrome

### DIFF
--- a/InventoryManagementApp.Tests/ThemeAdornerValidationOverrideTests.cs
+++ b/InventoryManagementApp.Tests/ThemeAdornerValidationOverrideTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ThemeAdornerValidationOverrideTests
+    {
+        [Fact]
+        public void AppResourcesLoadAdornerValidationOverridesAfterTextHierarchyOverrides()
+        {
+            var appXaml = ReadRepoFile("InventoryManagementApp", "App.xaml");
+
+            var textHierarchyIndex = appXaml.IndexOf("Theme.TextHierarchyOverrides.xaml", StringComparison.Ordinal);
+            var adornerIndex = appXaml.IndexOf("Theme.AdornerValidationOverrides.xaml", StringComparison.Ordinal);
+            var convertersIndex = appXaml.IndexOf("Resources/Converters.xaml", StringComparison.Ordinal);
+
+            Assert.True(textHierarchyIndex >= 0, "Text hierarchy overrides must stay in the app resource load order.");
+            Assert.True(adornerIndex > textHierarchyIndex, "Adorner and validation overrides should load after text hierarchy overrides.");
+            Assert.True(convertersIndex > adornerIndex, "Adorner and validation overrides should remain with the final theme layers before converters/templates.");
+        }
+
+        [Fact]
+        public void AdornerValidationOverridesThemeValidationFramesThroughAdminTokens()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Resources", "Theme.AdornerValidationOverrides.xaml");
+
+            Assert.Contains("ThemeValidationErrorTemplate", xaml, StringComparison.Ordinal);
+            Assert.Contains("AdornedElementPlaceholder", xaml, StringComparison.Ordinal);
+            Assert.Contains("Validation.ErrorTemplate", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeControlBorderThickness", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeInputCornerRadius", xaml, StringComparison.Ordinal);
+            Assert.Contains("ThemeControlShadow", xaml, StringComparison.Ordinal);
+            Assert.Contains("ErrorBrush", xaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void AdornerValidationOverridesCoverOuterPresenterChrome()
+        {
+            var xaml = ReadRepoFile("InventoryManagementApp", "Resources", "Theme.AdornerValidationOverrides.xaml");
+
+            Assert.Contains("TargetType=\"AdornerDecorator\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"AdornerLayer\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"BulletDecorator\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"Viewbox\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"primitives:ToolBarOverflowPanel\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"primitives:StatusBarPanel\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"primitives:DataGridDetailsPresenter\"", xaml, StringComparison.Ordinal);
+            Assert.Contains("TargetType=\"primitives:DataGridCellsPresenter\"", xaml, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/App.xaml
+++ b/InventoryManagementApp/App.xaml
@@ -27,6 +27,7 @@
                 <ResourceDictionary Source="Resources/Theme.RangeScrollChromeOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.PopupChromeOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Theme.TextHierarchyOverrides.xaml"/>
+                <ResourceDictionary Source="Resources/Theme.AdornerValidationOverrides.xaml"/>
                 <ResourceDictionary Source="Resources/Converters.xaml"/>
                 <ResourceDictionary Source="Resources/Templates.xaml"/>
             </ResourceDictionary.MergedDictionaries>

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-theme-adorner-validation-overrides.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-theme-adorner-validation-overrides.md
@@ -1,0 +1,16 @@
+# Theme Adorner and Validation Override Pass
+
+Date: 2026-06-21 11:11 NZST
+
+## Completed
+
+- Added `Theme.AdornerValidationOverrides.xaml` as a late-loaded admin theme resource layer.
+- Routed validation error frames for text boxes, combo boxes, date pickers, and password boxes through admin theme tokens for error color, control border thickness, input corner radius, focus visuals, transparency, and control shadow depth.
+- Added final styling hooks for outer WPF chrome that can sit around themed controls, including adorner decorators/layers, bullet decorators, viewboxes, toolbar/status panels, and data-grid presenters.
+- Loaded the new dictionary after the existing text hierarchy overrides and before converters/templates so it acts as a final theme coverage pass.
+- Added `ThemeAdornerValidationOverrideTests` to guard load order, validation template coverage, and outer presenter coverage.
+
+## Validation
+
+- GitHub connector readback and diff review were used for this scheduled Linux pass.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks remain blocked because this container does not have the .NET SDK/Windows WPF runtime and direct local clone/raw access is blocked by the network tunnel.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-18 03:11 NZST
+Last audit date/time: 2026-06-21 11:11 NZST
 
 ## Completed workflows
 
@@ -42,6 +42,7 @@ Last audit date/time: 2026-06-18 03:11 NZST
 - Auth entry surfaces now have a more deliberate first impression: login uses a two-panel workstation entry with branded context and stronger user cards, while password prompt and change-password dialogs use secure-access framing, clearer field guidance, wider inputs, and stronger action labels.
 - The setup wizard now presents first-run onboarding with a stronger launch header, setup checklist, guided field descriptions, framed logo preview, ready-check validation, and a `Complete Setup` action while preserving the existing setup command flow.
 - Search Tools now gives search results, checked-out items, recent searches, and unavailable demand stronger pane headers, clearer action affordances, a session-pulse summary strip, and roomier intelligence tables while preserving the existing command and keyboard paths.
+- Admin Settings theme customization now includes a final adorner/validation coverage layer so validation error frames, text/combo/date/password validation states, adorner layers, bullet decorators, viewboxes, toolbar/status panels, and data-grid presenters follow admin-controlled colors, transparency, borders, corners, focus visuals, and shadow depth.
 
 ## Partially complete workflows
 
@@ -62,6 +63,7 @@ Last audit date/time: 2026-06-18 03:11 NZST
 - Auth entry and setup wizard polish are in place for login, password prompt, change-password, and onboarding surfaces, but password-reset prompt and runtime auth/setup screenshot review still need follow-up.
 - Search Tools first-pass polish is in place for results, checked-out items, recent searches, and unavailable-demand intelligence, but runtime screenshot review still needs to confirm the new right-pane width, summary strip, and action wrapping at standard and narrow workstation sizes.
 - Settings Database, Branding, and Backups first-pass polish is in place, but runtime settings screenshot review still needs to confirm the new connection, logo preview, and recovery panels at standard and narrow admin workstation sizes.
+- Admin Settings theme customization now has broad resource, preset, profile, common-control, document, popup, text, layout, validation, and outer-chrome coverage, but runtime Windows screenshot review still needs to confirm extreme transparent, borderless, high-shadow, dense, and low-motion designs across the full app.
 
 ## Known broken workflows
 
@@ -71,10 +73,10 @@ Last audit date/time: 2026-06-18 03:11 NZST
 
 ## Next recommended target
 
-- Continue targeted UI polish on password-reset prompt and print-preview document styling. Run the enhanced Windows QA screenshot capture when a Windows/.NET workstation is available.
+- Continue targeted Admin Settings theme coverage and runtime Windows screenshot review, especially extreme transparent, borderless, and high-shadow profiles. Run the enhanced Windows QA screenshot capture when a Windows/.NET workstation is available.
 
 ## Validation status
 
-- GitHub connector readback reviewed the Settings XAML, ToDo progress log, and this checklist update.
+- GitHub connector readback reviewed the theme override XAML, App resource load order, contract tests, progress note, and this checklist update.
 - Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
 - Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/Resources/Theme.AdornerValidationOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.AdornerValidationOverrides.xaml
@@ -124,12 +124,8 @@
     </Style>
 
     <Style TargetType="primitives:DataGridDetailsPresenter">
-        <Setter Property="Background" Value="{DynamicResource GlassSurfaceAltBrush}"/>
-        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
-        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
-        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
-        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
     </Style>
 
     <Style TargetType="primitives:DataGridCellsPresenter">

--- a/InventoryManagementApp/Resources/Theme.AdornerValidationOverrides.xaml
+++ b/InventoryManagementApp/Resources/Theme.AdornerValidationOverrides.xaml
@@ -1,0 +1,139 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework">
+    <!--
+        Final adorner and validation chrome pass for Admin Settings theme customization.
+        Validation frames, drag/drop adorners, bullets, resize handles, and presenter surfaces sit
+        around controls rather than inside them, so this layer keeps those outer surfaces aligned
+        with admin-selected transparency, borders, focus, typography, and shadow depth.
+    -->
+
+    <ControlTemplate x:Key="ThemeValidationErrorTemplate">
+        <DockPanel LastChildFill="True" SnapsToDevicePixels="True">
+            <Border DockPanel.Dock="Right"
+                    MinWidth="18"
+                    MinHeight="18"
+                    Margin="4,0,0,0"
+                    Padding="4,1"
+                    Background="{DynamicResource ThemePopupSurfaceBrush}"
+                    BorderBrush="{DynamicResource ErrorBrush}"
+                    BorderThickness="{DynamicResource ThemeControlBorderThickness}"
+                    CornerRadius="{DynamicResource ThemeInputCornerRadius}"
+                    Effect="{DynamicResource ThemeControlShadow}">
+                <TextBlock Text="!"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           FontWeight="Bold"
+                           Foreground="{DynamicResource ErrorBrush}"
+                           FontFamily="{DynamicResource ThemeFontFamily}"
+                           FontSize="{DynamicResource ThemeCaptionFontSize}"/>
+            </Border>
+            <Border BorderBrush="{DynamicResource ErrorBrush}"
+                    BorderThickness="{DynamicResource ThemeControlBorderThickness}"
+                    CornerRadius="{DynamicResource ThemeInputCornerRadius}"
+                    Effect="{DynamicResource ThemeControlShadow}">
+                <AdornedElementPlaceholder/>
+            </Border>
+        </DockPanel>
+    </ControlTemplate>
+
+    <Style x:Key="ThemeValidationTextBoxStyle" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+        <Setter Property="Validation.ErrorTemplate" Value="{StaticResource ThemeValidationErrorTemplate}"/>
+        <Setter Property="ToolTipService.ShowDuration" Value="12000"/>
+        <Style.Triggers>
+            <Trigger Property="Validation.HasError" Value="True">
+                <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}"/>
+                <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="ThemeValidationComboBoxStyle" TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
+        <Setter Property="Validation.ErrorTemplate" Value="{StaticResource ThemeValidationErrorTemplate}"/>
+        <Setter Property="ToolTipService.ShowDuration" Value="12000"/>
+        <Style.Triggers>
+            <Trigger Property="Validation.HasError" Value="True">
+                <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}"/>
+                <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="ThemeValidationDatePickerStyle" TargetType="DatePicker" BasedOn="{StaticResource {x:Type DatePicker}}">
+        <Setter Property="Validation.ErrorTemplate" Value="{StaticResource ThemeValidationErrorTemplate}"/>
+        <Setter Property="ToolTipService.ShowDuration" Value="12000"/>
+        <Style.Triggers>
+            <Trigger Property="Validation.HasError" Value="True">
+                <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}"/>
+                <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="ThemeValidationPasswordBoxStyle" TargetType="PasswordBox" BasedOn="{StaticResource {x:Type PasswordBox}}">
+        <Setter Property="Validation.ErrorTemplate" Value="{StaticResource ThemeValidationErrorTemplate}"/>
+        <Setter Property="ToolTipService.ShowDuration" Value="12000"/>
+        <Style.Triggers>
+            <Trigger Property="Validation.HasError" Value="True">
+                <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}"/>
+                <Setter Property="FocusVisualStyle" Value="{StaticResource DefaultFocusVisual}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="TextBox" BasedOn="{StaticResource ThemeValidationTextBoxStyle}"/>
+    <Style TargetType="ComboBox" BasedOn="{StaticResource ThemeValidationComboBoxStyle}"/>
+    <Style TargetType="DatePicker" BasedOn="{StaticResource ThemeValidationDatePickerStyle}"/>
+    <Style TargetType="PasswordBox" BasedOn="{StaticResource ThemeValidationPasswordBoxStyle}"/>
+
+    <Style TargetType="AdornerDecorator">
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="AdornerLayer">
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="BulletDecorator">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="Viewbox">
+        <Setter Property="Stretch" Value="Uniform"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+
+    <Style TargetType="primitives:ToolBarOverflowPanel">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellMenuBrush}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="primitives:ToolBarPanel">
+        <Setter Property="Background" Value="{DynamicResource TransparentSurfaceBrush}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="primitives:StatusBarPanel">
+        <Setter Property="Background" Value="{DynamicResource ThemeShellFooterBrush}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="primitives:DataGridDetailsPresenter">
+        <Setter Property="Background" Value="{DynamicResource GlassSurfaceAltBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource ThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{DynamicResource ThemeBodyFontSize}"/>
+        <Setter Property="Effect" Value="{DynamicResource ThemeSurfaceShadow}"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="primitives:DataGridCellsPresenter">
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="UseLayoutRounding" Value="True"/>
+    </Style>
+</ResourceDictionary>


### PR DESCRIPTION
## Summary
- add a final `Theme.AdornerValidationOverrides.xaml` layer for validation error chrome and outer WPF presenter surfaces
- route text/combo/date/password validation states through admin theme tokens for error color, borders, corners, focus, transparency, and shadows
- wire the resource into `App.xaml` after the other final theme overrides and add contract tests for load order and coverage
- record the progress in the completion checklist and a dedicated progress note

## Validation
- GitHub connector readback and compare review completed
- Not run: `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct local clone/raw access is blocked by the network tunnel