### PR TITLE
Guard rental query inputs

### DIFF
--- a/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class RentalServiceQueryGuardContractTests
+    {
+        [Fact]
+        public void RentalHistoryQueriesValidatePositiveIdentifiersBeforeSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+
+            AssertContainsAll(
+                source,
+                "public async Task<List<Rental>> GetRentalHistoryForItemAsync(int itemID)",
+                "if (itemID < 1)",
+                "throw new ArgumentOutOfRangeException(nameof(itemID), \"Item ID must be greater than 0.\");",
+                "public async Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID)",
+                "if (customerID < 1)",
+                "throw new ArgumentOutOfRangeException(nameof(customerID), \"Customer ID must be greater than 0.\");");
+
+            Assert.True(
+                source.IndexOf("throw new ArgumentOutOfRangeException(nameof(itemID)", StringComparison.Ordinal) <
+                source.IndexOf("WHERE r.ItemID = @ItemID", StringComparison.Ordinal),
+                "Expected item rental history to validate the item id before building/executing SQL.");
+            Assert.True(
+                source.IndexOf("throw new ArgumentOutOfRangeException(nameof(customerID)", StringComparison.Ordinal) <
+                source.IndexOf("WHERE r.CustomerID = @CustomerID", StringComparison.Ordinal),
+                "Expected customer rental history to validate the customer id before building/executing SQL.");
+        }
+
+        [Fact]
+        public void RentalFrequencyValidatesPositiveLimitBeforeSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+
+            AssertContainsAll(
+                source,
+                "public async Task<List<ItemRentalFrequency>> GetRentalFrequencyAsync(int topN = 10)",
+                "if (topN < 1)",
+                "throw new ArgumentOutOfRangeException(nameof(topN), \"Top rental frequency count must be greater than 0.\");",
+                "LIMIT @TopN");
+
+            Assert.True(
+                source.IndexOf("throw new ArgumentOutOfRangeException(nameof(topN)", StringComparison.Ordinal) <
+                source.IndexOf("LIMIT @TopN", StringComparison.Ordinal),
+                "Expected rental frequency to validate the limit before building/executing SQL.");
+        }
+
+        private static void AssertContainsAll(string source, params string[] expectedSnippets)
+        {
+            foreach (var snippet in expectedSnippets)
+            {
+                Assert.Contains(snippet, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-rental-query-input-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-rental-query-input-guards.md
@@ -1,0 +1,12 @@
+# Rental Query Input Guards
+
+## Completed
+
+- Added service-boundary validation for item rental history lookups so invalid item IDs fail before SQL work begins.
+- Added service-boundary validation for customer rental history lookups so invalid customer IDs fail before SQL work begins.
+- Added service-boundary validation for rental frequency limits so non-positive `topN` values cannot turn into broad or misleading SQLite `LIMIT` behavior.
+- Added source-contract coverage for the new query guard placement.
+
+## Why it matters
+
+Rental query APIs now match the recent reservation and rental checkout guard pattern: invalid caller input fails clearly at the service boundary instead of relying on empty results or SQLite-specific limit handling.

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -1,4 +1,4 @@
-﻿// Services/Rentals/RentalService.cs
+// Services/Rentals/RentalService.cs
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -351,6 +351,9 @@ namespace InventoryManagementApp.Services.Rentals
 
         public async Task<List<Rental>> GetRentalHistoryForItemAsync(int itemID)
         {
+            if (itemID < 1)
+                throw new ArgumentOutOfRangeException(nameof(itemID), "Item ID must be greater than 0.");
+
             const string sql = BaseSelect + @" WHERE r.ItemID = @ItemID ORDER BY r.RentalDate DESC";
             var p = new[] { new SqliteParameter("@ItemID", itemID) };
             using var conn = _dbService.CreateConnection();
@@ -360,6 +363,9 @@ namespace InventoryManagementApp.Services.Rentals
 
         public async Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID)
         {
+            if (customerID < 1)
+                throw new ArgumentOutOfRangeException(nameof(customerID), "Customer ID must be greater than 0.");
+
             const string sql = BaseSelect + @" WHERE r.CustomerID = @CustomerID ORDER BY r.RentalDate DESC";
             var p = new[] { new SqliteParameter("@CustomerID", customerID) };
             using var conn = _dbService.CreateConnection();
@@ -369,6 +375,9 @@ namespace InventoryManagementApp.Services.Rentals
 
         public async Task<List<ItemRentalFrequency>> GetRentalFrequencyAsync(int topN = 10)
         {
+            if (topN < 1)
+                throw new ArgumentOutOfRangeException(nameof(topN), "Top rental frequency count must be greater than 0.");
+
             const string sql = @"
                 SELECT t.ItemID, t.ItemNumber, t.NameDescription, COUNT(r.RentalID) AS RentalCount
                 FROM Items t


### PR DESCRIPTION
## Summary

- Add positive ID validation to rental history lookups for items and customers before SQL work begins.
- Add positive limit validation to rental frequency queries before SQLite `LIMIT @TopN` is used.
- Add focused source-contract coverage and a progress note for the rental query guard behavior.

## Why This Matters

Recent reservation, kit, and rental checkout work moved stale or invalid inputs to explicit service-boundary failures. Rental query APIs still accepted invalid IDs as empty-result lookups, and non-positive frequency limits could rely on SQLite-specific `LIMIT` behavior. These guards keep rental query behavior clear and consistent before any database work starts.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `RentalService`, one focused source-contract test, and a progress note.
- GitHub connector readback confirmed `GetRentalHistoryForItemAsync`, `GetRentalHistoryForCustomerAsync`, and `GetRentalFrequencyAsync` validate inputs before their SQL snippets.
- GitHub connector status readback found no commit statuses attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata shows `master` is active.