### PR TITLE
Use shared Activity Logs context-menu selection

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
@@ -76,6 +76,18 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
+        public void ActivityLogsRightClick_UsesSharedGuardedGridSelection()
+        {
+            var pageCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml.cs");
+            var handler = ExtractMethodBody(pageCode, "private void ActivityGridRow_PreviewMouseRightButtonDown", "private async void RefreshLogs_Click");
+
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e);", handler, StringComparison.Ordinal);
+            Assert.DoesNotContain("if (sender is DataGridRow row", handler, StringComparison.Ordinal);
+            Assert.DoesNotContain("row.IsSelected = true;", handler, StringComparison.Ordinal);
+            Assert.DoesNotContain("e.Handled = true;", handler, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ActivityLogsLoadFailure_ClearsRowsFiltersSelectionAndKeepsFailureStatus()
         {
             var source = ReadRepositoryFile("InventoryManagementApp", "ViewModels", "ActivityLogsViewModel.cs");
@@ -210,6 +222,17 @@ namespace InventoryManagementApp.Tests.ViewModels
             var path = Path.Combine(directory!.FullName, Path.Combine(relativePathParts));
             Assert.True(File.Exists(path), $"Expected repository file at {path}");
             return File.ReadAllText(path);
+        }
+
+        static string ExtractMethodBody(string source, string methodStart, string nextMethodStart)
+        {
+            var start = source.IndexOf(methodStart, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Expected to find method starting with {methodStart}");
+
+            var end = source.IndexOf(nextMethodStart, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Expected to find next method starting with {nextMethodStart}");
+
+            return source.Substring(start, end - start);
         }
     }
 }

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-activity-logs-context-selection.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-activity-logs-context-selection.md
@@ -1,0 +1,13 @@
+# Activity Logs Context Selection Hardening - 2026-06-23
+
+## Completed
+
+- Replaced the Activity Logs grid's hand-rolled right-click row selection branch with the shared `GridContextMenuSelection.SelectRow` helper.
+- Kept the context menu preview event unhandled so WPF can continue opening the row menu normally after selection/focus is updated.
+- Added source-contract coverage in `InsightsPagesXamlTests` so Activity Logs keeps using the shared guarded helper and does not reintroduce direct row-only selection logic.
+
+## Validation Notes
+
+- Local `dotnet restore`, `dotnet build`, and `dotnet test` were not run in this scheduled Linux container because the .NET SDK/WPF runtime is unavailable.
+- WPF screenshots/runtime checks and local banned-word checks were not run for the same local environment limitation.
+- GitHub connector readback/compare should be used as the validation fallback for this focused three-file change.

--- a/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ActivityLogsPage.xaml.cs
@@ -35,11 +35,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void ActivityGridRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            if (sender is DataGridRow row && !row.IsSelected)
-            {
-                row.IsSelected = true;
-                row.Focus();
-            }
+            GridContextMenuSelection.SelectRow(sender, e);
         }
 
         private async void RefreshLogs_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary

- Replace the Activity Logs grid's local right-click row-selection branch with the shared guarded `GridContextMenuSelection.SelectRow` helper.
- Keep the context-menu preview event unhandled so row context menus continue opening normally after selection/focus updates.
- Add source-contract coverage and a progress note for the Activity Logs context-menu selection contract.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ActivityLogsPage.xaml.cs`, `InsightsPagesXamlTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is unavailable in this scheduled Linux container; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.