### PR TITLE
Use shared Import/Export context-menu selection

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ImportExportPageXamlTests.cs
@@ -44,14 +44,15 @@ namespace InventoryManagementApp.Tests.ViewModels
         }
 
         [Fact]
-        public void ImportExportLogRightClick_SelectsRowWithoutSuppressingContextMenu()
+        public void ImportExportLogRightClick_UsesSharedGuardedGridSelection()
         {
             var pageCode = ReadRepositoryFile("InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml.cs");
             var handler = ExtractMethodBody(pageCode, "private void ImportExportLogRow_PreviewMouseRightButtonDown", "private void OpenSelectedLog_Click");
 
-            Assert.Contains("if (sender is DataGridRow row && !row.IsSelected)", handler, StringComparison.Ordinal);
-            Assert.Contains("row.IsSelected = true;", handler, StringComparison.Ordinal);
-            Assert.Contains("row.Focus();", handler, StringComparison.Ordinal);
+            Assert.Contains("GridContextMenuSelection.SelectRow(sender, e);", handler, StringComparison.Ordinal);
+            Assert.DoesNotContain("if (sender is DataGridRow row", handler, StringComparison.Ordinal);
+            Assert.DoesNotContain("row.IsSelected = true;", handler, StringComparison.Ordinal);
+            Assert.DoesNotContain("row.Focus();", handler, StringComparison.Ordinal);
             Assert.DoesNotContain("e.Handled = true;", handler, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-import-export-shared-context-selection.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-import-export-shared-context-selection.md
@@ -1,0 +1,13 @@
+# Import / Export Context Selection Consolidation - 2026-06-23
+
+## Completed
+
+- Routed Import / Export run-log right-click row selection through the shared `GridContextMenuSelection.SelectRow` helper.
+- Kept the right-click preview event unhandled so WPF context menus continue opening normally after row selection and focus update.
+- Updated `ImportExportPageXamlTests` to guard the shared-helper contract and prevent local row-selection branches or handled mouse events from returning.
+
+## Validation Notes
+
+- Local `dotnet restore`, `dotnet build`, and `dotnet test` were not run in this scheduled Linux container because the .NET SDK/WPF runtime is unavailable.
+- Direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation are also unavailable here.
+- GitHub connector readback/compare is the validation fallback for this focused consolidation pass.

--- a/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/ImportExportPage.xaml.cs
@@ -25,11 +25,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void ImportExportLogRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            if (sender is DataGridRow row && !row.IsSelected)
-            {
-                row.IsSelected = true;
-                row.Focus();
-            }
+            GridContextMenuSelection.SelectRow(sender, e);
         }
 
         private void OpenSelectedLog_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary

- Route Import / Export run-log right-click row selection through the shared `GridContextMenuSelection.SelectRow` helper.
- Keep the context-menu preview event unhandled so WPF context menus continue opening normally after selection/focus updates.
- Update source-contract coverage and add a progress note for the shared-helper consolidation.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against current `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ImportExportPage.xaml.cs`, `ImportExportPageXamlTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.