### PR TITLE
[codex] Refresh reservations after operation failures

### DIFF
--- a/InventoryManagementApp.Tests/ReservationWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationWorkflowContractTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ReservationWorkflowContractTests
+    {
+        [Fact]
+        public void ReservationOperationFailuresRefreshVisibleRowsAndExplainState()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ReservationManagementViewModel.cs");
+
+            Assert.Contains("private async Task<bool> RefreshReservationsAfterOperationFailureAsync(int? preferredReservationId = null)", source, StringComparison.Ordinal);
+            Assert.Contains("var reservations = await _reservationService.GetAllReservationsAsync();", source, StringComparison.Ordinal);
+            Assert.Contains("ApplyFilter(preferredReservationId);", source, StringComparison.Ordinal);
+            Assert.Contains("Reservations.Clear();\n                FilteredReservations.Clear();\n                SelectedReservation = null;", source, StringComparison.Ordinal);
+            Assert.Contains("AppendReservationRefreshMessage(ex.Message, refreshed)", source, StringComparison.Ordinal);
+            Assert.Equal(6, CountOccurrences(source, "var refreshed = await RefreshReservationsAfterOperationFailureAsync("));
+            Assert.Contains("newReservation.ReservationID > 0 ? newReservation.ReservationID : null", source, StringComparison.Ordinal);
+            Assert.Contains("RefreshReservationsAfterOperationFailureAsync(clone.ReservationID)", source, StringComparison.Ordinal);
+            Assert.Contains("RefreshReservationsAfterOperationFailureAsync(reservation.ReservationID)", source, StringComparison.Ordinal);
+            Assert.Contains("RefreshReservationsAfterOperationFailureAsync(reservationId)", source, StringComparison.Ordinal);
+            Assert.Contains("The reservation list has been refreshed in case saved state changed before the failure.", source, StringComparison.Ordinal);
+            Assert.Contains("The reservation list could not be refreshed, so visible reservation rows were cleared until reload succeeds.", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ConfirmAndFulfillPreserveReservationIdForFailureRefresh()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ReservationManagementViewModel.cs");
+
+            Assert.Contains("var reservationId = SelectedReservation.ReservationID;\n            try\n            {\n                await _reservationService.ConfirmReservationAsync(reservationId);", source, StringComparison.Ordinal);
+            Assert.Contains("var reservationId = SelectedReservation.ReservationID;\n                try\n                {\n                    await _reservationService.FulfillReservationAsync(reservationId, rentalId);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("catch (Exception ex)\n            {\n                await _dialogService.ShowErrorAsync(\"Error confirming reservation\", ex.Message);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("catch (Exception ex)\n                {\n                    await _dialogService.ShowErrorAsync(\"Error fulfilling reservation\", ex.Message);", source, StringComparison.Ordinal);
+        }
+
+        private static int CountOccurrences(string source, string value)
+        {
+            var count = 0;
+            var index = 0;
+
+            while ((index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += value.Length;
+            }
+
+            return count;
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-reservation-failure-refresh.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-reservation-failure-refresh.md
@@ -1,0 +1,13 @@
+# Reservation failure refresh hardening - 2026-06-22
+
+## Completed
+
+- Added a shared reservation failure-refresh path in `ReservationManagementViewModel` so create, edit, delete, confirm, cancel, and fulfill failures reload reservations from the durable service when possible.
+- Cleared visible reservation rows and selected-hold state if the recovery refresh itself fails, preventing operators from continuing against unverified stale rows.
+- Updated operation failure messages to explain whether the reservation list was refreshed or cleared after the failure.
+- Added `ReservationWorkflowContractTests` to guard the refresh helper, operation catch-path coverage, and preserved reservation IDs for confirm/fulfill failure recovery.
+
+## Validation
+
+- GitHub connector readback/compare should verify this focused source-contract change before merge.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, runtime checks, and local banned-word checks were not run because this scheduled Linux container lacks the .NET SDK and Windows/WPF runtime, and direct clone/raw access is blocked by the network tunnel.

--- a/InventoryManagementApp/ViewModels/ReservationManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ReservationManagementViewModel.cs
@@ -194,6 +194,33 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
+        private async Task<bool> RefreshReservationsAfterOperationFailureAsync(int? preferredReservationId = null)
+        {
+            try
+            {
+                var reservations = await _reservationService.GetAllReservationsAsync();
+                Reservations.Clear();
+                foreach (var reservation in reservations)
+                {
+                    Reservations.Add(reservation);
+                }
+                ApplyFilter(preferredReservationId);
+                return true;
+            }
+            catch
+            {
+                Reservations.Clear();
+                FilteredReservations.Clear();
+                SelectedReservation = null;
+                OnPropertyChanged(nameof(ReservationResultsSummary));
+                return false;
+            }
+        }
+
+        private static string AppendReservationRefreshMessage(string message, bool refreshed) => refreshed
+            ? $"{message} The reservation list has been refreshed in case saved state changed before the failure."
+            : $"{message} The reservation list could not be refreshed, so visible reservation rows were cleared until reload succeeds.";
+
         private async Task AddReservationAsync()
         {
             var newReservation = new Reservation
@@ -233,7 +260,8 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error creating reservation", ex.Message);
+                    var refreshed = await RefreshReservationsAfterOperationFailureAsync(newReservation.ReservationID > 0 ? newReservation.ReservationID : null);
+                    await _dialogService.ShowErrorAsync("Error creating reservation", AppendReservationRefreshMessage(ex.Message, refreshed));
                 }
             }
         }
@@ -258,7 +286,8 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error updating reservation", ex.Message);
+                    var refreshed = await RefreshReservationsAfterOperationFailureAsync(clone.ReservationID);
+                    await _dialogService.ShowErrorAsync("Error updating reservation", AppendReservationRefreshMessage(ex.Message, refreshed));
                 }
             }
         }
@@ -283,7 +312,8 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error deleting reservation", ex.Message);
+                    var refreshed = await RefreshReservationsAfterOperationFailureAsync(reservation.ReservationID);
+                    await _dialogService.ShowErrorAsync("Error deleting reservation", AppendReservationRefreshMessage(ex.Message, refreshed));
                 }
             }
         }
@@ -292,9 +322,9 @@ namespace InventoryManagementApp.ViewModels
         {
             if (SelectedReservation == null) return;
 
+            var reservationId = SelectedReservation.ReservationID;
             try
             {
-                var reservationId = SelectedReservation.ReservationID;
                 await _reservationService.ConfirmReservationAsync(reservationId);
                 SelectedReservation.Status = "Confirmed";
                 ApplyFilter(reservationId);
@@ -302,7 +332,8 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                await _dialogService.ShowErrorAsync("Error confirming reservation", ex.Message);
+                var refreshed = await RefreshReservationsAfterOperationFailureAsync(reservationId);
+                await _dialogService.ShowErrorAsync("Error confirming reservation", AppendReservationRefreshMessage(ex.Message, refreshed));
             }
         }
 
@@ -326,7 +357,8 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error cancelling reservation", ex.Message);
+                    var refreshed = await RefreshReservationsAfterOperationFailureAsync(reservation.ReservationID);
+                    await _dialogService.ShowErrorAsync("Error cancelling reservation", AppendReservationRefreshMessage(ex.Message, refreshed));
                 }
             }
         }
@@ -341,9 +373,9 @@ namespace InventoryManagementApp.ViewModels
 
             if (!string.IsNullOrWhiteSpace(rentalIdText) && int.TryParse(rentalIdText, out var rentalId))
             {
+                var reservationId = SelectedReservation.ReservationID;
                 try
                 {
-                    var reservationId = SelectedReservation.ReservationID;
                     await _reservationService.FulfillReservationAsync(reservationId, rentalId);
                     SelectedReservation.Status = "Fulfilled";
                     SelectedReservation.RentalID = rentalId;
@@ -352,7 +384,8 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error fulfilling reservation", ex.Message);
+                    var refreshed = await RefreshReservationsAfterOperationFailureAsync(reservationId);
+                    await _dialogService.ShowErrorAsync("Error fulfilling reservation", AppendReservationRefreshMessage(ex.Message, refreshed));
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Add a shared reservation failure-refresh path so create, edit, delete, confirm, cancel, and fulfill failures reload reservations from durable state when possible.
- Clear visible reservation rows and selected-hold state if the recovery refresh itself fails, preventing operators from continuing against unverified stale rows.
- Add source-contract coverage for the failure-refresh helper, operation catch-path coverage, and preserved reservation IDs for confirm/fulfill recovery.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ReservationManagementViewModel`, `ReservationWorkflowContractTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime function checks were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime.