### PR TITLE
Guard calibration records against stale references

### DIFF
--- a/InventoryManagementApp.Tests/CalibrationServiceTests.cs
+++ b/InventoryManagementApp.Tests/CalibrationServiceTests.cs
@@ -60,6 +60,24 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task CreateCalibrationRecord_WithMissingItem_ShouldThrow()
+        {
+            var record = new CalibrationRecord
+            {
+                ItemID = 999,
+                CalibrationDate = DateTime.Now,
+                NextCalibrationDue = DateTime.Now.AddYears(1),
+                CalibratedBy = "Test Lab",
+                Result = "Pass",
+                Cost = 150.00m
+            };
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _calibrationService.CreateCalibrationRecordAsync(record));
+
+            Assert.Equal("Item not found.", ex.Message);
+        }
+
+        [Fact]
         public async Task GetAllCalibrationRecords_ShouldReturnList()
         {
             var record = new CalibrationRecord
@@ -113,6 +131,42 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task UpdateCalibrationRecord_WithMissingItem_ShouldThrow()
+        {
+            var record = new CalibrationRecord
+            {
+                ItemID = 1,
+                CalibrationDate = DateTime.Now,
+                NextCalibrationDue = DateTime.Now.AddYears(1),
+                Result = "Pass"
+            };
+            var id = await _calibrationService.CreateCalibrationRecordAsync(record);
+            record.CalibrationID = id;
+            record.ItemID = 999;
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _calibrationService.UpdateCalibrationRecordAsync(record));
+
+            Assert.Equal("Item not found.", ex.Message);
+        }
+
+        [Fact]
+        public async Task UpdateCalibrationRecord_WithMissingRecord_ShouldThrow()
+        {
+            var record = new CalibrationRecord
+            {
+                CalibrationID = 999,
+                ItemID = 1,
+                CalibrationDate = DateTime.Now,
+                NextCalibrationDue = DateTime.Now.AddYears(1),
+                Result = "Pass"
+            };
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _calibrationService.UpdateCalibrationRecordAsync(record));
+
+            Assert.Equal("Calibration record not found.", ex.Message);
+        }
+
+        [Fact]
         public async Task DeleteCalibrationRecord_ShouldSucceed()
         {
             var record = new CalibrationRecord
@@ -127,6 +181,14 @@ namespace InventoryManagementApp.Tests
             var result = await _calibrationService.DeleteCalibrationRecordAsync(id);
 
             Assert.True(result);
+        }
+
+        [Fact]
+        public async Task DeleteCalibrationRecord_WithMissingRecord_ShouldThrow()
+        {
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _calibrationService.DeleteCalibrationRecordAsync(999));
+
+            Assert.Equal("Calibration record not found.", ex.Message);
         }
     }
 }

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-calibration-record-reference-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-calibration-record-reference-guards.md
@@ -1,0 +1,11 @@
+# Calibration Record Reference Guards
+
+## Completed
+- Added explicit item existence validation before creating or updating calibration records.
+- Added explicit calibration record existence validation before update and delete operations.
+- Kept successful calibration lifecycle writes returning `true`, while stale row targets now fail clearly instead of silently returning `false`.
+- Added focused `CalibrationServiceTests` coverage for missing item references and missing calibration lifecycle rows.
+
+## Validation Notes
+- This scheduled Linux container does not have a local repository checkout, `dotnet`, PowerShell/`pwsh`, `gh`, or a Windows WPF runtime, so local build/test/full validation and WPF screenshots were not run here.
+- GitHub connector readback/compare should be used for this pass, followed by the next Windows/.NET-capable full validation run.

--- a/InventoryManagementApp/Services/Calibration/CalibrationService.cs
+++ b/InventoryManagementApp/Services/Calibration/CalibrationService.cs
@@ -133,6 +133,9 @@ namespace InventoryManagementApp.Services.Calibration
 
         public async Task<CalibrationRecord?> GetLatestCalibrationForItemAsync(int itemID)
         {
+            if (itemID < 1)
+                throw new ArgumentOutOfRangeException(nameof(itemID), "Item ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -156,6 +159,9 @@ namespace InventoryManagementApp.Services.Calibration
 
         public async Task<CalibrationRecord?> GetCalibrationRecordByIdAsync(int calibrationID)
         {
+            if (calibrationID < 1)
+                throw new ArgumentOutOfRangeException(nameof(calibrationID), "Calibration ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
@@ -177,9 +183,14 @@ namespace InventoryManagementApp.Services.Calibration
 
         public async Task<int> CreateCalibrationRecordAsync(CalibrationRecord record)
         {
+            if (record.ItemID < 1)
+                throw new ArgumentOutOfRangeException(nameof(record.ItemID), "Item ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureItemExists(conn, record.ItemID);
+
                 var sql = @"
                     INSERT INTO CalibrationRecords 
                     (ItemID, CalibrationDate, NextCalibrationDue, CalibratedBy, 
@@ -207,9 +218,17 @@ namespace InventoryManagementApp.Services.Calibration
 
         public async Task<bool> UpdateCalibrationRecordAsync(CalibrationRecord record)
         {
+            if (record.CalibrationID < 1)
+                throw new ArgumentOutOfRangeException(nameof(record.CalibrationID), "Calibration ID must be greater than 0.");
+            if (record.ItemID < 1)
+                throw new ArgumentOutOfRangeException(nameof(record.ItemID), "Item ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureCalibrationRecordExists(conn, record.CalibrationID);
+                EnsureItemExists(conn, record.ItemID);
+
                 var sql = @"
                     UPDATE CalibrationRecords 
                     SET ItemID = @ItemID,
@@ -233,19 +252,30 @@ namespace InventoryManagementApp.Services.Calibration
                 cmd.Parameters.AddWithValue("@Result", record.Result);
                 cmd.Parameters.AddWithValue("@Cost", record.Cost);
                 cmd.Parameters.AddWithValue("@Notes", record.Notes);
-                return cmd.ExecuteNonQuery() > 0;
+                if (cmd.ExecuteNonQuery() == 0)
+                    throw new InvalidOperationException("Calibration record not found.");
+
+                return true;
             });
         }
 
         public async Task<bool> DeleteCalibrationRecordAsync(int calibrationID)
         {
+            if (calibrationID < 1)
+                throw new ArgumentOutOfRangeException(nameof(calibrationID), "Calibration ID must be greater than 0.");
+
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureCalibrationRecordExists(conn, calibrationID);
+
                 var sql = "DELETE FROM CalibrationRecords WHERE CalibrationID = @CalibrationID";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@CalibrationID", calibrationID);
-                return cmd.ExecuteNonQuery() > 0;
+                if (cmd.ExecuteNonQuery() == 0)
+                    throw new InvalidOperationException("Calibration record not found.");
+
+                return true;
             });
         }
 
@@ -268,6 +298,24 @@ namespace InventoryManagementApp.Services.Calibration
                 UserID = reader.IsDBNull(reader.GetOrdinal("UserID")) ? 0 : reader.GetInt32(reader.GetOrdinal("UserID")),
                 CreatedAt = reader.GetDateTime(reader.GetOrdinal("CreatedAt"))
             };
+        }
+
+        private static void EnsureItemExists(SqliteConnection conn, int itemID)
+        {
+            using var itemCmd = new SqliteCommand("SELECT COUNT(*) FROM Items WHERE ItemID = @ItemID", conn);
+            itemCmd.Parameters.AddWithValue("@ItemID", itemID);
+            var itemCount = Convert.ToInt32(itemCmd.ExecuteScalar() ?? 0);
+            if (itemCount < 1)
+                throw new InvalidOperationException("Item not found.");
+        }
+
+        private static void EnsureCalibrationRecordExists(SqliteConnection conn, int calibrationID)
+        {
+            using var calibrationCmd = new SqliteCommand("SELECT COUNT(*) FROM CalibrationRecords WHERE CalibrationID = @CalibrationID", conn);
+            calibrationCmd.Parameters.AddWithValue("@CalibrationID", calibrationID);
+            var calibrationCount = Convert.ToInt32(calibrationCmd.ExecuteScalar() ?? 0);
+            if (calibrationCount < 1)
+                throw new InvalidOperationException("Calibration record not found.");
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add explicit item existence validation before creating or updating calibration records.
- Add explicit calibration record existence validation before update and delete operations.
- Keep successful calibration lifecycle writes returning `true`, while stale row targets now fail clearly instead of silently returning `false`.
- Add focused `CalibrationServiceTests` coverage for missing item references and missing calibration lifecycle rows.

## Why This Matters

Recent reservation, kit, rental, and maintenance hardening moved stale IDs and invalid references to clear service-boundary failures. Calibration records still trusted item IDs on create/update and silently returned `false` when stale UI actions targeted deleted calibration rows. These guards keep calibration writes consistent with the newer reliability pattern and avoid fresh orphaned calibration records when SQLite foreign-key enforcement is not active on the connection.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `CalibrationService`, focused calibration tests, and a progress note.
- GitHub connector readback confirmed create/update now call `EnsureItemExists`, update/delete call `EnsureCalibrationRecordExists`, invalid IDs fail before SQL write work, and tests cover missing item and missing calibration row failures.
- GitHub connector status readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local checkout is unavailable in this scheduled Linux container; only the memory folder is locally present for this run.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata shows `master` is active.