### PR TITLE
Repair banned-word check fallback for Windows CI

### DIFF
--- a/InventoryManagementApp.Tests/DependencyContractTests.cs
+++ b/InventoryManagementApp.Tests/DependencyContractTests.cs
@@ -44,6 +44,18 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void BannedWordScriptHasNonRipgrepPowerShellFallback()
+        {
+            var source = ReadRepoFile("scripts", "check-banned-words.sh");
+
+            Assert.Contains("command -v powershell.exe", source);
+            Assert.Contains("Get-ChildItem -Path . -Recurse -File -Force", source);
+            Assert.Contains("Select-String -Pattern", source);
+            Assert.Contains("neither rg nor powershell.exe is available", source);
+            Assert.DoesNotContain("$matches = rg", source, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void AppProjectPinsSupportedSqliteNativeBundle()
         {
             var source = ReadRepoFile("InventoryManagementApp", "InventoryManagementApp.csproj");

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-banned-word-fallback-repair.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-banned-word-fallback-repair.md
@@ -1,0 +1,16 @@
+# Banned-Word Fallback Repair - 2026-06-24
+
+## Completed
+
+- Replaced the banned-word script's broken no-`rg` fallback with a PowerShell recursive file scan.
+- Preserved the existing `rg` path and seeded CSV/script exclusions.
+- Added dependency-contract coverage so the fallback keeps using native PowerShell file scanning instead of calling `rg` from the fallback branch.
+
+## Why It Matters
+
+The Build and Test workflow now runs the banned-word check before build on Windows. If a runner image lacks ripgrep, the previous fallback still called `rg` and could fail before restore/build/test reached the actual WPF validation queue.
+
+## Validation Notes
+
+- Needs a Windows/.NET-capable validation pass to run `scripts/check-banned-words.sh` through both the normal `rg` path and the PowerShell fallback path.
+- Local validation was not run in the scheduled Linux container because direct clone access, `dotnet`, WPF runtime checks, and GitHub Actions log inspection through `gh` are unavailable here.

--- a/ToDo.md
+++ b/ToDo.md
@@ -16,19 +16,20 @@ Last updated: 2026-06-24.
 - A 2026-06-24 test dependency hygiene pass kept all direct test-only package references private to the test project, including `Microsoft.NET.Test.Sdk`, `Moq`, `xunit`, and `xunit.runner.visualstudio`.
 - A 2026-06-24 dependency-security pass added repository-level NuGet auditing in `Directory.Build.props` with transitive audit mode and dependency-contract coverage.
 - A 2026-06-24 CI validation repair retargeted the Build and Test workflow to `master`/`main`, moved it to the net10 SDK, runs the solution-level restore/build/test commands, and includes the banned-word check before build.
+- A 2026-06-24 CI validation hardening pass replaced the banned-word script's broken no-`rg` fallback with a PowerShell file scan and added dependency-contract coverage so Windows runners can still check source text when ripgrep is unavailable.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 
 ## Validation Needed Next
 
-The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, and Build and Test workflow retargeting:
+The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, and banned-word fallback repair:
 
 - `dotnet restore InventoryManagementApp.sln`
 - `dotnet build InventoryManagementApp.sln --no-restore`
 - `dotnet test InventoryManagementApp.sln --no-build`
 - `scripts/check-banned-words.sh`
 
-Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
+Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the banned-word script passes both its normal `rg` path and its PowerShell fallback path, and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
 
 ## Immediate Cleanup Queue
 

--- a/scripts/check-banned-words.sh
+++ b/scripts/check-banned-words.sh
@@ -5,11 +5,32 @@ set -euo pipefail
 # allowing the intentionally seeded item CSV data.
 if ! command -v rg >/dev/null 2>&1; then
   if command -v powershell.exe >/dev/null 2>&1; then
-    powershell.exe -NoProfile -Command "\$matches = rg --ignore-case --line-number --glob '!Items.csv' --glob '!items.csv' --glob '!scripts/check-banned-words.sh' --glob '!.git/**' '\\btool\\b' .; if (\$LASTEXITCODE -eq 0) { \$matches; Write-Error 'Banned word check failed: standalone banned term found outside allowed legacy files.'; exit 1 } elseif (\$LASTEXITCODE -eq 1) { Write-Output 'Banned word check passed.'; exit 0 } else { Write-Error \"rg failed with exit code \$LASTEXITCODE\"; exit \$LASTEXITCODE }"
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -Command - <<'POWERSHELL'
+$ErrorActionPreference = "Stop"
+$root = (Get-Location).Path.TrimEnd([char[]]@('\', '/'))
+$matches = Get-ChildItem -Path . -Recurse -File -Force |
+    Where-Object {
+        $relative = $_.FullName.Substring($root.Length).TrimStart([char[]]@('\', '/')).Replace('\', '/')
+        $relative -notlike ".git/*" -and
+            $relative -ne "Items.csv" -and
+            $relative -ne "items.csv" -and
+            $relative -ne "scripts/check-banned-words.sh"
+    } |
+    Select-String -Pattern "\btool\b"
+
+if ($matches) {
+    $matches | ForEach-Object { "{0}:{1}:{2}" -f $_.Path, $_.LineNumber, $_.Line.Trim() }
+    Write-Error "Banned word check failed: standalone banned term found outside allowed legacy files."
+    exit 1
+}
+
+Write-Output "Banned word check passed."
+exit 0
+POWERSHELL
     exit $?
   fi
 
-  echo "Banned word check failed: rg is not available on PATH." >&2
+  echo "Banned word check failed: neither rg nor powershell.exe is available on PATH." >&2
   exit 127
 fi
 


### PR DESCRIPTION
## Summary

- Replace the banned-word script's broken no-`rg` fallback with a PowerShell recursive file scan so Windows CI can still validate source text if ripgrep is unavailable.
- Preserve the existing fast `rg` path, seeded CSV exclusions, and script exclusion.
- Add `DependencyContractTests.BannedWordScriptHasNonRipgrepPowerShellFallback`, plus ToDo/progress notes for the next full Windows/.NET validation pass.

## Validation

- GitHub connector compare confirmed a focused 4-file diff against `master`, with the branch 4 commits ahead and 0 behind.
- Read back `scripts/check-banned-words.sh`, `DependencyContractTests.cs`, `ToDo.md`, and the new progress note through the GitHub connector.
- Not run locally: direct clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` and `gh` are unavailable in this scheduled Linux container, so local restore/build/test, WPF screenshots/runtime checks, local banned-word checks, and GitHub Actions log/status inspection through `gh` were not run.