### PR TITLE
Guard kit availability when required item rows are missing

### DIFF
--- a/InventoryManagementApp.Tests/KitServiceTests.cs
+++ b/InventoryManagementApp.Tests/KitServiceTests.cs
@@ -245,5 +245,29 @@ namespace InventoryManagementApp.Tests
 
             await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => _kitService.AddKitItemAsync(kitItem));
         }
+
+        [Fact]
+        public async Task CheckKitAvailability_WithMissingRequiredItem_ShouldReturnFalse()
+        {
+            var kit = new Kit
+            {
+                KitNumber = "KIT-011",
+                Name = "Kit with Missing Required Item",
+                IsActive = true
+            };
+            var kitId = await _kitService.CreateKitAsync(kit);
+
+            await _kitService.AddKitItemAsync(new KitItem
+            {
+                KitID = kitId,
+                ItemID = 999,
+                Quantity = 1,
+                IsOptional = false
+            });
+
+            var isAvailable = await _kitService.CheckKitAvailabilityAsync(kitId);
+
+            Assert.False(isAvailable);
+        }
     }
 }

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-kit-missing-required-item-availability.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-kit-missing-required-item-availability.md
@@ -1,0 +1,14 @@
+# Kit Missing Required Item Availability Guard
+
+Date: 2026-06-26
+
+## Completed
+
+- Updated kit availability checks so a required kit member whose item record cannot be joined is treated as unavailable.
+- Added focused kit service coverage for a required kit item pointing at a missing item record.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, WPF runtime/screenshots, local banned-word checks, and the full validation runner are unavailable here, so local build/test/full validation was not run.
+- GitHub connector readback/compare was used as fallback validation for the focused source changes.

--- a/InventoryManagementApp/Services/Kits/KitService.cs
+++ b/InventoryManagementApp/Services/Kits/KitService.cs
@@ -292,7 +292,7 @@ namespace InventoryManagementApp.Services.Kits
                     LEFT JOIN Items i ON ki.ItemID = i.ItemID
                     WHERE ki.KitID = @KitID
                     AND ki.IsOptional = 0
-                    AND i.AvailableQuantity < ki.Quantity";
+                    AND (i.ItemID IS NULL OR i.AvailableQuantity < ki.Quantity)";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@KitID", kitID);
                 var missingItems = Convert.ToInt32(cmd.ExecuteScalar());


### PR DESCRIPTION
## Summary

- Treat required kit members with missing joined item records as unavailable during kit availability checks.
- Add a focused kit service regression test for a required kit item whose item record is missing.
- Add a progress note for the kit availability guard.

## Why This Matters

`CheckKitAvailabilityAsync` used a left join, but only counted required kit members whose joined item quantity was lower than the required quantity. When the item row was missing, the quantity comparison evaluated to null and the kit could be reported as available even though a required item could not be found.

## Validation

- GitHub connector readback confirmed the service change, paired test, and progress note on `codex/guard-kit-missing-required-items`.
- GitHub connector compare confirmed the branch is current with `master` and changes only three focused files.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.