### PR TITLE
[codex] Harden grid right-click parent traversal

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
@@ -43,10 +43,27 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("GridContextMenuSelection.FindAncestor<System.Windows.Controls.DataGrid>(focusedElement)", source, StringComparison.Ordinal);
             Assert.DoesNotContain("VisualTreeHelper.GetParent", source, StringComparison.Ordinal);
             Assert.DoesNotContain("private static DependencyObject? GetParent", source, StringComparison.Ordinal);
-            Assert.Contains("return VisualTreeHelper.GetParent(current)", helper, StringComparison.Ordinal);
-            Assert.Contains("?? LogicalTreeHelper.GetParent(current);", helper, StringComparison.Ordinal);
-            Assert.Contains("catch (InvalidOperationException)", helper, StringComparison.Ordinal);
-            Assert.Contains("return LogicalTreeHelper.GetParent(current);", helper, StringComparison.Ordinal);
+            Assert.Contains("return TryGetVisualParent(current)", helper, StringComparison.Ordinal);
+            Assert.Contains("?? TryGetLogicalParent(current)", helper, StringComparison.Ordinal);
+            Assert.Contains("?? TryGetFrameworkParent(current);", helper, StringComparison.Ordinal);
+            Assert.Equal(2, CountOccurrences(helper, "catch (InvalidOperationException)"));
+            Assert.Contains("FrameworkElement element => element.Parent", helper, StringComparison.Ordinal);
+            Assert.Contains("FrameworkContentElement contentElement => contentElement.Parent", helper, StringComparison.Ordinal);
+            Assert.DoesNotContain("return LogicalTreeHelper.GetParent(current);", helper, StringComparison.Ordinal);
+        }
+
+        private static int CountOccurrences(string source, string value)
+        {
+            var count = 0;
+            var index = 0;
+
+            while ((index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += value.Length;
+            }
+
+            return count;
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp.Tests/Views/GridContextMenuSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/Views/GridContextMenuSelectionContractTests.cs
@@ -8,7 +8,7 @@ namespace InventoryManagementApp.Tests.Views
     public class GridContextMenuSelectionContractTests
     {
         [Fact]
-        public void SharedGridContextMenuSelectionUsesGuardedVisualAndLogicalTraversal()
+        public void SharedGridContextMenuSelectionUsesNonThrowingVisualLogicalAndFrameworkTraversal()
         {
             var helper = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "GridContextMenuSelection.cs");
 
@@ -16,10 +16,15 @@ namespace InventoryManagementApp.Tests.Views
             Assert.Contains("public static DataGridRow? SelectRow(object sender, MouseButtonEventArgs e)", helper, StringComparison.Ordinal);
             Assert.Contains("sender as DataGridRow ?? FindAncestor<DataGridRow>(e.OriginalSource as DependencyObject)", helper, StringComparison.Ordinal);
             Assert.Contains("FindAncestor<DataGrid>(row)", helper, StringComparison.Ordinal);
-            Assert.Contains("return VisualTreeHelper.GetParent(current)", helper, StringComparison.Ordinal);
-            Assert.Contains("?? LogicalTreeHelper.GetParent(current);", helper, StringComparison.Ordinal);
-            Assert.Contains("catch (InvalidOperationException)", helper, StringComparison.Ordinal);
-            Assert.Contains("return LogicalTreeHelper.GetParent(current);", helper, StringComparison.Ordinal);
+            Assert.Contains("return TryGetVisualParent(current)", helper, StringComparison.Ordinal);
+            Assert.Contains("?? TryGetLogicalParent(current)", helper, StringComparison.Ordinal);
+            Assert.Contains("?? TryGetFrameworkParent(current);", helper, StringComparison.Ordinal);
+            Assert.Contains("private static DependencyObject? TryGetVisualParent(DependencyObject current)", helper, StringComparison.Ordinal);
+            Assert.Contains("private static DependencyObject? TryGetLogicalParent(DependencyObject current)", helper, StringComparison.Ordinal);
+            Assert.Equal(2, CountOccurrences(helper, "catch (InvalidOperationException)"));
+            Assert.Contains("FrameworkElement element => element.Parent", helper, StringComparison.Ordinal);
+            Assert.Contains("FrameworkContentElement contentElement => contentElement.Parent", helper, StringComparison.Ordinal);
+            Assert.DoesNotContain("return LogicalTreeHelper.GetParent(current);", helper, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -65,6 +70,20 @@ namespace InventoryManagementApp.Tests.Views
                 foreach (var removedPattern in entry.Value)
                     Assert.DoesNotContain(removedPattern, source, StringComparison.Ordinal);
             }
+        }
+
+        private static int CountOccurrences(string source, string value)
+        {
+            var count = 0;
+            var index = 0;
+
+            while ((index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += value.Length;
+            }
+
+            return count;
         }
 
         private static string ReadRepositoryFile(params string[] relativePath)

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-grid-context-parent-lookup-hardening.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-grid-context-parent-lookup-hardening.md
@@ -1,0 +1,11 @@
+# Grid Context Parent Lookup Hardening - 2026-06-21
+
+## Completed
+
+- Hardened the shared grid context-menu selection helper so parent traversal is fully non-throwing when WPF supplies an unusual right-click hit-test source.
+- Split visual, logical, and framework parent fallback lookups into guarded helpers so a failing logical lookup cannot close the app while opening a grid context menu.
+- Updated source-contract coverage to require the non-throwing visual/logical/framework traversal path.
+
+## Validation
+
+- GitHub connector readback/compare should be used for this scheduled run because the container has no local checkout, no .NET SDK, and cannot run the Windows WPF UI.

--- a/InventoryManagementApp/Views/Pages/GridContextMenuSelection.cs
+++ b/InventoryManagementApp/Views/Pages/GridContextMenuSelection.cs
@@ -38,15 +38,43 @@ namespace InventoryManagementApp.Views.Pages
 
         private static DependencyObject? GetParent(DependencyObject current)
         {
+            return TryGetVisualParent(current)
+                ?? TryGetLogicalParent(current)
+                ?? TryGetFrameworkParent(current);
+        }
+
+        private static DependencyObject? TryGetVisualParent(DependencyObject current)
+        {
             try
             {
-                return VisualTreeHelper.GetParent(current)
-                    ?? LogicalTreeHelper.GetParent(current);
+                return VisualTreeHelper.GetParent(current);
             }
             catch (InvalidOperationException)
             {
+                return null;
+            }
+        }
+
+        private static DependencyObject? TryGetLogicalParent(DependencyObject current)
+        {
+            try
+            {
                 return LogicalTreeHelper.GetParent(current);
             }
+            catch (InvalidOperationException)
+            {
+                return null;
+            }
+        }
+
+        private static DependencyObject? TryGetFrameworkParent(DependencyObject current)
+        {
+            return current switch
+            {
+                FrameworkElement element => element.Parent,
+                FrameworkContentElement contentElement => contentElement.Parent,
+                _ => null
+            };
         }
     }
 }


### PR DESCRIPTION
## Summary

- Make `GridContextMenuSelection` parent traversal fully non-throwing when WPF supplies unusual right-click hit-test sources.
- Split visual, logical, and framework parent fallback lookup so a failing logical lookup cannot close the app while opening a grid context menu.
- Update shared and rental-specific source-contract tests to require the guarded visual/logical/framework traversal path.
- Add a focused progress note for the crash hardening pass.

## Validation

- GitHub connector compare confirmed a focused 4-file diff against current `master`, with the branch 4 commits ahead and 0 behind.
- Read back the updated shared helper and both contract test files through the GitHub connector.
- GitHub reports no attached status checks or workflow runs for branch head `ec5512bbf021634668219dd7f376b9ba63a59976`.
- Not run locally: `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, or a full runtime function check because there is no local repository checkout in this scheduled container, direct clone/raw access has repeatedly been blocked by `CONNECT tunnel failed, response 403`, this Linux container does not have the .NET SDK installed, and the Windows WPF UI cannot run here.