### PR TITLE
[codex] Guard item workflow refresh contracts

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ItemWorkflowRefreshContractTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ItemWorkflowRefreshContractTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.ViewModels
+{
+    public class ItemWorkflowRefreshContractTests
+    {
+        [Fact]
+        public void ItemWorkflowFailurePathsRefreshRowsBeforeShowingOperatorErrors()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp/ViewModels/ItemManagementViewModel.cs");
+
+            Assert.Contains("private async Task RefreshItemsAfterWorkflowFailureAsync(int itemId, CancellationToken cancellationToken)", source);
+            Assert.Contains("await ReloadItemsAfterItemWorkflowAsync(itemId, cancellationToken);", source);
+            Assert.Contains("Failed to refresh items after workflow failure for item {ItemID}", source);
+            Assert.Contains("SearchResults.FirstOrDefault(t => t.ItemID == itemId)", source);
+            Assert.Contains("CheckedOutItems.FirstOrDefault(t => t.ItemID == itemId)", source);
+
+            Assert.True(
+                CountOccurrences(source, "await RefreshItemsAfterWorkflowFailureAsync(item.ItemID, cancellationToken);") >= 3,
+                "Rent and check-out exception paths should refresh the item lists before notifying the operator.");
+            Assert.Contains("The item list has been refreshed in case the rental was saved before the failure.", source);
+            Assert.Contains("The item list has been refreshed in case the check-out status changed before the failure.", source);
+        }
+
+        private static string ReadRepositoryFile(string relativePath)
+        {
+            var root = FindRepositoryRoot();
+            return File.ReadAllText(Path.Combine(root, relativePath));
+        }
+
+        private static string FindRepositoryRoot()
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null)
+            {
+                if (File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                    return directory.FullName;
+
+                directory = directory.Parent;
+            }
+
+            throw new DirectoryNotFoundException("Could not find repository root containing InventoryManagementApp.sln.");
+        }
+
+        private static int CountOccurrences(string source, string value)
+        {
+            var count = 0;
+            var index = 0;
+            while ((index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += value.Length;
+            }
+
+            return count;
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-item-workflow-refresh-contract-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-item-workflow-refresh-contract-coverage.md
@@ -1,0 +1,14 @@
+# Item workflow refresh contract coverage
+
+Date: 2026-06-22
+
+## Completed
+
+- Added source-contract coverage for the item workflow failure refresh behavior that reloads item rows after rent and check-out exception paths.
+- Guarded the shared refresh helper so future changes preserve the post-failure row reload, selection restoration from fresh `SearchResults`/`Items`/`CheckedOutItems`, and secondary-refresh logging.
+- Covered the operator-facing messages that explain the item list has been refreshed after possible post-persistence failures.
+
+## Validation
+
+- GitHub connector readback/compare should be used for this scheduled pass because direct clone/raw access is blocked by `CONNECT tunnel failed, response 403`.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run in this Linux scheduled container.


### PR DESCRIPTION
## Summary

- Add source-contract coverage for the item workflow failure-refresh helper and row-selection restoration after rent/check-out exception paths.
- Guard the operator-facing refresh messages for possible post-persistence rental and check-out failures.
- Record the focused coverage pass in a progress note.

## Validation

- GitHub connector compare confirmed a focused 2-file diff against current `master`, with the branch 2 commits ahead and 0 behind.
- Read back the new `ItemWorkflowRefreshContractTests` and progress note through the GitHub connector.
- GitHub reports no attached status checks for branch head `699885e7e0966a8f4b2ea5a55b07d18069fbbbf7`.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime function checks were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime.