### PR TITLE
[codex] Clear dashboard rows after load failures

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/DashboardWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/DashboardWorkflowContractTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.ViewModels
+{
+    public class DashboardWorkflowContractTests
+    {
+        [Fact]
+        public void DashboardLoadFailures_ClearPaneRowsAndSelectionState()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "DashboardViewModel.cs");
+
+            Assert.Contains("ClearDashboardStatsAfterLoadFailure();", source, StringComparison.Ordinal);
+            Assert.Contains("ClearRecentActivityAfterLoadFailure();", source, StringComparison.Ordinal);
+            Assert.Contains("ClearCheckedOutItemsAfterLoadFailure();", source, StringComparison.Ordinal);
+            Assert.Contains("ClearRentedItemsAfterLoadFailure();", source, StringComparison.Ordinal);
+            Assert.Contains("ClearCommonlyUsedItemsAfterLoadFailure();", source, StringComparison.Ordinal);
+            Assert.Contains("ClearIncompleteItemsAfterLoadFailure();", source, StringComparison.Ordinal);
+
+            Assert.Contains("private void ClearDashboardStatsAfterLoadFailure()", source, StringComparison.Ordinal);
+            Assert.Contains("StatCards.Clear();", source, StringComparison.Ordinal);
+            Assert.Contains("RecentActivity.Clear();", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedActivity = null;", source, StringComparison.Ordinal);
+            Assert.Contains("CheckedOutItems.Clear();", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedCheckedOutItem = null;", source, StringComparison.Ordinal);
+            Assert.Contains("RentedItems.Clear();", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedRental = null;", source, StringComparison.Ordinal);
+            Assert.Contains("CommonlyUsedItems.Clear();", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedCommonlyUsedItem = null;", source, StringComparison.Ordinal);
+            Assert.Contains("IncompleteItems.Clear();", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedIncompleteItem = null;", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DashboardLoadFailures_RefreshSummariesAndCommandState()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "DashboardViewModel.cs");
+
+            Assert.Contains("ClearActivitySelectionIfMissing();", source, StringComparison.Ordinal);
+            Assert.Contains("private void ClearActivitySelectionIfMissing()", source, StringComparison.Ordinal);
+            Assert.Contains("RecentActivity.All(log => log.LogID != SelectedActivity.LogID)", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(OperationsSummary));", source, StringComparison.Ordinal);
+            Assert.Contains("OpenActivityDestinationCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+            Assert.Contains("CheckInSelectedItemCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+            Assert.Contains("ReturnSelectedRentalCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+        }
+
+        static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null && !File.Exists(Path.Combine(directory.FullName, "InventoryManagementApp.sln")))
+                directory = directory.Parent;
+
+            Assert.NotNull(directory);
+            var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
+            Assert.True(File.Exists(path), $"Expected repository file at {path}");
+            return File.ReadAllText(path);
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-dashboard-load-failure-clearing.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-dashboard-load-failure-clearing.md
@@ -1,0 +1,17 @@
+# Dashboard Load Failure Clearing
+
+Completed on 2026-06-22.
+
+## What changed
+
+- Dashboard statistics now clear partial stat cards after load failures.
+- Recent activity, checked-out items, active rentals, commonly used items, and incomplete item panes now clear their own visible rows and selected row state when their load path fails.
+- Dashboard summaries and row-action command state refresh after failure clearing so stale selected rows do not leave actions enabled.
+- Source-contract coverage guards the clearing helpers, summary refresh, and command-state notifications.
+
+## Validation
+
+- GitHub connector readback/compare was used for validation in the scheduled Linux environment.
+- Local clone/raw access is blocked by `CONNECT tunnel failed, response 403`.
+- `gh` is not installed.
+- `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run in this environment.

--- a/InventoryManagementApp/ViewModels/DashboardViewModel.cs
+++ b/InventoryManagementApp/ViewModels/DashboardViewModel.cs
@@ -282,6 +282,7 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load dashboard statistics");
+                ClearDashboardStatsAfterLoadFailure();
             }
         }
 
@@ -294,10 +295,12 @@ namespace InventoryManagementApp.ViewModels
                 if (!result.Success || result.Value == null)
                 {
                     _logger.LogError("Failed to load recent activity: {Error}", result.ErrorMessage);
+                    ClearRecentActivityAfterLoadFailure();
                     return;
                 }
                 foreach (var log in result.Value)
                     RecentActivity.Add(log);
+                ClearActivitySelectionIfMissing();
                 OnPropertyChanged(nameof(OperationsSummary));
             }
             catch (OperationCanceledException)
@@ -306,6 +309,7 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load recent activity");
+                ClearRecentActivityAfterLoadFailure();
             }
         }
 
@@ -326,6 +330,7 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load checked-out items");
+                ClearCheckedOutItemsAfterLoadFailure();
             }
         }
 
@@ -347,6 +352,7 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load rented items");
+                ClearRentedItemsAfterLoadFailure();
             }
         }
 
@@ -522,6 +528,7 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load commonly used items");
+                ClearCommonlyUsedItemsAfterLoadFailure();
             }
         }
 
@@ -542,6 +549,7 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load incomplete items");
+                ClearIncompleteItemsAfterLoadFailure();
             }
         }
 
@@ -673,6 +681,51 @@ namespace InventoryManagementApp.ViewModels
         {
             if (SelectedRental != null && RentedItems.All(rental => rental.RentalID != SelectedRental.RentalID))
                 SelectedRental = null;
+        }
+
+        private void ClearActivitySelectionIfMissing()
+        {
+            if (SelectedActivity != null && RecentActivity.All(log => log.LogID != SelectedActivity.LogID))
+                SelectedActivity = null;
+        }
+
+        private void ClearDashboardStatsAfterLoadFailure()
+        {
+            StatCards.Clear();
+        }
+
+        private void ClearRecentActivityAfterLoadFailure()
+        {
+            RecentActivity.Clear();
+            SelectedActivity = null;
+            OnPropertyChanged(nameof(OperationsSummary));
+        }
+
+        private void ClearCheckedOutItemsAfterLoadFailure()
+        {
+            CheckedOutItems.Clear();
+            SelectedCheckedOutItem = null;
+            OnPropertyChanged(nameof(OperationsSummary));
+        }
+
+        private void ClearRentedItemsAfterLoadFailure()
+        {
+            RentedItems.Clear();
+            SelectedRental = null;
+            OnPropertyChanged(nameof(OperationsSummary));
+        }
+
+        private void ClearCommonlyUsedItemsAfterLoadFailure()
+        {
+            CommonlyUsedItems.Clear();
+            SelectedCommonlyUsedItem = null;
+        }
+
+        private void ClearIncompleteItemsAfterLoadFailure()
+        {
+            IncompleteItems.Clear();
+            SelectedIncompleteItem = null;
+            OnPropertyChanged(nameof(OperationsSummary));
         }
 
         private static string DescribeItem(string prefix, ItemModel item)


### PR DESCRIPTION
## Summary

- Clear partial dashboard stat cards after statistic load failures.
- Clear recent activity, checked-out item, active rental, commonly used item, and incomplete item rows plus their selected-row state when their dashboard load paths fail.
- Refresh dashboard operation summaries and row-action command state after failure clearing so stale selected rows do not leave actions enabled.
- Add source-contract coverage for the Dashboard load-failure clearing helpers, selection clearing, summary refresh, and command notifications.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `DashboardViewModel`, `DashboardWorkflowContractTests`, and the progress note through the GitHub connector.
- GitHub reports no attached status checks or workflow runs for branch head `9219a84a122473c4416f172c856513964227d5a7`.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because this scheduled Linux container does not provide local .NET/WPF validation.