### PR TITLE
Guard reservation fulfillment rental reference

### DIFF
--- a/InventoryManagementApp.Tests/ReservationServiceTests.cs
+++ b/InventoryManagementApp.Tests/ReservationServiceTests.cs
@@ -264,6 +264,23 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task FulfillReservation_WithMissingRental_ShouldThrow()
+        {
+            var reservation = new Reservation
+            {
+                ItemID = 1,
+                CustomerID = 1,
+                StartDate = DateTime.Now.AddDays(1),
+                EndDate = DateTime.Now.AddDays(3),
+                Quantity = 1,
+                Status = "Confirmed"
+            };
+            var id = await _reservationService.CreateReservationAsync(reservation);
+
+            await Assert.ThrowsAsync<ArgumentException>(() => _reservationService.FulfillReservationAsync(id, 999));
+        }
+
+        [Fact]
         public async Task DeleteReservation_ShouldSucceed()
         {
             var reservation = new Reservation

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-reservation-fulfillment-rental-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-reservation-fulfillment-rental-guard.md
@@ -1,0 +1,15 @@
+# Reservation Fulfillment Rental Guard
+
+Date: 2026-06-26
+
+## Completed
+
+- Added a reservation fulfillment guard so `FulfillReservationAsync` only stores a `RentalID` that exists in the `Rentals` table.
+- Reused the reservation service record-existence helper to keep the check close to the fulfillment write path.
+- Added focused reservation service coverage for a missing rental reference during fulfillment.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and the full validation runner are unavailable here, so local build/test/full validation was not run.
+- GitHub connector readback/compare was used as fallback validation for the focused source changes.

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -299,6 +299,9 @@ namespace InventoryManagementApp.Services.Reservations
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                if (!RecordExists(conn, "SELECT COUNT(*) FROM Rentals WHERE RentalID = @ID", rentalID))
+                    throw new ArgumentException("Reservation fulfillment must reference an existing rental.", nameof(rentalID));
+
                 var sql = "UPDATE Reservations SET Status = 'Fulfilled', RentalID = @RentalID WHERE ReservationID = @ReservationID";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@ReservationID", reservationID);


### PR DESCRIPTION
## Summary

- Validate `FulfillReservationAsync` against the `Rentals` table before storing a fulfilled reservation rental reference.
- Prevent positive-but-missing rental IDs from creating fulfilled reservations with orphaned `RentalID` values.
- Add focused reservation service coverage for missing rental references during fulfillment.

## Why This Matters

Recent reservation work now validates item and customer references before create/update writes, but fulfillment could still attach any positive rental ID to a reservation. This keeps the fulfilled reservation lifecycle aligned with the database relationship and prevents fresh orphaned reservation-to-rental data.

## Validation

- GitHub connector readback confirmed the fulfillment guard, paired test, and progress note on `codex/guard-reservation-fulfillment-rental`.
- GitHub connector compare confirmed the branch is current with `master` and changes only three focused files.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet` is not installed in this container, so local build/test validation was not run.
- PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so full validation was not run.