### PR TITLE
Keep Import/Export run log context menus opening

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
@@ -44,6 +44,18 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void ImportExportLogRightClick_SelectsRowWithoutSuppressingContextMenu()
+        {
+            var pageCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml.cs");
+            var handler = ExtractMethodBody(pageCode, "private void ImportExportLogRow_PreviewMouseRightButtonDown", "private void OpenSelectedLog_Click");
+
+            Assert.Contains("if (sender is DataGridRow row && !row.IsSelected)", handler, StringComparison.Ordinal);
+            Assert.Contains("row.IsSelected = true;", handler, StringComparison.Ordinal);
+            Assert.Contains("row.Focus();", handler, StringComparison.Ordinal);
+            Assert.DoesNotContain("e.Handled = true;", handler, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ImportExportLogActions_FallBackToViewModelSelectedLog()
         {
             var pageCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-import-export-context-menu-right-click.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-import-export-context-menu-right-click.md
@@ -1,0 +1,12 @@
+# Import / Export Run Log Context Menu Fix - 2026-06-23
+
+## Completed
+
+- Import / Export run-log rows still become the selected row when operators right-click them.
+- The right-click preview handler no longer marks the mouse event as handled, so WPF can continue opening the row context menu normally.
+- Added source-contract coverage to keep right-click row selection, row focus, and unsuppressed context-menu behavior together.
+
+## Validation
+
+- GitHub connector readback/compare is the validation path for this scheduled Linux environment.
+- Local clone/raw access, `gh`, `dotnet` restore/build/test, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were unavailable in this environment.

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
@@ -28,7 +28,7 @@ namespace InventoryManagementApp.Views.Pages
             if (sender is DataGridRow row && !row.IsSelected)
             {
                 row.IsSelected = true;
-                e.Handled = true;
+                row.Focus();
             }
         }
 


### PR DESCRIPTION
## Summary

- Keep Import / Export run-log right-click row selection and focus behavior.
- Stop marking the right-click preview mouse event as handled so WPF can continue opening the row context menu normally.
- Add source-contract coverage and a progress note for the run-log right-click/context-menu behavior.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ImportExportPage.xaml.cs`, `ImportExportPageXamlTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.