### PR TITLE
Refresh kit item rows after mutation failures

### DIFF
--- a/InventoryManagementApp.Tests/KitManagementWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/KitManagementWorkflowContractTests.cs
@@ -32,6 +32,36 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("await _dialogService.ShowErrorAsync(\"Error loading kit items\", ex.Message);", source, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void KitItemMutationFailuresRefreshOrClearMemberRows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "KitManagementViewModel.cs");
+
+            Assert.Contains("private async Task RefreshKitItemsAfterMutationFailureAsync(string title, string message)", source, StringComparison.Ordinal);
+            Assert.Contains("await ReloadKitItemsForRecoveryAsync(SelectedKit.KitID);", source, StringComparison.Ordinal);
+            Assert.Contains("Kit item rows were refreshed in case the membership list changed before the failure.", source, StringComparison.Ordinal);
+            Assert.Contains("ClearKitItemsForReload();\n                await _dialogService.ShowErrorAsync(title, $\"{message} Kit item rows were cleared because refresh also failed: {refreshEx.Message}\");", source, StringComparison.Ordinal);
+            Assert.Contains("private async Task ReloadKitItemsForRecoveryAsync(int kitID)", source, StringComparison.Ordinal);
+            Assert.Equal(3, CountOccurrences(source, "await RefreshKitItemsAfterMutationFailureAsync(\"Error"));
+            Assert.DoesNotContain("await _dialogService.ShowErrorAsync(\"Error adding item to kit\", ex.Message);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await _dialogService.ShowErrorAsync(\"Error updating kit item\", ex.Message);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await _dialogService.ShowErrorAsync(\"Error removing item from kit\", ex.Message);", source, StringComparison.Ordinal);
+        }
+
+        private static int CountOccurrences(string source, string value)
+        {
+            var count = 0;
+            var index = 0;
+
+            while ((index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += value.Length;
+            }
+
+            return count;
+        }
+
         private static string ReadRepoFile(params string[] parts)
         {
             var directory = AppContext.BaseDirectory;

--- a/InventoryManagementApp/ViewModels/KitManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/KitManagementViewModel.cs
@@ -233,6 +233,39 @@ namespace InventoryManagementApp.ViewModels
             RefreshKitItemSummaries();
         }
 
+        private async Task RefreshKitItemsAfterMutationFailureAsync(string title, string message)
+        {
+            if (SelectedKit == null)
+            {
+                await _dialogService.ShowErrorAsync(title, message);
+                return;
+            }
+
+            try
+            {
+                await ReloadKitItemsForRecoveryAsync(SelectedKit.KitID);
+                await _dialogService.ShowErrorAsync(title, $"{message} Kit item rows were refreshed in case the membership list changed before the failure.");
+            }
+            catch (Exception refreshEx)
+            {
+                ClearKitItemsForReload();
+                await _dialogService.ShowErrorAsync(title, $"{message} Kit item rows were cleared because refresh also failed: {refreshEx.Message}");
+            }
+        }
+
+        private async Task ReloadKitItemsForRecoveryAsync(int kitID)
+        {
+            var selectedKitItemId = SelectedKitItem?.KitItemID;
+            ClearKitItemsForReload();
+            var items = await _kitService.GetKitItemsAsync(kitID);
+            foreach (var item in items)
+            {
+                KitItems.Add(item);
+            }
+            SelectedKitItem = KitItems.FirstOrDefault(i => i.KitItemID == selectedKitItemId) ?? KitItems.FirstOrDefault();
+            RefreshKitItemSummaries();
+        }
+
         private async Task AddKitAsync()
         {
             var newKit = new Kit
@@ -352,7 +385,7 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error adding item to kit", ex.Message);
+                    await RefreshKitItemsAfterMutationFailureAsync("Error adding item to kit", ex.Message);
                 }
             }
         }
@@ -386,7 +419,7 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error updating kit item", ex.Message);
+                    await RefreshKitItemsAfterMutationFailureAsync("Error updating kit item", ex.Message);
                 }
             }
         }
@@ -412,7 +445,7 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error removing item from kit", ex.Message);
+                    await RefreshKitItemsAfterMutationFailureAsync("Error removing item from kit", ex.Message);
                 }
             }
         }

--- a/docs/progress/2026-06-23-kit-item-mutation-failure-refresh.md
+++ b/docs/progress/2026-06-23-kit-item-mutation-failure-refresh.md
@@ -1,0 +1,7 @@
+# 2026-06-23 Kit Item Mutation Failure Refresh
+
+- Refreshed the selected kit's member rows after add/edit/remove kit item failures so the grid reflects durable state when a save may have partly completed before an exception.
+- Cleared kit member rows and selected kit-item state if the recovery refresh also fails, preventing edit/remove/print handoffs from using stale member lines.
+- Added source-contract coverage in `KitManagementWorkflowContractTests` for the mutation-failure refresh and clear-on-refresh-failure paths.
+
+Validation note: local clone/raw access, `dotnet`, WPF screenshots, and local banned-word checks are unavailable in this scheduled Linux container, so validation used GitHub connector readback and compare.


### PR DESCRIPTION
## Summary

- Refresh the selected kit's member rows after add/edit/remove kit item failures so the visible grid reflects durable state when a save may have partly completed before an exception.
- Clear member rows and selected kit-item state if the recovery refresh also fails, with operator-facing wording that explains the cleared rows.
- Add source-contract coverage for the kit item mutation failure refresh path and a progress note.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against `master`, with the branch 3 commits ahead and 0 behind.
- Read back `KitManagementViewModel.cs`, `KitManagementWorkflowContractTests.cs`, and the progress note through the GitHub connector.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` and WPF runtime validation are unavailable in this scheduled Linux container, so `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.