### PR TITLE
[codex] Refresh item lists after workflow exceptions

### DIFF
--- a/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
@@ -48,6 +48,21 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ItemWorkflowExceptionsRefreshListsAndExplainPossibleSavedState()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemManagementViewModel.cs");
+
+            Assert.Contains("private async Task RefreshItemsAfterWorkflowFailureAsync(int itemId, CancellationToken cancellationToken)", source, StringComparison.Ordinal);
+            Assert.Contains("await ReloadItemsAfterItemWorkflowAsync(itemId, cancellationToken);", source, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogError(refreshEx, \"Failed to refresh items after workflow failure for item {ItemID}\", itemId);", source, StringComparison.Ordinal);
+            Assert.Equal(3, CountOccurrences(source, "await RefreshItemsAfterWorkflowFailureAsync(item.ItemID, cancellationToken);"));
+            Assert.Equal(2, CountOccurrences(source, "The item list has been refreshed in case the rental was saved before the failure."));
+            Assert.Contains("Failed to update check-out status: {ex.Message} The item list has been refreshed in case the check-out status changed before the failure.", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await _dialogService.ShowInfoAsync($\"Failed to rent {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {ex.Message}\", \"Error\");", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await _dialogService.ShowInfoAsync($\"Failed to update check-out status: {ex.Message}\", \"Error\");", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void RentalHistoryLoadFailureShowsOperatorFeedback()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemManagementViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-item-workflow-exception-refresh.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-item-workflow-exception-refresh.md
@@ -1,0 +1,14 @@
+# Item Workflow Exception Refresh - 2026-06-22
+
+## Completed
+
+- Refreshed item rows after rent workflow exceptions from both item rental entry points so stale availability is less likely when a rental save succeeds before a later failure.
+- Refreshed item rows after check-out status exceptions for the same post-persistence/readback failure path.
+- Added a guarded refresh helper so secondary refresh failures are logged without hiding the original operator-facing error.
+- Updated operator-facing error messages to say the item list was refreshed after these failures.
+- Extended source-contract coverage for the exception refresh helper, rent exception messages, and check-out exception message.
+
+## Validation
+
+- GitHub connector readback/compare should confirm the focused `ItemManagementViewModel`, `ItemRentalWorkflowContractTests`, progress-note, and checklist changes.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`, `dotnet` is unavailable in this scheduled Linux container, and WPF cannot run here.

--- a/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
+++ b/InventoryManagementApp/ProgressNotes/APP_COMPLETION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # InventoryManagementApp Completion Checklist
 
-Last audit date/time: 2026-06-22 01:11 NZST
+Last audit date/time: 2026-06-22 06:11 NZST
 
 ## Completed workflows
 
@@ -10,6 +10,7 @@ Last audit date/time: 2026-06-22 01:11 NZST
 - Reports ViewModel now keeps `ReportResults` as a compatibility alias for `ReportLines`, protecting older tests/bindings while the reports page uses the newer dense report grid.
 - Item edit saves now clone all operational fields, show clear validation/database failure messages, and keep the selected row stable when a save fails.
 - Item checkout conflict and rental-history load failures now give visible operator feedback instead of silently returning or only logging, and checkout conflict handling refreshes the item lists before returning control to the desk.
+- Item rent and check-out exception paths now refresh item rows before reporting possible post-save failures, so stale availability is less likely after service readback or UI handoff errors.
 - Settings now opens with an admin service status panel that summarizes database, email, messaging, backup, branding, and workstation security state with the relevant action buttons available from the same view.
 - Settings Database, Branding, and Backups tabs now have stronger admin polish: connection-readiness guidance, a larger brand/logo identity preview, and a recovery-focused backup destination layout while preserving the existing commands and bindings.
 - QA screenshot capture now has a repository script and latest screenshot set covering login, overview/search, operational pages, reports/activity, import/export, users, settings, and print-label dialog surfaces; the script fails if the expected PNG count is not produced.
@@ -52,7 +53,7 @@ Last audit date/time: 2026-06-22 01:11 NZST
 - Import / Export has been redesigned and wired for log actions plus permission-matched image mapping, but runtime file-dialog, print, image-mapping, and screenshot checks still need a Windows/.NET workstation.
 - Kits now have a completed desktop workflow surface, but runtime add/edit/item-membership dialog validation still needs a Windows/.NET workstation.
 - Customers now have a completed desktop workflow surface, but runtime add/edit/delete/print/copy validation still need a Windows/.NET workstation.
-- Maintenance now has a completed desktop workflow surface, but runtime add/edit/complete/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
+- Maintenance now has a completed desktop workflow surface, but runtime add/edit/complete/delete/print/copy and screenshot validation still needs a Windows/.NET workstation.
 - Calibration now has a completed desktop workflow surface, but runtime add/edit/delete/print/copy and screenshot validation still needs a Windows/.NET workstation.
 - User permission editing now has a completed persistence/UI/navigation/editor-summary pass, impact review, and matching service-layer permission guards, but runtime login-as-each-role and screenshot validation still needs a Windows/.NET workstation.
 - Reservations now have a completed desktop workflow surface, but runtime add/edit/confirm/cancel/fulfill/delete/print/copy and screenshot validation still need a Windows/.NET workstation.
@@ -78,6 +79,6 @@ Last audit date/time: 2026-06-22 01:11 NZST
 
 ## Validation status
 
-- GitHub connector readback/compare should review the item workflow feedback changes, source-contract tests, progress note, and this checklist update.
+- GitHub connector readback/compare should review the item workflow exception refresh changes, source-contract tests, progress note, and this checklist update.
 - Local XAML parsing, `dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime function checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct local clone/raw fetches remain blocked by the network tunnel.
 - Did not run unrelated tests, per instruction.

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -518,7 +518,8 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to rent {ItemLabelSingular} {ItemID}", LabelProvider.Instance.ItemLabelSingular, item.ItemID);
-                await _dialogService.ShowInfoAsync($"Failed to rent {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {ex.Message}", "Error");
+                await RefreshItemsAfterWorkflowFailureAsync(item.ItemID, cancellationToken);
+                await _dialogService.ShowInfoAsync($"Failed to rent {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {ex.Message} The item list has been refreshed in case the rental was saved before the failure.", "Error");
             }
         }
 
@@ -546,7 +547,8 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to rent {ItemLabelSingular} {ItemID}", LabelProvider.Instance.ItemLabelSingular, item.ItemID);
-                await _dialogService.ShowInfoAsync($"Failed to rent {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {ex.Message}", "Error");
+                await RefreshItemsAfterWorkflowFailureAsync(item.ItemID, cancellationToken);
+                await _dialogService.ShowInfoAsync($"Failed to rent {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {ex.Message} The item list has been refreshed in case the rental was saved before the failure.", "Error");
             }
         }
 
@@ -558,6 +560,18 @@ namespace InventoryManagementApp.ViewModels
         private Task ReloadItemsAfterCheckoutAsync(int itemId, CancellationToken cancellationToken)
         {
             return ReloadItemsAfterItemWorkflowAsync(itemId, cancellationToken);
+        }
+
+        private async Task RefreshItemsAfterWorkflowFailureAsync(int itemId, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await ReloadItemsAfterItemWorkflowAsync(itemId, cancellationToken);
+            }
+            catch (Exception refreshEx)
+            {
+                _logger.LogError(refreshEx, "Failed to refresh items after workflow failure for item {ItemID}", itemId);
+            }
         }
 
         private async Task ReloadItemsAfterItemWorkflowAsync(int itemId, CancellationToken cancellationToken)
@@ -598,7 +612,8 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to toggle check out status for item {ItemID}", item.ItemID);
-                await _dialogService.ShowInfoAsync($"Failed to update check-out status: {ex.Message}", "Error");
+                await RefreshItemsAfterWorkflowFailureAsync(item.ItemID, cancellationToken);
+                await _dialogService.ShowInfoAsync($"Failed to update check-out status: {ex.Message} The item list has been refreshed in case the check-out status changed before the failure.", "Error");
             }
         }
 


### PR DESCRIPTION
## Summary

- Refresh item rows after rent workflow exceptions from both item-rental entry points so stale availability is less likely if a rental save succeeds before a later failure.
- Refresh item rows after check-out status exceptions for the matching post-persistence/readback failure path.
- Add a guarded refresh helper so secondary refresh failures are logged without hiding the original operator-facing error.
- Extend `ItemRentalWorkflowContractTests` and update progress notes/checklist for the completed item workflow hardening pass.

## Validation

- GitHub connector compare confirmed a focused 4-file diff against current `master`, with the branch 4 commits ahead and 0 behind.
- Read back the updated `ItemManagementViewModel`, updated `ItemRentalWorkflowContractTests`, progress note, and checklist through the GitHub connector.
- GitHub reports no attached status checks for branch head `38fb02d59ab7bf9acaa259ac8ff5e08a42d22858`.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime function checks were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime.