### PR TITLE
Keep test-only package assets private

### DIFF
--- a/InventoryManagementApp.Tests/DependencyContractTests.cs
+++ b/InventoryManagementApp.Tests/DependencyContractTests.cs
@@ -77,16 +77,30 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void TestProjectKeepsTestOnlyPackagesPrivate()
+        {
+            var source = ReadRepoFile("InventoryManagementApp.Tests", "InventoryManagementApp.Tests.csproj");
+            var packageReferences = GetPackageReferenceElements(source);
+            var testOnlyPackages = new[]
+            {
+                "Microsoft.NET.Test.Sdk",
+                "Moq",
+                "xunit",
+                "xunit.runner.visualstudio"
+            };
+
+            foreach (var packageName in testOnlyPackages)
+            {
+                Assert.Equal("all", packageReferences[packageName].Element("PrivateAssets")?.Value);
+            }
+        }
+
+        [Fact]
         public void TestProjectIsolatesXunitRunnerAssets()
         {
             var source = ReadRepoFile("InventoryManagementApp.Tests", "InventoryManagementApp.Tests.csproj");
-            var document = XDocument.Parse(source);
-            var runnerReference = document
-                .Descendants("PackageReference")
-                .Single(element => string.Equals(
-                    element.Attribute("Include")?.Value,
-                    "xunit.runner.visualstudio",
-                    StringComparison.OrdinalIgnoreCase));
+            var packageReferences = GetPackageReferenceElements(source);
+            var runnerReference = packageReferences["xunit.runner.visualstudio"];
 
             Assert.Equal("all", runnerReference.Element("PrivateAssets")?.Value);
             Assert.Equal("runtime; build; native; contentfiles; analyzers", runnerReference.Element("IncludeAssets")?.Value);
@@ -94,12 +108,21 @@ namespace InventoryManagementApp.Tests
 
         private static IReadOnlyDictionary<string, string> GetPackageReferences(string source)
         {
+            return GetPackageReferenceElements(source)
+                .ToDictionary(
+                    element => element.Key,
+                    element => element.Value.Attribute("Version")?.Value ?? string.Empty,
+                    StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static IReadOnlyDictionary<string, XElement> GetPackageReferenceElements(string source)
+        {
             var document = XDocument.Parse(source);
             return document
                 .Descendants("PackageReference")
                 .ToDictionary(
                     element => element.Attribute("Include")?.Value ?? string.Empty,
-                    element => element.Attribute("Version")?.Value ?? string.Empty,
+                    element => element,
                     StringComparer.OrdinalIgnoreCase);
         }
 

--- a/InventoryManagementApp.Tests/InventoryManagementApp.Tests.csproj
+++ b/InventoryManagementApp.Tests/InventoryManagementApp.Tests.csproj
@@ -6,13 +6,19 @@
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit" Version="2.9.3">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.70">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../InventoryManagementApp/InventoryManagementApp.csproj" />

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-private-test-package-assets.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-private-test-package-assets.md
@@ -1,0 +1,12 @@
+# 2026-06-24 - Private Test Package Assets
+
+## Completed
+
+- Kept direct test-only package references private to `InventoryManagementApp.Tests` by adding `PrivateAssets=all` to `Microsoft.NET.Test.Sdk`, `Moq`, and `xunit`, matching the existing private xUnit runner adapter metadata.
+- Added `DependencyContractTests.TestProjectKeepsTestOnlyPackagesPrivate` so future dependency updates keep test infrastructure from flowing transitively if the test project is ever referenced or packed by mistake.
+- Updated `ToDo.md` so the next Windows/.NET-capable validation pass checks private test-only package metadata alongside restore, build, test, banned-word, NuGet audit, and dependency-advisory review.
+
+## Validation Notes
+
+- Local validation was not run in the scheduled Linux container because `dotnet` is unavailable and direct repository cloning is blocked by `CONNECT tunnel failed, response 403`.
+- Use GitHub connector readback/compare for this pass, then rerun `dotnet restore InventoryManagementApp.sln`, `dotnet build InventoryManagementApp.sln --no-restore`, `dotnet test InventoryManagementApp.sln --no-build`, and `scripts/check-banned-words.sh` from a Windows/.NET-capable environment.

--- a/ToDo.md
+++ b/ToDo.md
@@ -13,20 +13,21 @@ Last updated: 2026-06-24.
 - A 2026-06-24 dependency consolidation pass aligned the app's direct `Microsoft.Extensions.*` runtime package pins with the net10 package line at 10.0.9.
 - A 2026-06-24 test infrastructure pass aligned the xUnit/VSTest package pins with the net10 test project by updating `Microsoft.NET.Test.Sdk`, `xunit`, and `xunit.runner.visualstudio` plus dependency-contract coverage.
 - A 2026-06-24 test dependency hygiene pass isolated `xunit.runner.visualstudio` test adapter assets with `PrivateAssets`/`IncludeAssets` metadata and source-contract coverage.
+- A 2026-06-24 test dependency hygiene pass kept all direct test-only package references private to the test project, including `Microsoft.NET.Test.Sdk`, `Moq`, `xunit`, and `xunit.runner.visualstudio`.
 - A 2026-06-24 dependency-security pass added repository-level NuGet auditing in `Directory.Build.props` with transitive audit mode and dependency-contract coverage.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 
 ## Validation Needed Next
 
-The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, and repository-level NuGet audit guard:
+The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, and repository-level NuGet audit guard:
 
 - `dotnet restore InventoryManagementApp.sln`
 - `dotnet build InventoryManagementApp.sln --no-restore`
 - `dotnet test InventoryManagementApp.sln --no-build`
 - `scripts/check-banned-words.sh`
 
-Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that the xUnit runner remains a private test adapter asset, and that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
+Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, and that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
 
 ## Immediate Cleanup Queue
 


### PR DESCRIPTION
## Summary

- Add `PrivateAssets=all` to direct test-only package references in `InventoryManagementApp.Tests`, covering `Microsoft.NET.Test.Sdk`, `Moq`, and `xunit` alongside the existing private xUnit runner adapter metadata.
- Add `DependencyContractTests.TestProjectKeepsTestOnlyPackagesPrivate` so future dependency updates keep the test infrastructure isolated to the test project.
- Update `ToDo.md` and add a progress note so the next validation pass checks private test package metadata with restore/build/test, NuGet audit, and dependency-advisory review.

## Validation

- GitHub connector compare confirmed a focused 4-file diff against `master`, with the branch 4 commits ahead and 0 behind.
- Read back `InventoryManagementApp.Tests.csproj`, `DependencyContractTests.cs`, and the new progress note through the GitHub connector.
- Verified via Microsoft NuGet PackageReference documentation that `PrivateAssets` is the PackageReference metadata used to prevent dependency assets from flowing to consuming projects.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` and `gh` are unavailable in this scheduled Linux container, so local restore/build/test, WPF screenshots/runtime checks, local banned-word checks, and full runtime validation were not run.