### PR TITLE
Strengthen validation result message contract

### DIFF
--- a/InventoryManagementApp.Tests/ValidationRunnerResultMessageContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationRunnerResultMessageContractTests.cs
@@ -27,6 +27,27 @@ namespace InventoryManagementApp.Tests
             AssertAppearsBefore(source, "Check banned words PowerShell fallback", "if ($SkipPublish)", "The full validation path should finish the forced fallback scan before printing the final result message.");
         }
 
+        [Fact]
+        public void ValidationRunnerEmitsResultMessagesOutsidePublishOnlyBranch()
+        {
+            var source = ReadRepoFile("scripts", "run-full-validation.ps1");
+            var publishValidationBlock = ExtractBracedBlock(source, "if (-not $SkipPublish)");
+
+            Assert.DoesNotContain("Compile-and-test validation completed successfully.", publishValidationBlock);
+            Assert.DoesNotContain("Full validation completed successfully.", publishValidationBlock);
+            AssertAppearsBefore(source, "if (-not $SkipPublish)", "if ($SkipPublish)", "Both validation paths should share the final result-message branch after release-only checks finish.");
+        }
+
+        [Fact]
+        public void SkipPublishResultMessageDoesNotClaimFullReleaseValidation()
+        {
+            var source = ReadRepoFile("scripts", "run-full-validation.ps1");
+            var resultMessageBlock = ExtractBracedBlock(source, "if ($SkipPublish)");
+
+            Assert.Contains("Compile-and-test validation completed successfully.", resultMessageBlock);
+            Assert.DoesNotContain("Full validation completed successfully.", resultMessageBlock);
+        }
+
         private static void AssertAppearsBefore(string source, string first, string second, string because)
         {
             var firstIndex = source.IndexOf(first, StringComparison.Ordinal);
@@ -35,6 +56,29 @@ namespace InventoryManagementApp.Tests
             Assert.True(firstIndex >= 0, $"Expected to find '{first}'.");
             Assert.True(secondIndex >= 0, $"Expected to find '{second}'.");
             Assert.True(firstIndex < secondIndex, because);
+        }
+
+        private static string ExtractBracedBlock(string source, string marker)
+        {
+            var markerIndex = source.IndexOf(marker, StringComparison.Ordinal);
+            Assert.True(markerIndex >= 0, $"Expected to find '{marker}'.");
+
+            var openIndex = source.IndexOf('{', markerIndex);
+            Assert.True(openIndex >= 0, $"Expected '{marker}' to start a braced block.");
+
+            var depth = 0;
+            for (var index = openIndex; index < source.Length; index++)
+            {
+                if (source[index] == '{')
+                    depth++;
+                else if (source[index] == '}')
+                    depth--;
+
+                if (depth == 0)
+                    return source.Substring(openIndex + 1, index - openIndex - 1);
+            }
+
+            throw new InvalidOperationException($"Could not find the end of the '{marker}' block.");
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-validation-result-contract-hardening.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-validation-result-contract-hardening.md
@@ -1,0 +1,12 @@
+# Validation Result Contract Hardening - 2026-06-25
+
+## Completed
+
+- Strengthened `ValidationRunnerResultMessageContractTests` so completion messages stay outside the publish-only validation branch.
+- Added coverage that keeps the `-SkipPublish` completion message scoped to compile/test validation instead of claiming full release validation.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, `gh`, PowerShell, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
+- GitHub connector file readback and PR compare are the fallback validation path for this focused source-contract change.


### PR DESCRIPTION
## Summary

- Strengthen `ValidationRunnerResultMessageContractTests` so the final completion messages stay outside the publish-only validation branch.
- Add source-contract coverage that keeps the `-SkipPublish` result message scoped to compile/test validation instead of claiming full release validation.
- Record the focused validation-contract hardening in a progress note.

## Why This Matters

Recent validation work split the full release-validation path from the faster `-SkipPublish` compile/test checkpoint. This adds a small guard against future edits accidentally moving completion messages into the release-only branch or letting the fast path sound like publish and scan checks ran.

## Validation

- GitHub connector file readback confirmed the updated test file and progress note on `codex/strengthen-validation-result-contract-current`.
- GitHub connector compare confirmed the branch is current with `master` and changes only two files.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, `gh`, PowerShell, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.