### PR TITLE
Show incremental item dialog launch failures

### DIFF
--- a/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
@@ -85,6 +85,22 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void IncrementalItemEditAndCreateDialogFailuresShowOperatorFeedback()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemsViewModel.cs");
+
+            Assert.Contains("var selected = SelectedItem;", source, StringComparison.Ordinal);
+            Assert.Contains("if (selected == null) return;", source, StringComparison.Ordinal);
+            Assert.Contains("ItemID = selected.ItemID,", source, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogError(ex, \"Failed to open edit item dialog for item {ItemID}\", selected.ItemID);", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync($\"Failed to open edit item dialog: {ex.Message}\", \"Error\").ConfigureAwait(false);", source, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogError(ex, \"Failed to open new item dialog\");", source, StringComparison.Ordinal);
+            Assert.Contains("await _dialogService.ShowInfoAsync($\"Failed to open new item dialog: {ex.Message}\", \"Error\").ConfigureAwait(false);", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("catch\n            {\n                return;\n            }", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("ItemID = SelectedItem.ItemID,", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void IncrementalItemDetailsAndHistoryFailuresShowOperatorFeedback()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemsViewModel.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-incremental-items-dialog-failure-feedback.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-incremental-items-dialog-failure-feedback.md
@@ -1,0 +1,12 @@
+# Incremental Items Dialog Failure Feedback - 2026-06-24
+
+## Completed
+
+- Stopped incremental item edit dialog launch failures from returning silently.
+- Stopped incremental new-item dialog launch failures from returning silently.
+- Captured the selected item before cloning it for edit so dialog failure logs refer to the row the operator invoked.
+- Added source-contract coverage in `ItemRentalWorkflowContractTests` for visible dialog failure feedback and the stable selected-row capture.
+
+## Validation
+
+- Connector readback/compare should be used for this scheduled pass because local repository clone/raw access, local .NET tooling, WPF runtime checks, and local banned-word checks are unavailable in the Linux scheduled environment.

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -324,34 +324,35 @@ namespace InventoryManagementApp.ViewModels
 
         private async Task EditItemAsync(CancellationToken ct)
         {
-            if (SelectedItem == null) return;
+            var selected = SelectedItem;
+            if (selected == null) return;
             ItemModel? updated;
             try
             {
                 var clone = new ItemModel
                 {
-                    ItemID = SelectedItem.ItemID,
-                    ItemNumber = SelectedItem.ItemNumber,
-                    PartNumber = SelectedItem.PartNumber,
-                    Name = SelectedItem.Name,
-                    Brand = SelectedItem.Brand,
-                    Location = SelectedItem.Location,
-                    QuantityOnHand = SelectedItem.QuantityOnHand,
-                    RentedQuantity = SelectedItem.RentedQuantity,
-                    Supplier = SelectedItem.Supplier,
-                    PurchasedDate = SelectedItem.PurchasedDate,
-                    Notes = SelectedItem.Notes,
-                    Keywords = SelectedItem.Keywords,
-                    IsPowered = SelectedItem.IsPowered,
-                    IsRentalItem = SelectedItem.IsRentalItem,
-                    IsCheckedOut = SelectedItem.IsCheckedOut,
-                    CheckedOutBy = SelectedItem.CheckedOutBy,
-                    CheckedOutTime = SelectedItem.CheckedOutTime,
-                    CheckedInBy = SelectedItem.CheckedInBy,
-                    CheckedInTime = SelectedItem.CheckedInTime,
-                    ImagePath = SelectedItem.ImagePath,
-                    Price = SelectedItem.Price,
-                    UpdatedAt = SelectedItem.UpdatedAt
+                    ItemID = selected.ItemID,
+                    ItemNumber = selected.ItemNumber,
+                    PartNumber = selected.PartNumber,
+                    Name = selected.Name,
+                    Brand = selected.Brand,
+                    Location = selected.Location,
+                    QuantityOnHand = selected.QuantityOnHand,
+                    RentedQuantity = selected.RentedQuantity,
+                    Supplier = selected.Supplier,
+                    PurchasedDate = selected.PurchasedDate,
+                    Notes = selected.Notes,
+                    Keywords = selected.Keywords,
+                    IsPowered = selected.IsPowered,
+                    IsRentalItem = selected.IsRentalItem,
+                    IsCheckedOut = selected.IsCheckedOut,
+                    CheckedOutBy = selected.CheckedOutBy,
+                    CheckedOutTime = selected.CheckedOutTime,
+                    CheckedInBy = selected.CheckedInBy,
+                    CheckedInTime = selected.CheckedInTime,
+                    ImagePath = selected.ImagePath,
+                    Price = selected.Price,
+                    UpdatedAt = selected.UpdatedAt
                 };
                 updated = await _dialogService.ShowEditItemDialogAsync(clone).ConfigureAwait(false);
             }
@@ -360,8 +361,10 @@ namespace InventoryManagementApp.ViewModels
                 _logger.LogDebug("Edit item dialog canceled");
                 return;
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Failed to open edit item dialog for item {ItemID}", selected.ItemID);
+                await _dialogService.ShowInfoAsync($"Failed to open edit item dialog: {ex.Message}", "Error").ConfigureAwait(false);
                 return;
             }
             if (updated == null) return;
@@ -427,8 +430,10 @@ namespace InventoryManagementApp.ViewModels
                 _logger.LogDebug("New item dialog canceled");
                 return;
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Failed to open new item dialog");
+                await _dialogService.ShowInfoAsync($"Failed to open new item dialog: {ex.Message}", "Error").ConfigureAwait(false);
                 return;
             }
             if (item == null) return;


### PR DESCRIPTION
## Summary

- Show visible operator feedback when the incremental Items edit dialog fails to open instead of silently returning.
- Show visible operator feedback when the incremental Items new-item dialog fails to open instead of silently returning.
- Capture the selected item before cloning it for edit so logs and dialogs refer to the row the operator invoked, with source-contract coverage guarding the behavior.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ItemsViewModel.cs`, `ItemRentalWorkflowContractTests.cs`, and the progress note through the GitHub connector.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` and `gh` are unavailable in this scheduled Linux container, so local restore/build/test, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.