### PR TITLE
Guard reservation status values

### DIFF
--- a/InventoryManagementApp.Tests/ReservationServiceTests.cs
+++ b/InventoryManagementApp.Tests/ReservationServiceTests.cs
@@ -233,6 +233,41 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task CreateReservation_WithUnknownStatus_ShouldThrow()
+        {
+            var reservation = new Reservation
+            {
+                ItemID = 1,
+                CustomerID = 1,
+                StartDate = DateTime.Today.AddDays(1),
+                EndDate = DateTime.Today.AddDays(2),
+                Quantity = 1,
+                Status = "Waiting"
+            };
+
+            await Assert.ThrowsAsync<ArgumentException>(() => _reservationService.CreateReservationAsync(reservation));
+        }
+
+        [Fact]
+        public async Task UpdateReservation_WithUnknownStatus_ShouldThrow()
+        {
+            var reservation = new Reservation
+            {
+                ItemID = 1,
+                CustomerID = 1,
+                StartDate = DateTime.Today.AddDays(1),
+                EndDate = DateTime.Today.AddDays(2),
+                Quantity = 1,
+                Status = "Pending"
+            };
+            var id = await _reservationService.CreateReservationAsync(reservation);
+            reservation.ReservationID = id;
+            reservation.Status = "Waiting";
+
+            await Assert.ThrowsAsync<ArgumentException>(() => _reservationService.UpdateReservationAsync(reservation));
+        }
+
+        [Fact]
         public async Task CheckAvailability_WithInvalidQuantity_ShouldThrow()
         {
             await Assert.ThrowsAsync<ArgumentOutOfRangeException>(

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-reservation-status-value-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-reservation-status-value-guard.md
@@ -1,0 +1,14 @@
+# Reservation Status Value Guard
+
+Date: 2026-06-26
+
+## Completed
+
+- Tightened `ReservationService` status normalization so blank status still defaults to `Pending`, but unknown lifecycle values are rejected before persistence.
+- Added reservation service tests for unknown status values on both create and update paths.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, WPF runtime/screenshots, local banned-word checks, and the full validation runner are unavailable here, so local build/test/full validation was not run.
+- GitHub connector readback/compare was used as fallback validation for the focused source changes.

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -386,7 +386,12 @@ namespace InventoryManagementApp.Services.Reservations
 
         private static string NormalizeStatus(string? status)
         {
-            return string.IsNullOrWhiteSpace(status) ? "Pending" : status.Trim();
+            var normalizedStatus = string.IsNullOrWhiteSpace(status) ? "Pending" : status.Trim();
+            return normalizedStatus switch
+            {
+                "Pending" or "Confirmed" or "Cancelled" or "Fulfilled" => normalizedStatus,
+                _ => throw new ArgumentException("Reservation status must be Pending, Confirmed, Cancelled, or Fulfilled.", nameof(status))
+            };
         }
 
         private static object ToDbNullableText(string? value)


### PR DESCRIPTION
## Summary

- Restrict reservation create/update status normalization to the lifecycle values the app already understands: `Pending`, `Confirmed`, `Cancelled`, and `Fulfilled`.
- Preserve the existing blank-status default to `Pending` while rejecting typo or unknown statuses before persistence.
- Add reservation service tests for invalid status values on both create and update paths, plus a progress note for this pass.

## Why This Matters

The recent reservation service validation pass normalized blank status values but still allowed arbitrary strings to be written. Unknown values can disappear from active reservation queries and display oddly in the reservation domain model. This keeps service-level validation aligned with the app's existing lifecycle states.

## Validation

- GitHub connector readback confirmed the service change, paired tests, and progress note on `codex/guard-reservation-status-values`.
- GitHub connector compare confirmed the branch is current with `master` and changes only three files.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.