### PR TITLE
[codex] Clear category rows after load failures

### DIFF
--- a/InventoryManagementApp.Tests/CategoryManagementWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/CategoryManagementWorkflowContractTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class CategoryManagementWorkflowContractTests
+    {
+        [Fact]
+        public void CategoryLoadFailuresClearStaleRowsSelectionAndEditState()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CategoryManagementViewModel.cs");
+
+            Assert.Contains("ClearCategoryStateAfterLoadFailure();\n                StatusMessage = \"Categories could not be loaded. Category rows were cleared until reload succeeds.\";", source, StringComparison.Ordinal);
+            Assert.Contains("private void ClearCategoryStateAfterLoadFailure()", source, StringComparison.Ordinal);
+            Assert.Contains("Categories.Clear();\n            FilteredCategories.Clear();\n            SelectedCategory = null;\n            CategoryName = \"\";\n            RaiseDirectoryProperties();", source, StringComparison.Ordinal);
+            Assert.Contains("_saveCommand = new AsyncCommand(SaveAsync, () => SelectedCategory != null && !string.IsNullOrWhiteSpace(CategoryName));", source, StringComparison.Ordinal);
+            Assert.Contains("_deleteCommand = new AsyncCommand(DeleteAsync, () => SelectedCategory != null);", source, StringComparison.Ordinal);
+            Assert.Contains("WpfMessageBox.Show(\"Categories could not be loaded. Category rows were cleared until reload succeeds. Please retry or check the application log.\"", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("StatusMessage = \"Categories could not be loaded. Review logs or retry refresh.\";\n                WpfMessageBox.Show(\"Categories could not be loaded. Please retry or check the application log.\"", source, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-category-load-failure-clearing.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-category-load-failure-clearing.md
@@ -1,0 +1,17 @@
+# Category load failure clearing
+
+- Date: 2026-06-22
+- Area: Categories workbench reliability
+
+## Completed
+
+- Cleared stale category directory rows when the category reload fails.
+- Cleared the selected category and edit name after failed reloads so rename and delete actions no longer point at unverified category data.
+- Updated the operator-facing load failure message to explain that category rows were cleared until reload succeeds.
+- Added source-contract coverage for the clearing helper, command-disablement dependencies, and refreshed directory summary notifications.
+
+## Validation Notes
+
+- Local clone/raw access is blocked in this scheduled container by `CONNECT tunnel failed, response 403`.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run in this Linux scheduled environment.
+- GitHub connector readback and compare were used as the validation fallback.

--- a/InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs
@@ -238,10 +238,20 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load categories for inventory {InventoryId}", SelectedInventoryId);
-                StatusMessage = "Categories could not be loaded. Review logs or retry refresh.";
-                WpfMessageBox.Show("Categories could not be loaded. Please retry or check the application log.", "Category Management", MessageBoxButton.OK, MessageBoxImage.Error);
+                ClearCategoryStateAfterLoadFailure();
+                StatusMessage = "Categories could not be loaded. Category rows were cleared until reload succeeds.";
+                WpfMessageBox.Show("Categories could not be loaded. Category rows were cleared until reload succeeds. Please retry or check the application log.", "Category Management", MessageBoxButton.OK, MessageBoxImage.Error);
             }
             finally { IsBusy = false; }
+        }
+
+        private void ClearCategoryStateAfterLoadFailure()
+        {
+            Categories.Clear();
+            FilteredCategories.Clear();
+            SelectedCategory = null;
+            CategoryName = "";
+            RaiseDirectoryProperties();
         }
 
         private void ApplyFilter(int? preferredSelectedId = null)


### PR DESCRIPTION
## Summary

- Clear stale category directory rows, selected category state, and edit-name state when category reloads fail.
- Update the category load-failure message so operators know category rows were cleared until reload succeeds.
- Add source-contract coverage for the load-failure clearing helper, command-disablement dependencies, and refreshed directory summaries.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `CategoryManagementViewModel`, `CategoryManagementWorkflowContractTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because this scheduled Linux container does not have local repo checkout/.NET/WPF validation.