### PR TITLE
Guard Build workflow branch triggers

### DIFF
--- a/InventoryManagementApp.Tests/ValidationRunnerContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationRunnerContractTests.cs
@@ -33,6 +33,21 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void BuildWorkflowRunsOnMasterAndMainPushesAndPullRequests()
+        {
+            var source = ReadRepoFile(".github", "workflows", "build.yml");
+            var pushTrigger = ExtractIndentedBlock(source, "  push:");
+            var pullRequestTrigger = ExtractIndentedBlock(source, "  pull_request:");
+
+            Assert.Contains("branches: [ master, main ]", pushTrigger);
+            Assert.Contains("branches: [ master, main ]", pullRequestTrigger);
+            Assert.Contains("  workflow_dispatch:", source);
+            AssertAppearsBefore(source, "  push:", "jobs:", "The Build and Test workflow should keep push validation enabled before job definitions.");
+            AssertAppearsBefore(source, "  pull_request:", "jobs:", "The Build and Test workflow should keep pull-request validation enabled before job definitions.");
+            AssertAppearsBefore(source, "  workflow_dispatch:", "jobs:", "The Build and Test workflow should keep manual dispatch available before job definitions.");
+        }
+
+        [Fact]
         public void FullValidationRunnerCleansPublishOutputBeforePublishing()
         {
             var source = ReadRepoFile("scripts", "run-full-validation.ps1");
@@ -139,6 +154,18 @@ namespace InventoryManagementApp.Tests
             }
 
             throw new InvalidOperationException($"Could not find the end of the '{marker}' block.");
+        }
+
+        private static string ExtractIndentedBlock(string source, string marker)
+        {
+            var markerIndex = source.IndexOf(marker, StringComparison.Ordinal);
+            Assert.True(markerIndex >= 0, $"Expected to find '{marker}'.");
+
+            var nextPeerIndex = source.IndexOf("\n  ", markerIndex + marker.Length, StringComparison.Ordinal);
+            if (nextPeerIndex < 0)
+                nextPeerIndex = source.Length;
+
+            return source.Substring(markerIndex, nextPeerIndex - markerIndex);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp.Tests/ValidationRunnerContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationRunnerContractTests.cs
@@ -35,12 +35,10 @@ namespace InventoryManagementApp.Tests
         [Fact]
         public void BuildWorkflowRunsOnMasterAndMainPushesAndPullRequests()
         {
-            var source = ReadRepoFile(".github", "workflows", "build.yml");
-            var pushTrigger = ExtractIndentedBlock(source, "  push:");
-            var pullRequestTrigger = ExtractIndentedBlock(source, "  pull_request:");
+            var source = ReadRepoFile(".github", "workflows", "build.yml").Replace("\r\n", "\n");
 
-            Assert.Contains("branches: [ master, main ]", pushTrigger);
-            Assert.Contains("branches: [ master, main ]", pullRequestTrigger);
+            Assert.Contains("  push:\n    branches: [ master, main ]", source);
+            Assert.Contains("  pull_request:\n    branches: [ master, main ]", source);
             Assert.Contains("  workflow_dispatch:", source);
             AssertAppearsBefore(source, "  push:", "jobs:", "The Build and Test workflow should keep push validation enabled before job definitions.");
             AssertAppearsBefore(source, "  pull_request:", "jobs:", "The Build and Test workflow should keep pull-request validation enabled before job definitions.");
@@ -154,18 +152,6 @@ namespace InventoryManagementApp.Tests
             }
 
             throw new InvalidOperationException($"Could not find the end of the '{marker}' block.");
-        }
-
-        private static string ExtractIndentedBlock(string source, string marker)
-        {
-            var markerIndex = source.IndexOf(marker, StringComparison.Ordinal);
-            Assert.True(markerIndex >= 0, $"Expected to find '{marker}'.");
-
-            var nextPeerIndex = source.IndexOf("\n  ", markerIndex + marker.Length, StringComparison.Ordinal);
-            if (nextPeerIndex < 0)
-                nextPeerIndex = source.Length;
-
-            return source.Substring(markerIndex, nextPeerIndex - markerIndex);
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-build-workflow-trigger-contract.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-build-workflow-trigger-contract.md
@@ -1,0 +1,14 @@
+# Build Workflow Trigger Contract
+
+Date: 2026-06-25
+
+## Completed
+
+- Added source-contract coverage that keeps the Build and Test workflow enabled for both `push` and `pull_request` validation on `master` and `main`.
+- Kept the existing manual `workflow_dispatch` trigger guarded so the workflow can still be launched from GitHub after validation maintenance changes.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, `gh`, PowerShell, WPF runtime/screenshots, local banned-word checks, and the checked-in validation runner are unavailable here.
+- GitHub connector branch readback/compare was used as fallback validation.


### PR DESCRIPTION
## Summary

- Add source-contract coverage that keeps the Build and Test workflow active for both `push` and `pull_request` events on `master` and `main`.
- Keep the manual `workflow_dispatch` trigger covered so validation can still be launched directly from GitHub.
- Record the validation-trigger contract progress note.

## Why This Matters

The recent validation work re-enabled and hardened the Windows Build and Test workflow, but existing source-contract coverage only checked that the `master/main` branch list appeared somewhere in the workflow. This makes the trigger contract explicit so future workflow edits cannot silently drop pull-request or push validation for the active branch names.

## Validation

- GitHub connector compare/readback confirmed the focused two-file diff on `codex/guard-build-workflow-triggers`.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, `gh`, PowerShell, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.