### PR TITLE
Clean publish output before full validation publish

### DIFF
--- a/InventoryManagementApp.Tests/ValidationRunnerContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationRunnerContractTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ValidationRunnerContractTests
+    {
+        [Fact]
+        public void FullValidationRunnerCleansPublishOutputBeforePublishing()
+        {
+            var source = ReadRepoFile("scripts", "run-full-validation.ps1");
+
+            Assert.Contains("$publishOutputPath = Join-Path $repoRoot \"publish\"", source);
+            Assert.Contains("Clean publish output", source);
+            Assert.Contains("Test-Path $publishOutputPath", source);
+            Assert.Contains("Remove-Item $publishOutputPath -Recurse -Force", source);
+
+            var cleanIndex = source.IndexOf("Clean publish output", StringComparison.Ordinal);
+            var publishIndex = source.IndexOf("dotnet publish InventoryManagementApp/InventoryManagementApp.csproj", StringComparison.Ordinal);
+
+            Assert.True(cleanIndex >= 0, "The full validation runner should name the publish-output cleanup step.");
+            Assert.True(publishIndex >= 0, "The full validation runner should publish the app.");
+            Assert.True(cleanIndex < publishIndex, "The full validation runner should clean stale publish output before publishing fresh artifacts.");
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-validation-runner-publish-cleanup.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-validation-runner-publish-cleanup.md
@@ -1,0 +1,21 @@
+# Validation Runner Publish Cleanup - 2026-06-25
+
+## Completed
+
+- Updated `scripts/run-full-validation.ps1` to remove the existing `publish/` output folder before running the release publish step.
+- Added `ValidationRunnerContractTests.FullValidationRunnerCleansPublishOutputBeforePublishing` to guard the cleanup path and ensure it stays before `dotnet publish`.
+- Updated `ToDo.md` so the next Windows/.NET-capable validation pass confirms stale publish artifacts are removed before fresh output is produced.
+
+## Why This Matters
+
+The full validation runner publishes before banned-word checks. The scanner now excludes generated `publish/` output, but stale files in that folder could still make the publish result look healthier than it is. Cleaning the folder before publishing keeps validation tied to freshly generated artifacts.
+
+## Validation Still Needed
+
+Run the full validation runner from a Windows/.NET-capable checkout:
+
+```powershell
+pwsh -File scripts/run-full-validation.ps1
+```
+
+Confirm restore/build/test, `win-x64` publish, normal banned-word scan, forced PowerShell fallback scan, NuGet audit warnings, dependency advisory status, and that `publish/` is recreated from a clean folder.

--- a/ToDo.md
+++ b/ToDo.md
@@ -24,12 +24,13 @@ Last updated: 2026-06-25.
 - A 2026-06-24 banned-word fallback scan hardening pass limited the PowerShell fallback to known text/source file extensions and a few text file names, avoiding binary asset scans when the forced fallback runs in CI.
 - A 2026-06-24 validation readiness pass added `scripts/run-full-validation.ps1` to run the current restore, build, test, publish, normal banned-word, and forced PowerShell fallback checks from one Windows/.NET-capable checkout.
 - A 2026-06-25 validation hardening pass excluded generated `publish/` output from both banned-word scan paths so the full validation runner can publish before running banned-word checks without scanning publish artifacts.
+- A 2026-06-25 validation runner hardening pass cleans the `publish/` output folder before publishing so full validation reports only freshly produced artifacts.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 
 ## Validation Needed Next
 
-The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, CI publish restore repair, generated-folder exclusion alignment, forced PowerShell fallback CI validation, PowerShell text-file scan narrowing, the checked-in validation runner, and generated `publish/` output exclusion:
+The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, CI publish restore repair, generated-folder exclusion alignment, forced PowerShell fallback CI validation, PowerShell text-file scan narrowing, the checked-in validation runner, generated `publish/` output exclusion, and publish-output cleanup:
 
 - `pwsh -File scripts/run-full-validation.ps1`
 
@@ -39,15 +40,16 @@ The runner executes:
 - `dotnet build InventoryManagementApp.sln --configuration Release --no-restore`
 - `dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal`
 - `dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64`
+- clean existing `publish/` output
 - `dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish`
 - `scripts/check-banned-words.sh`
 - `BANNED_WORD_CHECK_FORCE_POWERSHELL=1 scripts/check-banned-words.sh`
 
-Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the runtime-specific publish restore creates the `win-x64` assets used by the no-restore publish step, that the banned-word script passes its normal `rg` path plus both PowerShell fallback command paths (`powershell.exe` and `pwsh`, where available), that both banned-word scan paths skip generated `bin`, `obj`, and `publish` folders, that the forced fallback mode works while `rg` is present, that the PowerShell fallback scans source/text files without scanning binary assets, and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
+Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the runtime-specific publish restore creates the `win-x64` assets used by the no-restore publish step, that stale files are removed from `publish/` before fresh artifacts are produced, that the banned-word script passes its normal `rg` path plus both PowerShell fallback command paths (`powershell.exe` and `pwsh`, where available), that both banned-word scan paths skip generated `bin`, `obj`, and `publish` folders, that the forced fallback mode works while `rg` is present, that the PowerShell fallback scans source/text files without scanning binary assets, and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
 
 ## Immediate Cleanup Queue
 
-1. Re-run full validation with `pwsh -File scripts/run-full-validation.ps1` after the source-contract cleanup, dependency pins, and publish-output scan exclusion.
+1. Re-run full validation with `pwsh -File scripts/run-full-validation.ps1` after the source-contract cleanup, dependency pins, publish-output scan exclusion, and publish-output cleanup.
 2. Confirm the retargeted GitHub Actions Build and Test workflow runs on the next `master`/`main` pull request with the net10 SDK and both banned-word validation paths.
 3. Review any NU190x warnings surfaced by repository-level direct/transitive NuGet auditing and either update affected packages or document intentional risk decisions.
 4. Smoke test the dark-theme top navigation dropdown visually in the running WPF app.

--- a/scripts/run-full-validation.ps1
+++ b/scripts/run-full-validation.ps1
@@ -25,6 +25,7 @@ function Invoke-ValidationStep {
 }
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$publishOutputPath = Join-Path $repoRoot "publish"
 Push-Location $repoRoot
 
 try {
@@ -43,6 +44,12 @@ try {
     if (-not $SkipPublish) {
         Invoke-ValidationStep "Restore publish runtime" {
             dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime $Runtime
+        }
+
+        Invoke-ValidationStep "Clean publish output" {
+            if (Test-Path $publishOutputPath) {
+                Remove-Item $publishOutputPath -Recurse -Force
+            }
         }
 
         Invoke-ValidationStep "Publish app" {


### PR DESCRIPTION
## Summary

- Clean the existing `publish/` output folder before `scripts/run-full-validation.ps1` runs the release publish step.
- Add source-contract coverage that keeps the cleanup step before `dotnet publish`.
- Update validation tracking and add a progress note for the next Windows/.NET-capable validation pass.

## Why

The validation runner now publishes before running banned-word checks, and the scanner intentionally excludes generated `publish/` output. Cleaning stale publish output first keeps validation tied to freshly produced artifacts instead of whatever was left from a previous run.

## Validation

- GitHub connector readback confirmed the changed runner, test, and validation notes on branch `codex/clean-validation-publish-output`.
- GitHub connector compare reports a focused 4-file diff against `master` and the branch is not behind `master`.
- Local clone/raw access is blocked in this environment with `CONNECT tunnel failed, response 403`.
- `dotnet`, `gh`, PowerShell, local banned-word checks, WPF runtime/screenshots, and full restore/build/test/publish validation were not available in this environment.