### PR TITLE
Exclude publish output from banned-word scans

### DIFF
--- a/InventoryManagementApp.Tests/DependencyContractTests.cs
+++ b/InventoryManagementApp.Tests/DependencyContractTests.cs
@@ -88,9 +88,10 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("[System.IO.Path]::GetExtension($relative)", source);
             Assert.Contains("[System.IO.Path]::GetFileName($relative)", source);
             Assert.Contains("$textFileExtensions -contains $extension -or $textFileNames -contains $fileName", source);
-            Assert.Contains("$relative -notmatch '(^|/)(bin|obj)/'", source);
+            Assert.Contains("$relative -notmatch '(^|/)(bin|obj|publish)/'", source);
             Assert.Contains("--glob '!**/bin/**'", source);
             Assert.Contains("--glob '!**/obj/**'", source);
+            Assert.Contains("--glob '!**/publish/**'", source);
             Assert.Contains("Select-String -Pattern", source);
             Assert.Contains("neither rg nor PowerShell (powershell.exe or pwsh) is available", source);
             Assert.DoesNotContain("$matches = rg", source, StringComparison.OrdinalIgnoreCase);

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-banned-word-publish-output-exclusion.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-banned-word-publish-output-exclusion.md
@@ -1,0 +1,15 @@
+# Banned-Word Publish Output Exclusion
+
+Date: 2026-06-25
+
+## Completed
+
+- Treated the generated `publish/` output folder like `bin/` and `obj/` in both banned-word scan paths.
+- Kept the normal `rg` scan and forced PowerShell fallback aligned so the full validation runner can publish before running banned-word checks without scanning generated publish artifacts.
+- Extended `DependencyContractTests.BannedWordScriptHasNonRipgrepPowerShellFallback` so future script edits keep the publish-output exclusion in both scan implementations.
+
+## Validation Notes
+
+- Local clone/raw access is blocked in this scheduled Linux container by `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell, `gh`, WPF screenshots/runtime checks, local banned-word checks, and the checked-in full validation runner were not run locally.
+- Validate from a Windows/.NET-capable checkout with `pwsh -File scripts/run-full-validation.ps1`.

--- a/ToDo.md
+++ b/ToDo.md
@@ -1,6 +1,6 @@
 # Current Status And Remaining Work
 
-Last updated: 2026-06-24.
+Last updated: 2026-06-25.
 
 ## Build And Validation
 
@@ -23,12 +23,13 @@ Last updated: 2026-06-24.
 - A 2026-06-24 CI validation consolidation pass added `BANNED_WORD_CHECK_FORCE_POWERSHELL=1` so the Build and Test workflow exercises the PowerShell banned-word fallback even when `rg` is available.
 - A 2026-06-24 banned-word fallback scan hardening pass limited the PowerShell fallback to known text/source file extensions and a few text file names, avoiding binary asset scans when the forced fallback runs in CI.
 - A 2026-06-24 validation readiness pass added `scripts/run-full-validation.ps1` to run the current restore, build, test, publish, normal banned-word, and forced PowerShell fallback checks from one Windows/.NET-capable checkout.
+- A 2026-06-25 validation hardening pass excluded generated `publish/` output from both banned-word scan paths so the full validation runner can publish before running banned-word checks without scanning publish artifacts.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 
 ## Validation Needed Next
 
-The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, CI publish restore repair, generated-folder exclusion alignment, forced PowerShell fallback CI validation, PowerShell text-file scan narrowing, and the checked-in validation runner:
+The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, CI publish restore repair, generated-folder exclusion alignment, forced PowerShell fallback CI validation, PowerShell text-file scan narrowing, the checked-in validation runner, and generated `publish/` output exclusion:
 
 - `pwsh -File scripts/run-full-validation.ps1`
 
@@ -42,11 +43,11 @@ The runner executes:
 - `scripts/check-banned-words.sh`
 - `BANNED_WORD_CHECK_FORCE_POWERSHELL=1 scripts/check-banned-words.sh`
 
-Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the runtime-specific publish restore creates the `win-x64` assets used by the no-restore publish step, that the banned-word script passes its normal `rg` path plus both PowerShell fallback command paths (`powershell.exe` and `pwsh`, where available), that both banned-word scan paths skip generated `bin` and `obj` folders, that the forced fallback mode works while `rg` is present, that the PowerShell fallback scans source/text files without scanning binary assets, and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
+Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the runtime-specific publish restore creates the `win-x64` assets used by the no-restore publish step, that the banned-word script passes its normal `rg` path plus both PowerShell fallback command paths (`powershell.exe` and `pwsh`, where available), that both banned-word scan paths skip generated `bin`, `obj`, and `publish` folders, that the forced fallback mode works while `rg` is present, that the PowerShell fallback scans source/text files without scanning binary assets, and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
 
 ## Immediate Cleanup Queue
 
-1. Re-run full validation with `pwsh -File scripts/run-full-validation.ps1` after the source-contract cleanup and dependency pins.
+1. Re-run full validation with `pwsh -File scripts/run-full-validation.ps1` after the source-contract cleanup, dependency pins, and publish-output scan exclusion.
 2. Confirm the retargeted GitHub Actions Build and Test workflow runs on the next `master`/`main` pull request with the net10 SDK and both banned-word validation paths.
 3. Review any NU190x warnings surfaced by repository-level direct/transitive NuGet auditing and either update affected packages or document intentional risk decisions.
 4. Smoke test the dark-theme top navigation dropdown visually in the running WPF app.

--- a/scripts/check-banned-words.sh
+++ b/scripts/check-banned-words.sh
@@ -92,4 +92,4 @@ if rg --ignore-case --line-number \
   exit 1
 fi
 
-echo "Banned word check passed."} 想 
+echo "Banned word check passed."

--- a/scripts/check-banned-words.sh
+++ b/scripts/check-banned-words.sh
@@ -92,4 +92,4 @@ if rg --ignore-case --line-number \
   exit 1
 fi
 
-echo "Banned word check passed."}алар  
+echo "Banned word check passed."} 想 

--- a/scripts/check-banned-words.sh
+++ b/scripts/check-banned-words.sh
@@ -55,7 +55,7 @@ $matches = Get-ChildItem -Path . -Recurse -File -Force |
         $extension = [System.IO.Path]::GetExtension($relative).ToLowerInvariant()
         $fileName = [System.IO.Path]::GetFileName($relative)
         $relative -notlike ".git/*" -and
-            $relative -notmatch '(^|/)(bin|obj)/' -and
+            $relative -notmatch '(^|/)(bin|obj|publish)/' -and
             $relative -ne "Items.csv" -and
             $relative -ne "items.csv" -and
             $relative -ne "scripts/check-banned-words.sh" -and
@@ -86,9 +86,10 @@ if rg --ignore-case --line-number \
   --glob '!.git/**' \
   --glob '!**/bin/**' \
   --glob '!**/obj/**' \
+  --glob '!**/publish/**' \
   '\btool\b' .; then
   echo "Banned word check failed: standalone banned term found outside allowed legacy files." >&2
   exit 1
 fi
 
-echo "Banned word check passed."
+echo "Banned word check passed."}алар  


### PR DESCRIPTION
## Summary

- Exclude generated `publish/` output from both banned-word scan paths, matching the existing generated `bin`/`obj` exclusions.
- Extend dependency-contract coverage so the normal `rg` path and forced PowerShell fallback keep the publish-output exclusion aligned.
- Update validation tracking and add a progress note for the next full Windows/.NET validation run.

## Validation

- GitHub connector compare confirmed a focused 4-file diff against `master`, with the branch 6 commits ahead and 0 behind.
- Read back `scripts/check-banned-words.sh`, `DependencyContractTests.cs`, `ToDo.md`, and the new progress note through the GitHub connector.
- Not run locally: direct clone/raw access is blocked by `CONNECT tunnel failed, response 403`; `dotnet`, PowerShell, and `gh` are unavailable in this scheduled Linux container, so local restore/build/test, WPF screenshots/runtime checks, local banned-word checks, the checked-in full validation runner, and GitHub Actions log/status inspection through `gh` were not run.