### PR TITLE
Restore dashboard print preview service fallback

### DIFF
--- a/InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs
+++ b/InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs
@@ -40,7 +40,9 @@ namespace InventoryManagementApp.Tests
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "DashboardViewModel.cs");
 
             Assert.Contains("IDialogService? dialogService", source, StringComparison.Ordinal);
-            Assert.Contains("_dialogService.ShowPrintPreview(document, title, description)", source, StringComparison.Ordinal);
+            Assert.Contains("var dialogService = _dialogService", source, StringComparison.Ordinal);
+            Assert.Contains("Host.Services.GetService<IDialogService>()", source, StringComparison.Ordinal);
+            Assert.Contains("dialogService.ShowPrintPreview(document, title, description)", source, StringComparison.Ordinal);
             Assert.Contains("Dashboard checked-out item handoff", source, StringComparison.Ordinal);
             Assert.Contains("Dashboard operations snapshot", source, StringComparison.Ordinal);
             Assert.DoesNotContain("new System.Windows.Controls.PrintDialog", source, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-dashboard-print-preview-service-fallback.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-dashboard-print-preview-service-fallback.md
@@ -1,0 +1,18 @@
+# Dashboard Print Preview Service Fallback
+
+Completed on 2026-06-21.
+
+## What changed
+
+- Restored Dashboard print-preview availability for construction paths that do not pass `IDialogService` directly into `DashboardViewModel`.
+- The Dashboard print helper now uses the injected dialog service when available and falls back to the registered application dialog service before logging that preview is unavailable.
+- Updated source-contract coverage so the dashboard print route guards the preview fallback and stays off direct WPF `PrintDialog` printing.
+
+## Why it matters
+
+PR #1200 moved Dashboard print commands away from direct system printing, but the live dashboard navigation path still constructed the view model without the new optional dialog-service parameter. This follow-up keeps the shared preview workstation reachable from the dashboard while preserving compatibility with existing constructor call sites.
+
+## Validation
+
+- GitHub connector readback and compare should be used to verify the focused branch diff.
+- Not run locally: `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct local clone/raw access is blocked by the network tunnel.

--- a/InventoryManagementApp/ViewModels/DashboardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DashboardViewModel.cs
@@ -15,6 +15,7 @@ using InventoryManagementApp.Services.Maintenance;
 using InventoryManagementApp.Services.Calibration;
 using InventoryManagementApp.Services.Reservations;
 using InventoryManagementApp.Services.Kits;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using InventoryManagementApp.Utilities.Helpers;
@@ -611,13 +612,16 @@ namespace InventoryManagementApp.ViewModels
 
         private void ShowDashboardPrintPreview(System.Windows.Documents.FlowDocument document, string title, string description)
         {
-            if (_dialogService == null)
+            var dialogService = _dialogService
+                ?? (System.Windows.Application.Current as InventoryManagementApp.App)?.Host.Services.GetService<IDialogService>();
+
+            if (dialogService == null)
             {
                 _logger.LogWarning("Dashboard print preview service is not available for {Title}", title);
                 return;
             }
 
-            _dialogService.ShowPrintPreview(document, title, description);
+            dialogService.ShowPrintPreview(document, title, description);
         }
 
         private System.Windows.Documents.FlowDocument GenerateCheckedOutItemsDocument(string userName)


### PR DESCRIPTION
## Summary
- Restore Dashboard print-preview availability when `DashboardViewModel` is built through existing navigation paths that do not pass `IDialogService` directly.
- Keep injected dialog-service usage first, then fall back to the registered application dialog service before logging that preview is unavailable.
- Extend source-contract coverage so Dashboard print commands stay on the shared preview path and guard the fallback wiring.
- Add a focused progress note for the repair.

## Validation
- GitHub connector compare/readback confirmed a focused 3-file diff against `master`.
- Read back the updated Dashboard preview helper and source-contract assertions through the GitHub connector.
- Not run locally: `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct local clone/raw access is blocked by the network tunnel.