### PR TITLE
Guard kit item references before saving

### DIFF
--- a/InventoryManagementApp.Tests/KitServiceTests.cs
+++ b/InventoryManagementApp.Tests/KitServiceTests.cs
@@ -247,23 +247,88 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public async Task CheckKitAvailability_WithMissingRequiredItem_ShouldReturnFalse()
+        public async Task AddKitItem_WithMissingKit_ShouldThrow()
+        {
+            var kitItem = new KitItem
+            {
+                KitID = 999,
+                ItemID = 1,
+                Quantity = 1,
+                IsOptional = false
+            };
+
+            await Assert.ThrowsAsync<ArgumentException>(() => _kitService.AddKitItemAsync(kitItem));
+        }
+
+        [Fact]
+        public async Task AddKitItem_WithMissingItem_ShouldThrow()
         {
             var kit = new Kit
             {
                 KitNumber = "KIT-011",
-                Name = "Kit with Missing Required Item",
+                Name = "Kit Missing Item Guard",
                 IsActive = true
             };
             var kitId = await _kitService.CreateKitAsync(kit);
 
-            await _kitService.AddKitItemAsync(new KitItem
+            var kitItem = new KitItem
             {
                 KitID = kitId,
                 ItemID = 999,
                 Quantity = 1,
                 IsOptional = false
-            });
+            };
+
+            await Assert.ThrowsAsync<ArgumentException>(() => _kitService.AddKitItemAsync(kitItem));
+        }
+
+        [Fact]
+        public async Task UpdateKitItem_WithMissingItem_ShouldThrow()
+        {
+            var kit = new Kit
+            {
+                KitNumber = "KIT-012",
+                Name = "Kit Update Missing Item Guard",
+                IsActive = true
+            };
+            var kitId = await _kitService.CreateKitAsync(kit);
+            var kitItem = new KitItem
+            {
+                KitID = kitId,
+                ItemID = 1,
+                Quantity = 1,
+                IsOptional = false
+            };
+            var kitItemId = await _kitService.AddKitItemAsync(kitItem);
+            kitItem.KitItemID = kitItemId;
+            kitItem.ItemID = 999;
+
+            await Assert.ThrowsAsync<ArgumentException>(() => _kitService.UpdateKitItemAsync(kitItem));
+        }
+
+        [Fact]
+        public async Task CheckKitAvailability_WithMissingRequiredItem_ShouldReturnFalse()
+        {
+            var kit = new Kit
+            {
+                KitNumber = "KIT-013",
+                Name = "Kit with Missing Required Item",
+                IsActive = true
+            };
+            var kitId = await _kitService.CreateKitAsync(kit);
+
+            using (var conn = _databaseService.CreateConnection())
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = @"
+                    INSERT INTO KitItems (KitID, ItemID, Quantity, IsOptional)
+                    VALUES (@KitID, @ItemID, @Quantity, @IsOptional);";
+                cmd.Parameters.AddWithValue("@KitID", kitId);
+                cmd.Parameters.AddWithValue("@ItemID", 999);
+                cmd.Parameters.AddWithValue("@Quantity", 1);
+                cmd.Parameters.AddWithValue("@IsOptional", 0);
+                cmd.ExecuteNonQuery();
+            }
 
             var isAvailable = await _kitService.CheckKitAvailabilityAsync(kitId);
 

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-kit-item-reference-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-kit-item-reference-guards.md
@@ -1,0 +1,15 @@
+# Kit Item Reference Guards
+
+Date: 2026-06-26
+
+## Completed
+
+- Added kit item save guards so new or updated kit members must reference existing kit and item rows before persistence.
+- Kept legacy orphaned kit member handling covered by inserting the orphaned row directly in the availability regression test.
+- Added focused kit service coverage for missing kit references, missing item references, update-time missing item references, and the existing availability behavior for orphaned required rows.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, WPF runtime/screenshots, local banned-word checks, and the full validation runner are unavailable here, so local build/test/full validation was not run.
+- GitHub connector readback/compare was used as fallback validation for the focused source changes.

--- a/InventoryManagementApp/Services/Kits/KitService.cs
+++ b/InventoryManagementApp/Services/Kits/KitService.cs
@@ -225,6 +225,8 @@ namespace InventoryManagementApp.Services.Kits
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureKitItemReferencesExist(conn, kitItem);
+
                 var sql = @"
                     INSERT INTO KitItems 
                     (KitID, ItemID, Quantity, IsOptional)
@@ -248,6 +250,8 @@ namespace InventoryManagementApp.Services.Kits
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureKitItemReferencesExist(conn, kitItem);
+
                 var sql = @"
                     UPDATE KitItems 
                     SET ItemID = @ItemID,
@@ -354,6 +358,21 @@ namespace InventoryManagementApp.Services.Kits
                 throw new ArgumentOutOfRangeException(nameof(kitItem.ItemID), "Item ID must be greater than 0.");
             if (kitItem.Quantity < 1)
                 throw new ArgumentOutOfRangeException(nameof(kitItem.Quantity), "Quantity must be greater than 0.");
+        }
+
+        private static void EnsureKitItemReferencesExist(SqliteConnection conn, KitItem kitItem)
+        {
+            if (!RecordExists(conn, "SELECT COUNT(*) FROM Kits WHERE KitID = @ID", kitItem.KitID))
+                throw new ArgumentException("Kit item must reference an existing kit.", nameof(kitItem.KitID));
+            if (!RecordExists(conn, "SELECT COUNT(*) FROM Items WHERE ItemID = @ID", kitItem.ItemID))
+                throw new ArgumentException("Kit item must reference an existing item.", nameof(kitItem.ItemID));
+        }
+
+        private static bool RecordExists(SqliteConnection conn, string sql, int id)
+        {
+            using var cmd = new SqliteCommand(sql, conn);
+            cmd.Parameters.AddWithValue("@ID", id);
+            return Convert.ToInt32(cmd.ExecuteScalar()) > 0;
         }
 
         private static object ToDbNullableText(string? value)


### PR DESCRIPTION
## Summary

- Validate kit member saves against existing `Kits` and `Items` rows before insert/update.
- Keep legacy orphaned kit-member availability handling covered by inserting the orphan directly in the regression test.
- Add focused kit service tests for missing kit references, missing item references, update-time missing item references, and orphaned required-row availability.

## Why This Matters

The prior availability guard correctly treats orphaned required kit members as unavailable, but the kit service still allowed new `KitItems` rows to point at missing kits or items. This prevents fresh orphaned kit-member data while preserving defensive handling for older or manually damaged data already in the database.

## Validation

- GitHub connector readback confirmed the service guard, paired tests, and progress note on `codex/guard-kit-item-references`.
- GitHub connector compare confirmed the branch is current with `master` and changes only three focused files.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.