### PR TITLE
[codex] Show import mapping cancellation feedback

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
@@ -92,6 +92,8 @@ namespace InventoryManagementApp.Tests.ViewModels
         {
             var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
 
+            Assert.Contains("var message = $\"{plural} import mapping was cancelled.\";", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(message, $\"Import {plural}\");", source, StringComparison.Ordinal);
             Assert.Contains("var errorMessage = $\"Mapping for {singular} number is required.\";", source, StringComparison.Ordinal);
             Assert.Contains("await _dialogService.ShowInfoAsync(errorMessage, $\"Import {plural}\");", source, StringComparison.Ordinal);
             Assert.Contains("var errorMessage = $\"No importer found for file type: {extension}\";", source, StringComparison.Ordinal);
@@ -105,6 +107,8 @@ namespace InventoryManagementApp.Tests.ViewModels
             var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
             var method = ExtractMethodBody(source, "async Task ImportCustomersAsync", "async Task ExportCustomersAsync");
 
+            Assert.Contains("const string message = \"Customer import mapping was cancelled.\";", method, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(message, \"Import Customers\");", method, StringComparison.Ordinal);
             Assert.Contains("var errorMessage = $\"No importer found for file type: {extension}\";", method, StringComparison.Ordinal);
             Assert.Contains("await _dialogService.ShowInfoAsync(errorMessage, \"Import Customers\");", method, StringComparison.Ordinal);
             Assert.Contains("const string message = \"Customer import was cancelled.\";", method, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-import-export-mapping-cancel-feedback.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-import-export-mapping-cancel-feedback.md
@@ -1,0 +1,18 @@
+# Import / Export Mapping Cancellation Feedback - 2026-06-23
+
+## Completed
+
+- Made CSV mapping cancellation visible for item and customer imports after an operator has already selected a file.
+- Item CSV import mapping cancellation now records a selected run-log entry and shows the app information dialog before returning.
+- Customer CSV import mapping cancellation now records a selected run-log entry and shows the app information dialog before returning.
+- Added source-contract coverage in `ImportExportPageXamlTests` so mapping-cancel feedback stays aligned with the broader Import / Export failure-feedback contract.
+
+## Validation
+
+- GitHub connector readback/compare should review the focused view-model, test, and progress-note changes.
+- Local clone/raw access was blocked by `CONNECT tunnel failed, response 403` in the scheduled Linux container.
+- `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run because this environment does not provide local .NET/WPF validation.
+
+## Follow-up
+
+- Run the Import / Export CSV workflows on a Windows workstation to confirm mapping-cancel messaging feels natural from the real dialog flow.

--- a/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
@@ -225,7 +225,12 @@ namespace InventoryManagementApp.ViewModels
                         properties,
                         new[] { nameof(ItemImportDto.ItemNumber), nameof(ItemImportDto.Name) });
                     if (map == null)
+                    {
+                        var message = $"{plural} import mapping was cancelled.";
+                        AddLog(message);
+                        await _dialogService.ShowInfoAsync(message, $"Import {plural}");
                         return;
+                    }
                     
                     if (!map.TryGetValue(nameof(ItemImportDto.ItemNumber), out var itemNumberHeader) || string.IsNullOrWhiteSpace(itemNumberHeader))
                     {
@@ -350,7 +355,12 @@ namespace InventoryManagementApp.ViewModels
                     var properties = typeof(CustomerImportDto).GetProperties().Select(p => p.Name);
                     var map = _dialogService.ShowImportMapping(headers, properties);
                     if (map == null)
+                    {
+                        const string message = "Customer import mapping was cancelled.";
+                        AddLog(message);
+                        await _dialogService.ShowInfoAsync(message, "Import Customers");
                         return;
+                    }
                     var result = await _customerService.ImportCustomersFromCsvAsync(path, map, cancellationToken);
                     var successMessage = $"Successfully imported customers from {path}. Imported {result.ImportedCount} customers.";
                     AddLog(successMessage);


### PR DESCRIPTION
## Summary

- Show visible Import / Export feedback when item CSV mapping is cancelled after a file is selected.
- Show visible Import / Export feedback when customer CSV mapping is cancelled after a file is selected.
- Record both mapping-cancel paths in the run log and keep source-contract coverage aligned with the existing failure-feedback tests.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ImportExportViewModel`, `ImportExportPageXamlTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.