### PR TITLE
Add dependency audit step to full validation runner

### DIFF
--- a/InventoryManagementApp.Tests/DependencyContractTests.cs
+++ b/InventoryManagementApp.Tests/DependencyContractTests.cs
@@ -57,6 +57,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("[string]$Runtime = \"win-x64\"", source);
             Assert.Contains("[switch]$SkipPublish", source);
             Assert.Contains("dotnet restore InventoryManagementApp.sln", source);
+            Assert.Contains("dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive", source);
             Assert.Contains("dotnet build InventoryManagementApp.sln --configuration $Configuration --no-restore", source);
             Assert.Contains("dotnet test InventoryManagementApp.sln --configuration $Configuration --no-build --verbosity normal", source);
             Assert.Contains("dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime $Runtime", source);

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Manual equivalent:
 
 ```powershell
 dotnet restore InventoryManagementApp.sln
+dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive
 dotnet build InventoryManagementApp.sln --configuration Release --no-restore
 dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal
 dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64

--- a/ToDo.md
+++ b/ToDo.md
@@ -25,18 +25,20 @@ Last updated: 2026-06-25.
 - A 2026-06-24 validation readiness pass added `scripts/run-full-validation.ps1` to run the current restore, build, test, publish, normal banned-word, and forced PowerShell fallback checks from one Windows/.NET-capable checkout.
 - A 2026-06-25 validation hardening pass excluded generated `publish/` output from both banned-word scan paths so the full validation runner can publish before running banned-word checks without scanning publish artifacts.
 - A 2026-06-25 validation runner hardening pass cleans the `publish/` output folder before publishing so full validation reports only freshly produced artifacts.
+- A 2026-06-25 validation runner visibility pass adds an explicit `dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive` audit step after restore so dependency advisory review has a dedicated log section.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 
 ## Validation Needed Next
 
-The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, CI publish restore repair, generated-folder exclusion alignment, forced PowerShell fallback CI validation, PowerShell text-file scan narrowing, the checked-in validation runner, generated `publish/` output exclusion, and publish-output cleanup:
+The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, CI publish restore repair, generated-folder exclusion alignment, forced PowerShell fallback CI validation, PowerShell text-file scan narrowing, the checked-in validation runner, generated `publish/` output exclusion, publish-output cleanup, and the explicit dependency-audit runner step:
 
 - `pwsh -File scripts/run-full-validation.ps1`
 
 The runner executes:
 
 - `dotnet restore InventoryManagementApp.sln`
+- `dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive`
 - `dotnet build InventoryManagementApp.sln --configuration Release --no-restore`
 - `dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal`
 - `dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64`
@@ -45,13 +47,13 @@ The runner executes:
 - `scripts/check-banned-words.sh`
 - `BANNED_WORD_CHECK_FORCE_POWERSHELL=1 scripts/check-banned-words.sh`
 
-Confirm during restore that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the runtime-specific publish restore creates the `win-x64` assets used by the no-restore publish step, that stale files are removed from `publish/` before fresh artifacts are produced, that the banned-word script passes its normal `rg` path plus both PowerShell fallback command paths (`powershell.exe` and `pwsh`, where available), that both banned-word scan paths skip generated `bin`, `obj`, and `publish` folders, that the forced fallback mode works while `rg` is present, that the PowerShell fallback scans source/text files without scanning binary assets, and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
+Confirm during restore and dependency audit that the SQLite advisory is gone, that `SQLitePCLRaw.bundle_e_sqlite3` resolves through `SourceGear.sqlite3` 3.50.4.5 or newer, that the Microsoft.Extensions 10.0.9 pins restore without downgrade/conflict warnings, that the updated xUnit/VSTest packages discover and run the net10 test project cleanly, that direct test-only package references remain private assets, that repository-level NuGet auditing reports direct and transitive vulnerabilities through NU190x warnings, that the explicit vulnerable-package audit prints any remaining direct/transitive advisories in its own section, that the runtime-specific publish restore creates the `win-x64` assets used by the no-restore publish step, that stale files are removed from `publish/` before fresh artifacts are produced, that the banned-word script passes its normal `rg` path plus both PowerShell fallback command paths (`powershell.exe` and `pwsh`, where available), that both banned-word scan paths skip generated `bin`, `obj`, and `publish` folders, that the forced fallback mode works while `rg` is present, that the PowerShell fallback scans source/text files without scanning binary assets, and that GitHub Actions now runs the Windows net10 Build and Test workflow for `master`/`main` pushes and pull requests. If tests still fail, prefer behavior-focused tests or smaller targeted source-contract checks over exact multi-line source snippets.
 
 ## Immediate Cleanup Queue
 
-1. Re-run full validation with `pwsh -File scripts/run-full-validation.ps1` after the source-contract cleanup, dependency pins, publish-output scan exclusion, and publish-output cleanup.
+1. Re-run full validation with `pwsh -File scripts/run-full-validation.ps1` after the source-contract cleanup, dependency pins, publish-output scan exclusion, publish-output cleanup, and explicit dependency audit step.
 2. Confirm the retargeted GitHub Actions Build and Test workflow runs on the next `master`/`main` pull request with the net10 SDK and both banned-word validation paths.
-3. Review any NU190x warnings surfaced by repository-level direct/transitive NuGet auditing and either update affected packages or document intentional risk decisions.
+3. Review the runner's dedicated vulnerable-package audit output plus any NU190x warnings surfaced by repository-level direct/transitive NuGet auditing, then update affected packages or document intentional risk decisions.
 4. Smoke test the dark-theme top navigation dropdown visually in the running WPF app.
 5. Confirm the SQLite native package advisory is cleared during restore and continue the broader production dependency/security review.
 6. Continue replacing brittle source-text tests with behavior-focused tests where practical.

--- a/scripts/run-full-validation.ps1
+++ b/scripts/run-full-validation.ps1
@@ -33,6 +33,10 @@ try {
         dotnet restore InventoryManagementApp.sln
     }
 
+    Invoke-ValidationStep "Audit vulnerable packages" {
+        dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive
+    }
+
     Invoke-ValidationStep "Build solution" {
         dotnet build InventoryManagementApp.sln --configuration $Configuration --no-restore
     }


### PR DESCRIPTION
## Summary

- Add an explicit `dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive` step to `scripts/run-full-validation.ps1` immediately after restore.
- Extend dependency-contract coverage so the full validation runner keeps the dedicated vulnerable-package audit step.
- Update README and ToDo validation guidance so dependency advisory review is a first-class validation checkpoint.

## Why

The repository already enables transitive NuGet auditing during restore, but the current cleanup queue asks for explicit dependency advisory review. A dedicated runner step gives that review its own log section, making direct/transitive advisories easier to spot during the next Windows/.NET-capable validation pass.

## Validation

- GitHub connector compare confirmed a focused 4-file diff against `master`, with the branch 4 commits ahead and 0 behind.
- Read back `scripts/run-full-validation.ps1`, `InventoryManagementApp.Tests/DependencyContractTests.cs`, and `ToDo.md` from the branch through the GitHub connector.
- Local clone/raw access is blocked in this environment with `CONNECT tunnel failed, response 403`.
- `dotnet`, `gh`, PowerShell, local banned-word checks, WPF runtime/screenshots, and full restore/build/test/publish validation were not available in this environment.