### PR TITLE
[codex] Clear item rows after load failures

### DIFF
--- a/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
@@ -65,6 +65,27 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ItemLoadAndSearchFailuresClearStaleVisibleRows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemManagementViewModel.cs");
+
+            Assert.Contains("private void ClearItemStateAfterLoadFailure()", source, StringComparison.Ordinal);
+            Assert.Contains("Items.Clear();", source, StringComparison.Ordinal);
+            Assert.Contains("SearchResults.Clear();", source, StringComparison.Ordinal);
+            Assert.Contains("CheckedOutItems.Clear();", source, StringComparison.Ordinal);
+            Assert.Contains("Categories.ReplaceRange(new[] { \"All\" });", source, StringComparison.Ordinal);
+            Assert.Contains("_selectedCategory = \"All\";", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedItem = null;", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(SearchResultsSummary));", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(CheckedOutSummary));", source, StringComparison.Ordinal);
+            Assert.Equal(2, CountOccurrences(source, "ClearItemStateAfterLoadFailure();"));
+            Assert.Contains("_logger.LogError(ex, \"Failed to load item directory\");", source, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogError(ex, \"Failed to search item directory\");", source, StringComparison.Ordinal);
+            Assert.Contains("Failed to load {LabelProvider.Instance.ItemLabelPlural.ToLower()}: {ex.Message} Visible item rows were cleared until reload succeeds.", source, StringComparison.Ordinal);
+            Assert.Contains("Failed to search {LabelProvider.Instance.ItemLabelPlural.ToLower()}: {ex.Message} Visible item rows were cleared until reload succeeds.", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void RentalHistoryLoadFailureShowsOperatorFeedback()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemManagementViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-item-directory-load-failure-clearing.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-item-directory-load-failure-clearing.md
@@ -1,0 +1,15 @@
+# Item Directory Load Failure Clearing
+
+Date: 2026-06-22
+
+## Completed
+
+- Added a guarded item-state clearing path for item directory load and search failures.
+- The clearing path removes stale `Items`, `SearchResults`, checked-out rows, category choices, and selected item state so edit, rent, details, and history actions do not remain pointed at unverified rows.
+- Load and search failures now log the failed operation and show operator-facing guidance that visible item rows were cleared until reload succeeds.
+- Added source-contract coverage in `ItemRentalWorkflowContractTests` for the clearing helper, stale-row clearing, selected-item reset, summary notifications, and failure messages.
+
+## Validation
+
+- GitHub connector readback/compare used for validation in the scheduled Linux environment.
+- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` and `dotnet` are unavailable; WPF screenshots, runtime checks, and local banned-word checks were not run.

--- a/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemManagementViewModel.cs
@@ -280,6 +280,12 @@ namespace InventoryManagementApp.ViewModels
                 LoadCategories(Items);
                 await RefreshCheckedOutItemsAsync(CancellationToken.None);
             }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load item directory");
+                ClearItemStateAfterLoadFailure();
+                await _dialogService.ShowInfoAsync($"Failed to load {LabelProvider.Instance.ItemLabelPlural.ToLower()}: {ex.Message} Visible item rows were cleared until reload succeeds.", "Error");
+            }
             finally
             {
                 _suppressItemsChanged = false;
@@ -321,6 +327,13 @@ namespace InventoryManagementApp.ViewModels
             catch (OperationCanceledException ex)
             {
                 _logger.LogDebug(ex, "Item search cancelled");
+                return;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to search item directory");
+                ClearItemStateAfterLoadFailure();
+                await _dialogService.ShowInfoAsync($"Failed to search {LabelProvider.Instance.ItemLabelPlural.ToLower()}: {ex.Message} Visible item rows were cleared until reload succeeds.", "Error");
                 return;
             }
 
@@ -786,6 +799,27 @@ namespace InventoryManagementApp.ViewModels
             target.MissingComponentsNotes = source.MissingComponentsNotes;
             target.IssuesNotes = source.IssuesNotes;
             target.CheckoutCount = source.CheckoutCount;
+        }
+
+        private void ClearItemStateAfterLoadFailure()
+        {
+            _suppressItemsChanged = true;
+            try
+            {
+                Items.Clear();
+                SearchResults.Clear();
+                CheckedOutItems.Clear();
+                Categories.ReplaceRange(new[] { "All" });
+                _selectedCategory = "All";
+                OnPropertyChanged(nameof(SelectedCategory));
+                SelectedItem = null;
+                OnPropertyChanged(nameof(SearchResultsSummary));
+                OnPropertyChanged(nameof(CheckedOutSummary));
+            }
+            finally
+            {
+                _suppressItemsChanged = false;
+            }
         }
 
         void LoadCategories(IEnumerable<ItemModel> items, bool suppressSearch = false)


### PR DESCRIPTION
## Summary

- Clear stale item directory rows, search results, checked-out rows, categories, and selected item state when item load or search refreshes fail.
- Show operator-facing failure messages explaining that visible item rows were cleared until reload succeeds.
- Add source-contract coverage for the clearing helper, summary refresh, selected-item reset, and load/search failure messages.
- Record the completed reliability pass in a progress note.

Fixes #1230.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ItemManagementViewModel`, `ItemRentalWorkflowContractTests`, and the progress note through the GitHub connector.
- GitHub reports no attached status checks or workflow runs for branch head `b2ca5d53ad48b1c0ef792476a8e0a8396f02d2ba`.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because this scheduled Linux container does not provide local .NET/WPF validation.