### PR TITLE
[codex] Guard rental grid right-click row lookup

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
@@ -33,6 +33,22 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("bool CanPlaceRequestForSelectedRental() => SelectedRental != null && IsRentalActive(SelectedRental);", source, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void RentalGridRightClickSelectionUsesSafeTreeTraversal()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs");
+
+            Assert.Contains("using System;", source, StringComparison.Ordinal);
+            Assert.Contains("var row = sender as DataGridRow ?? FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject);", source, StringComparison.Ordinal);
+            Assert.Contains("current = GetParent(current);", source, StringComparison.Ordinal);
+            Assert.Contains("private static DependencyObject? GetParent(DependencyObject current)", source, StringComparison.Ordinal);
+            Assert.Contains("return VisualTreeHelper.GetParent(current)", source, StringComparison.Ordinal);
+            Assert.Contains("?? LogicalTreeHelper.GetParent(current);", source, StringComparison.Ordinal);
+            Assert.Contains("catch (InvalidOperationException)", source, StringComparison.Ordinal);
+            Assert.Contains("return LogicalTreeHelper.GetParent(current);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("current = VisualTreeHelper.GetParent(current);", source, StringComparison.Ordinal);
+        }
+
         private static string ReadRepoFile(params string[] parts)
         {
             var directory = AppContext.BaseDirectory;

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-rental-grid-right-click-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-rental-grid-right-click-guard.md
@@ -1,0 +1,18 @@
+# Rental Grid Right-Click Guard
+
+Completed on 2026-06-21.
+
+## What changed
+
+- Hardened `ManageRentalsPage` right-click row selection so rental and request grids use safe WPF tree traversal when locating the row under the pointer.
+- Reused the visual-tree plus logical-tree fallback pattern already present on the item search workflow.
+- Added source-contract coverage to guard the right-click selection path against regressing back to a direct `VisualTreeHelper.GetParent` walk.
+
+## Why it matters
+
+Right-click context menus are used for check-in, extend, request, print, and detail actions. Some WPF grid hit-test sources are not safe for direct visual-parent lookup, which can throw while opening a context menu and close the app. The rental desk now avoids that crash path before any item or rental action runs.
+
+## Validation
+
+- GitHub connector readback and compare were used because this scheduled Linux container cannot clone the repository through the GitHub network tunnel.
+- Not run locally: `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and a full function check because the local checkout is unavailable, `dotnet` is not installed, and this Linux container cannot run the Windows WPF UI.

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -184,10 +185,23 @@ namespace InventoryManagementApp.Views.Pages
                 if (current is T match)
                     return match;
 
-                current = VisualTreeHelper.GetParent(current);
+                current = GetParent(current);
             }
 
             return null;
+        }
+
+        private static DependencyObject? GetParent(DependencyObject current)
+        {
+            try
+            {
+                return VisualTreeHelper.GetParent(current)
+                    ?? LogicalTreeHelper.GetParent(current);
+            }
+            catch (InvalidOperationException)
+            {
+                return LogicalTreeHelper.GetParent(current);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Harden `ManageRentalsPage` right-click row selection with safe visual/logical tree traversal so grid context menus do not crash when WPF supplies a non-standard hit-test source.
- Keep rental and request context menu row selection behavior intact while avoiding direct `VisualTreeHelper.GetParent` walks.
- Add source-contract coverage for the guarded right-click traversal path and record a focused progress note.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master` with the branch 3 commits ahead and 0 behind.
- Read back the changed `ManageRentalsPage`, updated `ManageRentalsSelectionContractTests`, and progress note through the GitHub connector.
- Not run locally: `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and a full function check because this scheduled Linux container has no local repository checkout, direct clone/raw access is blocked, `dotnet` is not installed, and the Windows WPF UI cannot run here.