### PR TITLE
[codex] Clear user rows after load failures

### DIFF
--- a/InventoryManagementApp.Tests/UserManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/UserManagementViewModelTests.cs
@@ -16,6 +16,35 @@ namespace InventoryManagementApp.Tests
     public class UserManagementViewModelTests
     {
         [Fact]
+        public async Task LoadUsersAsync_WhenReloadFails_ClearsStaleRowsAndSelection()
+        {
+            var user = new UserModel { UserID = 4, UserName = "workshop4", Role = "Advisor" };
+            var service = new StubUserService();
+            service.Users.Add(user);
+            var dialog = new StubDialogService();
+            var vm = new UserManagementViewModel(service, new StubFileDialogService(), dialog);
+
+            await vm.LoadUsersAsync();
+            vm.SelectedUser = user;
+            Assert.Single(vm.Users);
+            Assert.True(vm.UpdateUserCommand.CanExecute(null));
+            Assert.True(vm.EditUserCommand.CanExecute(null));
+
+            service.ThrowOnGetAllUsers = true;
+            await vm.LoadUsersAsync();
+
+            Assert.Empty(vm.Users);
+            Assert.Null(vm.SelectedUser);
+            Assert.False(vm.UpdateUserCommand.CanExecute(null));
+            Assert.False(vm.EditUserCommand.CanExecute(null));
+            Assert.Equal("Error", dialog.LastTitle);
+            Assert.Contains("User rows were cleared until refresh succeeds", dialog.LastMessage);
+
+            vm.ClearUserSearchCommand.Execute(null);
+            Assert.Empty(vm.Users);
+        }
+
+        [Fact]
         public async Task ResetPasswordFromRowCommand_WhenPasswordChangeFails_ShowsErrorAndDoesNotMarkExpired()
         {
             var user = new UserModel { UserID = 7, UserName = "workshop7", PasswordExpired = false };
@@ -55,10 +84,16 @@ namespace InventoryManagementApp.Tests
         {
             public List<UserModel> Users { get; } = new();
             public bool ChangePasswordResult { get; set; } = true;
+            public bool ThrowOnGetAllUsers { get; set; }
             public int UpdateCallCount { get; private set; }
 
             public Task<List<UserModel>> GetAllUsersAsync(CancellationToken cancellationToken = default)
-                => Task.FromResult(Users.ToList());
+            {
+                if (ThrowOnGetAllUsers)
+                    throw new InvalidOperationException("Users are offline");
+
+                return Task.FromResult(Users.ToList());
+            }
 
             public Task<int> CountUsersAsync(CancellationToken cancellationToken = default)
                 => Task.FromResult(Users.Count);

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-users-load-failure-clearing.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-users-load-failure-clearing.md
@@ -1,0 +1,14 @@
+# Users load failure clearing
+
+Completed on 2026-06-22.
+
+## What changed
+
+- `UserManagementViewModel.LoadUsersAsync` now clears cached user rows, visible user rows, and the selected user when the user directory cannot be loaded.
+- The failure dialog tells operators that user rows were cleared until refresh succeeds, so edit, update, reset, and delete actions are not left pointed at stale account rows.
+- `UserManagementViewModelTests` now covers the reload-failure path, command disablement, visible message, and search-clear behavior after the failure.
+
+## Validation
+
+- Connector readback confirmed the Users view-model and test changes on the branch.
+- Local `dotnet` build/test, WPF screenshots, and local banned-word checks were not run because the scheduled Linux container cannot clone the repository and does not provide the .NET/WPF runtime.

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -276,7 +276,6 @@ namespace InventoryManagementApp.ViewModels
 
             var newUser = new UserModel
             {
-                UserID = 0,
                 UserName = name,
                 Role = "Workshop Staff",
                 IsAdmin = false,

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -111,8 +111,18 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load users");
-                await _dialogService.ShowInfoAsync($"Failed to load users: {ex.Message}", "Error");
+                ClearUsersAfterLoadFailure();
+                await _dialogService.ShowInfoAsync($"Failed to load users: {ex.Message}. User rows were cleared until refresh succeeds.", "Error");
             }
+        }
+
+        private void ClearUsersAfterLoadFailure()
+        {
+            _allUsers.Clear();
+            Users.Clear();
+            SelectedUser = null;
+            ((AsyncRelayCommand)UpdateUserCommand).NotifyCanExecuteChanged();
+            ((AsyncRelayCommand)EditUserCommand).NotifyCanExecuteChanged();
         }
 
         static string GetInitials(string? name)
@@ -266,6 +276,7 @@ namespace InventoryManagementApp.ViewModels
 
             var newUser = new UserModel
             {
+                UserID = 0,
                 UserName = name,
                 Role = "Workshop Staff",
                 IsAdmin = false,


### PR DESCRIPTION
## Summary

- Clear cached and visible Users rows when `UserManagementViewModel.LoadUsersAsync` fails.
- Clear the selected user and refresh edit/update command availability so stale account actions are not left enabled after an unverified reload.
- Update the failure message to tell operators that user rows were cleared until refresh succeeds.
- Add focused user-management test coverage for stale-row clearing, command disablement, failure messaging, and search-clear behavior after the failure.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 4 commits ahead and 0 behind.
- Read back `UserManagementViewModel`, `UserManagementViewModelTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository checkout is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because this scheduled Linux container does not provide local .NET/WPF validation.