### PR TITLE
Route admin data print outputs through preview

### DIFF
--- a/InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs
+++ b/InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class AdminDataPrintPreviewRouteTests
+    {
+        [Theory]
+        [InlineData("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml.cs")]
+        [InlineData("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs")]
+        [InlineData("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml.cs")]
+        public void AdminDataPrintActionsUseSharedPreviewWindow(params string[] path)
+        {
+            var source = ReadRepoFile(path);
+
+            Assert.Contains("PrintPreviewWindow", source, StringComparison.Ordinal);
+            Assert.Contains("ShowPreview(document", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("WpfPrintDialog", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("new PrintDialog", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CategoriesKeepBothDirectoryAndSelectedSheetPreviewRoutes()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs");
+
+            Assert.Contains("ShowPrintPreview(document, \"Category Directory\")", source, StringComparison.Ordinal);
+            Assert.Contains("ShowPrintPreview(document, $\"Category Sheet - {category.Name}\")", source, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-admin-data-print-preview-routing.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-admin-data-print-preview-routing.md
@@ -1,0 +1,17 @@
+# Admin/Data Print Preview Routing - 2026-06-21
+
+## Completed
+
+- Routed the Users directory print action through `PrintPreviewWindow` so administrators can review, page-setup, and print from the branded preview workstation.
+- Routed Category Directory and selected Category Sheet printing through the same preview surface.
+- Routed Import / Export run-log printing through the shared preview instead of opening the system print dialog immediately.
+- Added `AdminDataPrintPreviewRouteTests` to guard the source contract for these routes and prevent direct `PrintDialog` printing from returning to the admin/data pages.
+
+## Why it matters
+
+These admin/data outputs were still bypassing the shared print preview polish added earlier. Moving them through the preview surface gives staff one consistent review step for directories, setup sheets, and operational logs before anything reaches a printer.
+
+## Validation
+
+- GitHub connector compare/readback confirmed the focused branch diff and updated route/test files.
+- Not run locally: `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct local clone/raw access is blocked by the network tunnel.

--- a/InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs
@@ -11,7 +11,6 @@ using InventoryManagementApp.ViewModels;
 using InventoryManagementApp.Views.Windows;
 using Microsoft.Extensions.DependencyInjection;
 using WpfMessageBox = System.Windows.MessageBox;
-using WpfPrintDialog = System.Windows.Controls.PrintDialog;
 
 namespace InventoryManagementApp.Views.Pages
 {
@@ -138,7 +137,7 @@ namespace InventoryManagementApp.Views.Pages
             }
 
             var document = BuildDirectoryPrintDocument(vm.FilteredCategories.ToList(), vm.CategoryResultsSummary, vm.CategorySetupSummary);
-            PrintDocument(document, "Category Directory");
+            ShowPrintPreview(document, "Category Directory");
         }
 
         private void PrintSelectedCategory_Click(object sender, RoutedEventArgs e)
@@ -147,7 +146,7 @@ namespace InventoryManagementApp.Views.Pages
                 return;
 
             var document = BuildSelectedCategoryPrintDocument(category);
-            PrintDocument(document, $"Category Sheet - {category.Name}");
+            ShowPrintPreview(document, $"Category Sheet - {category.Name}");
         }
 
         private bool TryGetSelectedCategory(out CategoryManagementViewModel.CategoryItem category)
@@ -163,17 +162,9 @@ namespace InventoryManagementApp.Views.Pages
             return false;
         }
 
-        private static void PrintDocument(FlowDocument document, string title)
+        private static void ShowPrintPreview(FlowDocument document, string title)
         {
-            var printDialog = new WpfPrintDialog();
-            if (printDialog.ShowDialog() != true)
-                return;
-
-            document.PageWidth = printDialog.PrintableAreaWidth;
-            document.PageHeight = printDialog.PrintableAreaHeight;
-            document.PagePadding = new Thickness(36);
-            document.ColumnWidth = printDialog.PrintableAreaWidth;
-            printDialog.PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator, title);
+            new PrintPreviewWindow().ShowPreview(document, title, null);
         }
 
         private static string FormatCategoryDetail(CategoryManagementViewModel.CategoryItem category)

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
@@ -8,7 +8,6 @@ using System.Windows.Input;
 using InventoryManagementApp.ViewModels;
 using InventoryManagementApp.Views.Windows;
 using WpfMessageBox = System.Windows.MessageBox;
-using WpfPrintDialog = System.Windows.Controls.PrintDialog;
 
 namespace InventoryManagementApp.Views.Pages
 {
@@ -70,16 +69,8 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            var printDialog = new WpfPrintDialog();
-            if (printDialog.ShowDialog() != true)
-                return;
-
             var document = BuildPrintDocument(vm.ImportExportLogs.ToList(), vm.LogSummary);
-            document.PageWidth = printDialog.PrintableAreaWidth;
-            document.PageHeight = printDialog.PrintableAreaHeight;
-            document.PagePadding = new Thickness(36);
-            document.ColumnWidth = printDialog.PrintableAreaWidth;
-            printDialog.PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator, "Import / Export Log");
+            new PrintPreviewWindow().ShowPreview(document, "Import / Export Log", null);
         }
 
         private static FlowDocument BuildPrintDocument(IReadOnlyCollection<string> logs, string summary)

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml.cs
@@ -9,7 +9,6 @@ using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
 using InventoryManagementApp.Views.Windows;
 using WpfMessageBox = System.Windows.MessageBox;
-using WpfPrintDialog = System.Windows.Controls.PrintDialog;
 
 namespace InventoryManagementApp.Views.Pages
 {
@@ -90,16 +89,8 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            var printDialog = new WpfPrintDialog();
-            if (printDialog.ShowDialog() != true)
-                return;
-
             var document = BuildPrintDocument(ViewModel.Users.ToList(), $"Visible users: {ViewModel.Users.Count}");
-            document.PageWidth = printDialog.PrintableAreaWidth;
-            document.PageHeight = printDialog.PrintableAreaHeight;
-            document.PagePadding = new Thickness(36);
-            document.ColumnWidth = printDialog.PrintableAreaWidth;
-            printDialog.PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator, "User Directory");
+            ShowPrintPreview(document, "User Directory");
         }
 
         private static string FormatUserDetail(UserModel user)
@@ -172,6 +163,11 @@ namespace InventoryManagementApp.Views.Pages
 
             document.Blocks.Add(table);
             return document;
+        }
+
+        private static void ShowPrintPreview(FlowDocument document, string title)
+        {
+            new PrintPreviewWindow().ShowPreview(document, title, null);
         }
 
         private static void AddCell(TableRow row, string text)


### PR DESCRIPTION
## Summary
- Route Users directory printing through the shared `PrintPreviewWindow` instead of the system print dialog.
- Route Category Directory, selected Category Sheet, and Import / Export run-log printing through the same branded preview workstation.
- Add source-contract coverage that keeps these admin/data print routes on the preview path and blocks direct `PrintDialog` regression.
- Record the completed pass in a progress note.

## Validation
- GitHub connector compare/readback confirmed a focused 5-file diff against `master`.
- Not run locally: `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct local clone/raw access is blocked by the network tunnel.