### PR TITLE
Add side-by-side shared release updates

### DIFF
--- a/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class SharedReleaseUpdateScriptTests
+    {
+        [Fact]
+        public void UpdateScriptSupportsSideBySideActiveUserDeployment()
+        {
+            var script = ReadRepositoryFile("scripts", "update-shared-release.ps1");
+
+            Assert.Contains("[ValidateSet(\"InPlace\", \"SideBySide\")]", script, StringComparison.Ordinal);
+            Assert.Contains("$DeploymentMode = \"InPlace\"", script, StringComparison.Ordinal);
+            Assert.Contains("$releaseRoot = Join-Path $destinationPath \"_releases\"", script, StringComparison.Ordinal);
+            Assert.Contains("$currentReleaseMarker = Join-Path $destinationPath \"current-release.txt\"", script, StringComparison.Ordinal);
+            Assert.Contains("Set-Content -LiteralPath $currentReleaseMarker -Value $ReleaseName", script, StringComparison.Ordinal);
+            Assert.Contains("rerun with -DeploymentMode SideBySide", script, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DeploymentGuideDocumentsActiveUserUpdateFlowAndMigrationLimitation()
+        {
+            var guide = ReadRepositoryFile("SERVER_DEPLOYMENT_GUIDE.md");
+
+            Assert.Contains("## Updating While Users Are Active", guide, StringComparison.Ordinal);
+            Assert.Contains("-DeploymentMode SideBySide", guide, StringComparison.Ordinal);
+            Assert.Contains("current-release.txt", guide, StringComparison.Ordinal);
+            Assert.Contains("database migration", guide, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var baseDirectory = AppContext.BaseDirectory;
+            var repositoryRoot = Path.GetFullPath(Path.Combine(baseDirectory, "..", "..", "..", ".."));
+            return File.ReadAllText(Path.Combine(new[] { repositoryRoot }.Concat(relativePathParts).ToArray()));
+        }
+    }
+}

--- a/SERVER_DEPLOYMENT_GUIDE.md
+++ b/SERVER_DEPLOYMENT_GUIDE.md
@@ -71,6 +71,32 @@ When the resolved database path is on a UNC share or mapped network drive, the a
 
 If you copy the release folder to a shared directory and run the app from more than one computer, put `inventory.db` under the shared folder and point every workstation at the same path. Do not copy separate `Data/inventory.db` files to each computer unless each workstation should have its own independent inventory.
 
+
+## Updating While Users Are Active
+
+Windows locks executable files and loaded DLLs while users are running a WPF application from a shared folder, so a traditional in-place overwrite still requires everyone to close InventoryManagementApp first. To make updates possible during the workday, publish each build side-by-side and move new launches to the new release while existing users finish in the old copy.
+
+Recommended active-user update flow:
+
+1. Publish the new build to a clean local folder such as `publish-clean`.
+2. Stage the build without touching files active users already have loaded:
+
+   ```powershell
+   ./scripts/update-shared-release.ps1 -Source ./publish-clean -Destination X:\V2 -DeploymentMode SideBySide -ReleaseName 2026.06.25-1
+   ```
+
+3. Point the shared shortcut, launcher script, or deployment utility at `X:\V2\_releases\2026.06.25-1\InventoryManagementApp.exe`. The script also writes `X:\V2\current-release.txt` so a launcher can read the active release name.
+4. Ask users to restart the app when convenient. Users already running the previous release can continue current rentals/check-ins because the SQLite database and preserved asset folders remain shared.
+5. After confirming nobody is running the older release folder, archive or delete old folders under `_releases`.
+
+Use the default in-place mode only for maintenance windows when all users are closed:
+
+```powershell
+./scripts/update-shared-release.ps1 -Source ./publish-clean -Destination X:\V2
+```
+
+Side-by-side deployment avoids replacing locked application binaries, but it does not make database schema changes magically compatible with old clients. If a release includes a database migration that older app versions cannot safely use, schedule a normal maintenance window and have everyone close the app before launching the new release.
+
 ## Avoid Duplicate Reminder Emails
 
 Each running application instance can start its own reminder service when SMTP is configured. In a multi-user deployment, configure exactly one always-on instance with real SMTP settings.

--- a/scripts/update-shared-release.ps1
+++ b/scripts/update-shared-release.ps1
@@ -1,6 +1,9 @@
 param(
     [string]$Source = (Join-Path $PSScriptRoot "..\publish-clean"),
-    [string]$Destination = "X:\V2"
+    [string]$Destination = "X:\V2",
+    [ValidateSet("InPlace", "SideBySide")]
+    [string]$DeploymentMode = "InPlace",
+    [string]$ReleaseName = (Get-Date -Format "yyyyMMdd-HHmmss")
 )
 
 $ErrorActionPreference = "Stop"
@@ -21,6 +24,8 @@ $themesPath = Join-Path $destinationPath "Assets\Themes"
 $logsPath = Join-Path $destinationPath "Logs"
 $backupRoot = Join-Path $destinationPath "_pre_update_backups"
 $backupPath = Join-Path $backupRoot (Get-Date -Format "yyyyMMdd-HHmmss")
+$releaseRoot = Join-Path $destinationPath "_releases"
+$currentReleaseMarker = Join-Path $destinationPath "current-release.txt"
 $excludedDirectories = @(
     "Assets",
     "Assets\Data",
@@ -32,27 +37,9 @@ $excludedDirectories = @(
     "Assets\Themes",
     "Logs",
     "win-x64",
-    "_pre_update_backups"
+    "_pre_update_backups",
+    "_releases"
 )
-
-Write-Host "Updating InventoryManagementApp release"
-Write-Host "Source:      $sourcePath"
-Write-Host "Destination: $destinationPath"
-Write-Host "Preserving:  $dataPath"
-Write-Host "Preserving:  $itemImagesPath"
-Write-Host "Preserving:  $rentalPhotosPath"
-Write-Host "Preserving:  $companyLogoPath"
-Write-Host "Preserving:  $userPhotosPath"
-Write-Host "Preserving:  $backgroundsPath"
-Write-Host "Preserving:  $themesPath"
-Write-Host "Backup:      $backupPath"
-
-$running = Get-Process -Name "InventoryManagementApp" -ErrorAction SilentlyContinue
-if ($running) {
-    throw "InventoryManagementApp is still running. Close it on all computers before updating $destinationPath."
-}
-
-New-Item -ItemType Directory -Path $backupPath -Force | Out-Null
 $preservedPaths = @(
     "appsettings.json",
     "Assets\Data",
@@ -65,41 +52,103 @@ $preservedPaths = @(
     "Logs"
 )
 
-foreach ($relativePath in $preservedPaths) {
-    $sourceItem = Join-Path $destinationPath $relativePath
-    if (Test-Path -LiteralPath $sourceItem) {
-        $targetItem = Join-Path $backupPath $relativePath
-        $targetParent = Split-Path -Parent $targetItem
-        New-Item -ItemType Directory -Path $targetParent -Force | Out-Null
-        Copy-Item -LiteralPath $sourceItem -Destination $targetItem -Recurse -Force
+function Invoke-ReleaseMirror {
+    param(
+        [Parameter(Mandatory = $true)][string]$From,
+        [Parameter(Mandatory = $true)][string]$To,
+        [string[]]$ExcludedDirectories = @(),
+        [string[]]$ExcludedFiles = @()
+    )
+
+    $robocopyArgs = @($From, $To, "/MIR")
+
+    if ($ExcludedDirectories.Count -gt 0) {
+        $robocopyArgs += "/XD"
+        foreach ($relativePath in $ExcludedDirectories) {
+            $robocopyArgs += $relativePath
+            $robocopyArgs += Join-Path $From $relativePath
+            $robocopyArgs += Join-Path $To $relativePath
+        }
+    }
+
+    if ($ExcludedFiles.Count -gt 0) {
+        $robocopyArgs += "/XF"
+        $robocopyArgs += $ExcludedFiles
+    }
+
+    $robocopyArgs += @( "/R:2", "/W:2", "/NP" )
+
+    & robocopy @robocopyArgs
+    $exitCode = $LASTEXITCODE
+
+    if ($exitCode -ge 8) {
+        throw "Robocopy failed with exit code $exitCode."
     }
 }
 
-$robocopyArgs = @(
-    $sourcePath,
-    $destinationPath,
-    "/MIR",
-    "/XD"
-)
+function Backup-PreservedPaths {
+    New-Item -ItemType Directory -Path $backupPath -Force | Out-Null
 
-foreach ($relativePath in $excludedDirectories) {
-    $robocopyArgs += $relativePath
-    $robocopyArgs += Join-Path $sourcePath $relativePath
-    $robocopyArgs += Join-Path $destinationPath $relativePath
+    foreach ($relativePath in $preservedPaths) {
+        $sourceItem = Join-Path $destinationPath $relativePath
+        if (Test-Path -LiteralPath $sourceItem) {
+            $targetItem = Join-Path $backupPath $relativePath
+            $targetParent = Split-Path -Parent $targetItem
+            New-Item -ItemType Directory -Path $targetParent -Force | Out-Null
+            Copy-Item -LiteralPath $sourceItem -Destination $targetItem -Recurse -Force
+        }
+    }
 }
 
-$robocopyArgs += @(
-    "/XF", "appsettings.json",
-    "/R:2",
-    "/W:2",
-    "/NP"
-)
+Write-Host "Updating InventoryManagementApp release"
+Write-Host "Source:      $sourcePath"
+Write-Host "Destination: $destinationPath"
+Write-Host "Mode:        $DeploymentMode"
+Write-Host "Preserving:  $dataPath"
+Write-Host "Preserving:  $itemImagesPath"
+Write-Host "Preserving:  $rentalPhotosPath"
+Write-Host "Preserving:  $companyLogoPath"
+Write-Host "Preserving:  $userPhotosPath"
+Write-Host "Preserving:  $backgroundsPath"
+Write-Host "Preserving:  $themesPath"
+Write-Host "Backup:      $backupPath"
 
-& robocopy @robocopyArgs
-$exitCode = $LASTEXITCODE
+if ($DeploymentMode -eq "SideBySide") {
+    if ([string]::IsNullOrWhiteSpace($ReleaseName) -or $ReleaseName.IndexOfAny([System.IO.Path]::GetInvalidFileNameChars()) -ge 0) {
+        throw "ReleaseName must be a non-empty folder-safe name."
+    }
 
-if ($exitCode -ge 8) {
-    throw "Robocopy failed with exit code $exitCode."
+    $releasePath = Join-Path $releaseRoot $ReleaseName
+    if (Test-Path -LiteralPath $releasePath) {
+        throw "Release '$ReleaseName' already exists at $releasePath. Choose a new ReleaseName."
+    }
+
+    Write-Host "Release path: $releasePath"
+    Backup-PreservedPaths
+    New-Item -ItemType Directory -Path $releasePath -Force | Out-Null
+    Invoke-ReleaseMirror -From $sourcePath -To $releasePath -ExcludedDirectories @("Assets", "Logs") -ExcludedFiles @("appsettings.json")
+
+    foreach ($relativePath in $preservedPaths) {
+        $sourceItem = Join-Path $destinationPath $relativePath
+        if (Test-Path -LiteralPath $sourceItem) {
+            $targetItem = Join-Path $releasePath $relativePath
+            $targetParent = Split-Path -Parent $targetItem
+            New-Item -ItemType Directory -Path $targetParent -Force | Out-Null
+            Copy-Item -LiteralPath $sourceItem -Destination $targetItem -Recurse -Force
+        }
+    }
+
+    Set-Content -LiteralPath $currentReleaseMarker -Value $ReleaseName -Encoding UTF8
+    Write-Host "Side-by-side release staged. Running users can finish in their current copy; restart shortcuts should launch _releases\$ReleaseName."
+    return
 }
+
+$running = Get-Process -Name "InventoryManagementApp" -ErrorAction SilentlyContinue
+if ($running) {
+    throw "InventoryManagementApp is still running. Close it on all computers before updating $destinationPath, or rerun with -DeploymentMode SideBySide to stage a restart-based update."
+}
+
+Backup-PreservedPaths
+Invoke-ReleaseMirror -From $sourcePath -To $destinationPath -ExcludedDirectories $excludedDirectories -ExcludedFiles @("appsettings.json")
 
 Write-Host "Release update complete."


### PR DESCRIPTION
### Motivation
- Allow updating the deployed WPF app while some users remain signed in by staging new releases side-by-side instead of forcing an immediate in-place overwrite.
- Provide a simple marker for launchers/shortcuts to point new launches to the staged release without moving or deleting the shared SQLite database and preserved asset folders.

### Description
- Extended `scripts/update-shared-release.ps1` with a `-DeploymentMode` parameter supporting `InPlace` and `SideBySide`, a `-ReleaseName` option, and `_releases` staging under the destination folder.
- Implemented side-by-side staging logic that mirrors the publish folder to `_releases\<ReleaseName>` while preserving `appsettings.json`, `Assets/Data`, item images, rental photos, themes, and `Logs`, and writes a `current-release.txt` marker for launchers.
- Kept existing in-place behavior for maintenance windows and updated the running-process error message to suggest `SideBySide` when active users prevent an immediate update.
- Added documentation in `SERVER_DEPLOYMENT_GUIDE.md` describing the active-user update flow and caveats about incompatible database migrations, and added contract tests in `InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs` to assert script and guide content.

### Testing
- Ran `git diff --check` and it passed with no whitespace errors.
- Attempted `dotnet restore`, `dotnet build`, and `dotnet test` but they could not be executed in this environment because `dotnet` is not installed.
- Ran the banned-words check `./scripts/check-banned-words.sh`, which reported legacy CSV entries as failing the banned-word scan; no new non-legacy matches were introduced by the documentation wording update.
- PowerShell parser validation could not be executed because `pwsh` is not available in this environment, and the added tests were created but not executed for the same `dotnet` limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cd02257c483248f65f5cea2da9abb)