### PR TITLE
Loosen item rental workflow source contracts

### DIFF
--- a/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
@@ -11,7 +11,7 @@ namespace InventoryManagementApp.Tests
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemManagementViewModel.cs");
 
-            Assert.Equal(2, CountOccurrences(source, "await ReloadItemsAfterRentalAsync(item.ItemID, cancellationToken);"));
+            AssertAtLeastOccurrences(source, "await ReloadItemsAfterRentalAsync(item.ItemID, cancellationToken);", 2);
             Assert.Contains("private Task ReloadItemsAfterRentalAsync(int itemId, CancellationToken cancellationToken)", source, StringComparison.Ordinal);
             Assert.Contains("return ReloadItemsAfterItemWorkflowAsync(itemId, cancellationToken);", source, StringComparison.Ordinal);
             Assert.Contains("private async Task ReloadItemsAfterItemWorkflowAsync(int itemId, CancellationToken cancellationToken)", source, StringComparison.Ordinal);
@@ -57,8 +57,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("private async Task RefreshItemsAfterWorkflowFailureAsync(int itemId, CancellationToken cancellationToken)", source, StringComparison.Ordinal);
             Assert.Contains("await ReloadItemsAfterItemWorkflowAsync(itemId, cancellationToken);", source, StringComparison.Ordinal);
             Assert.Contains("_logger.LogError(refreshEx, \"Failed to refresh items after workflow failure for item {ItemID}\", itemId);", source, StringComparison.Ordinal);
-            Assert.Equal(3, CountOccurrences(source, "await RefreshItemsAfterWorkflowFailureAsync(item.ItemID, cancellationToken);"));
-            Assert.Equal(2, CountOccurrences(source, "The item list has been refreshed in case the rental was saved before the failure."));
+            AssertAtLeastOccurrences(source, "await RefreshItemsAfterWorkflowFailureAsync(item.ItemID, cancellationToken);", 3);
+            Assert.Contains("The item list has been refreshed in case the rental was saved before the failure.", source, StringComparison.Ordinal);
             Assert.Contains("Failed to update check-out status: {ex.Message} The item list has been refreshed in case the check-out status changed before the failure.", source, StringComparison.Ordinal);
             Assert.DoesNotContain("await _dialogService.ShowInfoAsync($\"Failed to rent {LabelProvider.Instance.ItemLabelSingular.ToLower()}: {ex.Message}\", \"Error\");", source, StringComparison.Ordinal);
             Assert.DoesNotContain("await _dialogService.ShowInfoAsync($\"Failed to update check-out status: {ex.Message}\", \"Error\");", source, StringComparison.Ordinal);
@@ -148,7 +148,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("SelectedItem = null;", source, StringComparison.Ordinal);
             Assert.Contains("OnPropertyChanged(nameof(SearchResultsSummary));", source, StringComparison.Ordinal);
             Assert.Contains("OnPropertyChanged(nameof(CheckedOutSummary));", source, StringComparison.Ordinal);
-            Assert.Equal(2, CountOccurrences(source, "ClearItemStateAfterLoadFailure();"));
+            AssertAtLeastOccurrences(source, "ClearItemStateAfterLoadFailure();", 2);
             Assert.Contains("_logger.LogError(ex, \"Failed to load item directory\");", source, StringComparison.Ordinal);
             Assert.Contains("_logger.LogError(ex, \"Failed to search item directory\");", source, StringComparison.Ordinal);
             Assert.Contains("Failed to load {LabelProvider.Instance.ItemLabelPlural.ToLower()}: {ex.Message} Visible item rows were cleared until reload succeeds.", source, StringComparison.Ordinal);
@@ -162,6 +162,15 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("_logger.LogError(ex, \"Failed to open rental history for {ItemLabelSingular} {ItemID}\"", source, StringComparison.Ordinal);
             Assert.Contains("await _dialogService.ShowInfoAsync($\"Failed to load rental history: {ex.Message}\", \"Error\");", source, StringComparison.Ordinal);
+        }
+
+        private static void AssertAtLeastOccurrences(string source, string value, int minimum)
+        {
+            var count = CountOccurrences(source, value);
+
+            Assert.True(
+                count >= minimum,
+                $"Expected at least {minimum} occurrence(s) of '{value}', but found {count}.");
         }
 
         private static int CountOccurrences(string source, string value)

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-item-rental-contract-brittleness-cleanup.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-item-rental-contract-brittleness-cleanup.md
@@ -1,0 +1,12 @@
+# Item/Rental Contract Brittleness Cleanup
+
+## Completed
+
+- Loosened the item/rental workflow source-contract assertions that were still depending on exact helper-call counts after repeated Items workflow hardening passes.
+- Kept the behavior markers that matter for validation: successful rental refreshes still require the shared reload helper, workflow exceptions still require recovery refreshes and operator feedback, and load/search failures still require stale visible rows and selected item state to be cleared.
+- Preserved negative checks against older direct-error and stale-selected-row patterns.
+
+## Validation Notes
+
+- This is a validation-support cleanup for the current `ToDo.md` queue to keep source-contract tests focused on behavior markers instead of exact formatting/counts.
+- Local full-suite validation still needs a Windows/.NET-capable checkout; this scheduled Linux container cannot clone the repo directly or run `dotnet` here.

--- a/ToDo.md
+++ b/ToDo.md
@@ -7,7 +7,7 @@ Last updated: 2026-06-24.
 - Restore passes: `dotnet restore InventoryManagementApp.sln`.
 - Build passes: `dotnet build InventoryManagementApp.sln --no-restore`.
 - Full test suite most recently reported failures in brittle source-text contract tests.
-- A 2026-06-24 cleanup pass loosened the known brittle source-contract assertions for category, reservation, kit, rentals, maintenance/calibration, and Import / Export workflow tests so they guard behavior markers without exact formatting/count assumptions.
+- A 2026-06-24 cleanup pass loosened the known brittle source-contract assertions for category, reservation, kit, rentals, maintenance/calibration, Import / Export, and item/rental workflow tests so they guard behavior markers without exact formatting/count assumptions.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 


### PR DESCRIPTION
## Summary

- Loosen item/rental workflow source-contract assertions that still depended on exact helper-call counts after repeated Items workflow hardening.
- Keep the behavior markers that matter for validation: successful rental refreshes, workflow-failure recovery refreshes, operator feedback, and stale visible-row clearing.
- Add a progress note and update `ToDo.md` so the validation queue reflects this cleanup.

## Validation

- GitHub connector compare confirmed a focused 3-file diff against `master`, with the branch 3 commits ahead and 0 behind.
- Read back `ItemRentalWorkflowContractTests.cs`, `ToDo.md`, and the new progress note through the GitHub connector.
- No commit statuses were reported for branch head `e00789ca538620f673fa55cf3e434ee8f111d4f9`.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` and `gh` are unavailable in this scheduled Linux container, so local restore/build/test, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.