### PR TITLE
Harden reservation and kit service validation

### DIFF
--- a/InventoryManagementApp.Tests/KitServiceTests.cs
+++ b/InventoryManagementApp.Tests/KitServiceTests.cs
@@ -196,5 +196,54 @@ namespace InventoryManagementApp.Tests
 
             Assert.True(result);
         }
+
+        [Fact]
+        public async Task CreateKit_WithBlankName_ShouldThrow()
+        {
+            var kit = new Kit
+            {
+                KitNumber = "KIT-009",
+                Name = " ",
+                IsActive = true
+            };
+
+            await Assert.ThrowsAsync<ArgumentException>(() => _kitService.CreateKitAsync(kit));
+        }
+
+        [Fact]
+        public async Task CreateKit_ShouldTrimRequiredFieldsAndPersistEmptyOptionalFieldsAsEmptyStrings()
+        {
+            var kit = new Kit
+            {
+                KitNumber = " KIT-010 ",
+                Name = " Trimmed Kit ",
+                Description = " ",
+                Category = null!,
+                IsActive = true
+            };
+
+            var id = await _kitService.CreateKitAsync(kit);
+
+            var saved = await _kitService.GetKitByIdAsync(id);
+            Assert.NotNull(saved);
+            Assert.Equal("KIT-010", saved.KitNumber);
+            Assert.Equal("Trimmed Kit", saved.Name);
+            Assert.Equal(string.Empty, saved.Description);
+            Assert.Equal(string.Empty, saved.Category);
+        }
+
+        [Fact]
+        public async Task AddKitItem_WithZeroQuantity_ShouldThrow()
+        {
+            var kitItem = new KitItem
+            {
+                KitID = 1,
+                ItemID = 1,
+                Quantity = 0,
+                IsOptional = false
+            };
+
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => _kitService.AddKitItemAsync(kitItem));
+        }
     }
 }

--- a/InventoryManagementApp.Tests/ReservationServiceTests.cs
+++ b/InventoryManagementApp.Tests/ReservationServiceTests.cs
@@ -193,5 +193,50 @@ namespace InventoryManagementApp.Tests
 
             Assert.True(result);
         }
+
+        [Fact]
+        public async Task CreateReservation_WithEndDateBeforeStartDate_ShouldThrow()
+        {
+            var reservation = new Reservation
+            {
+                ItemID = 1,
+                CustomerID = 1,
+                StartDate = DateTime.Today.AddDays(3),
+                EndDate = DateTime.Today.AddDays(2),
+                Quantity = 1,
+                Status = "Pending"
+            };
+
+            await Assert.ThrowsAsync<ArgumentException>(() => _reservationService.CreateReservationAsync(reservation));
+        }
+
+        [Fact]
+        public async Task CreateReservation_WithBlankStatus_ShouldDefaultToPending()
+        {
+            var reservation = new Reservation
+            {
+                ItemID = 1,
+                CustomerID = 1,
+                StartDate = DateTime.Today.AddDays(1),
+                EndDate = DateTime.Today.AddDays(2),
+                Quantity = 1,
+                Status = "  ",
+                Notes = "  "
+            };
+
+            var id = await _reservationService.CreateReservationAsync(reservation);
+
+            var saved = await _reservationService.GetReservationByIdAsync(id);
+            Assert.NotNull(saved);
+            Assert.Equal("Pending", saved.Status);
+            Assert.Equal(string.Empty, saved.Notes);
+        }
+
+        [Fact]
+        public async Task CheckAvailability_WithInvalidQuantity_ShouldThrow()
+        {
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+                () => _reservationService.CheckAvailabilityAsync(1, DateTime.Today, DateTime.Today.AddDays(1), 0));
+        }
     }
 }

--- a/InventoryManagementApp/Services/Kits/KitService.cs
+++ b/InventoryManagementApp/Services/Kits/KitService.cs
@@ -133,6 +133,8 @@ namespace InventoryManagementApp.Services.Kits
 
         public async Task<int> CreateKitAsync(Kit kit)
         {
+            ValidateKit(kit, requireExistingId: false);
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -143,10 +145,10 @@ namespace InventoryManagementApp.Services.Kits
                     (@KitNumber, @Name, @Description, @Category, @IsActive, @CreatedByUserID, @CreatedAt, @UpdatedAt);
                     SELECT last_insert_rowid();";
                 using var cmd = new SqliteCommand(sql, conn);
-                cmd.Parameters.AddWithValue("@KitNumber", kit.KitNumber);
-                cmd.Parameters.AddWithValue("@Name", kit.Name);
-                cmd.Parameters.AddWithValue("@Description", kit.Description);
-                cmd.Parameters.AddWithValue("@Category", kit.Category);
+                cmd.Parameters.AddWithValue("@KitNumber", kit.KitNumber.Trim());
+                cmd.Parameters.AddWithValue("@Name", kit.Name.Trim());
+                cmd.Parameters.AddWithValue("@Description", ToDbNullableText(kit.Description));
+                cmd.Parameters.AddWithValue("@Category", ToDbNullableText(kit.Category));
                 cmd.Parameters.AddWithValue("@IsActive", kit.IsActive ? 1 : 0);
                 cmd.Parameters.AddWithValue("@CreatedByUserID", _userContext.CurrentUser?.UserID ?? 0);
                 cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now);
@@ -158,6 +160,8 @@ namespace InventoryManagementApp.Services.Kits
 
         public async Task<bool> UpdateKitAsync(Kit kit)
         {
+            ValidateKit(kit, requireExistingId: true);
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -172,10 +176,10 @@ namespace InventoryManagementApp.Services.Kits
                     WHERE KitID = @KitID";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@KitID", kit.KitID);
-                cmd.Parameters.AddWithValue("@KitNumber", kit.KitNumber);
-                cmd.Parameters.AddWithValue("@Name", kit.Name);
-                cmd.Parameters.AddWithValue("@Description", kit.Description);
-                cmd.Parameters.AddWithValue("@Category", kit.Category);
+                cmd.Parameters.AddWithValue("@KitNumber", kit.KitNumber.Trim());
+                cmd.Parameters.AddWithValue("@Name", kit.Name.Trim());
+                cmd.Parameters.AddWithValue("@Description", ToDbNullableText(kit.Description));
+                cmd.Parameters.AddWithValue("@Category", ToDbNullableText(kit.Category));
                 cmd.Parameters.AddWithValue("@IsActive", kit.IsActive ? 1 : 0);
                 cmd.Parameters.AddWithValue("@UpdatedAt", DateTime.Now);
                 return cmd.ExecuteNonQuery() > 0;
@@ -184,6 +188,9 @@ namespace InventoryManagementApp.Services.Kits
 
         public async Task<bool> DeleteKitAsync(int kitID)
         {
+            if (kitID < 1)
+                throw new ArgumentOutOfRangeException(nameof(kitID), "Kit ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -213,6 +220,8 @@ namespace InventoryManagementApp.Services.Kits
 
         public async Task<int> AddKitItemAsync(KitItem kitItem)
         {
+            ValidateKitItem(kitItem, requireExistingId: false);
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -234,6 +243,8 @@ namespace InventoryManagementApp.Services.Kits
 
         public async Task<bool> UpdateKitItemAsync(KitItem kitItem)
         {
+            ValidateKitItem(kitItem, requireExistingId: true);
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -254,6 +265,9 @@ namespace InventoryManagementApp.Services.Kits
 
         public async Task<bool> RemoveKitItemAsync(int kitItemID)
         {
+            if (kitItemID < 1)
+                throw new ArgumentOutOfRangeException(nameof(kitItemID), "Kit item ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -266,6 +280,9 @@ namespace InventoryManagementApp.Services.Kits
 
         public async Task<bool> CheckKitAvailabilityAsync(int kitID)
         {
+            if (kitID < 1)
+                throw new ArgumentOutOfRangeException(nameof(kitID), "Kit ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -311,6 +328,37 @@ namespace InventoryManagementApp.Services.Kits
                 Quantity = reader.GetInt32(reader.GetOrdinal("Quantity")),
                 IsOptional = reader.GetInt32(reader.GetOrdinal("IsOptional")) == 1
             };
+        }
+
+        private static void ValidateKit(Kit kit, bool requireExistingId)
+        {
+            if (kit == null)
+                throw new ArgumentNullException(nameof(kit));
+            if (requireExistingId && kit.KitID < 1)
+                throw new ArgumentOutOfRangeException(nameof(kit.KitID), "Kit ID must be greater than 0.");
+            if (string.IsNullOrWhiteSpace(kit.KitNumber))
+                throw new ArgumentException("Kit number is required.", nameof(kit.KitNumber));
+            if (string.IsNullOrWhiteSpace(kit.Name))
+                throw new ArgumentException("Kit name is required.", nameof(kit.Name));
+        }
+
+        private static void ValidateKitItem(KitItem kitItem, bool requireExistingId)
+        {
+            if (kitItem == null)
+                throw new ArgumentNullException(nameof(kitItem));
+            if (requireExistingId && kitItem.KitItemID < 1)
+                throw new ArgumentOutOfRangeException(nameof(kitItem.KitItemID), "Kit item ID must be greater than 0.");
+            if (kitItem.KitID < 1)
+                throw new ArgumentOutOfRangeException(nameof(kitItem.KitID), "Kit ID must be greater than 0.");
+            if (kitItem.ItemID < 1)
+                throw new ArgumentOutOfRangeException(nameof(kitItem.ItemID), "Item ID must be greater than 0.");
+            if (kitItem.Quantity < 1)
+                throw new ArgumentOutOfRangeException(nameof(kitItem.Quantity), "Quantity must be greater than 0.");
+        }
+
+        private static object ToDbNullableText(string? value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? DBNull.Value : value.Trim();
         }
     }
 }

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -185,6 +185,8 @@ namespace InventoryManagementApp.Services.Reservations
 
         public async Task<int> CreateReservationAsync(Reservation reservation)
         {
+            ValidateReservation(reservation, requireExistingId: false);
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -203,8 +205,8 @@ namespace InventoryManagementApp.Services.Reservations
                 cmd.Parameters.AddWithValue("@StartDate", reservation.StartDate);
                 cmd.Parameters.AddWithValue("@EndDate", reservation.EndDate);
                 cmd.Parameters.AddWithValue("@Quantity", reservation.Quantity);
-                cmd.Parameters.AddWithValue("@Status", reservation.Status);
-                cmd.Parameters.AddWithValue("@Notes", reservation.Notes);
+                cmd.Parameters.AddWithValue("@Status", NormalizeStatus(reservation.Status));
+                cmd.Parameters.AddWithValue("@Notes", ToDbNullableText(reservation.Notes));
                 cmd.Parameters.AddWithValue("@CreatedByUserID", _userContext.CurrentUser?.UserID ?? 0);
                 cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now);
                 var id = Convert.ToInt32(cmd.ExecuteScalar());
@@ -214,6 +216,8 @@ namespace InventoryManagementApp.Services.Reservations
 
         public async Task<bool> UpdateReservationAsync(Reservation reservation)
         {
+            ValidateReservation(reservation, requireExistingId: true);
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -235,8 +239,8 @@ namespace InventoryManagementApp.Services.Reservations
                 cmd.Parameters.AddWithValue("@StartDate", reservation.StartDate);
                 cmd.Parameters.AddWithValue("@EndDate", reservation.EndDate);
                 cmd.Parameters.AddWithValue("@Quantity", reservation.Quantity);
-                cmd.Parameters.AddWithValue("@Status", reservation.Status);
-                cmd.Parameters.AddWithValue("@Notes", reservation.Notes);
+                cmd.Parameters.AddWithValue("@Status", NormalizeStatus(reservation.Status));
+                cmd.Parameters.AddWithValue("@Notes", ToDbNullableText(reservation.Notes));
                 cmd.Parameters.AddWithValue("@RentalID", reservation.RentalID.HasValue ? (object)reservation.RentalID.Value : DBNull.Value);
                 return cmd.ExecuteNonQuery() > 0;
             });
@@ -244,6 +248,9 @@ namespace InventoryManagementApp.Services.Reservations
 
         public async Task<bool> ConfirmReservationAsync(int reservationID)
         {
+            if (reservationID < 1)
+                throw new ArgumentOutOfRangeException(nameof(reservationID), "Reservation ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -256,6 +263,9 @@ namespace InventoryManagementApp.Services.Reservations
 
         public async Task<bool> CancelReservationAsync(int reservationID)
         {
+            if (reservationID < 1)
+                throw new ArgumentOutOfRangeException(nameof(reservationID), "Reservation ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -268,6 +278,11 @@ namespace InventoryManagementApp.Services.Reservations
 
         public async Task<bool> FulfillReservationAsync(int reservationID, int rentalID)
         {
+            if (reservationID < 1)
+                throw new ArgumentOutOfRangeException(nameof(reservationID), "Reservation ID must be greater than 0.");
+            if (rentalID < 1)
+                throw new ArgumentOutOfRangeException(nameof(rentalID), "Rental ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -281,6 +296,9 @@ namespace InventoryManagementApp.Services.Reservations
 
         public async Task<bool> DeleteReservationAsync(int reservationID)
         {
+            if (reservationID < 1)
+                throw new ArgumentOutOfRangeException(nameof(reservationID), "Reservation ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -293,6 +311,13 @@ namespace InventoryManagementApp.Services.Reservations
 
         public async Task<bool> CheckAvailabilityAsync(int itemID, DateTime startDate, DateTime endDate, int quantity)
         {
+            if (itemID < 1)
+                throw new ArgumentOutOfRangeException(nameof(itemID), "Item ID must be greater than 0.");
+            if (quantity < 1)
+                throw new ArgumentOutOfRangeException(nameof(quantity), "Quantity must be greater than 0.");
+            if (endDate < startDate)
+                throw new ArgumentException("End date must be on or after start date.", nameof(endDate));
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -341,6 +366,32 @@ namespace InventoryManagementApp.Services.Reservations
                 CreatedAt = reader.GetDateTime(reader.GetOrdinal("CreatedAt")),
                 RentalID = reader.IsDBNull(reader.GetOrdinal("RentalID")) ? null : reader.GetInt32(reader.GetOrdinal("RentalID"))
             };
+        }
+
+        private static void ValidateReservation(Reservation reservation, bool requireExistingId)
+        {
+            if (reservation == null)
+                throw new ArgumentNullException(nameof(reservation));
+            if (requireExistingId && reservation.ReservationID < 1)
+                throw new ArgumentOutOfRangeException(nameof(reservation.ReservationID), "Reservation ID must be greater than 0.");
+            if (reservation.ItemID < 1)
+                throw new ArgumentOutOfRangeException(nameof(reservation.ItemID), "Item ID must be greater than 0.");
+            if (reservation.CustomerID < 1)
+                throw new ArgumentOutOfRangeException(nameof(reservation.CustomerID), "Customer ID must be greater than 0.");
+            if (reservation.Quantity < 1)
+                throw new ArgumentOutOfRangeException(nameof(reservation.Quantity), "Quantity must be greater than 0.");
+            if (reservation.EndDate < reservation.StartDate)
+                throw new ArgumentException("End date must be on or after start date.", nameof(reservation.EndDate));
+        }
+
+        private static string NormalizeStatus(string? status)
+        {
+            return string.IsNullOrWhiteSpace(status) ? "Pending" : status.Trim();
+        }
+
+        private static object ToDbNullableText(string? value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? DBNull.Value : value.Trim();
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent invalid data and runtime errors by validating inputs for reservation and kit operations and normalizing user-provided text before persisting to the database.
- Ensure reservation lifecycle methods (confirm/cancel/fulfill/delete) and availability checks fail fast on invalid IDs/quantities/date ranges.
- Reduce surprising null/blank handling for optional text fields by converting them to safe DB values.

### Description
- Reservation service: added `ValidateReservation` with checks for required fields and date ordering, added `NormalizeStatus` and `ToDbNullableText`, and added argument validation to `CreateReservationAsync`, `UpdateReservationAsync`, `ConfirmReservationAsync`, `CancelReservationAsync`, `FulfillReservationAsync`, `DeleteReservationAsync`, and `CheckAvailabilityAsync` to enforce valid IDs/quantities/dates.
- Kit service: added `ValidateKit` and `ValidateKitItem`, trim and normalize `KitNumber`/`Name` before persist, convert optional `Description`/`Category` to DB-safe values via `ToDbNullableText`, and added argument checks to `CreateKitAsync`, `UpdateKitAsync`, `DeleteKitAsync`, `AddKitItemAsync`, `UpdateKitItemAsync`, `RemoveKitItemAsync`, and `CheckKitAvailabilityAsync`.
- Tests: added unit tests in `InventoryManagementApp.Tests/ReservationServiceTests.cs` covering invalid date ranges, blank status normalization and blank notes handling, and invalid availability quantity; and in `InventoryManagementApp.Tests/KitServiceTests.cs` covering blank kit name, trimming/normalization of kit fields, and invalid kit-item quantity.

### Testing
- No automated test run was executed in this environment because `dotnet` is not available here (attempting `dotnet restore/build/test` returned `dotnet: command not found`).
- Unit tests were added to the test project and should be executed in a dev environment by running `dotnet restore InventoryManagementApp.sln`, `dotnet build InventoryManagementApp.sln --no-restore`, and `dotnet test InventoryManagementApp.sln --no-build`.
- After running the above commands in a proper .NET-enabled environment, all new and existing tests should be executed to confirm the changes; no failures were observed locally because tests could not be run in this CI-like environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cdf2ac2b88324b561810ec5c0e9db)