### PR TITLE
Fix print preview description routing

### DIFF
--- a/InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs
+++ b/InventoryManagementApp.Tests/AdminDataPrintPreviewRouteTests.cs
@@ -51,6 +51,21 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void PrintPreviewDescriptionIsNotTreatedAsLogoPath()
+        {
+            var dialogService = ReadRepoFile("InventoryManagementApp", "Services", "DialogService.cs");
+            var previewSource = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "PrintPreviewWindow.xaml.cs");
+            var previewXaml = ReadRepoFile("InventoryManagementApp", "Views", "Windows", "PrintPreviewWindow.xaml");
+
+            Assert.Contains("ShowPreview(document, title, description)", dialogService, StringComparison.Ordinal);
+            Assert.Contains("string? description = null, string? logoPath = null", previewSource, StringComparison.Ordinal);
+            Assert.Contains("PreviewDescription.Text = _description", previewSource, StringComparison.Ordinal);
+            Assert.Contains("_logoPath = logoPath ?? string.Empty", previewSource, StringComparison.Ordinal);
+            Assert.Contains("ResolveLogoUri(_logoPath)", previewSource, StringComparison.Ordinal);
+            Assert.Contains("x:Name=\"PreviewDescription\"", previewXaml, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void CategoriesKeepBothDirectoryAndSelectedSheetPreviewRoutes()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-print-preview-description-contract.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-print-preview-description-contract.md
@@ -1,0 +1,18 @@
+# Print Preview Description Contract
+
+Completed on 2026-06-21.
+
+## What changed
+
+- Fixed `PrintPreviewWindow.ShowPreview` so the shared preview route description is displayed in the preview header instead of being interpreted as a logo path.
+- Kept logo-path handling as a separate optional argument, preserving existing default-logo behavior for print routes that do not provide custom branding.
+- Added source-contract coverage for the dialog-service handoff, preview-window signature, visible description field, and separated logo-path resolution.
+
+## Why it matters
+
+Recent print-preview routing work moved more app outputs through `IDialogService.ShowPrintPreview(document, title, description)`. The preview window still treated the third argument as a logo path, which could show invalid logo-path warnings for normal workflow descriptions and hide the intended preview guidance. This repair keeps the shared preview workstation consistent for Dashboard, customer, kit, admin data, and future print routes.
+
+## Validation
+
+- GitHub connector readback and compare should be used to verify the focused branch diff.
+- Not run locally: `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct local clone/raw access is blocked by the network tunnel.

--- a/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml
+++ b/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml
@@ -39,7 +39,7 @@
                                    Style="{StaticResource HeadingTextBlock}"
                                    TextWrapping="Wrap"
                                    MaxWidth="580"/>
-                        <TextBlock Text="Review page setup, content, and branding before sending output to the printer."
+                        <TextBlock x:Name="PreviewDescription"
                                    Style="{StaticResource CaptionTextBlock}"
                                    TextWrapping="Wrap"
                                    MaxWidth="620"

--- a/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml.cs
@@ -17,6 +17,7 @@ namespace InventoryManagementApp.Views.Windows
     {
         private FlowDocument? _document;
         private string _title = string.Empty;
+        private string _description = string.Empty;
         private string _logoPath = string.Empty;
 
         public PrintPreviewWindow()
@@ -26,14 +27,16 @@ namespace InventoryManagementApp.Views.Windows
             this.DisposeDataContextOnUnload();
         }
 
-        public void ShowPreview(FlowDocument document, string title, string? logoPath)
+        public void ShowPreview(FlowDocument document, string title, string? description = null, string? logoPath = null)
         {
             _document = document ?? throw new ArgumentNullException(nameof(document));
             _title = title ?? throw new ArgumentNullException(nameof(title));
+            _description = SafeText(description, "Review page setup, content, and branding before sending output to the printer.");
             _logoPath = logoPath ?? string.Empty;
 
-            Title = $"Print Preview – {_title}";
+            Title = $"Print Preview - {_title}";
             PreviewTitle.Text = _title;
+            PreviewDescription.Text = _description;
 
             var logoUri = ResolveLogoUri(_logoPath);
             var bmp = new BitmapImage();


### PR DESCRIPTION
## Summary
- Fix `PrintPreviewWindow.ShowPreview` so route descriptions are displayed in the preview header instead of being interpreted as logo paths.
- Keep logo-path handling as a separate optional argument while preserving existing default-logo behavior for current print routes.
- Add source-contract coverage for the dialog-service preview handoff, visible description field, and separated logo-path resolution.
- Add a focused progress note for the repair.

## Validation
- GitHub connector compare/readback confirmed a focused 4-file diff against `master`.
- Read back the updated preview window code-behind, preview XAML header, and source-contract assertions through the GitHub connector.
- Not run locally: `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct local clone/raw access is blocked by the network tunnel.