### PR TITLE
[codex] Guard rental request refresh contracts

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
@@ -48,6 +48,21 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void OpenRequestRefreshFailuresAreContainedBeforeStatusErrorDialogs()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ManageRentalsViewModel.cs");
+
+            Assert.Contains("async Task LoadPendingRequestsAsync(bool notifyOnFailure = false)", source, StringComparison.Ordinal);
+            Assert.Contains("catch (Exception ex)\n            {\n                _logger.LogError(ex, \"Failed to load open reservations for rentals page\");", source, StringComparison.Ordinal);
+            Assert.Contains("PendingRequests.Clear();\n                SelectedRequest = null;", source, StringComparison.Ordinal);
+            Assert.Contains("finally\n            {\n                OnPropertyChanged(nameof(RequestSummary));\n            }", source, StringComparison.Ordinal);
+            Assert.Contains("await LoadPendingRequestsAsync();\n                await _dialogService.ShowInfoAsync($\"Failed to confirm request: {ex.Message}", source, StringComparison.Ordinal);
+            Assert.Contains("await LoadPendingRequestsAsync();\n                await _dialogService.ShowInfoAsync($\"Failed to cancel request: {ex.Message}", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await LoadPendingRequestsAsync(notifyOnFailure: true);\n                await _dialogService.ShowInfoAsync($\"Failed to confirm request", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await LoadPendingRequestsAsync(notifyOnFailure: true);\n                await _dialogService.ShowInfoAsync($\"Failed to cancel request", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void RequestPlacementAndQueueLoadFailuresRefreshAndExplainState()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ManageRentalsViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-rental-request-refresh-contract-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-rental-request-refresh-contract-coverage.md
@@ -1,0 +1,12 @@
+# Rental Request Refresh Contract Coverage - 2026-06-22
+
+## Completed
+
+- Added focused source-contract coverage for the Rentals open-request refresh helper behavior used after confirm/cancel request failures.
+- Guarded the expectation that `LoadPendingRequestsAsync` contains refresh exceptions, clears stale request selection, and still raises `RequestSummary` updates.
+- Covered the confirm/cancel exception paths that depend on the non-throwing queue refresh before showing operator-facing status failure messages.
+
+## Validation
+
+- GitHub connector readback/compare should confirm the focused test and progress-note changes.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`, `dotnet` is unavailable in this scheduled Linux container, and WPF cannot run here.


### PR DESCRIPTION
## Summary

- Add source-contract coverage for the Rentals open-request refresh behavior used by confirm/cancel request failure paths.
- Guard that `LoadPendingRequestsAsync` contains refresh exceptions, clears stale selected request state, and still updates request summary state.
- Record the focused coverage pass in a progress note.

## Validation

- GitHub connector compare confirmed a focused 2-file diff against current `master`, with the branch 2 commits ahead and 0 behind.
- Read back the updated `ManageRentalsSelectionContractTests` and new progress note through the GitHub connector.
- GitHub reports no attached status checks for branch head `06b1e40a5d318f9383bd11efb01e7eeb070a965d`.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime.