### PR TITLE
[codex] Guard backup startup failure feedback

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
@@ -65,6 +65,22 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void ImportExportViewModel_ShowsVisibleFeedbackForBackupStartupFailures()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
+            var backup = ExtractMethodBody(source, "async Task BackupDatabaseAsync", "    }\n}");
+
+            Assert.Contains("string? path = null;", backup, StringComparison.Ordinal);
+            Assert.Contains("var initialDirectory = _rentalConfigService == null", backup, StringComparison.Ordinal);
+            Assert.Contains("path = _fileDialogService.SaveFile(\"SQLite Database|*.db\", initialDirectory);", backup, StringComparison.Ordinal);
+            Assert.Contains("var failureMessage = string.IsNullOrWhiteSpace(path)", backup, StringComparison.Ordinal);
+            Assert.Contains("? $\"Failed to start database backup: {ex.Message}\"", backup, StringComparison.Ordinal);
+            Assert.Contains(": $\"Failed to backup database to {path}: {ex.Message}\";", backup, StringComparison.Ordinal);
+            Assert.Contains("AddLog(failureMessage);", backup, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(failureMessage, \"Database Backup\");", backup, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ImportExportViewModel_ShowsVisibleFeedbackForFileDialogCancellations()
         {
             var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-import-export-backup-startup-feedback.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-import-export-backup-startup-feedback.md
@@ -1,0 +1,18 @@
+# Import / Export Backup Startup Feedback - 2026-06-23
+
+## Completed
+
+- Moved database backup startup setup into the existing guarded backup execution path.
+- If reading the configured backup directory fails before a destination path exists, Import / Export now records a selected run-log entry and shows a visible Database Backup information dialog instead of letting the exception escape.
+- Preserved destination-specific failure wording once a backup path has been chosen.
+- Added source-contract coverage in `ImportExportPageXamlTests` for the backup startup failure branch.
+
+## Validation
+
+- GitHub connector readback/compare should review the focused view-model, test, and progress-note changes.
+- Local clone/raw access was blocked by `CONNECT tunnel failed, response 403` in the scheduled Linux container.
+- `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run because this environment does not provide local .NET/WPF validation.
+
+## Follow-up
+
+- Run the backup workflow on a Windows workstation with an invalid or inaccessible saved backup directory to confirm the visible startup-failure copy feels natural in the real WPF shell.

--- a/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ImportExportViewModel.cs
@@ -480,17 +480,20 @@ namespace InventoryManagementApp.ViewModels
         /// <returns>A <see cref="Task"/> representing the asynchronous backup operation.</returns>
         async Task BackupDatabaseAsync(CancellationToken cancellationToken)
         {
-            var initialDirectory = _rentalConfigService == null
-                ? null
-                : await _rentalConfigService.GetBackupDirectoryAsync(cancellationToken).ConfigureAwait(false);
-            var path = _fileDialogService.SaveFile("SQLite Database|*.db", initialDirectory);
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                await CancelFileSelectionAsync("Database backup destination selection was cancelled.", "Database Backup");
-                return;
-            }
+            string? path = null;
+
             try
             {
+                var initialDirectory = _rentalConfigService == null
+                    ? null
+                    : await _rentalConfigService.GetBackupDirectoryAsync(cancellationToken).ConfigureAwait(false);
+                path = _fileDialogService.SaveFile("SQLite Database|*.db", initialDirectory);
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    await CancelFileSelectionAsync("Database backup destination selection was cancelled.", "Database Backup");
+                    return;
+                }
+
                 await _databaseService.BackupDatabaseAsync(path, cancellationToken);
                 var successMessage = $"Successfully backed up database to {path}.";
                 AddLog(successMessage);
@@ -505,7 +508,9 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to backup database to {Path}", path);
-                var failureMessage = $"Failed to backup database to {path}: {ex.Message}";
+                var failureMessage = string.IsNullOrWhiteSpace(path)
+                    ? $"Failed to start database backup: {ex.Message}"
+                    : $"Failed to backup database to {path}: {ex.Message}";
                 AddLog(failureMessage);
                 await _dialogService.ShowInfoAsync(failureMessage, "Database Backup");
             }


### PR DESCRIPTION
## Summary

- Move database backup startup setup into the guarded backup execution path.
- Show visible Database Backup feedback and record a selected run-log entry if the configured backup directory lookup fails before a destination path exists.
- Preserve destination-specific failure wording once a backup path has been selected, and add source-contract coverage for the startup-failure branch.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ImportExportViewModel`, `ImportExportPageXamlTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.