### PR TITLE
Validate shared shortcut release marker names

### DIFF
--- a/InventoryManagementApp.Tests/SharedReleaseDesktopShortcutScriptTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseDesktopShortcutScriptTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class SharedReleaseDesktopShortcutScriptTests
+    {
+        [Fact]
+        public void DesktopShortcutScriptRejectsUnsafeCurrentReleaseMarkerNames()
+        {
+            var script = ReadRepositoryFile("scripts", "create-shared-desktop-shortcut.ps1");
+            var normalizedScript = script.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+            Assert.Contains("[char[]]$windowsInvalidFileNameCharacters = @(", script, StringComparison.Ordinal);
+            Assert.Contains("'<'", script, StringComparison.Ordinal);
+            Assert.Contains("'>'", script, StringComparison.Ordinal);
+            Assert.Contains("':'", script, StringComparison.Ordinal);
+            Assert.Contains("'\"'", script, StringComparison.Ordinal);
+            Assert.Contains("'/'", script, StringComparison.Ordinal);
+            Assert.Contains("'\\'", script, StringComparison.Ordinal);
+            Assert.Contains("'|'", script, StringComparison.Ordinal);
+            Assert.Contains("'?'", script, StringComparison.Ordinal);
+            Assert.Contains("'*'", script, StringComparison.Ordinal);
+            Assert.Contains("function Test-ReleaseNameHasInvalidWindowsFileNameCharacter", script, StringComparison.Ordinal);
+            Assert.Contains("$ReleaseName.IndexOfAny($windowsInvalidFileNameCharacters) -ge 0", script, StringComparison.Ordinal);
+            Assert.Contains("function Test-ReleaseNameIsReservedDeviceName", script, StringComparison.Ordinal);
+            Assert.Contains("\"CONIN$\"", script, StringComparison.Ordinal);
+            Assert.Contains("\"CONOUT$\"", script, StringComparison.Ordinal);
+            Assert.Contains("function Assert-CurrentReleaseNameIsSafe", script, StringComparison.Ordinal);
+            Assert.Contains("ReleaseName in current-release.txt must be a folder-safe Windows name", script, StringComparison.Ordinal);
+            Assert.Contains("Assert-CurrentReleaseNameIsSafe -ReleaseName $currentReleaseName", script, StringComparison.Ordinal);
+            Assert.DoesNotContain("GetInvalidFileNameChars", script, StringComparison.Ordinal);
+
+            var validationIndex = normalizedScript.IndexOf(
+                "$currentReleaseName = $currentRelease.Trim()\n            Assert-CurrentReleaseNameIsSafe -ReleaseName $currentReleaseName\n            $releaseExecutablePath = Join-Path",
+                StringComparison.Ordinal);
+            Assert.True(validationIndex >= 0, "Desktop shortcut refresh should reject unsafe current-release.txt names before resolving the release executable path or falling back to the root executable.");
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var baseDirectory = AppContext.BaseDirectory;
+            var repositoryRoot = Path.GetFullPath(Path.Combine(baseDirectory, "..", "..", "..", ".."));
+            return File.ReadAllText(Path.Combine(new[] { repositoryRoot }.Concat(relativePathParts).ToArray()));
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-shortcut-release-marker-validation.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-shortcut-release-marker-validation.md
@@ -1,0 +1,14 @@
+# Shortcut Release Marker Validation
+
+Date: 2026-06-26
+
+## Completed
+
+- Hardened `scripts/create-shared-desktop-shortcut.ps1` so shortcut refreshes validate `current-release.txt` release names before resolving `_releases/<ReleaseName>/InventoryManagementApp.exe`.
+- Reused the same folder-safe Windows release-name rules as the shared updater/current-release launcher: non-empty after trimming, no invalid Windows filename characters, no trailing dot or space, no `.` or `..`, and no reserved device names such as `CON`, `CONIN$`, `CONOUT$`, `NUL`, `COM1`, or `LPT1`.
+- Added `SharedReleaseDesktopShortcutScriptTests` source-contract coverage so the desktop shortcut helper cannot silently fall back to the root executable when `current-release.txt` contains an unsafe release name.
+
+## Validation Notes
+
+- Local restore/build/test and PowerShell execution were not run in this scheduled Linux environment because direct checkout/raw access, `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, and the full validation runner are unavailable here.
+- Use GitHub connector readback/compare for branch verification in this environment, then run `pwsh -File scripts/run-full-validation.ps1` from a Windows/.NET-capable checkout when available.

--- a/scripts/create-shared-desktop-shortcut.ps1
+++ b/scripts/create-shared-desktop-shortcut.ps1
@@ -12,6 +12,71 @@ if (-not (Test-Path -LiteralPath $Destination)) {
 }
 
 $destinationPath = (Resolve-Path -LiteralPath $Destination).Path
+[char[]]$windowsInvalidFileNameCharacters = @(
+    '<',
+    '>',
+    ':',
+    '"',
+    '/',
+    '\',
+    '|',
+    '?',
+    '*'
+)
+$windowsReservedDeviceNames = @(
+    "CON",
+    "CONIN$",
+    "CONOUT$",
+    "PRN",
+    "AUX",
+    "NUL",
+    "COM1",
+    "COM2",
+    "COM3",
+    "COM4",
+    "COM5",
+    "COM6",
+    "COM7",
+    "COM8",
+    "COM9",
+    "LPT1",
+    "LPT2",
+    "LPT3",
+    "LPT4",
+    "LPT5",
+    "LPT6",
+    "LPT7",
+    "LPT8",
+    "LPT9"
+)
+
+function Test-ReleaseNameHasInvalidWindowsFileNameCharacter {
+    param(
+        [Parameter(Mandatory = $true)][string]$ReleaseName
+    )
+
+    return $ReleaseName.IndexOfAny($windowsInvalidFileNameCharacters) -ge 0
+}
+
+function Test-ReleaseNameIsReservedDeviceName {
+    param(
+        [Parameter(Mandatory = $true)][string]$ReleaseName
+    )
+
+    $normalizedReleaseName = $ReleaseName.TrimEnd([char[]]@(' ', '.'))
+    $baseName = [System.IO.Path]::GetFileNameWithoutExtension($normalizedReleaseName).ToUpperInvariant()
+    return $windowsReservedDeviceNames -contains $baseName
+}
+
+function Assert-CurrentReleaseNameIsSafe {
+    param(
+        [Parameter(Mandatory = $true)][string]$ReleaseName
+    )
+
+    if ($ReleaseName.EndsWith(".") -or $ReleaseName.EndsWith(" ") -or (Test-ReleaseNameHasInvalidWindowsFileNameCharacter -ReleaseName $ReleaseName) -or $ReleaseName -eq "." -or $ReleaseName -eq ".." -or (Test-ReleaseNameIsReservedDeviceName -ReleaseName $ReleaseName)) {
+        throw "ReleaseName in current-release.txt must be a folder-safe Windows name that does not contain invalid filename characters, end with a dot or space, or use a reserved device name."
+    }
+}
 
 function Convert-ToUncPathIfMappedDrive {
     param(
@@ -43,6 +108,8 @@ function Get-CurrentReleaseExecutablePath {
             Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
             Select-Object -First 1
         if (-not [string]::IsNullOrWhiteSpace($currentRelease)) {
+            $currentReleaseName = $currentRelease.Trim()
+            Assert-CurrentReleaseNameIsSafe -ReleaseName $currentReleaseName
             $releaseExecutablePath = Join-Path (Join-Path (Join-Path $destinationPath "_releases") $currentRelease.Trim()) "InventoryManagementApp.exe"
             if (Test-Path -LiteralPath $releaseExecutablePath) {
                 return $releaseExecutablePath


### PR DESCRIPTION
## Summary

- Add folder-safe Windows release-name validation to `scripts/create-shared-desktop-shortcut.ps1` before it resolves `_releases/<ReleaseName>/InventoryManagementApp.exe` from `current-release.txt`.
- Reuse the same invalid-character, trailing dot/space, dot-directory, and reserved device-name guard shape used by the shared updater/current-release launcher.
- Add source-contract coverage and a progress note for the shortcut marker validation path.

## Why This Matters

The updater and current-release launcher now reject unsafe release names, but the desktop shortcut refresh helper still trusted `current-release.txt` when resolving the release executable and could silently fall back to the root executable if the derived path was bad or missing. That made shared shortcut refresh less strict than the launcher users actually run. This keeps the deployment tooling consistent and fails clearly when the marker contains an unsafe release name.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only the shortcut script, a focused source-contract test, and a progress note.
- GitHub connector readback confirmed the shortcut script validates the trimmed marker before joining the release executable path, and the test guards the same contract.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.