### PR TITLE
[codex] Refresh rental requests after load failures

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
@@ -46,6 +46,19 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void RequestPlacementAndQueueLoadFailuresRefreshAndExplainState()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ManageRentalsViewModel.cs");
+
+            Assert.Contains("await LoadPendingRequestsAsync(notifyOnFailure: true);", source, StringComparison.Ordinal);
+            Assert.Contains("async Task LoadPendingRequestsAsync(bool notifyOnFailure = false)", source, StringComparison.Ordinal);
+            Assert.Contains("PendingRequests.Clear();\n                SelectedRequest = null;", source, StringComparison.Ordinal);
+            Assert.Contains("if (notifyOnFailure)", source, StringComparison.Ordinal);
+            Assert.Contains("Failed to load open requests: {ex.Message} The open request queue has been cleared until it can be refreshed.", source, StringComparison.Ordinal);
+            Assert.Contains("await LoadPendingRequestsAsync();\n                await _dialogService.ShowInfoAsync($\"Failed to place request: {ex.Message} The open request queue has been refreshed in case the request was saved before the failure.\", \"Error\");", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void RentalOperationFailuresRefreshDeskAndExplainState()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ManageRentalsViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-rental-request-load-failure-refresh.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-rental-request-load-failure-refresh.md
@@ -1,0 +1,13 @@
+# Rental Request Load Failure Refresh - 2026-06-22
+
+## Completed
+
+- Made the Rentals desk show an operator-facing message when the open request queue fails during a full desk load.
+- Cleared stale selected request state when reservation loading fails so request actions do not remain enabled against unavailable queue data.
+- Refreshed the open request queue after request placement failures in case reservation persistence succeeded before a later readback or UI handoff failed.
+- Added source-contract coverage for the request placement failure refresh, queue-load failure notification, and selected-request clearing behavior.
+
+## Validation
+
+- GitHub connector readback/compare should confirm the focused `ManageRentalsViewModel`, `ManageRentalsSelectionContractTests`, and progress-note changes.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`, `dotnet` is unavailable in this scheduled Linux container, and WPF cannot run here.

--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -227,7 +227,7 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 _allRentals = await _rentalService.GetAllRentalsAsync();
-                await LoadPendingRequestsAsync();
+                await LoadPendingRequestsAsync(notifyOnFailure: true);
                 RefreshActiveRentals();
                 ApplyFilter(selectedRentalId);
             }
@@ -242,7 +242,7 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        async Task LoadPendingRequestsAsync()
+        async Task LoadPendingRequestsAsync(bool notifyOnFailure = false)
         {
             if (_reservationService == null)
             {
@@ -263,6 +263,9 @@ namespace InventoryManagementApp.ViewModels
             {
                 _logger.LogError(ex, "Failed to load open reservations for rentals page");
                 PendingRequests.Clear();
+                SelectedRequest = null;
+                if (notifyOnFailure)
+                    await _dialogService.ShowInfoAsync($"Failed to load open requests: {ex.Message} The open request queue has been cleared until it can be refreshed.", "Open Requests");
             }
             finally
             {
@@ -525,7 +528,8 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to place request for rental {RentalID}", rental.RentalID);
-                await _dialogService.ShowInfoAsync($"Failed to place request: {ex.Message}", "Error");
+                await LoadPendingRequestsAsync();
+                await _dialogService.ShowInfoAsync($"Failed to place request: {ex.Message} The open request queue has been refreshed in case the request was saved before the failure.", "Error");
             }
         }
 


### PR DESCRIPTION
## Summary

- Show visible operator feedback when the Rentals open-request queue fails during a full desk load.
- Clear stale selected request state when reservation loading fails so request commands do not remain enabled against unavailable queue data.
- Refresh the open-request queue after request placement failures in case persistence succeeded before a later readback or UI handoff failed.
- Add source-contract coverage for queue-load failure messaging, selected-request clearing, and request-placement failure refresh behavior.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back the updated `ManageRentalsViewModel`, updated `ManageRentalsSelectionContractTests`, and new progress note through the GitHub connector.
- GitHub reports no attached status checks for branch head `2fc763a0befe06bf1232154c676dcebc1ac668b3`.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime function checks were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime.