### PR TITLE
Clear Activity Logs load timestamp after failures

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogsFailureStateContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogsFailureStateContractTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ActivityLogsFailureStateContractTests
+    {
+        [Fact]
+        public void LoadFailureClearsRowsSelectionAndLastLoadedTimestamp()
+        {
+            var source = File.ReadAllText(Path.Combine(
+                AppContext.BaseDirectory,
+                "..", "..", "..", "..",
+                "InventoryManagementApp",
+                "ViewModels",
+                "ActivityLogsViewModel.cs"));
+
+            var helperStart = source.IndexOf("private void ClearActivityLogRowsAfterLoadFailure", StringComparison.Ordinal);
+            Assert.True(helperStart >= 0, "ActivityLogsViewModel must keep a single helper for load-failure cleanup.");
+
+            var helperEnd = source.IndexOf("private void ClearFilters", helperStart, StringComparison.Ordinal);
+            Assert.True(helperEnd > helperStart, "The load-failure cleanup helper should stay before ClearFilters.");
+
+            var helperBody = source.Substring(helperStart, helperEnd - helperStart);
+
+            Assert.Contains("Logs.Clear();", helperBody);
+            Assert.Contains("FilteredLogs.Clear();", helperBody);
+            Assert.Contains("SelectedLog = null;", helperBody);
+            Assert.Contains("LastLoadedAt = null;", helperBody);
+            Assert.Contains("StatusMessage = message;", helperBody);
+            Assert.Contains("OnPropertyChanged(nameof(LastLoadedText));", source);
+        }
+    }
+}

--- a/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ActivityLogsViewModel.cs
@@ -207,6 +207,7 @@ namespace InventoryManagementApp.ViewModels
             Logs.Clear();
             FilteredLogs.Clear();
             SelectedLog = null;
+            LastLoadedAt = null;
             RebuildFilterLists();
             OnPropertyChanged(nameof(TotalLogCount));
             OnPropertyChanged(nameof(FilteredLogCount));


### PR DESCRIPTION
## Summary

- Clear `LastLoadedAt` when Activity Logs refresh fails and stale rows are cleared.
- Keep the visible last-loaded footer honest by letting `LastLoadedText` return `Not loaded` after failure cleanup.
- Add source-contract coverage for Activity Logs load-failure cleanup so rows, selection, timestamp, and failure status stay aligned.

## Validation

- GitHub connector compare confirmed a focused 2-file diff against `master`, with the branch 2 commits ahead and 0 behind.
- Read back `ActivityLogsViewModel.cs` and `ActivityLogsFailureStateContractTests.cs` through the GitHub connector.
- Not run locally: this scheduled Linux container has no repository checkout and direct GitHub raw/clone access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` is not installed, so `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.