### PR TITLE
[codex] Clear reservations after load failures

### DIFF
--- a/InventoryManagementApp.Tests/ReservationWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationWorkflowContractTests.cs
@@ -7,6 +7,16 @@ namespace InventoryManagementApp.Tests
     public class ReservationWorkflowContractTests
     {
         [Fact]
+        public void ReservationLoadFailuresClearStaleVisibleRowsAndExplainState()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ReservationManagementViewModel.cs");
+
+            Assert.Contains("catch (Exception ex)\n            {\n                Reservations.Clear();\n                FilteredReservations.Clear();\n                SelectedReservation = null;", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(ReservationResultsSummary));\n                await _dialogService.ShowErrorAsync(\"Error loading reservations\", $\"{ex.Message} The reservation list has been cleared until reload succeeds.\");", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("catch (Exception ex)\n            {\n                await _dialogService.ShowErrorAsync(\"Error loading reservations\", ex.Message);", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ReservationOperationFailuresRefreshVisibleRowsAndExplainState()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ReservationManagementViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-reservation-load-failure-clearing.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-reservation-load-failure-clearing.md
@@ -1,0 +1,12 @@
+# Reservation Load Failure Clearing - 2026-06-22
+
+## Completed
+
+- Cleared `Reservations`, `FilteredReservations`, and selected hold state when the reservation list fails to load.
+- Updated the load-failure dialog to explain that visible reservation rows were cleared until reload succeeds, preventing operators from acting on stale holds after a failed refresh.
+- Added source-contract coverage for the load failure clearing path and the updated operator message.
+
+## Validation
+
+- GitHub connector readback/compare should confirm the focused view-model, contract-test, and progress-note changes.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`, `dotnet` is unavailable in this scheduled Linux container, and WPF cannot run here.

--- a/InventoryManagementApp/ViewModels/ReservationManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ReservationManagementViewModel.cs
@@ -190,7 +190,11 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                await _dialogService.ShowErrorAsync("Error loading reservations", ex.Message);
+                Reservations.Clear();
+                FilteredReservations.Clear();
+                SelectedReservation = null;
+                OnPropertyChanged(nameof(ReservationResultsSummary));
+                await _dialogService.ShowErrorAsync("Error loading reservations", $"{ex.Message} The reservation list has been cleared until reload succeeds.");
             }
         }
 


### PR DESCRIPTION
## Summary

- Clear visible reservation rows and selected-hold state when the reservation list fails to load.
- Update the load-failure dialog so operators know visible rows were cleared until reload succeeds.
- Add source-contract coverage for the reservation load failure clearing path.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ReservationManagementViewModel`, `ReservationWorkflowContractTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime.