### PR TITLE
Isolate xUnit runner adapter assets

### DIFF
--- a/InventoryManagementApp.Tests/DependencyContractTests.cs
+++ b/InventoryManagementApp.Tests/DependencyContractTests.cs
@@ -58,6 +58,22 @@ namespace InventoryManagementApp.Tests
             Assert.Equal("3.1.5", packageReferences["xunit.runner.visualstudio"]);
         }
 
+        [Fact]
+        public void TestProjectIsolatesXunitRunnerAssets()
+        {
+            var source = ReadRepoFile("InventoryManagementApp.Tests", "InventoryManagementApp.Tests.csproj");
+            var document = XDocument.Parse(source);
+            var runnerReference = document
+                .Descendants("PackageReference")
+                .Single(element => string.Equals(
+                    element.Attribute("Include")?.Value,
+                    "xunit.runner.visualstudio",
+                    StringComparison.OrdinalIgnoreCase));
+
+            Assert.Equal("all", runnerReference.Element("PrivateAssets")?.Value);
+            Assert.Equal("runtime; build; native; contentfiles; analyzers", runnerReference.Element("IncludeAssets")?.Value);
+        }
+
         private static IReadOnlyDictionary<string, string> GetPackageReferences(string source)
         {
             var document = XDocument.Parse(source);

--- a/InventoryManagementApp.Tests/InventoryManagementApp.Tests.csproj
+++ b/InventoryManagementApp.Tests/InventoryManagementApp.Tests.csproj
@@ -7,7 +7,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
   </ItemGroup>

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-xunit-runner-asset-isolation.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-xunit-runner-asset-isolation.md
@@ -1,0 +1,16 @@
+# xUnit Runner Asset Isolation
+
+Date: 2026-06-24
+
+## Completed
+
+- Updated `InventoryManagementApp.Tests.csproj` so `xunit.runner.visualstudio` follows the package's recommended PackageReference metadata:
+  - `PrivateAssets` is `all`.
+  - `IncludeAssets` is limited to `runtime; build; native; contentfiles; analyzers`.
+- Added dependency source-contract coverage to keep the runner adapter isolated during future package maintenance.
+- Updated `ToDo.md` so the next Windows/.NET-capable validation pass checks test discovery/runtime behavior and confirms the runner stays a private test adapter asset.
+
+## Validation Notes
+
+- Local restore/build/test was not run in the scheduled Linux container because direct clone access is blocked and the .NET SDK is unavailable.
+- GitHub connector readback/compare should be used for this pass, then a full validation run should be completed on a Windows/.NET-capable checkout.

--- a/ToDo.md
+++ b/ToDo.md
@@ -12,19 +12,20 @@ Last updated: 2026-06-24.
 - A 2026-06-24 dependency maintenance pass pinned the app to `Microsoft.Data.Sqlite` 10.0.9 and `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 so restore should resolve the supported `SourceGear.sqlite3` native package instead of the deprecated legacy native SQLite package.
 - A 2026-06-24 dependency consolidation pass aligned the app's direct `Microsoft.Extensions.*` runtime package pins with the net10 package line at 10.0.9.
 - A 2026-06-24 test infrastructure pass aligned the xUnit/VSTest package pins with the net10 test project by updating `Microsoft.NET.Test.Sdk`, `xunit`, and `xunit.runner.visualstudio` plus dependency-contract coverage.
+- A 2026-06-24 test dependency hygiene pass isolated `xunit.runner.visualstudio` test adapter assets with `PrivateAssets`/`IncludeAssets` metadata and source-contract coverage.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 
 ## Validation Needed Next
 
-The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, and net10 test infrastructure alignment:
+The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, and xUnit runner asset isolation:
 
 - `dotnet restore InventoryManagementApp.sln`
 - `dotnet build InventoryManagementApp.sln --no-restore`
 - `dotnet test InventoryManagementApp.sln --no-build`
 - `scripts/check-banned-words.sh`
 
-Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, and that the updated xUnit/VSTest packages discover and run the net10 test project cleanly. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
+Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, and that the xUnit runner remains a private test adapter asset. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
 
 ## Immediate Cleanup Queue
 


### PR DESCRIPTION
## Summary

- Add the recommended `PrivateAssets` and `IncludeAssets` metadata to the `xunit.runner.visualstudio` package reference so the test adapter stays isolated to the test project.
- Add `DependencyContractTests.TestProjectIsolatesXunitRunnerAssets` to guard the package-reference metadata during future dependency updates.
- Update `ToDo.md` and add a progress note so the next Windows/.NET-capable validation pass checks test discovery/runtime behavior and confirms the runner remains a private test adapter asset.

## Validation

- GitHub connector compare confirmed a focused 4-file diff against `master`, with the branch 4 commits ahead and 0 behind.
- Read back `InventoryManagementApp.Tests.csproj`, `DependencyContractTests.cs`, and the new progress note through the GitHub connector.
- Verified the `xunit.runner.visualstudio` 3.1.5 NuGet page recommends `PrivateAssets=all` and `IncludeAssets=runtime; build; native; contentfiles; analyzers` for PackageReference usage.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` and `gh` are unavailable in this scheduled Linux container, so local restore/build/test, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.