### PR TITLE
[codex] Cover item import failure feedback

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
@@ -64,6 +64,18 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("await _dialogService.ShowInfoAsync(message, \"Database Backup\");", source, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void ImportExportViewModel_ShowsVisibleFeedbackForItemImportFailures()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
+
+            Assert.Contains("var errorMessage = $\"Mapping for {singular} number is required.\";", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(errorMessage, $\"Import {plural}\");", source, StringComparison.Ordinal);
+            Assert.Contains("var errorMessage = $\"No importer found for file type: {extension}\";", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync($\"{plural} import was cancelled.\", $\"Import {plural}\");", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync($\"Failed to import {plural} from {path}: {ex.Message}\", $\"Import {plural}\");", source, StringComparison.Ordinal);
+        }
+
         static string ReadRepositoryFile(params string[] relativePathParts)
         {
             var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-import-export-item-import-feedback-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-import-export-item-import-feedback-coverage.md
@@ -1,0 +1,16 @@
+# Import / Export Item Import Feedback Coverage - 2026-06-22
+
+## Completed
+
+- Added source-contract coverage for item import failure feedback in `ImportExportPageXamlTests`.
+- Guarded the visible dialog contract for missing CSV item-number mapping, unsupported item import file types, item import cancellation, and unexpected item import failures.
+- Kept the pass focused on validation/consolidation around the recently completed Import / Export failure-feedback work instead of adding more Admin Settings theme layers.
+
+## Validation
+
+- GitHub connector readback/compare should review the focused test and progress-note changes.
+- Local clone/raw access failed with `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run in this scheduled Linux container.
+
+## Follow-up
+
+- Run the Import / Export item import workflow on a Windows/.NET workstation to verify the dialogs and run-log selection with real file-dialog cancellation, unsupported extensions, and CSV mapping cancellation.


### PR DESCRIPTION
## Summary

- Add source-contract coverage for visible item import failure feedback in `ImportExportPageXamlTests`.
- Guard the dialog contract for missing CSV item-number mapping, unsupported item import file types, item import cancellation, and unexpected item import failures.
- Record the focused validation/consolidation pass in a progress note.

## Validation

- GitHub connector compare confirmed a focused 2-file diff against current `master`, with the branch 2 commits ahead and 0 behind.
- Read back `ImportExportPageXamlTests` and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.