### PR TITLE
Add current-release launcher for side-by-side deployments

### DIFF
--- a/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
@@ -35,6 +35,21 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void CurrentReleaseLauncherUsesMarkerAndFallsBackToInPlaceExecutable()
+        {
+            var launcher = ReadRepositoryFile("scripts", "start-current-release.ps1");
+
+            Assert.Contains("$ExecutableName = \"InventoryManagementApp.exe\"", launcher, StringComparison.Ordinal);
+            Assert.Contains("$currentReleaseMarker = Join-Path $destinationPath \"current-release.txt\"", launcher, StringComparison.Ordinal);
+            Assert.Contains("Get-Content -LiteralPath $currentReleaseMarker", launcher, StringComparison.Ordinal);
+            Assert.Contains("$releaseRoot = Join-Path $destinationPath \"_releases\"", launcher, StringComparison.Ordinal);
+            Assert.Contains("ReleaseName in current-release.txt must be a folder-safe name.", launcher, StringComparison.Ordinal);
+            Assert.Contains("$rootExecutable = Join-Path $destinationPath $ExecutableName", launcher, StringComparison.Ordinal);
+            Assert.Contains("No current-release.txt marker was found", launcher, StringComparison.Ordinal);
+            Assert.Contains("Start-Process -FilePath $executablePath", launcher, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void DeploymentGuideDocumentsActiveUserUpdateFlowAndMigrationLimitation()
         {
             var guide = ReadRepositoryFile("SERVER_DEPLOYMENT_GUIDE.md");

--- a/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
@@ -57,6 +57,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("## Updating While Users Are Active", guide, StringComparison.Ordinal);
             Assert.Contains("-DeploymentMode SideBySide", guide, StringComparison.Ordinal);
             Assert.Contains("current-release.txt", guide, StringComparison.Ordinal);
+            Assert.Contains("start-current-release.ps1", guide, StringComparison.Ordinal);
+            Assert.Contains("falls back to `X:\\V2\\InventoryManagementApp.exe`", guide, StringComparison.Ordinal);
             Assert.Contains("database migration", guide, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("links the release-local data, photo, theme, and log folders back to the shared destination folders", guide, StringComparison.Ordinal);
         }

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-current-release-launcher.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-current-release-launcher.md
@@ -1,0 +1,16 @@
+# Current Release Launcher
+
+Date: 2026-06-25
+
+## Completed
+
+- Added `scripts/start-current-release.ps1` so shared shortcuts can launch the release named by `current-release.txt` after a side-by-side deployment.
+- The launcher validates marker values, starts `_releases/<ReleaseName>/InventoryManagementApp.exe`, and falls back to the destination-root executable for in-place deployments without a marker.
+- Updated `SERVER_DEPLOYMENT_GUIDE.md` with the launcher command and fallback behavior.
+- Extended `SharedReleaseUpdateScriptTests` with source-contract coverage for the launcher and guide markers.
+
+## Validation Notes
+
+- Local clone/raw repository access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, WPF runtime/screenshots, and local banned-word checks are unavailable here, so local build/test/script execution/full validation was not run.
+- Use GitHub connector readback/compare as fallback validation for this pass, then run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.

--- a/SERVER_DEPLOYMENT_GUIDE.md
+++ b/SERVER_DEPLOYMENT_GUIDE.md
@@ -85,7 +85,13 @@ Recommended active-user update flow:
    ./scripts/update-shared-release.ps1 -Source ./publish-clean -Destination X:\V2 -DeploymentMode SideBySide -ReleaseName 2026.06.25-1
    ```
 
-3. Point the shared shortcut, launcher script, or deployment utility at `X:\V2\_releases\2026.06.25-1\InventoryManagementApp.exe`. The script also writes `X:\V2\current-release.txt` so a launcher can read the active release name.
+3. Point the shared shortcut, launcher script, or deployment utility at the current-release launcher instead of at a specific release executable:
+
+   ```powershell
+   powershell.exe -ExecutionPolicy Bypass -File .\scripts\start-current-release.ps1 -Destination X:\V2
+   ```
+
+   `start-current-release.ps1` reads `X:\V2\current-release.txt`, starts `X:\V2\_releases\<ReleaseName>\InventoryManagementApp.exe`, and falls back to `X:\V2\InventoryManagementApp.exe` when no marker exists for an in-place deployment.
 4. Ask users to restart the app when convenient. Users already running the previous release can continue current rentals/check-ins because the SQLite database and preserved asset folders remain shared.
 5. After confirming nobody is running the older release folder, archive or delete old folders under `_releases`.
 

--- a/scripts/start-current-release.ps1
+++ b/scripts/start-current-release.ps1
@@ -1,0 +1,46 @@
+param(
+    [string]$Destination = "X:\V2",
+    [string]$ExecutableName = "InventoryManagementApp.exe",
+    [string[]]$ArgumentList = @()
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $Destination)) {
+    throw "Destination '$Destination' does not exist."
+}
+
+$destinationPath = (Resolve-Path -LiteralPath $Destination).Path
+$currentReleaseMarker = Join-Path $destinationPath "current-release.txt"
+$releaseRoot = Join-Path $destinationPath "_releases"
+$rootExecutable = Join-Path $destinationPath $ExecutableName
+$releaseName = $null
+
+if (Test-Path -LiteralPath $currentReleaseMarker) {
+    $releaseName = Get-Content -LiteralPath $currentReleaseMarker -ErrorAction Stop |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        Select-Object -First 1
+}
+
+if (-not [string]::IsNullOrWhiteSpace($releaseName)) {
+    if ($releaseName.IndexOfAny([System.IO.Path]::GetInvalidFileNameChars()) -ge 0 -or $releaseName -eq "." -or $releaseName -eq "..") {
+        throw "ReleaseName in current-release.txt must be a folder-safe name."
+    }
+
+    $releasePath = Join-Path $releaseRoot $releaseName
+    $executablePath = Join-Path $releasePath $ExecutableName
+
+    if (-not (Test-Path -LiteralPath $executablePath)) {
+        throw "Current release '$releaseName' was selected by current-release.txt, but '$executablePath' was not found. Rerun scripts/update-shared-release.ps1 or update the marker."
+    }
+} else {
+    $executablePath = $rootExecutable
+
+    if (-not (Test-Path -LiteralPath $executablePath)) {
+        throw "No current-release.txt marker was found and '$executablePath' does not exist. Stage a side-by-side release or deploy an in-place executable first."
+    }
+}
+
+$workingDirectory = Split-Path -Parent $executablePath
+Write-Host "Starting $executablePath"
+Start-Process -FilePath $executablePath -WorkingDirectory $workingDirectory -ArgumentList $ArgumentList


### PR DESCRIPTION
## Summary

- Add `scripts/start-current-release.ps1` so shared shortcuts can launch the release named by `current-release.txt` after side-by-side deployment.
- Validate marker values, start `_releases/<ReleaseName>/InventoryManagementApp.exe`, and fall back to the destination-root executable for in-place deployments without a marker.
- Update the server deployment guide and source-contract coverage for the launcher and documentation markers.

## Why This Matters

The side-by-side updater now writes `current-release.txt`, and the guide tells operators a launcher can read that marker. This PR makes that path concrete so new launches move to the staged release without requiring each shortcut to be repointed at a versioned executable folder.

## Validation

- GitHub connector readback confirmed the launcher script, guide update, source-contract coverage, and progress note on `codex/add-current-release-launcher`.
- GitHub connector compare confirmed the branch is current with `master` and changes only the launcher script, deployment guide, source-contract test, and progress note.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/script execution/full validation was not run.