### PR TITLE
Guard reservation query inputs

### DIFF
--- a/InventoryManagementApp.Tests/ReservationServiceTests.cs
+++ b/InventoryManagementApp.Tests/ReservationServiceTests.cs
@@ -117,6 +117,24 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task GetReservationsByCustomer_WithInvalidCustomerId_ShouldThrow()
+        {
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => _reservationService.GetReservationsByCustomerAsync(0));
+        }
+
+        [Fact]
+        public async Task GetUpcomingReservations_WithNegativeDays_ShouldThrow()
+        {
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => _reservationService.GetUpcomingReservationsAsync(-1));
+        }
+
+        [Fact]
+        public async Task GetReservationById_WithInvalidReservationId_ShouldThrow()
+        {
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => _reservationService.GetReservationByIdAsync(0));
+        }
+
+        [Fact]
         public async Task UpdateReservation_ShouldSucceed()
         {
             var reservation = new Reservation

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-reservation-query-input-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-reservation-query-input-guards.md
@@ -1,0 +1,14 @@
+# Reservation Query Input Guards
+
+Date: 2026-06-26
+
+## Completed
+
+- Added service-level guard checks for reservation customer lookup, upcoming reservation windows, and reservation ID lookup so invalid query inputs fail fast before database work.
+- Added focused reservation service tests for invalid customer IDs, negative upcoming-day windows, and invalid reservation IDs.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, WPF runtime/screenshots, local banned-word checks, and the full validation runner are unavailable here, so local build/test/full validation was not run.
+- GitHub connector readback/compare was used as fallback validation for the focused source changes.

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -114,6 +114,9 @@ namespace InventoryManagementApp.Services.Reservations
 
         public async Task<List<Reservation>> GetReservationsByCustomerAsync(int customerID)
         {
+            if (customerID < 1)
+                throw new ArgumentOutOfRangeException(nameof(customerID), "Customer ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 var reservations = new List<Reservation>();
@@ -138,6 +141,9 @@ namespace InventoryManagementApp.Services.Reservations
 
         public async Task<List<Reservation>> GetUpcomingReservationsAsync(int days = 7)
         {
+            if (days < 0)
+                throw new ArgumentOutOfRangeException(nameof(days), "Days must be greater than or equal to 0.");
+
             return await Task.Run(() =>
             {
                 var reservations = new List<Reservation>();
@@ -163,6 +169,9 @@ namespace InventoryManagementApp.Services.Reservations
 
         public async Task<Reservation?> GetReservationByIdAsync(int reservationID)
         {
+            if (reservationID < 1)
+                throw new ArgumentOutOfRangeException(nameof(reservationID), "Reservation ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();


### PR DESCRIPTION
## Summary

- Add reservation service guard checks for customer reservation lookup, upcoming reservation windows, and reservation ID lookup.
- Fail fast on invalid customer IDs, negative upcoming-day windows, and invalid reservation IDs before database work.
- Add focused reservation service tests and a progress note for this validation pass.

## Why This Matters

The recent reservation validation work hardened create/update and lifecycle operations, but a few read/query paths still accepted invalid inputs. This keeps reservation service input handling consistent across write, lifecycle, availability, and query flows.

## Validation

- GitHub connector readback confirmed the service guards, paired tests, and progress note on `codex/guard-reservation-query-inputs`.
- GitHub connector compare confirmed the branch is current with `master` and changes only three files.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.