### PR TITLE
Refresh maintenance after mutation failures

### DIFF
--- a/InventoryManagementApp.Tests/MaintenanceCalibrationWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/MaintenanceCalibrationWorkflowContractTests.cs
@@ -20,6 +20,28 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void MaintenanceMutationFailuresRefreshRowsOrClearAfterRecoveryFailure()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "MaintenanceManagementViewModel.cs");
+
+            Assert.Contains("await RefreshMaintenanceAfterMutationFailureAsync(\n                        newRecord.MaintenanceID > 0 ? newRecord.MaintenanceID : null,\n                        \"Error creating maintenance record\",\n                        $\"{ex.Message} Maintenance rows were refreshed from saved data.\");", source, StringComparison.Ordinal);
+            Assert.Contains("await RefreshMaintenanceAfterMutationFailureAsync(\n                        clone.MaintenanceID,\n                        \"Error updating maintenance record\",\n                        $\"{ex.Message} Maintenance rows were refreshed from saved data.\");", source, StringComparison.Ordinal);
+            Assert.Contains("var deletedRecord = SelectedRecord;\n                try", source, StringComparison.Ordinal);
+            Assert.Contains("await RefreshMaintenanceAfterMutationFailureAsync(\n                        deletedRecord.MaintenanceID,\n                        \"Error deleting maintenance record\",\n                        $\"{ex.Message} Maintenance rows were refreshed from saved data.\",\n                        clearSelectionWhenAffectedRecordIsGone: true);", source, StringComparison.Ordinal);
+            Assert.Contains("var completedId = SelectedRecord.MaintenanceID;\n                try", source, StringComparison.Ordinal);
+            Assert.Contains("await RefreshMaintenanceAfterMutationFailureAsync(\n                        completedId,\n                        \"Error completing maintenance\",\n                        $\"{ex.Message} Maintenance rows were refreshed from saved data.\");", source, StringComparison.Ordinal);
+            Assert.Contains("private async Task RefreshMaintenanceAfterMutationFailureAsync(", source, StringComparison.Ordinal);
+            Assert.Contains("var records = await _maintenanceService.GetAllMaintenanceRecordsAsync();\n                MaintenanceRecords.Clear();", source, StringComparison.Ordinal);
+            Assert.Contains("clearSelectionWhenAffectedRecordIsGone\n                    && preferredMaintenanceId.HasValue\n                    && MaintenanceRecords.All(r => r.MaintenanceID != preferredMaintenanceId.Value)", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedRecord = null;", source, StringComparison.Ordinal);
+            Assert.Contains("Recovery refresh also failed: {refreshEx.Message} Maintenance rows were cleared until reload succeeds.", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await _dialogService.ShowErrorAsync(\"Error creating maintenance record\", ex.Message);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await _dialogService.ShowErrorAsync(\"Error updating maintenance record\", ex.Message);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await _dialogService.ShowErrorAsync(\"Error deleting maintenance record\", ex.Message);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await _dialogService.ShowErrorAsync(\"Error completing maintenance\", ex.Message);", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void CalibrationLoadFailuresClearStaleRowsAndSelection()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CalibrationManagementViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-maintenance-mutation-failure-refresh.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-maintenance-mutation-failure-refresh.md
@@ -1,0 +1,11 @@
+# Maintenance Mutation Failure Refresh
+
+## Completed
+- Refreshed maintenance rows after create, update, delete, and complete exceptions so the workbench reflects saved data when a mutation may have partly completed before surfacing an error.
+- Preserved the affected maintenance selection after recovery refresh when it still exists, and cleared selection after delete recovery when the deleted record is gone.
+- Cleared maintenance rows and selected work state if the recovery refresh also fails.
+- Added source-contract coverage for the mutation failure refresh path.
+
+## Validation Notes
+- Local `dotnet` and WPF runtime validation are unavailable in the scheduled Linux container.
+- Direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; validation uses GitHub connector readback and compare.

--- a/InventoryManagementApp/ViewModels/MaintenanceManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/MaintenanceManagementViewModel.cs
@@ -216,7 +216,10 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error creating maintenance record", ex.Message);
+                    await RefreshMaintenanceAfterMutationFailureAsync(
+                        newRecord.MaintenanceID > 0 ? newRecord.MaintenanceID : null,
+                        "Error creating maintenance record",
+                        $"{ex.Message} Maintenance rows were refreshed from saved data.");
                 }
             }
         }
@@ -256,7 +259,10 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error updating maintenance record", ex.Message);
+                    await RefreshMaintenanceAfterMutationFailureAsync(
+                        clone.MaintenanceID,
+                        "Error updating maintenance record",
+                        $"{ex.Message} Maintenance rows were refreshed from saved data.");
                 }
             }
         }
@@ -271,9 +277,9 @@ namespace InventoryManagementApp.ViewModels
 
             if (confirmed)
             {
+                var deletedRecord = SelectedRecord;
                 try
                 {
-                    var deletedRecord = SelectedRecord;
                     await _maintenanceService.DeleteMaintenanceRecordAsync(deletedRecord.MaintenanceID);
                     MaintenanceRecords.Remove(deletedRecord);
                     ApplyFilter();
@@ -281,7 +287,11 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error deleting maintenance record", ex.Message);
+                    await RefreshMaintenanceAfterMutationFailureAsync(
+                        deletedRecord.MaintenanceID,
+                        "Error deleting maintenance record",
+                        $"{ex.Message} Maintenance rows were refreshed from saved data.",
+                        clearSelectionWhenAffectedRecordIsGone: true);
                 }
             }
         }
@@ -296,9 +306,9 @@ namespace InventoryManagementApp.ViewModels
 
             if (!string.IsNullOrWhiteSpace(performedBy))
             {
+                var completedId = SelectedRecord.MaintenanceID;
                 try
                 {
-                    var completedId = SelectedRecord.MaintenanceID;
                     await _maintenanceService.CompleteMaintenanceAsync(
                         completedId,
                         performedBy,
@@ -312,7 +322,10 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error completing maintenance", ex.Message);
+                    await RefreshMaintenanceAfterMutationFailureAsync(
+                        completedId,
+                        "Error completing maintenance",
+                        $"{ex.Message} Maintenance rows were refreshed from saved data.");
                 }
             }
         }
@@ -330,6 +343,39 @@ namespace InventoryManagementApp.ViewModels
             FilteredMaintenanceRecords.Clear();
             SelectedRecord = null;
             NotifyCommandStatesAndSummaries();
+        }
+
+        private async Task RefreshMaintenanceAfterMutationFailureAsync(
+            int? preferredMaintenanceId,
+            string title,
+            string message,
+            bool clearSelectionWhenAffectedRecordIsGone = false)
+        {
+            try
+            {
+                var records = await _maintenanceService.GetAllMaintenanceRecordsAsync();
+                MaintenanceRecords.Clear();
+                foreach (var record in records)
+                {
+                    MaintenanceRecords.Add(record);
+                }
+
+                ApplyFilter(preferredMaintenanceId);
+                if (clearSelectionWhenAffectedRecordIsGone
+                    && preferredMaintenanceId.HasValue
+                    && MaintenanceRecords.All(r => r.MaintenanceID != preferredMaintenanceId.Value))
+                {
+                    SelectedRecord = null;
+                }
+
+                NotifyCommandStatesAndSummaries();
+                await _dialogService.ShowErrorAsync(title, message);
+            }
+            catch (Exception refreshEx)
+            {
+                ClearMaintenanceStateAfterLoadFailure();
+                await _dialogService.ShowErrorAsync(title, $"{message} Recovery refresh also failed: {refreshEx.Message} Maintenance rows were cleared until reload succeeds.");
+            }
         }
 
         private void ApplyFilter(int? preferredMaintenanceId = null)


### PR DESCRIPTION
## Summary

- Refresh maintenance rows after create, update, delete, and complete exceptions so the workbench reflects saved data when a mutation may have partly completed before surfacing an error.
- Preserve the affected maintenance selection when recovery refresh still finds the record, and clear selection after delete recovery when the deleted work order is gone.
- Clear maintenance rows and selected work state if the recovery refresh also fails, with source-contract coverage for the refresh-or-clear path.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against `master`, with the branch 3 commits ahead and 0 behind.
- Read back `MaintenanceManagementViewModel.cs` and `MaintenanceCalibrationWorkflowContractTests.cs` through the GitHub connector and confirmed the refresh-on-mutation-failure contract.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet`, `gh`, WPF screenshots/runtime checks, local banned-word checks, local test execution, and full runtime validation are unavailable in this scheduled Linux container.