### PR TITLE
Clear kit member rows after load failures

### DIFF
--- a/InventoryManagementApp.Tests/KitManagementWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/KitManagementWorkflowContractTests.cs
@@ -20,6 +20,18 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("catch (Exception ex)\n            {\n                await _dialogService.ShowErrorAsync(\"Error loading kits\", ex.Message);\n            }", source, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void KitItemLoadFailuresClearStaleMemberRowsAndSelection()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "KitManagementViewModel.cs");
+
+            Assert.Contains("var selectedKitItemId = SelectedKitItem?.KitItemID;\n            ClearKitItemsForReload();", source, StringComparison.Ordinal);
+            Assert.Contains("private void ClearKitItemsForReload()", source, StringComparison.Ordinal);
+            Assert.Contains("KitItems.Clear();\n            SelectedKitItem = null;\n            RefreshKitItemSummaries();", source, StringComparison.Ordinal);
+            Assert.Contains("ClearKitItemsForReload();\n                await _dialogService.ShowErrorAsync(\"Error loading kit items\", $\"{ex.Message} Kit item rows were cleared until reload succeeds.\");", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await _dialogService.ShowErrorAsync(\"Error loading kit items\", ex.Message);", source, StringComparison.Ordinal);
+        }
+
         private static string ReadRepoFile(params string[] parts)
         {
             var directory = AppContext.BaseDirectory;

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-kit-item-load-failure-clearing.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-kit-item-load-failure-clearing.md
@@ -1,0 +1,10 @@
+# Kit Item Load Failure Cleanup
+
+- Cleared visible kit item rows and selected kit-item state before reloading a selected kit's member lines so stale membership does not remain visible while a new selection refreshes.
+- Kept kit item rows cleared when member-line loading fails and updated the operator-facing error to explain that item rows were cleared until reload succeeds.
+- Added source-contract coverage to guard the kit item reload cleanup path, the shared item-row clearing helper, and the expanded failure message.
+
+Validation notes:
+
+- GitHub connector readback/compare should be used for this scheduled pass because direct local clone/raw access is blocked in this Linux container.
+- Not run locally: `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots/runtime checks, and local banned-word checks are unavailable here because local repository checkout is blocked and `dotnet` is not installed.

--- a/InventoryManagementApp/ViewModels/KitManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/KitManagementViewModel.cs
@@ -412,7 +412,7 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error removing item", ex.Message);
+                    await _dialogService.ShowErrorAsync("Error removing item from kit", ex.Message);
                 }
             }
         }

--- a/InventoryManagementApp/ViewModels/KitManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/KitManagementViewModel.cs
@@ -72,9 +72,7 @@ namespace InventoryManagementApp.ViewModels
                     }
                     else
                     {
-                        KitItems.Clear();
-                        SelectedKitItem = null;
-                        RefreshKitItemSummaries();
+                        ClearKitItemsForReload();
                     }
                 }
             }
@@ -208,11 +206,12 @@ namespace InventoryManagementApp.ViewModels
 
         private async Task LoadKitItemsAsync(int kitID)
         {
+            var selectedKitItemId = SelectedKitItem?.KitItemID;
+            ClearKitItemsForReload();
+
             try
             {
-                var selectedKitItemId = SelectedKitItem?.KitItemID;
                 var items = await _kitService.GetKitItemsAsync(kitID);
-                KitItems.Clear();
                 foreach (var item in items)
                 {
                     KitItems.Add(item);
@@ -222,8 +221,16 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                await _dialogService.ShowErrorAsync("Error loading kit items", ex.Message);
+                ClearKitItemsForReload();
+                await _dialogService.ShowErrorAsync("Error loading kit items", $"{ex.Message} Kit item rows were cleared until reload succeeds.");
             }
+        }
+
+        private void ClearKitItemsForReload()
+        {
+            KitItems.Clear();
+            SelectedKitItem = null;
+            RefreshKitItemSummaries();
         }
 
         private async Task AddKitAsync()
@@ -405,7 +412,7 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error removing item from kit", ex.Message);
+                    await _dialogService.ShowErrorAsync("Error removing item", ex.Message);
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Clear visible kit item/member rows and selected kit-item state before reloading a selected kit's membership list.
- Keep member rows cleared when kit item loading fails, with an operator-facing message that explains the rows were cleared until reload succeeds.
- Add source-contract coverage for the kit item reload cleanup path and progress note.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against `master`, with the branch 4 commits ahead and 0 behind.
- Read back `KitManagementViewModel.cs`, `KitManagementWorkflowContractTests.cs`, and the progress note through the GitHub connector.
- GitHub reported PR #1257 mergeable with no attached commit statuses.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `gh` and `dotnet` are unavailable, so `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.