### PR TITLE
[codex] Cover customer import failure feedback

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
@@ -76,6 +76,20 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("await _dialogService.ShowInfoAsync($\"Failed to import {plural} from {path}: {ex.Message}\", $\"Import {plural}\");", source, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void ImportExportViewModel_ShowsVisibleFeedbackForCustomerImportFailures()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
+            var method = ExtractMethodBody(source, "async Task ImportCustomersAsync", "async Task ExportCustomersAsync");
+
+            Assert.Contains("var errorMessage = $\"No importer found for file type: {extension}\";", method, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(errorMessage, \"Import Customers\");", method, StringComparison.Ordinal);
+            Assert.Contains("const string message = \"Customer import was cancelled.\";", method, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(message, \"Import Customers\");", method, StringComparison.Ordinal);
+            Assert.Contains("var failureMessage = $\"Failed to import customers from {path}: {ex.Message}\";", method, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(failureMessage, \"Import Customers\");", method, StringComparison.Ordinal);
+        }
+
         static string ReadRepositoryFile(params string[] relativePathParts)
         {
             var directory = new DirectoryInfo(AppContext.BaseDirectory);
@@ -86,6 +100,17 @@ namespace InventoryManagementApp.Tests.ViewModels
             var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
             Assert.True(File.Exists(path), $"Expected repository file at {path}");
             return File.ReadAllText(path);
+        }
+
+        static string ExtractMethodBody(string source, string methodStart, string nextMethodStart)
+        {
+            var start = source.IndexOf(methodStart, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Expected to find method starting with {methodStart}");
+
+            var end = source.IndexOf(nextMethodStart, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Expected to find next method starting with {nextMethodStart}");
+
+            return source.Substring(start, end - start);
         }
     }
 }

--- a/InventoryManagementApp/ProgressNotes/2026-06-22-customer-import-feedback-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-22-customer-import-feedback-coverage.md
@@ -1,0 +1,12 @@
+# Customer Import Feedback Coverage
+
+Date: 2026-06-22
+
+## Completed
+- Added focused source-contract coverage for the `ImportCustomersAsync` failure-feedback branch.
+- Guarded visible app information dialogs for unsupported customer import file types, customer import cancellation, and unexpected customer import failures.
+- Kept the pass validation-focused and outside the repeated Admin Settings theme expansion loop.
+
+## Validation Notes
+- Local clone/raw access was blocked in the scheduled Linux container.
+- `dotnet`, WPF screenshots/runtime checks, and local banned-word checks were unavailable, so connector readback and branch compare are the validation fallback for this pass.


### PR DESCRIPTION
## Summary

- Add focused source-contract coverage for the `ImportCustomersAsync` failure-feedback branch.
- Guard visible app information dialogs for unsupported customer import file types, customer import cancellation, and unexpected customer import failures.
- Record the validation-focused pass in a progress note.

## Validation

- GitHub connector compare confirmed a focused 2-file diff against current `master`, with the branch 2 commits ahead and 0 behind.
- Read back `ImportExportPageXamlTests` and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.