### PR TITLE
Guard README validation runner entrypoint

### DIFF
--- a/InventoryManagementApp.Tests/ValidationDocumentationContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationDocumentationContractTests.cs
@@ -24,8 +24,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains(skipPublishCommand, source);
             Assert.Contains(manualEquivalent, source);
             AssertAppearsBefore(source, currentStatusGuidance, fullRunnerCommand, "The README should present the checked-in validation runner as the current validation entrypoint.");
-            AssertAppearsBefore(source, developmentGuidance, fullRunnerCommand, "The Development section should point maintainers to the runner before listing manual commands.");
-            AssertAppearsBefore(source, fullRunnerCommand, manualEquivalent, "The manual validation sequence should remain secondary to the checked-in validation runner.");
+            AssertAppearsBeforeAfter(source, developmentGuidance, fullRunnerCommand, manualEquivalent, "The Development section should point maintainers to the runner before listing manual commands.");
             AssertAppearsBefore(source, skipPublishGuidance, skipPublishCommand, "The README should document the fast compile-and-test checkpoint with the explicit SkipPublish command.");
         }
 
@@ -105,6 +104,19 @@ namespace InventoryManagementApp.Tests
 
             Assert.True(firstIndex >= 0, $"Expected to find '{first}'.");
             Assert.True(secondIndex >= 0, $"Expected to find '{second}'.");
+            Assert.True(firstIndex < secondIndex, because);
+        }
+
+        private static void AssertAppearsBeforeAfter(string source, string anchor, string first, string second, string because)
+        {
+            var anchorIndex = source.IndexOf(anchor, StringComparison.Ordinal);
+            Assert.True(anchorIndex >= 0, $"Expected to find '{anchor}'.");
+
+            var firstIndex = source.IndexOf(first, anchorIndex, StringComparison.Ordinal);
+            var secondIndex = source.IndexOf(second, anchorIndex, StringComparison.Ordinal);
+
+            Assert.True(firstIndex >= 0, $"Expected to find '{first}' after '{anchor}'.");
+            Assert.True(secondIndex >= 0, $"Expected to find '{second}' after '{anchor}'.");
             Assert.True(firstIndex < secondIndex, because);
         }
 

--- a/InventoryManagementApp.Tests/ValidationDocumentationContractTests.cs
+++ b/InventoryManagementApp.Tests/ValidationDocumentationContractTests.cs
@@ -7,6 +7,29 @@ namespace InventoryManagementApp.Tests
     public class ValidationDocumentationContractTests
     {
         [Fact]
+        public void ReadmeDocumentsValidationRunnerAsPrimaryEntryPoint()
+        {
+            var source = ReadRepoFile("README.md");
+            const string currentStatusGuidance = "Use the checked-in validation runner for the current restore/build/test/publish/check sequence:";
+            const string developmentGuidance = "Validation commands from the repository root:";
+            const string fullRunnerCommand = "pwsh -File scripts/run-full-validation.ps1";
+            const string skipPublishCommand = "pwsh -File scripts/run-full-validation.ps1 -SkipPublish";
+            const string skipPublishGuidance = "For a faster compile-and-test pass without publishing or source scan checks:";
+            const string manualEquivalent = "Manual equivalent:";
+
+            Assert.Contains(currentStatusGuidance, source);
+            Assert.Contains(developmentGuidance, source);
+            Assert.Contains(fullRunnerCommand, source);
+            Assert.Contains(skipPublishGuidance, source);
+            Assert.Contains(skipPublishCommand, source);
+            Assert.Contains(manualEquivalent, source);
+            AssertAppearsBefore(source, currentStatusGuidance, fullRunnerCommand, "The README should present the checked-in validation runner as the current validation entrypoint.");
+            AssertAppearsBefore(source, developmentGuidance, fullRunnerCommand, "The Development section should point maintainers to the runner before listing manual commands.");
+            AssertAppearsBefore(source, fullRunnerCommand, manualEquivalent, "The manual validation sequence should remain secondary to the checked-in validation runner.");
+            AssertAppearsBefore(source, skipPublishGuidance, skipPublishCommand, "The README should document the fast compile-and-test checkpoint with the explicit SkipPublish command.");
+        }
+
+        [Fact]
         public void ReadmeManualValidationAuditsVulnerablePackagesAfterRestoreBeforeBuild()
         {
             var source = ReadRepoFile("README.md");

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-readme-validation-runner-entrypoint.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-readme-validation-runner-entrypoint.md
@@ -1,0 +1,14 @@
+# README Validation Runner Entrypoint Guard
+
+Date: 2026-06-25
+
+## Completed
+
+- Added source-contract coverage that keeps the README's checked-in validation runner as the primary validation entrypoint.
+- Guarded the fast `-SkipPublish` compile-and-test checkpoint documentation so maintainers can distinguish it from the full publish and source-scan validation path.
+- Left the manual command sequence as a secondary equivalent while preserving the existing order-focused documentation contracts.
+
+## Validation
+
+- GitHub connector readback/compare should confirm the focused documentation-contract/progress-note diff.
+- Direct local clone/raw access, `dotnet`, PowerShell, WPF screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable in the scheduled Linux container, so local test execution was not run here.


### PR DESCRIPTION
## Summary

- Add README documentation-contract coverage that keeps the checked-in full validation runner as the primary validation entrypoint.
- Guard the documented `-SkipPublish` compile-and-test checkpoint so it stays distinct from the full publish and source-scan path.
- Record the validation-documentation consolidation in a progress note.

## Why This Matters

Recent work consolidated restore, dependency audit, build, test, publish, and banned-word checks into `scripts/run-full-validation.ps1`. The README still includes a useful manual equivalent, but the runner should remain the first path maintainers reach for while validation is being stabilized. This prevents the documentation from drifting back toward a hand-maintained command list as the source of truth.

## Validation

- GitHub connector readback confirmed the updated documentation contract test and progress note on `codex/guard-readme-validation-runner-entrypoint`.
- GitHub connector compare confirmed the branch is current with `master` and changes only two files.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.