### PR TITLE
Harden incremental item load-more failures

### DIFF
--- a/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRentalWorkflowContractTests.cs
@@ -102,6 +102,20 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void IncrementalItemLoadMoreFailuresClearRowsAndShowFeedback()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemsViewModel.cs");
+
+            Assert.Contains("catch (Exception ex)\n            {\n                await ClearItemsAfterLoadMoreFailureAsync(ex).ConfigureAwait(false);\n            }", NormalizeNewlines(source), StringComparison.Ordinal);
+            Assert.Contains("private async Task ClearItemsAfterLoadMoreFailureAsync(Exception ex)", source, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogError(ex, \"Failed to load more incremental item rows\");", source, StringComparison.Ordinal);
+            Assert.Contains("Items.Reset();", source, StringComparison.Ordinal);
+            Assert.Contains("SelectedItem = null;", source, StringComparison.Ordinal);
+            Assert.Contains("Failed to load more items: {ex.Message} Visible item rows were cleared until reload succeeds.", source, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogDebug(\"Incremental load canceled\");", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void IncrementalItemEditAndCreateDialogFailuresShowOperatorFeedback()
         {
             var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ItemsViewModel.cs");
@@ -186,6 +200,8 @@ namespace InventoryManagementApp.Tests
 
             return count;
         }
+
+        private static string NormalizeNewlines(string source) => source.Replace("\r\n", "\n");
 
         private static string ReadRepoFile(params string[] parts)
         {

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-incremental-items-load-more-failure-feedback.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-incremental-items-load-more-failure-feedback.md
@@ -1,0 +1,14 @@
+# Incremental Items Load-More Failure Feedback
+
+Date: 2026-06-24
+
+## Completed
+
+- Hardened `ItemsViewModel.LoadMoreAsync` so non-cancellation incremental page-load failures no longer escape silently or leave stale rows actionable.
+- Added a shared cleanup path for load-more failures that logs the failure, clears visible incremental item rows, clears the selected item, and shows operator-facing feedback.
+- Added `ItemRentalWorkflowContractTests` coverage to guard the load-more failure handler, row clearing, selection clearing, and cancellation branch.
+
+## Validation
+
+- Source-contract coverage was added for the changed path.
+- Full local validation still needs to run on a Windows/.NET-capable checkout because this scheduled Linux container cannot clone the repository and does not include the .NET SDK.

--- a/InventoryManagementApp/ViewModels/ItemsViewModel.cs
+++ b/InventoryManagementApp/ViewModels/ItemsViewModel.cs
@@ -217,6 +217,10 @@ namespace InventoryManagementApp.ViewModels
             {
                 _logger.LogDebug("Incremental load canceled");
             }
+            catch (Exception ex)
+            {
+                await ClearItemsAfterLoadMoreFailureAsync(ex).ConfigureAwait(false);
+            }
         }
 
         private Task StartFilterAsync()
@@ -312,6 +316,17 @@ namespace InventoryManagementApp.ViewModels
                 SelectedItem = null;
             }).ConfigureAwait(false);
             await _dialogService.ShowInfoAsync($"Failed to apply item {optionName}: {ex.Message} Visible item rows were cleared until reload succeeds.", "Error").ConfigureAwait(false);
+        }
+
+        private async Task ClearItemsAfterLoadMoreFailureAsync(Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load more incremental item rows");
+            await InvokeOnUiThreadAsync(() =>
+            {
+                Items.Reset();
+                SelectedItem = null;
+            }).ConfigureAwait(false);
+            await _dialogService.ShowInfoAsync($"Failed to load more items: {ex.Message} Visible item rows were cleared until reload succeeds.", "Error").ConfigureAwait(false);
         }
 
         private async Task<bool> RefreshItemsAfterMutationFailureAsync(int? preferredItemId, CancellationToken cancellationToken)

--- a/ToDo.md
+++ b/ToDo.md
@@ -8,6 +8,7 @@ Last updated: 2026-06-24.
 - Build passes: `dotnet build InventoryManagementApp.sln --no-restore`.
 - Full test suite most recently reported failures in brittle source-text contract tests.
 - A 2026-06-24 cleanup pass loosened the known brittle source-contract assertions for category, reservation, kit, rentals, maintenance/calibration, Import / Export, and item/rental workflow tests so they guard behavior markers without exact formatting/count assumptions.
+- A 2026-06-24 incremental Items pass hardened load-more failures so they clear visible rows and show operator feedback instead of escaping silently.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 


### PR DESCRIPTION
## Summary

- Clear incremental item rows and selected item state when a non-cancellation load-more failure occurs instead of letting the failure escape with stale rows still visible.
- Show operator-facing feedback for load-more failures and log the failed incremental load path.
- Add source-contract coverage plus a progress note for the load-more failure cleanup path.

## Validation

- GitHub connector compare confirmed a focused 4-file diff against `master`, with the branch 4 commits ahead and 0 behind.
- Read back `ItemsViewModel.cs`, `ItemRentalWorkflowContractTests.cs`, and the new progress note through the GitHub connector.
- No commit statuses were reported for branch head `f81eb9407afe2fa1333f04c87aa81dc6d59f8450`.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` and `gh` are unavailable in this scheduled Linux container, so local restore/build/test, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.