### PR TITLE
Refresh incremental items after mutation failures

### DIFF
--- a/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
@@ -65,6 +65,26 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void IncrementalItemMutationsRefreshRowsAfterOperationFailures()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemsViewModel.cs");
+
+            Assert.Contains("private async Task<bool> RefreshItemsAfterMutationFailureAsync(int? preferredItemId, CancellationToken cancellationToken)", source, StringComparison.Ordinal);
+            Assert.Contains("var firstPage = await LoadPageAsync(1, cancellationToken).ConfigureAwait(false);", source, StringComparison.Ordinal);
+            Assert.Contains("Items.ResetWith(firstPage);", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedItem = preferredItemId.HasValue", source, StringComparison.Ordinal);
+            Assert.Contains("Items.FirstOrDefault(item => item.ItemID == preferredItemId.Value)", source, StringComparison.Ordinal);
+            Assert.Contains("Items.Reset();", source, StringComparison.Ordinal);
+            Assert.Contains("The item list has been refreshed in case saved state changed before the failure.", source, StringComparison.Ordinal);
+            Assert.Contains("The item list could not be refreshed, so visible item rows were cleared until reload succeeds.", source, StringComparison.Ordinal);
+            Assert.Contains("await RefreshItemsAfterMutationFailureAsync(updated.ItemID, ct).ConfigureAwait(false);", source, StringComparison.Ordinal);
+            Assert.Contains("await RefreshItemsAfterMutationFailureAsync(item.ItemID > 0 ? item.ItemID : null, ct).ConfigureAwait(false);", source, StringComparison.Ordinal);
+            Assert.Contains("await RefreshItemsAfterMutationFailureAsync(toRemove.FirstOrDefault()?.ItemID, ct).ConfigureAwait(false);", source, StringComparison.Ordinal);
+            Assert.Contains("await RefreshItemsAfterMutationFailureAsync(edits.FirstOrDefault()?.ItemID, ct).ConfigureAwait(false);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("Failed to save changes: {ex.Message}", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ItemLoadAndSearchFailuresClearStaleVisibleRows()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemManagementViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-incremental-items-mutation-failure-refresh.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-incremental-items-mutation-failure-refresh.md
@@ -1,0 +1,12 @@
+# Incremental Items Mutation Failure Refresh - 2026-06-24
+
+## Completed
+
+- Refreshed the incremental Items directory first page after edit, create, delete, and bulk-save exceptions so visible rows reflect durable saved state when a mutation may have partly completed before surfacing an error.
+- Restored the affected item selection when it remains visible after recovery refresh, and cleared visible rows plus selected item state if recovery refresh also fails.
+- Replaced silent edit/create failure branches with operator-facing error messages that explain whether the list was refreshed or cleared.
+- Added source-contract coverage in `ItemRentalWorkflowContractTests` for the incremental item mutation recovery helper, operator messages, and guarded failure branches.
+
+## Validation
+
+- Connector readback/compare should be used for this scheduled pass because local repository clone/raw access and local .NET tooling are unavailable in the Linux scheduled environment.

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -277,6 +277,41 @@ namespace InventoryManagementApp.ViewModels
             await _settingsService.SaveSettingAsync("PageSize", value.ToString()).ConfigureAwait(false);
         }
 
+        private async Task<bool> RefreshItemsAfterMutationFailureAsync(int? preferredItemId, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var firstPage = await LoadPageAsync(1, cancellationToken).ConfigureAwait(false);
+                await InvokeOnUiThreadAsync(() =>
+                {
+                    Items.ResetWith(firstPage);
+                    SelectedItem = preferredItemId.HasValue
+                        ? Items.FirstOrDefault(item => item.ItemID == preferredItemId.Value)
+                        : null;
+                }).ConfigureAwait(false);
+                return true;
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogDebug("Item mutation recovery refresh canceled");
+                throw;
+            }
+            catch (Exception refreshEx)
+            {
+                _logger.LogError(refreshEx, "Failed to refresh incremental item list after mutation failure");
+                await InvokeOnUiThreadAsync(() =>
+                {
+                    Items.Reset();
+                    SelectedItem = null;
+                }).ConfigureAwait(false);
+                return false;
+            }
+        }
+
+        private static string AppendItemMutationRefreshMessage(string message, bool refreshed) => refreshed
+            ? $"{message} The item list has been refreshed in case saved state changed before the failure."
+            : $"{message} The item list could not be refreshed, so visible item rows were cleared until reload succeeds.";
+
         private void Item_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (sender is not ItemModel item) return;
@@ -338,8 +373,10 @@ namespace InventoryManagementApp.ViewModels
             {
                 _logger.LogDebug("Edit item canceled");
             }
-            catch
+            catch (Exception ex)
             {
+                var refreshed = await RefreshItemsAfterMutationFailureAsync(updated.ItemID, ct).ConfigureAwait(false);
+                await _dialogService.ShowInfoAsync($"Failed to update {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {AppendItemMutationRefreshMessage(ex.Message, refreshed)}", "Error").ConfigureAwait(false);
             }
         }
 
@@ -392,15 +429,17 @@ namespace InventoryManagementApp.ViewModels
             try
             {
                 await _itemService.AddItemAsync(item, ct).ConfigureAwait(false);
-            InvokeOnUiThread(Items.Reset);
+                InvokeOnUiThread(Items.Reset);
                 await Items.LoadMoreAsync(ct).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
                 _logger.LogDebug("New item creation canceled");
             }
-            catch
+            catch (Exception ex)
             {
+                var refreshed = await RefreshItemsAfterMutationFailureAsync(item.ItemID > 0 ? item.ItemID : null, ct).ConfigureAwait(false);
+                await _dialogService.ShowInfoAsync($"Failed to create {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {AppendItemMutationRefreshMessage(ex.Message, refreshed)}", "Error").ConfigureAwait(false);
             }
         }
 
@@ -415,9 +454,9 @@ namespace InventoryManagementApp.ViewModels
                 : $"Delete {items.Count} {LabelProvider.Instance.ItemLabelPlural.ToLower()}?";
             var confirm = await _dialogService.ShowConfirmationAsync(message, "Confirm Delete").ConfigureAwait(false);
             if (!confirm) return;
+            var toRemove = items.Cast<ItemModel>().ToList();
             try
             {
-                var toRemove = items.Cast<ItemModel>().ToList();
                 foreach (var item in toRemove)
                 {
                     await _itemService.DeleteItemAsync(item.ItemID, ct).ConfigureAwait(false);
@@ -439,7 +478,8 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                await _dialogService.ShowInfoAsync($"Failed to delete {LabelProvider.Instance.ItemLabelPlural.ToLower()}: {ex.Message}", "Error").ConfigureAwait(false);
+                var refreshed = await RefreshItemsAfterMutationFailureAsync(toRemove.FirstOrDefault()?.ItemID, ct).ConfigureAwait(false);
+                await _dialogService.ShowInfoAsync($"Failed to delete {LabelProvider.Instance.ItemLabelPlural.ToLower()}: {AppendItemMutationRefreshMessage(ex.Message, refreshed)}", "Error").ConfigureAwait(false);
             }
         }
 
@@ -486,7 +526,10 @@ namespace InventoryManagementApp.ViewModels
             }
             catch (Exception ex)
             {
-                await _dialogService.ShowInfoAsync($"Failed to save changes: {ex.Message}", "Error").ConfigureAwait(false);
+                var refreshed = await RefreshItemsAfterMutationFailureAsync(edits.FirstOrDefault()?.ItemID, ct).ConfigureAwait(false);
+                if (refreshed)
+                    _pendingEdits.Clear();
+                await _dialogService.ShowInfoAsync($"Failed to save changes: {AppendItemMutationRefreshMessage(ex.Message, refreshed)}", "Error").ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
## Summary

- Refresh the incremental Items directory first page after edit, create, delete, and bulk-save exceptions so visible rows reflect durable saved state when a mutation may have partly completed before surfacing an error.
- Restore the affected item selection when recovery refresh still finds it, and clear visible rows plus selected item state if recovery refresh also fails.
- Replace silent edit/create failure branches with operator-facing error messages and add source-contract coverage for the incremental item mutation recovery path.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ItemsViewModel.cs`, `ItemRentalWorkflowContractTests.cs`, and the progress note through the GitHub connector and confirmed the mutation-failure refresh contract.
- No commit statuses were reported for branch head `57750e07c4620d420f1e1f0b6538845f7e6e697d`.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet`, `gh`, WPF screenshots/runtime checks, local banned-word checks, local test execution, and full runtime validation are unavailable in this scheduled Linux container.