### PR TITLE
[codex] Remove guest login fallback

### DIFF
--- a/InventoryManagementApp.Tests/MainViewModelCategoriesCommandTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelCategoriesCommandTests.cs
@@ -334,7 +334,7 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void SwitchUserCommand_CancelledLogin_LeavesUserSignedOut()
+        public void SwitchUserCommand_CancelledLogin_ShutsDownApplication()
         {
             Exception? threadEx = null;
             var thread = new Thread(() =>
@@ -368,6 +368,7 @@ namespace InventoryManagementApp.Tests
                     var reservationService = new ReservationService(db, userContext);
                     var kitService = new KitService(db, userContext);
                     var loginShown = false;
+                    var shutdownRequested = false;
                     MainViewModel? vm = null;
 
                     vm = new MainViewModel(
@@ -395,7 +396,9 @@ namespace InventoryManagementApp.Tests
                             return Task.FromResult(false);
                         },
                         new StubDispatcherTimer(),
-                        new StubDispatcherTimer());
+                        new StubDispatcherTimer(),
+                        null,
+                        () => shutdownRequested = true);
 
                     vm.OpenCategoriesCommand.ExecuteAsync(null).GetAwaiter().GetResult();
                     Assert.IsType<CategoriesPage>(vm.CurrentPage);
@@ -403,6 +406,7 @@ namespace InventoryManagementApp.Tests
                     vm.SwitchUserCommand.ExecuteAsync(null).GetAwaiter().GetResult();
 
                     Assert.True(loginShown);
+                    Assert.True(shutdownRequested);
                     Assert.Null(userContext.CurrentUser);
                     Assert.IsType<DashboardPage>(vm.CurrentPage);
 

--- a/InventoryManagementApp/Services/Users/ApplicationUserContext.cs
+++ b/InventoryManagementApp/Services/Users/ApplicationUserContext.cs
@@ -44,7 +44,7 @@ namespace InventoryManagementApp.Services.Users
 
         public bool IsAdmin => CurrentUser?.IsAdmin ?? false;
 
-        public string UserName => CurrentUser?.UserName ?? "Guest";
+        public string UserName => CurrentUser?.UserName ?? string.Empty;
 
         public string Role
         {
@@ -53,7 +53,10 @@ namespace InventoryManagementApp.Services.Users
                 if (IsAdmin)
                     return "Admin";
 
-                return string.IsNullOrWhiteSpace(CurrentUser?.Role)
+                if (CurrentUser == null)
+                    return string.Empty;
+
+                return string.IsNullOrWhiteSpace(CurrentUser.Role)
                     ? "User"
                     : CurrentUser.Role;
             }

--- a/InventoryManagementApp/ViewModels/MainViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MainViewModel.cs
@@ -47,6 +47,7 @@ namespace InventoryManagementApp.ViewModels
         readonly IThemeService _themeService;
         readonly ILogger<MainViewModel> _logger;
         readonly Func<Task<bool>> _showLoginWindow;
+        readonly Action _shutdownApplication;
         readonly IDispatcherTimer _autoLogoutTimer;
         readonly IDispatcherTimer _globalSearchDebounceTimer;
         int _autoLogoutMinutes;
@@ -412,7 +413,8 @@ namespace InventoryManagementApp.ViewModels
                              Func<Task<bool>>? showLoginWindow = null,
                                 IDispatcherTimer? autoLogoutTimer = null,
                                 IDispatcherTimer? globalSearchDebounceTimer = null,
-                             IEmailAccountDiscoveryService? emailAccountDiscoveryService = null)
+                             IEmailAccountDiscoveryService? emailAccountDiscoveryService = null,
+                             Action? shutdownApplication = null)
         {
             _itemService = itemService;
             _userService = userService;
@@ -425,6 +427,7 @@ namespace InventoryManagementApp.ViewModels
             _dialogService = dialogService;
             _fileDialogService = fileDialogService;
             _logger = logger ?? NullLogger<MainViewModel>.Instance;
+            _shutdownApplication = shutdownApplication ?? (() => Application.Current?.Shutdown());
             _showLoginWindow = showLoginWindow ?? new Func<Task<bool>>(async () =>
             {
                 var app = (App)System.Windows.Application.Current;
@@ -801,6 +804,7 @@ namespace InventoryManagementApp.ViewModels
                     else
                     {
                         _logger.LogInformation("Login cancelled after signing out.");
+                        _shutdownApplication();
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
## Summary

- Shut down the app when switch-user login is cancelled instead of leaving the shell open with no current user.
- Stop presenting a missing current user as `Guest` in the shared user context.
- Update switch-user coverage to assert shutdown is requested after a cancelled login.

## Validation

- `dotnet restore InventoryManagementApp.sln`
- `dotnet build InventoryManagementApp.sln --no-restore`
- `dotnet test InventoryManagementApp.sln --no-build`
- `bash -c "tr -d '\r' < scripts/check-banned-words.sh | bash"` reported `Banned word check passed`; the script also printed `rg: command not found` under this Bash environment.