### PR TITLE
[codex] Show item workflow failure feedback

### DIFF
--- a/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
@@ -30,10 +30,30 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("private Task ReloadItemsAfterCheckoutAsync(int itemId, CancellationToken cancellationToken)", source, StringComparison.Ordinal);
             Assert.Equal(2, CountOccurrences(source, "return ReloadItemsAfterItemWorkflowAsync(itemId, cancellationToken);"));
             Assert.Contains("var result = await _itemService.ToggleItemCheckOutStatusAsync(item.ItemID, cancellationToken).ConfigureAwait(false);", source, StringComparison.Ordinal);
-            Assert.Contains("if (!result) return;", source, StringComparison.Ordinal);
             Assert.Contains("await ReloadItemsAfterCheckoutAsync(item.ItemID, cancellationToken);", source, StringComparison.Ordinal);
             Assert.DoesNotContain("var refreshed = await _itemService.GetItemByIDAsync(item.ItemID, cancellationToken).ConfigureAwait(false);", source, StringComparison.Ordinal);
             Assert.Contains("?? CheckedOutItems.FirstOrDefault(t => t.ItemID == itemId)", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ItemCheckoutToggleFailureRefreshesAndExplainsTheConflict()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemManagementViewModel.cs");
+
+            Assert.Contains("if (!result)", source, StringComparison.Ordinal);
+            Assert.Contains("await ReloadItemsAfterCheckoutAsync(item.ItemID, cancellationToken);", source, StringComparison.Ordinal);
+            Assert.Contains("Check-out status could not be updated. The item may have been changed by another user; the list has been refreshed.", source, StringComparison.Ordinal);
+            Assert.Contains("\"Check-out Status\"", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("if (!result) return;", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RentalHistoryLoadFailureShowsOperatorFeedback()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemManagementViewModel.cs");
+
+            Assert.Contains("_logger.LogError(ex, \"Failed to open rental history for {ItemLabelSingular} {ItemID}\"", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync($\"Failed to load rental history: {ex.Message}\", \"Error\");", source, StringComparison.Ordinal);
         }
 
         private static int CountOccurrences(string source, string value)

--- a/InventoryManagementApp/ProgressNotes/2026-06-21-item-workflow-failure-feedback.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-21-item-workflow-failure-feedback.md
@@ -1,0 +1,17 @@
+# Item Workflow Failure Feedback Hardening - 2026-06-21
+
+## Completed
+
+- Added visible operator feedback when `ToggleItemCheckOutStatusAsync` returns `false` instead of silently doing nothing.
+- Refreshes the item lists after that failed toggle response so stale checkout state is not left on screen.
+- Added visible error feedback when rental-history loading fails from the item workflow; the failure was previously only logged.
+- Extended `ItemRentalWorkflowContractTests` so the checkout conflict message, refresh path, and rental-history failure message stay covered.
+
+## Validation
+
+- GitHub connector readback/compare should be used for this pass because direct local clone/raw access remains blocked in the scheduled Linux container.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime function checks were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime.
+
+## Follow-up
+
+- Continue broader item/rental service-level validation around rent, return/check-in, extend, request, and checkout paths, especially conflict/permission/error messages that should refresh or disable stale UI state.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-21 11:11 NZST
+Last audit date/time: 2026-06-22 01:11 NZST
 
 ## Completed workflows
 
@@ -9,6 +9,7 @@ Last audit date/time: 2026-06-21 11:11 NZST
 - Reservation editor supports item lookup inside the popup so advisors/admins can search inventory and apply item details without leaving the workflow.
 - Reports ViewModel now keeps `ReportResults` as a compatibility alias for `ReportLines`, protecting older tests/bindings while the reports page uses the newer dense report grid.
 - Item edit saves now clone all operational fields, show clear validation/database failure messages, and keep the selected row stable when a save fails.
+- Item checkout conflict and rental-history load failures now give visible operator feedback instead of silently returning or only logging, and checkout conflict handling refreshes the item lists before returning control to the desk.
 - Settings now opens with an admin service status panel that summarizes database, email, messaging, backup, branding, and workstation security state with the relevant action buttons available from the same view.
 - Settings Database, Branding, and Backups tabs now have stronger admin polish: connection-readiness guidance, a larger brand/logo identity preview, and a recovery-focused backup destination layout while preserving the existing commands and bindings.
 - QA screenshot capture now has a repository script and latest screenshot set covering login, overview/search, operational pages, reports/activity, import/export, users, settings, and print-label dialog surfaces; the script fails if the expected PNG count is not produced.
@@ -73,10 +74,10 @@ Last audit date/time: 2026-06-21 11:11 NZST
 
 ## Next recommended target
 
-- Continue targeted Admin Settings theme coverage and runtime Windows screenshot review, especially extreme transparent, borderless, and high-shadow profiles. Run the enhanced Windows QA screenshot capture when a Windows/.NET workstation is available.
+- Continue broader item/rental service-level validation around rent, return/check-in, extend, request, and checkout paths, especially conflict, permission, and stale-state messages that should refresh or disable UI state safely. Use Admin Settings theme work only when current evidence shows a concrete remaining gap or regression.
 
 ## Validation status
 
-- GitHub connector readback reviewed the theme override XAML, App resource load order, contract tests, progress note, and this checklist update.
-- Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
+- GitHub connector readback/compare should review the item workflow feedback changes, source-contract tests, progress note, and this checklist update.
+- Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime function checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
 - Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -449,6 +449,7 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to open rental history for {ItemLabelSingular} {ItemID}", LabelProvider.Instance.ItemLabelSingular, item.ItemID);
+                await _dialogService.ShowInfoAsync($"Failed to load rental history: {ex.Message}", "Error");
             }
         }
 
@@ -578,7 +579,12 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 var result = await _itemService.ToggleItemCheckOutStatusAsync(item.ItemID, cancellationToken).ConfigureAwait(false);
-                if (!result) return;
+                if (!result)
+                {
+                    await ReloadItemsAfterCheckoutAsync(item.ItemID, cancellationToken);
+                    await _dialogService.ShowInfoAsync("Check-out status could not be updated. The item may have been changed by another user; the list has been refreshed.", "Check-out Status");
+                    return;
+                }
 
                 await ReloadItemsAfterCheckoutAsync(item.ItemID, cancellationToken);
             }


### PR DESCRIPTION
## Summary

- Show visible operator feedback when item check-out status updates return `false` instead of silently doing nothing.
- Refresh item lists after that failed check-out toggle response so stale checkout state is not left on screen.
- Show visible feedback when rental-history loading fails from the item workflow; it was previously only logged.
- Extend `ItemRentalWorkflowContractTests` and update progress notes/checklist to keep future runs focused on workflow validation instead of speculative theme expansion.

## Validation

- GitHub connector compare confirmed a focused 4-file diff against current `master`, with the branch 4 commits ahead and 0 behind.
- Read back the changed `ItemManagementViewModel`, updated `ItemRentalWorkflowContractTests`, progress note, and completion checklist through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime function checks were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime.