### PR TITLE
Harden grid context parent traversal exceptions

### DIFF
--- a/InventoryManagementApp.Tests/Views/GridContextMenuSelectionContractTests.cs
+++ b/InventoryManagementApp.Tests/Views/GridContextMenuSelectionContractTests.cs
@@ -21,7 +21,10 @@ namespace InventoryManagementApp.Tests.Views
             Assert.Contains("?? TryGetFrameworkParent(current);", helper, StringComparison.Ordinal);
             Assert.Contains("private static DependencyObject? TryGetVisualParent(DependencyObject current)", helper, StringComparison.Ordinal);
             Assert.Contains("private static DependencyObject? TryGetLogicalParent(DependencyObject current)", helper, StringComparison.Ordinal);
-            Assert.Equal(2, CountOccurrences(helper, "catch (InvalidOperationException)"));
+            Assert.Equal(2, CountOccurrences(helper, "catch (Exception ex) when"));
+            Assert.Equal(2, CountOccurrences(helper, "ex is InvalidOperationException"));
+            Assert.Equal(2, CountOccurrences(helper, "ex is ArgumentException"));
+            Assert.DoesNotContain("catch (InvalidOperationException)", helper, StringComparison.Ordinal);
             Assert.Contains("FrameworkElement element => element.Parent", helper, StringComparison.Ordinal);
             Assert.Contains("FrameworkContentElement contentElement => contentElement.Parent", helper, StringComparison.Ordinal);
             Assert.DoesNotContain("return LogicalTreeHelper.GetParent(current);", helper, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-grid-context-parent-exception-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-grid-context-parent-exception-guard.md
@@ -1,0 +1,12 @@
+# Grid Context Parent Exception Guard - 2026-06-23
+
+## Completed
+
+- Hardened the shared grid context-menu selection helper so WPF visual and logical parent traversal treats both invalid-operation and argument failures as non-fatal.
+- Preserved the existing fallback chain from visual parent lookup to logical parent lookup to framework parent lookup.
+- Updated `GridContextMenuSelectionContractTests` so the broader exception guard remains part of the source contract.
+
+## Validation
+
+- GitHub connector compare/readback should be used for this scheduled pass.
+- Local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` and `dotnet` are unavailable, so local restore/build/test execution, WPF screenshots/runtime checks, and local banned-word checks were not run.

--- a/InventoryManagementApp/Views/Pages/GridContextMenuSelection.cs
+++ b/InventoryManagementApp/Views/Pages/GridContextMenuSelection.cs
@@ -49,7 +49,7 @@ namespace InventoryManagementApp.Views.Pages
             {
                 return VisualTreeHelper.GetParent(current);
             }
-            catch (InvalidOperationException)
+            catch (Exception ex) when (ex is InvalidOperationException || ex is ArgumentException)
             {
                 return null;
             }
@@ -62,7 +62,7 @@ namespace InventoryManagementApp.Views.Pages
                 var parent = LogicalTreeHelper.GetParent(current);
                 return parent;
             }
-            catch (InvalidOperationException)
+            catch (Exception ex) when (ex is InvalidOperationException || ex is ArgumentException)
             {
                 return null;
             }


### PR DESCRIPTION
## Summary

- Harden the shared grid context-menu selection helper so WPF visual/logical parent traversal treats both invalid-operation and argument failures as non-fatal.
- Preserve the existing fallback chain from visual parent lookup to logical parent lookup to framework parent lookup.
- Update `GridContextMenuSelectionContractTests` so the broader exception guard stays covered.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against `master`, with the branch 3 commits ahead and 0 behind.
- Read back `GridContextMenuSelection.cs`, `GridContextMenuSelectionContractTests.cs`, and the progress note through the GitHub connector.
- Not run locally: this scheduled Linux container has no repository checkout because direct GitHub clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` and `dotnet` are unavailable, so `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.