### PR TITLE
Guard validation dependency audit ordering

### DIFF
--- a/InventoryManagementApp.Tests/ValidationDocumentationContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationDocumentationContractTests.cs
@@ -7,6 +7,22 @@ namespace InventoryManagementApp.Tests
     public class ValidationDocumentationContractTests
     {
         [Fact]
+        public void ReadmeManualValidationAuditsVulnerablePackagesAfterRestoreBeforeBuild()
+        {
+            var source = ReadRepoFile("README.md");
+            const string restoreCommand = "dotnet restore InventoryManagementApp.sln";
+            const string auditCommand = "dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive";
+            const string buildCommand = "dotnet build InventoryManagementApp.sln --configuration Release --no-restore";
+
+            Assert.Contains("Manual equivalent:", source);
+            Assert.Contains(restoreCommand, source);
+            Assert.Contains(auditCommand, source);
+            Assert.Contains(buildCommand, source);
+            AssertAppearsBefore(source, restoreCommand, auditCommand, "The README manual validation sequence should audit packages after restore.");
+            AssertAppearsBefore(source, auditCommand, buildCommand, "The README manual validation sequence should audit packages before the no-restore build.");
+        }
+
+        [Fact]
         public void ReadmeManualValidationCleansPublishOutputBeforePublishing()
         {
             var source = ReadRepoFile("README.md");
@@ -23,6 +39,16 @@ namespace InventoryManagementApp.Tests
             Assert.True(cleanIndex >= 0, "The README manual validation sequence should document publish-output cleanup.");
             Assert.True(publishIndex >= 0, "The README manual validation sequence should document the publish command.");
             Assert.True(cleanIndex < publishIndex, "The README manual validation sequence should clean stale publish output before publishing fresh artifacts.");
+        }
+
+        private static void AssertAppearsBefore(string source, string first, string second, string because)
+        {
+            var firstIndex = source.IndexOf(first, StringComparison.Ordinal);
+            var secondIndex = source.IndexOf(second, StringComparison.Ordinal);
+
+            Assert.True(firstIndex >= 0, $"Expected to find '{first}'.");
+            Assert.True(secondIndex >= 0, $"Expected to find '{second}'.");
+            Assert.True(firstIndex < secondIndex, because);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp.Tests/ValidationRunnerContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationRunnerContractTests.cs
@@ -7,6 +7,32 @@ namespace InventoryManagementApp.Tests
     public class ValidationRunnerContractTests
     {
         [Fact]
+        public void FullValidationRunnerAuditsVulnerablePackagesAfterRestoreBeforeBuild()
+        {
+            var source = ReadRepoFile("scripts", "run-full-validation.ps1");
+
+            Assert.Contains("Audit vulnerable packages", source);
+            Assert.Contains("dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive", source);
+            AssertAppearsBefore(source, "Restore solution", "Audit vulnerable packages", "The full validation runner should audit packages immediately after restore.");
+            AssertAppearsBefore(source, "Audit vulnerable packages", "Build solution", "The full validation runner should audit packages before build/test work continues.");
+            AssertAppearsBefore(source, "dotnet restore InventoryManagementApp.sln", "dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive", "The audit command should run after solution restore.");
+            AssertAppearsBefore(source, "dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive", "dotnet build InventoryManagementApp.sln --configuration $Configuration --no-restore", "The audit command should run before the no-restore build.");
+        }
+
+        [Fact]
+        public void BuildWorkflowAuditsVulnerablePackagesAfterRestoreBeforeValidationContinues()
+        {
+            var source = ReadRepoFile(".github", "workflows", "build.yml");
+
+            Assert.Contains("Audit vulnerable packages", source);
+            Assert.Contains("dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive", source);
+            AssertAppearsBefore(source, "Restore dependencies", "Audit vulnerable packages", "The Build and Test workflow should audit packages immediately after restore.");
+            AssertAppearsBefore(source, "Audit vulnerable packages", "Check banned words", "The Build and Test workflow should surface dependency advisories before source validation continues.");
+            AssertAppearsBefore(source, "dotnet restore InventoryManagementApp.sln", "dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive", "The workflow audit command should run after solution restore.");
+            AssertAppearsBefore(source, "dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive", "bash scripts/check-banned-words.sh", "The workflow audit command should run before later validation steps.");
+        }
+
+        [Fact]
         public void FullValidationRunnerCleansPublishOutputBeforePublishing()
         {
             var source = ReadRepoFile("scripts", "run-full-validation.ps1");
@@ -39,6 +65,16 @@ namespace InventoryManagementApp.Tests
             Assert.True(cleanIndex >= 0, "The Build and Test workflow should name the publish-output cleanup step.");
             Assert.True(publishIndex >= 0, "The Build and Test workflow should publish the app.");
             Assert.True(cleanIndex < publishIndex, "The Build and Test workflow should clean stale publish output before publishing fresh artifacts.");
+        }
+
+        private static void AssertAppearsBefore(string source, string first, string second, string because)
+        {
+            var firstIndex = source.IndexOf(first, StringComparison.Ordinal);
+            var secondIndex = source.IndexOf(second, StringComparison.Ordinal);
+
+            Assert.True(firstIndex >= 0, $"Expected to find '{first}'.");
+            Assert.True(secondIndex >= 0, $"Expected to find '{second}'.");
+            Assert.True(firstIndex < secondIndex, because);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-validation-audit-ordering-contracts.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-validation-audit-ordering-contracts.md
@@ -1,0 +1,15 @@
+# Validation Audit Ordering Contracts
+
+Date: 2026-06-25
+
+## Completed
+
+- Added source-contract coverage that keeps the full validation runner's vulnerable-package audit immediately after solution restore and before build/test validation continues.
+- Added source-contract coverage that keeps the Windows Build and Test workflow audit immediately after restore and before later validation steps.
+- Added README manual-validation coverage so the documented command sequence keeps the dependency audit between restore and the no-restore build.
+
+## Validation Notes
+
+- Local clone/raw access remains blocked in the scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, `gh`, PowerShell, WPF runtime/screenshots, local banned-word checks, and the checked-in full validation runner are unavailable here.
+- Use GitHub connector readback/compare as the fallback review path for this focused source-contract change.


### PR DESCRIPTION
## Summary

- Add source-contract coverage that keeps the full validation runner's vulnerable-package audit immediately after restore and before build/test validation continues.
- Add matching workflow coverage so the Windows Build and Test audit remains directly after restore and before later validation steps.
- Add README manual-validation coverage so documented commands keep the dependency audit between restore and the no-restore build.
- Record the completed validation-contract guard in a progress note.

## Why This Matters

Recent work added explicit vulnerable-package audit steps to the local validation runner, CI, and README manual sequence. The existing tests mostly checked that the command existed; this PR guards the intended ordering so dependency advisories surface early and the no-restore build remains tied to a freshly restored solution.

## Validation

- GitHub connector compare/readback confirmed the focused three-file diff on `codex/guard-validation-audit-ordering-current`.
- Local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, `gh`, PowerShell, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.