### PR TITLE
Guard console device release names

### DIFF
--- a/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
@@ -62,6 +62,8 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("$windowsReservedDeviceNames = @(", script, StringComparison.Ordinal);
             Assert.Contains("\"CON\"", script, StringComparison.Ordinal);
+            Assert.Contains("\"CONIN$\"", script, StringComparison.Ordinal);
+            Assert.Contains("\"CONOUT$\"", script, StringComparison.Ordinal);
             Assert.Contains("\"NUL\"", script, StringComparison.Ordinal);
             Assert.Contains("\"COM1\"", script, StringComparison.Ordinal);
             Assert.Contains("\"LPT1\"", script, StringComparison.Ordinal);
@@ -73,6 +75,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("reserved Windows device name", script, StringComparison.Ordinal);
 
             Assert.Contains("$windowsReservedDeviceNames = @(", launcher, StringComparison.Ordinal);
+            Assert.Contains("\"CONIN$\"", launcher, StringComparison.Ordinal);
+            Assert.Contains("\"CONOUT$\"", launcher, StringComparison.Ordinal);
             Assert.Contains("$releaseName.EndsWith(\".\")", launcher, StringComparison.Ordinal);
             Assert.Contains("$releaseName.EndsWith(\" \")", launcher, StringComparison.Ordinal);
             Assert.Contains("function Test-ReleaseNameIsReservedDeviceName", launcher, StringComparison.Ordinal);
@@ -80,7 +84,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("Test-ReleaseNameIsReservedDeviceName -ReleaseName $releaseName", launcher, StringComparison.Ordinal);
             Assert.Contains("folder-safe, non-reserved name", launcher, StringComparison.Ordinal);
 
-            Assert.Contains("Avoid Windows reserved device names such as `CON`, `NUL`, `COM1`, or `LPT1`", guide, StringComparison.Ordinal);
+            Assert.Contains("Avoid Windows reserved device names such as `CON`, `CONIN$`, `CONOUT$`, `NUL`, `COM1`, or `LPT1`", guide, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-console-device-release-name-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-console-device-release-name-guard.md
@@ -1,0 +1,16 @@
+# Console Device Release Name Guard
+
+Date: 2026-06-26
+
+## Summary
+
+- Added `CONIN$` and `CONOUT$` to the reserved Windows device-name lists in `scripts/update-shared-release.ps1` and `scripts/start-current-release.ps1`.
+- The side-by-side updater now rejects those console device names before creating a release folder or publishing `current-release.txt`.
+- The shared launcher now rejects manually edited markers that point at those reserved console names before resolving `_releases/<ReleaseName>`.
+- Updated `SERVER_DEPLOYMENT_GUIDE.md` and `SharedReleaseUpdateScriptTests.SideBySideDeploymentRejectsReservedWindowsReleaseNames` so the operator guidance and source-contract coverage stay aligned.
+
+## Validation Notes
+
+- Direct local clone access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
+- Use GitHub connector readback and compare for this branch, then run the full Windows/.NET validation runner and a shared-deployment smoke test in a capable checkout.

--- a/SERVER_DEPLOYMENT_GUIDE.md
+++ b/SERVER_DEPLOYMENT_GUIDE.md
@@ -85,7 +85,7 @@ Recommended active-user update flow:
    ./scripts/update-shared-release.ps1 -Source ./publish-clean -Destination X:\V2 -DeploymentMode SideBySide -ReleaseName 2026.06.25-1
    ```
 
-   Use a folder-safe release name that does not end with a dot or space. Avoid Windows reserved device names such as `CON`, `NUL`, `COM1`, or `LPT1`, because those names are invalid deployment folder targets on Windows.
+   Use a folder-safe release name that does not end with a dot or space. Avoid Windows reserved device names such as `CON`, `CONIN$`, `CONOUT$`, `NUL`, `COM1`, or `LPT1`, because those names are invalid deployment folder targets on Windows.
 
    The update script also refreshes the launcher at `X:\V2\scripts\start-current-release.ps1` so shared shortcuts can target the deployed folder instead of depending on a repository checkout.
 3. Point the shared shortcut, launcher script, or deployment utility at the current-release launcher instead of at a specific release executable:

--- a/scripts/start-current-release.ps1
+++ b/scripts/start-current-release.ps1
@@ -8,6 +8,8 @@ $ErrorActionPreference = "Stop"
 
 $windowsReservedDeviceNames = @(
     "CON",
+    "CONIN$",
+    "CONOUT$",
     "PRN",
     "AUX",
     "NUL",

--- a/scripts/update-shared-release.ps1
+++ b/scripts/update-shared-release.ps1
@@ -31,6 +31,8 @@ $launcherDestinationDirectory = Join-Path $destinationPath "scripts"
 $launcherDestinationPath = Join-Path $launcherDestinationDirectory "start-current-release.ps1"
 $windowsReservedDeviceNames = @(
     "CON",
+    "CONIN$",
+    "CONOUT$",
     "PRN",
     "AUX",
     "NUL",
@@ -258,4 +260,4 @@ Invoke-ReleaseMirror -From $sourcePath -To $destinationPath -ExcludedDirectories
 Copy-CurrentReleaseLauncher
 Clear-CurrentReleaseMarker
 
-Write-Host "Release update complete."
+Write-Host "Release update complete."}      | sed -n '1,20p' >/dev/null

--- a/scripts/update-shared-release.ps1
+++ b/scripts/update-shared-release.ps1
@@ -260,4 +260,4 @@ Invoke-ReleaseMirror -From $sourcePath -To $destinationPath -ExcludedDirectories
 Copy-CurrentReleaseLauncher
 Clear-CurrentReleaseMarker
 
-Write-Host "Release update complete."}      | sed -n '1,20p' >/dev/null
+Write-Host "Release update complete."


### PR DESCRIPTION
## Summary

- Add `CONIN$` and `CONOUT$` to the reserved Windows device-name lists used by the side-by-side deployment updater and current-release launcher.
- Keep deployment docs aligned so active-user release names avoid those console device names alongside `CON`, `NUL`, `COM1`, and `LPT1`.
- Extend `SharedReleaseUpdateScriptTests` source-contract coverage and add a progress note for the deployment hardening pass.

## Why This Matters

Windows treats `CONIN$` and `CONOUT$` as reserved console device names. The recent deployment guard already rejected classic reserved names before creating `_releases/<ReleaseName>` or trusting `current-release.txt`, but these two names were still allowed. This closes the same class of side-by-side deployment and launcher marker failure for console device names.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only the updater, launcher, deployment guide, source-contract test, and progress note.
- GitHub connector readback confirmed both scripts include `CONIN$` and `CONOUT$`, and the updater file ending is clean after correcting an initial connector-edit typo.
- Direct local clone access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.