### PR TITLE
[codex] Refresh rental desk after operation failures

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
@@ -40,7 +40,7 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("var updated = await _reservationService.ConfirmReservationAsync(requestId);", source, StringComparison.Ordinal);
             Assert.Contains("var updated = await _reservationService.CancelReservationAsync(request.ReservationID);", source, StringComparison.Ordinal);
-            Assert.Equal(5, CountOccurrences(source, "await LoadPendingRequestsAsync();"));
+            Assert.Equal(6, CountOccurrences(source, "await LoadPendingRequestsAsync();"));
             Assert.Contains("The selected request could not be confirmed. It may have been removed or changed by another user. The open request queue has been refreshed.", source, StringComparison.Ordinal);
             Assert.Contains("The selected request could not be cancelled. It may have been removed or changed by another user. The open request queue has been refreshed.", source, StringComparison.Ordinal);
         }

--- a/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
@@ -46,6 +46,26 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void RentalOperationFailuresRefreshDeskAndExplainState()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ManageRentalsViewModel.cs");
+
+            Assert.Contains("async Task RefreshRentalDeskAfterOperationFailureAsync(int rentalId)", source, StringComparison.Ordinal);
+            Assert.Contains("_allRentals = await _rentalService.GetAllRentalsAsync();", source, StringComparison.Ordinal);
+            Assert.Contains("await LoadPendingRequestsAsync();", source, StringComparison.Ordinal);
+            Assert.Contains("RefreshActiveRentals();", source, StringComparison.Ordinal);
+            Assert.Contains("ApplyFilter(rentalId);", source, StringComparison.Ordinal);
+            Assert.Equal(3, CountOccurrences(source, "await RefreshRentalDeskAfterOperationFailureAsync("));
+            Assert.Contains("var rentalToExtend = SelectedRental;", source, StringComparison.Ordinal);
+            Assert.Contains("await _rentalService.ExtendRentalAsync(rentalToExtend.RentalID, newDueDate);", source, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogError(ex, \"Failed to extend rental {RentalID}\", rentalToExtend.RentalID);", source, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogError(ex, \"Failed to delete rental {RentalID}\", rentalToDelete.RentalID);", source, StringComparison.Ordinal);
+            Assert.Equal(3, CountOccurrences(source, "The rental desk has been refreshed so current rental actions match the latest saved state."));
+            Assert.DoesNotContain("_logger.LogError(ex, \"Failed to extend rental {RentalID}\", SelectedRental.RentalID);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("_logger.LogError(ex, \"Failed to delete rental {RentalID}\", rentalToDelete?.RentalID);", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void RentalGridRightClickSelectionUsesSharedSafeTreeTraversal()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-rental-operation-failure-refresh.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-rental-operation-failure-refresh.md
@@ -12,5 +12,5 @@ Date: 2026-06-22 03:11 NZST scheduled pass
 
 ## Validation
 
-- GitHub connector readback/compare should confirm the focused view-model, test, checklist, and progress-note changes.
+- GitHub connector readback/compare should confirm the focused view-model, test, and progress-note changes.
 - Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` is not installed; Windows/WPF runtime screenshots, local banned-word checks, and full runtime function checks are unavailable in this scheduled Linux container.

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-rental-operation-failure-refresh.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-rental-operation-failure-refresh.md
@@ -1,0 +1,16 @@
+# Rental Operation Failure Refresh
+
+Date: 2026-06-22 03:11 NZST scheduled pass
+
+## Completed
+
+- Added a shared rental-desk recovery path for failed check-in, extend, and delete operations.
+- When one of those service calls throws after another user or service changes rental state, the Rentals desk reloads rentals, reloads open requests, refreshes active-rental summaries, reapplies the current filters, and restores or clears selection from fresh rows.
+- Updated operator-facing failure messages so users know the desk was refreshed and current actions now match the latest saved state.
+- Captured the rental being extended before the async service call so error logging and refresh recovery do not depend on a possibly changed `SelectedRental` reference.
+- Added source-contract coverage in `ManageRentalsSelectionContractTests` for the recovery helper, affected operations, and refreshed-state messages.
+
+## Validation
+
+- GitHub connector readback/compare should confirm the focused view-model, test, checklist, and progress-note changes.
+- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` is not installed; Windows/WPF runtime screenshots, local banned-word checks, and full runtime function checks are unavailable in this scheduled Linux container.

--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -347,7 +347,8 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to check in rental {RentalID}", returnedRental.RentalID);
-                await _dialogService.ShowInfoAsync($"Failed to check in rental: {ex.Message}", "Error");
+                await RefreshRentalDeskAfterOperationFailureAsync(returnedRental.RentalID);
+                await _dialogService.ShowInfoAsync($"Failed to check in rental: {ex.Message} The rental desk has been refreshed so current rental actions match the latest saved state.", "Error");
             }
             finally
             {
@@ -378,11 +379,13 @@ namespace InventoryManagementApp.ViewModels
         {
             if (SelectedRental == null)
                 return;
+
+            var rentalToExtend = SelectedRental;
             try
             {
                 IsLoading = true;
-                var newDueDate = SelectedRental.DueDate.AddDays(7);
-                await _rentalService.ExtendRentalAsync(SelectedRental.RentalID, newDueDate);
+                var newDueDate = rentalToExtend.DueDate.AddDays(7);
+                await _rentalService.ExtendRentalAsync(rentalToExtend.RentalID, newDueDate);
                 await LoadRentalsAsync();
             }
             catch (UnauthorizedAccessException)
@@ -391,12 +394,28 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to extend rental {RentalID}", SelectedRental.RentalID);
-                await _dialogService.ShowInfoAsync($"Failed to extend rental: {ex.Message}", "Error");
+                _logger.LogError(ex, "Failed to extend rental {RentalID}", rentalToExtend.RentalID);
+                await RefreshRentalDeskAfterOperationFailureAsync(rentalToExtend.RentalID);
+                await _dialogService.ShowInfoAsync($"Failed to extend rental: {ex.Message} The rental desk has been refreshed so current rental actions match the latest saved state.", "Error");
             }
             finally
             {
                 IsLoading = false;
+            }
+        }
+
+        async Task RefreshRentalDeskAfterOperationFailureAsync(int rentalId)
+        {
+            try
+            {
+                _allRentals = await _rentalService.GetAllRentalsAsync();
+                await LoadPendingRequestsAsync();
+                RefreshActiveRentals();
+                ApplyFilter(rentalId);
+            }
+            catch (Exception refreshEx)
+            {
+                _logger.LogError(refreshEx, "Failed to refresh rentals after operation failure for rental {RentalID}", rentalId);
             }
         }
 
@@ -891,8 +910,9 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to delete rental {RentalID}", rentalToDelete?.RentalID);
-                await _dialogService.ShowInfoAsync($"Failed to delete rental: {ex.Message}", "Error");
+                _logger.LogError(ex, "Failed to delete rental {RentalID}", rentalToDelete.RentalID);
+                await RefreshRentalDeskAfterOperationFailureAsync(rentalToDelete.RentalID);
+                await _dialogService.ShowInfoAsync($"Failed to delete rental: {ex.Message} The rental desk has been refreshed so current rental actions match the latest saved state.", "Error");
             }
             finally
             {


### PR DESCRIPTION
## Summary

- Refresh the Rentals desk from saved state after check-in, extend, or delete service failures so stale rows and commands do not remain active after concurrent changes.
- Preserve the affected rental ID through async operations, reapply the current filters, and restore or clear selection from freshly loaded rows.
- Add source-contract coverage for the failure-refresh helper and updated operator messages.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 5 commits ahead and 0 behind.
- Read back the updated `ManageRentalsViewModel`, `ManageRentalsSelectionContractTests`, and progress note through the GitHub connector.
- Not run locally: direct clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` is not installed; WPF screenshots, local banned-word checks, local test execution, and full runtime function checks are unavailable in this scheduled Linux container.