### PR TITLE
[codex] Show import/export file dialog cancellation feedback

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
@@ -65,6 +65,32 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void ImportExportViewModel_ShowsVisibleFeedbackForFileDialogCancellations()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
+
+            Assert.Contains("async Task CancelFileSelectionAsync(string message, string title)", source, StringComparison.Ordinal);
+            Assert.Contains("AddLog(message);", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(message, title);", source, StringComparison.Ordinal);
+
+            var itemImport = ExtractMethodBody(source, "async Task ImportItemsAsync", "async Task ExportItemsAsync");
+            Assert.Contains("if (string.IsNullOrWhiteSpace(path))", itemImport, StringComparison.Ordinal);
+            Assert.Contains("await CancelFileSelectionAsync($\"{plural} import file selection was cancelled.\", $\"Import {plural}\");", itemImport, StringComparison.Ordinal);
+
+            var itemExport = ExtractMethodBody(source, "async Task ExportItemsAsync", "async Task ImportCustomersAsync");
+            Assert.Contains("await CancelFileSelectionAsync($\"{plural} export destination selection was cancelled.\", $\"Export {plural}\");", itemExport, StringComparison.Ordinal);
+
+            var customerImport = ExtractMethodBody(source, "async Task ImportCustomersAsync", "async Task ExportCustomersAsync");
+            Assert.Contains("await CancelFileSelectionAsync(\"Customer import file selection was cancelled.\", \"Import Customers\");", customerImport, StringComparison.Ordinal);
+
+            var customerExport = ExtractMethodBody(source, "async Task ExportCustomersAsync", "async Task BackupDatabaseAsync");
+            Assert.Contains("await CancelFileSelectionAsync(\"Customer export destination selection was cancelled.\", \"Export Customers\");", customerExport, StringComparison.Ordinal);
+
+            var backup = ExtractMethodBody(source, "async Task BackupDatabaseAsync", "    }\n}");
+            Assert.Contains("await CancelFileSelectionAsync(\"Database backup destination selection was cancelled.\", \"Database Backup\");", backup, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ImportExportViewModel_ShowsVisibleFeedbackForSuccessfulDataOperations()
         {
             var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-import-export-file-dialog-cancel-feedback.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-import-export-file-dialog-cancel-feedback.md
@@ -1,0 +1,17 @@
+# Import / Export File Dialog Cancellation Feedback - 2026-06-23
+
+## Completed
+
+- Made Import / Export file and destination dialog cancellations visible instead of silently returning when an operator backs out before choosing a path.
+- Item import/export, customer import/export, and database backup dialog cancellations now record a selected run-log entry and show the app information dialog.
+- Added source-contract coverage in `ImportExportPageXamlTests` for the shared cancellation helper and all five file-dialog cancellation paths.
+
+## Validation
+
+- GitHub connector readback/compare should review the focused view-model, test, and progress-note changes.
+- Local clone/raw access was blocked by `CONNECT tunnel failed, response 403` in the scheduled Linux container.
+- `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run because this environment does not provide local .NET/WPF validation.
+
+## Follow-up
+
+- Run the Import / Export file and destination cancellation flows on a Windows workstation to confirm the dialog timing and copy feel natural in the real WPF shell.

--- a/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
@@ -195,6 +195,12 @@ namespace InventoryManagementApp.ViewModels
             ClearImportExportLogsCommand.NotifyCanExecuteChanged();
         }
 
+        async Task CancelFileSelectionAsync(string message, string title)
+        {
+            AddLog(message);
+            await _dialogService.ShowInfoAsync(message, title);
+        }
+
         async Task ImportItemsAsync(CancellationToken cancellationToken)
         {
             // Build combined file filter for all supported formats
@@ -205,7 +211,12 @@ namespace InventoryManagementApp.ViewModels
             var combinedFilter = string.Join("|", filters) + "|All Files|*.*";
             
             var path = _fileDialogService.OpenFile(combinedFilter, AppContext.BaseDirectory);
-            if (string.IsNullOrWhiteSpace(path)) return;
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                var plural = LabelProvider.Instance.ItemLabelPlural;
+                await CancelFileSelectionAsync($"{plural} import file selection was cancelled.", $"Import {plural}");
+                return;
+            }
             
             try
             {
@@ -293,7 +304,12 @@ namespace InventoryManagementApp.ViewModels
             var combinedFilter = string.Join("|", filters);
             
             var path = _fileDialogService.SaveFile(combinedFilter);
-            if (string.IsNullOrWhiteSpace(path)) return;
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                var plural = LabelProvider.Instance.ItemLabelPlural;
+                await CancelFileSelectionAsync($"{plural} export destination selection was cancelled.", $"Export {plural}");
+                return;
+            }
             
             try
             {
@@ -342,7 +358,11 @@ namespace InventoryManagementApp.ViewModels
             var combinedFilter = string.Join("|", filters) + "|All Files|*.*";
             
             var path = _fileDialogService.OpenFile(combinedFilter, AppContext.BaseDirectory);
-            if (string.IsNullOrWhiteSpace(path)) return;
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                await CancelFileSelectionAsync("Customer import file selection was cancelled.", "Import Customers");
+                return;
+            }
             
             try
             {
@@ -410,7 +430,11 @@ namespace InventoryManagementApp.ViewModels
             var combinedFilter = string.Join("|", filters);
             
             var path = _fileDialogService.SaveFile(combinedFilter);
-            if (string.IsNullOrWhiteSpace(path)) return;
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                await CancelFileSelectionAsync("Customer export destination selection was cancelled.", "Export Customers");
+                return;
+            }
             
             try
             {
@@ -460,7 +484,11 @@ namespace InventoryManagementApp.ViewModels
                 ? null
                 : await _rentalConfigService.GetBackupDirectoryAsync(cancellationToken).ConfigureAwait(false);
             var path = _fileDialogService.SaveFile("SQLite Database|*.db", initialDirectory);
-            if (string.IsNullOrWhiteSpace(path)) return;
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                await CancelFileSelectionAsync("Database backup destination selection was cancelled.", "Database Backup");
+                return;
+            }
             try
             {
                 await _databaseService.BackupDatabaseAsync(path, cancellationToken);


### PR DESCRIPTION
## Summary

- Show visible Import / Export feedback when operators cancel file or destination selection before a path is chosen.
- Record selected run-log entries for item import/export, customer import/export, and database backup dialog cancellations.
- Add source-contract coverage for the shared cancellation helper and all five file-dialog cancellation paths.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ImportExportViewModel`, `ImportExportPageXamlTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.