### PR TITLE
Keep side-by-side releases on shared data folders

### DIFF
--- a/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
@@ -21,6 +21,20 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void SideBySideDeploymentLinksSharedOperationalFoldersInsteadOfForkingData()
+        {
+            var script = ReadRepositoryFile("scripts", "update-shared-release.ps1");
+
+            Assert.Contains("$sideBySideLinkedDirectories = $preservedPaths | Where-Object { $_ -ne \"appsettings.json\" }", script, StringComparison.Ordinal);
+            Assert.Contains("function Copy-ReleaseConfiguration", script, StringComparison.Ordinal);
+            Assert.Contains("function Link-PreservedDirectoryToRelease", script, StringComparison.Ordinal);
+            Assert.Contains("New-Item -ItemType Junction -Path $targetItem -Target $sourceItem", script, StringComparison.Ordinal);
+            Assert.Contains("Copy-ReleaseConfiguration -ReleasePath $releasePath", script, StringComparison.Ordinal);
+            Assert.Contains("Link-PreservedDirectoriesToRelease -ReleasePath $releasePath", script, StringComparison.Ordinal);
+            Assert.Contains("shared data folders linked from $destinationPath", script, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void DeploymentGuideDocumentsActiveUserUpdateFlowAndMigrationLimitation()
         {
             var guide = ReadRepositoryFile("SERVER_DEPLOYMENT_GUIDE.md");
@@ -29,6 +43,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("-DeploymentMode SideBySide", guide, StringComparison.Ordinal);
             Assert.Contains("current-release.txt", guide, StringComparison.Ordinal);
             Assert.Contains("database migration", guide, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("links the release-local data, photo, theme, and log folders back to the shared destination folders", guide, StringComparison.Ordinal);
         }
 
         private static string ReadRepositoryFile(params string[] relativePathParts)

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-side-by-side-shared-data-links.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-side-by-side-shared-data-links.md
@@ -1,0 +1,10 @@
+# Side-by-Side Shared Data Link Repair - 2026-06-25
+
+Completed a focused repair for the shared-release update script after the side-by-side deployment pass.
+
+- Side-by-side releases now mirror only versioned application files into `_releases/<ReleaseName>`.
+- Preserved operational directories such as `Assets\Data`, uploaded photos, themes, and `Logs` are linked back to the shared destination folder instead of being copied into each staged release.
+- The staged release still receives the preserved destination `appsettings.json`, and `current-release.txt` continues to mark the active release name for launchers.
+- Added source-contract coverage so future deployment-script edits keep the shared-folder link behavior documented and guarded.
+
+Validation note: local clone/raw access, `dotnet`, PowerShell, WPF screenshots, and local banned-word checks were unavailable in the scheduled Linux environment, so validation relied on GitHub connector readback and compare review.

--- a/SERVER_DEPLOYMENT_GUIDE.md
+++ b/SERVER_DEPLOYMENT_GUIDE.md
@@ -89,6 +89,8 @@ Recommended active-user update flow:
 4. Ask users to restart the app when convenient. Users already running the previous release can continue current rentals/check-ins because the SQLite database and preserved asset folders remain shared.
 5. After confirming nobody is running the older release folder, archive or delete old folders under `_releases`.
 
+In side-by-side mode, the script copies the preserved `appsettings.json` into the staged release and links the release-local data, photo, theme, and log folders back to the shared destination folders. That keeps versioned binaries isolated while the operational SQLite database, uploaded photos, theme files, and logs continue to use the shared location.
+
 Use the default in-place mode only for maintenance windows when all users are closed:
 
 ```powershell

--- a/scripts/update-shared-release.ps1
+++ b/scripts/update-shared-release.ps1
@@ -51,6 +51,7 @@ $preservedPaths = @(
     "Assets\Themes",
     "Logs"
 )
+$sideBySideLinkedDirectories = $preservedPaths | Where-Object { $_ -ne "appsettings.json" }
 
 function Invoke-ReleaseMirror {
     param(
@@ -100,6 +101,45 @@ function Backup-PreservedPaths {
     }
 }
 
+function Copy-ReleaseConfiguration {
+    param(
+        [Parameter(Mandatory = $true)][string]$ReleasePath
+    )
+
+    $sourceItem = Join-Path $destinationPath "appsettings.json"
+    if (Test-Path -LiteralPath $sourceItem) {
+        $targetItem = Join-Path $ReleasePath "appsettings.json"
+        Copy-Item -LiteralPath $sourceItem -Destination $targetItem -Force
+    }
+}
+
+function Link-PreservedDirectoryToRelease {
+    param(
+        [Parameter(Mandatory = $true)][string]$ReleasePath,
+        [Parameter(Mandatory = $true)][string]$RelativePath
+    )
+
+    $sourceItem = Join-Path $destinationPath $RelativePath
+    if (-not (Test-Path -LiteralPath $sourceItem)) {
+        return
+    }
+
+    $targetItem = Join-Path $ReleasePath $RelativePath
+    $targetParent = Split-Path -Parent $targetItem
+    New-Item -ItemType Directory -Path $targetParent -Force | Out-Null
+    New-Item -ItemType Junction -Path $targetItem -Target $sourceItem | Out-Null
+}
+
+function Link-PreservedDirectoriesToRelease {
+    param(
+        [Parameter(Mandatory = $true)][string]$ReleasePath
+    )
+
+    foreach ($relativePath in $sideBySideLinkedDirectories) {
+        Link-PreservedDirectoryToRelease -ReleasePath $ReleasePath -RelativePath $relativePath
+    }
+}
+
 Write-Host "Updating InventoryManagementApp release"
 Write-Host "Source:      $sourcePath"
 Write-Host "Destination: $destinationPath"
@@ -127,19 +167,11 @@ if ($DeploymentMode -eq "SideBySide") {
     Backup-PreservedPaths
     New-Item -ItemType Directory -Path $releasePath -Force | Out-Null
     Invoke-ReleaseMirror -From $sourcePath -To $releasePath -ExcludedDirectories @("Assets", "Logs") -ExcludedFiles @("appsettings.json")
-
-    foreach ($relativePath in $preservedPaths) {
-        $sourceItem = Join-Path $destinationPath $relativePath
-        if (Test-Path -LiteralPath $sourceItem) {
-            $targetItem = Join-Path $releasePath $relativePath
-            $targetParent = Split-Path -Parent $targetItem
-            New-Item -ItemType Directory -Path $targetParent -Force | Out-Null
-            Copy-Item -LiteralPath $sourceItem -Destination $targetItem -Recurse -Force
-        }
-    }
+    Copy-ReleaseConfiguration -ReleasePath $releasePath
+    Link-PreservedDirectoriesToRelease -ReleasePath $releasePath
 
     Set-Content -LiteralPath $currentReleaseMarker -Value $ReleaseName -Encoding UTF8
-    Write-Host "Side-by-side release staged. Running users can finish in their current copy; restart shortcuts should launch _releases\$ReleaseName."
+    Write-Host "Side-by-side release staged. Running users can finish in their current copy; restart shortcuts should launch _releases\$ReleaseName with shared data folders linked from $destinationPath."
     return
 }
 


### PR DESCRIPTION
## Summary

- Fix the side-by-side shared-release updater so staged releases mirror versioned app files while linking preserved operational folders back to the shared destination.
- Copy the preserved destination `appsettings.json` into staged releases, keep `current-release.txt`, and avoid forking data/photo/theme/log folders per release.
- Add source-contract coverage and guide wording so the active-user update flow stays aligned with the shared-data behavior.

## Why This Matters

The previous side-by-side pass staged a new release by copying preserved folders into `_releases/<ReleaseName>`. That could silently split `Assets/Data/inventory.db`, uploaded photos, themes, and logs away from the shared destination when launchers moved to the staged executable. This keeps binaries side-by-side while operational state remains shared, matching the deployment guide's active-user update intent.

## Validation

- GitHub connector readback confirmed the script, test, and guide changes on `codex/fix-side-by-side-shared-data`.
- GitHub connector compare confirmed the branch is current with `master` and changes only the deployment script, deployment guide, source-contract test, and progress note.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, WPF runtime/screenshots, and local banned-word checks are unavailable here, so local build/test/script execution/full validation was not run.