### PR TITLE
[codex] Clear customer rows after refresh failures

### DIFF
--- a/InventoryManagementApp.Tests/CustomerManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/CustomerManagementViewModelTests.cs
@@ -75,9 +75,58 @@ namespace InventoryManagementApp.Tests
             Assert.Equal(string.Empty, vm.CustomerSearchTerm);
         }
 
+        [Fact]
+        public async Task LoadCustomersAsync_WhenRefreshFails_ClearsStaleRowsSelectionAndExplainsState()
+        {
+            var service = new StubCustomerService();
+            service.Customers.Add(new CustomerModel { CustomerID = 1, Company = "Alpha", Contact = "Alex" });
+            var dialog = new StubDialogService();
+            var vm = new CustomerManagementViewModel(service, dialog);
+            await vm.LoadCustomersAsync();
+            Assert.Single(vm.Customers);
+            Assert.NotNull(vm.SelectedCustomer);
+
+            service.ThrowOnGetAllCustomers = true;
+            await vm.LoadCustomersAsync();
+
+            Assert.Empty(vm.Customers);
+            Assert.Null(vm.SelectedCustomer);
+            Assert.Equal("0 customers shown", vm.CustomerResultsSummary);
+            Assert.Equal(string.Empty, vm.NewCustomerName);
+            Assert.False(vm.UpdateCustomerCommand.CanExecute(null));
+            Assert.False(vm.PrintSelectedCustomerCommand.CanExecute(null));
+            Assert.Equal("Customer Load Failed", dialog.LastInfoTitle);
+            Assert.Contains("Customer rows were cleared until reload succeeds.", dialog.LastInfoMessage);
+        }
+
+        [Fact]
+        public async Task SearchCustomersCommand_WhenRefreshFails_ClearsStaleRowsSelectionAndExplainsState()
+        {
+            var service = new StubCustomerService();
+            service.Customers.Add(new CustomerModel { CustomerID = 1, Company = "Alpha", Contact = "Alex" });
+            service.Customers.Add(new CustomerModel { CustomerID = 2, Company = "Beta", Contact = "Blair" });
+            var dialog = new StubDialogService();
+            var vm = new CustomerManagementViewModel(service, dialog);
+            await vm.LoadCustomersAsync();
+            vm.CustomerSearchTerm = "Alpha";
+
+            service.ThrowOnGetAllCustomers = true;
+            await vm.SearchCustomersCommand.ExecuteAsync(null);
+
+            Assert.Empty(vm.Customers);
+            Assert.Null(vm.SelectedCustomer);
+            Assert.Equal("0 customers shown for \"Alpha\"", vm.CustomerResultsSummary);
+            Assert.False(vm.OpenCustomerDetailsCommand.CanExecute(null));
+            Assert.False(vm.CopySelectedCustomerCommand.CanExecute(null));
+            Assert.Equal("Customer Search Failed", dialog.LastInfoTitle);
+            Assert.Contains("Customer rows were cleared until reload succeeds.", dialog.LastInfoMessage);
+        }
+
         private sealed class StubCustomerService : ICustomerService
         {
             public List<CustomerModel> Customers { get; } = new();
+            public bool ThrowOnGetAllCustomers { get; set; }
+
             public Task AddCustomerAsync(CustomerModel customer, CancellationToken cancellationToken = default)
             {
                 Customers.Add(customer);
@@ -97,7 +146,12 @@ namespace InventoryManagementApp.Tests
             public Task<CustomerModel?> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default)
                 => Task.FromResult<CustomerModel?>(Customers.First(c => c.CustomerID == customerID));
             public Task<List<CustomerModel>> GetAllCustomersAsync(CancellationToken cancellationToken = default)
-                => Task.FromResult(Customers.ToList());
+            {
+                if (ThrowOnGetAllCustomers)
+                    return Task.FromException<List<CustomerModel>>(new System.InvalidOperationException("database offline"));
+
+                return Task.FromResult(Customers.ToList());
+            }
             public Task<int> CountCustomersAsync(CancellationToken cancellationToken = default)
                 => Task.FromResult(Customers.Count);
             public Task<List<CustomerModel>> SearchCustomersAsync(string searchTerm, CancellationToken cancellationToken = default)
@@ -116,8 +170,19 @@ namespace InventoryManagementApp.Tests
         {
             public CustomerModel? AddCustomerResult { get; set; }
             public CustomerModel? EditCustomerResult { get; set; }
-            public void ShowInfo(string message, string title) { }
-            public Task ShowInfoAsync(string message, string title) => Task.CompletedTask;
+            public string? LastInfoMessage { get; private set; }
+            public string? LastInfoTitle { get; private set; }
+            public void ShowInfo(string message, string title)
+            {
+                LastInfoMessage = message;
+                LastInfoTitle = title;
+            }
+            public Task ShowInfoAsync(string message, string title)
+            {
+                LastInfoMessage = message;
+                LastInfoTitle = title;
+                return Task.CompletedTask;
+            }
             public bool ShowConfirmation(string message, string title) => true;
             public Task<bool> ShowConfirmationAsync(string message, string title) => Task.FromResult(true);
             public ItemModel? ShowEditItemDialog(ItemModel item) => null;
@@ -129,7 +194,7 @@ namespace InventoryManagementApp.Tests
             public void ShowRentalsFilter(ManageRentalsViewModel viewModel) { }
             public void ShowRentalHistory(ItemModel item, IEnumerable<RentalModel> history) { }
             public Dictionary<string, string>? ShowImportMapping(IEnumerable<string> headers, IEnumerable<string> properties, IEnumerable<string>? requiredPropertyNames = null) => null;
-            public Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
+            public System.Func<ItemModel, IEnumerable<string>>? ShowImageImportMapping() => null;
             public void ShowPrintPreview(FlowDocument document, string title, string description) { }
             public void ShowPrintLabelDialog() { }
         }

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-customer-load-failure-clearing.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-customer-load-failure-clearing.md
@@ -1,0 +1,10 @@
+# Customer Load Failure Clearing
+
+- Cleared stale customer directory rows when a customer load or search refresh fails.
+- Cleared the selected customer and dependent edit/print/copy/detail actions so operators cannot continue from unverified rows after a failed refresh.
+- Updated customer load/search failure messages to explain that rows were cleared until reload succeeds.
+- Added focused customer view-model tests for load and search refresh failure clearing, summary updates, command disablement, and operator feedback.
+
+Validation notes:
+- Not run locally in this scheduled Linux environment: direct repository clone/raw access, `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks remain unavailable here.
+- GitHub connector readback/compare was used as the fallback validation path.

--- a/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
@@ -153,8 +153,9 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
+                ClearCustomerDirectoryAfterLoadFailure();
                 if (_dialogService != null)
-                    await _dialogService.ShowInfoAsync($"Failed to load customers: {ex.Message}", "Customer Load Failed");
+                    await _dialogService.ShowInfoAsync($"Failed to load customers: {ex.Message} Customer rows were cleared until reload succeeds.", "Customer Load Failed");
             }
         }
 
@@ -236,9 +237,17 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
+                ClearCustomerDirectoryAfterLoadFailure();
                 if (_dialogService != null)
-                    await _dialogService.ShowInfoAsync($"Failed to search customers: {ex.Message}", "Customer Search Failed");
+                    await _dialogService.ShowInfoAsync($"Failed to search customers: {ex.Message} Customer rows were cleared until reload succeeds.", "Customer Search Failed");
             }
+        }
+
+        private void ClearCustomerDirectoryAfterLoadFailure()
+        {
+            Customers.Clear();
+            SelectedCustomer = null;
+            OnPropertyChanged(nameof(CustomerResultsSummary));
         }
 
         private void ClearNewCustomerFields()


### PR DESCRIPTION
## Summary

- Clear stale customer directory rows and selected-customer state when customer load or search refreshes fail.
- Update customer load/search failure messages so operators know visible rows were cleared until reload succeeds.
- Add focused customer view-model tests for failure clearing, summary updates, command disablement, and operator feedback.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `CustomerManagementViewModel`, `CustomerManagementViewModelTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is unavailable in this scheduled container; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because this environment does not provide local repo checkout/.NET/WPF validation.