### PR TITLE
[codex] Clear rentals after load failures

### DIFF
--- a/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/ManageRentalsSelectionContractTests.cs
@@ -22,6 +22,19 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void RentalsLoadFailuresClearStaleRowsAndDisableRentalActions()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ManageRentalsViewModel.cs");
+
+            Assert.Contains("ClearRentalStateAfterLoadFailure();\n                await _dialogService.ShowInfoAsync($\"Failed to load rentals: {ex.Message} Rental rows were cleared until reload succeeds.\", \"Error\");", source, StringComparison.Ordinal);
+            Assert.Contains("void ClearRentalStateAfterLoadFailure()", source, StringComparison.Ordinal);
+            Assert.Contains("_allRentals.Clear();\n            Rentals.Clear();\n            ActiveRentals.Clear();\n            SelectedRental = null;", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(SearchSummary));\n            OnPropertyChanged(nameof(CheckedOutSummary));", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(SelectedRequestHolderLine));\n            OnPropertyChanged(nameof(SelectedRequestNextAction));", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await _dialogService.ShowInfoAsync($\"Failed to load rentals: {ex.Message}\", \"Error\");", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void MissingSelectionAfterFilterClearsRentalActions()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ManageRentalsViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-rentals-load-failure-clearing.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-rentals-load-failure-clearing.md
@@ -1,0 +1,12 @@
+# Rentals Load Failure Clearing - 2026-06-22
+
+## Completed
+
+- Cleared the Rentals desk's cached rental rows, filtered rows, active-rental summary, and selected rental when the full rental list fails to load.
+- Updated the load-failure message so operators know rental rows were cleared until reload succeeds instead of leaving stale Check In, Extend, Delete, or print actions active.
+- Added source-contract coverage for the load-failure clearing helper, refreshed summaries, and the updated operator message.
+
+## Validation
+
+- GitHub connector readback/compare should confirm the focused view-model, contract-test, and progress-note changes.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`, `dotnet` is unavailable in this scheduled Linux container, and WPF cannot run here.

--- a/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ManageRentalsViewModel.cs
@@ -234,12 +234,25 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load rentals");
-                await _dialogService.ShowInfoAsync($"Failed to load rentals: {ex.Message}", "Error");
+                ClearRentalStateAfterLoadFailure();
+                await _dialogService.ShowInfoAsync($"Failed to load rentals: {ex.Message} Rental rows were cleared until reload succeeds.", "Error");
             }
             finally
             {
                 IsLoading = false;
             }
+        }
+
+        void ClearRentalStateAfterLoadFailure()
+        {
+            _allRentals.Clear();
+            Rentals.Clear();
+            ActiveRentals.Clear();
+            SelectedRental = null;
+            OnPropertyChanged(nameof(SearchSummary));
+            OnPropertyChanged(nameof(CheckedOutSummary));
+            OnPropertyChanged(nameof(SelectedRequestHolderLine));
+            OnPropertyChanged(nameof(SelectedRequestNextAction));
         }
 
         async Task LoadPendingRequestsAsync(bool notifyOnFailure = false)


### PR DESCRIPTION
## Summary

- Clear cached rental rows, visible filtered rows, active-rental summaries, and selected rental state when the Rentals desk fails to load rentals.
- Update the load-failure message so operators know rental rows were cleared until reload succeeds instead of leaving stale Check In, Extend, Delete, or print actions available.
- Add source-contract coverage for the load-failure clearing helper and refreshed summary notifications.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ManageRentalsViewModel`, `ManageRentalsSelectionContractTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because this scheduled Linux container does not have the .NET SDK or Windows/WPF runtime.