### PR TITLE
Show incremental item view option failures

### DIFF
--- a/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
@@ -85,6 +85,23 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void IncrementalItemViewOptionFailuresClearRowsAndShowFeedback()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemsViewModel.cs");
+
+            Assert.Contains("private async Task ClearItemsAfterViewOptionFailureAsync(string optionName, Exception ex)", source, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogError(ex, \"Failed to apply incremental item {OptionName}\", optionName);", source, StringComparison.Ordinal);
+            Assert.Contains("Items.Reset();", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedItem = null;", source, StringComparison.Ordinal);
+            Assert.Contains("Failed to apply item {optionName}: {ex.Message} Visible item rows were cleared until reload succeeds.", source, StringComparison.Ordinal);
+            Assert.Contains("await ClearItemsAfterViewOptionFailureAsync(\"filter\", ex).ConfigureAwait(false);", source, StringComparison.Ordinal);
+            Assert.Contains("await ClearItemsAfterViewOptionFailureAsync(\"sort\", ex).ConfigureAwait(false);", source, StringComparison.Ordinal);
+            Assert.Contains("await ClearItemsAfterViewOptionFailureAsync(\"page size\", ex).ConfigureAwait(false);", source, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogDebug(\"Sort application canceled\");", source, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogDebug(\"Page size application canceled\");", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void IncrementalItemEditAndCreateDialogFailuresShowOperatorFeedback()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemsViewModel.cs");

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -249,6 +249,10 @@ namespace InventoryManagementApp.ViewModels
             {
                 _logger.LogDebug("Filter application canceled");
             }
+            catch (Exception ex)
+            {
+                await ClearItemsAfterViewOptionFailureAsync("filter", ex).ConfigureAwait(false);
+            }
         }
 
         private void OnSteadyExceeded(object? sender, EventArgs e) =>
@@ -261,20 +265,53 @@ namespace InventoryManagementApp.ViewModels
 
         private async Task ApplySortAsync(SortOption value)
         {
-            var firstPage = await LoadPageAsync(1, _loadCts.Token).ConfigureAwait(false);
-            InvokeOnUiThread(() => Items.ResetWith(firstPage));
-            await _settingsService.SaveSettingAsync("LastSort", $"{value.Field}|{value.Direction}").ConfigureAwait(false);
+            try
+            {
+                var firstPage = await LoadPageAsync(1, _loadCts.Token).ConfigureAwait(false);
+                InvokeOnUiThread(() => Items.ResetWith(firstPage));
+                await _settingsService.SaveSettingAsync("LastSort", $"{value.Field}|{value.Direction}").ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogDebug("Sort application canceled");
+            }
+            catch (Exception ex)
+            {
+                await ClearItemsAfterViewOptionFailureAsync("sort", ex).ConfigureAwait(false);
+            }
         }
 
         partial void OnPageSizeChanged(int value) => _ = ApplyPageSizeAsync(value);
 
         private async Task ApplyPageSizeAsync(int value)
         {
-            Items.PageSize = value;
-            InvokeOnUiThread(() => Items.TrimToWindow(value * 3));
-            var firstPage = await LoadPageAsync(1, _loadCts.Token).ConfigureAwait(false);
-            InvokeOnUiThread(() => Items.ResetWith(firstPage));
-            await _settingsService.SaveSettingAsync("PageSize", value.ToString()).ConfigureAwait(false);
+            try
+            {
+                Items.PageSize = value;
+                InvokeOnUiThread(() => Items.TrimToWindow(value * 3));
+                var firstPage = await LoadPageAsync(1, _loadCts.Token).ConfigureAwait(false);
+                InvokeOnUiThread(() => Items.ResetWith(firstPage));
+                await _settingsService.SaveSettingAsync("PageSize", value.ToString()).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogDebug("Page size application canceled");
+            }
+            catch (Exception ex)
+            {
+                await ClearItemsAfterViewOptionFailureAsync("page size", ex).ConfigureAwait(false);
+            }
+        }
+
+        private async Task ClearItemsAfterViewOptionFailureAsync(string optionName, Exception ex)
+        {
+            _logger.LogError(ex, "Failed to apply incremental item {OptionName}", optionName);
+            await InvokeOnUiThreadAsync(() =>
+            {
+                Items.Reset();
+                SelectedItem = null;
+            }).ConfigureAwait(false);
+            await _dialogService.ShowInfoAsync($"Failed to apply item {optionName}: {ex.Message} Visible item rows were cleared until reload succeeds.", "Error").ConfigureAwait(false);
         }
 
         private async Task<bool> RefreshItemsAfterMutationFailureAsync(int? preferredItemId, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

- Show visible operator feedback when incremental Items filter, sort, or page-size refresh/persistence fails instead of leaving the background task silent.
- Clear incremental item rows and selected item state after those view-option failures so stale visible rows are not left actionable.
- Add source-contract coverage guarding the shared failure handler and filter/sort/page-size call sites.

## Validation

- GitHub connector compare confirmed a focused 2-file diff against `master`, with the branch 2 commits ahead and 0 behind.
- Read back `ItemsViewModel.cs` and `ItemRentalWorkflowContractTests.cs` through the GitHub connector and confirmed the failure-feedback/clear-state contract.
- No commit statuses were reported for branch head `b16cab971d0b2e36a49317914be7a389872df607`.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` and `gh` are unavailable in this scheduled Linux container, so local restore/build/test, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.