### PR TITLE
Refresh users after mutation failures

### DIFF
--- a/InventoryManagementApp.Tests/UserManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/UserManagementViewModelTests.cs
@@ -45,6 +45,74 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task AddUserAsync_WhenAddFailsAfterPersistence_RefreshesRowsAndSelectsSavedUser()
+        {
+            var service = new StubUserService { ThrowAfterAdd = true };
+            var dialog = new StubDialogService();
+            var vm = new UserManagementViewModel(service, new StubFileDialogService(), dialog);
+
+            await vm.AddUserAsync();
+
+            var user = Assert.Single(vm.Users);
+            Assert.Single(service.Users);
+            Assert.Same(user, vm.SelectedUser);
+            Assert.Equal("workshop1", user.UserName);
+            Assert.Equal("Error", dialog.LastTitle);
+            Assert.Contains("Failed to add user", dialog.LastMessage);
+            Assert.Contains("User rows were refreshed from saved data", dialog.LastMessage);
+        }
+
+        [Fact]
+        public async Task DeleteUserFromRowCommand_WhenDeleteFailsAfterPersistence_RefreshesRowsAndClearsDeletedSelection()
+        {
+            var deleteTarget = new UserModel { UserID = 11, UserName = "remove-me", Role = "Workshop Staff" };
+            var keepTarget = new UserModel { UserID = 12, UserName = "keep-me", Role = "Advisor" };
+            var service = new StubUserService { ThrowAfterDelete = true };
+            service.Users.Add(deleteTarget);
+            service.Users.Add(keepTarget);
+            var dialog = new StubDialogService();
+            var vm = new UserManagementViewModel(service, new StubFileDialogService(), dialog);
+
+            await vm.LoadUsersAsync();
+            vm.SelectedUser = deleteTarget;
+            vm.UserSearchText = "keep";
+            vm.SearchUsersCommand.Execute(null);
+
+            await vm.DeleteUserFromRowCommand.ExecuteAsync(deleteTarget);
+
+            var user = Assert.Single(vm.Users);
+            Assert.Same(keepTarget, user);
+            Assert.DoesNotContain(service.Users, existing => existing.UserID == deleteTarget.UserID);
+            Assert.Null(vm.SelectedUser);
+            Assert.Equal("keep", vm.UserSearchText);
+            Assert.Equal("Error", dialog.LastTitle);
+            Assert.Contains("Failed to delete user", dialog.LastMessage);
+            Assert.Contains("User rows were refreshed from saved data", dialog.LastMessage);
+        }
+
+        [Fact]
+        public async Task DeleteUserFromRowCommand_WhenDeleteAndRecoveryRefreshFail_ClearsRowsAndSelection()
+        {
+            var deleteTarget = new UserModel { UserID = 21, UserName = "remove-me", Role = "Workshop Staff" };
+            var service = new StubUserService { ThrowAfterDelete = true, ThrowOnGetAllUsersAfterMutation = true };
+            service.Users.Add(deleteTarget);
+            var dialog = new StubDialogService();
+            var vm = new UserManagementViewModel(service, new StubFileDialogService(), dialog);
+
+            await vm.LoadUsersAsync();
+            vm.SelectedUser = deleteTarget;
+
+            await vm.DeleteUserFromRowCommand.ExecuteAsync(deleteTarget);
+
+            Assert.Empty(vm.Users);
+            Assert.Null(vm.SelectedUser);
+            Assert.False(vm.UpdateUserCommand.CanExecute(null));
+            Assert.False(vm.EditUserCommand.CanExecute(null));
+            Assert.Equal("Error", dialog.LastTitle);
+            Assert.Contains("User rows were cleared because the recovery refresh failed", dialog.LastMessage);
+        }
+
+        [Fact]
         public async Task ResetPasswordFromRowCommand_WhenPasswordChangeFails_ShowsErrorAndDoesNotMarkExpired()
         {
             var user = new UserModel { UserID = 7, UserName = "workshop7", PasswordExpired = false };
@@ -85,11 +153,14 @@ namespace InventoryManagementApp.Tests
             public List<UserModel> Users { get; } = new();
             public bool ChangePasswordResult { get; set; } = true;
             public bool ThrowOnGetAllUsers { get; set; }
+            public bool ThrowOnGetAllUsersAfterMutation { get; set; }
+            public bool ThrowAfterAdd { get; set; }
+            public bool ThrowAfterDelete { get; set; }
             public int UpdateCallCount { get; private set; }
 
             public Task<List<UserModel>> GetAllUsersAsync(CancellationToken cancellationToken = default)
             {
-                if (ThrowOnGetAllUsers)
+                if (ThrowOnGetAllUsers || ThrowOnGetAllUsersAfterMutation)
                     throw new InvalidOperationException("Users are offline");
 
                 return Task.FromResult(Users.ToList());
@@ -109,7 +180,14 @@ namespace InventoryManagementApp.Tests
 
             public Task AddUserAsync(UserModel user)
             {
+                if (user.UserID == 0)
+                    user.UserID = Users.Count == 0 ? 1 : Users.Max(existing => existing.UserID) + 1;
+
                 Users.Add(user);
+
+                if (ThrowAfterAdd)
+                    throw new InvalidOperationException("Add failed after save");
+
                 return Task.CompletedTask;
             }
 
@@ -124,6 +202,10 @@ namespace InventoryManagementApp.Tests
             public Task<bool> TryDeleteUserAsync(int userID)
             {
                 Users.RemoveAll(user => user.UserID == userID);
+
+                if (ThrowAfterDelete)
+                    throw new InvalidOperationException("Delete failed after save");
+
                 return Task.FromResult(true);
             }
 

--- a/InventoryManagementApp.Tests/UserManagementViewModelTests.cs
+++ b/InventoryManagementApp.Tests/UserManagementViewModelTests.cs
@@ -94,13 +94,14 @@ namespace InventoryManagementApp.Tests
         public async Task DeleteUserFromRowCommand_WhenDeleteAndRecoveryRefreshFail_ClearsRowsAndSelection()
         {
             var deleteTarget = new UserModel { UserID = 21, UserName = "remove-me", Role = "Workshop Staff" };
-            var service = new StubUserService { ThrowAfterDelete = true, ThrowOnGetAllUsersAfterMutation = true };
+            var service = new StubUserService { ThrowAfterDelete = true };
             service.Users.Add(deleteTarget);
             var dialog = new StubDialogService();
             var vm = new UserManagementViewModel(service, new StubFileDialogService(), dialog);
 
             await vm.LoadUsersAsync();
             vm.SelectedUser = deleteTarget;
+            service.ThrowOnGetAllUsersAfterMutation = true;
 
             await vm.DeleteUserFromRowCommand.ExecuteAsync(deleteTarget);
 

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-user-mutation-failure-refresh.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-user-mutation-failure-refresh.md
@@ -1,0 +1,15 @@
+# User Mutation Failure Refresh
+
+Date: 2026-06-24
+
+## Summary
+
+- Refreshed the Users directory after add, update, edit-dialog update, password reset, photo update, and delete exceptions so visible rows reflect saved data when a mutation may have partly completed before an exception.
+- Preserved the active user search filter during recovery refreshes.
+- Reselected the affected user when it still exists after recovery, and cleared selection when a deleted user is no longer present.
+- Cleared user rows and disabled selected-user commands when the recovery refresh also fails.
+
+## Validation
+
+- Added focused `UserManagementViewModelTests` coverage for add/delete exception recovery, preserved filters, deleted-user selection clearing, and recovery-refresh failure cleanup.
+- Local `dotnet` restore/build/test was not run in the scheduled Linux container because direct repository clone/raw access is blocked and the Windows WPF validation environment is unavailable here.

--- a/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/UserManagementViewModel.cs
@@ -106,7 +106,7 @@ namespace InventoryManagementApp.ViewModels
             {
                 _allUsers = await _userService.GetAllUsersAsync(CancellationToken.None);
                 AssignInitialsBrushes(_allUsers);
-                Users.ReplaceRange(_allUsers);
+                Users.ReplaceRange(FilterUsers(_allUsers));
             }
             catch (Exception ex)
             {
@@ -123,6 +123,46 @@ namespace InventoryManagementApp.ViewModels
             SelectedUser = null;
             ((AsyncRelayCommand)UpdateUserCommand).NotifyCanExecuteChanged();
             ((AsyncRelayCommand)EditUserCommand).NotifyCanExecuteChanged();
+        }
+
+        private async Task<bool> RefreshUsersAfterMutationFailureAsync(int? preferredUserId, bool clearSelectionWhenMissing)
+        {
+            try
+            {
+                _allUsers = await _userService.GetAllUsersAsync(CancellationToken.None);
+                AssignInitialsBrushes(_allUsers);
+                Users.ReplaceRange(FilterUsers(_allUsers));
+
+                var refreshedSelection = preferredUserId.HasValue
+                    ? Users.FirstOrDefault(user => user.UserID == preferredUserId.Value)
+                    : null;
+
+                if (refreshedSelection != null || clearSelectionWhenMissing)
+                {
+                    SelectedUser = refreshedSelection;
+                }
+                else if (SelectedUser != null)
+                {
+                    SelectedUser = Users.FirstOrDefault(user => user.UserID == SelectedUser.UserID);
+                }
+
+                return true;
+            }
+            catch (Exception refreshEx)
+            {
+                _logger.LogError(refreshEx, "Failed to refresh users after mutation failure");
+                ClearUsersAfterLoadFailure();
+                return false;
+            }
+        }
+
+        private static string BuildMutationFailureMessage(string baseMessage, Exception ex, bool refreshed)
+        {
+            var recoveryMessage = refreshed
+                ? "User rows were refreshed from saved data."
+                : "User rows were cleared because the recovery refresh failed.";
+
+            return $"{baseMessage}: {ex.Message}. {recoveryMessage}";
         }
 
         static string GetInitials(string? name)
@@ -226,8 +266,9 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
+                var refreshed = await RefreshUsersAfterMutationFailureAsync(SelectedUser.UserID, clearSelectionWhenMissing: true);
                 _logger.LogError(ex, "Failed to update user photo");
-                await _dialogService.ShowInfoAsync($"Failed to update user photo: {ex.Message}", "Error");
+                await _dialogService.ShowInfoAsync(BuildMutationFailureMessage("Failed to update user photo", ex, refreshed), "Error");
             }
         }
 
@@ -250,8 +291,9 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
+                var refreshed = await RefreshUsersAfterMutationFailureAsync(SelectedUser.UserID, clearSelectionWhenMissing: true);
                 _logger.LogError(ex, "Failed to update user");
-                await _dialogService.ShowInfoAsync($"Failed to update user: {ex.Message}", "Error");
+                await _dialogService.ShowInfoAsync(BuildMutationFailureMessage("Failed to update user", ex, refreshed), "Error");
             }
         }
 
@@ -314,8 +356,9 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
+                var refreshed = await RefreshUsersAfterMutationFailureAsync(newUser.UserID, clearSelectionWhenMissing: false);
                 _logger.LogError(ex, "Failed to add user");
-                await _dialogService.ShowInfoAsync($"Failed to add user: {ex.Message}", "Error");
+                await _dialogService.ShowInfoAsync(BuildMutationFailureMessage("Failed to add user", ex, refreshed), "Error");
             }
         }
 
@@ -351,20 +394,25 @@ namespace InventoryManagementApp.ViewModels
 
         void SearchUsers()
         {
-            IEnumerable<UserModel> filtered = _allUsers;
-            if (!string.IsNullOrWhiteSpace(UserSearchText))
+            Users.ReplaceRange(FilterUsers(_allUsers));
+        }
+
+        private IEnumerable<UserModel> FilterUsers(IEnumerable<UserModel> users)
+        {
+            if (string.IsNullOrWhiteSpace(UserSearchText))
             {
-                var term = UserSearchText.Trim();
-                filtered = filtered.Where(u =>
-                    (u.UserName?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (u.Role?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (u.Email?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (u.Phone?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (u.Mobile?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (u.Address?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                    (u.AccessSummary?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false));
+                return users;
             }
-            Users.ReplaceRange(filtered);
+
+            var term = UserSearchText.Trim();
+            return users.Where(u =>
+                (u.UserName?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (u.Role?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (u.Email?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (u.Phone?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (u.Mobile?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (u.Address?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (u.AccessSummary?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false));
         }
 
         void ClearUserSearch()
@@ -438,8 +486,9 @@ namespace InventoryManagementApp.ViewModels
                     }
                     catch (Exception ex)
                     {
+                        var refreshed = await RefreshUsersAfterMutationFailureAsync(clone.UserID, clearSelectionWhenMissing: true);
                         _logger.LogError(ex, "Failed to update user");
-                        _dialogService.ShowInfo($"Failed to update user: {ex.Message}", "Error");
+                        _dialogService.ShowInfo(BuildMutationFailureMessage("Failed to update user", ex, refreshed), "Error");
                     }
                 },
                 onCancel: () =>
@@ -493,8 +542,9 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
+                var refreshed = await RefreshUsersAfterMutationFailureAsync(user.UserID, clearSelectionWhenMissing: true);
                 _logger.LogError(ex, "Failed to reset password for user {UserID}", user.UserID);
-                await _dialogService.ShowInfoAsync($"Failed to reset password: {ex.Message}", "Error");
+                await _dialogService.ShowInfoAsync(BuildMutationFailureMessage("Failed to reset password", ex, refreshed), "Error");
             }
         }
 
@@ -522,8 +572,9 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
+                var refreshed = await RefreshUsersAfterMutationFailureAsync(user.UserID, clearSelectionWhenMissing: true);
                 _logger.LogError(ex, "Failed to delete user {UserID}", user.UserID);
-                await _dialogService.ShowInfoAsync($"Failed to delete user: {ex.Message}", "Error");
+                await _dialogService.ShowInfoAsync(BuildMutationFailureMessage("Failed to delete user", ex, refreshed), "Error");
             }
         }
     }


### PR DESCRIPTION
## Summary

- Refresh the Users directory after add, update, edit-dialog update, photo update, password reset, and delete exceptions so visible rows reflect saved data when a mutation may have partly completed before an exception.
- Preserve the active user search filter during recovery refreshes, reselect affected users when they still exist, and clear deleted-user selection when recovery shows the user is gone.
- Clear user rows and selected-user command state if the recovery refresh also fails, with focused coverage for add/delete recovery paths.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against `master`, with the branch 4 commits ahead and 0 behind.
- Read back `UserManagementViewModel.cs`, `UserManagementViewModelTests.cs`, and the progress note through the GitHub connector.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet`, `gh`, WPF screenshots/runtime checks, local banned-word checks, local test execution, and full runtime validation are unavailable in this scheduled Linux container.