### PR TITLE
Retarget build workflow to net10 validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       run: dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal
 
     - name: Publish
-      run: dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-build -o ./publish
+      run: dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,38 +2,43 @@ name: Build and Test
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ master, main ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ master, main ]
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: windows-latest
     permissions:
       contents: read
-    
+
     steps:
-    - uses: actions/checkout@v3
-    
+    - uses: actions/checkout@v4
+
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
-    
+        dotnet-version: 10.0.x
+
     - name: Restore dependencies
-      run: dotnet restore
-    
+      run: dotnet restore InventoryManagementApp.sln
+
+    - name: Check banned words
+      shell: bash
+      run: bash scripts/check-banned-words.sh
+
     - name: Build
-      run: dotnet build --configuration Release --no-restore
-    
+      run: dotnet build InventoryManagementApp.sln --configuration Release --no-restore
+
     - name: Test
-      run: dotnet test --configuration Release --no-build --verbosity normal
-    
+      run: dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal
+
     - name: Publish
-      run: dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false -o ./publish
-    
+      run: dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-build -o ./publish
+
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: inventory-management-app
         path: ./publish/

--- a/InventoryManagementApp.Tests/DependencyContractTests.cs
+++ b/InventoryManagementApp.Tests/DependencyContractTests.cs
@@ -28,6 +28,22 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void BuildWorkflowRunsCurrentNet10Validation()
+        {
+            var source = ReadRepoFile(".github", "workflows", "build.yml");
+
+            Assert.Contains("branches: [ master, main ]", source);
+            Assert.Contains("actions/checkout@v4", source);
+            Assert.Contains("actions/setup-dotnet@v4", source);
+            Assert.Contains("dotnet-version: 10.0.x", source);
+            Assert.Contains("dotnet restore InventoryManagementApp.sln", source);
+            Assert.Contains("bash scripts/check-banned-words.sh", source);
+            Assert.Contains("dotnet build InventoryManagementApp.sln --configuration Release --no-restore", source);
+            Assert.Contains("dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal", source);
+            Assert.Contains("actions/upload-artifact@v4", source);
+        }
+
+        [Fact]
         public void AppProjectPinsSupportedSqliteNativeBundle()
         {
             var source = ReadRepoFile("InventoryManagementApp", "InventoryManagementApp.csproj");

--- a/ToDo.md
+++ b/ToDo.md
@@ -15,27 +15,29 @@ Last updated: 2026-06-24.
 - A 2026-06-24 test dependency hygiene pass isolated `xunit.runner.visualstudio` test adapter assets with `PrivateAssets`/`IncludeAssets` metadata and source-contract coverage.
 - A 2026-06-24 test dependency hygiene pass kept all direct test-only package references private to the test project, including `Microsoft.NET.Test.Sdk`, `Moq`, `xunit`, and `xunit.runner.visualstudio`.
 - A 2026-06-24 dependency-security pass added repository-level NuGet auditing in `Directory.Build.props` with transitive audit mode and dependency-contract coverage.
+- A 2026-06-24 CI validation repair retargeted the Build and Test workflow to `master`/`main`, moved it to the net10 SDK, runs the solution-level restore/build/test commands, and includes the banned-word check before build.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 
 ## Validation Needed Next
 
-The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, and repository-level NuGet audit guard:
+The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, and Build and Test workflow retargeting:
 
 - `dotnet restore InventoryManagementApp.sln`
 - `dotnet build InventoryManagementApp.sln --no-restore`
 - `dotnet test InventoryManagementApp.sln --no-build`
 - `scripts/check-banned-words.sh`
 
-Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, and that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
+Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
 
 ## Immediate Cleanup Queue
 
 1. Re-run full validation after the source-contract cleanup and dependency pins: restore, build, test, banned-word check.
-2. Review any NU190x warnings surfaced by repository-level direct/transitive NuGet auditing and either update affected packages or document intentional risk decisions.
-3. Smoke test the dark-theme top navigation dropdown visually in the running WPF app.
-4. Confirm the SQLite native package advisory is cleared during restore and continue the broader production dependency/security review.
-5. Continue replacing brittle source-text tests with behavior-focused tests where practical.
+2. Confirm the retargeted GitHub Actions Build and Test workflow runs on the next `master`/`main` pull request with the net10 SDK.
+3. Review any NU190x warnings surfaced by repository-level direct/transitive NuGet auditing and either update affected packages or document intentional risk decisions.
+4. Smoke test the dark-theme top navigation dropdown visually in the running WPF app.
+5. Confirm the SQLite native package advisory is cleared during restore and continue the broader production dependency/security review.
+6. Continue replacing brittle source-text tests with behavior-focused tests where practical.
 
 ## App Completion Status
 

--- a/progress-notes/2026-06-24-net10-build-workflow-validation.md
+++ b/progress-notes/2026-06-24-net10-build-workflow-validation.md
@@ -1,0 +1,23 @@
+# 2026-06-24 Net10 Build Workflow Validation
+
+## Completed
+
+- Retargeted `.github/workflows/build.yml` from the stale `main`/`develop` trigger set to the active `master`/`main` branch set.
+- Updated the workflow from .NET 8 setup to the .NET 10 SDK so CI matches the current `net10.0-windows` app and test projects.
+- Switched GitHub Actions dependencies to current major versions for checkout, setup-dotnet, and artifact upload.
+- Made the workflow run the solution-level restore, build, and test commands tracked in `ToDo.md`.
+- Added the banned-word script to the Windows workflow before build so source guardrails run with the same CI pass.
+- Added `DependencyContractTests.BuildWorkflowRunsCurrentNet10Validation` to keep the workflow branch, SDK, command, and Actions-version markers from drifting again.
+
+## Validation Notes
+
+- Local clone/raw access is still blocked in this scheduled Linux container by `CONNECT tunnel failed, response 403`.
+- `dotnet` is unavailable, so restore/build/test could not be run locally.
+- `gh` is unavailable, so GitHub Actions logs and local workflow status inspection could not be queried from this container.
+- WPF runtime screenshots and local banned-word checks were not run in this environment.
+- Use GitHub connector readback/compare and the next workflow run as the validation fallback.
+
+## Next Check
+
+- Confirm the next `master`/`main` pull request starts the Build and Test workflow on Windows with .NET 10.
+- Review restore output for NU190x warnings, SQLite native package advisory clearance, Microsoft.Extensions downgrade/conflict warnings, and xUnit/VSTest discovery.


### PR DESCRIPTION
## Summary

- Retarget the Build and Test workflow from the stale `main`/`develop` trigger set to the active `master`/`main` branches.
- Move CI from .NET 8 setup to the .NET 10 SDK and run the solution-level restore/build/test commands tracked in `ToDo.md`.
- Add banned-word validation to the Windows workflow and update checkout/setup-dotnet/upload-artifact actions to current major versions.
- Add `DependencyContractTests.BuildWorkflowRunsCurrentNet10Validation` plus a progress note so the workflow contract stays aligned with the net10 app/test projects.

## Validation

- GitHub connector compare confirmed a focused 4-file diff against `master`, with the branch 5 commits ahead and 0 behind.
- Read back `.github/workflows/build.yml`, `DependencyContractTests.cs`, `ToDo.md`, and the new progress note through the GitHub connector.
- Not run locally: direct local clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` and `gh` are unavailable in this scheduled Linux container, so local restore/build/test, WPF screenshots/runtime checks, local banned-word checks, and GitHub Actions log/status inspection through `gh` were not run.