### PR TITLE
Refresh calibration after mutation failures

### DIFF
--- a/InventoryManagementApp.Tests/MaintenanceCalibrationWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/MaintenanceCalibrationWorkflowContractTests.cs
@@ -54,6 +54,25 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("await _dialogService.ShowErrorAsync(\"Error loading calibration records\", ex.Message);", source, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void CalibrationMutationFailuresRefreshRowsOrClearAfterRecoveryFailure()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "CalibrationManagementViewModel.cs");
+
+            Assert.Contains("await RefreshCalibrationAfterMutationFailureAsync(\n                        newRecord.CalibrationID > 0 ? newRecord.CalibrationID : null,\n                        \"Error creating calibration record\",\n                        $\"{ex.Message} Calibration rows were refreshed from saved data.\");", source, StringComparison.Ordinal);
+            Assert.Contains("await RefreshCalibrationAfterMutationFailureAsync(\n                        clone.CalibrationID,\n                        \"Error updating calibration record\",\n                        $\"{ex.Message} Calibration rows were refreshed from saved data.\");", source, StringComparison.Ordinal);
+            Assert.Contains("var deletedRecord = SelectedRecord;\n                try", source, StringComparison.Ordinal);
+            Assert.Contains("await RefreshCalibrationAfterMutationFailureAsync(\n                        deletedRecord.CalibrationID,\n                        \"Error deleting calibration record\",\n                        $\"{ex.Message} Calibration rows were refreshed from saved data.\",\n                        clearSelectionWhenAffectedRecordIsGone: true);", source, StringComparison.Ordinal);
+            Assert.Contains("private async Task RefreshCalibrationAfterMutationFailureAsync(", source, StringComparison.Ordinal);
+            Assert.Contains("var records = await _calibrationService.GetAllCalibrationRecordsAsync();\n                CalibrationRecords.Clear();", source, StringComparison.Ordinal);
+            Assert.Contains("clearSelectionWhenAffectedRecordIsGone\n                    && preferredCalibrationId.HasValue\n                    && CalibrationRecords.All(r => r.CalibrationID != preferredCalibrationId.Value)", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedRecord = null;", source, StringComparison.Ordinal);
+            Assert.Contains("Recovery refresh also failed: {refreshEx.Message} Calibration rows were cleared until reload succeeds.", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await _dialogService.ShowErrorAsync(\"Error creating calibration record\", ex.Message);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await _dialogService.ShowErrorAsync(\"Error updating calibration record\", ex.Message);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("await _dialogService.ShowErrorAsync(\"Error deleting calibration record\", ex.Message);", source, StringComparison.Ordinal);
+        }
+
         private static string ReadRepoFile(params string[] parts)
         {
             var directory = AppContext.BaseDirectory;

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-calibration-mutation-failure-refresh.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-calibration-mutation-failure-refresh.md
@@ -1,0 +1,11 @@
+# Calibration Mutation Failure Refresh
+
+## Completed
+- Refreshed calibration rows after create, update, and delete exceptions so the workbench reflects saved data when a mutation may have partly completed before surfacing an error.
+- Preserved the affected calibration selection after recovery refresh when it still exists, and cleared selection after delete recovery when the deleted record is gone.
+- Cleared calibration rows and selected certificate state if the recovery refresh also fails.
+- Added source-contract coverage for the mutation failure refresh path.
+
+## Validation Notes
+- Local `dotnet` and WPF runtime validation are unavailable in the scheduled Linux container.
+- Direct repository clone/raw access is blocked by `CONNECT tunnel failed, response 403`; validation uses GitHub connector readback and compare.

--- a/InventoryManagementApp/ViewModels/CalibrationManagementViewModel.cs
+++ b/InventoryManagementApp/ViewModels/CalibrationManagementViewModel.cs
@@ -206,7 +206,10 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error creating calibration record", ex.Message);
+                    await RefreshCalibrationAfterMutationFailureAsync(
+                        newRecord.CalibrationID > 0 ? newRecord.CalibrationID : null,
+                        "Error creating calibration record",
+                        $"{ex.Message} Calibration rows were refreshed from saved data.");
                 }
             }
         }
@@ -246,7 +249,10 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error updating calibration record", ex.Message);
+                    await RefreshCalibrationAfterMutationFailureAsync(
+                        clone.CalibrationID,
+                        "Error updating calibration record",
+                        $"{ex.Message} Calibration rows were refreshed from saved data.");
                 }
             }
         }
@@ -261,9 +267,9 @@ namespace InventoryManagementApp.ViewModels
 
             if (confirmed)
             {
+                var deletedRecord = SelectedRecord;
                 try
                 {
-                    var deletedRecord = SelectedRecord;
                     await _calibrationService.DeleteCalibrationRecordAsync(deletedRecord.CalibrationID);
                     CalibrationRecords.Remove(deletedRecord);
                     ApplyFilter();
@@ -271,7 +277,11 @@ namespace InventoryManagementApp.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    await _dialogService.ShowErrorAsync("Error deleting calibration record", ex.Message);
+                    await RefreshCalibrationAfterMutationFailureAsync(
+                        deletedRecord.CalibrationID,
+                        "Error deleting calibration record",
+                        $"{ex.Message} Calibration rows were refreshed from saved data.",
+                        clearSelectionWhenAffectedRecordIsGone: true);
                 }
             }
         }
@@ -289,6 +299,39 @@ namespace InventoryManagementApp.ViewModels
             FilteredCalibrationRecords.Clear();
             SelectedRecord = null;
             NotifyCommandStatesAndSummaries();
+        }
+
+        private async Task RefreshCalibrationAfterMutationFailureAsync(
+            int? preferredCalibrationId,
+            string title,
+            string message,
+            bool clearSelectionWhenAffectedRecordIsGone = false)
+        {
+            try
+            {
+                var records = await _calibrationService.GetAllCalibrationRecordsAsync();
+                CalibrationRecords.Clear();
+                foreach (var record in records)
+                {
+                    CalibrationRecords.Add(record);
+                }
+
+                ApplyFilter(preferredCalibrationId);
+                if (clearSelectionWhenAffectedRecordIsGone
+                    && preferredCalibrationId.HasValue
+                    && CalibrationRecords.All(r => r.CalibrationID != preferredCalibrationId.Value))
+                {
+                    SelectedRecord = null;
+                }
+
+                NotifyCommandStatesAndSummaries();
+                await _dialogService.ShowErrorAsync(title, message);
+            }
+            catch (Exception refreshEx)
+            {
+                ClearCalibrationStateAfterLoadFailure();
+                await _dialogService.ShowErrorAsync(title, $"{message} Recovery refresh also failed: {refreshEx.Message} Calibration rows were cleared until reload succeeds.");
+            }
         }
 
         private void ApplyFilter(int? preferredCalibrationId = null)


### PR DESCRIPTION
## Summary

- Refresh calibration rows after create, update, and delete exceptions so visible certificate state reflects saved data when a mutation may have partly completed before surfacing an error.
- Preserve the affected calibration selection when recovery refresh still finds the record, and clear selection after delete recovery when the deleted certificate is gone.
- Clear calibration rows and selected certificate state if the recovery refresh also fails, with source-contract coverage for the refresh-or-clear path.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against `master`, with the branch 3 commits ahead and 0 behind.
- Read back `CalibrationManagementViewModel.cs`, `MaintenanceCalibrationWorkflowContractTests.cs`, and the progress note through the GitHub connector and confirmed the calibration mutation-failure refresh contract.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet`, `gh`, WPF screenshots/runtime checks, local banned-word checks, local test execution, and full runtime validation are unavailable in this scheduled Linux container.