### PR TITLE
[codex] Refresh rental requests after status exceptions

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
@@ -34,15 +34,17 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void RequestConflictResponsesRefreshOpenRequestQueue()
+        public void RequestStatusUpdatesRefreshOpenRequestQueue()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ManageRentalsViewModel.cs");
 
             Assert.Contains("var updated = await _reservationService.ConfirmReservationAsync(requestId);", source, StringComparison.Ordinal);
             Assert.Contains("var updated = await _reservationService.CancelReservationAsync(request.ReservationID);", source, StringComparison.Ordinal);
-            Assert.Equal(6, CountOccurrences(source, "await LoadPendingRequestsAsync();"));
+            Assert.Equal(8, CountOccurrences(source, "await LoadPendingRequestsAsync();"));
             Assert.Contains("The selected request could not be confirmed. It may have been removed or changed by another user. The open request queue has been refreshed.", source, StringComparison.Ordinal);
             Assert.Contains("The selected request could not be cancelled. It may have been removed or changed by another user. The open request queue has been refreshed.", source, StringComparison.Ordinal);
+            Assert.Contains("await LoadPendingRequestsAsync();\n                await _dialogService.ShowInfoAsync($\"Failed to confirm request: {ex.Message} The open request queue has been refreshed in case the request status changed before the failure.\", \"Error\");", source, StringComparison.Ordinal);
+            Assert.Contains("await LoadPendingRequestsAsync();\n                await _dialogService.ShowInfoAsync($\"Failed to cancel request: {ex.Message} The open request queue has been refreshed in case the request status changed before the failure.\", \"Error\");", source, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-rental-request-status-exception-refresh.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-rental-request-status-exception-refresh.md
@@ -1,0 +1,13 @@
+# Rental Request Status Exception Refresh - 2026-06-22
+
+## Completed
+
+- Refreshed the Rentals open request queue after confirm-request exceptions so operators do not keep acting on stale request rows if status persistence succeeded before a later failure.
+- Refreshed the open request queue after cancel-request exceptions for the same concurrent-change/readback failure path.
+- Updated operator-facing error messages to say the request queue has been refreshed after those status update failures.
+- Extended source-contract coverage for request status update refresh behavior across conflict and exception paths.
+
+## Validation
+
+- GitHub connector readback/compare should confirm the focused `ManageRentalsViewModel`, `ManageRentalsSelectionContractTests`, and progress-note changes.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`, `dotnet` is unavailable in this scheduled Linux container, and WPF cannot run here.

--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -595,7 +595,8 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to confirm request {ReservationID}", requestId);
-                await _dialogService.ShowInfoAsync($"Failed to confirm request: {ex.Message}", "Error");
+                await LoadPendingRequestsAsync();
+                await _dialogService.ShowInfoAsync($"Failed to confirm request: {ex.Message} The open request queue has been refreshed in case the request status changed before the failure.", "Error");
             }
             finally
             {
@@ -630,7 +631,8 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to cancel request {ReservationID}", request.ReservationID);
-                await _dialogService.ShowInfoAsync($"Failed to cancel request: {ex.Message}", "Error");
+                await LoadPendingRequestsAsync();
+                await _dialogService.ShowInfoAsync($"Failed to cancel request: {ex.Message} The open request queue has been refreshed in case the request status changed before the failure.", "Error");
             }
             finally
             {


### PR DESCRIPTION
## Summary

- Refresh the Rentals open-request queue after confirm-request exceptions so stale rows are not left active if persistence succeeded before a later failure.
- Refresh the same queue after cancel-request exceptions for the matching status-update failure path.
- Update operator-facing error messages to say the open request queue has been refreshed after these failures.
- Extend `ManageRentalsSelectionContractTests` to guard status update refresh behavior across conflict and exception paths.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back the updated `ManageRentalsViewModel`, `ManageRentalsSelectionContractTests`, and progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime function checks were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime.