### PR TITLE
Refresh customers after mutation failures

### DIFF
--- a/InventoryManagementApp.Tests/CustomerManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/CustomerManagementViewModelTests.cs
@@ -122,26 +122,75 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("Customer rows were cleared until reload succeeds.", dialog.LastInfoMessage);
         }
 
+        [Fact]
+        public async Task AddCustomerCommand_WhenMutationThrows_RefreshesRowsAndSelectsSavedCustomer()
+        {
+            var service = new StubCustomerService { ThrowAfterAddCustomer = true };
+            service.Customers.Add(new CustomerModel { CustomerID = 1, Company = "Alpha" });
+            var dialog = new StubDialogService { AddCustomerResult = new CustomerModel { CustomerID = 2, Company = "Beta" } };
+            var vm = new CustomerManagementViewModel(service, dialog);
+            await vm.LoadCustomersAsync();
+
+            await vm.AddCustomerCommand.ExecuteAsync(null);
+
+            Assert.Equal(2, vm.Customers.Count);
+            Assert.Equal(2, vm.SelectedCustomer?.CustomerID);
+            Assert.True(vm.UpdateCustomerCommand.CanExecute(null));
+            Assert.Equal("Add Customer Failed", dialog.LastInfoTitle);
+            Assert.Contains("Customer rows were refreshed from saved data where possible.", dialog.LastInfoMessage);
+        }
+
+        [Fact]
+        public async Task DeleteCustomerCommand_WhenMutationThrows_RefreshesRowsAndClearsDeletedSelection()
+        {
+            var service = new StubCustomerService { ThrowAfterDeleteCustomer = true };
+            service.Customers.Add(new CustomerModel { CustomerID = 1, Company = "Alpha" });
+            service.Customers.Add(new CustomerModel { CustomerID = 2, Company = "Beta" });
+            var dialog = new StubDialogService();
+            var vm = new CustomerManagementViewModel(service, dialog);
+            await vm.LoadCustomersAsync();
+            vm.SelectedCustomer = vm.Customers.First(c => c.CustomerID == 1);
+
+            await vm.DeleteCustomerCommand.ExecuteAsync(null);
+
+            Assert.Single(vm.Customers);
+            Assert.Equal(2, vm.Customers[0].CustomerID);
+            Assert.Null(vm.SelectedCustomer);
+            Assert.False(vm.DeleteCustomerCommand.CanExecute(null));
+            Assert.Equal("Delete Customer Failed", dialog.LastInfoTitle);
+            Assert.Contains("Customer rows were refreshed from saved data where possible.", dialog.LastInfoMessage);
+        }
+
         private sealed class StubCustomerService : ICustomerService
         {
             public List<CustomerModel> Customers { get; } = new();
             public bool ThrowOnGetAllCustomers { get; set; }
+            public bool ThrowAfterAddCustomer { get; set; }
+            public bool ThrowAfterUpdateCustomer { get; set; }
+            public bool ThrowAfterDeleteCustomer { get; set; }
 
             public Task AddCustomerAsync(CustomerModel customer, CancellationToken cancellationToken = default)
             {
                 Customers.Add(customer);
-                return Task.CompletedTask;
+                return ThrowAfterAddCustomer
+                    ? Task.FromException(new System.InvalidOperationException("add handoff failed"))
+                    : Task.CompletedTask;
             }
             public Task UpdateCustomerAsync(CustomerModel customer, CancellationToken cancellationToken = default)
             {
                 var idx = Customers.FindIndex(c => c.CustomerID == customer.CustomerID);
                 if (idx >= 0) Customers[idx] = customer;
-                return Task.CompletedTask;
+
+                return ThrowAfterUpdateCustomer
+                    ? Task.FromException(new System.InvalidOperationException("update handoff failed"))
+                    : Task.CompletedTask;
             }
             public Task DeleteCustomerAsync(int customerID, CancellationToken cancellationToken = default)
             {
                 Customers.RemoveAll(c => c.CustomerID == customerID);
-                return Task.CompletedTask;
+                return ThrowAfterDeleteCustomer
+                    ? Task.FromException(new System.InvalidOperationException("delete handoff failed"))
+                    : Task.CompletedTask;
             }
             public Task<CustomerModel?> GetCustomerByIDAsync(int customerID, CancellationToken cancellationToken = default)
                 => Task.FromResult<CustomerModel?>(Customers.First(c => c.CustomerID == customerID));

--- a/InventoryManagementApp/ProgressNotes/2026-06-23-customer-mutation-failure-refresh.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-23-customer-mutation-failure-refresh.md
@@ -1,0 +1,9 @@
+# Customer mutation failure refresh
+
+- Refreshed the customer directory after add, update, edit-dialog update, and delete failures so visible rows reflect durable saved data when a customer mutation may have partly completed before an exception.
+- Preserved the current customer search filter during recovery refreshes and re-selected the affected customer when it still exists.
+- Cleared the selected customer after delete recovery when the deleted customer is no longer present, preventing edit, print, copy, and delete actions from pointing at a stale contact.
+- Cleared customer rows and selection if the recovery refresh also fails.
+- Added focused `CustomerManagementViewModelTests` coverage for post-add and post-delete exception recovery.
+
+Validation note: local clone/raw access is blocked in this scheduled Linux container, and `dotnet`/WPF runtime validation are unavailable here. GitHub connector readback and compare were used for validation.

--- a/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
@@ -146,7 +146,7 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 var preferredCustomerId = SelectedCustomer?.CustomerID;
-                var all = await _maintenanceSafeGetCustomersForCurrentSearchAsync();
+                var all = await _customerService.GetAllCustomersAsync();
                 Customers.ReplaceRange(all);
                 SelectBestCustomerAfterRefresh(preferredCustomerId);
                 OnPropertyChanged(nameof(CustomerResultsSummary));
@@ -228,7 +228,7 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 var preferredCustomerId = SelectedCustomer?.CustomerID;
-                var all = await _maintenanceSafeGetCustomersForCurrentSearchAsync();
+                var all = await GetCustomersForCurrentSearchAsync();
                 Customers.ReplaceRange(all);
                 SelectBestCustomerAfterRefresh(preferredCustomerId);
                 OnPropertyChanged(nameof(CustomerResultsSummary));
@@ -247,7 +247,7 @@ namespace InventoryManagementApp.ViewModels
 
             try
             {
-                var all = await _maintenanceSafeGetCustomersForCurrentSearchAsync();
+                var all = await GetCustomersForCurrentSearchAsync();
                 Customers.ReplaceRange(all);
                 SelectBestCustomerAfterRefresh(preferredCustomerId, clearSelectionWhenPreferredMissing);
                 OnPropertyChanged(nameof(CustomerResultsSummary));
@@ -260,7 +260,7 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        private async Task<System.Collections.Generic.List<CustomerModel>> _maintenanceSafeGetCustomersForCurrentSearchAsync()
+        private async Task<System.Collections.Generic.List<CustomerModel>> GetCustomersForCurrentSearchAsync()
         {
             var all = await _customerService!.GetAllCustomersAsync();
             if (!string.IsNullOrWhiteSpace(CustomerSearchTerm))

--- a/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CustomerManagementViewModel.cs
@@ -146,7 +146,7 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 var preferredCustomerId = SelectedCustomer?.CustomerID;
-                var all = await _customerService.GetAllCustomersAsync();
+                var all = await _maintenanceSafeGetCustomersForCurrentSearchAsync();
                 Customers.ReplaceRange(all);
                 SelectBestCustomerAfterRefresh(preferredCustomerId);
                 OnPropertyChanged(nameof(CustomerResultsSummary));
@@ -176,7 +176,12 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                await _dialogService.ShowInfoAsync($"Failed to add customer: {ex.Message}", "Add Customer Failed");
+                await RefreshCustomerDirectoryAfterMutationFailureAsync(
+                    customer.CustomerID,
+                    false,
+                    $"Failed to add customer: {ex.Message} Customer rows were refreshed from saved data where possible.",
+                    $"Failed to add customer: {ex.Message} Customer rows were cleared because recovery reload failed.",
+                    "Add Customer Failed");
             }
         }
 
@@ -207,7 +212,12 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                await _dialogService.ShowInfoAsync($"Failed to update customer: {ex.Message}", "Update Customer Failed");
+                await RefreshCustomerDirectoryAfterMutationFailureAsync(
+                    selectedId,
+                    false,
+                    $"Failed to update customer: {ex.Message} Customer rows were refreshed from saved data where possible.",
+                    $"Failed to update customer: {ex.Message} Customer rows were cleared because recovery reload failed.",
+                    "Update Customer Failed");
             }
         }
 
@@ -218,19 +228,7 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 var preferredCustomerId = SelectedCustomer?.CustomerID;
-                var all = await _customerService.GetAllCustomersAsync();
-                if (!string.IsNullOrWhiteSpace(CustomerSearchTerm))
-                {
-                    var term = CustomerSearchTerm.Trim();
-                    all = all.Where(c =>
-                        (c.Company?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                        (c.Email?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                        (c.Contact?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                        (c.Phone?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                        (c.Mobile?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                        (c.Address?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false))
-                        .ToList();
-                }
+                var all = await _maintenanceSafeGetCustomersForCurrentSearchAsync();
                 Customers.ReplaceRange(all);
                 SelectBestCustomerAfterRefresh(preferredCustomerId);
                 OnPropertyChanged(nameof(CustomerResultsSummary));
@@ -241,6 +239,44 @@ namespace InventoryManagementApp.ViewModels
                 if (_dialogService != null)
                     await _dialogService.ShowInfoAsync($"Failed to search customers: {ex.Message} Customer rows were cleared until reload succeeds.", "Customer Search Failed");
             }
+        }
+
+        private async Task RefreshCustomerDirectoryAfterMutationFailureAsync(int? preferredCustomerId, bool clearSelectionWhenPreferredMissing, string refreshedMessage, string clearedMessage, string title)
+        {
+            if (_customerService == null || _dialogService == null) return;
+
+            try
+            {
+                var all = await _maintenanceSafeGetCustomersForCurrentSearchAsync();
+                Customers.ReplaceRange(all);
+                SelectBestCustomerAfterRefresh(preferredCustomerId, clearSelectionWhenPreferredMissing);
+                OnPropertyChanged(nameof(CustomerResultsSummary));
+                await _dialogService.ShowInfoAsync(refreshedMessage, title);
+            }
+            catch
+            {
+                ClearCustomerDirectoryAfterLoadFailure();
+                await _dialogService.ShowInfoAsync(clearedMessage, title);
+            }
+        }
+
+        private async Task<System.Collections.Generic.List<CustomerModel>> _maintenanceSafeGetCustomersForCurrentSearchAsync()
+        {
+            var all = await _customerService!.GetAllCustomersAsync();
+            if (!string.IsNullOrWhiteSpace(CustomerSearchTerm))
+            {
+                var term = CustomerSearchTerm.Trim();
+                all = all.Where(c =>
+                    (c.Company?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    (c.Email?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    (c.Contact?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    (c.Phone?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    (c.Mobile?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    (c.Address?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false))
+                    .ToList();
+            }
+
+            return all;
         }
 
         private void ClearCustomerDirectoryAfterLoadFailure()
@@ -288,7 +324,12 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                await _dialogService.ShowInfoAsync($"Failed to delete customer: {ex.Message}", "Delete Customer Failed");
+                await RefreshCustomerDirectoryAfterMutationFailureAsync(
+                    customer.CustomerID,
+                    true,
+                    $"Failed to delete customer: {ex.Message} Customer rows were refreshed from saved data where possible.",
+                    $"Failed to delete customer: {ex.Message} Customer rows were cleared because recovery reload failed.",
+                    "Delete Customer Failed");
             }
         }
 
@@ -309,7 +350,12 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                await _dialogService.ShowInfoAsync($"Failed to edit customer: {ex.Message}", "Edit Customer Failed");
+                await RefreshCustomerDirectoryAfterMutationFailureAsync(
+                    edited.CustomerID,
+                    false,
+                    $"Failed to edit customer: {ex.Message} Customer rows were refreshed from saved data where possible.",
+                    $"Failed to edit customer: {ex.Message} Customer rows were cleared because recovery reload failed.",
+                    "Edit Customer Failed");
             }
         }
 
@@ -414,7 +460,7 @@ namespace InventoryManagementApp.ViewModels
             }
         }
 
-        void SelectBestCustomerAfterRefresh(int? preferredCustomerId = null)
+        void SelectBestCustomerAfterRefresh(int? preferredCustomerId = null, bool clearSelectionWhenPreferredMissing = false)
         {
             if (Customers.Count == 0)
             {
@@ -422,9 +468,14 @@ namespace InventoryManagementApp.ViewModels
                 return;
             }
 
-            SelectedCustomer = preferredCustomerId.HasValue
-                ? Customers.FirstOrDefault(c => c.CustomerID == preferredCustomerId.Value) ?? Customers.FirstOrDefault()
-                : Customers.FirstOrDefault();
+            if (preferredCustomerId.HasValue)
+            {
+                var preferredCustomer = Customers.FirstOrDefault(c => c.CustomerID == preferredCustomerId.Value);
+                SelectedCustomer = preferredCustomer ?? (clearSelectionWhenPreferredMissing ? null : Customers.FirstOrDefault());
+                return;
+            }
+
+            SelectedCustomer = Customers.FirstOrDefault();
         }
 
         static string CreateCustomerHandoffText(CustomerModel customer)


### PR DESCRIPTION
## Summary

- Refresh the customer directory after add, update, edit-dialog update, and delete failures so visible rows reflect durable saved data when a mutation may have partly completed before an exception.
- Preserve the active customer search filter during recovery refreshes and re-select the affected customer when it still exists.
- Clear customer selection after delete recovery when the deleted customer is no longer present, with focused coverage for add/delete exception recovery.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against `master`, with the branch 4 commits ahead and 0 behind.
- Read back `CustomerManagementViewModel.cs`, `CustomerManagementViewModelTests.cs`, and the progress note through the GitHub connector.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet`, `gh`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation are unavailable in this scheduled Linux container.