### PR TITLE
Guard reservation lifecycle writes against missing rows

### DIFF
--- a/InventoryManagementApp.Tests/ReservationServiceTests.cs
+++ b/InventoryManagementApp.Tests/ReservationServiceTests.cs
@@ -224,6 +224,23 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task UpdateReservation_WithMissingReservation_ShouldThrow()
+        {
+            var reservation = new Reservation
+            {
+                ReservationID = 999,
+                ItemID = 1,
+                CustomerID = 1,
+                StartDate = DateTime.Today.AddDays(1),
+                EndDate = DateTime.Today.AddDays(2),
+                Quantity = 1,
+                Status = "Pending"
+            };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _reservationService.UpdateReservationAsync(reservation));
+        }
+
+        [Fact]
         public async Task UpdateReservation_ShouldSucceed()
         {
             var reservation = new Reservation
@@ -264,6 +281,12 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task ConfirmReservation_WithMissingReservation_ShouldThrow()
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _reservationService.ConfirmReservationAsync(999));
+        }
+
+        [Fact]
         public async Task CancelReservation_ShouldUpdateStatus()
         {
             var reservation = new Reservation
@@ -280,6 +303,12 @@ namespace InventoryManagementApp.Tests
             var result = await _reservationService.CancelReservationAsync(id);
 
             Assert.True(result);
+        }
+
+        [Fact]
+        public async Task CancelReservation_WithMissingReservation_ShouldThrow()
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _reservationService.CancelReservationAsync(999));
         }
 
         [Fact]
@@ -300,6 +329,12 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task FulfillReservation_WithMissingReservation_ShouldThrow()
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _reservationService.FulfillReservationAsync(999, 1));
+        }
+
+        [Fact]
         public async Task DeleteReservation_ShouldSucceed()
         {
             var reservation = new Reservation
@@ -316,6 +351,12 @@ namespace InventoryManagementApp.Tests
             var result = await _reservationService.DeleteReservationAsync(id);
 
             Assert.True(result);
+        }
+
+        [Fact]
+        public async Task DeleteReservation_WithMissingReservation_ShouldThrow()
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _reservationService.DeleteReservationAsync(999));
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-reservation-lifecycle-missing-row-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-reservation-lifecycle-missing-row-guard.md
@@ -1,0 +1,15 @@
+# Reservation Lifecycle Missing Row Guard
+
+Date: 2026-06-26
+
+## Completed
+
+- Added a shared reservation existence guard for lifecycle write paths before they mutate reservation rows.
+- Updated reservation update, confirm, cancel, fulfill, and delete operations so positive-but-missing reservation IDs fail explicitly instead of returning a silent no-op.
+- Added focused reservation service coverage for missing reservation rows across update, confirm, cancel, fulfill, and delete paths.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and the full validation runner are unavailable here, so local build/test/full validation was not run.
+- GitHub connector readback/compare was used as fallback validation for the focused source changes.

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -232,6 +232,7 @@ namespace InventoryManagementApp.Services.Reservations
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureReservationExists(conn, reservation.ReservationID);
                 EnsureReservationReferencesExist(conn, reservation);
                 EnsureReservationRentalReferenceExists(conn, reservation);
 
@@ -268,6 +269,8 @@ namespace InventoryManagementApp.Services.Reservations
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureReservationExists(conn, reservationID);
+
                 var sql = "UPDATE Reservations SET Status = 'Confirmed' WHERE ReservationID = @ReservationID";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@ReservationID", reservationID);
@@ -283,6 +286,8 @@ namespace InventoryManagementApp.Services.Reservations
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureReservationExists(conn, reservationID);
+
                 var sql = "UPDATE Reservations SET Status = 'Cancelled' WHERE ReservationID = @ReservationID";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@ReservationID", reservationID);
@@ -300,6 +305,7 @@ namespace InventoryManagementApp.Services.Reservations
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureReservationExists(conn, reservationID);
                 if (!RecordExists(conn, "SELECT COUNT(*) FROM Rentals WHERE RentalID = @ID", rentalID))
                     throw new ArgumentException("Reservation fulfillment must reference an existing rental.", nameof(rentalID));
 
@@ -319,6 +325,8 @@ namespace InventoryManagementApp.Services.Reservations
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureReservationExists(conn, reservationID);
+
                 var sql = "DELETE FROM Reservations WHERE ReservationID = @ReservationID";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@ReservationID", reservationID);
@@ -399,6 +407,12 @@ namespace InventoryManagementApp.Services.Reservations
                 throw new ArgumentOutOfRangeException(nameof(reservation.Quantity), "Quantity must be greater than 0.");
             if (reservation.EndDate < reservation.StartDate)
                 throw new ArgumentException("End date must be on or after start date.", nameof(reservation.EndDate));
+        }
+
+        private static void EnsureReservationExists(SqliteConnection conn, int reservationID)
+        {
+            if (!RecordExists(conn, "SELECT COUNT(*) FROM Reservations WHERE ReservationID = @ID", reservationID))
+                throw new InvalidOperationException("Reservation not found.");
         }
 
         private static void EnsureReservationReferencesExist(SqliteConnection conn, Reservation reservation)


### PR DESCRIPTION
## Summary

- Add a shared reservation existence guard before lifecycle write operations mutate reservation rows.
- Prevent update, confirm, cancel, fulfill, and delete operations from silently no-oping when a positive reservation ID no longer exists.
- Add focused reservation service coverage for missing reservation rows across the lifecycle write paths.

## Why This Matters

Recent reservation hardening validated item/customer/rental references before saving. The lifecycle write paths could still accept a positive reservation ID that no longer pointed at a row and simply return `false`, which can hide stale UI actions or damaged data. This makes stale reservation writes fail explicitly at the service boundary.

## Validation

- GitHub connector readback confirmed the shared guard, lifecycle write call sites, paired tests, and progress note on `codex/guard-reservation-lifecycle-missing-row`.
- GitHub connector compare confirmed the branch is current with `master` and changes only three focused files.
- The repository's actual default branch is `master`; a user instruction referenced `main`, but GitHub reports `master`, so this PR targets `master`.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.