### PR TITLE
Use selected Import/Export log for result actions

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
@@ -44,6 +44,19 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void ImportExportLogActions_FallBackToViewModelSelectedLog()
+        {
+            var pageCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml.cs");
+
+            Assert.Contains("private string GetSelectedLogForAction()", pageCode, StringComparison.Ordinal);
+            Assert.Contains("if (ImportExportLogGrid.SelectedItem is string gridLog && !string.IsNullOrWhiteSpace(gridLog))", pageCode, StringComparison.Ordinal);
+            Assert.Contains("DataContext is ImportExportViewModel vm && !string.IsNullOrWhiteSpace(vm.SelectedImportExportLog)", pageCode, StringComparison.Ordinal);
+            Assert.Contains("? vm.SelectedImportExportLog", pageCode, StringComparison.Ordinal);
+            Assert.Contains("var log = GetSelectedLogForAction();", pageCode, StringComparison.Ordinal);
+            Assert.DoesNotContain("if (ImportExportLogGrid.SelectedItem is not string log || string.IsNullOrWhiteSpace(log))", pageCode, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ImportExportViewModel_ShowsVisibleFeedbackForFailedDataOperations()
         {
             var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-import-export-selected-log-fallback.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-import-export-selected-log-fallback.md
@@ -1,0 +1,13 @@
+# Import / Export Selected Log Action Fallback
+
+## Completed
+
+- Routed Import / Export selected-result actions through a shared log resolver.
+- Preserved row-specific run-log behavior when the grid has a selected row.
+- Added a fallback to `ImportExportViewModel.SelectedImportExportLog` so overview and handoff-panel copy/detail actions can use the currently visible selected operation even when the run-log grid is not the active interaction surface.
+- Added source-contract coverage in `ImportExportPageXamlTests` to guard the fallback and prevent direct grid-only selection checks from returning.
+
+## Validation
+
+- GitHub connector compare/readback should be used for this scheduled pass.
+- Local clone/raw access, `dotnet`, WPF screenshots, and local banned-word checks are unavailable in the scheduled Linux environment, so local build/test/runtime validation was not run.

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
@@ -36,7 +36,8 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Import / Export", () =>
             {
-                if (ImportExportLogGrid.SelectedItem is not string log || string.IsNullOrWhiteSpace(log))
+                var log = GetSelectedLogForAction();
+                if (string.IsNullOrWhiteSpace(log))
                 {
                     WpfMessageBox.Show("Select an import/export log row first.", "Import / Export", MessageBoxButton.OK, MessageBoxImage.Information);
                     return;
@@ -57,7 +58,8 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Import / Export", () =>
             {
-                if (ImportExportLogGrid.SelectedItem is not string log || string.IsNullOrWhiteSpace(log))
+                var log = GetSelectedLogForAction();
+                if (string.IsNullOrWhiteSpace(log))
                 {
                     WpfMessageBox.Show("Select an import/export log row first.", "Import / Export", MessageBoxButton.OK, MessageBoxImage.Information);
                     return;
@@ -65,6 +67,16 @@ namespace InventoryManagementApp.Views.Pages
 
                 System.Windows.Clipboard.SetText(log);
             });
+        }
+
+        private string GetSelectedLogForAction()
+        {
+            if (ImportExportLogGrid.SelectedItem is string gridLog && !string.IsNullOrWhiteSpace(gridLog))
+                return gridLog;
+
+            return DataContext is ImportExportViewModel vm && !string.IsNullOrWhiteSpace(vm.SelectedImportExportLog)
+                ? vm.SelectedImportExportLog
+                : string.Empty;
         }
 
         private void PrintLogs_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary

- Route Import / Export copy/detail result actions through a shared selected-log resolver.
- Preserve grid-row selection behavior while falling back to `ImportExportViewModel.SelectedImportExportLog` for overview and handoff-panel actions.
- Add source-contract coverage and a progress note for the selected run-log action fallback.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ImportExportPage.xaml.cs`, `ImportExportPageXamlTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.