### PR TITLE
[codex] Cover signed-out user context display contract

### DIFF
--- a/InventoryManagementApp.Tests/ApplicationUserContextTests.cs
+++ b/InventoryManagementApp.Tests/ApplicationUserContextTests.cs
@@ -85,5 +85,95 @@ namespace InventoryManagementApp.Tests
             thread.Join();
             if (threadEx != null) throw threadEx;
         }
+
+        [Fact]
+        public void SignedOutUser_HasBlankDisplayNameAndRole()
+        {
+            RunOnStaThread(() =>
+            {
+                WpfTestHelper.CreateApplication();
+                var ctx = new ApplicationUserContext();
+
+                ctx.CurrentUser = null;
+
+                Assert.Null(ctx.CurrentUser);
+                Assert.False(ctx.IsAdmin);
+                Assert.Equal(string.Empty, ctx.UserName);
+                Assert.Equal(string.Empty, ctx.Role);
+            });
+        }
+
+        [Fact]
+        public void NonAdminUserWithBlankRole_StillFallsBackToUserRole()
+        {
+            RunOnStaThread(() =>
+            {
+                WpfTestHelper.CreateApplication();
+                var ctx = new ApplicationUserContext
+                {
+                    CurrentUser = new User
+                    {
+                        UserID = 7,
+                        UserName = "Desk Operator",
+                        IsAdmin = false,
+                        Role = "   "
+                    }
+                };
+
+                Assert.Equal("Desk Operator", ctx.UserName);
+                Assert.Equal("User", ctx.Role);
+            });
+        }
+
+        [Fact]
+        public void AdminUser_PreservesAdminRoleLabel()
+        {
+            RunOnStaThread(() =>
+            {
+                WpfTestHelper.CreateApplication();
+                var ctx = new ApplicationUserContext
+                {
+                    CurrentUser = new User
+                    {
+                        UserID = 9,
+                        UserName = "Admin Operator",
+                        IsAdmin = true,
+                        Role = "Supervisor"
+                    }
+                };
+
+                Assert.True(ctx.IsAdmin);
+                Assert.Equal("Admin Operator", ctx.UserName);
+                Assert.Equal("Admin", ctx.Role);
+            });
+        }
+
+        private static void RunOnStaThread(Action action)
+        {
+            Exception? threadEx = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    WpfTestHelper.ShutdownApplication();
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    threadEx = ex;
+                }
+                finally
+                {
+                    WpfTestHelper.ShutdownApplication();
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (threadEx != null)
+                throw threadEx;
+        }
     }
 }

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-user-context-signed-out-contract.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-user-context-signed-out-contract.md
@@ -1,0 +1,11 @@
+# User Context Signed-Out Contract
+
+## Completed
+
+- Added focused regression coverage for `ApplicationUserContext` after the switch-user cancellation repair.
+- Locked the signed-out display contract so missing current users expose blank user name and role values instead of a normal-looking fallback identity.
+- Guarded the remaining role behavior so ordinary users with blank roles still display `User`, while admins still display `Admin`.
+
+## Why it matters
+
+The switch-user flow now shuts down when login is cancelled, and the shared user context should not present that transient signed-out state as a valid operator. These tests keep the authentication display contract explicit without adding another theme or visual customization layer.


### PR DESCRIPTION
## Summary

- Extend `ApplicationUserContextTests` with focused coverage for the signed-out display contract after the switch-user cancellation repair.
- Guard that missing current users expose blank user name and role values instead of a normal-looking fallback identity.
- Preserve the expected role labels for non-admin users with blank roles and admin users.
- Add a focused progress note for the completed regression coverage.

## Validation

- GitHub connector compare confirmed a focused 2-file diff against current `master` with the branch 2 commits ahead and 0 behind.
- Read back the updated `ApplicationUserContextTests` and progress note through the GitHub connector.
- GitHub reports no attached status checks for the branch head.
- Not run locally: `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks because this scheduled Linux container has no local repository checkout and `dotnet` is not installed.