### PR TITLE
Prefer stable shared shortcut icon

### DIFF
--- a/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
+++ b/InventoryManagementApp.Tests/SharedReleaseUpdateScriptTests.cs
@@ -157,13 +157,17 @@ namespace InventoryManagementApp.Tests
         public void DesktopShortcutScriptUsesStableAppIcon()
         {
             var script = ReadRepositoryFile("scripts", "create-shared-desktop-shortcut.ps1");
+            var normalizedScript = script.Replace("\r\n", "\n", StringComparison.Ordinal);
 
             Assert.Contains("$currentReleaseMarker = Join-Path $destinationPath \"current-release.txt\"", script, StringComparison.Ordinal);
             Assert.Contains("function Convert-ToUncPathIfMappedDrive", script, StringComparison.Ordinal);
             Assert.Contains("function Get-CurrentReleaseExecutablePath", script, StringComparison.Ordinal);
             Assert.Contains("$network.EnumNetworkDrives()", script, StringComparison.Ordinal);
-            Assert.Contains("$releaseExecutablePath = Join-Path (Join-Path (Join-Path $destinationPath \"_releases\") $currentRelease.Trim()) \"InventoryManagementApp.exe\"", script, StringComparison.Ordinal);
+            Assert.Contains("$currentReleaseName = $currentRelease.Trim()", script, StringComparison.Ordinal);
+            Assert.Contains("$releaseExecutablePath = Join-Path (Join-Path (Join-Path $destinationPath \"_releases\") $currentReleaseName) \"InventoryManagementApp.exe\"", script, StringComparison.Ordinal);
+            Assert.DoesNotContain("$releaseExecutablePath = Join-Path (Join-Path (Join-Path $destinationPath \"_releases\") $currentRelease.Trim()) \"InventoryManagementApp.exe\"", script, StringComparison.Ordinal);
             Assert.Contains("$appIconPath = Join-Path $destinationPath \"Resources\\AppIcon.ico\"", script, StringComparison.Ordinal);
+            Assert.Contains("if (Test-Path -LiteralPath $appIconPath) {\n    $iconPath = $appIconPath\n} else {\n    $iconPath = $currentReleaseExecutablePath\n}", normalizedScript, StringComparison.Ordinal);
             Assert.Contains("[switch]$PointToSharedShortcut", script, StringComparison.Ordinal);
             Assert.Contains("$shortcut.TargetPath = Convert-ToUncPathIfMappedDrive -Path $targetPath", script, StringComparison.Ordinal);
             Assert.Contains("$shortcut.IconLocation = \"$(Convert-ToUncPathIfMappedDrive -Path $iconPath),0\"", script, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-shared-shortcut-icon-priority.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-shared-shortcut-icon-priority.md
@@ -1,0 +1,15 @@
+# Shared Shortcut Icon Priority
+
+Date: 2026-06-26
+
+## Completed
+
+- Updated `scripts/create-shared-desktop-shortcut.ps1` so refreshed shortcuts prefer the deployed shared `Resources\AppIcon.ico` when it exists.
+- Kept the executable icon as the fallback when the shared icon has not been deployed.
+- Reused the normalized `current-release.txt` marker value when resolving side-by-side release executables.
+- Extended `SharedReleaseUpdateScriptTests` source-contract coverage for the stable icon priority and normalized marker path.
+
+## Validation
+
+- GitHub connector readback/compare should confirm the focused script, source-contract test, and progress-note changes.
+- Local .NET tests, PowerShell script execution, WPF screenshots, banned-word checks, and full validation were not run in the scheduled Linux environment because direct checkout/raw access is blocked and `dotnet`, PowerShell/`pwsh`, and `gh` are unavailable.

--- a/scripts/create-shared-desktop-shortcut.ps1
+++ b/scripts/create-shared-desktop-shortcut.ps1
@@ -110,7 +110,7 @@ function Get-CurrentReleaseExecutablePath {
         if (-not [string]::IsNullOrWhiteSpace($currentRelease)) {
             $currentReleaseName = $currentRelease.Trim()
             Assert-CurrentReleaseNameIsSafe -ReleaseName $currentReleaseName
-            $releaseExecutablePath = Join-Path (Join-Path (Join-Path $destinationPath "_releases") $currentRelease.Trim()) "InventoryManagementApp.exe"
+            $releaseExecutablePath = Join-Path (Join-Path (Join-Path $destinationPath "_releases") $currentReleaseName) "InventoryManagementApp.exe"
             if (Test-Path -LiteralPath $releaseExecutablePath) {
                 return $releaseExecutablePath
             }
@@ -142,20 +142,11 @@ if ($PointToSharedShortcut -and
     $workingDirectory = $destinationPath
 }
 
-$iconPath = $currentReleaseExecutablePath
-
-if ([string]::IsNullOrWhiteSpace($iconPath)) {
-    $appIconPath = Join-Path $destinationPath "Resources\AppIcon.ico"
-    if (Test-Path -LiteralPath $appIconPath) {
-        $iconPath = $appIconPath
-    }
-}
-
-if ([string]::IsNullOrWhiteSpace($iconPath)) {
-    $rootExecutablePath = Join-Path $destinationPath "InventoryManagementApp.exe"
-    if (Test-Path -LiteralPath $rootExecutablePath) {
-        $iconPath = $rootExecutablePath
-    }
+$appIconPath = Join-Path $destinationPath "Resources\AppIcon.ico"
+if (Test-Path -LiteralPath $appIconPath) {
+    $iconPath = $appIconPath
+} else {
+    $iconPath = $currentReleaseExecutablePath
 }
 
 $shell = New-Object -ComObject WScript.Shell


### PR DESCRIPTION
## Summary

- Update `scripts/create-shared-desktop-shortcut.ps1` so refreshed shortcuts prefer the deployed shared `Resources\AppIcon.ico` when it exists.
- Keep the resolved executable as the icon fallback when the shared icon has not been deployed.
- Reuse the already-normalized `current-release.txt` marker value when resolving side-by-side release executable paths.
- Extend `SharedReleaseUpdateScriptTests` source-contract coverage and add a progress note for the shortcut behavior.

## Why This Matters

The shared deployment updater now copies `Resources\AppIcon.ico` into the shared destination, but the shortcut helper still initialized `$iconPath` to the current release executable first. That made the shared icon fallback effectively unreachable on the normal successful path and could let shortcut icons vary by release executable location. This keeps refreshed shortcuts anchored to the stable shared icon while preserving the executable fallback.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only the shortcut script, one focused source-contract test, and a progress note.
- GitHub connector readback confirmed the shortcut now uses `Resources\AppIcon.ico` before falling back to the current release executable and builds release executable paths from `$currentReleaseName`.
- Direct local checkout is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.