### PR TITLE
[codex] Share safe grid right-click selection

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
@@ -34,19 +34,19 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void RentalGridRightClickSelectionUsesSafeTreeTraversal()
+        public void RentalGridRightClickSelectionUsesSharedSafeTreeTraversal()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs");
+            var helper = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "GridContextMenuSelection.cs");
 
-            Assert.Contains("using System;", source, StringComparison.Ordinal);
-            Assert.Contains("var row = sender as DataGridRow ?? FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject);", source, StringComparison.Ordinal);
-            Assert.Contains("current = GetParent(current);", source, StringComparison.Ordinal);
-            Assert.Contains("private static DependencyObject? GetParent(DependencyObject current)", source, StringComparison.Ordinal);
-            Assert.Contains("return VisualTreeHelper.GetParent(current)", source, StringComparison.Ordinal);
-            Assert.Contains("?? LogicalTreeHelper.GetParent(current);", source, StringComparison.Ordinal);
-            Assert.Contains("catch (InvalidOperationException)", source, StringComparison.Ordinal);
-            Assert.Contains("return LogicalTreeHelper.GetParent(current);", source, StringComparison.Ordinal);
-            Assert.DoesNotContain("current = VisualTreeHelper.GetParent(current);", source, StringComparison.Ordinal);
+            Assert.Contains("var row = GridContextMenuSelection.SelectRow(sender, e);", source, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.FindAncestor<System.Windows.Controls.DataGrid>(focusedElement)", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("VisualTreeHelper.GetParent", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("private static DependencyObject? GetParent", source, StringComparison.Ordinal);
+            Assert.Contains("return VisualTreeHelper.GetParent(current)", helper, StringComparison.Ordinal);
+            Assert.Contains("?? LogicalTreeHelper.GetParent(current);", helper, StringComparison.Ordinal);
+            Assert.Contains("catch (InvalidOperationException)", helper, StringComparison.Ordinal);
+            Assert.Contains("return LogicalTreeHelper.GetParent(current);", helper, StringComparison.Ordinal);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp.Tests/Views/GridContextMenuSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/Views/GridContextMenuSelectionContractTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.Views
+{
+    public class GridContextMenuSelectionContractTests
+    {
+        [Fact]
+        public void SharedGridContextMenuSelectionUsesGuardedVisualAndLogicalTraversal()
+        {
+            var helper = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "GridContextMenuSelection.cs");
+
+            Assert.Contains("internal static class GridContextMenuSelection", helper, StringComparison.Ordinal);
+            Assert.Contains("public static DataGridRow? SelectRow(object sender, MouseButtonEventArgs e)", helper, StringComparison.Ordinal);
+            Assert.Contains("sender as DataGridRow ?? FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject)", helper, StringComparison.Ordinal);
+            Assert.Contains("FindAncestor<DataGrid>(row)", helper, StringComparison.Ordinal);
+            Assert.Contains("return VisualTreeHelper.GetParent(current)", helper, StringComparison.Ordinal);
+            Assert.Contains("?? LogicalTreeHelper.GetParent(current);", helper, StringComparison.Ordinal);
+            Assert.Contains("catch (InvalidOperationException)", helper, StringComparison.Ordinal);
+            Assert.Contains("return LogicalTreeHelper.GetParent(current);", helper, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OperationalGridPagesUseSharedContextMenuSelectionHelper()
+        {
+            var pagePaths = new[]
+            {
+                new[] { "InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "ReservationPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "MaintenancePage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "CalibrationPage.xaml.cs" }
+            };
+
+            foreach (var pagePath in pagePaths)
+            {
+                var source = ReadRepositoryFile(pagePath);
+                Assert.Contains("GridContextMenuSelection.SelectRow(sender, e)", source, StringComparison.Ordinal);
+            }
+        }
+
+        [Fact]
+        public void UpdatedGridPagesDoNotOwnDirectContextMenuParentWalks()
+        {
+            var pagePaths = new Dictionary<string[], string[]>
+            {
+                [new[] { "InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml.cs" }] = new[] { "private static T? FindAncestor", "private static DependencyObject? GetParent" },
+                [new[] { "InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs" }] = new[] { "private static T? FindAncestor", "private static DependencyObject? GetParent" },
+                [new[] { "InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs" }] = new[] { "current = VisualTreeHelper.GetParent(current);" },
+                [new[] { "InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml.cs" }] = new[] { "private static T? FindParent", "VisualTreeHelper.GetParent(child)" },
+                [new[] { "InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs" }] = new[] { "private static T? FindParent", "VisualTreeHelper.GetParent(child)" }
+            };
+
+            foreach (var entry in pagePaths)
+            {
+                var source = ReadRepositoryFile(entry.Key);
+                foreach (var removedPattern in entry.Value)
+                    Assert.DoesNotContain(removedPattern, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePath)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null)
+            {
+                var candidate = Path.Combine(directory.FullName, Path.Combine(relativePath));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                directory = directory.Parent;
+            }
+
+            throw new FileNotFoundException("Could not locate repository file.", Path.Combine(relativePath));
+        }
+    }
+}

--- a/InventoryManagementApp.Tests/Views/ItemSearchRightClickTests.cs
+++ b/InventoryManagementApp.Tests/Views/ItemSearchRightClickTests.cs
@@ -7,15 +7,17 @@ namespace InventoryManagementApp.Tests.Views
     public class ItemSearchRightClickTests
     {
         [Fact]
-        public void ItemSearchPage_RightClickSelectionFallsBackToLogicalTreeForTextContent()
+        public void ItemSearchPage_RightClickSelectionUsesSharedSafeTreeTraversal()
         {
             var code = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml.cs");
+            var helper = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "GridContextMenuSelection.cs");
 
             Assert.Contains("ItemGrid_PreviewMouseRightButtonDown", code, StringComparison.Ordinal);
-            Assert.Contains("GetParent(current)", code, StringComparison.Ordinal);
-            Assert.Contains("VisualTreeHelper.GetParent(current)", code, StringComparison.Ordinal);
-            Assert.Contains("LogicalTreeHelper.GetParent(current)", code, StringComparison.Ordinal);
-            Assert.Contains("catch (InvalidOperationException)", code, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e)", code, StringComparison.Ordinal);
+            Assert.DoesNotContain("private static DependencyObject? GetParent", code, StringComparison.Ordinal);
+            Assert.Contains("VisualTreeHelper.GetParent(current)", helper, StringComparison.Ordinal);
+            Assert.Contains("LogicalTreeHelper.GetParent(current)", helper, StringComparison.Ordinal);
+            Assert.Contains("catch (InvalidOperationException)", helper, StringComparison.Ordinal);
         }
 
         private static string ReadRepositoryFile(params string[] relativePath)

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-grid-context-menu-selection-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-grid-context-menu-selection-guard.md
@@ -1,0 +1,11 @@
+# Grid Context Menu Selection Guard
+
+Completed a focused right-click crash hardening pass for operational grids.
+
+- Added shared `GridContextMenuSelection` helper for row context-menu selection.
+- The helper uses guarded visual/logical tree traversal so right-clicks from text, popup, templated, or non-visual elements do not crash the app.
+- Routed item, rental, dashboard, reservation, kit, category, report, customer, maintenance, and calibration grid right-click handlers through the shared helper.
+- Preserved row focus and selected-item synchronization for context-menu actions.
+- Added source-contract coverage for the helper and updated page usage so future direct parent-walk regressions are easier to catch.
+
+Validation note: local WPF runtime checks, screenshots, `dotnet build`, and `dotnet test` still require a Windows/.NET environment and were not available in this scheduled Linux container.

--- a/InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CalibrationPage.xaml.cs
@@ -31,11 +31,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void CalibrationRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            if (sender is DataGridRow row && !row.IsSelected)
-            {
-                row.IsSelected = true;
-                row.Focus();
-            }
+            GridContextMenuSelection.SelectRow(sender, e);
         }
     }
 }

--- a/InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CategoriesPage.xaml.cs
@@ -98,11 +98,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void CategoryRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            if (sender is DataGridRow row && !row.IsSelected)
-            {
-                row.Focus();
-                row.IsSelected = true;
-            }
+            GridContextMenuSelection.SelectRow(sender, e);
         }
 
         private void OpenCategoryDetail_Click(object sender, RoutedEventArgs e)

--- a/InventoryManagementApp/Views/Pages/CustomersPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/CustomersPage.xaml.cs
@@ -31,11 +31,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void CustomerRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            if (sender is DataGridRow row && !row.IsSelected)
-            {
-                row.IsSelected = true;
-                row.Focus();
-            }
+            GridContextMenuSelection.SelectRow(sender, e);
         }
     }
 }

--- a/InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/DashboardPage.xaml.cs
@@ -2,7 +2,6 @@ using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media;
 using InventoryManagementApp.Models;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
@@ -117,14 +116,8 @@ namespace InventoryManagementApp.Views.Pages
 
         private void DashboardGrid_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            var row = FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject);
-            if (row == null)
-                return;
-
-            row.IsSelected = true;
-            row.Focus();
-
-            if (DataContext is not DashboardViewModel vm)
+            var row = GridContextMenuSelection.SelectRow(sender, e);
+            if (row == null || DataContext is not DashboardViewModel vm)
                 return;
 
             switch (row.Item)
@@ -149,7 +142,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private static void OpenFocusedRow(DashboardViewModel vm)
         {
-            if (Keyboard.FocusedElement is DependencyObject focusedElement && FindAncestor<System.Windows.Controls.DataGrid>(focusedElement) is System.Windows.Controls.DataGrid grid)
+            if (Keyboard.FocusedElement is DependencyObject focusedElement && GridContextMenuSelection.FindAncestor<System.Windows.Controls.DataGrid>(focusedElement) is System.Windows.Controls.DataGrid grid)
             {
                 switch (grid.Name)
                 {
@@ -172,19 +165,6 @@ namespace InventoryManagementApp.Views.Pages
             }
 
             vm.OpenItemsCommand.Execute(null);
-        }
-
-        private static T? FindAncestor<T>(DependencyObject? current) where T : DependencyObject
-        {
-            while (current != null)
-            {
-                if (current is T match)
-                    return match;
-
-                current = VisualTreeHelper.GetParent(current);
-            }
-
-            return null;
         }
     }
 }

--- a/InventoryManagementApp/Views/Pages/GridContextMenuSelection.cs
+++ b/InventoryManagementApp/Views/Pages/GridContextMenuSelection.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace InventoryManagementApp.Views.Pages
+{
+    internal static class GridContextMenuSelection
+    {
+        public static DataGridRow? SelectRow(object sender, MouseButtonEventArgs e)
+        {
+            var row = sender as DataGridRow ?? FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject);
+            if (row == null)
+                return null;
+
+            row.IsSelected = true;
+            row.Focus();
+
+            if (FindAncestor<DataGrid>(row) is DataGrid grid)
+                grid.SelectedItem = row.Item;
+
+            return row;
+        }
+
+        public static T? FindAncestor<T>(DependencyObject? current) where T : DependencyObject
+        {
+            while (current != null)
+            {
+                if (current is T match)
+                    return match;
+
+                current = GetParent(current);
+            }
+
+            return null;
+        }
+
+        private static DependencyObject? GetParent(DependencyObject current)
+        {
+            try
+            {
+                return VisualTreeHelper.GetParent(current)
+                    ?? LogicalTreeHelper.GetParent(current);
+            }
+            catch (InvalidOperationException)
+            {
+                return LogicalTreeHelper.GetParent(current);
+            }
+        }
+    }
+}

--- a/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ItemSearchPage.xaml.cs
@@ -88,12 +88,10 @@ namespace InventoryManagementApp.Views.Pages
             if (sender is not WpfDataGrid grid)
                 return;
 
-            var row = FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject);
+            var row = GridContextMenuSelection.SelectRow(sender, e);
             if (row?.Item is not ItemModel item)
                 return;
 
-            row.IsSelected = true;
-            row.Focus();
             grid.SelectedItem = item;
 
             if (DataContext is ItemManagementViewModel vm)
@@ -137,32 +135,6 @@ namespace InventoryManagementApp.Views.Pages
             {
                 UiActionGuard.Run(this, "Item Search", () => OpenSelectedItemDetails(vm));
                 e.Handled = true;
-            }
-        }
-
-        private static T? FindAncestor<T>(DependencyObject? current) where T : DependencyObject
-        {
-            while (current != null)
-            {
-                if (current is T match)
-                    return match;
-
-                current = GetParent(current);
-            }
-
-            return null;
-        }
-
-        private static DependencyObject? GetParent(DependencyObject current)
-        {
-            try
-            {
-                return System.Windows.Media.VisualTreeHelper.GetParent(current)
-                    ?? LogicalTreeHelper.GetParent(current);
-            }
-            catch (InvalidOperationException)
-            {
-                return LogicalTreeHelper.GetParent(current);
             }
         }
 

--- a/InventoryManagementApp/Views/Pages/KitManagementPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/KitManagementPage.xaml.cs
@@ -1,7 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media;
 using InventoryManagementApp.ViewModels;
 
 namespace InventoryManagementApp.Views.Pages
@@ -70,25 +69,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void DataGridRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            if (sender is DataGridRow row)
-            {
-                row.IsSelected = true;
-                var dataGrid = FindParent<System.Windows.Controls.DataGrid>(row);
-                if (dataGrid != null)
-                    dataGrid.SelectedItem = row.Item;
-            }
-        }
-
-        private static T? FindParent<T>(DependencyObject child) where T : DependencyObject
-        {
-            var parent = VisualTreeHelper.GetParent(child);
-            while (parent != null)
-            {
-                if (parent is T typedParent)
-                    return typedParent;
-                parent = VisualTreeHelper.GetParent(parent);
-            }
-            return null;
+            GridContextMenuSelection.SelectRow(sender, e);
         }
     }
 }

--- a/InventoryManagementApp/Views/Pages/MaintenancePage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/MaintenancePage.xaml.cs
@@ -31,11 +31,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void MaintenanceRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            if (sender is DataGridRow row && !row.IsSelected)
-            {
-                row.IsSelected = true;
-                e.Handled = true;
-            }
+            GridContextMenuSelection.SelectRow(sender, e);
         }
     }
 }

--- a/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageItemsPage.xaml.cs
@@ -26,11 +26,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void DataGridRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            if (sender is DataGridRow row && !row.IsSelected)
-            {
-                row.IsSelected = true;
-                e.Handled = true;
-            }
+            GridContextMenuSelection.SelectRow(sender, e);
         }
 
         private void DataGridRow_Loaded(object sender, RoutedEventArgs e)

--- a/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ManageRentalsPage.xaml.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media;
 using InventoryManagementApp.Models.Domain;
 using InventoryManagementApp.ViewModels;
 namespace InventoryManagementApp.Views.Pages
@@ -144,7 +142,7 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Rentals", () =>
             {
-                if (Keyboard.FocusedElement is DependencyObject focusedElement && FindAncestor<System.Windows.Controls.DataGrid>(focusedElement) is System.Windows.Controls.DataGrid grid)
+                if (Keyboard.FocusedElement is DependencyObject focusedElement && GridContextMenuSelection.FindAncestor<System.Windows.Controls.DataGrid>(focusedElement) is System.Windows.Controls.DataGrid grid)
                 {
                     if (grid.SelectedItem is Reservation && vm.OpenRequestDetailsCommand.CanExecute(null))
                     {
@@ -162,12 +160,9 @@ namespace InventoryManagementApp.Views.Pages
 
         private void SelectRowForContextMenu(object sender, MouseButtonEventArgs e)
         {
-            var row = sender as DataGridRow ?? FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject);
+            var row = GridContextMenuSelection.SelectRow(sender, e);
             if (row == null)
                 return;
-
-            row.IsSelected = true;
-            row.Focus();
 
             if (DataContext is ManageRentalsViewModel vm)
             {
@@ -175,32 +170,6 @@ namespace InventoryManagementApp.Views.Pages
                     vm.SelectedRental = rental;
                 else if (row.Item is Reservation request)
                     vm.SelectedRequest = request;
-            }
-        }
-
-        private static T? FindAncestor<T>(DependencyObject? current) where T : DependencyObject
-        {
-            while (current != null)
-            {
-                if (current is T match)
-                    return match;
-
-                current = GetParent(current);
-            }
-
-            return null;
-        }
-
-        private static DependencyObject? GetParent(DependencyObject current)
-        {
-            try
-            {
-                return VisualTreeHelper.GetParent(current)
-                    ?? LogicalTreeHelper.GetParent(current);
-            }
-            catch (InvalidOperationException)
-            {
-                return LogicalTreeHelper.GetParent(current);
             }
         }
     }

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
 using System.Windows.Documents;
 using System.Windows.Input;
 using InventoryManagementApp.ViewModels;
@@ -31,9 +30,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void ReportGrid_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            var row = FindParent<DataGridRow>(e.OriginalSource as DependencyObject);
-            if (row != null && !row.IsSelected)
-                row.IsSelected = true;
+            GridContextMenuSelection.SelectRow(sender, e);
         }
 
         private void CopySelectedRow_Click(object sender, RoutedEventArgs e)
@@ -194,20 +191,6 @@ namespace InventoryManagementApp.Views.Pages
                 BorderThickness = new Thickness(0, 0, 0, 0.5),
                 Padding = new Thickness(3, 2, 3, 2)
             });
-        }
-
-        private static T? FindParent<T>(DependencyObject? child) where T : DependencyObject
-        {
-            while (child != null)
-            {
-                if (child is T parent)
-                    return parent;
-                child = child is Popup popup
-                    ? popup.PlacementTarget
-                    : System.Windows.Media.VisualTreeHelper.GetParent(child);
-            }
-
-            return null;
         }
     }
 }

--- a/InventoryManagementApp/Views/Pages/ReservationPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReservationPage.xaml.cs
@@ -37,7 +37,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void ReservationRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            SelectRowForContextMenu(sender, e);
+            GridContextMenuSelection.SelectRow(sender, e);
         }
 
         private void ReservationPage_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
@@ -125,32 +125,9 @@ namespace InventoryManagementApp.Views.Pages
             searchBox.SelectAll();
         }
 
-        private void SelectRowForContextMenu(object sender, MouseButtonEventArgs e)
-        {
-            var row = sender as DataGridRow ?? FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject);
-            if (row == null)
-                return;
-
-            row.IsSelected = true;
-            row.Focus();
-        }
-
         private static bool IsTextInputFocused()
         {
             return Keyboard.FocusedElement is TextBoxBase or PasswordBox;
-        }
-
-        private static T? FindAncestor<T>(DependencyObject? current) where T : DependencyObject
-        {
-            while (current != null)
-            {
-                if (current is T match)
-                    return match;
-
-                current = VisualTreeHelper.GetParent(current);
-            }
-
-            return null;
         }
 
         private static T? FindDescendant<T>(DependencyObject current) where T : DependencyObject


### PR DESCRIPTION
## Summary

- Add a shared `GridContextMenuSelection` helper that selects/focuses grid rows through guarded visual/logical WPF tree traversal.
- Route item, rental, dashboard, reservation, kit, category, report, customer, maintenance, and calibration grid right-click handlers through the shared helper.
- Preserve selected-item synchronization for context-menu actions while avoiding direct `VisualTreeHelper.GetParent` parent-walk crash paths.
- Add source-contract coverage for the helper, updated item/rental tests, and a progress note.

## Validation

- GitHub connector compare confirmed a focused 16-file diff against current `master`, with the branch 16 commits ahead and 0 behind.
- Read back the new shared helper, broader contract tests, and updated dashboard handler through the GitHub connector.
- GitHub reports no attached status checks or workflow runs for branch head `f9a09cb980b061ece7cd30c2c53dd3685b5e58da`.
- Not run locally: `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, banned-word checks, or a full function check because direct clone/raw access is blocked by `CONNECT tunnel failed, response 403`, this Linux scheduled container does not have the .NET SDK installed, and the Windows WPF UI cannot run here.