### PR TITLE
Exclude generated folders from banned-word scans

### DIFF
--- a/InventoryManagementApp.Tests/DependencyContractTests.cs
+++ b/InventoryManagementApp.Tests/DependencyContractTests.cs
@@ -55,6 +55,9 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("powershell_command=(powershell.exe -NoProfile -ExecutionPolicy Bypass -Command -)", source);
             Assert.Contains("powershell_command=(pwsh -NoProfile -Command -)", source);
             Assert.Contains("Get-ChildItem -Path . -Recurse -File -Force", source);
+            Assert.Contains("$relative -notmatch '(^|/)(bin|obj)/'", source);
+            Assert.Contains("--glob '!**/bin/**'", source);
+            Assert.Contains("--glob '!**/obj/**'", source);
             Assert.Contains("Select-String -Pattern", source);
             Assert.Contains("neither rg nor PowerShell (powershell.exe or pwsh) is available", source);
             Assert.DoesNotContain("$matches = rg", source, StringComparison.OrdinalIgnoreCase);

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-banned-word-generated-folder-exclusions.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-banned-word-generated-folder-exclusions.md
@@ -1,0 +1,24 @@
+# Banned Word Generated Folder Exclusions
+
+Date: 2026-06-24
+
+## Completed
+
+- Aligned the banned-word script's fast `rg` path and no-`rg` PowerShell fallback so both skip generated `bin` and `obj` folders.
+- Kept the existing seeded CSV and script exclusions intact.
+- Updated `DependencyContractTests.BannedWordScriptHasNonRipgrepPowerShellFallback` so future changes preserve the generated-folder exclusions in both scanning paths.
+
+## Why This Matters
+
+Generated build and test outputs can contain copied dependencies, compiled artifacts, or transient generated files that are not repository source. Excluding `bin` and `obj` keeps the validation check focused on authored source text and prevents the fallback scanner from disagreeing with the `rg` path on a Windows runner.
+
+## Validation Needed
+
+Run the normal validation matrix when a Windows/.NET-capable checkout is available:
+
+- `dotnet restore InventoryManagementApp.sln`
+- `dotnet build InventoryManagementApp.sln --configuration Release --no-restore`
+- `dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal`
+- `scripts/check-banned-words.sh`
+
+Also validate the no-`rg` fallback with Windows PowerShell or PowerShell Core where available. Local validation was not run in the scheduled Linux environment because direct clone/raw access is blocked and the .NET SDK is unavailable.

--- a/ToDo.md
+++ b/ToDo.md
@@ -19,12 +19,13 @@ Last updated: 2026-06-24.
 - A 2026-06-24 CI validation hardening pass replaced the banned-word script's broken no-`rg` fallback with a PowerShell file scan and added dependency-contract coverage so Windows runners can still check source text when ripgrep is unavailable.
 - A 2026-06-24 CI validation hardening follow-up made the no-`rg` fallback use either Windows PowerShell (`powershell.exe`) or PowerShell Core (`pwsh`) so the script remains usable on non-Windows validation hosts that have PowerShell Core but not ripgrep.
 - A 2026-06-24 CI publish repair added an explicit `win-x64` restore before the workflow's `--no-restore` publish step so runtime-specific assets are present for the Windows publish job.
+- A 2026-06-24 banned-word fallback hardening pass aligned the `rg` path and PowerShell fallback so both skip generated `bin` and `obj` folders, with dependency-contract coverage for both exclusion paths.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 
 ## Validation Needed Next
 
-The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, and CI publish restore repair:
+The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, CI publish restore repair, and generated-folder exclusion alignment:
 
 - `dotnet restore InventoryManagementApp.sln`
 - `dotnet build InventoryManagementApp.sln --no-restore`
@@ -33,7 +34,7 @@ The current priority is to rerun full validation after the 2026-06-24 contract-t
 - `dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish`
 - `scripts/check-banned-words.sh`
 
-Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the runtime-specific publish restore creates the `win-x64` assets used by the no-restore publish step, that the banned-word script passes its normal `rg` path plus both PowerShell fallback command paths (`powershell.exe` and `pwsh`, where available), and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
+Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the runtime-specific publish restore creates the `win-x64` assets used by the no-restore publish step, that the banned-word script passes its normal `rg` path plus both PowerShell fallback command paths (`powershell.exe` and `pwsh`, where available), that both banned-word scan paths skip generated `bin` and `obj` folders, and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
 
 ## Immediate Cleanup Queue
 

--- a/scripts/check-banned-words.sh
+++ b/scripts/check-banned-words.sh
@@ -19,6 +19,7 @@ $matches = Get-ChildItem -Path . -Recurse -File -Force |
     Where-Object {
         $relative = $_.FullName.Substring($root.Length).TrimStart([char[]]@('\', '/')).Replace('\', '/')
         $relative -notlike ".git/*" -and
+            $relative -notmatch '(^|/)(bin|obj)/' -and
             $relative -ne "Items.csv" -and
             $relative -ne "items.csv" -and
             $relative -ne "scripts/check-banned-words.sh"
@@ -46,6 +47,8 @@ if rg --ignore-case --line-number \
   --glob '!items.csv' \
   --glob '!scripts/check-banned-words.sh' \
   --glob '!.git/**' \
+  --glob '!**/bin/**' \
+  --glob '!**/obj/**' \
   '\btool\b' .; then
   echo "Banned word check failed: standalone banned term found outside allowed legacy files." >&2
   exit 1


### PR DESCRIPTION
## Summary

- Align the banned-word script's fast `rg` scan and no-`rg` PowerShell fallback so both skip generated `bin` and `obj` folders.
- Extend `DependencyContractTests.BannedWordScriptHasNonRipgrepPowerShellFallback` to guard the generated-folder exclusions in both scan paths.
- Update `ToDo.md` and add a progress note for the next full validation pass.

## Validation

- GitHub connector compare confirmed a focused 4-file diff against `master`, with the branch 4 commits ahead and 0 behind.
- Read back `scripts/check-banned-words.sh`, `DependencyContractTests.cs`, `ToDo.md`, and the new progress note through the GitHub connector.
- Not run locally: direct clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` is unavailable in this scheduled Linux container, so local restore/build/test, WPF screenshots/runtime checks, local banned-word checks, and PowerShell fallback execution were not run.