### PR TITLE
[codex] Clear activity log rows after load failures

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
@@ -76,6 +76,24 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void ActivityLogsLoadFailure_ClearsRowsFiltersSelectionAndKeepsFailureStatus()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ActivityLogsViewModel.cs");
+
+            Assert.Contains("ClearActivityLogRowsAfterLoadFailure(\"Activity logs could not be loaded. Activity rows were cleared until refresh succeeds.\");", source, StringComparison.Ordinal);
+            Assert.Contains("private void ClearActivityLogRowsAfterLoadFailure(string message)", source, StringComparison.Ordinal);
+            Assert.Contains("Logs.Clear();", source, StringComparison.Ordinal);
+            Assert.Contains("FilteredLogs.Clear();", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedLog = null;", source, StringComparison.Ordinal);
+            Assert.Contains("RebuildFilterLists();", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(TotalLogCount));", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(FilteredLogCount));", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(ActivitySummary));", source, StringComparison.Ordinal);
+            Assert.Contains("StatusMessage = message;", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("StatusMessage = \"Activity logs could not be loaded.\";", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void InsightPrintActions_RouteThroughSharedPrintPreview()
         {
             var reportsCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-activity-log-load-failure-clearing.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-activity-log-load-failure-clearing.md
@@ -1,0 +1,13 @@
+# Activity Log Load Failure Clearing - 2026-06-22
+
+## Completed
+
+- Added explicit Activity Logs load-failure clearing so failed audit refreshes clear stale backing rows, visible rows, and selected-row handoff state.
+- Rebuilds audit user/action filter lists after load failures so stale filter choices from prior rows are removed.
+- Keeps operator-facing failure status visible instead of letting the normal filter summary overwrite it with a misleading zero-row message.
+- Added source-contract coverage in `InsightsPagesXamlTests` for the failure-clearing helper, row/selection clearing, filter rebuild, summary notifications, and preserved failure status.
+
+## Validation Notes
+
+- GitHub connector readback and compare should be used for validation in this scheduled environment.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run because direct repository checkout is blocked by `CONNECT tunnel failed, response 403` and this Linux scheduled container does not provide local .NET/WPF validation.

--- a/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
@@ -180,9 +180,8 @@ namespace InventoryManagementApp.ViewModels
                 var result = await _service.GetRecentLogsAsync();
                 if (!result.Success || result.Value == null)
                 {
-                    StatusMessage = "Activity logs could not be loaded.";
                     _logger.LogError("Failed to load activity logs: {Error}", result.ErrorMessage);
-                    ApplyFilters();
+                    ClearActivityLogRowsAfterLoadFailure("Activity logs could not be loaded. Activity rows were cleared until refresh succeeds.");
                     return false;
                 }
 
@@ -197,11 +196,23 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                StatusMessage = "Activity logs could not be loaded.";
                 _logger.LogError(ex, "Failed to load activity logs");
-                ApplyFilters();
+                ClearActivityLogRowsAfterLoadFailure("Activity logs could not be loaded. Activity rows were cleared until refresh succeeds.");
                 return false;
             }
+        }
+
+        private void ClearActivityLogRowsAfterLoadFailure(string message)
+        {
+            Logs.Clear();
+            FilteredLogs.Clear();
+            SelectedLog = null;
+            RebuildFilterLists();
+            OnPropertyChanged(nameof(TotalLogCount));
+            OnPropertyChanged(nameof(FilteredLogCount));
+            OnPropertyChanged(nameof(ActivitySummary));
+            ClearFiltersCommand.NotifyCanExecuteChanged();
+            StatusMessage = message;
         }
 
         private void ClearFilters()


### PR DESCRIPTION
## Summary

- Clear stale Activity Logs rows, filtered rows, and selected audit handoff state when activity-log loading fails.
- Rebuild activity user/action filter lists after load failures so stale filter choices from prior rows are removed.
- Keep the operator-facing load-failure message visible instead of letting normal filter status overwrite it with a misleading zero-row summary.
- Add source-contract coverage for the failure-clearing helper, filter rebuild, summary notifications, and preserved failure status.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ActivityLogsViewModel`, `InsightsPagesXamlTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository checkout is blocked by `CONNECT tunnel failed, response 403`; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because this scheduled Linux container does not provide local .NET/WPF validation.