### PR TITLE
Enable repository NuGet audit guard

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>low</NuGetAuditLevel>
+  </PropertyGroup>
+</Project>

--- a/InventoryManagementApp.Tests/DependencyContractTests.cs
+++ b/InventoryManagementApp.Tests/DependencyContractTests.cs
@@ -10,6 +10,24 @@ namespace InventoryManagementApp.Tests
     public class DependencyContractTests
     {
         [Fact]
+        public void RepositoryEnablesTransitiveNuGetAudit()
+        {
+            var source = ReadRepoFile("Directory.Build.props");
+            var document = XDocument.Parse(source);
+            var properties = document
+                .Descendants("PropertyGroup")
+                .Elements()
+                .ToDictionary(
+                    element => element.Name.LocalName,
+                    element => element.Value,
+                    StringComparer.OrdinalIgnoreCase);
+
+            Assert.Equal("true", properties["NuGetAudit"]);
+            Assert.Equal("all", properties["NuGetAuditMode"]);
+            Assert.Equal("low", properties["NuGetAuditLevel"]);
+        }
+
+        [Fact]
         public void AppProjectPinsSupportedSqliteNativeBundle()
         {
             var source = ReadRepoFile("InventoryManagementApp", "InventoryManagementApp.csproj");

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-repository-nuget-audit.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-repository-nuget-audit.md
@@ -1,0 +1,21 @@
+# Repository NuGet Audit Guard
+
+Date: 2026-06-24
+
+## Completed
+
+- Added a repository-level `Directory.Build.props` so every project opts into NuGet package vulnerability auditing during restore.
+- Set audit mode to `all` so both direct and transitive dependencies are checked.
+- Set audit level to `low` so restore surfaces the full advisory set while the current validation queue confirms the latest package updates.
+- Added dependency contract coverage to keep the repository-level audit settings from being removed accidentally.
+
+## Validation needed
+
+Run the full validation queue on a Windows/.NET-capable checkout:
+
+- `dotnet restore InventoryManagementApp.sln`
+- `dotnet build InventoryManagementApp.sln --no-restore`
+- `dotnet test InventoryManagementApp.sln --no-build`
+- `scripts/check-banned-words.sh`
+
+During restore, confirm the SQLite advisory remains cleared, transitive package auditing runs, and any NU190x warnings are either remediated or intentionally documented.

--- a/ToDo.md
+++ b/ToDo.md
@@ -13,26 +13,28 @@ Last updated: 2026-06-24.
 - A 2026-06-24 dependency consolidation pass aligned the app's direct `Microsoft.Extensions.*` runtime package pins with the net10 package line at 10.0.9.
 - A 2026-06-24 test infrastructure pass aligned the xUnit/VSTest package pins with the net10 test project by updating `Microsoft.NET.Test.Sdk`, `xunit`, and `xunit.runner.visualstudio` plus dependency-contract coverage.
 - A 2026-06-24 test dependency hygiene pass isolated `xunit.runner.visualstudio` test adapter assets with `PrivateAssets`/`IncludeAssets` metadata and source-contract coverage.
+- A 2026-06-24 dependency-security pass added repository-level NuGet auditing in `Directory.Build.props` with transitive audit mode and dependency-contract coverage.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 
 ## Validation Needed Next
 
-The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, and xUnit runner asset isolation:
+The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, and repository-level NuGet audit guard:
 
 - `dotnet restore InventoryManagementApp.sln`
 - `dotnet build InventoryManagementApp.sln --no-restore`
 - `dotnet test InventoryManagementApp.sln --no-build`
 - `scripts/check-banned-words.sh`
 
-Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, and that the xUnit runner remains a private test adapter asset. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
+Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that the xUnit runner remains a private test adapter asset, and that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
 
 ## Immediate Cleanup Queue
 
 1. Re-run full validation after the source-contract cleanup and dependency pins: restore, build, test, banned-word check.
-2. Smoke test the dark-theme top navigation dropdown visually in the running WPF app.
-3. Confirm the SQLite native package advisory is cleared during restore and continue the broader production dependency/security review.
-4. Continue replacing brittle source-text tests with behavior-focused tests where practical.
+2. Review any NU190x warnings surfaced by repository-level direct/transitive NuGet auditing and either update affected packages or document intentional risk decisions.
+3. Smoke test the dark-theme top navigation dropdown visually in the running WPF app.
+4. Confirm the SQLite native package advisory is cleared during restore and continue the broader production dependency/security review.
+5. Continue replacing brittle source-text tests with behavior-focused tests where practical.
 
 ## App Completion Status
 


### PR DESCRIPTION
## Summary

- Add repository-level `Directory.Build.props` NuGet audit settings so every project restores with package vulnerability auditing enabled.
- Set audit mode to `all` and audit level to `low` so direct and transitive dependency advisories surface during the next restore validation pass.
- Add `DependencyContractTests.RepositoryEnablesTransitiveNuGetAudit` and update `ToDo.md` plus a progress note so future dependency work keeps the audit guard visible.

## Validation

- GitHub connector compare confirmed a focused 4-file diff against `master`, with the branch 4 commits ahead and 0 behind.
- Read back `Directory.Build.props`, `DependencyContractTests.cs`, `ToDo.md`, and the new progress note through the GitHub connector.
- Verified current Microsoft NuGet Audit documentation recommends repository-level audit configuration through MSBuild properties and documents `NuGetAudit`, `NuGetAuditMode`, and `NuGetAuditLevel` values.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` and `gh` are unavailable in this scheduled Linux container, so local restore/build/test, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.