### PR TITLE
Trim current release marker in launcher

### DIFF
--- a/InventoryManagementApp.Tests/SharedReleaseLauncherMarkerContractTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseLauncherMarkerContractTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class SharedReleaseLauncherMarkerContractTests
+    {
+        [Fact]
+        public void CurrentReleaseLauncherTrimsMarkerBeforeValidationAndPathResolution()
+        {
+            var launcher = ReadRepositoryFile("scripts", "start-current-release.ps1");
+            var normalizedLauncher = launcher.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+            Assert.Contains("$releaseName = $releaseName.Trim()", launcher, StringComparison.Ordinal);
+
+            var normalizationIndex = normalizedLauncher.IndexOf(
+                "$releaseName = $releaseName.Trim()\n\n    if ($releaseName.EndsWith(\".\")",
+                StringComparison.Ordinal);
+            Assert.True(normalizationIndex >= 0, "The launcher should normalize the current-release marker before applying folder-safety validation.");
+
+            var pathResolutionIndex = normalizedLauncher.IndexOf(
+                "$releasePath = Join-Path $releaseRoot $releaseName\n    $executablePath = Join-Path $releasePath $ExecutableName",
+                StringComparison.Ordinal);
+            Assert.True(pathResolutionIndex > normalizationIndex, "The launcher should resolve the side-by-side release path from the normalized marker value.");
+        }
+
+        private static string ReadRepositoryFile(params string[] relativePathParts)
+        {
+            var baseDirectory = AppContext.BaseDirectory;
+            var repositoryRoot = Path.GetFullPath(Path.Combine(baseDirectory, "..", "..", "..", ".."));
+            return File.ReadAllText(Path.Combine(new[] { repositoryRoot }.Concat(relativePathParts).ToArray()));
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-launcher-marker-trim.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-launcher-marker-trim.md
@@ -1,0 +1,15 @@
+# Launcher Marker Trim
+
+Date: 2026-06-26
+
+## Completed
+
+- Normalized non-empty `current-release.txt` values in `scripts/start-current-release.ps1` before folder-safety validation and side-by-side release path resolution.
+- Kept the launcher aligned with `scripts/create-shared-desktop-shortcut.ps1`, which already trims the marker before resolving `_releases/<ReleaseName>/InventoryManagementApp.exe`.
+- Added `SharedReleaseLauncherMarkerContractTests` coverage so the trim happens before validation and path construction.
+
+## Validation Notes
+
+- GitHub connector readback/compare should be used to confirm the focused branch diff in this scheduled environment.
+- Direct local checkout is blocked here by `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable in this scheduled Linux container, so local build/test/full validation was not run.

--- a/scripts/start-current-release.ps1
+++ b/scripts/start-current-release.ps1
@@ -80,6 +80,8 @@ if (Test-Path -LiteralPath $currentReleaseMarker) {
 }
 
 if (-not [string]::IsNullOrWhiteSpace($releaseName)) {
+    $releaseName = $releaseName.Trim()
+
     if ($releaseName.EndsWith(".") -or $releaseName.EndsWith(" ") -or (Test-ReleaseNameHasInvalidWindowsFileNameCharacter -ReleaseName $releaseName) -or $releaseName -eq "." -or $releaseName -eq ".." -or (Test-ReleaseNameIsReservedDeviceName -ReleaseName $releaseName)) {
         throw "ReleaseName in current-release.txt must be a folder-safe Windows name that does not contain invalid filename characters, end with a dot or space, or use a reserved device name."
     }


### PR DESCRIPTION
## Summary

- Normalize non-empty `current-release.txt` values in `scripts/start-current-release.ps1` before folder-safety validation and side-by-side release path resolution.
- Keep launcher behavior aligned with the desktop shortcut helper, which already trims marker values before resolving `_releases/<ReleaseName>/InventoryManagementApp.exe`.
- Add focused source-contract coverage and a progress note for the launcher marker normalization path.

## Why This Matters

Recent shared-deployment hardening made the updater, launcher, and shortcut helper reject unsafe release names. The shortcut helper trims marker values before validation, but the launcher used the raw first non-empty line. A manually edited marker with extra whitespace could therefore resolve differently depending on which helper touched it. This keeps the startup path tolerant of harmless marker whitespace while still rejecting unsafe folder names before any release path is built.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only the launcher script, one focused source-contract test, and a progress note.
- GitHub connector readback confirmed the launcher trims `$releaseName` before folder-safety validation and uses the normalized value for path resolution.
- Direct local checkout is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.