### PR TITLE
Guard Reports printing against stale output

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
@@ -132,6 +132,18 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void ReportsPrintAction_RequiresCompletedFreshReportOutput()
+        {
+            var viewModel = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ReportsViewModel.cs");
+            var pageCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs");
+
+            Assert.Contains("public bool CanPrintCurrentReport => LastRunAt.HasValue && ReportLines.Count > 0 && !string.Equals(ReportStatus, \"Report failed.\", StringComparison.Ordinal);", viewModel, StringComparison.Ordinal);
+            Assert.Contains("OnPropertyChanged(nameof(CanPrintCurrentReport));", viewModel, StringComparison.Ordinal);
+            Assert.Contains("if (DataContext is not ReportsViewModel vm || !vm.CanPrintCurrentReport)", pageCode, StringComparison.Ordinal);
+            Assert.DoesNotContain("if (DataContext is not ReportsViewModel vm || vm.ReportLines.Count == 0)", pageCode, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void InsightPrintActions_RouteThroughSharedPrintPreview()
         {
             var reportsCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-reports-print-fresh-output-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-reports-print-fresh-output-guard.md
@@ -1,0 +1,18 @@
+# Reports Print Fresh Output Guard
+
+Date: 2026-06-23
+
+## What changed
+
+- Added a `CanPrintCurrentReport` source contract to `ReportsViewModel` so report printing requires a completed run timestamp, current report rows, and a non-failed report status.
+- Updated the Reports page print action to use that explicit eligibility contract instead of only checking for visible rows.
+- Added source-contract coverage to keep the print guard wired to the view model and prevent stale report rows from being printed after failed, cleared, or not-yet-run report states.
+
+## Why it matters
+
+The Reports workbench recently started clearing stale output when the selected report type changes or generation fails. The print button is another operator-facing boundary: it should only produce preview documents from fresh completed report output, not from any stale rows that might be left behind by a future regression.
+
+## Validation notes
+
+- GitHub connector readback and compare are required for this scheduled pass because direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`.
+- Local `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, local banned-word checks, and full runtime validation were not run in this Linux scheduled environment.

--- a/InventoryManagementApp/ViewModels/ReportsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ReportsViewModel.cs
@@ -98,12 +98,16 @@ namespace InventoryManagementApp.ViewModels
             set
             {
                 if (SetProperty(ref _lastRunAt, value))
+                {
                     OnPropertyChanged(nameof(LastRunText));
+                    OnPropertyChanged(nameof(CanPrintCurrentReport));
+                }
             }
         }
 
         public string LastRunText => LastRunAt.HasValue ? LastRunAt.Value.ToString("g") : "Not run";
         public int ReportLineCount => ReportLines.Count;
+        public bool CanPrintCurrentReport => LastRunAt.HasValue && ReportLines.Count > 0 && !string.Equals(ReportStatus, "Report failed.", StringComparison.Ordinal);
         public string ReportOperatorPath => string.IsNullOrWhiteSpace(SelectedReport)
             ? "Choose a report, run it, then open the source page from any row that needs follow-up."
             : $"Run {SelectedReport}, select a row, then open {BuildDestinationName(SelectedReport, SelectedReportLine?.Category)} to continue the workflow.";
@@ -195,6 +199,7 @@ namespace InventoryManagementApp.ViewModels
                 ReportStatus = "Report failed.";
                 LastRunAt = DateTime.Now;
                 OnPropertyChanged(nameof(ReportLineCount));
+                OnPropertyChanged(nameof(CanPrintCurrentReport));
                 OnPropertyChanged(nameof(ReportOperatorPath));
                 ClearReportCommand.NotifyCanExecuteChanged();
             }
@@ -239,6 +244,7 @@ namespace InventoryManagementApp.ViewModels
             if (ReportLines.Count > 0)
                 SelectedReportLine = ReportLines[0];
             OnPropertyChanged(nameof(ReportLineCount));
+            OnPropertyChanged(nameof(CanPrintCurrentReport));
             OnPropertyChanged(nameof(ReportOperatorPath));
             ClearReportCommand.NotifyCanExecuteChanged();
         }
@@ -256,6 +262,7 @@ namespace InventoryManagementApp.ViewModels
                 : $"Run {reportName} to refresh report rows.";
             LastRunAt = null;
             OnPropertyChanged(nameof(ReportLineCount));
+            OnPropertyChanged(nameof(CanPrintCurrentReport));
             OnPropertyChanged(nameof(ReportOperatorPath));
             ClearReportCommand.NotifyCanExecuteChanged();
         }
@@ -270,6 +277,7 @@ namespace InventoryManagementApp.ViewModels
             ReportStatus = "Report cleared.";
             LastRunAt = null;
             OnPropertyChanged(nameof(ReportLineCount));
+            OnPropertyChanged(nameof(CanPrintCurrentReport));
             OnPropertyChanged(nameof(ReportOperatorPath));
             ClearReportCommand.NotifyCanExecuteChanged();
         }

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
@@ -51,7 +51,7 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Reports", () =>
             {
-                if (DataContext is not ReportsViewModel vm || vm.ReportLines.Count == 0)
+                if (DataContext is not ReportsViewModel vm || !vm.CanPrintCurrentReport)
                 {
                     WpfMessageBox.Show("Run a report before printing.", "Reports", MessageBoxButton.OK, MessageBoxImage.Information);
                     return;


### PR DESCRIPTION
## Summary

- Add `CanPrintCurrentReport` to `ReportsViewModel` so report printing requires a completed report run, current rows, and a non-failed report status.
- Update `ReportsPage` to use that explicit print eligibility contract before opening print preview.
- Add source-contract coverage and a progress note for the Reports print freshness guard.

## Validation

- GitHub connector compare/readback confirmed the focused four-file diff on `codex/reports-print-fresh-output-guard`.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `gh` is not installed and `dotnet` is unavailable, so local restore/build/test execution, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.