### PR TITLE
[codex] Stabilize rental selection after refresh

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ManageRentalsSelectionContractTests
+    {
+        [Fact]
+        public void RentalsReloadRestoresSelectionFromFreshFilteredRows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ManageRentalsViewModel.cs");
+
+            Assert.Contains("var selectedRentalId = SelectedRental?.RentalID;", source, StringComparison.Ordinal);
+            Assert.Contains("ApplyFilter(selectedRentalId);", source, StringComparison.Ordinal);
+            Assert.Contains("void ApplyFilter() => ApplyFilter(SelectedRental?.RentalID);", source, StringComparison.Ordinal);
+            Assert.Contains("void ApplyFilter(int? selectedRentalId)", source, StringComparison.Ordinal);
+            Assert.Contains("Rentals.ReplaceRange(filtered.ToList());", source, StringComparison.Ordinal);
+            Assert.Contains("RestoreSelectedRental(selectedRentalId);", source, StringComparison.Ordinal);
+            Assert.Contains("void RestoreSelectedRental(int? selectedRentalId)", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedRental = Rentals.FirstOrDefault(r => r.RentalID == selectedRentalId.Value);", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void MissingSelectionAfterFilterClearsRentalActions()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ManageRentalsViewModel.cs");
+
+            Assert.Contains("if (!selectedRentalId.HasValue)", source, StringComparison.Ordinal);
+            Assert.Contains("if (SelectedRental != null && !Rentals.Contains(SelectedRental))", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedRental = null;", source, StringComparison.Ordinal);
+            Assert.Contains("bool CanReturnSelectedRental() => SelectedRental != null && IsRentalActive(SelectedRental);", source, StringComparison.Ordinal);
+            Assert.Contains("bool CanPlaceRequestForSelectedRental() => SelectedRental != null && IsRentalActive(SelectedRental);", source, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-rental-selection-refresh-contract.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-rental-selection-refresh-contract.md
@@ -1,0 +1,19 @@
+# Rental Selection Refresh Contract
+
+Completed on 2026-06-21.
+
+## What changed
+
+- Preserved the selected rental ID before rental desk reloads and filter refreshes.
+- Rebound `SelectedRental` to the freshly loaded filtered row after reloads instead of leaving commands pointed at stale pre-action objects.
+- Cleared the selected rental when the current filters no longer include that row, which disables check-in, extend, and follow-up request actions after status-changing operations.
+- Added source-contract coverage for the reload/filter selection path and the no-selection action guard.
+
+## Why it matters
+
+Rental actions such as check-in and extend depend on the current selected rental state. If a check-in reload left the old `Rented` object selected, repeated toolbar, context-menu, or keyboard actions could target an already-returned rental and surface avoidable errors. The rentals desk now refreshes selection from the current filtered rows before commands evaluate again.
+
+## Validation
+
+- GitHub connector readback and compare were used because this scheduled Linux container cannot clone the repository through the GitHub network tunnel.
+- Not run locally: `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks because the local checkout is unavailable and `dotnet` is not installed in this scheduled environment.

--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -222,13 +222,14 @@ namespace InventoryManagementApp.ViewModels
 
         public async Task LoadRentalsAsync()
         {
+            var selectedRentalId = SelectedRental?.RentalID;
             IsLoading = true;
             try
             {
                 _allRentals = await _rentalService.GetAllRentalsAsync();
                 await LoadPendingRequestsAsync();
                 RefreshActiveRentals();
-                ApplyFilter();
+                ApplyFilter(selectedRentalId);
             }
             catch (Exception ex)
             {
@@ -269,7 +270,9 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        void ApplyFilter()
+        void ApplyFilter() => ApplyFilter(SelectedRental?.RentalID);
+
+        void ApplyFilter(int? selectedRentalId)
         {
             if (FilterFrom.HasValue && FilterTo.HasValue && FilterFrom > FilterTo)
             {
@@ -295,18 +298,33 @@ namespace InventoryManagementApp.ViewModels
             if (!string.IsNullOrWhiteSpace(SelectedStatus) && SelectedStatus != "All")
                 filtered = filtered.Where(r => string.Equals(r.Status, SelectedStatus, StringComparison.OrdinalIgnoreCase));
 
-            Rentals.ReplaceRange(filtered);
+            Rentals.ReplaceRange(filtered.ToList());
+            RestoreSelectedRental(selectedRentalId);
             OnPropertyChanged(nameof(SearchSummary));
         }
 
         void ClearFilter()
         {
+            var selectedRentalId = SelectedRental?.RentalID;
             SearchText = string.Empty;
             FilterFrom = null;
             FilterTo = null;
             SelectedStatus = StatusOptions.First();
             Rentals.ReplaceRange(_allRentals);
+            RestoreSelectedRental(selectedRentalId);
             OnPropertyChanged(nameof(SearchSummary));
+        }
+
+        void RestoreSelectedRental(int? selectedRentalId)
+        {
+            if (!selectedRentalId.HasValue)
+            {
+                if (SelectedRental != null && !Rentals.Contains(SelectedRental))
+                    SelectedRental = null;
+                return;
+            }
+
+            SelectedRental = Rentals.FirstOrDefault(r => r.RentalID == selectedRentalId.Value);
         }
 
         async Task CheckInAsync()


### PR DESCRIPTION
## Summary

- Preserve the selected rental ID before rental desk reloads and filter refreshes.
- Rebind `SelectedRental` to the freshly loaded filtered row after refreshes instead of leaving toolbar, context-menu, and keyboard commands pointed at stale pre-action objects.
- Clear the selected rental when the current filters no longer include that row, so Check In, Extend, and Request actions disable after status-changing operations such as check-in.
- Add source-contract coverage for the rental selection refresh path and no-selection command guard.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master` with the branch 3 commits ahead and 0 behind.
- Read back the changed `ManageRentalsViewModel`, new source-contract test, and progress note through the GitHub connector.
- GitHub reports no attached status checks for the branch head.
- Not run locally: `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks because this scheduled Linux container has no local repository checkout, direct clone/raw access is blocked by the GitHub network tunnel, and `dotnet` is not installed.