### PR TITLE
[codex] Guard switch-user successful login route

### DIFF
--- a/InventoryManagementApp.Tests/MainViewModelSwitchUserContractTests.cs
+++ b/InventoryManagementApp.Tests/MainViewModelSwitchUserContractTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class MainViewModelSwitchUserContractTests
+    {
+        [Fact]
+        public void SwitchUserSuccessKeepsShellOnAuthenticatedDashboard()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "MainViewModel.cs");
+            var switchUserStart = source.IndexOf("SwitchUserCommand = new AsyncRelayCommand", StringComparison.Ordinal);
+            var exitCommandStart = source.IndexOf("ExitCommand = new RelayCommand", StringComparison.Ordinal);
+
+            Assert.True(switchUserStart >= 0, "SwitchUserCommand source block was not found.");
+            Assert.True(exitCommandStart > switchUserStart, "SwitchUserCommand block should appear before ExitCommand.");
+
+            var switchUserSource = source.Substring(switchUserStart, exitCommandStart - switchUserStart);
+            var loginSuccessIndex = switchUserSource.IndexOf("if (await _showLoginWindow())", StringComparison.Ordinal);
+            var loginCancelledIndex = switchUserSource.IndexOf("else", loginSuccessIndex, StringComparison.Ordinal);
+
+            Assert.True(loginSuccessIndex >= 0, "SwitchUserCommand should branch on a successful login result.");
+            Assert.True(loginCancelledIndex > loginSuccessIndex, "SwitchUserCommand should keep a separate cancelled-login branch.");
+
+            var signOutPreparation = switchUserSource.Substring(0, loginSuccessIndex);
+            Assert.Contains("_userContext.CurrentUser = null", signOutPreparation, StringComparison.Ordinal);
+            Assert.Contains("RefreshCurrentUser();", signOutPreparation, StringComparison.Ordinal);
+            Assert.Contains("CloseNonMainWindows();", signOutPreparation, StringComparison.Ordinal);
+            Assert.Contains("ClearSearch();", signOutPreparation, StringComparison.Ordinal);
+            Assert.Contains("SetNavSection(NavSectionKeys.Overview);", signOutPreparation, StringComparison.Ordinal);
+            Assert.Contains("await OpenDashboardCommand.ExecuteAsync(null);", signOutPreparation, StringComparison.Ordinal);
+
+            var loginSuccessBranch = switchUserSource.Substring(loginSuccessIndex, loginCancelledIndex - loginSuccessIndex);
+            Assert.Contains("await OpenDashboardCommand.ExecuteAsync(null);", loginSuccessBranch, StringComparison.Ordinal);
+            Assert.DoesNotContain("_shutdownApplication", loginSuccessBranch, StringComparison.Ordinal);
+
+            var loginCancelledBranch = switchUserSource.Substring(loginCancelledIndex);
+            Assert.Contains("_shutdownApplication();", loginCancelledBranch, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-switch-user-success-contract.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-switch-user-success-contract.md
@@ -1,0 +1,16 @@
+# Switch User Success Contract Coverage
+
+Date: 2026-06-21 19:11 NZST scheduled pass
+
+## Completed
+
+- Added source-contract coverage for the successful switch-user path in `MainViewModel`.
+- The contract guards the recent auth-shell repair by ensuring switch-user first signs out, clears shell state, closes non-main windows, returns to Overview/Dashboard before showing login, and reopens Dashboard after a successful login.
+- The same contract verifies the successful login branch does not request application shutdown, preserving the separate cancelled-login shutdown behavior added previously.
+
+## Validation notes
+
+- Local clone/raw access is blocked in this scheduled Linux container by the GitHub network tunnel.
+- `dotnet` is not installed in this scheduled Linux container, so local restore/build/test could not run.
+- WPF screenshot validation is unavailable in this Linux container.
+- Use GitHub connector readback/compare as the validation fallback for this pass.


### PR DESCRIPTION
## Summary

- Add source-contract coverage for the successful switch-user login path in `MainViewModel`.
- Guard the recent auth-shell repair so switch-user signs out, clears shell state, closes non-main windows, returns to Overview/Dashboard before login, and reopens Dashboard after successful login.
- Verify the successful login branch does not request shutdown, preserving the separate cancelled-login shutdown behavior covered by existing tests.
- Add a focused progress note for this consolidation pass.

## Validation

- GitHub connector compare confirmed a focused 2-file diff against current `master` with the branch 2 commits ahead and 0 behind.
- Read back the added source-contract test and progress note through the GitHub connector.
- Not run locally: `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks because this scheduled Linux container has no local repository checkout, direct clone/raw access is blocked by the GitHub network tunnel, and `dotnet` is not installed.