### PR TITLE
Guard maintenance records against stale references

### DIFF
--- a/InventoryManagementApp.Tests/MaintenanceServiceTests.cs
+++ b/InventoryManagementApp.Tests/MaintenanceServiceTests.cs
@@ -60,6 +60,24 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task CreateMaintenanceRecord_WithMissingItem_ShouldThrow()
+        {
+            var record = new MaintenanceRecord
+            {
+                ItemID = 999,
+                ScheduledDate = DateTime.Now.AddDays(7),
+                MaintenanceType = "Routine",
+                Description = "Missing item maintenance",
+                Status = "Scheduled",
+                Cost = 100.00m
+            };
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _maintenanceService.CreateMaintenanceRecordAsync(record));
+
+            Assert.Equal("Item not found.", ex.Message);
+        }
+
+        [Fact]
         public async Task GetAllMaintenanceRecords_ShouldReturnList()
         {
             var record = new MaintenanceRecord
@@ -113,6 +131,42 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task UpdateMaintenanceRecord_WithMissingItem_ShouldThrow()
+        {
+            var record = new MaintenanceRecord
+            {
+                ItemID = 1,
+                ScheduledDate = DateTime.Now.AddDays(7),
+                MaintenanceType = "Routine",
+                Status = "Scheduled"
+            };
+            var id = await _maintenanceService.CreateMaintenanceRecordAsync(record);
+            record.MaintenanceID = id;
+            record.ItemID = 999;
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _maintenanceService.UpdateMaintenanceRecordAsync(record));
+
+            Assert.Equal("Item not found.", ex.Message);
+        }
+
+        [Fact]
+        public async Task UpdateMaintenanceRecord_WithMissingRecord_ShouldThrow()
+        {
+            var record = new MaintenanceRecord
+            {
+                MaintenanceID = 999,
+                ItemID = 1,
+                ScheduledDate = DateTime.Now.AddDays(7),
+                MaintenanceType = "Routine",
+                Status = "Scheduled"
+            };
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _maintenanceService.UpdateMaintenanceRecordAsync(record));
+
+            Assert.Equal("Maintenance record not found.", ex.Message);
+        }
+
+        [Fact]
         public async Task CompleteMaintenanceAsync_ShouldMarkAsCompleted()
         {
             var record = new MaintenanceRecord
@@ -130,6 +184,14 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task CompleteMaintenanceAsync_WithMissingRecord_ShouldThrow()
+        {
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _maintenanceService.CompleteMaintenanceAsync(999, "John Doe"));
+
+            Assert.Equal("Maintenance record not found.", ex.Message);
+        }
+
+        [Fact]
         public async Task DeleteMaintenanceRecord_ShouldSucceed()
         {
             var record = new MaintenanceRecord
@@ -144,6 +206,14 @@ namespace InventoryManagementApp.Tests
             var result = await _maintenanceService.DeleteMaintenanceRecordAsync(id);
 
             Assert.True(result);
+        }
+
+        [Fact]
+        public async Task DeleteMaintenanceRecord_WithMissingRecord_ShouldThrow()
+        {
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _maintenanceService.DeleteMaintenanceRecordAsync(999));
+
+            Assert.Equal("Maintenance record not found.", ex.Message);
         }
     }
 }

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-maintenance-reference-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-maintenance-reference-guards.md
@@ -1,0 +1,7 @@
+# Maintenance Reference Guard Hardening
+
+- Added explicit item existence validation before creating or updating maintenance records so stale item IDs fail before a maintenance row is inserted or moved.
+- Added explicit maintenance record existence validation before update, complete, and delete operations so stale UI actions fail clearly instead of silently returning `false`.
+- Added focused `MaintenanceServiceTests` coverage for missing item references and missing maintenance row lifecycle operations.
+
+Validation note: this scheduled Linux environment does not provide local repository checkout, `dotnet`, PowerShell/`pwsh`, `gh`, WPF screenshots, or the full validation runner, so validation used GitHub connector readback/compare instead of local build/test execution.

--- a/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
+++ b/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
@@ -138,6 +138,9 @@ namespace InventoryManagementApp.Services.Maintenance
 
         public async Task<MaintenanceRecord?> GetMaintenanceRecordByIdAsync(int maintenanceID)
         {
+            if (maintenanceID < 1)
+                throw new ArgumentOutOfRangeException(nameof(maintenanceID), "Maintenance ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -159,9 +162,14 @@ namespace InventoryManagementApp.Services.Maintenance
 
         public async Task<int> CreateMaintenanceRecordAsync(MaintenanceRecord record)
         {
+            if (record.ItemID < 1)
+                throw new ArgumentOutOfRangeException(nameof(record.ItemID), "Item ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureItemExists(conn, record.ItemID);
+
                 var sql = @"
                     INSERT INTO MaintenanceRecords 
                     (ItemID, ScheduledDate, CompletedDate, MaintenanceType, Description, 
@@ -189,9 +197,17 @@ namespace InventoryManagementApp.Services.Maintenance
 
         public async Task<bool> UpdateMaintenanceRecordAsync(MaintenanceRecord record)
         {
+            if (record.MaintenanceID < 1)
+                throw new ArgumentOutOfRangeException(nameof(record.MaintenanceID), "Maintenance ID must be greater than 0.");
+            if (record.ItemID < 1)
+                throw new ArgumentOutOfRangeException(nameof(record.ItemID), "Item ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureMaintenanceRecordExists(conn, record.MaintenanceID);
+                EnsureItemExists(conn, record.ItemID);
+
                 var sql = @"
                     UPDATE MaintenanceRecords 
                     SET ItemID = @ItemID,
@@ -215,15 +231,23 @@ namespace InventoryManagementApp.Services.Maintenance
                 cmd.Parameters.AddWithValue("@Cost", record.Cost);
                 cmd.Parameters.AddWithValue("@Status", record.Status);
                 cmd.Parameters.AddWithValue("@Notes", record.Notes);
-                return cmd.ExecuteNonQuery() > 0;
+                if (cmd.ExecuteNonQuery() == 0)
+                    throw new InvalidOperationException("Maintenance record not found.");
+
+                return true;
             });
         }
 
         public async Task<bool> CompleteMaintenanceAsync(int maintenanceID, string performedBy, string notes = "")
         {
+            if (maintenanceID < 1)
+                throw new ArgumentOutOfRangeException(nameof(maintenanceID), "Maintenance ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureMaintenanceRecordExists(conn, maintenanceID);
+
                 var sql = @"
                     UPDATE MaintenanceRecords 
                     SET Status = 'Completed',
@@ -236,19 +260,30 @@ namespace InventoryManagementApp.Services.Maintenance
                 cmd.Parameters.AddWithValue("@CompletedDate", DateTime.Now);
                 cmd.Parameters.AddWithValue("@PerformedBy", performedBy);
                 cmd.Parameters.AddWithValue("@Notes", notes);
-                return cmd.ExecuteNonQuery() > 0;
+                if (cmd.ExecuteNonQuery() == 0)
+                    throw new InvalidOperationException("Maintenance record not found.");
+
+                return true;
             });
         }
 
         public async Task<bool> DeleteMaintenanceRecordAsync(int maintenanceID)
         {
+            if (maintenanceID < 1)
+                throw new ArgumentOutOfRangeException(nameof(maintenanceID), "Maintenance ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureMaintenanceRecordExists(conn, maintenanceID);
+
                 var sql = "DELETE FROM MaintenanceRecords WHERE MaintenanceID = @MaintenanceID";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@MaintenanceID", maintenanceID);
-                return cmd.ExecuteNonQuery() > 0;
+                if (cmd.ExecuteNonQuery() == 0)
+                    throw new InvalidOperationException("Maintenance record not found.");
+
+                return true;
             });
         }
 
@@ -271,6 +306,24 @@ namespace InventoryManagementApp.Services.Maintenance
                 UserID = reader.IsDBNull(reader.GetOrdinal("UserID")) ? 0 : reader.GetInt32(reader.GetOrdinal("UserID")),
                 CreatedAt = reader.GetDateTime(reader.GetOrdinal("CreatedAt"))
             };
+        }
+
+        private static void EnsureItemExists(SqliteConnection conn, int itemID)
+        {
+            using var itemCmd = new SqliteCommand("SELECT COUNT(*) FROM Items WHERE ItemID = @ItemID", conn);
+            itemCmd.Parameters.AddWithValue("@ItemID", itemID);
+            var itemCount = Convert.ToInt32(itemCmd.ExecuteScalar() ?? 0);
+            if (itemCount < 1)
+                throw new InvalidOperationException("Item not found.");
+        }
+
+        private static void EnsureMaintenanceRecordExists(SqliteConnection conn, int maintenanceID)
+        {
+            using var maintenanceCmd = new SqliteCommand("SELECT COUNT(*) FROM MaintenanceRecords WHERE MaintenanceID = @MaintenanceID", conn);
+            maintenanceCmd.Parameters.AddWithValue("@MaintenanceID", maintenanceID);
+            var maintenanceCount = Convert.ToInt32(maintenanceCmd.ExecuteScalar() ?? 0);
+            if (maintenanceCount < 1)
+                throw new InvalidOperationException("Maintenance record not found.");
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add explicit item existence validation before creating or updating maintenance records.
- Add explicit maintenance record existence validation before update, complete, and delete operations.
- Keep successful maintenance lifecycle methods returning `true`, while stale row targets now fail clearly instead of silently returning `false`.
- Add focused `MaintenanceServiceTests` coverage for missing item references and missing maintenance lifecycle rows.

## Why This Matters

Recent reservation, kit, and rental hardening moved stale IDs and invalid references to clear service-boundary failures. Maintenance records still trusted item IDs on create/update and silently returned `false` when stale UI actions targeted deleted maintenance rows. These guards keep maintenance writes consistent with the newer reliability pattern and avoid fresh orphaned maintenance records when SQLite foreign-key enforcement is not active on the connection.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `MaintenanceService`, focused maintenance tests, and a progress note.
- GitHub connector readback confirmed create/update now call `EnsureItemExists`, update/complete/delete call `EnsureMaintenanceRecordExists`, and the tests cover missing item and missing maintenance row failures.
- GitHub connector status readback found no commit statuses attached to the branch head before PR creation.
- Direct local checkout is unavailable in this scheduled Linux container; only the memory folder is locally present for this run.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata shows `master` is active.