### PR TITLE
[codex] Cover reports failure clearing

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
@@ -94,6 +94,25 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void ReportsGenerationFailure_ClearsRowsSelectionAndKeepsFailureStatus()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ReportsViewModel.cs");
+
+            Assert.Contains("catch (Exception ex)", source, StringComparison.Ordinal);
+            Assert.Contains("ReportLines.Clear();", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedReportLine = null;", source, StringComparison.Ordinal);
+            Assert.Contains("ReportTitle = SelectedReport;", source, StringComparison.Ordinal);
+            Assert.Contains("ReportSubtitle = \"The report could not be generated.\";", source, StringComparison.Ordinal);
+            Assert.Contains("ReportSummary = ex.Message;", source, StringComparison.Ordinal);
+            Assert.Contains("ReportStatus = \"Report failed.\";", source, StringComparison.Ordinal);
+            Assert.Contains("LastRunAt = DateTime.Now;", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(ReportLineCount));", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(ReportOperatorPath));", source, StringComparison.Ordinal);
+            Assert.Contains("ClearReportCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("catch (Exception ex)\n            {\n                LoadReport(null);", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void InsightPrintActions_RouteThroughSharedPrintPreview()
         {
             var reportsCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-reports-failure-clearing-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-reports-failure-clearing-coverage.md
@@ -1,0 +1,12 @@
+# Reports Failure Clearing Coverage - 2026-06-23
+
+## Completed
+
+- Added source-contract coverage for the `ReportsViewModel` report-generation failure branch.
+- Guarded that failed report generation clears stale report rows, clears the selected report line, keeps the report title tied to the requested report, records the exception message in the summary, and leaves the visible status as `Report failed.`
+- Guarded count/routing command notifications so the Reports workbench does not leave stale row actions enabled after a failed refresh.
+
+## Validation Notes
+
+- GitHub connector readback and compare should be used for validation in this scheduled environment.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run because direct repository checkout is blocked by `CONNECT tunnel failed, response 403` and this Linux scheduled container does not provide local .NET/WPF validation.


### PR DESCRIPTION
## Summary

- Add source-contract coverage for the `ReportsViewModel` report-generation failure path.
- Guard that failed report generation clears stale report rows and selected report-line state while keeping the visible `Report failed.` status and exception summary.
- Record the focused validation pass in a progress note.

## Validation

- GitHub connector compare confirmed a focused 2-file diff against current `master`, with the branch 2 commits ahead and 0 behind.
- Read back `InsightsPagesXamlTests` and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` is not installed; WPF screenshots, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.