### PR TITLE
Install current-release launcher during shared deployments

### DIFF
--- a/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
@@ -35,6 +35,21 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void UpdateScriptInstallsCurrentReleaseLauncherIntoSharedDestination()
+        {
+            var script = ReadRepositoryFile("scripts", "update-shared-release.ps1");
+
+            Assert.Contains("$launcherSourcePath = Join-Path $PSScriptRoot \"start-current-release.ps1\"", script, StringComparison.Ordinal);
+            Assert.Contains("$launcherDestinationDirectory = Join-Path $destinationPath \"scripts\"", script, StringComparison.Ordinal);
+            Assert.Contains("$launcherDestinationPath = Join-Path $launcherDestinationDirectory \"start-current-release.ps1\"", script, StringComparison.Ordinal);
+            Assert.Contains("function Copy-CurrentReleaseLauncher", script, StringComparison.Ordinal);
+            Assert.Contains("Current release launcher was not found at $launcherSourcePath.", script, StringComparison.Ordinal);
+            Assert.Contains("Copy-Item -LiteralPath $launcherSourcePath -Destination $launcherDestinationPath -Force", script, StringComparison.Ordinal);
+            Assert.Contains("Link-PreservedDirectoriesToRelease -ReleasePath $releasePath\n    Copy-CurrentReleaseLauncher", script, StringComparison.Ordinal);
+            Assert.Contains("Invoke-ReleaseMirror -From $sourcePath -To $destinationPath -ExcludedDirectories $excludedDirectories -ExcludedFiles @(\"appsettings.json\")\nCopy-CurrentReleaseLauncher", script, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void CurrentReleaseLauncherUsesMarkerAndFallsBackToInPlaceExecutable()
         {
             var launcher = ReadRepositoryFile("scripts", "start-current-release.ps1");
@@ -58,6 +73,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("-DeploymentMode SideBySide", guide, StringComparison.Ordinal);
             Assert.Contains("current-release.txt", guide, StringComparison.Ordinal);
             Assert.Contains("start-current-release.ps1", guide, StringComparison.Ordinal);
+            Assert.Contains("refreshes the launcher at `X:\\V2\\scripts\\start-current-release.ps1`", guide, StringComparison.Ordinal);
             Assert.Contains("falls back to `X:\\V2\\InventoryManagementApp.exe`", guide, StringComparison.Ordinal);
             Assert.Contains("database migration", guide, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("links the release-local data, photo, theme, and log folders back to the shared destination folders", guide, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-deployed-current-release-launcher.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-deployed-current-release-launcher.md
@@ -1,0 +1,13 @@
+# Deployed Current-Release Launcher Fix - 2026-06-25
+
+## Completed
+
+- Updated `scripts/update-shared-release.ps1` so every shared deployment refreshes `scripts/start-current-release.ps1` into the destination folder.
+- Kept side-by-side release launches aligned with the documented shared shortcut path at `X:\V2\scripts\start-current-release.ps1`.
+- Added source-contract coverage that guards launcher installation for both side-by-side staging and in-place updates.
+- Updated `SERVER_DEPLOYMENT_GUIDE.md` so operators point shortcuts at the deployed launcher instead of a repository checkout.
+
+## Validation Notes
+
+- Local clone/raw access, `dotnet`, PowerShell/`pwsh`, WPF screenshots, local banned-word checks, and full validation are unavailable in the scheduled Linux container.
+- Validate on a Windows/.NET-capable checkout with `pwsh -File scripts/run-full-validation.ps1` and a manual side-by-side deployment smoke test.

--- a/SERVER_DEPLOYMENT_GUIDE.md
+++ b/SERVER_DEPLOYMENT_GUIDE.md
@@ -85,10 +85,11 @@ Recommended active-user update flow:
    ./scripts/update-shared-release.ps1 -Source ./publish-clean -Destination X:\V2 -DeploymentMode SideBySide -ReleaseName 2026.06.25-1
    ```
 
+   The update script also refreshes the launcher at `X:\V2\scripts\start-current-release.ps1` so shared shortcuts can target the deployed folder instead of depending on a repository checkout.
 3. Point the shared shortcut, launcher script, or deployment utility at the current-release launcher instead of at a specific release executable:
 
    ```powershell
-   powershell.exe -ExecutionPolicy Bypass -File .\scripts\start-current-release.ps1 -Destination X:\V2
+   powershell.exe -ExecutionPolicy Bypass -File X:\V2\scripts\start-current-release.ps1 -Destination X:\V2
    ```
 
    `start-current-release.ps1` reads `X:\V2\current-release.txt`, starts `X:\V2\_releases\<ReleaseName>\InventoryManagementApp.exe`, and falls back to `X:\V2\InventoryManagementApp.exe` when no marker exists for an in-place deployment.

--- a/scripts/update-shared-release.ps1
+++ b/scripts/update-shared-release.ps1
@@ -26,6 +26,9 @@ $backupRoot = Join-Path $destinationPath "_pre_update_backups"
 $backupPath = Join-Path $backupRoot (Get-Date -Format "yyyyMMdd-HHmmss")
 $releaseRoot = Join-Path $destinationPath "_releases"
 $currentReleaseMarker = Join-Path $destinationPath "current-release.txt"
+$launcherSourcePath = Join-Path $PSScriptRoot "start-current-release.ps1"
+$launcherDestinationDirectory = Join-Path $destinationPath "scripts"
+$launcherDestinationPath = Join-Path $launcherDestinationDirectory "start-current-release.ps1"
 $excludedDirectories = @(
     "Assets",
     "Assets\Data",
@@ -101,6 +104,15 @@ function Backup-PreservedPaths {
     }
 }
 
+function Copy-CurrentReleaseLauncher {
+    if (-not (Test-Path -LiteralPath $launcherSourcePath)) {
+        throw "Current release launcher was not found at $launcherSourcePath."
+    }
+
+    New-Item -ItemType Directory -Path $launcherDestinationDirectory -Force | Out-Null
+    Copy-Item -LiteralPath $launcherSourcePath -Destination $launcherDestinationPath -Force
+}
+
 function Copy-ReleaseConfiguration {
     param(
         [Parameter(Mandatory = $true)][string]$ReleasePath
@@ -169,6 +181,7 @@ if ($DeploymentMode -eq "SideBySide") {
     Invoke-ReleaseMirror -From $sourcePath -To $releasePath -ExcludedDirectories @("Assets", "Logs") -ExcludedFiles @("appsettings.json")
     Copy-ReleaseConfiguration -ReleasePath $releasePath
     Link-PreservedDirectoriesToRelease -ReleasePath $releasePath
+    Copy-CurrentReleaseLauncher
 
     Set-Content -LiteralPath $currentReleaseMarker -Value $ReleaseName -Encoding UTF8
     Write-Host "Side-by-side release staged. Running users can finish in their current copy; restart shortcuts should launch _releases\$ReleaseName with shared data folders linked from $destinationPath."
@@ -182,5 +195,6 @@ if ($running) {
 
 Backup-PreservedPaths
 Invoke-ReleaseMirror -From $sourcePath -To $destinationPath -ExcludedDirectories $excludedDirectories -ExcludedFiles @("appsettings.json")
+Copy-CurrentReleaseLauncher
 
 Write-Host "Release update complete."


### PR DESCRIPTION
## Summary

- Copy `scripts/start-current-release.ps1` into the shared destination during both side-by-side and in-place release updates.
- Keep the documented shortcut target at `X:\V2\scripts\start-current-release.ps1` available after deployment, even though publish output does not include repository scripts.
- Add source-contract coverage and update the server deployment guide for the deployed launcher path.

## Why This Matters

The current side-by-side deployment guide tells operators to point shared shortcuts at the current-release launcher, but the updater only mirrors the published app output. Without refreshing the launcher into the destination folder, a deployed `X:\V2\scripts\start-current-release.ps1` shortcut could be missing or stale. This makes the newest active-user update flow self-contained in the shared deployment folder.

## Validation

- GitHub connector readback confirmed the updater script, source-contract tests, guide update, and progress note on `codex/install-current-release-launcher`.
- GitHub connector compare confirmed the branch is current with `master` and changes only the deployment script, deployment guide, source-contract test, and progress note.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/script execution/full validation was not run.