### PR TITLE
Refresh categories after mutation failures

### DIFF
--- a/InventoryManagementApp.Tests/CategoryManagementWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/CategoryManagementWorkflowContractTests.cs
@@ -20,6 +20,27 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("StatusMessage = \"Categories could not be loaded. Review logs or retry refresh.\";\n                WpfMessageBox.Show(\"Categories could not be loaded. Please retry or check the application log.\"", source, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void CategoryMutationFailuresRefreshOrClearVisibleRows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CategoryManagementViewModel.cs");
+
+            Assert.Contains("private async Task RefreshCategoryDirectoryAfterMutationFailureAsync(int? preferredSelectedId, string refreshedStatusMessage, string clearedStatusMessage)", source, StringComparison.Ordinal);
+            Assert.Contains("var list = await _service.GetCategoriesForInventoryAsync(SelectedInventoryId);\n                Categories.Clear();\n                foreach (var c in list) Categories.Add(new CategoryItem { CategoryID = c.CategoryID, Name = c.Name });\n                ApplyFilter(preferredSelectedId);\n                StatusMessage = refreshedStatusMessage;", source, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogWarning(refreshEx, \"Failed to refresh categories after a category mutation failure for inventory {InventoryId}\", SelectedInventoryId);\n                ClearCategoryStateAfterLoadFailure();\n                StatusMessage = clearedStatusMessage;", source, StringComparison.Ordinal);
+            Assert.Contains("int? createdCategoryId = null;", source, StringComparison.Ordinal);
+            Assert.Contains("createdCategoryId = id;", source, StringComparison.Ordinal);
+            Assert.Contains("await RefreshCategoryDirectoryAfterMutationFailureAsync(\n                    createdCategoryId,\n                    $\"Category rows were refreshed after '{name}' failed to finish creating.\",\n                    $\"Category rows were cleared after '{name}' failed to finish creating and recovery reload failed.\");", source, StringComparison.Ordinal);
+            Assert.Contains("await RefreshCategoryDirectoryAfterMutationFailureAsync(\n                        id,\n                        $\"Category rows were refreshed after category #{id} could not be renamed.\",\n                        $\"Category rows were cleared after category #{id} could not be renamed and recovery reload failed.\");", source, StringComparison.Ordinal);
+            Assert.Contains("await RefreshCategoryDirectoryAfterMutationFailureAsync(\n                    id,\n                    $\"Category rows were refreshed after category #{id} failed to finish saving.\",\n                    $\"Category rows were cleared after category #{id} failed to finish saving and recovery reload failed.\");", source, StringComparison.Ordinal);
+            Assert.Contains("await RefreshCategoryDirectoryAfterMutationFailureAsync(\n                        category.CategoryID,\n                        $\"Category rows were refreshed after '{category.Name}' could not be deleted.\",\n                        $\"Category rows were cleared after '{category.Name}' could not be deleted and recovery reload failed.\");", source, StringComparison.Ordinal);
+            Assert.Contains("await RefreshCategoryDirectoryAfterMutationFailureAsync(\n                    category.CategoryID,\n                    $\"Category rows were refreshed after '{category.Name}' failed to finish deleting.\",\n                    $\"Category rows were cleared after '{category.Name}' failed to finish deleting and recovery reload failed.\");", source, StringComparison.Ordinal);
+            Assert.Contains("Category rows were refreshed from the saved data where possible.", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("StatusMessage = $\"Category '{name}' could not be created.\";\n                WpfMessageBox.Show($\"Category '{name}' could not be created. Please retry or check the application log.\"", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("StatusMessage = $\"Category #{id} could not be renamed.\";\n                    WpfMessageBox.Show(\"The category was not renamed. Refresh and try again.\"", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("StatusMessage = $\"Category '{category.Name}' could not be deleted.\";\n                    WpfMessageBox.Show(\"The category was not deleted. Refresh and try again.\"", source, StringComparison.Ordinal);
+        }
+
         private static string ReadRepoFile(params string[] parts)
         {
             var directory = AppContext.BaseDirectory;

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-category-mutation-failure-refresh.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-category-mutation-failure-refresh.md
@@ -1,0 +1,8 @@
+# Category mutation failure refresh
+
+- Refreshed the category directory after create, rename, and delete failures so visible rows reflect durable saved data when a category mutation may have partly completed before an exception.
+- Re-selected the affected category when it still exists in the refreshed filtered rows.
+- Cleared category rows, filtered rows, selected category, and edit text when the recovery refresh also fails.
+- Added source-contract coverage in `CategoryManagementWorkflowContractTests` so the refresh-or-clear mutation failure pattern stays guarded.
+
+Validation note: local clone/raw access is blocked in this scheduled Linux container, and `dotnet`/WPF runtime validation are unavailable here. GitHub connector readback and compare were used for validation.

--- a/InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CategoryManagementViewModel.cs
@@ -254,6 +254,31 @@ namespace InventoryManagementApp.ViewModels
             RaiseDirectoryProperties();
         }
 
+        private async Task RefreshCategoryDirectoryAfterMutationFailureAsync(int? preferredSelectedId, string refreshedStatusMessage, string clearedStatusMessage)
+        {
+            if (SelectedInventoryId <= 0)
+            {
+                ClearCategoryStateAfterLoadFailure();
+                StatusMessage = clearedStatusMessage;
+                return;
+            }
+
+            try
+            {
+                var list = await _service.GetCategoriesForInventoryAsync(SelectedInventoryId);
+                Categories.Clear();
+                foreach (var c in list) Categories.Add(new CategoryItem { CategoryID = c.CategoryID, Name = c.Name });
+                ApplyFilter(preferredSelectedId);
+                StatusMessage = refreshedStatusMessage;
+            }
+            catch (Exception refreshEx)
+            {
+                _logger.LogWarning(refreshEx, "Failed to refresh categories after a category mutation failure for inventory {InventoryId}", SelectedInventoryId);
+                ClearCategoryStateAfterLoadFailure();
+                StatusMessage = clearedStatusMessage;
+            }
+        }
+
         private void ApplyFilter(int? preferredSelectedId = null)
         {
             var search = SearchText.Trim();
@@ -291,10 +316,12 @@ namespace InventoryManagementApp.ViewModels
             var name = CategoryName.Trim();
             if (name.Length == 0) return;
 
+            int? createdCategoryId = null;
             IsBusy = true;
             try
             {
                 var id = await _service.EnsureCategoryAsync(name);
+                createdCategoryId = id;
                 try
                 {
                     await _service.LinkCategoryToInventoryAsync(id, SelectedInventoryId);
@@ -312,8 +339,11 @@ namespace InventoryManagementApp.ViewModels
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to add category {CategoryName}", name);
-                StatusMessage = $"Category '{name}' could not be created.";
-                WpfMessageBox.Show($"Category '{name}' could not be created. Please retry or check the application log.", "Create Category", MessageBoxButton.OK, MessageBoxImage.Error);
+                await RefreshCategoryDirectoryAfterMutationFailureAsync(
+                    createdCategoryId,
+                    $"Category rows were refreshed after '{name}' failed to finish creating.",
+                    $"Category rows were cleared after '{name}' failed to finish creating and recovery reload failed.");
+                WpfMessageBox.Show($"Category '{name}' could not be created. Category rows were refreshed from the saved data where possible.", "Create Category", MessageBoxButton.OK, MessageBoxImage.Error);
             }
             finally { IsBusy = false; }
         }
@@ -338,15 +368,21 @@ namespace InventoryManagementApp.ViewModels
                 }
                 else
                 {
-                    StatusMessage = $"Category #{id} could not be renamed.";
-                    WpfMessageBox.Show("The category was not renamed. Refresh and try again.", "Save Category", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    await RefreshCategoryDirectoryAfterMutationFailureAsync(
+                        id,
+                        $"Category rows were refreshed after category #{id} could not be renamed.",
+                        $"Category rows were cleared after category #{id} could not be renamed and recovery reload failed.");
+                    WpfMessageBox.Show("The category was not renamed. Category rows were refreshed from the saved data where possible.", "Save Category", MessageBoxButton.OK, MessageBoxImage.Warning);
                 }
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to rename category {CategoryId}", id);
-                StatusMessage = $"Category #{id} could not be renamed.";
-                WpfMessageBox.Show("The category could not be saved. Please retry or check the application log.", "Save Category", MessageBoxButton.OK, MessageBoxImage.Error);
+                await RefreshCategoryDirectoryAfterMutationFailureAsync(
+                    id,
+                    $"Category rows were refreshed after category #{id} failed to finish saving.",
+                    $"Category rows were cleared after category #{id} failed to finish saving and recovery reload failed.");
+                WpfMessageBox.Show("The category could not be saved. Category rows were refreshed from the saved data where possible.", "Save Category", MessageBoxButton.OK, MessageBoxImage.Error);
             }
             finally { IsBusy = false; }
         }
@@ -377,15 +413,21 @@ namespace InventoryManagementApp.ViewModels
                 }
                 else
                 {
-                    StatusMessage = $"Category '{category.Name}' could not be deleted.";
-                    WpfMessageBox.Show("The category was not deleted. Refresh and try again.", "Delete Category", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    await RefreshCategoryDirectoryAfterMutationFailureAsync(
+                        category.CategoryID,
+                        $"Category rows were refreshed after '{category.Name}' could not be deleted.",
+                        $"Category rows were cleared after '{category.Name}' could not be deleted and recovery reload failed.");
+                    WpfMessageBox.Show("The category was not deleted. Category rows were refreshed from the saved data where possible.", "Delete Category", MessageBoxButton.OK, MessageBoxImage.Warning);
                 }
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to delete category {CategoryId}", category.CategoryID);
-                StatusMessage = $"Category '{category.Name}' could not be deleted.";
-                WpfMessageBox.Show("The category could not be deleted. It may still be needed by other records.", "Delete Category", MessageBoxButton.OK, MessageBoxImage.Error);
+                await RefreshCategoryDirectoryAfterMutationFailureAsync(
+                    category.CategoryID,
+                    $"Category rows were refreshed after '{category.Name}' failed to finish deleting.",
+                    $"Category rows were cleared after '{category.Name}' failed to finish deleting and recovery reload failed.");
+                WpfMessageBox.Show("The category could not be deleted. Category rows were refreshed from the saved data where possible.", "Delete Category", MessageBoxButton.OK, MessageBoxImage.Error);
             }
             finally { IsBusy = false; }
         }


### PR DESCRIPTION
## Summary

- Refresh category directory rows after create, rename, and delete failures so visible rows reflect durable saved data when a mutation may have partly completed before an exception.
- Preserve or restore the affected category selection when it is still present in the refreshed filtered rows.
- Clear category rows, filtered rows, selected category, and edit text if the recovery refresh also fails, with source-contract coverage for the refresh-or-clear pattern.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against `master`, with the branch 3 commits ahead and 0 behind.
- Read back `CategoryManagementViewModel.cs`, `CategoryManagementWorkflowContractTests.cs`, and the progress note through the GitHub connector.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet`, `gh`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation are unavailable in this scheduled Linux container.