### PR TITLE
Guard Activity Logs actions behind selected audit rows

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
@@ -94,6 +94,20 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void ActivityLogsSelectedRowActions_UseGridOrViewModelSelectedLog()
+        {
+            var pageCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml.cs");
+
+            Assert.Contains("private ActivityLog? GetSelectedActivityLogForAction()", pageCode, StringComparison.Ordinal);
+            Assert.Contains("if (ActivityGrid.SelectedItem is ActivityLog gridLog)", pageCode, StringComparison.Ordinal);
+            Assert.Contains("return DataContext is ActivityLogsViewModel vm", pageCode, StringComparison.Ordinal);
+            Assert.Contains("? vm.SelectedLog", pageCode, StringComparison.Ordinal);
+            Assert.Contains("var log = GetSelectedActivityLogForAction();", pageCode, StringComparison.Ordinal);
+            Assert.Contains("switch (ActivityLogsViewModel.BuildDestinationKey(log.Action))", pageCode, StringComparison.Ordinal);
+            Assert.DoesNotContain("ActivityGrid.SelectedItem is not ActivityLog log", pageCode, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ReportsGenerationFailure_ClearsRowsSelectionAndKeepsFailureStatus()
         {
             var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ReportsViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-activity-logs-selected-action-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-activity-logs-selected-action-guard.md
@@ -1,0 +1,12 @@
+# Activity Logs Selected Action Guard - 2026-06-23
+
+## Completed
+
+- Activity Logs open-detail, open-related-page, and copy actions now resolve the selected audit row through a shared helper.
+- The helper prefers the actual grid row when present and falls back to `ActivityLogsViewModel.SelectedLog` so handoff-panel actions can act on the visible selected audit row.
+- Added source-contract coverage in `InsightsPagesXamlTests` to keep the selected-row resolver and to prevent the old grid-only selection check from returning.
+
+## Validation
+
+- GitHub connector readback/compare is the validation path for this scheduled Linux environment.
+- Local clone/raw access, `gh`, `dotnet` restore/build/test, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were unavailable in this environment.

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
@@ -54,7 +54,8 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Activity Logs", () =>
             {
-                if (ActivityGrid.SelectedItem is not ActivityLog log)
+                var log = GetSelectedActivityLogForAction();
+                if (log == null)
                 {
                     WpfMessageBox.Show("Select an activity row first.", "Activity Logs", MessageBoxButton.OK, MessageBoxImage.Information);
                     return;
@@ -75,7 +76,8 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Activity Logs", () =>
             {
-                if (ActivityGrid.SelectedItem is not ActivityLog log)
+                var log = GetSelectedActivityLogForAction();
+                if (log == null)
                 {
                     WpfMessageBox.Show("Select an activity row first.", "Activity Logs", MessageBoxButton.OK, MessageBoxImage.Information);
                     return;
@@ -127,7 +129,8 @@ namespace InventoryManagementApp.Views.Pages
         {
             UiActionGuard.Run(this, "Activity Logs", () =>
             {
-                if (ActivityGrid.SelectedItem is not ActivityLog log)
+                var log = GetSelectedActivityLogForAction();
+                if (log == null)
                 {
                     WpfMessageBox.Show("Select an activity row first.", "Activity Logs", MessageBoxButton.OK, MessageBoxImage.Information);
                     return;
@@ -153,6 +156,16 @@ namespace InventoryManagementApp.Views.Pages
                     "Activity Logs",
                     "Review the filtered audit trail, destination routing, and operator handoff before printing.");
             });
+        }
+
+        private ActivityLog? GetSelectedActivityLogForAction()
+        {
+            if (ActivityGrid.SelectedItem is ActivityLog gridLog)
+                return gridLog;
+
+            return DataContext is ActivityLogsViewModel vm
+                ? vm.SelectedLog
+                : null;
         }
 
         private static string FormatLogDetail(ActivityLog log)


### PR DESCRIPTION
## Summary

- Resolve Activity Logs detail, related-page, and copy actions through a shared selected-audit-row helper.
- Prefer the actual grid row when present and fall back to `ActivityLogsViewModel.SelectedLog` for handoff-panel actions.
- Add source-contract coverage and a progress note so the grid-only selection check does not regress.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ActivityLogsPage.xaml.cs`, `InsightsPagesXamlTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.