### PR TITLE
Publish side-by-side release marker atomically

### DIFF
--- a/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
@@ -16,8 +16,24 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("$DeploymentMode = \"InPlace\"", script, StringComparison.Ordinal);
             Assert.Contains("$releaseRoot = Join-Path $destinationPath \"_releases\"", script, StringComparison.Ordinal);
             Assert.Contains("$currentReleaseMarker = Join-Path $destinationPath \"current-release.txt\"", script, StringComparison.Ordinal);
-            Assert.Contains("Set-Content -LiteralPath $currentReleaseMarker -Value $ReleaseName", script, StringComparison.Ordinal);
+            Assert.Contains("Set-CurrentReleaseMarker -ReleaseName $ReleaseName", script, StringComparison.Ordinal);
             Assert.Contains("rerun with -DeploymentMode SideBySide", script, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SideBySideDeploymentPublishesCurrentReleaseMarkerAfterStagingCompletes()
+        {
+            var script = ReadRepositoryFile("scripts", "update-shared-release.ps1");
+
+            Assert.Contains("function Set-CurrentReleaseMarker", script, StringComparison.Ordinal);
+            Assert.Contains("current-release.{0}.tmp", script, StringComparison.Ordinal);
+            Assert.Contains("[System.Guid]::NewGuid().ToString(\"N\")", script, StringComparison.Ordinal);
+            Assert.Contains("Set-Content -LiteralPath $temporaryMarker -Value $ReleaseName -Encoding UTF8", script, StringComparison.Ordinal);
+            Assert.Contains("Move-Item -LiteralPath $temporaryMarker -Destination $currentReleaseMarker -Force", script, StringComparison.Ordinal);
+            Assert.Contains("Remove-Item -LiteralPath $temporaryMarker -Force", script, StringComparison.Ordinal);
+
+            var stagingIndex = script.IndexOf("Copy-CurrentReleaseLauncher\n\n    Set-CurrentReleaseMarker -ReleaseName $ReleaseName", StringComparison.Ordinal);
+            Assert.True(stagingIndex >= 0, "Side-by-side deployment should publish current-release.txt only after release staging and launcher refresh complete.");
         }
 
         [Fact]

--- a/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
@@ -24,6 +24,7 @@ namespace InventoryManagementApp.Tests
         public void SideBySideDeploymentPublishesCurrentReleaseMarkerAfterStagingCompletes()
         {
             var script = ReadRepositoryFile("scripts", "update-shared-release.ps1");
+            var normalizedScript = script.Replace("\r\n", "\n", StringComparison.Ordinal);
 
             Assert.Contains("function Set-CurrentReleaseMarker", script, StringComparison.Ordinal);
             Assert.Contains("current-release.{0}.tmp", script, StringComparison.Ordinal);
@@ -32,7 +33,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("Move-Item -LiteralPath $temporaryMarker -Destination $currentReleaseMarker -Force", script, StringComparison.Ordinal);
             Assert.Contains("Remove-Item -LiteralPath $temporaryMarker -Force", script, StringComparison.Ordinal);
 
-            var stagingIndex = script.IndexOf("Copy-CurrentReleaseLauncher\n\n    Set-CurrentReleaseMarker -ReleaseName $ReleaseName", StringComparison.Ordinal);
+            var stagingIndex = normalizedScript.IndexOf("Copy-CurrentReleaseLauncher\n\n    Set-CurrentReleaseMarker -ReleaseName $ReleaseName", StringComparison.Ordinal);
             Assert.True(stagingIndex >= 0, "Side-by-side deployment should publish current-release.txt only after release staging and launcher refresh complete.");
         }
 

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-atomic-current-release-marker.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-atomic-current-release-marker.md
@@ -1,0 +1,15 @@
+# Atomic Current Release Marker Hardening
+
+Date: 2026-06-25
+
+## Completed
+
+- Hardened `scripts/update-shared-release.ps1` so side-by-side deployments write `current-release.txt` through a unique temporary marker file and move it into place only after release staging and launcher refresh complete.
+- Added cleanup for the temporary marker file if marker publication fails, so interrupted deployments do not leave stale temp markers in the shared destination.
+- Updated `SharedReleaseUpdateScriptTests` so source-contract coverage guards the temp-file marker publication flow and verifies the marker swap happens after `Copy-CurrentReleaseLauncher`.
+
+## Validation Notes
+
+- Local clone/raw repository access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/script execution/full validation was not run.
+- Use GitHub connector readback/compare as fallback validation for this pass, then run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout and include a side-by-side deployment script smoke test.

--- a/scripts/update-shared-release.ps1
+++ b/scripts/update-shared-release.ps1
@@ -251,4 +251,4 @@ Backup-PreservedPaths
 Invoke-ReleaseMirror -From $sourcePath -To $destinationPath -ExcludedDirectories $excludedDirectories -ExcludedFiles @("appsettings.json")
 Copy-CurrentReleaseLauncher
 
-Write-Host "Release update complete."}
+Write-Host "Release update complete."

--- a/scripts/update-shared-release.ps1
+++ b/scripts/update-shared-release.ps1
@@ -147,6 +147,26 @@ function Copy-CurrentReleaseLauncher {
     Copy-Item -LiteralPath $launcherSourcePath -Destination $launcherDestinationPath -Force
 }
 
+function Set-CurrentReleaseMarker {
+    param(
+        [Parameter(Mandatory = $true)][string]$ReleaseName
+    )
+
+    $markerDirectory = Split-Path -Parent $currentReleaseMarker
+    $temporaryMarker = Join-Path $markerDirectory ("current-release.{0}.tmp" -f [System.Guid]::NewGuid().ToString("N"))
+
+    try {
+        Set-Content -LiteralPath $temporaryMarker -Value $ReleaseName -Encoding UTF8
+        Move-Item -LiteralPath $temporaryMarker -Destination $currentReleaseMarker -Force
+    } catch {
+        if (Test-Path -LiteralPath $temporaryMarker) {
+            Remove-Item -LiteralPath $temporaryMarker -Force
+        }
+
+        throw
+    }
+}
+
 function Copy-ReleaseConfiguration {
     param(
         [Parameter(Mandatory = $true)][string]$ReleasePath
@@ -217,7 +237,7 @@ if ($DeploymentMode -eq "SideBySide") {
     Link-PreservedDirectoriesToRelease -ReleasePath $releasePath
     Copy-CurrentReleaseLauncher
 
-    Set-Content -LiteralPath $currentReleaseMarker -Value $ReleaseName -Encoding UTF8
+    Set-CurrentReleaseMarker -ReleaseName $ReleaseName
     Write-Host "Side-by-side release staged. Running users can finish in their current copy; restart shortcuts should launch _releases\$ReleaseName with shared data folders linked from $destinationPath."
     return
 }
@@ -231,4 +251,4 @@ Backup-PreservedPaths
 Invoke-ReleaseMirror -From $sourcePath -To $destinationPath -ExcludedDirectories $excludedDirectories -ExcludedFiles @("appsettings.json")
 Copy-CurrentReleaseLauncher
 
-Write-Host "Release update complete."
+Write-Host "Release update complete."}


### PR DESCRIPTION
## Summary

- Write side-by-side `current-release.txt` updates through a unique temporary marker file before moving it into place.
- Keep the marker publication after release staging, shared launcher refresh, configuration copy, and shared-folder linking complete.
- Add source-contract coverage and a progress note for the deployment-script marker publication contract.

## Why This Matters

The side-by-side deployment flow moves new launches by updating `current-release.txt`. Writing that marker directly can leave a blank or partial marker if the write is interrupted or read while the update is in progress. Publishing through a temporary file and replacing the marker keeps shared shortcuts pointed at a complete release name only after the staged release is ready.

## Validation

- GitHub connector readback confirmed the updater script, source-contract test, and progress note on `codex/atomic-current-release-marker`.
- GitHub connector compare confirmed the branch is current with `master` and changes only the deployment script, deployment contract test, and progress note.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/script execution/full validation was not run.