### PR TITLE
Clear Reports last-run timestamp after failures

### DIFF
--- a/InventoryManagementApp.Tests/ReportsFailureStateContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportsFailureStateContractTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ReportsFailureStateContractTests
+    {
+        [Fact]
+        public void ReportGenerationFailureClearsLastRunTimestamp()
+        {
+            var source = File.ReadAllText(Path.Combine(
+                AppContext.BaseDirectory,
+                "..", "..", "..", "..",
+                "InventoryManagementApp",
+                "ViewModels",
+                "ReportsViewModel.cs"));
+
+            var catchStart = source.IndexOf("catch (Exception ex)", StringComparison.Ordinal);
+            Assert.True(catchStart >= 0, "ReportsViewModel must keep an explicit report-generation failure branch.");
+
+            var catchEnd = source.IndexOf("finally", catchStart, StringComparison.Ordinal);
+            Assert.True(catchEnd > catchStart, "The report-generation failure branch should stay before the finally block.");
+
+            var failureBody = source.Substring(catchStart, catchEnd - catchStart);
+
+            Assert.Contains("ReportLines.Clear();", failureBody);
+            Assert.Contains("SelectedReportLine = null;", failureBody);
+            Assert.Contains("ReportStatus = \"Report failed.\";", failureBody);
+            Assert.Contains("LastRunAt = null;", failureBody);
+            Assert.DoesNotContain("LastRunAt = DateTime.Now;", failureBody);
+            Assert.Contains("OnPropertyChanged(nameof(LastRunText));", source);
+            Assert.Contains("LastRunAt.HasValue", source);
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-reports-failure-last-run.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-reports-failure-last-run.md
@@ -1,0 +1,11 @@
+# Reports Failure Last-Run Cleanup - 2026-06-23
+
+## Completed
+
+- Cleared `ReportsViewModel.LastRunAt` after report generation exceptions clear report rows and selected-row handoff state.
+- Kept failed report output visibly distinct from a completed run by returning `LastRunText` to `Not run` while preserving the `Report failed.` status and exception summary.
+- Added `ReportsFailureStateContractTests` coverage so the failure branch keeps clearing rows, selection, and the last-run timestamp instead of stamping a fresh failed-attempt time.
+
+## Validation
+
+- GitHub connector readback/compare should be used for this scheduled pass because local clone/raw access, `dotnet`, WPF runtime screenshots, and local banned-word checks are unavailable in the Linux scheduled container.

--- a/InventoryManagementApp/ViewModels/ReportsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ReportsViewModel.cs
@@ -197,7 +197,7 @@ namespace InventoryManagementApp.ViewModels
                 ReportSubtitle = "The report could not be generated.";
                 ReportSummary = ex.Message;
                 ReportStatus = "Report failed.";
-                LastRunAt = DateTime.Now;
+                LastRunAt = null;
                 OnPropertyChanged(nameof(ReportLineCount));
                 OnPropertyChanged(nameof(CanPrintCurrentReport));
                 OnPropertyChanged(nameof(ReportOperatorPath));


### PR DESCRIPTION
## Summary

- Clear `ReportsViewModel.LastRunAt` when report generation exceptions clear stale rows and selected-row handoff state.
- Keep failed report output visibly distinct from completed runs by returning `LastRunText` to `Not run` while preserving the `Report failed.` status and exception summary.
- Add source-contract coverage for the Reports failure branch so it keeps clearing rows, selection, and the last-run timestamp.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ReportsViewModel.cs`, `ReportsFailureStateContractTests.cs`, and the progress note through the GitHub connector.
- Not run locally: this scheduled Linux container has no repository checkout and direct GitHub raw/clone access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` is not installed, so `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.