### PR TITLE
[codex] Show import/export success feedback

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
@@ -65,6 +65,29 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void ImportExportViewModel_ShowsVisibleFeedbackForSuccessfulDataOperations()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
+
+            Assert.Contains("var successMessage = $\"Successfully exported {plural} to {path} ({exporter.FormatName} format).\";", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(successMessage, $\"Export {plural}\");", source, StringComparison.Ordinal);
+
+            var customerImport = ExtractMethodBody(source, "async Task ImportCustomersAsync", "async Task ExportCustomersAsync");
+            Assert.Contains("var successMessage = $\"Successfully imported customers from {path}. Imported {result.ImportedCount} customers.\";", customerImport, StringComparison.Ordinal);
+            Assert.Contains("successMessage += $\" {result.SkippedRows.Count} skipped row", customerImport, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(successMessage, \"Import Customers\");", customerImport, StringComparison.Ordinal);
+            Assert.Contains("var successMessage = $\"Successfully imported {importedCount} customers from {path} ({importer.FormatName} format).\";", customerImport, StringComparison.Ordinal);
+
+            var customerExport = ExtractMethodBody(source, "async Task ExportCustomersAsync", "async Task BackupDatabaseAsync");
+            Assert.Contains("var successMessage = $\"Successfully exported customers to {path} ({exporter.FormatName} format).\";", customerExport, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(successMessage, \"Export Customers\");", customerExport, StringComparison.Ordinal);
+
+            var backup = ExtractMethodBody(source, "async Task BackupDatabaseAsync", "    }\n}");
+            Assert.Contains("var successMessage = $\"Successfully backed up database to {path}.\";", backup, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(successMessage, \"Database Backup\");", backup, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ImportExportViewModel_ShowsVisibleFeedbackForItemImportFailures()
         {
             var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-import-export-success-feedback.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-import-export-success-feedback.md
@@ -1,0 +1,18 @@
+# Import / Export Success Feedback - 2026-06-23
+
+## Completed
+
+- Made Import / Export completion feedback consistent with the existing failure-feedback dialogs.
+- Item export, customer CSV import, customer JSON/XML import, customer export, and database backup success paths now show the app information dialog after recording the run-log entry.
+- Customer CSV imports with skipped rows keep detailed skipped-row entries in the run log while summarizing the skipped count in the visible completion dialog.
+- Added source-contract coverage in `ImportExportPageXamlTests` to guard the success-dialog calls and run-log message flow.
+
+## Validation
+
+- GitHub connector readback/compare should review the focused view-model, test, and progress-note changes.
+- Local clone/raw access was blocked by `CONNECT tunnel failed, response 403` in the scheduled Linux container.
+- `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run because this environment does not provide local .NET/WPF validation.
+
+## Follow-up
+
+- Run the Import / Export workflow on a Windows workstation to confirm the completion dialogs feel right with real file dialogs, long paths, skipped customer rows, and backup destinations.

--- a/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
@@ -306,7 +306,9 @@ namespace InventoryManagementApp.ViewModels
                 }
                 
                 await _itemService.ExportItemsAsync(path, exporter, cancellationToken);
-                AddLog($"Successfully exported {plural} to {path} ({exporter.FormatName} format).");
+                var successMessage = $"Successfully exported {plural} to {path} ({exporter.FormatName} format).";
+                AddLog(successMessage);
+                await _dialogService.ShowInfoAsync(successMessage, $"Export {plural}");
             }
             catch (OperationCanceledException)
             {
@@ -350,9 +352,13 @@ namespace InventoryManagementApp.ViewModels
                     if (map == null)
                         return;
                     var result = await _customerService.ImportCustomersFromCsvAsync(path, map, cancellationToken);
-                    AddLog($"Successfully imported customers from {path}. Imported {result.ImportedCount} customers.");
+                    var successMessage = $"Successfully imported customers from {path}. Imported {result.ImportedCount} customers.";
+                    AddLog(successMessage);
+                    if (result.SkippedRows.Any())
+                        successMessage += $" {result.SkippedRows.Count} skipped row{(result.SkippedRows.Count == 1 ? "" : "s")} were recorded in the run log.";
                     foreach (var msg in result.SkippedRows)
                         AddLog($"Skipped {msg}");
+                    await _dialogService.ShowInfoAsync(successMessage, "Import Customers");
                 }
                 else
                 {
@@ -367,7 +373,9 @@ namespace InventoryManagementApp.ViewModels
                     }
                     
                     var importedCount = await _customerService.ImportCustomersAsync(path, importer, cancellationToken);
-                    AddLog($"Successfully imported {importedCount} customers from {path} ({importer.FormatName} format).");
+                    var successMessage = $"Successfully imported {importedCount} customers from {path} ({importer.FormatName} format).";
+                    AddLog(successMessage);
+                    await _dialogService.ShowInfoAsync(successMessage, "Import Customers");
                 }
             }
             catch (OperationCanceledException)
@@ -409,7 +417,9 @@ namespace InventoryManagementApp.ViewModels
                 }
                 
                 await _customerService.ExportCustomersAsync(path, exporter, cancellationToken);
-                AddLog($"Successfully exported customers to {path} ({exporter.FormatName} format).");
+                var successMessage = $"Successfully exported customers to {path} ({exporter.FormatName} format).";
+                AddLog(successMessage);
+                await _dialogService.ShowInfoAsync(successMessage, "Export Customers");
             }
             catch (OperationCanceledException)
             {
@@ -444,7 +454,9 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 await _databaseService.BackupDatabaseAsync(path, cancellationToken);
-                AddLog($"Successfully backed up database to {path}.");
+                var successMessage = $"Successfully backed up database to {path}.";
+                AddLog(successMessage);
+                await _dialogService.ShowInfoAsync(successMessage, "Database Backup");
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
## Summary

- Show the app information dialog after successful item exports, customer imports, customer exports, and database backups instead of recording completion only in the run log.
- Keep run-log entries selected for copy/print/review, and summarize skipped customer CSV rows in the visible completion message while leaving detailed skipped-row entries in the run log.
- Add source-contract coverage in `ImportExportPageXamlTests` and record the focused reliability pass in a progress note.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ImportExportViewModel`, `ImportExportPageXamlTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.