### PR TITLE
Guard reservation item and customer references

### DIFF
--- a/InventoryManagementApp.Tests/ReservationServiceTests.cs
+++ b/InventoryManagementApp.Tests/ReservationServiceTests.cs
@@ -135,6 +135,76 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task CreateReservation_WithMissingItem_ShouldThrow()
+        {
+            var reservation = new Reservation
+            {
+                ItemID = 999,
+                CustomerID = 1,
+                StartDate = DateTime.Today.AddDays(1),
+                EndDate = DateTime.Today.AddDays(2),
+                Quantity = 1,
+                Status = "Pending"
+            };
+
+            await Assert.ThrowsAsync<ArgumentException>(() => _reservationService.CreateReservationAsync(reservation));
+        }
+
+        [Fact]
+        public async Task CreateReservation_WithMissingCustomer_ShouldThrow()
+        {
+            var reservation = new Reservation
+            {
+                ItemID = 1,
+                CustomerID = 999,
+                StartDate = DateTime.Today.AddDays(1),
+                EndDate = DateTime.Today.AddDays(2),
+                Quantity = 1,
+                Status = "Pending"
+            };
+
+            await Assert.ThrowsAsync<ArgumentException>(() => _reservationService.CreateReservationAsync(reservation));
+        }
+
+        [Fact]
+        public async Task UpdateReservation_WithMissingItem_ShouldThrow()
+        {
+            var reservation = new Reservation
+            {
+                ItemID = 1,
+                CustomerID = 1,
+                StartDate = DateTime.Today.AddDays(1),
+                EndDate = DateTime.Today.AddDays(2),
+                Quantity = 1,
+                Status = "Pending"
+            };
+            var id = await _reservationService.CreateReservationAsync(reservation);
+            reservation.ReservationID = id;
+            reservation.ItemID = 999;
+
+            await Assert.ThrowsAsync<ArgumentException>(() => _reservationService.UpdateReservationAsync(reservation));
+        }
+
+        [Fact]
+        public async Task UpdateReservation_WithMissingCustomer_ShouldThrow()
+        {
+            var reservation = new Reservation
+            {
+                ItemID = 1,
+                CustomerID = 1,
+                StartDate = DateTime.Today.AddDays(1),
+                EndDate = DateTime.Today.AddDays(2),
+                Quantity = 1,
+                Status = "Pending"
+            };
+            var id = await _reservationService.CreateReservationAsync(reservation);
+            reservation.ReservationID = id;
+            reservation.CustomerID = 999;
+
+            await Assert.ThrowsAsync<ArgumentException>(() => _reservationService.UpdateReservationAsync(reservation));
+        }
+
+        [Fact]
         public async Task UpdateReservation_ShouldSucceed()
         {
             var reservation = new Reservation

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-reservation-reference-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-reservation-reference-guards.md
@@ -1,0 +1,15 @@
+# Reservation Reference Guards
+
+Date: 2026-06-26
+
+## Completed
+
+- Added reservation save guards so new or updated reservations must reference existing item and customer rows before persistence.
+- Kept the guard close to the create/update database write path so positive-but-missing IDs fail before orphaned reservation data can be inserted or updated.
+- Added focused reservation service coverage for missing item and missing customer references on both create and update paths.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, WPF runtime/screenshots, local banned-word checks, and the full validation runner are unavailable here, so local build/test/full validation was not run.
+- GitHub connector readback/compare was used as fallback validation for the focused source changes.

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -199,6 +199,8 @@ namespace InventoryManagementApp.Services.Reservations
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureReservationReferencesExist(conn, reservation);
+
                 var sql = @"
                     INSERT INTO Reservations 
                     (ItemID, CustomerID, ReservationDate, StartDate, EndDate, 
@@ -230,6 +232,8 @@ namespace InventoryManagementApp.Services.Reservations
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureReservationReferencesExist(conn, reservation);
+
                 var sql = @"
                     UPDATE Reservations 
                     SET ItemID = @ItemID,
@@ -391,6 +395,21 @@ namespace InventoryManagementApp.Services.Reservations
                 throw new ArgumentOutOfRangeException(nameof(reservation.Quantity), "Quantity must be greater than 0.");
             if (reservation.EndDate < reservation.StartDate)
                 throw new ArgumentException("End date must be on or after start date.", nameof(reservation.EndDate));
+        }
+
+        private static void EnsureReservationReferencesExist(SqliteConnection conn, Reservation reservation)
+        {
+            if (!RecordExists(conn, "SELECT COUNT(*) FROM Items WHERE ItemID = @ID", reservation.ItemID))
+                throw new ArgumentException("Reservation must reference an existing item.", nameof(reservation.ItemID));
+            if (!RecordExists(conn, "SELECT COUNT(*) FROM Customers WHERE CustomerID = @ID", reservation.CustomerID))
+                throw new ArgumentException("Reservation must reference an existing customer.", nameof(reservation.CustomerID));
+        }
+
+        private static bool RecordExists(SqliteConnection conn, string sql, int id)
+        {
+            using var cmd = new SqliteCommand(sql, conn);
+            cmd.Parameters.AddWithValue("@ID", id);
+            return Convert.ToInt32(cmd.ExecuteScalar()) > 0;
         }
 
         private static string NormalizeStatus(string? status)


### PR DESCRIPTION
## Summary

- Validate reservation create/update writes against existing `Items` and `Customers` rows before persistence.
- Prevent positive-but-missing item/customer IDs from creating orphaned reservation records.
- Add focused reservation service tests for missing item and missing customer references on create and update paths.

## Why This Matters

The recent reservation validation work guards invalid IDs, dates, quantities, and status values, but create/update still accepted positive IDs that did not point at real item or customer rows. That could leave reservation rows without a usable item/customer join. This mirrors the recent kit-member reference guard and prevents new orphaned reservation data at the service boundary.

## Validation

- GitHub connector readback confirmed the service guard, paired tests, and progress note on `codex/guard-reservation-references`.
- GitHub connector compare confirmed the branch is current with `master` and changes only three focused files.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.