### PR TITLE
Guard release names against Windows-invalid characters

### DIFF
--- a/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
@@ -105,7 +105,8 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("Test-ReleaseNameIsReservedDeviceName -ReleaseName $releaseName", launcher, StringComparison.Ordinal);
             Assert.Contains("folder-safe Windows name", launcher, StringComparison.Ordinal);
 
-            Assert.Contains("Do not use Windows filename characters such as `\\`, `/`, `:`, `*`, `?`, `\"`, `<`, `>`, or `|`", guide, StringComparison.Ordinal);
+            Assert.Contains("Do not use Windows filename characters such as", guide, StringComparison.Ordinal);
+            Assert.Contains("or `|`", guide, StringComparison.Ordinal);
             Assert.Contains("Avoid Windows reserved device names such as `CON`, `CONIN$`, `CONOUT$`, `NUL`, `COM1`, or `LPT1`", guide, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
@@ -54,11 +54,26 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void SideBySideDeploymentRejectsReservedWindowsReleaseNames()
+        public void SideBySideDeploymentRejectsUnsafeWindowsReleaseNames()
         {
             var script = ReadRepositoryFile("scripts", "update-shared-release.ps1");
             var launcher = ReadRepositoryFile("scripts", "start-current-release.ps1");
             var guide = ReadRepositoryFile("SERVER_DEPLOYMENT_GUIDE.md");
+
+            Assert.Contains("$windowsInvalidFileNameCharacters = @(", script, StringComparison.Ordinal);
+            Assert.Contains("'<'", script, StringComparison.Ordinal);
+            Assert.Contains("'>'", script, StringComparison.Ordinal);
+            Assert.Contains("':'", script, StringComparison.Ordinal);
+            Assert.Contains("'\"'", script, StringComparison.Ordinal);
+            Assert.Contains("'/'", script, StringComparison.Ordinal);
+            Assert.Contains("'\\'", script, StringComparison.Ordinal);
+            Assert.Contains("'|'", script, StringComparison.Ordinal);
+            Assert.Contains("'?'", script, StringComparison.Ordinal);
+            Assert.Contains("'*'", script, StringComparison.Ordinal);
+            Assert.Contains("function Test-ReleaseNameHasInvalidWindowsFileNameCharacter", script, StringComparison.Ordinal);
+            Assert.Contains("$ReleaseName.IndexOfAny($windowsInvalidFileNameCharacters) -ge 0", script, StringComparison.Ordinal);
+            Assert.Contains("Test-ReleaseNameHasInvalidWindowsFileNameCharacter -ReleaseName $ReleaseName", script, StringComparison.Ordinal);
+            Assert.DoesNotContain("GetInvalidFileNameChars", script, StringComparison.Ordinal);
 
             Assert.Contains("$windowsReservedDeviceNames = @(", script, StringComparison.Ordinal);
             Assert.Contains("\"CON\"", script, StringComparison.Ordinal);
@@ -72,8 +87,14 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("function Test-ReleaseNameIsReservedDeviceName", script, StringComparison.Ordinal);
             Assert.Contains("$ReleaseName.TrimEnd([char[]]@(' ', '.'))", script, StringComparison.Ordinal);
             Assert.Contains("Test-ReleaseNameIsReservedDeviceName -ReleaseName $ReleaseName", script, StringComparison.Ordinal);
+            Assert.Contains("folder-safe Windows name", script, StringComparison.Ordinal);
             Assert.Contains("reserved Windows device name", script, StringComparison.Ordinal);
 
+            Assert.Contains("$windowsInvalidFileNameCharacters = @(", launcher, StringComparison.Ordinal);
+            Assert.Contains("function Test-ReleaseNameHasInvalidWindowsFileNameCharacter", launcher, StringComparison.Ordinal);
+            Assert.Contains("$ReleaseName.IndexOfAny($windowsInvalidFileNameCharacters) -ge 0", launcher, StringComparison.Ordinal);
+            Assert.Contains("Test-ReleaseNameHasInvalidWindowsFileNameCharacter -ReleaseName $releaseName", launcher, StringComparison.Ordinal);
+            Assert.DoesNotContain("GetInvalidFileNameChars", launcher, StringComparison.Ordinal);
             Assert.Contains("$windowsReservedDeviceNames = @(", launcher, StringComparison.Ordinal);
             Assert.Contains("\"CONIN$\"", launcher, StringComparison.Ordinal);
             Assert.Contains("\"CONOUT$\"", launcher, StringComparison.Ordinal);
@@ -82,8 +103,9 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("function Test-ReleaseNameIsReservedDeviceName", launcher, StringComparison.Ordinal);
             Assert.Contains("$ReleaseName.TrimEnd([char[]]@(' ', '.'))", launcher, StringComparison.Ordinal);
             Assert.Contains("Test-ReleaseNameIsReservedDeviceName -ReleaseName $releaseName", launcher, StringComparison.Ordinal);
-            Assert.Contains("folder-safe, non-reserved name", launcher, StringComparison.Ordinal);
+            Assert.Contains("folder-safe Windows name", launcher, StringComparison.Ordinal);
 
+            Assert.Contains("Do not use Windows filename characters such as `\\`, `/`, `:`, `*`, `?`, `\"`, `<`, `>`, or `|`", guide, StringComparison.Ordinal);
             Assert.Contains("Avoid Windows reserved device names such as `CON`, `CONIN$`, `CONOUT$`, `NUL`, `COM1`, or `LPT1`", guide, StringComparison.Ordinal);
         }
 

--- a/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
@@ -60,7 +60,7 @@ namespace InventoryManagementApp.Tests
             var launcher = ReadRepositoryFile("scripts", "start-current-release.ps1");
             var guide = ReadRepositoryFile("SERVER_DEPLOYMENT_GUIDE.md");
 
-            Assert.Contains("$windowsInvalidFileNameCharacters = @(", script, StringComparison.Ordinal);
+            Assert.Contains("[char[]]$windowsInvalidFileNameCharacters = @(", script, StringComparison.Ordinal);
             Assert.Contains("'<'", script, StringComparison.Ordinal);
             Assert.Contains("'>'", script, StringComparison.Ordinal);
             Assert.Contains("':'", script, StringComparison.Ordinal);
@@ -90,7 +90,7 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("folder-safe Windows name", script, StringComparison.Ordinal);
             Assert.Contains("reserved Windows device name", script, StringComparison.Ordinal);
 
-            Assert.Contains("$windowsInvalidFileNameCharacters = @(", launcher, StringComparison.Ordinal);
+            Assert.Contains("[char[]]$windowsInvalidFileNameCharacters = @(", launcher, StringComparison.Ordinal);
             Assert.Contains("function Test-ReleaseNameHasInvalidWindowsFileNameCharacter", launcher, StringComparison.Ordinal);
             Assert.Contains("$ReleaseName.IndexOfAny($windowsInvalidFileNameCharacters) -ge 0", launcher, StringComparison.Ordinal);
             Assert.Contains("Test-ReleaseNameHasInvalidWindowsFileNameCharacter -ReleaseName $releaseName", launcher, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-windows-release-name-character-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-windows-release-name-character-guard.md
@@ -1,0 +1,14 @@
+# Windows Release Name Character Guard
+
+Date: 2026-06-26
+
+## Summary
+
+- Added an explicit Windows invalid filename character guard to the shared release updater and current-release launcher.
+- Kept release-name validation host-independent so side-by-side deployment names are checked against Windows folder rules even if PowerShell runs from a non-Windows environment.
+- Updated the server deployment guide and source-contract coverage for the invalid-character and reserved-device-name release checks.
+
+## Validation
+
+- GitHub connector readback/compare should confirm the focused script, guide, test, and progress-note changes.
+- Local `dotnet`, PowerShell, WPF runtime, and deployment smoke validation still require a Windows/.NET-capable checkout.

--- a/SERVER_DEPLOYMENT_GUIDE.md
+++ b/SERVER_DEPLOYMENT_GUIDE.md
@@ -85,7 +85,7 @@ Recommended active-user update flow:
    ./scripts/update-shared-release.ps1 -Source ./publish-clean -Destination X:\V2 -DeploymentMode SideBySide -ReleaseName 2026.06.25-1
    ```
 
-   Use a folder-safe release name that does not end with a dot or space. Avoid Windows reserved device names such as `CON`, `CONIN$`, `CONOUT$`, `NUL`, `COM1`, or `LPT1`, because those names are invalid deployment folder targets on Windows.
+   Use a folder-safe Windows release name that does not end with a dot or space. Do not use Windows filename characters such as `\`, `/`, `:`, `*`, `?`, `"`, `<`, `>`, or `|`. Avoid Windows reserved device names such as `CON`, `CONIN$`, `CONOUT$`, `NUL`, `COM1`, or `LPT1`, because those names are invalid deployment folder targets on Windows.
 
    The update script also refreshes the launcher at `X:\V2\scripts\start-current-release.ps1` so shared shortcuts can target the deployed folder instead of depending on a repository checkout.
 3. Point the shared shortcut, launcher script, or deployment utility at the current-release launcher instead of at a specific release executable:

--- a/scripts/start-current-release.ps1
+++ b/scripts/start-current-release.ps1
@@ -6,7 +6,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$windowsInvalidFileNameCharacters = @(
+[char[]]$windowsInvalidFileNameCharacters = @(
     '<',
     '>',
     ':',

--- a/scripts/start-current-release.ps1
+++ b/scripts/start-current-release.ps1
@@ -6,6 +6,17 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+$windowsInvalidFileNameCharacters = @(
+    '<',
+    '>',
+    ':',
+    '"',
+    '/',
+    '\',
+    '|',
+    '?',
+    '*'
+)
 $windowsReservedDeviceNames = @(
     "CON",
     "CONIN$",
@@ -32,6 +43,14 @@ $windowsReservedDeviceNames = @(
     "LPT8",
     "LPT9"
 )
+
+function Test-ReleaseNameHasInvalidWindowsFileNameCharacter {
+    param(
+        [Parameter(Mandatory = $true)][string]$ReleaseName
+    )
+
+    return $ReleaseName.IndexOfAny($windowsInvalidFileNameCharacters) -ge 0
+}
 
 function Test-ReleaseNameIsReservedDeviceName {
     param(
@@ -60,8 +79,8 @@ if (Test-Path -LiteralPath $currentReleaseMarker) {
 }
 
 if (-not [string]::IsNullOrWhiteSpace($releaseName)) {
-    if ($releaseName.EndsWith(".") -or $releaseName.EndsWith(" ") -or $releaseName.IndexOfAny([System.IO.Path]::GetInvalidFileNameChars()) -ge 0 -or $releaseName -eq "." -or $releaseName -eq ".." -or (Test-ReleaseNameIsReservedDeviceName -ReleaseName $releaseName)) {
-        throw "ReleaseName in current-release.txt must be a folder-safe, non-reserved name that does not end with a dot or space."
+    if ($releaseName.EndsWith(".") -or $releaseName.EndsWith(" ") -or (Test-ReleaseNameHasInvalidWindowsFileNameCharacter -ReleaseName $releaseName) -or $releaseName -eq "." -or $releaseName -eq ".." -or (Test-ReleaseNameIsReservedDeviceName -ReleaseName $releaseName)) {
+        throw "ReleaseName in current-release.txt must be a folder-safe Windows name that does not contain invalid filename characters, end with a dot or space, or use a reserved device name."
     }
 
     $releasePath = Join-Path $releaseRoot $releaseName

--- a/scripts/update-shared-release.ps1
+++ b/scripts/update-shared-release.ps1
@@ -29,7 +29,7 @@ $currentReleaseMarker = Join-Path $destinationPath "current-release.txt"
 $launcherSourcePath = Join-Path $PSScriptRoot "start-current-release.ps1"
 $launcherDestinationDirectory = Join-Path $destinationPath "scripts"
 $launcherDestinationPath = Join-Path $launcherDestinationDirectory "start-current-release.ps1"
-$windowsInvalidFileNameCharacters = @(
+[char[]]$windowsInvalidFileNameCharacters = @(
     '<',
     '>',
     ':',

--- a/scripts/update-shared-release.ps1
+++ b/scripts/update-shared-release.ps1
@@ -29,6 +29,17 @@ $currentReleaseMarker = Join-Path $destinationPath "current-release.txt"
 $launcherSourcePath = Join-Path $PSScriptRoot "start-current-release.ps1"
 $launcherDestinationDirectory = Join-Path $destinationPath "scripts"
 $launcherDestinationPath = Join-Path $launcherDestinationDirectory "start-current-release.ps1"
+$windowsInvalidFileNameCharacters = @(
+    '<',
+    '>',
+    ':',
+    '"',
+    '/',
+    '\',
+    '|',
+    '?',
+    '*'
+)
 $windowsReservedDeviceNames = @(
     "CON",
     "CONIN$",
@@ -81,6 +92,14 @@ $preservedPaths = @(
     "Logs"
 )
 $sideBySideLinkedDirectories = $preservedPaths | Where-Object { $_ -ne "appsettings.json" }
+
+function Test-ReleaseNameHasInvalidWindowsFileNameCharacter {
+    param(
+        [Parameter(Mandatory = $true)][string]$ReleaseName
+    )
+
+    return $ReleaseName.IndexOfAny($windowsInvalidFileNameCharacters) -ge 0
+}
 
 function Test-ReleaseNameIsReservedDeviceName {
     param(
@@ -228,8 +247,8 @@ Write-Host "Preserving:  $themesPath"
 Write-Host "Backup:      $backupPath"
 
 if ($DeploymentMode -eq "SideBySide") {
-    if ([string]::IsNullOrWhiteSpace($ReleaseName) -or $ReleaseName.EndsWith(".") -or $ReleaseName.EndsWith(" ") -or $ReleaseName.IndexOfAny([System.IO.Path]::GetInvalidFileNameChars()) -ge 0 -or (Test-ReleaseNameIsReservedDeviceName -ReleaseName $ReleaseName)) {
-        throw "ReleaseName must be a non-empty folder-safe name and cannot end with a dot or space or use a reserved Windows device name."
+    if ([string]::IsNullOrWhiteSpace($ReleaseName) -or $ReleaseName.EndsWith(".") -or $ReleaseName.EndsWith(" ") -or (Test-ReleaseNameHasInvalidWindowsFileNameCharacter -ReleaseName $ReleaseName) -or (Test-ReleaseNameIsReservedDeviceName -ReleaseName $ReleaseName)) {
+        throw "ReleaseName must be a non-empty folder-safe Windows name and cannot contain invalid filename characters, end with a dot or space, or use a reserved Windows device name."
     }
 
     $releasePath = Join-Path $releaseRoot $ReleaseName


### PR DESCRIPTION
## Summary

- Add an explicit Windows invalid filename character guard to the shared deployment updater and current-release launcher.
- Keep side-by-side release-name validation independent from the OS running PowerShell, so names containing characters like `:`, `*`, `?`, `\`, or `|` are rejected before `current-release.txt` or `_releases/<ReleaseName>` can point at them.
- Update the server deployment guide, source-contract coverage, and progress note for the release-name safety rule.

## Why This Matters

The deployment scripts already rejected trailing dots/spaces and reserved Windows device names. They still relied on `[System.IO.Path]::GetInvalidFileNameChars()`, which is host-dependent. If an admin ran PowerShell from a non-Windows host against a Windows shared deployment folder, Windows-invalid characters could be allowed through. This makes the deployment guard match the target platform explicitly.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only the updater, launcher, deployment guide, source-contract test, and progress note.
- GitHub connector readback confirmed both scripts use an explicit `[char[]]$windowsInvalidFileNameCharacters` list and call `Test-ReleaseNameHasInvalidWindowsFileNameCharacter` before accepting release names.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.