### PR TITLE
Clear in-place release marker after deployment

### DIFF
--- a/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
@@ -38,6 +38,22 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void InPlaceDeploymentClearsCurrentReleaseMarkerAfterLauncherRefresh()
+        {
+            var script = ReadRepositoryFile("scripts", "update-shared-release.ps1");
+            var normalizedScript = script.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+            Assert.Contains("function Clear-CurrentReleaseMarker", script, StringComparison.Ordinal);
+            Assert.Contains("Test-Path -LiteralPath $currentReleaseMarker", script, StringComparison.Ordinal);
+            Assert.Contains("Remove-Item -LiteralPath $currentReleaseMarker -Force", script, StringComparison.Ordinal);
+
+            var inPlaceIndex = normalizedScript.IndexOf(
+                "Invoke-ReleaseMirror -From $sourcePath -To $destinationPath -ExcludedDirectories $excludedDirectories -ExcludedFiles @(\"appsettings.json\")\nCopy-CurrentReleaseLauncher\nClear-CurrentReleaseMarker",
+                StringComparison.Ordinal);
+            Assert.True(inPlaceIndex >= 0, "In-place deployment should clear current-release.txt after refreshing the shared launcher so restart shortcuts use the root executable.");
+        }
+
+        [Fact]
         public void SideBySideDeploymentRejectsReservedWindowsReleaseNames()
         {
             var script = ReadRepositoryFile("scripts", "update-shared-release.ps1");

--- a/InventoryManagementApp/ProgressNotes/2026-06-25-inplace-release-marker-cleanup.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-25-inplace-release-marker-cleanup.md
@@ -1,0 +1,15 @@
+# In-Place Release Marker Cleanup
+
+Date: 2026-06-25
+
+## Summary
+
+- Added an explicit `Clear-CurrentReleaseMarker` helper to `scripts/update-shared-release.ps1`.
+- The in-place deployment path now removes `current-release.txt` after mirroring the root deployment and refreshing the shared launcher.
+- Added `SharedReleaseUpdateScriptTests.InPlaceDeploymentClearsCurrentReleaseMarkerAfterLauncherRefresh` so restart shortcuts keep falling back to the root executable after an in-place update instead of following an older side-by-side marker.
+
+## Validation Notes
+
+- Local clone/raw access was blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` were unavailable here.
+- Use GitHub connector readback and compare for this branch, then run the full Windows/.NET validation runner in a capable checkout.

--- a/scripts/update-shared-release.ps1
+++ b/scripts/update-shared-release.ps1
@@ -167,6 +167,12 @@ function Set-CurrentReleaseMarker {
     }
 }
 
+function Clear-CurrentReleaseMarker {
+    if (Test-Path -LiteralPath $currentReleaseMarker) {
+        Remove-Item -LiteralPath $currentReleaseMarker -Force
+    }
+}
+
 function Copy-ReleaseConfiguration {
     param(
         [Parameter(Mandatory = $true)][string]$ReleasePath
@@ -250,5 +256,6 @@ if ($running) {
 Backup-PreservedPaths
 Invoke-ReleaseMirror -From $sourcePath -To $destinationPath -ExcludedDirectories $excludedDirectories -ExcludedFiles @("appsettings.json")
 Copy-CurrentReleaseLauncher
+Clear-CurrentReleaseMarker
 
 Write-Host "Release update complete."


### PR DESCRIPTION
## Summary

- Add an explicit `Clear-CurrentReleaseMarker` helper to the shared deployment updater.
- Clear `current-release.txt` after in-place deployment mirrors the root app and refreshes the shared launcher.
- Add source-contract coverage so in-place updates keep restart shortcuts falling back to the root executable instead of an older side-by-side marker.

## Why This Matters

The side-by-side deployment flow intentionally writes `current-release.txt` so the shared launcher starts the active release folder. An in-place deployment should return that launcher to the root executable path. Robocopy mirroring may remove the marker today, but this makes the intent explicit and protects the in-place path from stale side-by-side markers if the mirror behavior or exclusions change later.

## Validation

- GitHub connector compare confirmed the branch is current with `master` and changes only the updater, its source-contract test, and a progress note.
- GitHub connector readback confirmed `Clear-CurrentReleaseMarker` is called after `Copy-CurrentReleaseLauncher` in the in-place deployment path.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.