### PR TITLE
Guard dashboard selected item detail routing

### DIFF
--- a/InventoryManagementApp.Tests/DashboardSelectedItemContractTests.cs
+++ b/InventoryManagementApp.Tests/DashboardSelectedItemContractTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class DashboardSelectedItemContractTests
+    {
+        [Fact]
+        public void SelectedDashboardItemCommandsOpenItemDetailsInsteadOfManageItems()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "DashboardViewModel.cs");
+
+            Assert.Matches(BuildCommandPattern("OpenSelectedCommonItemCommand", "OpenItemDetails", "SelectedCommonlyUsedItem", "HasSelectedCommonItem"), source);
+            Assert.Matches(BuildCommandPattern("OpenSelectedCheckedOutItemCommand", "OpenItemDetails", "SelectedCheckedOutItem", "HasSelectedCheckedOutItem"), source);
+            Assert.Matches(BuildCommandPattern("OpenSelectedIncompleteItemCommand", "OpenItemDetails", "SelectedIncompleteItem", "HasSelectedIncompleteItem"), source);
+            Assert.Contains("OpenItemsCommand = new RelayCommand(OpenItemsWorkflow);", source);
+
+            Assert.DoesNotMatch(BuildCommandPattern("OpenSelectedCommonItemCommand", "OpenItemsWorkflow", "", "HasSelectedCommonItem"), source);
+            Assert.DoesNotMatch(BuildCommandPattern("OpenSelectedCheckedOutItemCommand", "OpenItemsWorkflow", "", "HasSelectedCheckedOutItem"), source);
+            Assert.DoesNotMatch(BuildCommandPattern("OpenSelectedIncompleteItemCommand", "OpenItemsWorkflow", "", "HasSelectedIncompleteItem"), source);
+        }
+
+        [Fact]
+        public void DashboardItemDetailsUsesDialogServiceWithAppFallback()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "DashboardViewModel.cs");
+            var method = ExtractMethod(source, "private void OpenItemDetails(ItemModel? item)");
+
+            Assert.Contains("if (item == null)", method);
+            Assert.Contains("_dialogService", method);
+            Assert.Contains("Host.Services.GetService<IDialogService>()", method);
+            Assert.Contains("dialogService.ShowItemDetails(item)", method);
+            Assert.Contains("Item details service is not available", method);
+        }
+
+        private static Regex BuildCommandPattern(string commandName, string actionName, string selectedProperty, string canExecuteProperty)
+        {
+            var actionPattern = string.IsNullOrEmpty(selectedProperty)
+                ? Regex.Escape(actionName)
+                : $"\\(\\)\\s*=>\\s*{Regex.Escape(actionName)}\\({Regex.Escape(selectedProperty)}\\)";
+
+            return new Regex(
+                $"{Regex.Escape(commandName)}\\s*=\\s*new\\s+RelayCommand\\(\\s*{actionPattern}\\s*,\\s*\\(\\)\\s*=>\\s*{Regex.Escape(canExecuteProperty)}\\s*\\)\\s*;",
+                RegexOptions.Singleline);
+        }
+
+        private static string ExtractMethod(string source, string signature)
+        {
+            var start = source.IndexOf(signature, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Expected to find method signature '{signature}'.");
+
+            var braceStart = source.IndexOf('{', start);
+            Assert.True(braceStart >= 0, $"Expected to find method body for '{signature}'.");
+
+            var depth = 0;
+            for (var index = braceStart; index < source.Length; index++)
+            {
+                if (source[index] == '{')
+                    depth++;
+                else if (source[index] == '}')
+                    depth--;
+
+                if (depth == 0)
+                    return source.Substring(start, index - start + 1);
+            }
+
+            throw new InvalidOperationException($"Could not extract method body for '{signature}'.");
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-dashboard-selected-item-details-contract.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-dashboard-selected-item-details-contract.md
@@ -1,0 +1,14 @@
+# Dashboard Selected Item Details Contract
+
+Date: 2026-06-25
+
+## Completed
+
+- Added source-contract coverage that keeps Dashboard selected common, checked-out, and incomplete item commands routed to item details instead of the Manage Items page.
+- Guarded the item-details dialog-service lookup, including the application-level fallback path used when Dashboard is constructed without an injected dialog service.
+- Preserved the general Dashboard `OpenItemsCommand` route for the full Manage Items workflow.
+
+## Validation
+
+- GitHub connector readback/compare should confirm the focused test/progress-note diff.
+- Direct local clone/raw access, `dotnet`, PowerShell, WPF screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable in the scheduled Linux container, so local test execution was not run here.


### PR DESCRIPTION
## Summary

- Add dashboard source-contract coverage that keeps selected common, checked-out, and incomplete item commands routed to item details instead of the Manage Items page.
- Guard the item-details dialog-service lookup and application fallback path used when Dashboard is constructed without an injected dialog service.
- Record the completed dashboard routing guard in a progress note.

## Why This Matters

A recent dashboard fix changed selected item commands so double-click/Enter style actions open the item details dialog instead of redirecting operators to Manage Items. This adds a focused contract around that behavior so a future dashboard cleanup does not accidentally restore the old page-navigation route while leaving the general Manage Items command intact.

## Validation

- GitHub connector readback confirmed the new dashboard contract test and progress note on `codex/guard-dashboard-selected-item-details`.
- GitHub connector compare confirmed the branch is current with `master` and changes only two files.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.