### PR TITLE
Prefer selected Import/Export log when printing

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
@@ -57,6 +57,25 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void ImportExportLogPrint_PrefersSelectedResultBeforeWholeSessionLog()
+        {
+            var pageCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml.cs");
+            var printMethod = ExtractMethodBody(pageCode, "private void PrintLogs_Click", "private static FlowDocument BuildPrintDocument");
+
+            Assert.Contains("var selectedLog = GetSelectedLogForAction();", printMethod, StringComparison.Ordinal);
+            Assert.Contains("if (!string.IsNullOrWhiteSpace(selectedLog))", printMethod, StringComparison.Ordinal);
+            Assert.Contains("BuildPrintDocument(new[] { selectedLog }, \"Selected import/export operation result.\", \"Import / Export Selected Result\")", printMethod, StringComparison.Ordinal);
+            Assert.Contains("ShowPreview(selectedDocument, \"Import / Export Selected Result\", null);", printMethod, StringComparison.Ordinal);
+            Assert.Contains("return;", printMethod, StringComparison.Ordinal);
+            Assert.Contains("DataContext is not ImportExportViewModel vm || vm.ImportExportLogs.Count == 0", printMethod, StringComparison.Ordinal);
+            Assert.Contains("BuildPrintDocument(vm.ImportExportLogs.ToList(), vm.LogSummary)", printMethod, StringComparison.Ordinal);
+            Assert.True(
+                printMethod.IndexOf("var selectedLog = GetSelectedLogForAction();", StringComparison.Ordinal) <
+                printMethod.IndexOf("DataContext is not ImportExportViewModel vm", StringComparison.Ordinal),
+                "Selected result printing should be resolved before falling back to the whole session log.");
+        }
+
+        [Fact]
         public void ImportExportViewModel_ShowsVisibleFeedbackForFailedDataOperations()
         {
             var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ImportExportViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-import-export-selected-log-print.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-import-export-selected-log-print.md
@@ -1,0 +1,13 @@
+# Import / Export Selected Result Printing
+
+## Completed
+
+- Updated Import / Export printing so a selected run-log row or handoff-panel selected result prints that exact operation result first.
+- Preserved the existing whole-session log print fallback when no run-log result is selected.
+- Reused the existing print-preview document builder and added an explicit selected-result print preview title.
+- Added source-contract coverage in `ImportExportPageXamlTests` so selected-result print resolution stays ahead of the whole-session log fallback.
+
+## Validation
+
+- GitHub connector compare/readback should be used for this scheduled pass.
+- Local clone/raw access, `gh`, `dotnet`, WPF screenshots, local banned-word checks, and full runtime validation are unavailable in the scheduled Linux environment, so local build/test/runtime validation was not run.

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
@@ -79,6 +79,22 @@ namespace InventoryManagementApp.Views.Pages
                 : string.Empty;
         }
 
+        private void PrintSelectedLog_Click(object sender, RoutedEventArgs e)
+        {
+            UiActionGuard.Run(this, "Import / Export", () =>
+            {
+                var log = GetSelectedLogForAction();
+                if (string.IsNullOrWhiteSpace(log))
+                {
+                    WpfMessageBox.Show("Select an import/export log row first.", "Import / Export", MessageBoxButton.OK, MessageBoxImage.Information);
+                    return;
+                }
+
+                var document = BuildPrintDocument(new[] { log }, "Selected import/export operation result.", "Import / Export Selected Result");
+                new PrintPreviewWindow().ShowPreview(document, "Import / Export Selected Result", null);
+            });
+        }
+
         private void PrintLogs_Click(object sender, RoutedEventArgs e)
         {
             UiActionGuard.Run(this, "Import / Export", () =>
@@ -94,7 +110,10 @@ namespace InventoryManagementApp.Views.Pages
             });
         }
 
-        private static FlowDocument BuildPrintDocument(IReadOnlyCollection<string> logs, string summary)
+        private static FlowDocument BuildPrintDocument(
+            IReadOnlyCollection<string> logs,
+            string summary,
+            string title = "Import / Export Operation Log")
         {
             var document = new FlowDocument
             {
@@ -102,7 +121,7 @@ namespace InventoryManagementApp.Views.Pages
                 FontSize = 11
             };
 
-            document.Blocks.Add(new Paragraph(new Run("Import / Export Operation Log"))
+            document.Blocks.Add(new Paragraph(new Run(title))
             {
                 FontSize = 16,
                 FontWeight = FontWeights.SemiBold,

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
@@ -79,26 +79,18 @@ namespace InventoryManagementApp.Views.Pages
                 : string.Empty;
         }
 
-        private void PrintSelectedLog_Click(object sender, RoutedEventArgs e)
-        {
-            UiActionGuard.Run(this, "Import / Export", () =>
-            {
-                var log = GetSelectedLogForAction();
-                if (string.IsNullOrWhiteSpace(log))
-                {
-                    WpfMessageBox.Show("Select an import/export log row first.", "Import / Export", MessageBoxButton.OK, MessageBoxImage.Information);
-                    return;
-                }
-
-                var document = BuildPrintDocument(new[] { log }, "Selected import/export operation result.", "Import / Export Selected Result");
-                new PrintPreviewWindow().ShowPreview(document, "Import / Export Selected Result", null);
-            });
-        }
-
         private void PrintLogs_Click(object sender, RoutedEventArgs e)
         {
             UiActionGuard.Run(this, "Import / Export", () =>
             {
+                var selectedLog = GetSelectedLogForAction();
+                if (!string.IsNullOrWhiteSpace(selectedLog))
+                {
+                    var selectedDocument = BuildPrintDocument(new[] { selectedLog }, "Selected import/export operation result.", "Import / Export Selected Result");
+                    new PrintPreviewWindow().ShowPreview(selectedDocument, "Import / Export Selected Result", null);
+                    return;
+                }
+
                 if (DataContext is not ImportExportViewModel vm || vm.ImportExportLogs.Count == 0)
                 {
                     WpfMessageBox.Show("There are no import/export log rows to print.", "Import / Export", MessageBoxButton.OK, MessageBoxImage.Information);


### PR DESCRIPTION
## Summary

- Prefer the selected Import / Export run-log result when a print action is launched with a selected row or handoff-panel result.
- Preserve the existing whole-session log print fallback when no result is selected.
- Add source-contract coverage and a progress note for the selected-result print behavior.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 4 commits ahead and 0 behind.
- Read back `ImportExportPage.xaml.cs`, `ImportExportPageXamlTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.