### PR TITLE
Show incremental item detail and history failures

### DIFF
--- a/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
@@ -85,6 +85,23 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void IncrementalItemDetailsAndHistoryFailuresShowOperatorFeedback()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemsViewModel.cs");
+
+            Assert.Contains("var item = SelectedItem;", source, StringComparison.Ordinal);
+            Assert.Contains("_dialogService.ShowItemDetails(item);", source, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogError(ex, \"Failed to open item details for item {ItemID}\", item.ItemID);", source, StringComparison.Ordinal);
+            Assert.Contains("_dialogService.ShowInfo($\"Failed to open item details: {ex.Message}\", \"Error\");", source, StringComparison.Ordinal);
+            Assert.Contains("var history = await _rentalService.GetRentalHistoryForItemAsync(item.ItemID).ConfigureAwait(false);", source, StringComparison.Ordinal);
+            Assert.Contains("_dialogService.ShowRentalHistory(item, history);", source, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogError(ex, \"Failed to open incremental rental history for item {ItemID}\", item.ItemID);", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync($\"Failed to load rental history: {ex.Message}\", \"Error\").ConfigureAwait(false);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("_dialogService.ShowItemDetails(SelectedItem);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("_dialogService.ShowRentalHistory(SelectedItem, history);", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ItemLoadAndSearchFailuresClearStaleVisibleRows()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemManagementViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-incremental-items-detail-history-feedback.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-incremental-items-detail-history-feedback.md
@@ -1,0 +1,12 @@
+# Incremental Items Detail And History Feedback - 2026-06-24
+
+## Completed
+
+- Stopped the incremental Items directory from silently swallowing selected-item detail dialog failures.
+- Stopped selected-item rental history load/display failures from disappearing without operator feedback.
+- Captured the selected item before opening details/history so logs and messages refer to the row the operator actually invoked.
+- Added source-contract coverage in `ItemRentalWorkflowContractTests` for the visible feedback and stable selected-item capture.
+
+## Validation
+
+- Connector readback/compare should be used for this scheduled pass because local repository clone/raw access, local .NET tooling, WPF runtime checks, and local banned-word checks are unavailable in the Linux scheduled environment.

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -382,30 +382,36 @@ namespace InventoryManagementApp.ViewModels
 
         private void ViewDetails()
         {
-            if (SelectedItem == null) return;
+            var item = SelectedItem;
+            if (item == null) return;
             try
             {
-                _dialogService.ShowItemDetails(SelectedItem);
+                _dialogService.ShowItemDetails(item);
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Failed to open item details for item {ItemID}", item.ItemID);
+                _dialogService.ShowInfo($"Failed to open item details: {ex.Message}", "Error");
             }
         }
 
         private async Task OpenRentalHistoryAsync(CancellationToken ct)
         {
-            if (SelectedItem == null) return;
+            var item = SelectedItem;
+            if (item == null) return;
             try
             {
-                var history = await _rentalService.GetRentalHistoryForItemAsync(SelectedItem.ItemID).ConfigureAwait(false);
-                _dialogService.ShowRentalHistory(SelectedItem, history);
+                var history = await _rentalService.GetRentalHistoryForItemAsync(item.ItemID).ConfigureAwait(false);
+                _dialogService.ShowRentalHistory(item, history);
             }
             catch (OperationCanceledException)
             {
                 _logger.LogDebug("Rental history load canceled");
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Failed to open incremental rental history for item {ItemID}", item.ItemID);
+                await _dialogService.ShowInfoAsync($"Failed to load rental history: {ex.Message}", "Error").ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
## Summary

- Show visible operator feedback when the incremental Items directory cannot open selected-item details instead of silently swallowing the exception.
- Show visible operator feedback when selected-item rental history loading/display fails from the incremental Items directory.
- Capture the selected item before opening details/history so logs and dialogs refer to the row the operator invoked, with source-contract coverage guarding the behavior.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ItemsViewModel.cs`, `ItemRentalWorkflowContractTests.cs`, and the progress note through the GitHub connector.
- No commit statuses were reported for branch head `54ca6fd6618e34b0e9d8530d3aba192ee01d31f1`.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` and `gh` are unavailable in this scheduled Linux container, so local restore/build/test, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.