### PR TITLE
[codex] Clear stale reports output on selection change

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
@@ -113,6 +113,25 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void ReportsSelectionChange_ClearsStaleRowsSelectionAndRunStateBeforeNextRun()
+        {
+            var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ReportsViewModel.cs");
+
+            Assert.Contains("ClearReportOutputForSelection(value);", source, StringComparison.Ordinal);
+            Assert.Contains("private void ClearReportOutputForSelection(string reportName)", source, StringComparison.Ordinal);
+            Assert.Contains("ReportLines.Clear();", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedReportLine = null;", source, StringComparison.Ordinal);
+            Assert.Contains("ReportTitle = string.IsNullOrWhiteSpace(reportName) ? \"Reports\" : reportName;", source, StringComparison.Ordinal);
+            Assert.Contains("ReportSummary = string.IsNullOrWhiteSpace(reportName)", source, StringComparison.Ordinal);
+            Assert.Contains("? \"No report has been run yet.\"", source, StringComparison.Ordinal);
+            Assert.Contains(": $\"Run {reportName} to refresh report rows.\";", source, StringComparison.Ordinal);
+            Assert.Contains("LastRunAt = null;", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(ReportLineCount));", source, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(ReportOperatorPath));", source, StringComparison.Ordinal);
+            Assert.Contains("ClearReportCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void InsightPrintActions_RouteThroughSharedPrintPreview()
         {
             var reportsCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs");
@@ -125,8 +144,8 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("\"Activity Logs\"", activityCode, StringComparison.Ordinal);
             Assert.Contains("Review the filtered audit trail, destination routing, and operator handoff before printing.", activityCode, StringComparison.Ordinal);
             Assert.DoesNotContain("WpfPrintDialog", reportsCode, StringComparison.Ordinal);
-            Assert.DoesNotContain("WpfPrintDialog", activityCode, StringComparison.Ordinal);
             Assert.DoesNotContain("PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator", reportsCode, StringComparison.Ordinal);
+            Assert.DoesNotContain("WpfPrintDialog", activityCode, StringComparison.Ordinal);
             Assert.DoesNotContain("PrintDocument(((IDocumentPaginatorSource)document).DocumentPaginator", activityCode, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-reports-selection-stale-output.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-reports-selection-stale-output.md
@@ -1,0 +1,18 @@
+# Reports Selection Stale Output Clearing
+
+Date: 2026-06-23
+
+## What changed
+
+- Cleared report rows and selected report-line handoff as soon as the selected report type changes.
+- Reset the report title, subtitle, summary, last-run timestamp, row count notification, operator-path notification, and Clear command state before the next report run.
+- Added source-contract coverage so the Reports workbench does not regress to showing stale rows from the previously run report after operators choose a different report type.
+
+## Why it matters
+
+The Reports workbench can route operators from selected rows into source pages. Leaving old rows visible after a report type change could make the visible title/status describe one report while the grid and selected handoff still belonged to the previous report. Clearing the stale output keeps print, copy, and open-source actions aligned with the report operators are about to run.
+
+## Validation notes
+
+- GitHub connector readback and compare are required for this scheduled pass because direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run in this Linux scheduled environment.

--- a/InventoryManagementApp/ViewModels/ReportsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ReportsViewModel.cs
@@ -30,6 +30,7 @@ namespace InventoryManagementApp.ViewModels
                     ReportStatus = string.IsNullOrWhiteSpace(value)
                         ? "Select a report to begin."
                         : $"Ready to run {value}.";
+                    ClearReportOutputForSelection(value);
                     RunReportCommand.NotifyCanExecuteChanged();
                 }
             }
@@ -237,6 +238,23 @@ namespace InventoryManagementApp.ViewModels
                 : $"{SelectedReport} completed with {ReportLines.Count} line(s). Select a row or open the source page.";
             if (ReportLines.Count > 0)
                 SelectedReportLine = ReportLines[0];
+            OnPropertyChanged(nameof(ReportLineCount));
+            OnPropertyChanged(nameof(ReportOperatorPath));
+            ClearReportCommand.NotifyCanExecuteChanged();
+        }
+
+        private void ClearReportOutputForSelection(string reportName)
+        {
+            ReportLines.Clear();
+            SelectedReportLine = null;
+            ReportTitle = string.IsNullOrWhiteSpace(reportName) ? "Reports" : reportName;
+            ReportSubtitle = string.IsNullOrWhiteSpace(reportName)
+                ? "Run operational reports for inventory, rentals, maintenance, reservations, and usage."
+                : BuildSubtitle(reportName);
+            ReportSummary = string.IsNullOrWhiteSpace(reportName)
+                ? "No report has been run yet."
+                : $"Run {reportName} to refresh report rows.";
+            LastRunAt = null;
             OnPropertyChanged(nameof(ReportLineCount));
             OnPropertyChanged(nameof(ReportOperatorPath));
             ClearReportCommand.NotifyCanExecuteChanged();


### PR DESCRIPTION
## Summary

- Clear stale report rows and selected report-line handoff when the selected report type changes.
- Reset report title/subtitle/summary, last-run timestamp, row-count/operator-path notifications, and Clear command state before the next run.
- Add source-contract coverage for the Reports workbench selection-change clearing contract and record the reliability pass in a progress note.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ReportsViewModel`, `InsightsPagesXamlTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` is not installed; WPF screenshots, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.