### PR TITLE
Add full validation runner

### DIFF
--- a/InventoryManagementApp.Tests/DependencyContractTests.cs
+++ b/InventoryManagementApp.Tests/DependencyContractTests.cs
@@ -48,6 +48,25 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void FullValidationRunnerCoversRestoreBuildTestPublishAndBannedWordChecks()
+        {
+            var source = ReadRepoFile("scripts", "run-full-validation.ps1");
+
+            Assert.Contains("param(", source);
+            Assert.Contains("[string]$Configuration = \"Release\"", source);
+            Assert.Contains("[string]$Runtime = \"win-x64\"", source);
+            Assert.Contains("[switch]$SkipPublish", source);
+            Assert.Contains("dotnet restore InventoryManagementApp.sln", source);
+            Assert.Contains("dotnet build InventoryManagementApp.sln --configuration $Configuration --no-restore", source);
+            Assert.Contains("dotnet test InventoryManagementApp.sln --configuration $Configuration --no-build --verbosity normal", source);
+            Assert.Contains("dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime $Runtime", source);
+            Assert.Contains("dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c $Configuration -r $Runtime --self-contained false --no-restore -o ./publish", source);
+            Assert.Contains("bash scripts/check-banned-words.sh", source);
+            Assert.Contains("BANNED_WORD_CHECK_FORCE_POWERSHELL", source);
+            Assert.Contains("Remove-Item Env:BANNED_WORD_CHECK_FORCE_POWERSHELL", source);
+        }
+
+        [Fact]
         public void BannedWordScriptHasNonRipgrepPowerShellFallback()
         {
             var source = ReadRepoFile("scripts", "check-banned-words.sh");

--- a/InventoryManagementApp/ProgressNotes/2026-06-24-full-validation-runner.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-24-full-validation-runner.md
@@ -1,0 +1,12 @@
+# Full Validation Runner
+
+## Completed
+
+- Added `scripts/run-full-validation.ps1` so a Windows/.NET-capable checkout can run the current restore, build, test, publish, normal banned-word, and forced PowerShell fallback checks from one command.
+- Documented the runner in `README.md` and `ToDo.md`.
+- Added dependency-contract coverage for the runner's restore/build/test/publish and banned-word validation commands.
+
+## Validation Notes
+
+- Full validation still needs to run in a Windows/.NET-capable checkout.
+- The scheduled Linux container cannot run local validation because direct repository clone/raw access is blocked, `dotnet` is unavailable, `gh` is unavailable, and PowerShell is unavailable.

--- a/README.md
+++ b/README.md
@@ -13,11 +13,19 @@ The app uses MVVM and SQLite persistence through the existing `DatabaseService`.
 
 Last local validation: 2026-06-23.
 
-- `dotnet restore InventoryManagementApp.sln`: passes with existing NuGet warnings.
-- `dotnet build InventoryManagementApp.sln --no-restore`: passes with warnings.
-- `dotnet test InventoryManagementApp.sln --no-build`: currently fails 14 unrelated brittle source-contract tests in category, reservation, kit, import/export, maintenance/calibration, and rental workflow contract areas.
-- Focused navigation dropdown tests pass after the dark-theme hover fix.
-- `./scripts/check-banned-words.sh`: passes after line-ending cleanup and seeded CSV exclusions.
+Recent 2026-06-24 maintenance updated the app and test projects to the .NET 10 package line, pinned the supported SQLite native bundle, enabled repository-level NuGet auditing, retargeted the Windows Build and Test workflow, and repaired the banned-word validation fallback path. Full validation still needs to be rerun in a Windows/.NET-capable checkout after those changes.
+
+Use the checked-in validation runner for the current restore/build/test/publish/check sequence:
+
+```powershell
+pwsh -File scripts/run-full-validation.ps1
+```
+
+For a faster compile-and-test pass without publishing:
+
+```powershell
+pwsh -File scripts/run-full-validation.ps1 -SkipPublish
+```
 
 See [ToDo.md](ToDo.md) for the current cleanup queue and known remaining work.
 
@@ -48,19 +56,24 @@ Keep production credentials out of source control. Use `appsettings.Production.j
 Prerequisite:
 
 - .NET 10 SDK with Windows desktop workload/runtime support.
+- PowerShell and Git Bash for the repository validation runner.
 
 Validation commands from the repository root:
 
 ```powershell
-dotnet restore InventoryManagementApp.sln
-dotnet build InventoryManagementApp.sln --no-restore
-dotnet test InventoryManagementApp.sln --no-build
+pwsh -File scripts/run-full-validation.ps1
 ```
 
-Run the banned-word check:
+Manual equivalent:
 
-```bash
-./scripts/check-banned-words.sh
+```powershell
+dotnet restore InventoryManagementApp.sln
+dotnet build InventoryManagementApp.sln --configuration Release --no-restore
+dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal
+dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64
+dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish
+bash scripts/check-banned-words.sh
+$env:BANNED_WORD_CHECK_FORCE_POWERSHELL = "1"; bash scripts/check-banned-words.sh; Remove-Item Env:BANNED_WORD_CHECK_FORCE_POWERSHELL
 ```
 
 Repository rules:

--- a/ToDo.md
+++ b/ToDo.md
@@ -22,16 +22,21 @@ Last updated: 2026-06-24.
 - A 2026-06-24 banned-word fallback hardening pass aligned the `rg` path and PowerShell fallback so both skip generated `bin` and `obj` folders, with dependency-contract coverage for both exclusion paths.
 - A 2026-06-24 CI validation consolidation pass added `BANNED_WORD_CHECK_FORCE_POWERSHELL=1` so the Build and Test workflow exercises the PowerShell banned-word fallback even when `rg` is available.
 - A 2026-06-24 banned-word fallback scan hardening pass limited the PowerShell fallback to known text/source file extensions and a few text file names, avoiding binary asset scans when the forced fallback runs in CI.
+- A 2026-06-24 validation readiness pass added `scripts/run-full-validation.ps1` to run the current restore, build, test, publish, normal banned-word, and forced PowerShell fallback checks from one Windows/.NET-capable checkout.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 
 ## Validation Needed Next
 
-The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, CI publish restore repair, generated-folder exclusion alignment, forced PowerShell fallback CI validation, and PowerShell text-file scan narrowing:
+The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, CI publish restore repair, generated-folder exclusion alignment, forced PowerShell fallback CI validation, PowerShell text-file scan narrowing, and the checked-in validation runner:
+
+- `pwsh -File scripts/run-full-validation.ps1`
+
+The runner executes:
 
 - `dotnet restore InventoryManagementApp.sln`
-- `dotnet build InventoryManagementApp.sln --no-restore`
-- `dotnet test InventoryManagementApp.sln --no-build`
+- `dotnet build InventoryManagementApp.sln --configuration Release --no-restore`
+- `dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal`
 - `dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64`
 - `dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish`
 - `scripts/check-banned-words.sh`
@@ -41,7 +46,7 @@ Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bund
 
 ## Immediate Cleanup Queue
 
-1. Re-run full validation after the source-contract cleanup and dependency pins: restore, build, test, publish restore/publish, normal banned-word check, and forced PowerShell fallback banned-word check.
+1. Re-run full validation with `pwsh -File scripts/run-full-validation.ps1` after the source-contract cleanup and dependency pins.
 2. Confirm the retargeted GitHub Actions Build and Test workflow runs on the next `master`/`main` pull request with the net10 SDK and both banned-word validation paths.
 3. Review any NU190x warnings surfaced by repository-level direct/transitive NuGet auditing and either update affected packages or document intentional risk decisions.
 4. Smoke test the dark-theme top navigation dropdown visually in the running WPF app.

--- a/scripts/run-full-validation.ps1
+++ b/scripts/run-full-validation.ps1
@@ -1,0 +1,78 @@
+param(
+    [string]$Configuration = "Release",
+    [string]$Runtime = "win-x64",
+    [switch]$SkipPublish
+)
+
+$ErrorActionPreference = "Stop"
+
+function Invoke-ValidationStep {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Action
+    )
+
+    Write-Host ""
+    Write-Host "==> $Name"
+    & $Action
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Name failed with exit code $LASTEXITCODE."
+    }
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Push-Location $repoRoot
+
+try {
+    Invoke-ValidationStep "Restore solution" {
+        dotnet restore InventoryManagementApp.sln
+    }
+
+    Invoke-ValidationStep "Build solution" {
+        dotnet build InventoryManagementApp.sln --configuration $Configuration --no-restore
+    }
+
+    Invoke-ValidationStep "Test solution" {
+        dotnet test InventoryManagementApp.sln --configuration $Configuration --no-build --verbosity normal
+    }
+
+    if (-not $SkipPublish) {
+        Invoke-ValidationStep "Restore publish runtime" {
+            dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime $Runtime
+        }
+
+        Invoke-ValidationStep "Publish app" {
+            dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c $Configuration -r $Runtime --self-contained false --no-restore -o ./publish
+        }
+    }
+
+    Invoke-ValidationStep "Check banned words" {
+        bash scripts/check-banned-words.sh
+    }
+
+    Invoke-ValidationStep "Check banned words PowerShell fallback" {
+        $previousForce = $env:BANNED_WORD_CHECK_FORCE_POWERSHELL
+        $env:BANNED_WORD_CHECK_FORCE_POWERSHELL = "1"
+        try {
+            bash scripts/check-banned-words.sh
+        }
+        finally {
+            if ($null -eq $previousForce) {
+                Remove-Item Env:BANNED_WORD_CHECK_FORCE_POWERSHELL -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:BANNED_WORD_CHECK_FORCE_POWERSHELL = $previousForce
+            }
+        }
+    }
+
+    Write-Host ""
+    Write-Host "Full validation completed successfully."
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary

- Add `scripts/run-full-validation.ps1` so a Windows/.NET-capable checkout can run restore, build, test, publish, normal banned-word validation, and forced PowerShell fallback validation from one command.
- Document the runner in `README.md` and `ToDo.md`, replacing the stale README test-failure snapshot with the current validation-needed state.
- Add dependency-contract coverage so the runner keeps the expected validation commands aligned with the workflow and cleanup queue.

## Validation

- GitHub connector compare confirmed a focused 5-file diff against `master`.
- Read back `scripts/run-full-validation.ps1`, `DependencyContractTests.cs`, `README.md`, `ToDo.md`, and the new progress note through the GitHub connector.
- Not run locally: direct clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet`, `gh`, and PowerShell are unavailable in this scheduled Linux container, so local restore/build/test, runtime publish, WPF screenshots/runtime checks, local banned-word checks, forced PowerShell fallback execution, and GitHub Actions log/status inspection through `gh` were not run.