### PR TITLE
[codex] Stabilize item checkout refresh flow

### DIFF
--- a/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Linq;
 using Xunit;
 
 namespace InventoryManagementApp.Tests
@@ -13,11 +12,27 @@ namespace InventoryManagementApp.Tests
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemManagementViewModel.cs");
 
             Assert.Equal(2, CountOccurrences(source, "await ReloadItemsAfterRentalAsync(item.ItemID, cancellationToken);"));
-            Assert.Contains("private async Task ReloadItemsAfterRentalAsync(int itemId, CancellationToken cancellationToken)", source, StringComparison.Ordinal);
+            Assert.Contains("private Task ReloadItemsAfterRentalAsync(int itemId, CancellationToken cancellationToken)", source, StringComparison.Ordinal);
+            Assert.Contains("return ReloadItemsAfterItemWorkflowAsync(itemId, cancellationToken);", source, StringComparison.Ordinal);
+            Assert.Contains("private async Task ReloadItemsAfterItemWorkflowAsync(int itemId, CancellationToken cancellationToken)", source, StringComparison.Ordinal);
             Assert.Contains("await LoadItemsAsync(new ItemPage(1, PageSize));", source, StringComparison.Ordinal);
             Assert.Contains("await FilterItemsAsync();", source, StringComparison.Ordinal);
             Assert.Contains("SelectedItem = SearchResults.FirstOrDefault(t => t.ItemID == itemId)", source, StringComparison.Ordinal);
             Assert.Contains("?? Items.FirstOrDefault(t => t.ItemID == itemId)", source, StringComparison.Ordinal);
+            Assert.Contains("?? CheckedOutItems.FirstOrDefault(t => t.ItemID == itemId)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ItemCheckoutToggleRefreshesAllItemCollectionsAfterSuccessfulToggle()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemManagementViewModel.cs");
+
+            Assert.Contains("private Task ReloadItemsAfterCheckoutAsync(int itemId, CancellationToken cancellationToken)", source, StringComparison.Ordinal);
+            Assert.Equal(2, CountOccurrences(source, "return ReloadItemsAfterItemWorkflowAsync(itemId, cancellationToken);"));
+            Assert.Contains("var result = await _itemService.ToggleItemCheckOutStatusAsync(item.ItemID, cancellationToken).ConfigureAwait(false);", source, StringComparison.Ordinal);
+            Assert.Contains("if (!result) return;", source, StringComparison.Ordinal);
+            Assert.Contains("await ReloadItemsAfterCheckoutAsync(item.ItemID, cancellationToken);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("var refreshed = await _itemService.GetItemByIDAsync(item.ItemID, cancellationToken).ConfigureAwait(false);", source, StringComparison.Ordinal);
             Assert.Contains("?? CheckedOutItems.FirstOrDefault(t => t.ItemID == itemId)", source, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-item-checkout-refresh-hardening.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-item-checkout-refresh-hardening.md
@@ -1,0 +1,21 @@
+# Item Checkout Refresh Hardening - 2026-06-21
+
+## Completed
+
+- Routed successful item checkout/check-in toggles through the same full item workflow refresh path used by rental creation.
+- Reloaded item rows, reapplied the active search/category filter, refreshed the checked-out list, and restored selection by item ID after a successful toggle.
+- Removed the fragile single-row refresh behavior that could update only the row object used to launch the command while leaving the main item list or checked-out list stale.
+- Added source-contract coverage for both rent and checkout item refresh paths.
+
+## Why it matters
+
+Operators can start item actions from more than one grid. A checkout toggle launched from the checked-out list should not leave the search results grid showing stale checkout state, and a toggle launched from search results should not leave the checked-out grid stale.
+
+## Validation
+
+- GitHub connector readback and compare were used because the scheduled Linux container cannot clone the repository, fetch raw files, run WPF, or run local .NET tests.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run in this environment.
+
+## Follow-up
+
+- Run full Windows/.NET validation for item rent, item checkout, item check-in, rental check-in, rental extend, request creation, and dashboard/search/rentals refresh behavior when a workstation with the .NET SDK and WPF runtime is available.

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -549,7 +549,17 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        private async Task ReloadItemsAfterRentalAsync(int itemId, CancellationToken cancellationToken)
+        private Task ReloadItemsAfterRentalAsync(int itemId, CancellationToken cancellationToken)
+        {
+            return ReloadItemsAfterItemWorkflowAsync(itemId, cancellationToken);
+        }
+
+        private Task ReloadItemsAfterCheckoutAsync(int itemId, CancellationToken cancellationToken)
+        {
+            return ReloadItemsAfterItemWorkflowAsync(itemId, cancellationToken);
+        }
+
+        private async Task ReloadItemsAfterItemWorkflowAsync(int itemId, CancellationToken cancellationToken)
         {
             var previousSelection = SelectedItem;
 
@@ -570,17 +580,7 @@ namespace InventoryManagementApp.ViewModels
                 var result = await _itemService.ToggleItemCheckOutStatusAsync(item.ItemID, cancellationToken).ConfigureAwait(false);
                 if (!result) return;
 
-                var refreshed = await _itemService.GetItemByIDAsync(item.ItemID, cancellationToken).ConfigureAwait(false);
-                if (refreshed == null)
-                {
-                    _logger.LogWarning("Item {ItemID} was toggled but could not be refreshed from storage", item.ItemID);
-                    await LoadItemsAsync(new ItemPage(1, PageSize));
-                    await FilterItemsAsync();
-                    return;
-                }
-
-                ApplyItemState(item, refreshed);
-                await RefreshCheckedOutItemsAsync(cancellationToken);
+                await ReloadItemsAfterCheckoutAsync(item.ItemID, cancellationToken);
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
## Summary

- Route successful item checkout/check-in toggles through the shared item workflow refresh path instead of updating only the row object that launched the action.
- Reload item rows, reapply the active search/category filter, refresh the checked-out list, and restore selection by item ID after checkout toggles.
- Extend item workflow source-contract coverage so rent actions and checkout toggles both preserve the full refresh/selection behavior.
- Add a focused progress note for the completed item workflow hardening pass.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master` with the branch 3 commits ahead and 0 behind.
- Read back the changed `ItemManagementViewModel`, updated `ItemRentalWorkflowContractTests`, and progress note through the GitHub connector.
- GitHub reports no attached status checks for the branch head.
- Not run locally: `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and a full function check because this scheduled Linux container cannot clone the repository or fetch raw files (`CONNECT tunnel failed, response 403` / raw 403), has no `dotnet` or `gh` installed, and cannot run the Windows WPF UI.