### PR TITLE
Address SQLite native package advisory

### DIFF
--- a/InventoryManagementApp.Tests/DependencyContractTests.cs
+++ b/InventoryManagementApp.Tests/DependencyContractTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class DependencyContractTests
+    {
+        [Fact]
+        public void AppProjectPinsSupportedSqliteNativeBundle()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "InventoryManagementApp.csproj");
+            var document = XDocument.Parse(source);
+            var packageReferences = document
+                .Descendants("PackageReference")
+                .ToDictionary(
+                    element => element.Attribute("Include")?.Value ?? string.Empty,
+                    element => element.Attribute("Version")?.Value ?? string.Empty,
+                    StringComparer.OrdinalIgnoreCase);
+
+            Assert.Equal("10.0.9", packageReferences["Microsoft.Data.Sqlite"]);
+            Assert.Equal("3.0.3", packageReferences["SQLitePCLRaw.bundle_e_sqlite3"]);
+            Assert.DoesNotContain("SQLitePCLRaw.lib.e_sqlite3", source, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/InventoryManagementApp.csproj
+++ b/InventoryManagementApp/InventoryManagementApp.csproj
@@ -89,7 +89,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.8" />
   </ItemGroup>

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-sqlite-native-package-advisory.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-sqlite-native-package-advisory.md
@@ -1,0 +1,19 @@
+# SQLite Native Package Advisory
+
+Date: 2026-06-24
+
+## Completed
+
+- Updated `InventoryManagementApp/InventoryManagementApp.csproj` to use `Microsoft.Data.Sqlite` 10.0.9 for the net10 WPF app.
+- Added an explicit `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 package pin so restore resolves the supported `SourceGear.sqlite3` native package path instead of the deprecated legacy `SQLitePCLRaw.lib.e_sqlite3` dependency.
+- Added `DependencyContractTests.AppProjectPinsSupportedSqliteNativeBundle` to guard the package pin and prevent a direct legacy native-package reference from returning.
+- Updated `ToDo.md` so the next validation pass confirms restore/build/test/banned-word checks and verifies the SQLite advisory is cleared.
+
+## Validation Notes
+
+- Local validation was not run in this scheduled Linux container because direct repository clone/raw access is blocked, `dotnet` is unavailable, `gh` is unavailable, and WPF runtime/screenshots cannot run here.
+- The branch should be validated on a Windows/.NET-capable checkout with:
+  - `dotnet restore InventoryManagementApp.sln`
+  - `dotnet build InventoryManagementApp.sln --no-restore`
+  - `dotnet test InventoryManagementApp.sln --no-build`
+  - `scripts/check-banned-words.sh`

--- a/ToDo.md
+++ b/ToDo.md
@@ -9,25 +9,26 @@ Last updated: 2026-06-24.
 - Full test suite most recently reported failures in brittle source-text contract tests.
 - A 2026-06-24 cleanup pass loosened the known brittle source-contract assertions for category, reservation, kit, rentals, maintenance/calibration, Import / Export, and item/rental workflow tests so they guard behavior markers without exact formatting/count assumptions.
 - A 2026-06-24 incremental Items pass hardened load-more failures so they clear visible rows and show operator feedback instead of escaping silently.
+- A 2026-06-24 dependency maintenance pass pinned the app to `Microsoft.Data.Sqlite` 10.0.9 and `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 so restore should resolve the supported `SourceGear.sqlite3` native package instead of the deprecated legacy native SQLite package.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 
 ## Validation Needed Next
 
-The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup:
+The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup and SQLite native package pin:
 
 - `dotnet restore InventoryManagementApp.sln`
 - `dotnet build InventoryManagementApp.sln --no-restore`
 - `dotnet test InventoryManagementApp.sln --no-build`
 - `scripts/check-banned-words.sh`
 
-If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
+Confirm during restore that the SQLite advisory is gone and that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
 
 ## Immediate Cleanup Queue
 
-1. Re-run full validation after the source-contract cleanup: restore, build, test, banned-word check.
+1. Re-run full validation after the source-contract cleanup and SQLite dependency pin: restore, build, test, banned-word check.
 2. Smoke test the dark-theme top navigation dropdown visually in the running WPF app.
-3. Review the existing NuGet warnings, especially the `SQLitePCLRaw.lib.e_sqlite3` advisory surfaced during restore/build.
+3. Confirm the SQLite native package advisory is cleared during restore and continue the broader production dependency/security review.
 4. Continue replacing brittle source-text tests with behavior-focused tests where practical.
 
 ## App Completion Status


### PR DESCRIPTION
## Summary

- Update the app project to use `Microsoft.Data.Sqlite` 10.0.9 for the net10 WPF application.
- Add an explicit `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 package pin so restore resolves the supported `SourceGear.sqlite3` native package path instead of the deprecated legacy `SQLitePCLRaw.lib.e_sqlite3` dependency.
- Add `DependencyContractTests` coverage for the SQLite package contract and update `ToDo.md` plus a progress note for the required restore/build/test validation pass.

## Validation

- GitHub connector compare confirmed a focused 4-file diff against current `master`, with the branch 4 commits ahead and 0 behind.
- Read back `InventoryManagementApp.csproj`, `DependencyContractTests.cs`, `ToDo.md`, and the new progress note through the GitHub connector.
- NuGet readback confirmed `SQLitePCLRaw.lib.e_sqlite3` is deprecated/vulnerable and recommends `SourceGear.sqlite3`; `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 depends on `SourceGear.sqlite3` >= 3.50.4.5.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` and `gh` are unavailable in this scheduled Linux container, so local restore/build/test, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.