### PR TITLE
Guard rental checkout against missing references

### DIFF
--- a/InventoryManagementApp.Tests/RentalServiceReferenceGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceReferenceGuardContractTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class RentalServiceReferenceGuardContractTests
+    {
+        [Fact]
+        public void RentItemGuardsItemAndCustomerReferencesBeforeInsert()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+
+            AssertContainsAll(
+                source,
+                "var avail = await GetAvailableQuantityForExistingItemAsync(conn, tx, itemID);",
+                "await EnsureCustomerExistsAsync(conn, tx, customerID);",
+                "await SqliteHelper.ExecuteNonQueryAsync(conn, tx,",
+                "INSERT INTO Rentals (ItemID, CustomerID, RentalDate, DueDate, Status)",
+                "throw new InvalidOperationException(\"Item not found.\");",
+                "throw new InvalidOperationException(\"Customer not found.\");");
+            Assert.True(
+                source.IndexOf("GetAvailableQuantityForExistingItemAsync(conn, tx, itemID)", StringComparison.Ordinal) <
+                source.IndexOf("INSERT INTO Rentals (ItemID, CustomerID, RentalDate, DueDate, Status)", StringComparison.Ordinal),
+                "Expected item existence validation before rental insert.");
+            Assert.True(
+                source.IndexOf("EnsureCustomerExistsAsync(conn, tx, customerID)", StringComparison.Ordinal) <
+                source.IndexOf("INSERT INTO Rentals (ItemID, CustomerID, RentalDate, DueDate, Status)", StringComparison.Ordinal),
+                "Expected customer existence validation before rental insert.");
+            Assert.DoesNotContain("Convert.ToInt32(await availCmd.ExecuteScalarAsync() ?? 0)", source, StringComparison.Ordinal);
+        }
+
+        private static void AssertContainsAll(string source, params string[] expectedSnippets)
+        {
+            foreach (var snippet in expectedSnippets)
+            {
+                Assert.Contains(snippet, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-rental-checkout-reference-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-rental-checkout-reference-guards.md
@@ -1,0 +1,12 @@
+# Rental Checkout Reference Guards
+
+## Completed
+
+- Added explicit item existence validation before rental checkout uses item availability.
+- Added explicit customer existence validation before rental checkout inserts a `Rentals` row.
+- Kept the existing insufficient-quantity check after the item row is known to exist.
+- Added source-contract coverage so checkout keeps validating item and customer references before the rental insert.
+
+## Why it matters
+
+Rental checkout now follows the same service-boundary integrity pattern as the recent reservation and kit hardening work. Stale UI actions or damaged IDs fail clearly before the service can create a fresh orphaned rental row.

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -173,11 +173,9 @@ namespace InventoryManagementApp.Services.Rentals
             _auth.EnsureAdmin();
             await ExecuteWithTransactionAsync(async (conn, tx) =>
             {
-                var availCmd = new SqliteCommand(
-                    "SELECT AvailableQuantity FROM Items WHERE ItemID=@ItemID",
-                    conn, tx);
-                availCmd.Parameters.AddWithValue("@ItemID", itemID);
-                int avail = Convert.ToInt32(await availCmd.ExecuteScalarAsync() ?? 0);
+                var avail = await GetAvailableQuantityForExistingItemAsync(conn, tx, itemID);
+                await EnsureCustomerExistsAsync(conn, tx, customerID);
+
                 if (avail < 1)
                     throw new InvalidOperationException("Insufficient quantity.");
 
@@ -400,6 +398,30 @@ namespace InventoryManagementApp.Services.Rentals
             }
             
             return frequencies;
+        }
+
+        private static async Task<int> GetAvailableQuantityForExistingItemAsync(SqliteConnection conn, SqliteTransaction tx, int itemID)
+        {
+            var availCmd = new SqliteCommand(
+                "SELECT AvailableQuantity FROM Items WHERE ItemID=@ItemID",
+                conn, tx);
+            availCmd.Parameters.AddWithValue("@ItemID", itemID);
+            var result = await availCmd.ExecuteScalarAsync();
+            if (result == null || result is DBNull)
+                throw new InvalidOperationException("Item not found.");
+
+            return Convert.ToInt32(result);
+        }
+
+        private static async Task EnsureCustomerExistsAsync(SqliteConnection conn, SqliteTransaction tx, int customerID)
+        {
+            var customerCmd = new SqliteCommand(
+                "SELECT COUNT(*) FROM Customers WHERE CustomerID=@CustomerID",
+                conn, tx);
+            customerCmd.Parameters.AddWithValue("@CustomerID", customerID);
+            var customerCount = Convert.ToInt32(await customerCmd.ExecuteScalarAsync() ?? 0);
+            if (customerCount < 1)
+                throw new InvalidOperationException("Customer not found.");
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add explicit item existence validation before rental checkout interprets item availability.
- Add explicit customer existence validation before inserting a `Rentals` row.
- Keep insufficient-quantity handling for existing items after the item row is confirmed.
- Add focused source-contract coverage and a progress note for the checkout reference guard.

## Why This Matters

Recent reservation and kit hardening closed paths that could create fresh orphaned records or silently act on stale IDs. Rental checkout still trusted a positive customer ID and could insert a rental for a missing customer when SQLite foreign-key enforcement was not active on the connection. This keeps checkout failures clear at the service boundary before a rental row is written.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `RentalService`, one focused source-contract test, and a progress note.
- GitHub connector readback confirmed `RentItemAsync` now calls item and customer reference guards before the `INSERT INTO Rentals` statement, and the helper methods throw clear `Item not found.` / `Customer not found.` failures.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the requested `main` branch does not appear to be the active default in GitHub metadata.