### PR TITLE
[codex] Refresh rental requests on conflict responses

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
@@ -40,7 +40,7 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("var updated = await _reservationService.ConfirmReservationAsync(requestId);", source, StringComparison.Ordinal);
             Assert.Contains("var updated = await _reservationService.CancelReservationAsync(request.ReservationID);", source, StringComparison.Ordinal);
-            Assert.Equal(4, CountOccurrences(source, "await LoadPendingRequestsAsync();"));
+            Assert.Equal(5, CountOccurrences(source, "await LoadPendingRequestsAsync();"));
             Assert.Contains("The selected request could not be confirmed. It may have been removed or changed by another user. The open request queue has been refreshed.", source, StringComparison.Ordinal);
             Assert.Contains("The selected request could not be cancelled. It may have been removed or changed by another user. The open request queue has been refreshed.", source, StringComparison.Ordinal);
         }

--- a/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
@@ -34,6 +34,18 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void RequestConflictResponsesRefreshOpenRequestQueue()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ManageRentalsViewModel.cs");
+
+            Assert.Contains("var updated = await _reservationService.ConfirmReservationAsync(requestId);", source, StringComparison.Ordinal);
+            Assert.Contains("var updated = await _reservationService.CancelReservationAsync(request.ReservationID);", source, StringComparison.Ordinal);
+            Assert.Equal(4, CountOccurrences(source, "await LoadPendingRequestsAsync();"));
+            Assert.Contains("The selected request could not be confirmed. It may have been removed or changed by another user. The open request queue has been refreshed.", source, StringComparison.Ordinal);
+            Assert.Contains("The selected request could not be cancelled. It may have been removed or changed by another user. The open request queue has been refreshed.", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void RentalGridRightClickSelectionUsesSharedSafeTreeTraversal()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-rental-request-conflict-refresh.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-rental-request-conflict-refresh.md
@@ -1,0 +1,17 @@
+# Rental Request Conflict Refresh Hardening - 2026-06-22
+
+## Completed
+
+- Confirming an open rental request now refreshes the open request queue when the reservation service reports that no record was updated.
+- Cancelling an open rental request now refreshes the open request queue when the reservation service reports that no record was updated.
+- Conflict messages now tell the operator that the open request queue has been refreshed, reducing stale queue/action risk after another user changes or removes the request.
+- Extended `ManageRentalsSelectionContractTests` so confirm/cancel conflict paths keep the refresh behavior and updated operator messages.
+
+## Validation
+
+- GitHub connector readback/compare should be used for this pass because direct local clone/raw access remains blocked in the scheduled Linux container.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime function checks were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime.
+
+## Follow-up
+
+- Continue broader rental/request workflow validation around check-in, extend, delete, request placement, and reservation load failures where stale selections or silent failures could leave the desk with unsafe actions enabled.

--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -561,7 +561,8 @@ namespace InventoryManagementApp.ViewModels
                 var updated = await _reservationService.ConfirmReservationAsync(requestId);
                 if (!updated)
                 {
-                    await _dialogService.ShowInfoAsync("The selected request could not be confirmed. It may have been removed or changed by another user.", "Confirm Request");
+                    await LoadPendingRequestsAsync();
+                    await _dialogService.ShowInfoAsync("The selected request could not be confirmed. It may have been removed or changed by another user. The open request queue has been refreshed.", "Confirm Request");
                     return;
                 }
 
@@ -595,7 +596,8 @@ namespace InventoryManagementApp.ViewModels
                 var updated = await _reservationService.CancelReservationAsync(request.ReservationID);
                 if (!updated)
                 {
-                    await _dialogService.ShowInfoAsync("The selected request could not be cancelled. It may have been removed or changed by another user.", "Cancel Request");
+                    await LoadPendingRequestsAsync();
+                    await _dialogService.ShowInfoAsync("The selected request could not be cancelled. It may have been removed or changed by another user. The open request queue has been refreshed.", "Cancel Request");
                     return;
                 }
 


### PR DESCRIPTION
## Summary

- Refresh the rentals open-request queue when confirm/cancel reservation updates return `false` so stale request rows are not left in place after another user changes or removes a request.
- Update the confirm/cancel conflict messages to tell operators the open request queue has been refreshed.
- Extend `ManageRentalsSelectionContractTests` and add a focused progress note for the rental request conflict-refresh pass.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 4 commits ahead and 0 behind.
- Read back the updated `ManageRentalsViewModel`, updated `ManageRentalsSelectionContractTests`, and new progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime function checks were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime.