### PR TITLE
Route dashboard print outputs through preview

### DIFF
--- a/InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs
+++ b/InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs
@@ -35,6 +35,20 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void DashboardPrintActionsUseDialogPreviewService()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "DashboardViewModel.cs");
+
+            Assert.Contains("IDialogService? dialogService", source, StringComparison.Ordinal);
+            Assert.Contains("_dialogService.ShowPrintPreview(document, title, description)", source, StringComparison.Ordinal);
+            Assert.Contains("Dashboard checked-out item handoff", source, StringComparison.Ordinal);
+            Assert.Contains("Dashboard operations snapshot", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("new System.Windows.Controls.PrintDialog", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("new PrintDialog", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("PrintDocument(((System.Windows.Documents.IDocumentPaginatorSource)doc).DocumentPaginator", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void CategoriesKeepBothDirectoryAndSelectedSheetPreviewRoutes()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-dashboard-print-preview-routing.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-dashboard-print-preview-routing.md
@@ -1,0 +1,15 @@
+# Dashboard Print Preview Routing
+
+Completed on 2026-06-21.
+
+## What changed
+
+- Routed Dashboard checked-out item printing through the shared dialog print-preview service.
+- Routed Dashboard operations snapshot printing through the shared dialog print-preview service.
+- Removed the direct WPF `PrintDialog` handoff from `DashboardViewModel` so staff can review dashboard handoff documents before printing.
+- Extended source-contract coverage to guard Dashboard print commands against direct print-dialog regressions.
+
+## Validation notes
+
+- GitHub connector readback/compare was used because local clone/raw access is blocked in the scheduled Linux container.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run because this environment lacks the .NET SDK/Windows WPF runtime and direct local clone/raw access is blocked.

--- a/InventoryManagementApp/ViewModels/DashboardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DashboardViewModel.cs
@@ -46,6 +46,7 @@ namespace InventoryManagementApp.ViewModels
         readonly IRelayCommand _openRentalsCommand;
         readonly IRelayCommand _openImportExportCommand;
         readonly ILogger<DashboardViewModel> _logger;
+        readonly IDialogService? _dialogService;
         ItemModel? _selectedCommonlyUsedItem;
         ItemModel? _selectedCheckedOutItem;
         ItemModel? _selectedIncompleteItem;
@@ -185,7 +186,8 @@ namespace InventoryManagementApp.ViewModels
                                   CalibrationService? calibrationService = null,
                                   ReservationService? reservationService = null,
                                   KitService? kitService = null,
-                                  ILogger<DashboardViewModel>? logger = null)
+                                  ILogger<DashboardViewModel>? logger = null,
+                                  IDialogService? dialogService = null)
         {
             _itemService = itemService ?? throw new ArgumentNullException(nameof(itemService));
             _rentalService = rentalService ?? throw new ArgumentNullException(nameof(rentalService));
@@ -200,6 +202,7 @@ namespace InventoryManagementApp.ViewModels
             _openRentalsCommand = openRentalsCommand ?? throw new ArgumentNullException(nameof(openRentalsCommand));
             _openImportExportCommand = openImportExportCommand ?? throw new ArgumentNullException(nameof(openImportExportCommand));
             _logger = logger ?? NullLogger<DashboardViewModel>.Instance;
+            _dialogService = dialogService;
 
             NewItemCommand = new RelayCommand(OpenItemsWorkflow);
             OpenItemsCommand = new RelayCommand(OpenItemsWorkflow);
@@ -583,13 +586,7 @@ namespace InventoryManagementApp.ViewModels
                 var currentUser = await _userService.GetCurrentUserAsync().ConfigureAwait(false);
                 var userName = currentUser?.UserName ?? "Unknown";
                 var doc = GenerateCheckedOutItemsDocument(userName);
-                
-                var printDialog = new System.Windows.Controls.PrintDialog();
-                if (printDialog.ShowDialog() == true)
-                {
-                    var paginator = ((System.Windows.Documents.IDocumentPaginatorSource)doc).DocumentPaginator;
-                    printDialog.PrintDocument(paginator, $"Checked Out Items - {userName}");
-                }
+                ShowDashboardPrintPreview(doc, $"Checked Out Items - {userName}", "Dashboard checked-out item handoff");
             }
             catch (Exception ex)
             {
@@ -604,18 +601,23 @@ namespace InventoryManagementApp.ViewModels
                 var currentUser = await _userService.GetCurrentUserAsync().ConfigureAwait(false);
                 var userName = currentUser?.UserName ?? "Unknown";
                 var doc = GenerateDashboardSnapshotDocument(userName);
-
-                var printDialog = new System.Windows.Controls.PrintDialog();
-                if (printDialog.ShowDialog() == true)
-                {
-                    var paginator = ((System.Windows.Documents.IDocumentPaginatorSource)doc).DocumentPaginator;
-                    printDialog.PrintDocument(paginator, $"Dashboard Snapshot - {DateTime.Now:yyyy-MM-dd HH:mm}");
-                }
+                ShowDashboardPrintPreview(doc, $"Dashboard Snapshot - {DateTime.Now:yyyy-MM-dd HH:mm}", "Dashboard operations snapshot");
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to print dashboard snapshot");
             }
+        }
+
+        private void ShowDashboardPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description)
+        {
+            if (_dialogService == null)
+            {
+                _logger.LogWarning("Dashboard print preview service is not available for {Title}", title);
+                return;
+            }
+
+            _dialogService.ShowPrintPreview(document, title, description);
         }
 
         private System.Windows.Documents.FlowDocument GenerateCheckedOutItemsDocument(string userName)

--- a/InventoryManagementApp/ViewModels/DashboardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DashboardViewModel.cs
@@ -583,7 +583,7 @@ namespace InventoryManagementApp.ViewModels
         {
             try
             {
-                var currentUser = await _userService.GetCurrentUserAsync().ConfigureAwait(false);
+                var currentUser = await _userService.GetCurrentUserAsync();
                 var userName = currentUser?.UserName ?? "Unknown";
                 var doc = GenerateCheckedOutItemsDocument(userName);
                 ShowDashboardPrintPreview(doc, $"Checked Out Items - {userName}", "Dashboard checked-out item handoff");
@@ -598,7 +598,7 @@ namespace InventoryManagementApp.ViewModels
         {
             try
             {
-                var currentUser = await _userService.GetCurrentUserAsync().ConfigureAwait(false);
+                var currentUser = await _userService.GetCurrentUserAsync();
                 var userName = currentUser?.UserName ?? "Unknown";
                 var doc = GenerateDashboardSnapshotDocument(userName);
                 ShowDashboardPrintPreview(doc, $"Dashboard Snapshot - {DateTime.Now:yyyy-MM-dd HH:mm}", "Dashboard operations snapshot");


### PR DESCRIPTION
## Summary
- Route Dashboard checked-out item and operations snapshot print commands through the shared dialog print-preview service instead of direct WPF print dialogs.
- Keep the preview handoff on the normal WPF UI context after loading the current user.
- Extend print-route source-contract coverage so Dashboard cannot regress to direct `PrintDialog` printing.
- Add a focused progress note for the validation/consolidation pass.

## Validation
- GitHub connector compare/readback confirmed a focused 3-file diff against `master`.
- Read back the updated Dashboard print methods and source-contract test through the GitHub connector.
- Not run locally: `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct local clone/raw access is blocked by the network tunnel.