### PR TITLE
Guard README manual validation sequence

### DIFF
--- a/InventoryManagementApp.Tests/ValidationDocumentationContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationDocumentationContractTests.cs
@@ -41,6 +41,40 @@ namespace InventoryManagementApp.Tests
             Assert.True(cleanIndex < publishIndex, "The README manual validation sequence should clean stale publish output before publishing fresh artifacts.");
         }
 
+        [Fact]
+        public void ReadmeManualValidationDocumentsFullReleaseSequenceInRunnerOrder()
+        {
+            var source = ReadRepoFile("README.md");
+            var orderedCommands = new[]
+            {
+                "dotnet restore InventoryManagementApp.sln",
+                "dotnet list InventoryManagementApp.sln package --vulnerable --include-transitive",
+                "dotnet build InventoryManagementApp.sln --configuration Release --no-restore",
+                "dotnet test InventoryManagementApp.sln --configuration Release --no-build --verbosity normal",
+                "dotnet restore InventoryManagementApp/InventoryManagementApp.csproj --runtime win-x64",
+                "if (Test-Path ./publish) { Remove-Item ./publish -Recurse -Force }",
+                "dotnet publish InventoryManagementApp/InventoryManagementApp.csproj -c Release -r win-x64 --self-contained false --no-restore -o ./publish",
+                "bash scripts/check-banned-words.sh",
+                "$env:BANNED_WORD_CHECK_FORCE_POWERSHELL = \"1\"; bash scripts/check-banned-words.sh; Remove-Item Env:BANNED_WORD_CHECK_FORCE_POWERSHELL"
+            };
+
+            Assert.Contains("Manual equivalent:", source);
+
+            for (var index = 0; index < orderedCommands.Length; index++)
+            {
+                Assert.Contains(orderedCommands[index], source);
+
+                if (index > 0)
+                {
+                    AssertAppearsBefore(
+                        source,
+                        orderedCommands[index - 1],
+                        orderedCommands[index],
+                        "The README manual validation sequence should stay aligned with the checked-in validation runner order.");
+                }
+            }
+        }
+
         private static void AssertAppearsBefore(string source, string first, string second, string because)
         {
             var firstIndex = source.IndexOf(first, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-readme-validation-sequence-contract.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-readme-validation-sequence-contract.md
@@ -1,0 +1,15 @@
+# README Validation Sequence Contract
+
+Date: 2026-06-25
+
+## Completed
+
+- Added source-contract coverage that treats the README manual validation commands as a full release-validation sequence.
+- Guarded the documented order from solution restore through dependency audit, build, test, runtime restore, publish cleanup, publish, normal banned-word scan, and forced PowerShell fallback scan.
+- Kept the change focused on validation/documentation alignment instead of extending the Admin Settings theme system.
+
+## Validation Notes
+
+- Local clone/raw access remains blocked in the scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, `gh`, PowerShell, WPF runtime/screenshots, local banned-word checks, and the checked-in full validation runner are unavailable here.
+- GitHub connector readback/compare is the fallback review path for this focused source-contract change.


### PR DESCRIPTION
## Summary

- Add source-contract coverage that treats the README manual validation commands as a complete release-validation sequence.
- Guard the documented ordering from solution restore through dependency audit, build, test, runtime restore, publish cleanup, publish, normal banned-word scan, and forced PowerShell fallback scan.
- Record the completed validation-documentation guard in a progress note.

## Why This Matters

Recent work aligned the validation runner, CI workflow, and README around dependency audit, publish cleanup, and generated-output handling. This PR keeps the README's manual fallback from drifting out of runner order as the release-validation path continues to settle.

## Validation

- GitHub connector compare/readback confirmed the focused two-file diff on `codex/guard-readme-validation-sequence`.
- Local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, `gh`, PowerShell, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.