### PR TITLE
Guard reservation update rental reference

### DIFF
--- a/InventoryManagementApp.Tests/ReservationServiceTests.cs
+++ b/InventoryManagementApp.Tests/ReservationServiceTests.cs
@@ -205,6 +205,25 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task UpdateReservation_WithMissingRental_ShouldThrow()
+        {
+            var reservation = new Reservation
+            {
+                ItemID = 1,
+                CustomerID = 1,
+                StartDate = DateTime.Today.AddDays(1),
+                EndDate = DateTime.Today.AddDays(2),
+                Quantity = 1,
+                Status = "Pending"
+            };
+            var id = await _reservationService.CreateReservationAsync(reservation);
+            reservation.ReservationID = id;
+            reservation.RentalID = 999;
+
+            await Assert.ThrowsAsync<ArgumentException>(() => _reservationService.UpdateReservationAsync(reservation));
+        }
+
+        [Fact]
         public async Task UpdateReservation_ShouldSucceed()
         {
             var reservation = new Reservation

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-reservation-update-rental-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-reservation-update-rental-guard.md
@@ -1,0 +1,15 @@
+# Reservation Update Rental Guard
+
+Date: 2026-06-26
+
+## Completed
+
+- Added an update-time reservation guard so `UpdateReservationAsync` only stores a `RentalID` that exists in the `Rentals` table.
+- Kept the rental-reference validation close to the reservation update write path, alongside the existing item and customer reference checks.
+- Added focused reservation service coverage for a missing rental reference during reservation update.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and the full validation runner are unavailable here, so local build/test/full validation was not run.
+- GitHub connector readback/compare was used as fallback validation for the focused source changes.

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -233,6 +233,7 @@ namespace InventoryManagementApp.Services.Reservations
             {
                 using var conn = _databaseService.CreateConnection();
                 EnsureReservationReferencesExist(conn, reservation);
+                EnsureReservationRentalReferenceExists(conn, reservation);
 
                 var sql = @"
                     UPDATE Reservations 
@@ -406,6 +407,12 @@ namespace InventoryManagementApp.Services.Reservations
                 throw new ArgumentException("Reservation must reference an existing item.", nameof(reservation.ItemID));
             if (!RecordExists(conn, "SELECT COUNT(*) FROM Customers WHERE CustomerID = @ID", reservation.CustomerID))
                 throw new ArgumentException("Reservation must reference an existing customer.", nameof(reservation.CustomerID));
+        }
+
+        private static void EnsureReservationRentalReferenceExists(SqliteConnection conn, Reservation reservation)
+        {
+            if (reservation.RentalID.HasValue && !RecordExists(conn, "SELECT COUNT(*) FROM Rentals WHERE RentalID = @ID", reservation.RentalID.Value))
+                throw new ArgumentException("Reservation must reference an existing rental.", nameof(reservation.RentalID));
         }
 
         private static bool RecordExists(SqliteConnection conn, string sql, int id)


### PR DESCRIPTION
## Summary

- Validate `UpdateReservationAsync` against the `Rentals` table before storing a positive reservation `RentalID`.
- Prevent reservation updates from creating orphaned reservation-to-rental links.
- Add focused reservation service coverage for missing rental references during update.

## Why This Matters

Recent reservation hardening now validates item/customer references on create/update and validates rental references during fulfillment. The general update path could still write any positive `RentalID` directly to the reservation row. This keeps update-time reservation persistence aligned with fulfillment and prevents fresh orphaned rental links.

## Validation

- GitHub connector readback confirmed the update guard, paired test, and progress note on `codex/guard-reservation-update-rental-reference`.
- GitHub connector compare confirmed the branch is current with `master` and changes only three focused files.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet` is not installed in this container, so local build/test validation was not run.
- PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so full validation was not run.