### PR TITLE
Clarify SkipPublish validation result message

### DIFF
--- a/InventoryManagementApp.Tests/ValidationRunnerResultMessageContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationRunnerResultMessageContractTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ValidationRunnerResultMessageContractTests
+    {
+        [Fact]
+        public void ValidationRunnerUsesDistinctResultMessagesForFullAndSkipPublishPaths()
+        {
+            var source = ReadRepoFile("scripts", "run-full-validation.ps1");
+
+            Assert.Contains("if ($SkipPublish)", source);
+            Assert.Contains("Compile-and-test validation completed successfully.", source);
+            Assert.Contains("Full validation completed successfully.", source);
+            AssertAppearsBefore(source, "if ($SkipPublish)", "Compile-and-test validation completed successfully.", "The fast validation path should identify that only compile-and-test validation ran.");
+            AssertAppearsBefore(source, "else {", "Full validation completed successfully.", "The full validation path should keep the full-validation success message.");
+        }
+
+        [Fact]
+        public void ValidationRunnerKeepsSkipPublishMessageAfterPublishBlock()
+        {
+            var source = ReadRepoFile("scripts", "run-full-validation.ps1");
+
+            AssertAppearsBefore(source, "if (-not $SkipPublish)", "if ($SkipPublish)", "The final result message should be emitted after the publish validation branch completes or is skipped.");
+            AssertAppearsBefore(source, "Check banned words PowerShell fallback", "if ($SkipPublish)", "The full validation path should finish the forced fallback scan before printing the final result message.");
+        }
+
+        private static void AssertAppearsBefore(string source, string first, string second, string because)
+        {
+            var firstIndex = source.IndexOf(first, StringComparison.Ordinal);
+            var secondIndex = source.IndexOf(second, StringComparison.Ordinal);
+
+            Assert.True(firstIndex >= 0, $"Expected to find '{first}'.");
+            Assert.True(secondIndex >= 0, $"Expected to find '{second}'.");
+            Assert.True(firstIndex < secondIndex, because);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-skip-publish-result-message.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-skip-publish-result-message.md
@@ -1,0 +1,12 @@
+# SkipPublish Result Message Clarification - 2026-06-25
+
+## Completed
+
+- Updated `scripts/run-full-validation.ps1` so `-SkipPublish` prints `Compile-and-test validation completed successfully.` after restore, dependency audit, build, and test complete.
+- Kept the normal full validation path on `Full validation completed successfully.` after publish and both banned-word scan paths complete.
+- Added source-contract coverage in `ValidationRunnerResultMessageContractTests` so the fast validation checkpoint remains clearly labeled in future validation logs.
+
+## Validation
+
+- Connector readback/compare was used because local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, `gh`, PowerShell, local banned-word checks, WPF runtime/screenshots, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.

--- a/scripts/run-full-validation.ps1
+++ b/scripts/run-full-validation.ps1
@@ -84,7 +84,12 @@ try {
     }
 
     Write-Host ""
-    Write-Host "Full validation completed successfully."
+    if ($SkipPublish) {
+        Write-Host "Compile-and-test validation completed successfully."
+    }
+    else {
+        Write-Host "Full validation completed successfully."
+    }
 }
 finally {
     Pop-Location


### PR DESCRIPTION
## Summary

- Print `Compile-and-test validation completed successfully.` when `scripts/run-full-validation.ps1 -SkipPublish` completes.
- Keep `Full validation completed successfully.` for the normal publish-and-scan validation path.
- Add source-contract coverage and a progress note so the fast validation checkpoint remains clearly labeled in validation logs.

## Why This Matters

Recent work intentionally scoped `-SkipPublish` to restore, vulnerable-package audit, build, and test only. The runner still ended with the full-validation success message, which made fast-path logs sound like publish and banned-word scans had also run. This keeps the log output aligned with the validation path that actually executed.

## Validation

- GitHub connector compare/readback confirmed the focused three-file diff on `codex/clarify-skip-publish-validation-result`.
- Local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, `gh`, PowerShell, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.