### PR TITLE
Guard grid context menus against handled right-click events

### DIFF
--- a/InventoryManagementApp.Tests/Views/GridContextMenuSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/Views/GridContextMenuSelectionContractTests.cs
@@ -30,26 +30,28 @@ namespace InventoryManagementApp.Tests.Views
         [Fact]
         public void OperationalGridPagesUseSharedContextMenuSelectionHelper()
         {
-            var pagePaths = new[]
-            {
-                new[] { "InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml.cs" },
-                new[] { "InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml.cs" },
-                new[] { "InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs" },
-                new[] { "InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs" },
-                new[] { "InventoryManagementApp", "Views", "Pages", "ReservationPage.xaml.cs" },
-                new[] { "InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml.cs" },
-                new[] { "InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs" },
-                new[] { "InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs" },
-                new[] { "InventoryManagementApp", "Views", "Pages", "UsersPage.xaml.cs" },
-                new[] { "InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml.cs" },
-                new[] { "InventoryManagementApp", "Views", "Pages", "MaintenancePage.xaml.cs" },
-                new[] { "InventoryManagementApp", "Views", "Pages", "CalibrationPage.xaml.cs" }
-            };
+            var pagePaths = OperationalGridPagePaths();
 
             foreach (var pagePath in pagePaths)
             {
                 var source = ReadRepositoryFile(pagePath);
                 Assert.Contains("GridContextMenuSelection.SelectRow(sender, e)", source, StringComparison.Ordinal);
+            }
+        }
+
+        [Fact]
+        public void OperationalGridRightClickHandlersDoNotSuppressContextMenus()
+        {
+            foreach (var pagePath in OperationalGridPagePaths())
+            {
+                var source = ReadRepositoryFile(pagePath);
+                foreach (var handler in ExtractRightClickHandlers(source))
+                {
+                    Assert.Contains("GridContextMenuSelection.SelectRow(sender, e)", handler, StringComparison.Ordinal);
+                    Assert.DoesNotContain("e.Handled = true;", handler, StringComparison.Ordinal);
+                    Assert.DoesNotContain("if (sender is DataGridRow row", handler, StringComparison.Ordinal);
+                    Assert.DoesNotContain("row.IsSelected = true;", handler, StringComparison.Ordinal);
+                }
             }
         }
 
@@ -71,6 +73,59 @@ namespace InventoryManagementApp.Tests.Views
                 var source = ReadRepositoryFile(entry.Key);
                 foreach (var removedPattern in entry.Value)
                     Assert.DoesNotContain(removedPattern, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static string[][] OperationalGridPagePaths()
+        {
+            return new[]
+            {
+                new[] { "InventoryManagementApp", "Views", "Pages", "ManageItemsPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "ItemSearchPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "ManageRentalsPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "DashboardPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "ReservationPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "KitManagementPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "CategoriesPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "ReportsPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "ActivityLogsPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "ImportExportPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "UsersPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "CustomersPage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "MaintenancePage.xaml.cs" },
+                new[] { "InventoryManagementApp", "Views", "Pages", "CalibrationPage.xaml.cs" }
+            };
+        }
+
+        private static IEnumerable<string> ExtractRightClickHandlers(string source)
+        {
+            const string signature = "PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)";
+            var searchIndex = 0;
+
+            while ((searchIndex = source.IndexOf(signature, searchIndex, StringComparison.Ordinal)) >= 0)
+            {
+                var bodyStart = source.IndexOf('{', searchIndex);
+                Assert.True(bodyStart >= 0, "Expected right-click handler body to start with an opening brace.");
+
+                var depth = 0;
+                for (var index = bodyStart; index < source.Length; index++)
+                {
+                    if (source[index] == '{')
+                    {
+                        depth++;
+                    }
+                    else if (source[index] == '}')
+                    {
+                        depth--;
+                        if (depth == 0)
+                        {
+                            var end = index + 1;
+                            yield return source.Substring(searchIndex, end - searchIndex);
+                            searchIndex = end;
+                            break;
+                        }
+                    }
+                }
             }
         }
 

--- a/InventoryManagementApp.Tests/Views/GridContextMenuSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/Views/GridContextMenuSelectionContractTests.cs
@@ -45,13 +45,17 @@ namespace InventoryManagementApp.Tests.Views
             foreach (var pagePath in OperationalGridPagePaths())
             {
                 var source = ReadRepositoryFile(pagePath);
+                var handlerCount = 0;
+
                 foreach (var handler in ExtractRightClickHandlers(source))
                 {
-                    Assert.Contains("GridContextMenuSelection.SelectRow(sender, e)", handler, StringComparison.Ordinal);
+                    handlerCount++;
                     Assert.DoesNotContain("e.Handled = true;", handler, StringComparison.Ordinal);
                     Assert.DoesNotContain("if (sender is DataGridRow row", handler, StringComparison.Ordinal);
                     Assert.DoesNotContain("row.IsSelected = true;", handler, StringComparison.Ordinal);
                 }
+
+                Assert.True(handlerCount > 0, $"Expected at least one grid right-click handler in {Path.Combine(pagePath)}.");
             }
         }
 

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-grid-context-menu-contract.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-grid-context-menu-contract.md
@@ -1,0 +1,11 @@
+# Grid Context Menu Contract Coverage - 2026-06-23
+
+## Completed
+- Added a shared source-contract guard for operational grid right-click handlers.
+- The contract now scans the grid page code-behind files and verifies right-click preview handlers route selection through `GridContextMenuSelection.SelectRow` without marking the event handled.
+- Included the recently repaired Users, Import / Export, and Activity Logs grid surfaces in the central operational-grid coverage list.
+
+## Validation Notes
+- Local clone/raw access is blocked in the scheduled Linux container by `CONNECT tunnel failed, response 403`.
+- `gh` and `dotnet` are unavailable, so local restore/build/test execution, WPF screenshots/runtime checks, and local banned-word checks were not run.
+- GitHub connector readback/compare was used as the validation fallback.


### PR DESCRIPTION
## Summary

- Centralize the operational grid page list inside `GridContextMenuSelectionContractTests`.
- Add a source-contract guard that scans operational grid right-click preview handlers and blocks the regression pattern that marked right-click events handled or manually selected `DataGridRow` instances.
- Include the recently repaired Users, Import / Export, and Activity Logs grid surfaces in the shared operational-grid coverage list.

## Validation

- GitHub connector compare confirmed a focused 2-file diff against `master`, with the branch ahead and not behind.
- Read back `GridContextMenuSelectionContractTests` and the progress note through the GitHub connector.
- Not run locally: direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` is not installed; `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run because this scheduled Linux container does not provide local .NET/WPF validation.