### PR TITLE
Add admin print preview route coverage

### DIFF
--- a/InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs
+++ b/InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs
@@ -10,12 +10,25 @@ namespace InventoryManagementApp.Tests
         [InlineData("InventoryManagementApp", "Views", "Pages", "UsersPage.xaml.cs")]
         [InlineData("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs")]
         [InlineData("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml.cs")]
-        public void AdminDataPrintActionsUseSharedPreviewWindow(params string[] path)
+        public void AdminDataPagePrintActionsUseSharedPreviewWindow(params string[] path)
         {
             var source = ReadRepoFile(path);
 
             Assert.Contains("PrintPreviewWindow", source, StringComparison.Ordinal);
             Assert.Contains("ShowPreview(document", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("WpfPrintDialog", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("new PrintDialog", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator", source, StringComparison.Ordinal);
+        }
+
+        [Theory]
+        [InlineData("InventoryManagementApp", "ViewModels", "CustomerManagementViewModel.cs")]
+        [InlineData("InventoryManagementApp", "ViewModels", "KitManagementViewModel.cs")]
+        public void AdminDataViewModelPrintActionsUseDialogPreviewService(params string[] path)
+        {
+            var source = ReadRepoFile(path);
+
+            Assert.Contains("_dialogService.ShowPrintPreview(doc", source, StringComparison.Ordinal);
             Assert.DoesNotContain("WpfPrintDialog", source, StringComparison.Ordinal);
             Assert.DoesNotContain("new PrintDialog", source, StringComparison.Ordinal);
             Assert.DoesNotContain("PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator", source, StringComparison.Ordinal);
@@ -28,6 +41,18 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("ShowPrintPreview(document, \"Category Directory\")", source, StringComparison.Ordinal);
             Assert.Contains("ShowPrintPreview(document, $\"Category Sheet - {category.Name}\")", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CustomerAndKitOutputsKeepDirectoryAndSelectedSheetPreviewRoutes()
+        {
+            var customerSource = ReadRepoFile("InventoryManagementApp", "ViewModels", "CustomerManagementViewModel.cs");
+            var kitSource = ReadRepoFile("InventoryManagementApp", "ViewModels", "KitManagementViewModel.cs");
+
+            Assert.Contains("_dialogService.ShowPrintPreview(doc, \"Customer Directory\"", customerSource, StringComparison.Ordinal);
+            Assert.Contains("CreateCustomerDocument($\"Customer Sheet - {ValueOrNotRecorded(customer.Company)}\")", customerSource, StringComparison.Ordinal);
+            Assert.Contains("_dialogService.ShowPrintPreview(doc, \"Kit Directory\"", kitSource, StringComparison.Ordinal);
+            Assert.Contains("CreateKitDocument($\"Kit Pick Sheet - {ValueOrNotRecorded(kit.Name)}\")", kitSource, StringComparison.Ordinal);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-admin-print-preview-route-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-admin-print-preview-route-coverage.md
@@ -1,0 +1,16 @@
+# Admin Print Preview Route Coverage - 2026-06-21
+
+## Completed
+
+- Expanded `AdminDataPrintPreviewRouteTests` so customer and kit print outputs are covered alongside Users, Categories, and Import / Export admin/data print routes.
+- Guarded customer directory, customer sheet, kit directory, and kit pick sheet routes against falling back to direct WPF print dialogs.
+- Kept the validation focused on the existing print-preview routing contract rather than adding another theme customization layer.
+
+## Why it matters
+
+The recent print-preview routing work moved more admin/data outputs into the branded preview workstation. This pass broadens the source-contract coverage to adjacent customer and kit handoff outputs so future edits are less likely to bypass the shared preview path.
+
+## Validation
+
+- GitHub connector readback and compare should be used to verify this focused branch diff.
+- Not run locally: `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct local clone/raw access is blocked by the network tunnel.


### PR DESCRIPTION
## Summary
- Expand `AdminDataPrintPreviewRouteTests` to cover customer and kit print outputs alongside Users, Categories, and Import / Export routes.
- Guard customer directory, customer sheet, kit directory, and kit pick sheet paths against direct WPF print-dialog regressions.
- Add a focused progress note for the completed coverage pass.

## Validation
- GitHub connector compare/readback confirmed a focused 2-file diff against `master`.
- Not run locally: `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct local clone/raw access is blocked by the network tunnel.