### PR TITLE
[codex] Show import/export failure dialogs

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
@@ -43,6 +43,27 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("DataRunLogCard", xaml, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void ImportExportViewModel_ShowsVisibleFeedbackForFailedDataOperations()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
+
+            Assert.Contains("await _dialogService.ShowInfoAsync(errorMessage, $\"Export {plural}\");", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(failureMessage, $\"Export {plural}\");", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(message, $\"Export {plural}\");", source, StringComparison.Ordinal);
+
+            Assert.Contains("await _dialogService.ShowInfoAsync(errorMessage, \"Import Customers\");", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(failureMessage, \"Import Customers\");", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(message, \"Import Customers\");", source, StringComparison.Ordinal);
+
+            Assert.Contains("await _dialogService.ShowInfoAsync(errorMessage, \"Export Customers\");", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(failureMessage, \"Export Customers\");", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(message, \"Export Customers\");", source, StringComparison.Ordinal);
+
+            Assert.Contains("await _dialogService.ShowInfoAsync(failureMessage, \"Database Backup\");", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(message, \"Database Backup\");", source, StringComparison.Ordinal);
+        }
+
         static string ReadRepositoryFile(params string[] relativePathParts)
         {
             var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-import-export-visible-failure-feedback.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-import-export-visible-failure-feedback.md
@@ -1,0 +1,17 @@
+# Import / Export Visible Failure Feedback - 2026-06-22
+
+## Completed
+
+- Made Import / Export data operation feedback more consistent by showing the app information dialog when item export, customer import, customer export, or database backup operations fail or are cancelled.
+- Added visible feedback for unsupported item and customer export file types so operators do not need to discover those failures only from the run log.
+- Preserved the existing run-log behavior so every visible failure message is still recorded and selected for copy/print/review.
+- Added source-contract coverage in `ImportExportPageXamlTests` to guard the visible failure-feedback calls for item export, customer import/export, and database backup paths.
+
+## Validation
+
+- GitHub connector readback/compare should review the focused view-model, test, and progress-note changes.
+- Local clone/raw access, `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run because this scheduled Linux container cannot access the repository clone/raw content and does not provide Windows/WPF validation.
+
+## Follow-up
+
+- Run the Import / Export workflow on a Windows workstation to confirm the visible dialogs, run-log selection, and cancellation paths feel right with real file dialogs and backup destinations.

--- a/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
@@ -301,6 +301,7 @@ namespace InventoryManagementApp.ViewModels
                 {
                     var errorMessage = $"No exporter found for file type: {extension}";
                     AddLog(errorMessage);
+                    await _dialogService.ShowInfoAsync(errorMessage, $"Export {plural}");
                     return;
                 }
                 
@@ -310,13 +311,17 @@ namespace InventoryManagementApp.ViewModels
             catch (OperationCanceledException)
             {
                 var plural = LabelProvider.Instance.ItemLabelPlural;
-                AddLog($"{plural} export was cancelled.");
+                var message = $"{plural} export was cancelled.";
+                AddLog(message);
+                await _dialogService.ShowInfoAsync(message, $"Export {plural}");
             }
             catch (Exception ex)
             {
                 var plural = LabelProvider.Instance.ItemLabelPlural;
                 _logger.LogError(ex, "Failed to export {ItemLabelPlural} to {Path}", plural, path);
-                AddLog($"Failed to export {plural} to {path}: {ex.Message}");
+                var failureMessage = $"Failed to export {plural} to {path}: {ex.Message}";
+                AddLog(failureMessage);
+                await _dialogService.ShowInfoAsync(failureMessage, $"Export {plural}");
             }
         }
 
@@ -367,12 +372,16 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (OperationCanceledException)
             {
-                AddLog("Customer import was cancelled.");
+                const string message = "Customer import was cancelled.";
+                AddLog(message);
+                await _dialogService.ShowInfoAsync(message, "Import Customers");
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to import customers from {Path}", path);
-                AddLog($"Failed to import customers from {path}: {ex.Message}");
+                var failureMessage = $"Failed to import customers from {path}: {ex.Message}";
+                AddLog(failureMessage);
+                await _dialogService.ShowInfoAsync(failureMessage, "Import Customers");
             }
         }
 
@@ -395,6 +404,7 @@ namespace InventoryManagementApp.ViewModels
                 {
                     var errorMessage = $"No exporter found for file type: {extension}";
                     AddLog(errorMessage);
+                    await _dialogService.ShowInfoAsync(errorMessage, "Export Customers");
                     return;
                 }
                 
@@ -403,12 +413,16 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (OperationCanceledException)
             {
-                AddLog("Customer export was cancelled.");
+                const string message = "Customer export was cancelled.";
+                AddLog(message);
+                await _dialogService.ShowInfoAsync(message, "Export Customers");
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to export customers to {Path}", path);
-                AddLog($"Failed to export customers to {path}: {ex.Message}");
+                var failureMessage = $"Failed to export customers to {path}: {ex.Message}";
+                AddLog(failureMessage);
+                await _dialogService.ShowInfoAsync(failureMessage, "Export Customers");
             }
         }
 
@@ -434,12 +448,16 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (OperationCanceledException)
             {
-                AddLog("Database backup was cancelled.");
+                const string message = "Database backup was cancelled.";
+                AddLog(message);
+                await _dialogService.ShowInfoAsync(message, "Database Backup");
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to backup database to {Path}", path);
-                AddLog($"Failed to backup database to {path}: {ex.Message}");
+                var failureMessage = $"Failed to backup database to {path}: {ex.Message}";
+                AddLog(failureMessage);
+                await _dialogService.ShowInfoAsync(failureMessage, "Database Backup");
             }
         }
     }


### PR DESCRIPTION
## Summary

- Show visible app information dialogs when item export, customer import, customer export, or database backup operations fail or are cancelled.
- Show visible feedback for unsupported item/customer export file types instead of only writing those failures to the run log.
- Preserve the existing Import / Export run-log entries and selected-log behavior for copy/print/review.
- Add source-contract coverage for the visible failure-feedback calls.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ImportExportViewModel`, `ImportExportPageXamlTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime checks were not run because this scheduled Linux container does not provide local .NET/WPF validation.