### PR TITLE
Align Reports failure test with cleared timestamp

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs
@@ -131,7 +131,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("ReportSubtitle = \"The report could not be generated.\";", source, StringComparison.Ordinal);
             Assert.Contains("ReportSummary = ex.Message;", source, StringComparison.Ordinal);
             Assert.Contains("ReportStatus = \"Report failed.\";", source, StringComparison.Ordinal);
-            Assert.Contains("LastRunAt = DateTime.Now;", source, StringComparison.Ordinal);
+            Assert.Contains("LastRunAt = null;", source, StringComparison.Ordinal);
             Assert.Contains("OnPropertyChanged(nameof(ReportLineCount));", source, StringComparison.Ordinal);
             Assert.Contains("OnPropertyChanged(nameof(ReportOperatorPath));", source, StringComparison.Ordinal);
             Assert.Contains("ClearReportCommand.NotifyCanExecuteChanged();", source, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

- Update the Reports failure source-contract test so it expects `ReportsViewModel` to clear `LastRunAt` after generation failures.
- Preserve the safer current behavior that leaves failed report output visibly unrun and keeps print gating tied to completed report output.

## Validation

- GitHub connector compare confirmed a focused 1-file diff against `master`, with the branch 1 commit ahead and 0 behind.
- Read back `InventoryManagementApp.Tests/ViewModels/InsightsPagesXamlTests.cs` through the GitHub connector and confirmed the Reports failure test now expects `LastRunAt = null;`.
- No commit statuses were reported for commit `09b483f8b969e383d112407b82bff92cd3955743`.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` and `gh` are unavailable in this scheduled Linux container, so `dotnet restore`, `dotnet build`, `dotnet test`, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.