### PR TITLE
Guard Reports source actions behind selected rows

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
@@ -144,6 +144,22 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void ReportsSelectedRowActions_RequireActualSelectedReportLine()
+        {
+            var pageCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs");
+
+            Assert.Contains("private ReportLine? GetSelectedReportLineForAction()", pageCode, StringComparison.Ordinal);
+            Assert.Contains("if (ReportGrid.SelectedItem is ReportLine gridLine)", pageCode, StringComparison.Ordinal);
+            Assert.Contains("return DataContext is ReportsViewModel vm", pageCode, StringComparison.Ordinal);
+            Assert.Contains("? vm.SelectedReportLine", pageCode, StringComparison.Ordinal);
+            Assert.Contains("var line = GetSelectedReportLineForAction();", pageCode, StringComparison.Ordinal);
+            Assert.Contains("if (line == null || string.IsNullOrWhiteSpace(line.DestinationKey))", pageCode, StringComparison.Ordinal);
+            Assert.Contains("switch (line.DestinationKey)", pageCode, StringComparison.Ordinal);
+            Assert.DoesNotContain("key = vm.SelectedLineDestinationKey;", pageCode, StringComparison.Ordinal);
+            Assert.DoesNotContain("var key = line?.DestinationKey;", pageCode, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void InsightPrintActions_RouteThroughSharedPrintPreview()
         {
             var reportsCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-reports-selected-row-action-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-reports-selected-row-action-guard.md
@@ -1,0 +1,15 @@
+# Reports Selected Row Action Guard
+
+Date: 2026-06-23 10:11 NZST scheduled pass
+
+## Completed
+
+- Tightened Reports row actions so copy and source-page navigation resolve an actual selected `ReportLine` from the grid or view model selection.
+- Removed the fallback that inferred a destination from the selected report type when no report row was selected.
+- Preserved the existing operator prompt when rows have been cleared, the report type has changed, or no result row is selected.
+- Added source-contract coverage in `InsightsPagesXamlTests` so Reports source actions continue to require a real selected report row.
+
+## Validation Notes
+
+- Local repository clone/raw access, `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots, and local banned-word checks were not available in this scheduled Linux container.
+- GitHub connector readback/compare was used as the validation fallback.

--- a/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ReportsPage.xaml.cs
@@ -37,7 +37,8 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Reports", () =>
             {
-                if (ReportGrid.SelectedItem is not ReportLine line)
+                var line = GetSelectedReportLineForAction();
+                if (line == null)
                 {
                     WpfMessageBox.Show("Select a report row first.", "Reports", MessageBoxButton.OK, MessageBoxImage.Information);
                     return;
@@ -67,12 +68,8 @@ namespace InventoryManagementApp.Views.Pages
 
         private void OpenSelectedDestination()
         {
-            var line = ReportGrid.SelectedItem as ReportLine;
-            var key = line?.DestinationKey;
-            if (string.IsNullOrWhiteSpace(key) && DataContext is ReportsViewModel vm)
-                key = vm.SelectedLineDestinationKey;
-
-            if (string.IsNullOrWhiteSpace(key))
+            var line = GetSelectedReportLineForAction();
+            if (line == null || string.IsNullOrWhiteSpace(line.DestinationKey))
             {
                 WpfMessageBox.Show("Run a report and select a row first.", "Reports", MessageBoxButton.OK, MessageBoxImage.Information);
                 return;
@@ -84,7 +81,7 @@ namespace InventoryManagementApp.Views.Pages
                 return;
             }
 
-            switch (key)
+            switch (line.DestinationKey)
             {
                 case "ActivityLogs":
                     main.OpenActivityLogsCommand.Execute(null);
@@ -117,6 +114,16 @@ namespace InventoryManagementApp.Views.Pages
                     main.OpenDashboardCommand.Execute(null);
                     break;
             }
+        }
+
+        private ReportLine? GetSelectedReportLineForAction()
+        {
+            if (ReportGrid.SelectedItem is ReportLine gridLine)
+                return gridLine;
+
+            return DataContext is ReportsViewModel vm
+                ? vm.SelectedReportLine
+                : null;
         }
 
         private static string FormatHandoff(ReportLine line)


### PR DESCRIPTION
## Summary

- Resolve Reports copy/open-source actions through an actual selected `ReportLine` from the grid or view model selection.
- Remove report-type destination fallback so cleared output or changed report types cannot navigate to a source page without a selected result row.
- Add source-contract coverage and a progress note for the selected-row action guard.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ReportsPage.xaml.cs`, `InsightsPagesXamlTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is unavailable in this scheduled Linux container; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.