### PR TITLE
[codex] Document manual publish cleanup validation

### DIFF
--- a/InventoryManagementApp.Tests/ValidationDocumentationContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationDocumentationContractTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ValidationDocumentationContractTests
+    {
+        [Fact]
+        public void ReadmeManualValidationCleansPublishOutputBeforePublishing()
+        {
+            var source = ReadRepoFile("README.md");
+            const string cleanPublishCommand = "if (Test-Path ./publish) { Remove-Item ./publish -Recurse -Force }";
+            const string publishCommand = "dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish";
+
+            Assert.Contains("Manual equivalent:", source);
+            Assert.Contains(cleanPublishCommand, source);
+            Assert.Contains(publishCommand, source);
+
+            var cleanIndex = source.IndexOf(cleanPublishCommand, StringComparison.Ordinal);
+            var publishIndex = source.IndexOf(publishCommand, StringComparison.Ordinal);
+
+            Assert.True(cleanIndex >= 0, "The README manual validation sequence should document publish-output cleanup.");
+            Assert.True(publishIndex >= 0, "The README manual validation sequence should document the publish command.");
+            Assert.True(cleanIndex < publishIndex, "The README manual validation sequence should clean stale publish output before publishing fresh artifacts.");
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-readme-manual-publish-cleanup.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-readme-manual-publish-cleanup.md
@@ -1,0 +1,14 @@
+# README Manual Publish Cleanup
+
+Date: 2026-06-25
+
+## Completed
+
+- Updated the README manual validation sequence so it mirrors the full validation runner and CI publish flow by cleaning `publish/` before `dotnet publish` creates fresh artifacts.
+- Added `ValidationDocumentationContractTests.ReadmeManualValidationCleansPublishOutputBeforePublishing` so the documentation keeps the cleanup command ordered before the manual publish command.
+
+## Validation Notes
+
+- Local clone/raw access remains blocked in the scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, `gh`, PowerShell, WPF runtime/screenshots, local banned-word checks, and the checked-in full validation runner are unavailable here.
+- Use GitHub connector readback/compare as the fallback review path for this focused documentation/source-contract change.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive
 dotnet build InventoryManagementApp.sln --configuration Release --no-restore
 dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal
 dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64
+if (Test-Path ./publish) { Remove-Item ./publish -Recurse -Force }
 dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish
 bash scripts/check-banned-words.sh
 $env:BANNED_WORD_CHECK_FORCE_POWERSHELL = "1"; bash scripts/check-banned-words.sh; Remove-Item Env:BANNED_WORD_CHECK_FORCE_POWERSHELL

--- a/ToDo.md
+++ b/ToDo.md
@@ -28,12 +28,13 @@ Last updated: 2026-06-25.
 - A 2026-06-25 validation runner visibility pass adds an explicit `dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive` audit step after restore so dependency advisory review has a dedicated log section.
 - A 2026-06-25 CI validation visibility pass adds the same explicit vulnerable-package audit step to the Windows Build and Test workflow immediately after restore, with dependency-contract coverage so CI and the local runner stay aligned.
 - A 2026-06-25 CI publish hardening pass cleans `publish/` before the workflow publishes artifacts, matching the local full validation runner's stale-output protection and guarding the ordering with source-contract coverage.
+- A 2026-06-25 documentation contract pass aligned the README manual validation sequence with the runner and CI by documenting the `publish/` cleanup before manual `dotnet publish`, with source-contract coverage for the command ordering.
 - Focused navigation menu tests pass after the dark-theme dropdown hover fix.
 - Banned-word script passes after line-ending cleanup, seeded CSV exclusions, and replacing the remaining standalone hits.
 
 ## Validation Needed Next
 
-The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, CI publish restore repair, generated-folder exclusion alignment, forced PowerShell fallback CI validation, PowerShell text-file scan narrowing, the checked-in validation runner, generated `publish/` output exclusion, publish-output cleanup, the explicit dependency-audit runner step, the matching CI vulnerable-package audit step, and CI publish-output cleanup:
+The current priority is to rerun full validation after the 2026-06-24 contract-test cleanup, SQLite native package pin, Microsoft.Extensions net10 package alignment, net10 test infrastructure alignment, xUnit runner asset isolation, private test-only package metadata, repository-level NuGet audit guard, Build and Test workflow retargeting, banned-word fallback repair, CI publish restore repair, generated-folder exclusion alignment, forced PowerShell fallback CI validation, PowerShell text-file scan narrowing, the checked-in validation runner, generated `publish/` output exclusion, publish-output cleanup, the explicit dependency-audit runner step, the matching CI vulnerable-package audit step, CI publish-output cleanup, and README manual validation cleanup documentation:
 
 - `pwsh -File scripts/run-full-validation.ps1`
 
@@ -53,7 +54,7 @@ Confirm during restore and dependency audit that the SQLite advisory is gone, th
 
 ## Immediate Cleanup Queue
 
-1. Re-run full validation with `pwsh -File scripts/run-full-validation.ps1` after the source-contract cleanup, dependency pins, publish-output scan exclusion, publish-output cleanup, explicit dependency audit step, matching CI audit step, and CI publish cleanup.
+1. Re-run full validation with `pwsh -File scripts/run-full-validation.ps1` after the source-contract cleanup, dependency pins, publish-output scan exclusion, publish-output cleanup, explicit dependency audit step, matching CI audit step, CI publish cleanup, and README manual validation cleanup documentation.
 2. Confirm the retargeted GitHub Actions Build and Test workflow runs on the next `master`/`main` pull request with the net10 SDK, dedicated vulnerable-package audit, both banned-word validation paths, and clean publish output before artifact generation.
 3. Review the runner's dedicated vulnerable-package audit output plus any NU190x warnings surfaced by repository-level direct/transitive NuGet auditing, then update affected packages or document intentional risk decisions.
 4. Smoke test the dark-theme top navigation dropdown visually in the running WPF app.


### PR DESCRIPTION
## Summary

- Updated the README manual validation sequence so it cleans `publish/` before manual `dotnet publish`, matching the checked-in full validation runner and Windows Build and Test workflow.
- Added a README source-contract test that guards the cleanup command and its ordering before publish.
- Recorded the completed validation-doc cleanup in `ToDo.md` and a progress note.

## Why This Matters

The validation runner and CI were recently hardened to remove stale publish artifacts before producing fresh output, but the README's manual equivalent still skipped that cleanup command. This keeps developer-facing validation instructions aligned with the current release-validation path.

## Validation

- GitHub connector compare/readback confirmed the intended four-file diff on `codex/document-manual-publish-cleanup`.
- Local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, `gh`, PowerShell, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.