### PR TITLE
[codex] Clear kit rows after load failures

### DIFF
--- a/InventoryManagementApp.Tests/KitManagementWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/KitManagementWorkflowContractTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class KitManagementWorkflowContractTests
+    {
+        [Fact]
+        public void KitLoadFailuresClearStaleRowsSelectionAndItems()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "KitManagementViewModel.cs");
+
+            Assert.Contains("ClearKitStateAfterLoadFailure();\n                await _dialogService.ShowErrorAsync(\"Error loading kits\", $\"{ex.Message} Kit rows were cleared until reload succeeds.\");", source, StringComparison.Ordinal);
+            Assert.Contains("private void ClearKitStateAfterLoadFailure()", source, StringComparison.Ordinal);
+            Assert.Contains("Kits.Clear();\n            FilteredKits.Clear();\n            SelectedKit = null;\n            SelectedKitItem = null;\n            KitItems.Clear();", source, StringComparison.Ordinal);
+            Assert.Contains("RefreshKitItemSummaries();\n            OnPropertyChanged(nameof(KitResultsSummary));\n            OnPropertyChanged(nameof(SelectedKitAvailabilitySummary));\n            PrintKitListCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+            Assert.Contains("private bool CanEditOrDelete() => SelectedKit != null;", source, StringComparison.Ordinal);
+            Assert.Contains("private bool CanEditOrRemoveKitItem() => SelectedKitItem != null;", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("catch (Exception ex)\n            {\n                await _dialogService.ShowErrorAsync(\"Error loading kits\", ex.Message);\n            }", source, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-kit-load-failure-clearing.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-kit-load-failure-clearing.md
@@ -1,0 +1,17 @@
+# Kit load failure clearing
+
+- Date: 2026-06-22
+- Area: Kits workbench reliability
+
+## Completed
+
+- Cleared stale kit directory rows when the main kit reload fails.
+- Cleared the selected kit, selected kit item, and visible kit item lines after failed reloads so edit, delete, availability, membership, copy, and print-selected actions no longer point at unverified data.
+- Updated the operator-facing load failure message to explain that kit rows were cleared until reload succeeds.
+- Added source-contract coverage for the clearing helper, command-disablement dependencies, and refreshed summary notifications.
+
+## Validation Notes
+
+- Local clone/raw access is blocked in this scheduled container by `CONNECT tunnel failed, response 403`.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run in this Linux scheduled environment.
+- GitHub connector readback and compare were used as the validation fallback.

--- a/InventoryManagementApp/ViewModels/KitManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/KitManagementViewModel.cs
@@ -188,8 +188,22 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                await _dialogService.ShowErrorAsync("Error loading kits", ex.Message);
+                ClearKitStateAfterLoadFailure();
+                await _dialogService.ShowErrorAsync("Error loading kits", $"{ex.Message} Kit rows were cleared until reload succeeds.");
             }
+        }
+
+        private void ClearKitStateAfterLoadFailure()
+        {
+            Kits.Clear();
+            FilteredKits.Clear();
+            SelectedKit = null;
+            SelectedKitItem = null;
+            KitItems.Clear();
+            RefreshKitItemSummaries();
+            OnPropertyChanged(nameof(KitResultsSummary));
+            OnPropertyChanged(nameof(SelectedKitAvailabilitySummary));
+            PrintKitListCommand.NotifyCanExecuteChanged();
         }
 
         private async Task LoadKitItemsAsync(int kitID)


### PR DESCRIPTION
## Summary

- Clear stale kit directory rows, selected kit state, selected kit item state, and visible kit item lines when the main kit reload fails.
- Update the kit load-failure message so operators know kit rows were cleared until reload succeeds.
- Add source-contract coverage for the load-failure clearing helper, command-disablement dependencies, and refreshed summary notifications.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `KitManagementViewModel`, `KitManagementWorkflowContractTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because this scheduled Linux container does not have local repo checkout/.NET/WPF validation.