### PR TITLE
[codex] Cover item import success feedback

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
@@ -111,6 +111,11 @@ namespace InventoryManagementApp.Tests.ViewModels
         {
             var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");
 
+            var itemImport = ExtractMethodBody(source, "async Task ImportItemsAsync", "async Task ExportItemsAsync");
+            Assert.Contains("var successMessage = $\"Successfully imported {plural} from {path}.\";", itemImport, StringComparison.Ordinal);
+            Assert.Contains("successMessage += $\" {skippedMessage}\";", itemImport, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync(successMessage, $\"Import {plural}\");", itemImport, StringComparison.Ordinal);
+
             Assert.Contains("var successMessage = $\"Successfully exported {plural} to {path} ({exporter.FormatName} format).\";", source, StringComparison.Ordinal);
             Assert.Contains("await _dialogService.ShowInfoAsync(successMessage, $\"Export {plural}\");", source, StringComparison.Ordinal);
 

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-item-import-success-feedback-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-item-import-success-feedback-coverage.md
@@ -1,0 +1,12 @@
+# Item Import Success Feedback Coverage
+
+## Completed
+
+- Added source-contract coverage for successful item import feedback in `ImportExportPageXamlTests`.
+- Guarded the existing item import success path so it continues to add skipped-row details to the visible completion message before showing the Import dialog.
+- Kept this pass focused on validation coverage for the recent Import / Export reliability work instead of expanding Admin Settings theme customization.
+
+## Validation
+
+- GitHub connector readback/compare should be used for this scheduled pass.
+- Local clone/raw access, `dotnet`, WPF screenshots, and local banned-word checks are unavailable in the scheduled Linux container, so local build/test execution was not run here.


### PR DESCRIPTION
## Summary

- Add focused source-contract coverage for successful item import feedback in `ImportExportPageXamlTests`.
- Guard the existing item import completion dialog contract, including skipped-row details being appended before the visible Import dialog is shown.
- Record the validation-focused pass in a progress note while avoiding more Admin Settings theme expansion.

## Validation

- GitHub connector compare confirmed a focused 2-file diff against current `master`, with the branch 2 commits ahead and 0 behind.
- Read back `ImportExportPageXamlTests` and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.