### PR TITLE
Use shared Users context-menu selection

### DIFF
--- a/InventoryManagementApp.Tests/Views/GridContextMenuSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/Views/GridContextMenuSelectionContractTests.cs
@@ -40,6 +40,7 @@ namespace InventoryManagementApp.Tests.Views
                 new[] { "InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml.cs" },
                 new[] { "InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs" },
                 new[] { "InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "UsersPage.xaml.cs" },
                 new[] { "InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml.cs" },
                 new[] { "InventoryManagementApp", "Views", "Pages", "MaintenancePage.xaml.cs" },
                 new[] { "InventoryManagementApp", "Views", "Pages", "CalibrationPage.xaml.cs" }
@@ -61,7 +62,8 @@ namespace InventoryManagementApp.Tests.Views
                 [new[] { "InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs" }] = new[] { "private static T? FindAncestor", "private static DependencyObject? GetParent" },
                 [new[] { "InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs" }] = new[] { "current = VisualTreeHelper.GetParent(current);" },
                 [new[] { "InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml.cs" }] = new[] { "private static T? FindParent", "VisualTreeHelper.GetParent(child)" },
-                [new[] { "InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs" }] = new[] { "private static T? FindParent", "VisualTreeHelper.GetParent(child)" }
+                [new[] { "InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs" }] = new[] { "private static T? FindParent", "VisualTreeHelper.GetParent(child)" },
+                [new[] { "InventoryManagementApp", "Views", "Pages", "UsersPage.xaml.cs" }] = new[] { "if (sender is DataGridRow row", "row.IsSelected = true;", "e.Handled = true;" }
             };
 
             foreach (var entry in pagePaths)

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-users-context-menu-selection.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-users-context-menu-selection.md
@@ -1,0 +1,10 @@
+# Users Context Menu Selection Fix - 2026-06-23
+
+## Completed
+- Routed the Users directory row right-click handler through the shared `GridContextMenuSelection.SelectRow` helper.
+- Removed the old local row-selection branch that marked preview right-click events handled and could suppress the normal WPF context menu.
+- Extended `GridContextMenuSelectionContractTests` so Users stays covered by the shared helper contract and does not reintroduce direct row selection or handled right-click events.
+
+## Validation Notes
+- Local clone/raw access, `dotnet`, WPF screenshots/runtime checks, and local banned-word checks were unavailable in the scheduled Linux container.
+- GitHub connector readback/compare was used as the validation fallback.

--- a/InventoryManagementApp/Views/Pages/UsersPage.xaml.cs
+++ b/InventoryManagementApp/Views/Pages/UsersPage.xaml.cs
@@ -34,11 +34,7 @@ namespace InventoryManagementApp.Views.Pages
 
         private void UserRow_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            if (sender is DataGridRow row && !row.IsSelected)
-            {
-                row.IsSelected = true;
-                e.Handled = true;
-            }
+            GridContextMenuSelection.SelectRow(sender, e);
         }
 
         private void OpenSelectedUser_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary

- Route Users directory row right-click selection through the shared `GridContextMenuSelection.SelectRow` helper.
- Remove the old local `DataGridRow` selection branch that marked the preview right-click event handled and could suppress the normal WPF context menu.
- Extend `GridContextMenuSelectionContractTests` so Users stays covered by the shared helper contract and cannot reintroduce direct row selection or handled right-click events.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against `master`, with the branch 3 commits ahead and 0 behind.
- Read back `UsersPage.xaml.cs`, `GridContextMenuSelectionContractTests`, and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.