### PR TITLE
Restore win-x64 assets before CI publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ jobs:
     - name: Test
       run: dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal
 
+    - name: Restore publish runtime
+      run: dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64
+
     - name: Publish
       run: dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish
 

--- a/InventoryManagementApp.Tests/DependencyContractTests.cs
+++ b/InventoryManagementApp.Tests/DependencyContractTests.cs
@@ -40,6 +40,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("bash scripts/check-banned-words.sh", source);
             Assert.Contains("dotnet build InventoryManagementApp.sln --configuration Release --no-restore", source);
             Assert.Contains("dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal", source);
+            Assert.Contains("dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64", source);
+            Assert.Contains("dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish", source);
             Assert.Contains("actions/upload-artifact@v4", source);
         }
 

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-ci-publish-runtime-restore.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-ci-publish-runtime-restore.md
@@ -1,0 +1,25 @@
+# CI Publish Runtime Restore
+
+Date: 2026-06-24
+
+## Completed
+
+- Added an explicit `dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64` step before the Build and Test workflow publishes the WPF app for `win-x64` with `--no-restore`.
+- Kept the solution restore, banned-word check, build, and test order intact so normal validation still runs before publish artifact creation.
+- Updated `DependencyContractTests.BuildWorkflowRunsCurrentNet10Validation` so the workflow keeps the runtime-specific publish restore next to the existing publish command.
+
+## Why This Matters
+
+The workflow build restore covers the solution's normal target assets, while the publish command asks for a Windows runtime identifier. Restoring the app project for `win-x64` before the no-restore publish step makes the expected runtime-specific assets available and reduces the chance of CI failing only at artifact publish time.
+
+## Validation Needed
+
+Run the Build and Test workflow or a Windows/.NET-capable checkout with:
+
+- `dotnet restore InventoryManagementApp.sln`
+- `dotnet build InventoryManagementApp.sln --configuration Release --no-restore`
+- `dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal`
+- `dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64`
+- `dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish`
+
+Local validation was not run in the scheduled Linux environment because direct clone/raw access is blocked and the .NET SDK is unavailable.

--- a/ToDo.md
+++ b/ToDo.md
@@ -18,23 +18,26 @@ Last updated: 2026-06-24.
 - A 2026-06-24 CI validation repair retargeted the Build and Test workflow to `master`/`main`, moved it to the net10 SDK, runs the solution-level restore/build/test commands, and includes the banned-word check before build.
 - A 2026-06-24 CI validation hardening pass replaced the banned-word script's broken no-`rg` fallback with a PowerShell file scan and added dependency-contract coverage so Windows runners can still check source text when ripgrep is unavailable.
 - A 2026-06-24 CI validation hardening follow-up made the no-`rg` fallback use either Windows PowerShell (`powershell.exe`) or PowerShell Core (`pwsh`) so the script remains usable on non-Windows validation hosts that have PowerShell Core but not ripgrep.
+- A 2026-06-24 CI publish repair added an explicit `win-x64` restore before the workflow's `--no-restore` publish step so runtime-specific assets are present for the Windows publish job.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 
 ## Validation Needed Next
 
-The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, and banned-word fallback repair:
+The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, and CI publish restore repair:
 
 - `dotnet restore InventoryManagementApp.sln`
 - `dotnet build InventoryManagementApp.sln --no-restore`
 - `dotnet test InventoryManagementApp.sln --no-build`
+- `dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64`
+- `dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish`
 - `scripts/check-banned-words.sh`
 
-Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the banned-word script passes its normal `rg` path plus both PowerShell fallback command paths (`powershell.exe` and `pwsh`, where available), and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
+Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the runtime-specific publish restore creates the `win-x64` assets used by the no-restore publish step, that the banned-word script passes its normal `rg` path plus both PowerShell fallback command paths (`powershell.exe` and `pwsh`, where available), and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
 
 ## Immediate Cleanup Queue
 
-1. Re-run full validation after the source-contract cleanup and dependency pins: restore, build, test, banned-word check.
+1. Re-run full validation after the source-contract cleanup and dependency pins: restore, build, test, publish restore/publish, banned-word check.
 2. Confirm the retargeted GitHub Actions Build and Test workflow runs on the next `master`/`main` pull request with the net10 SDK.
 3. Review any NU190x warnings surfaced by repository-level direct/transitive NuGet auditing and either update affected packages or document intentional risk decisions.
 4. Smoke test the dark-theme top navigation dropdown visually in the running WPF app.


### PR DESCRIPTION
## Summary

- Add an explicit `dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64` step before the workflow publishes the WPF app for `win-x64` with `--no-restore`.
- Extend `DependencyContractTests.BuildWorkflowRunsCurrentNet10Validation` so the Build and Test workflow keeps the runtime-specific publish restore beside the publish command.
- Update `ToDo.md` plus a progress note so the next validation pass checks restore/build/test, RID-specific restore/publish, banned-word checks, NuGet audit output, and package warning status.

## Validation

- GitHub connector compare confirmed a focused 4-file diff against `master`, with the branch 4 commits ahead and 0 behind.
- Read back `.github/workflows/build.yml`, `DependencyContractTests.cs`, `ToDo.md`, and the new progress note through the GitHub connector.
- Not run locally: direct clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` and `gh` are unavailable in this scheduled Linux container, so local restore/build/test, runtime-specific publish validation, WPF screenshots/runtime checks, local banned-word checks, and GitHub Actions log/status inspection through `gh` were not run.