### PR TITLE
[codex] Clear maintenance and calibration rows after load failures

### DIFF
--- a/InventoryManagementApp.Tests/MaintenanceCalibrationWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/MaintenanceCalibrationWorkflowContractTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class MaintenanceCalibrationWorkflowContractTests
+    {
+        [Fact]
+        public void MaintenanceLoadFailuresClearStaleRowsAndSelection()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "MaintenanceManagementViewModel.cs");
+
+            Assert.Contains("ClearMaintenanceStateAfterLoadFailure();\n                await _dialogService.ShowErrorAsync(\"Error loading maintenance records\", $\"{ex.Message} Maintenance rows were cleared until reload succeeds.\");", source, StringComparison.Ordinal);
+            Assert.Contains("private void ClearMaintenanceStateAfterLoadFailure()", source, StringComparison.Ordinal);
+            Assert.Contains("MaintenanceRecords.Clear();\n            FilteredMaintenanceRecords.Clear();\n            SelectedRecord = null;\n            NotifyCommandStatesAndSummaries();", source, StringComparison.Ordinal);
+            Assert.Contains("CompleteMaintenanceCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(MaintenanceBacklogSummary));\n            OnPropertyChanged(nameof(MaintenanceResultsSummary));", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await _dialogService.ShowErrorAsync(\"Error loading maintenance records\", ex.Message);", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationLoadFailuresClearStaleRowsAndSelection()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CalibrationManagementViewModel.cs");
+
+            Assert.Contains("ClearCalibrationStateAfterLoadFailure();\n                await _dialogService.ShowErrorAsync(\"Error loading calibration records\", $\"{ex.Message} Calibration rows were cleared until reload succeeds.\");", source, StringComparison.Ordinal);
+            Assert.Contains("private void ClearCalibrationStateAfterLoadFailure()", source, StringComparison.Ordinal);
+            Assert.Contains("CalibrationRecords.Clear();\n            FilteredCalibrationRecords.Clear();\n            SelectedRecord = null;\n            NotifyCommandStatesAndSummaries();", source, StringComparison.Ordinal);
+            Assert.Contains("EditCalibrationCommand.NotifyCanExecuteChanged();\n            DeleteCalibrationCommand.NotifyCanExecuteChanged();\n            OpenCalibrationDetailsCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(CalibrationBacklogSummary));\n            OnPropertyChanged(nameof(CalibrationResultsSummary));", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await _dialogService.ShowErrorAsync(\"Error loading calibration records\", ex.Message);", source, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-maintenance-calibration-load-failure-clearing.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-maintenance-calibration-load-failure-clearing.md
@@ -1,0 +1,18 @@
+# Maintenance and calibration load failure clearing
+
+- Date: 2026-06-22
+- Area: Maintenance and Calibration workbench reliability
+
+## Completed
+
+- Cleared stale maintenance directory rows when maintenance record reloads fail.
+- Cleared stale calibration directory rows when calibration record reloads fail.
+- Cleared selected maintenance and calibration rows after failed reloads so edit, delete, complete, copy, print, and details actions no longer point at unverified data.
+- Updated operator-facing load failure messages to explain that rows were cleared until reload succeeds.
+- Added source-contract coverage for the clearing helpers, command-disablement notifications, and refreshed summary notifications.
+
+## Validation Notes
+
+- Direct repository clone/raw access is blocked in this scheduled container by `CONNECT tunnel failed, response 403`.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run in this Linux scheduled environment.
+- GitHub connector readback and compare were used as the validation fallback.

--- a/InventoryManagementApp/ViewModels/CalibrationManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CalibrationManagementViewModel.cs
@@ -179,7 +179,8 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                await _dialogService.ShowErrorAsync("Error loading calibration records", ex.Message);
+                ClearCalibrationStateAfterLoadFailure();
+                await _dialogService.ShowErrorAsync("Error loading calibration records", $"{ex.Message} Calibration rows were cleared until reload succeeds.");
             }
         }
 
@@ -280,6 +281,14 @@ namespace InventoryManagementApp.ViewModels
             SearchText = string.Empty;
             SelectedFilter = "All";
             ApplyFilter();
+        }
+
+        private void ClearCalibrationStateAfterLoadFailure()
+        {
+            CalibrationRecords.Clear();
+            FilteredCalibrationRecords.Clear();
+            SelectedRecord = null;
+            NotifyCommandStatesAndSummaries();
         }
 
         private void ApplyFilter(int? preferredCalibrationId = null)
@@ -458,6 +467,18 @@ namespace InventoryManagementApp.ViewModels
         }
 
         private bool CanEditOrDelete() => SelectedRecord != null;
+
+        private void NotifyCommandStatesAndSummaries()
+        {
+            EditCalibrationCommand.NotifyCanExecuteChanged();
+            DeleteCalibrationCommand.NotifyCanExecuteChanged();
+            OpenCalibrationDetailsCommand.NotifyCanExecuteChanged();
+            PrintSelectedCalibrationCommand.NotifyCanExecuteChanged();
+            CopySelectedCalibrationCommand.NotifyCanExecuteChanged();
+            OnSelectedRecordSummariesChanged();
+            OnPropertyChanged(nameof(CalibrationBacklogSummary));
+            OnPropertyChanged(nameof(CalibrationResultsSummary));
+        }
 
         private void OnSelectedRecordSummariesChanged()
         {

--- a/InventoryManagementApp/ViewModels/MaintenanceManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MaintenanceManagementViewModel.cs
@@ -189,7 +189,8 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                await _dialogService.ShowErrorAsync("Error loading maintenance records", ex.Message);
+                ClearMaintenanceStateAfterLoadFailure();
+                await _dialogService.ShowErrorAsync("Error loading maintenance records", $"{ex.Message} Maintenance rows were cleared until reload succeeds.");
             }
         }
 
@@ -321,6 +322,14 @@ namespace InventoryManagementApp.ViewModels
             SearchText = string.Empty;
             SelectedFilter = "All";
             ApplyFilter();
+        }
+
+        private void ClearMaintenanceStateAfterLoadFailure()
+        {
+            MaintenanceRecords.Clear();
+            FilteredMaintenanceRecords.Clear();
+            SelectedRecord = null;
+            NotifyCommandStatesAndSummaries();
         }
 
         private void ApplyFilter(int? preferredMaintenanceId = null)


### PR DESCRIPTION
## Summary

- Clear stale maintenance directory rows and selected work state when maintenance reloads fail.
- Clear stale calibration directory rows and selected certificate state when calibration reloads fail.
- Update load-failure messages so operators know rows were cleared until reload succeeds.
- Add source-contract coverage for the clearing helpers, command disablement notifications, and refreshed summaries.

## Validation

- GitHub connector compare confirmed a focused 4-file diff against current `master`, with the branch 4 commits ahead and 0 behind.
- Read back `MaintenanceManagementViewModel`, `CalibrationManagementViewModel`, `MaintenanceCalibrationWorkflowContractTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because this scheduled Linux container does not have local repo checkout/.NET/WPF validation.