### PR TITLE
[codex] Cover checked-out refresh fallback

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ItemWorkflowRefreshContractTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ItemWorkflowRefreshContractTests.cs
@@ -24,6 +24,22 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("The item list has been refreshed in case the check-out status changed before the failure.", source);
         }
 
+        [Fact]
+        public void CheckedOutRefreshKeepsFallbackToLoadedRowsWhenServiceCannotReturnFreshRows()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp/ViewModels/ItemManagementViewModel.cs");
+
+            Assert.Contains("async Task RefreshCheckedOutItemsAsync(CancellationToken cancellationToken = default)", source);
+            Assert.Contains("if (checkedOutItemsTask == null)", source);
+            Assert.Contains("if (checkedOutItems == null)", source);
+            Assert.Contains("catch (NullReferenceException)", source);
+            Assert.True(
+                CountOccurrences(source, "ReplaceCheckedOutItemsFromLoadedItems();") >= 3,
+                "Checked-out refresh should fall back to loaded item rows when the service cannot provide a usable checked-out list.");
+            Assert.Contains("var checkedOutItems = Items.Where(t => t.IsCheckedOut)", source);
+            Assert.Contains("CheckedOutItems.ReplaceRange(checkedOutItems);", source);
+        }
+
         private static string ReadRepositoryFile(string relativePath)
         {
             var root = FindRepositoryRoot();

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-checked-out-refresh-fallback-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-checked-out-refresh-fallback-coverage.md
@@ -1,0 +1,13 @@
+# Checked-out refresh fallback coverage
+
+Date: 2026-06-22
+
+## Completed
+
+- Added source-contract coverage for `ItemManagementViewModel.RefreshCheckedOutItemsAsync` so the checked-out item pane keeps its fallback behavior when the checked-out item service returns no task, returns no rows, or hits the existing null-reference recovery path.
+- Guarded the loaded-row fallback helper that rebuilds `CheckedOutItems` from currently loaded `Items` where `IsCheckedOut` is true, preserving a useful checked-out pane when the dedicated refresh source cannot provide usable data.
+
+## Validation
+
+- GitHub connector readback/compare should be used for this scheduled pass because direct clone/raw access is blocked by `CONNECT tunnel failed, response 403`.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not run in this Linux scheduled container.


### PR DESCRIPTION
## Summary

- Add source-contract coverage for `ItemManagementViewModel.RefreshCheckedOutItemsAsync` checked-out item fallback behavior.
- Guard the contract that falls back to loaded `Items` rows when the checked-out service returns no task, returns no rows, or hits the existing null-reference recovery path.
- Record the validation-focused pass in a progress note.

## Validation

- GitHub connector compare confirmed a focused 2-file diff against current `master`, with the branch 2 commits ahead and 0 behind.
- Read back `ItemWorkflowRefreshContractTests` and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.