### PR TITLE
Add insight print preview descriptions

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
@@ -81,8 +81,12 @@ namespace InventoryManagementApp.Tests.ViewModels
             var reportsCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs");
             var activityCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml.cs");
 
-            Assert.Contains("new PrintPreviewWindow().ShowPreview(document, vm.ReportTitle, null)", reportsCode, StringComparison.Ordinal);
-            Assert.Contains("new PrintPreviewWindow().ShowPreview(document, \"Activity Logs\", null)", activityCode, StringComparison.Ordinal);
+            Assert.Contains("new PrintPreviewWindow().ShowPreview(", reportsCode, StringComparison.Ordinal);
+            Assert.Contains("vm.ReportTitle", reportsCode, StringComparison.Ordinal);
+            Assert.Contains("Review the report summary, destination routing, and next-action handoff before printing.", reportsCode, StringComparison.Ordinal);
+            Assert.Contains("new PrintPreviewWindow().ShowPreview(", activityCode, StringComparison.Ordinal);
+            Assert.Contains("\"Activity Logs\"", activityCode, StringComparison.Ordinal);
+            Assert.Contains("Review the filtered audit trail, destination routing, and operator handoff before printing.", activityCode, StringComparison.Ordinal);
             Assert.DoesNotContain("WpfPrintDialog", reportsCode, StringComparison.Ordinal);
             Assert.DoesNotContain("WpfPrintDialog", activityCode, StringComparison.Ordinal);
             Assert.DoesNotContain("PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator", reportsCode, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-insights-preview-descriptions.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-insights-preview-descriptions.md
@@ -1,0 +1,12 @@
+# Insights Preview Descriptions - 2026-06-21 17:11 NZST
+
+## Completed
+
+- Added a visible print-preview route description for Reports output so operators know to verify summary lines, destination routing, and next-action handoff before printing.
+- Added a visible print-preview route description for Activity Logs output so audit staff know to verify the filtered trail, routing, and handoff context before printing.
+- Extended `InsightsPagesXamlTests` so the insight print routes keep using the shared preview surface and keep passing meaningful descriptions into the preview header.
+
+## Validation
+
+- GitHub connector readback and compare were used because local clone/raw access is blocked by the scheduled environment network tunnel.
+- Local `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks could not be run because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct clone/raw access is blocked.

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
@@ -137,7 +137,10 @@ namespace InventoryManagementApp.Views.Pages
             }
 
             var document = BuildPrintDocument(vm.FilteredLogs.ToList(), vm.StatusMessage, vm.ActivitySummary);
-            new PrintPreviewWindow().ShowPreview(document, "Activity Logs", null);
+            new PrintPreviewWindow().ShowPreview(
+                document,
+                "Activity Logs",
+                "Review the filtered audit trail, destination routing, and operator handoff before printing.");
         }
 
         private static string FormatLogDetail(ActivityLog log)

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
@@ -56,7 +56,10 @@ namespace InventoryManagementApp.Views.Pages
             }
 
             var document = BuildReportDocument(vm.ReportTitle, vm.ReportSummary, vm.LastRunText, vm.ReportLines.ToList());
-            new PrintPreviewWindow().ShowPreview(document, vm.ReportTitle, null);
+            new PrintPreviewWindow().ShowPreview(
+                document,
+                vm.ReportTitle,
+                "Review the report summary, destination routing, and next-action handoff before printing.");
         }
 
         private void OpenSelectedDestination()


### PR DESCRIPTION
## Summary
- Add visible route descriptions to Reports and Activity Logs print-preview handoffs so operators know what to verify before printing.
- Preserve the shared `PrintPreviewWindow` route while exercising the recently repaired preview-description header path.
- Extend `InsightsPagesXamlTests` to guard the preview descriptions and keep blocking direct system print-dialog regressions.
- Add a focused progress note for the completed polish.

## Validation
- GitHub connector compare confirmed a focused 4-file diff against current `master` with the branch 4 commits ahead and 0 behind.
- Read back the updated Reports, Activity Logs, source-contract test, and progress note through the GitHub connector.
- GitHub reports no attached status checks or workflow runs for the branch head.
- Not run locally: `dotnet build`, `dotnet test`, WPF screenshots, local XAML parsing, and local banned-word checks because this scheduled Linux container lacks the .NET SDK/Windows WPF runtime and direct local clone/raw access is blocked by the network tunnel.