### PR TITLE
Support PowerShell Core banned-word fallback

### DIFF
--- a/InventoryManagementApp.Tests/DependencyContractTests.cs
+++ b/InventoryManagementApp.Tests/DependencyContractTests.cs
@@ -49,9 +49,12 @@ namespace InventoryManagementApp.Tests
             var source = ReadRepoFile("scripts", "check-banned-words.sh");
 
             Assert.Contains("command -v powershell.exe", source);
+            Assert.Contains("command -v pwsh", source);
+            Assert.Contains("powershell_command=(powershell.exe -NoProfile -ExecutionPolicy Bypass -Command -)", source);
+            Assert.Contains("powershell_command=(pwsh -NoProfile -Command -)", source);
             Assert.Contains("Get-ChildItem -Path . -Recurse -File -Force", source);
             Assert.Contains("Select-String -Pattern", source);
-            Assert.Contains("neither rg nor powershell.exe is available", source);
+            Assert.Contains("neither rg nor PowerShell (powershell.exe or pwsh) is available", source);
             Assert.DoesNotContain("$matches = rg", source, StringComparison.OrdinalIgnoreCase);
         }
 

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-banned-word-pwsh-fallback.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-banned-word-pwsh-fallback.md
@@ -1,0 +1,18 @@
+# Banned-Word PowerShell Core Fallback - 2026-06-24
+
+## Completed
+
+- Kept the banned-word script's fast `rg` path unchanged.
+- Expanded the no-`rg` fallback so it can run through either Windows PowerShell (`powershell.exe`) or PowerShell Core (`pwsh`).
+- Avoided passing Windows-only execution-policy arguments to `pwsh` while preserving the existing execution-policy bypass for Windows PowerShell.
+- Updated dependency-contract coverage for both fallback command paths.
+
+## Why It Matters
+
+The validation queue now depends on the banned-word check running before the net10 WPF restore/build/test pass. Supporting `pwsh` keeps the fallback useful on non-Windows validation hosts that have PowerShell Core installed but do not have ripgrep.
+
+## Validation Notes
+
+- Needs a Windows/.NET-capable validation pass to run `scripts/check-banned-words.sh` through the normal `rg` path and the Windows PowerShell fallback path.
+- Needs a PowerShell Core validation pass with `rg` unavailable to confirm the `pwsh` fallback path.
+- Local validation was not run in the scheduled Linux container because direct clone access is blocked, `dotnet` is unavailable, WPF runtime checks cannot run here, local banned-word checks cannot read the full repository, and GitHub Actions log inspection through `gh` is unavailable.

--- a/ToDo.md
+++ b/ToDo.md
@@ -17,6 +17,7 @@ Last updated: 2026-06-24.
 - A 2026-06-24 dependency-security pass added repository-level NuGet auditing in `Directory.Build.props` with transitive audit mode and dependency-contract coverage.
 - A 2026-06-24 CI validation repair retargeted the Build and Test workflow to `master`/`main`, moved it to the net10 SDK, runs the solution-level restore/build/test commands, and includes the banned-word check before build.
 - A 2026-06-24 CI validation hardening pass replaced the banned-word script's broken no-`rg` fallback with a PowerShell file scan and added dependency-contract coverage so Windows runners can still check source text when ripgrep is unavailable.
+- A 2026-06-24 CI validation hardening follow-up made the no-`rg` fallback use either Windows PowerShell (`powershell.exe`) or PowerShell Core (`pwsh`) so the script remains usable on non-Windows validation hosts that have PowerShell Core but not ripgrep.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 
@@ -29,7 +30,7 @@ The current priority is to rerun full validation after the 2026-06-24 contract-t
 - `dotnet test InventoryManagementApp.sln --no-build`
 - `scripts/check-banned-words.sh`
 
-Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the banned-word script passes both its normal `rg` path and its PowerShell fallback path, and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
+Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the banned-word script passes its normal `rg` path plus both PowerShell fallback command paths (`powershell.exe` and `pwsh`, where available), and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
 
 ## Immediate Cleanup Queue
 

--- a/scripts/check-banned-words.sh
+++ b/scripts/check-banned-words.sh
@@ -4,8 +4,15 @@ set -euo pipefail
 # Keep the legacy standalone lowercase banned term out of source files while
 # allowing the intentionally seeded item CSV data.
 if ! command -v rg >/dev/null 2>&1; then
+  powershell_command=()
   if command -v powershell.exe >/dev/null 2>&1; then
-    powershell.exe -NoProfile -ExecutionPolicy Bypass -Command - <<'POWERSHELL'
+    powershell_command=(powershell.exe -NoProfile -ExecutionPolicy Bypass -Command -)
+  elif command -v pwsh >/dev/null 2>&1; then
+    powershell_command=(pwsh -NoProfile -Command -)
+  fi
+
+  if ((${#powershell_command[@]} > 0)); then
+    "${powershell_command[@]}" <<'POWERSHELL'
 $ErrorActionPreference = "Stop"
 $root = (Get-Location).Path.TrimEnd([char[]]@('\', '/'))
 $matches = Get-ChildItem -Path . -Recurse -File -Force |
@@ -30,7 +37,7 @@ POWERSHELL
     exit $?
   fi
 
-  echo "Banned word check failed: neither rg nor powershell.exe is available on PATH." >&2
+  echo "Banned word check failed: neither rg nor PowerShell (powershell.exe or pwsh) is available on PATH." >&2
   exit 127
 fi
 


### PR DESCRIPTION
## Summary

- Keep the banned-word script's fast `rg` path unchanged while expanding the no-`rg` fallback to use either Windows PowerShell (`powershell.exe`) or PowerShell Core (`pwsh`).
- Avoid passing Windows-only execution-policy arguments to `pwsh`, while preserving the existing execution-policy bypass for Windows PowerShell.
- Update dependency-contract coverage plus ToDo/progress notes for the fallback validation matrix.

## Validation

- GitHub connector compare confirmed a focused 4-file diff against `master`, with the branch 4 commits ahead and 0 behind.
- Read back `scripts/check-banned-words.sh`, `DependencyContractTests.cs`, `ToDo.md`, and the new progress note through the GitHub connector.
- Verified the current NuGet xUnit runner PackageReference snippet while orienting dependency-test context; no dependency file changes were made.
- Not run locally: direct clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` and `gh` are unavailable in this scheduled Linux container, so local restore/build/test, WPF screenshots/runtime checks, local banned-word checks over the full repository, and GitHub Actions log/status inspection through `gh` were not run.