### PR TITLE
Guard side-by-side release names for Windows deployment

### DIFF
--- a/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
@@ -21,6 +21,30 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void SideBySideDeploymentRejectsReservedWindowsReleaseNames()
+        {
+            var script = ReadRepositoryFile("scripts", "update-shared-release.ps1");
+            var launcher = ReadRepositoryFile("scripts", "start-current-release.ps1");
+            var guide = ReadRepositoryFile("SERVER_DEPLOYMENT_GUIDE.md");
+
+            Assert.Contains("$windowsReservedDeviceNames = @(", script, StringComparison.Ordinal);
+            Assert.Contains("\"CON\"", script, StringComparison.Ordinal);
+            Assert.Contains("\"NUL\"", script, StringComparison.Ordinal);
+            Assert.Contains("\"COM1\"", script, StringComparison.Ordinal);
+            Assert.Contains("\"LPT1\"", script, StringComparison.Ordinal);
+            Assert.Contains("function Test-ReleaseNameIsReservedDeviceName", script, StringComparison.Ordinal);
+            Assert.Contains("Test-ReleaseNameIsReservedDeviceName -ReleaseName $ReleaseName", script, StringComparison.Ordinal);
+            Assert.Contains("reserved Windows device name", script, StringComparison.Ordinal);
+
+            Assert.Contains("$windowsReservedDeviceNames = @(", launcher, StringComparison.Ordinal);
+            Assert.Contains("function Test-ReleaseNameIsReservedDeviceName", launcher, StringComparison.Ordinal);
+            Assert.Contains("Test-ReleaseNameIsReservedDeviceName -ReleaseName $releaseName", launcher, StringComparison.Ordinal);
+            Assert.Contains("folder-safe, non-reserved name", launcher, StringComparison.Ordinal);
+
+            Assert.Contains("Avoid Windows reserved device names such as `CON`, `NUL`, `COM1`, or `LPT1`", guide, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void SideBySideDeploymentLinksSharedOperationalFoldersInsteadOfForkingData()
         {
             var script = ReadRepositoryFile("scripts", "update-shared-release.ps1");
@@ -58,7 +82,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("$currentReleaseMarker = Join-Path $destinationPath \"current-release.txt\"", launcher, StringComparison.Ordinal);
             Assert.Contains("Get-Content -LiteralPath $currentReleaseMarker", launcher, StringComparison.Ordinal);
             Assert.Contains("$releaseRoot = Join-Path $destinationPath \"_releases\"", launcher, StringComparison.Ordinal);
-            Assert.Contains("ReleaseName in current-release.txt must be a folder-safe name.", launcher, StringComparison.Ordinal);
+            Assert.Contains("ReleaseName in current-release.txt must be a folder-safe", launcher, StringComparison.Ordinal);
             Assert.Contains("$rootExecutable = Join-Path $destinationPath $ExecutableName", launcher, StringComparison.Ordinal);
             Assert.Contains("No current-release.txt marker was found", launcher, StringComparison.Ordinal);
             Assert.Contains("Start-Process -FilePath $executablePath", launcher, StringComparison.Ordinal);

--- a/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
@@ -32,12 +32,18 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("\"NUL\"", script, StringComparison.Ordinal);
             Assert.Contains("\"COM1\"", script, StringComparison.Ordinal);
             Assert.Contains("\"LPT1\"", script, StringComparison.Ordinal);
+            Assert.Contains("$ReleaseName.EndsWith(\".\")", script, StringComparison.Ordinal);
+            Assert.Contains("$ReleaseName.EndsWith(\" \")", script, StringComparison.Ordinal);
             Assert.Contains("function Test-ReleaseNameIsReservedDeviceName", script, StringComparison.Ordinal);
+            Assert.Contains("$ReleaseName.TrimEnd([char[]]@(' ', '.'))", script, StringComparison.Ordinal);
             Assert.Contains("Test-ReleaseNameIsReservedDeviceName -ReleaseName $ReleaseName", script, StringComparison.Ordinal);
             Assert.Contains("reserved Windows device name", script, StringComparison.Ordinal);
 
             Assert.Contains("$windowsReservedDeviceNames = @(", launcher, StringComparison.Ordinal);
+            Assert.Contains("$releaseName.EndsWith(\".\")", launcher, StringComparison.Ordinal);
+            Assert.Contains("$releaseName.EndsWith(\" \")", launcher, StringComparison.Ordinal);
             Assert.Contains("function Test-ReleaseNameIsReservedDeviceName", launcher, StringComparison.Ordinal);
+            Assert.Contains("$ReleaseName.TrimEnd([char[]]@(' ', '.'))", launcher, StringComparison.Ordinal);
             Assert.Contains("Test-ReleaseNameIsReservedDeviceName -ReleaseName $releaseName", launcher, StringComparison.Ordinal);
             Assert.Contains("folder-safe, non-reserved name", launcher, StringComparison.Ordinal);
 

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-reserved-release-name-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-reserved-release-name-guard.md
@@ -1,0 +1,16 @@
+# Reserved Release Name Deployment Guard
+
+Date: 2026-06-25
+
+## Completed
+
+- Hardened `scripts/update-shared-release.ps1` so side-by-side release names reject reserved Windows device names such as `CON`, `NUL`, `COM1`, and `LPT1` before staging a release folder or writing `current-release.txt`.
+- Added the same reserved-name guard to `scripts/start-current-release.ps1` so manually edited `current-release.txt` markers fail fast instead of attempting to launch an invalid Windows path.
+- Updated `SERVER_DEPLOYMENT_GUIDE.md` with the folder-safe, non-reserved release-name requirement for active-user deployments.
+- Extended `SharedReleaseUpdateScriptTests` with source-contract coverage for the updater, launcher, and guide wording.
+
+## Validation Notes
+
+- Local clone/raw repository access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/script execution/full validation was not run.
+- Use GitHub connector readback/compare as fallback validation for this pass, then run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout.

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-reserved-release-name-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-reserved-release-name-guard.md
@@ -5,7 +5,8 @@ Date: 2026-06-25
 ## Completed
 
 - Hardened `scripts/update-shared-release.ps1` so side-by-side release names reject reserved Windows device names such as `CON`, `NUL`, `COM1`, and `LPT1` before staging a release folder or writing `current-release.txt`.
-- Added the same reserved-name guard to `scripts/start-current-release.ps1` so manually edited `current-release.txt` markers fail fast instead of attempting to launch an invalid Windows path.
+- Rejected release names ending with a dot or space, which are also unsafe Windows folder targets.
+- Added the same release-name guard to `scripts/start-current-release.ps1` so manually edited `current-release.txt` markers fail fast instead of attempting to launch an invalid Windows path.
 - Updated `SERVER_DEPLOYMENT_GUIDE.md` with the folder-safe, non-reserved release-name requirement for active-user deployments.
 - Extended `SharedReleaseUpdateScriptTests` with source-contract coverage for the updater, launcher, and guide wording.
 

--- a/SERVER_DEPLOYMENT_GUIDE.md
+++ b/SERVER_DEPLOYMENT_GUIDE.md
@@ -85,7 +85,7 @@ Recommended active-user update flow:
    ./scripts/update-shared-release.ps1 -Source ./publish-clean -Destination X:\V2 -DeploymentMode SideBySide -ReleaseName 2026.06.25-1
    ```
 
-   Use a folder-safe release name. Avoid Windows reserved device names such as `CON`, `NUL`, `COM1`, or `LPT1`, because those names are invalid deployment folder targets on Windows.
+   Use a folder-safe release name that does not end with a dot or space. Avoid Windows reserved device names such as `CON`, `NUL`, `COM1`, or `LPT1`, because those names are invalid deployment folder targets on Windows.
 
    The update script also refreshes the launcher at `X:\V2\scripts\start-current-release.ps1` so shared shortcuts can target the deployed folder instead of depending on a repository checkout.
 3. Point the shared shortcut, launcher script, or deployment utility at the current-release launcher instead of at a specific release executable:

--- a/SERVER_DEPLOYMENT_GUIDE.md
+++ b/SERVER_DEPLOYMENT_GUIDE.md
@@ -85,6 +85,8 @@ Recommended active-user update flow:
    ./scripts/update-shared-release.ps1 -Source ./publish-clean -Destination X:\V2 -DeploymentMode SideBySide -ReleaseName 2026.06.25-1
    ```
 
+   Use a folder-safe release name. Avoid Windows reserved device names such as `CON`, `NUL`, `COM1`, or `LPT1`, because those names are invalid deployment folder targets on Windows.
+
    The update script also refreshes the launcher at `X:\V2\scripts\start-current-release.ps1` so shared shortcuts can target the deployed folder instead of depending on a repository checkout.
 3. Point the shared shortcut, launcher script, or deployment utility at the current-release launcher instead of at a specific release executable:
 

--- a/scripts/start-current-release.ps1
+++ b/scripts/start-current-release.ps1
@@ -36,7 +36,8 @@ function Test-ReleaseNameIsReservedDeviceName {
         [Parameter(Mandatory = $true)][string]$ReleaseName
     )
 
-    $baseName = [System.IO.Path]::GetFileNameWithoutExtension($ReleaseName).ToUpperInvariant()
+    $normalizedReleaseName = $ReleaseName.TrimEnd([char[]]@(' ', '.'))
+    $baseName = [System.IO.Path]::GetFileNameWithoutExtension($normalizedReleaseName).ToUpperInvariant()
     return $windowsReservedDeviceNames -contains $baseName
 }
 
@@ -57,8 +58,8 @@ if (Test-Path -LiteralPath $currentReleaseMarker) {
 }
 
 if (-not [string]::IsNullOrWhiteSpace($releaseName)) {
-    if ($releaseName.IndexOfAny([System.IO.Path]::GetInvalidFileNameChars()) -ge 0 -or $releaseName -eq "." -or $releaseName -eq ".." -or (Test-ReleaseNameIsReservedDeviceName -ReleaseName $releaseName)) {
-        throw "ReleaseName in current-release.txt must be a folder-safe, non-reserved name."
+    if ($releaseName.EndsWith(".") -or $releaseName.EndsWith(" ") -or $releaseName.IndexOfAny([System.IO.Path]::GetInvalidFileNameChars()) -ge 0 -or $releaseName -eq "." -or $releaseName -eq ".." -or (Test-ReleaseNameIsReservedDeviceName -ReleaseName $releaseName)) {
+        throw "ReleaseName in current-release.txt must be a folder-safe, non-reserved name that does not end with a dot or space."
     }
 
     $releasePath = Join-Path $releaseRoot $releaseName

--- a/scripts/start-current-release.ps1
+++ b/scripts/start-current-release.ps1
@@ -6,6 +6,40 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+$windowsReservedDeviceNames = @(
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    "COM1",
+    "COM2",
+    "COM3",
+    "COM4",
+    "COM5",
+    "COM6",
+    "COM7",
+    "COM8",
+    "COM9",
+    "LPT1",
+    "LPT2",
+    "LPT3",
+    "LPT4",
+    "LPT5",
+    "LPT6",
+    "LPT7",
+    "LPT8",
+    "LPT9"
+)
+
+function Test-ReleaseNameIsReservedDeviceName {
+    param(
+        [Parameter(Mandatory = $true)][string]$ReleaseName
+    )
+
+    $baseName = [System.IO.Path]::GetFileNameWithoutExtension($ReleaseName).ToUpperInvariant()
+    return $windowsReservedDeviceNames -contains $baseName
+}
+
 if (-not (Test-Path -LiteralPath $Destination)) {
     throw "Destination '$Destination' does not exist."
 }
@@ -23,8 +57,8 @@ if (Test-Path -LiteralPath $currentReleaseMarker) {
 }
 
 if (-not [string]::IsNullOrWhiteSpace($releaseName)) {
-    if ($releaseName.IndexOfAny([System.IO.Path]::GetInvalidFileNameChars()) -ge 0 -or $releaseName -eq "." -or $releaseName -eq "..") {
-        throw "ReleaseName in current-release.txt must be a folder-safe name."
+    if ($releaseName.IndexOfAny([System.IO.Path]::GetInvalidFileNameChars()) -ge 0 -or $releaseName -eq "." -or $releaseName -eq ".." -or (Test-ReleaseNameIsReservedDeviceName -ReleaseName $releaseName)) {
+        throw "ReleaseName in current-release.txt must be a folder-safe, non-reserved name."
     }
 
     $releasePath = Join-Path $releaseRoot $releaseName

--- a/scripts/update-shared-release.ps1
+++ b/scripts/update-shared-release.ps1
@@ -29,6 +29,30 @@ $currentReleaseMarker = Join-Path $destinationPath "current-release.txt"
 $launcherSourcePath = Join-Path $PSScriptRoot "start-current-release.ps1"
 $launcherDestinationDirectory = Join-Path $destinationPath "scripts"
 $launcherDestinationPath = Join-Path $launcherDestinationDirectory "start-current-release.ps1"
+$windowsReservedDeviceNames = @(
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    "COM1",
+    "COM2",
+    "COM3",
+    "COM4",
+    "COM5",
+    "COM6",
+    "COM7",
+    "COM8",
+    "COM9",
+    "LPT1",
+    "LPT2",
+    "LPT3",
+    "LPT4",
+    "LPT5",
+    "LPT6",
+    "LPT7",
+    "LPT8",
+    "LPT9"
+)
 $excludedDirectories = @(
     "Assets",
     "Assets\Data",
@@ -55,6 +79,15 @@ $preservedPaths = @(
     "Logs"
 )
 $sideBySideLinkedDirectories = $preservedPaths | Where-Object { $_ -ne "appsettings.json" }
+
+function Test-ReleaseNameIsReservedDeviceName {
+    param(
+        [Parameter(Mandatory = $true)][string]$ReleaseName
+    )
+
+    $baseName = [System.IO.Path]::GetFileNameWithoutExtension($ReleaseName).ToUpperInvariant()
+    return $windowsReservedDeviceNames -contains $baseName
+}
 
 function Invoke-ReleaseMirror {
     param(
@@ -166,8 +199,8 @@ Write-Host "Preserving:  $themesPath"
 Write-Host "Backup:      $backupPath"
 
 if ($DeploymentMode -eq "SideBySide") {
-    if ([string]::IsNullOrWhiteSpace($ReleaseName) -or $ReleaseName.IndexOfAny([System.IO.Path]::GetInvalidFileNameChars()) -ge 0) {
-        throw "ReleaseName must be a non-empty folder-safe name."
+    if ([string]::IsNullOrWhiteSpace($ReleaseName) -or $ReleaseName.IndexOfAny([System.IO.Path]::GetInvalidFileNameChars()) -ge 0 -or (Test-ReleaseNameIsReservedDeviceName -ReleaseName $ReleaseName)) {
+        throw "ReleaseName must be a non-empty folder-safe name and cannot be a reserved Windows device name."
     }
 
     $releasePath = Join-Path $releaseRoot $ReleaseName

--- a/scripts/update-shared-release.ps1
+++ b/scripts/update-shared-release.ps1
@@ -85,7 +85,8 @@ function Test-ReleaseNameIsReservedDeviceName {
         [Parameter(Mandatory = $true)][string]$ReleaseName
     )
 
-    $baseName = [System.IO.Path]::GetFileNameWithoutExtension($ReleaseName).ToUpperInvariant()
+    $normalizedReleaseName = $ReleaseName.TrimEnd([char[]]@(' ', '.'))
+    $baseName = [System.IO.Path]::GetFileNameWithoutExtension($normalizedReleaseName).ToUpperInvariant()
     return $windowsReservedDeviceNames -contains $baseName
 }
 
@@ -199,8 +200,8 @@ Write-Host "Preserving:  $themesPath"
 Write-Host "Backup:      $backupPath"
 
 if ($DeploymentMode -eq "SideBySide") {
-    if ([string]::IsNullOrWhiteSpace($ReleaseName) -or $ReleaseName.IndexOfAny([System.IO.Path]::GetInvalidFileNameChars()) -ge 0 -or (Test-ReleaseNameIsReservedDeviceName -ReleaseName $ReleaseName)) {
-        throw "ReleaseName must be a non-empty folder-safe name and cannot be a reserved Windows device name."
+    if ([string]::IsNullOrWhiteSpace($ReleaseName) -or $ReleaseName.EndsWith(".") -or $ReleaseName.EndsWith(" ") -or $ReleaseName.IndexOfAny([System.IO.Path]::GetInvalidFileNameChars()) -ge 0 -or (Test-ReleaseNameIsReservedDeviceName -ReleaseName $ReleaseName)) {
+        throw "ReleaseName must be a non-empty folder-safe name and cannot end with a dot or space or use a reserved Windows device name."
     }
 
     $releasePath = Join-Path $releaseRoot $ReleaseName


### PR DESCRIPTION
## Summary

- Reject side-by-side release names that end with a dot or space or use reserved Windows device names such as `CON`, `NUL`, `COM1`, or `LPT1` before staging a release or writing `current-release.txt`.
- Apply the same validation in `scripts/start-current-release.ps1` so manually edited markers fail fast instead of attempting to launch an invalid Windows path.
- Update the server deployment guide and source-contract coverage for the folder-safe release-name contract.

## Why This Matters

The new side-by-side deployment flow creates Windows folders under `_releases` and later resolves the selected release from `current-release.txt`. Windows reserved device names and trailing dot/space names can produce confusing deployment or launch failures even when the string does not contain invalid path characters. This keeps the active-user update flow from writing or trusting invalid release markers.

## Validation

- GitHub connector readback confirmed the updater, launcher, guide, source-contract test, and progress note on `codex/guard-reserved-release-names`.
- GitHub connector compare confirmed the branch is current with `master` and changes only the deployment scripts, deployment guide, source-contract test, and progress note.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/script execution/full validation was not run.