### PR TITLE
Guard kit lifecycle writes against missing rows

### DIFF
--- a/InventoryManagementApp.Tests/KitServiceTests.cs
+++ b/InventoryManagementApp.Tests/KitServiceTests.cs
@@ -108,6 +108,20 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task UpdateKit_WithMissingKit_ShouldThrow()
+        {
+            var kit = new Kit
+            {
+                KitID = 999,
+                KitNumber = "KIT-MISSING",
+                Name = "Missing Kit",
+                IsActive = true
+            };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _kitService.UpdateKitAsync(kit));
+        }
+
+        [Fact]
         public async Task AddKitItem_ShouldSucceed()
         {
             var kit = new Kit
@@ -182,6 +196,12 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task RemoveKitItem_WithMissingKitItem_ShouldThrow()
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _kitService.RemoveKitItemAsync(999));
+        }
+
+        [Fact]
         public async Task DeleteKit_ShouldSucceed()
         {
             var kit = new Kit
@@ -195,6 +215,23 @@ namespace InventoryManagementApp.Tests
             var result = await _kitService.DeleteKitAsync(id);
 
             Assert.True(result);
+        }
+
+        [Fact]
+        public async Task DeleteKit_WithMissingKit_ShouldThrowWithoutDeletingLegacyKitItems()
+        {
+            using (var conn = _databaseService.CreateConnection())
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = @"
+                    INSERT INTO KitItems (KitID, ItemID, Quantity, IsOptional)
+                    VALUES (999, 1, 1, 0);";
+                cmd.ExecuteNonQuery();
+            }
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _kitService.DeleteKitAsync(999));
+
+            Assert.Equal(1, CountKitItemsForKit(999));
         }
 
         [Fact]
@@ -283,11 +320,33 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public async Task UpdateKitItem_WithMissingItem_ShouldThrow()
+        public async Task UpdateKitItem_WithMissingKitItem_ShouldThrow()
         {
             var kit = new Kit
             {
                 KitNumber = "KIT-012",
+                Name = "Kit Update Missing Kit Item Guard",
+                IsActive = true
+            };
+            var kitId = await _kitService.CreateKitAsync(kit);
+            var kitItem = new KitItem
+            {
+                KitItemID = 999,
+                KitID = kitId,
+                ItemID = 1,
+                Quantity = 1,
+                IsOptional = false
+            };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _kitService.UpdateKitItemAsync(kitItem));
+        }
+
+        [Fact]
+        public async Task UpdateKitItem_WithMissingItem_ShouldThrow()
+        {
+            var kit = new Kit
+            {
+                KitNumber = "KIT-013",
                 Name = "Kit Update Missing Item Guard",
                 IsActive = true
             };
@@ -311,7 +370,7 @@ namespace InventoryManagementApp.Tests
         {
             var kit = new Kit
             {
-                KitNumber = "KIT-013",
+                KitNumber = "KIT-014",
                 Name = "Kit with Insufficient Required Item",
                 IsActive = true
             };
@@ -333,6 +392,15 @@ namespace InventoryManagementApp.Tests
             var isAvailable = await _kitService.CheckKitAvailabilityAsync(kitId);
 
             Assert.False(isAvailable);
+        }
+
+        private int CountKitItemsForKit(int kitID)
+        {
+            using var conn = _databaseService.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM KitItems WHERE KitID = @KitID";
+            cmd.Parameters.AddWithValue("@KitID", kitID);
+            return Convert.ToInt32(cmd.ExecuteScalar());
         }
     }
 }

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-kit-lifecycle-missing-row-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-kit-lifecycle-missing-row-guard.md
@@ -1,0 +1,12 @@
+# Kit Lifecycle Missing Row Guard
+
+## Completed
+
+- Added explicit kit existence validation before updating or deleting a kit.
+- Added explicit kit-item existence validation before updating or removing a kit item.
+- Kept `DeleteKitAsync` from deleting legacy orphaned `KitItems` rows when the requested kit row is already missing.
+- Added focused `KitServiceTests` coverage for missing kit, missing kit-item, and legacy orphan preservation behavior.
+
+## Why it matters
+
+Kit lifecycle writes now behave like the recently hardened reservation lifecycle writes: stale UI actions or damaged IDs fail clearly at the service boundary instead of silently returning `false` or mutating related rows before discovering the target record is gone.

--- a/InventoryManagementApp/Services/Kits/KitService.cs
+++ b/InventoryManagementApp/Services/Kits/KitService.cs
@@ -165,6 +165,8 @@ namespace InventoryManagementApp.Services.Kits
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureKitExists(conn, kit.KitID);
+
                 var sql = @"
                     UPDATE Kits 
                     SET KitNumber = @KitNumber,
@@ -194,6 +196,7 @@ namespace InventoryManagementApp.Services.Kits
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureKitExists(conn, kitID);
                 using var transaction = conn.BeginTransaction();
                 try
                 {
@@ -250,6 +253,7 @@ namespace InventoryManagementApp.Services.Kits
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureKitItemExists(conn, kitItem.KitItemID);
                 EnsureKitItemReferencesExist(conn, kitItem);
 
                 var sql = @"
@@ -275,6 +279,8 @@ namespace InventoryManagementApp.Services.Kits
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureKitItemExists(conn, kitItemID);
+
                 var sql = "DELETE FROM KitItems WHERE KitItemID = @KitItemID";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@KitItemID", kitItemID);
@@ -358,6 +364,18 @@ namespace InventoryManagementApp.Services.Kits
                 throw new ArgumentOutOfRangeException(nameof(kitItem.ItemID), "Item ID must be greater than 0.");
             if (kitItem.Quantity < 1)
                 throw new ArgumentOutOfRangeException(nameof(kitItem.Quantity), "Quantity must be greater than 0.");
+        }
+
+        private static void EnsureKitExists(SqliteConnection conn, int kitID)
+        {
+            if (!RecordExists(conn, "SELECT COUNT(*) FROM Kits WHERE KitID = @ID", kitID))
+                throw new InvalidOperationException("Kit not found.");
+        }
+
+        private static void EnsureKitItemExists(SqliteConnection conn, int kitItemID)
+        {
+            if (!RecordExists(conn, "SELECT COUNT(*) FROM KitItems WHERE KitItemID = @ID", kitItemID))
+                throw new InvalidOperationException("Kit item not found.");
         }
 
         private static void EnsureKitItemReferencesExist(SqliteConnection conn, KitItem kitItem)


### PR DESCRIPTION
## Summary

- Add explicit kit existence validation before updating or deleting a kit.
- Add explicit kit-item existence validation before updating or removing a kit item.
- Preserve legacy orphaned `KitItems` rows when a delete request targets a missing kit instead of deleting related rows before returning `false`.
- Add focused `KitServiceTests` coverage for missing kit, missing kit-item, and legacy orphan preservation behavior.

## Why This Matters

Recent reservation lifecycle work now fails clearly when stale UI actions target rows that no longer exist. Kit lifecycle writes still silently returned `false`, and `DeleteKitAsync` deleted `KitItems` for the requested ID before it knew whether the kit row existed. This brings kits in line with the reservation guard pattern and avoids accidental mutation when the target kit is already gone.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `KitService`, focused kit service tests, and a progress note.
- GitHub connector readback confirmed the service now calls `EnsureKitExists` and `EnsureKitItemExists` before lifecycle writes, and that tests cover missing-row behavior.
- Direct local checkout/raw clone is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.