### PR TITLE
Validate banned-word PowerShell fallback in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,10 @@ jobs:
       shell: bash
       run: bash scripts/check-banned-words.sh
 
+    - name: Check banned words PowerShell fallback
+      shell: bash
+      run: BANNED_WORD_CHECK_FORCE_POWERSHELL=1 bash scripts/check-banned-words.sh
+
     - name: Build
       run: dotnet build InventoryManagementApp.sln --configuration Release --no-restore
 

--- a/InventoryManagementApp.Tests/DependencyContractTests.cs
+++ b/InventoryManagementApp.Tests/DependencyContractTests.cs
@@ -38,6 +38,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("dotnet-version: 10.0.x", source);
             Assert.Contains("dotnet restore InventoryManagementApp.sln", source);
             Assert.Contains("bash scripts/check-banned-words.sh", source);
+            Assert.Contains("Check banned words PowerShell fallback", source);
+            Assert.Contains("BANNED_WORD_CHECK_FORCE_POWERSHELL=1 bash scripts/check-banned-words.sh", source);
             Assert.Contains("dotnet build InventoryManagementApp.sln --configuration Release --no-restore", source);
             Assert.Contains("dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal", source);
             Assert.Contains("dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64", source);
@@ -50,6 +52,8 @@ namespace InventoryManagementApp.Tests
         {
             var source = ReadRepoFile("scripts", "check-banned-words.sh");
 
+            Assert.Contains("BANNED_WORD_CHECK_FORCE_POWERSHELL", source);
+            Assert.Contains("use_powershell_fallback=true", source);
             Assert.Contains("command -v powershell.exe", source);
             Assert.Contains("command -v pwsh", source);
             Assert.Contains("powershell_command=(powershell.exe -NoProfile -ExecutionPolicy Bypass -Command -)", source);

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-forced-banned-word-fallback-ci.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-forced-banned-word-fallback-ci.md
@@ -1,0 +1,17 @@
+# Forced Banned-Word Fallback CI Validation
+
+Date: 2026-06-24
+
+## Completed
+
+- Added `BANNED_WORD_CHECK_FORCE_POWERSHELL=1` to `scripts/check-banned-words.sh` so validation can exercise the PowerShell scan path even when `rg` is installed.
+- Added a Build and Test workflow step that runs the forced PowerShell fallback after the normal banned-word check.
+- Extended dependency contract coverage so future workflow/script edits keep the forced fallback validation path visible.
+
+## Validation Needed
+
+Run the next Windows/.NET-capable validation pass and confirm:
+
+- `bash scripts/check-banned-words.sh` passes through the normal `rg` path.
+- `BANNED_WORD_CHECK_FORCE_POWERSHELL=1 bash scripts/check-banned-words.sh` passes through the PowerShell fallback while `rg` is still available.
+- The Build and Test workflow runs both banned-word validation steps before restore/build/test/publish validation finishes.

--- a/ToDo.md
+++ b/ToDo.md
@@ -20,12 +20,13 @@ Last updated: 2026-06-24.
 - A 2026-06-24 CI validation hardening follow-up made the no-`rg` fallback use either Windows PowerShell (`powershell.exe`) or PowerShell Core (`pwsh`) so the script remains usable on non-Windows validation hosts that have PowerShell Core but not ripgrep.
 - A 2026-06-24 CI publish repair added an explicit `win-x64` restore before the workflow's `--no-restore` publish step so runtime-specific assets are present for the Windows publish job.
 - A 2026-06-24 banned-word fallback hardening pass aligned the `rg` path and PowerShell fallback so both skip generated `bin` and `obj` folders, with dependency-contract coverage for both exclusion paths.
+- A 2026-06-24 CI validation consolidation pass added `BANNED_WORD_CHECK_FORCE_POWERSHELL=1` so the Build and Test workflow exercises the PowerShell banned-word fallback even when `rg` is available.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 
 ## Validation Needed Next
 
-The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, CI publish restore repair, and generated-folder exclusion alignment:
+The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, CI publish restore repair, generated-folder exclusion alignment, and forced PowerShell fallback CI validation:
 
 - `dotnet restore InventoryManagementApp.sln`
 - `dotnet build InventoryManagementApp.sln --no-restore`
@@ -33,13 +34,14 @@ The current priority is to rerun full validation after the 2026-06-24 contract-t
 - `dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64`
 - `dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish`
 - `scripts/check-banned-words.sh`
+- `BANNED_WORD_CHECK_FORCE_POWERSHELL=1 scripts/check-banned-words.sh`
 
-Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the runtime-specific publish restore creates the `win-x64` assets used by the no-restore publish step, that the banned-word script passes its normal `rg` path plus both PowerShell fallback command paths (`powershell.exe` and `pwsh`, where available), that both banned-word scan paths skip generated `bin` and `obj` folders, and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
+Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the runtime-specific publish restore creates the `win-x64` assets used by the no-restore publish step, that the banned-word script passes its normal `rg` path plus both PowerShell fallback command paths (`powershell.exe` and `pwsh`, where available), that both banned-word scan paths skip generated `bin` and `obj` folders, that the forced fallback mode works while `rg` is present, and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
 
 ## Immediate Cleanup Queue
 
-1. Re-run full validation after the source-contract cleanup and dependency pins: restore, build, test, publish restore/publish, banned-word check.
-2. Confirm the retargeted GitHub Actions Build and Test workflow runs on the next `master`/`main` pull request with the net10 SDK.
+1. Re-run full validation after the source-contract cleanup and dependency pins: restore, build, test, publish restore/publish, normal banned-word check, and forced PowerShell fallback banned-word check.
+2. Confirm the retargeted GitHub Actions Build and Test workflow runs on the next `master`/`main` pull request with the net10 SDK and both banned-word validation paths.
 3. Review any NU190x warnings surfaced by repository-level direct/transitive NuGet auditing and either update affected packages or document intentional risk decisions.
 4. Smoke test the dark-theme top navigation dropdown visually in the running WPF app.
 5. Confirm the SQLite native package advisory is cleared during restore and continue the broader production dependency/security review.

--- a/scripts/check-banned-words.sh
+++ b/scripts/check-banned-words.sh
@@ -3,7 +3,15 @@ set -euo pipefail
 
 # Keep the legacy standalone lowercase banned term out of source files while
 # allowing the intentionally seeded item CSV data.
-if ! command -v rg >/dev/null 2>&1; then
+force_powershell_fallback="${BANNED_WORD_CHECK_FORCE_POWERSHELL:-}"
+use_powershell_fallback=false
+if [[ -n "$force_powershell_fallback" ]]; then
+  use_powershell_fallback=true
+elif ! command -v rg >/dev/null 2>&1; then
+  use_powershell_fallback=true
+fi
+
+if [[ "$use_powershell_fallback" == true ]]; then
   powershell_command=()
   if command -v powershell.exe >/dev/null 2>&1; then
     powershell_command=(powershell.exe -NoProfile -ExecutionPolicy Bypass -Command -)


### PR DESCRIPTION
## Summary

- Add `BANNED_WORD_CHECK_FORCE_POWERSHELL=1` to force the banned-word script through its PowerShell fallback even when `rg` is available.
- Run that forced fallback as an explicit Windows Build and Test workflow step after the normal banned-word check.
- Extend dependency contract coverage plus ToDo/progress notes so the fallback validation path stays visible.

## Validation

- GitHub connector compare confirmed a focused 5-file diff against `master`, with the branch 5 commits ahead and 0 behind.
- Read back `scripts/check-banned-words.sh`, `.github/workflows/build.yml`, and `DependencyContractTests.cs` through the GitHub connector.
- Not run locally: direct clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet` and `gh` are unavailable in this scheduled Linux container, so local restore/build/test, WPF screenshots/runtime checks, local banned-word checks, forced PowerShell fallback execution, and GitHub Actions log/status inspection through `gh` were not run.