### PR TITLE
[codex] Stabilize item rental refresh flow

### DIFF
--- a/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ItemRentalWorkflowContractTests
+    {
+        [Fact]
+        public void ItemRentActionsRefreshFilteredRowsAndSelectionAfterSuccessfulRental()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemManagementViewModel.cs");
+
+            Assert.Equal(2, CountOccurrences(source, "await ReloadItemsAfterRentalAsync(item.ItemID, cancellationToken);"));
+            Assert.Contains("private async Task ReloadItemsAfterRentalAsync(int itemId, CancellationToken cancellationToken)", source, StringComparison.Ordinal);
+            Assert.Contains("await LoadItemsAsync(new ItemPage(1, PageSize));", source, StringComparison.Ordinal);
+            Assert.Contains("await FilterItemsAsync();", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedItem = SearchResults.FirstOrDefault(t => t.ItemID == itemId)", source, StringComparison.Ordinal);
+            Assert.Contains("?? Items.FirstOrDefault(t => t.ItemID == itemId)", source, StringComparison.Ordinal);
+            Assert.Contains("?? CheckedOutItems.FirstOrDefault(t => t.ItemID == itemId)", source, StringComparison.Ordinal);
+        }
+
+        private static int CountOccurrences(string source, string value)
+        {
+            var count = 0;
+            var index = 0;
+
+            while ((index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += value.Length;
+            }
+
+            return count;
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-item-rental-refresh-contract.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-item-rental-refresh-contract.md
@@ -1,0 +1,14 @@
+# Item Rental Refresh Contract
+
+Date: 2026-06-21
+
+## Completed
+
+- Consolidated successful item rental refresh handling in `ItemManagementViewModel` so both rental entry points use the same post-rental path.
+- After a rental is saved, the item workflow now reloads inventory rows, reapplies the current search/category filter, refreshes checked-out state through the normal load path, and restores selection by item ID where possible.
+- Added source-contract coverage that guards both rent entry points and the shared filtered-row/selection refresh behavior.
+
+## Validation
+
+- GitHub connector readback/compare required in this scheduled Linux environment.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and banned-word checks still require a Windows/.NET-capable checkout.

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -503,7 +503,7 @@ namespace InventoryManagementApp.ViewModels
                         customer.CustomerID,
                         DateTime.Today,
                         dueDate);
-                    await LoadItemsAsync(new ItemPage(1, PageSize));
+                    await ReloadItemsAfterRentalAsync(item.ItemID, cancellationToken);
                 }
             }
             catch (OperationCanceledException)
@@ -532,7 +532,7 @@ namespace InventoryManagementApp.ViewModels
                 {
                     var (customer, dueDate) = result.Value;
                     await _rentalService.RentItemAsync(item.ItemID, customer.CustomerID, DateTime.Today, dueDate);
-                    await LoadItemsAsync(new ItemPage(1, PageSize));
+                    await ReloadItemsAfterRentalAsync(item.ItemID, cancellationToken);
                 }
             }
             catch (OperationCanceledException)
@@ -547,6 +547,19 @@ namespace InventoryManagementApp.ViewModels
                 _logger.LogError(ex, "Failed to rent {ItemLabelSingular} {ItemID}", LabelProvider.Instance.ItemLabelSingular, item.ItemID);
                 await _dialogService.ShowInfoAsync($"Failed to rent {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {ex.Message}", "Error");
             }
+        }
+
+        private async Task ReloadItemsAfterRentalAsync(int itemId, CancellationToken cancellationToken)
+        {
+            var previousSelection = SelectedItem;
+
+            await LoadItemsAsync(new ItemPage(1, PageSize));
+            await FilterItemsAsync();
+
+            SelectedItem = SearchResults.FirstOrDefault(t => t.ItemID == itemId)
+                ?? Items.FirstOrDefault(t => t.ItemID == itemId)
+                ?? CheckedOutItems.FirstOrDefault(t => t.ItemID == itemId)
+                ?? previousSelection;
         }
 
         private async Task ToggleCheckOutAsync(ItemModel? item, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

- Consolidate successful item rental refresh handling in `ItemManagementViewModel` so both rental entry points use the same post-rental path.
- After a rental is saved, reload item rows, reapply the active search/category filter, refresh checked-out state through the normal load path, and restore selection by item ID where possible.
- Add focused source-contract coverage guarding both rent entry points and the shared filtered-row/selection refresh behavior.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master` with the branch 3 commits ahead and 0 behind.
- Read back the changed `ItemManagementViewModel`, new source-contract test, and progress note through the GitHub connector.
- Not run locally: `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks because this scheduled Linux container has no local repository checkout, direct clone/raw access is blocked by the GitHub network tunnel, and `dotnet` is not installed.