### PR TITLE
Guard checkout history activity lookups against invalid item IDs

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ActivityLogCheckoutHistoryContractTests
+    {
+        [Fact]
+        public void CheckoutHistoryRejectsInvalidItemIdsBeforeSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");
+            var method = ExtractMethod(
+                source,
+                "public virtual async Task<Result<List<ActivityLog>>> GetCheckoutHistoryForItemAsync",
+                "public virtual async Task<Result> PurgeOldLogsAsync");
+
+            Assert.Contains("if (itemID < 1)", method, StringComparison.Ordinal);
+            Assert.Contains("return new Result<List<ActivityLog>>(null, false, \"Item ID must be positive.\");", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("new Result<List<ActivityLog>>(new List<ActivityLog>(), true)", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (itemID < 1)", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection()", StringComparison.Ordinal),
+                "The invalid item id guard should run before checkout-history SQL work starts.");
+        }
+
+        [Fact]
+        public void CheckoutHistoryStillSearchesLegacyAndItemNumberActivityFormats()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");
+            var method = ExtractMethod(
+                source,
+                "public virtual async Task<Result<List<ActivityLog>>> GetCheckoutHistoryForItemAsync",
+                "public virtual async Task<Result> PurgeOldLogsAsync");
+
+            Assert.Contains("%item {itemID} check-out status%", method, StringComparison.Ordinal);
+            Assert.Contains("%item {itemNumber.Trim()} ({itemID})%", method, StringComparison.Ordinal);
+            Assert.Contains("Action LIKE @LegacyTogglePattern", method, StringComparison.Ordinal);
+            Assert.Contains("OR Action LIKE @ItemNumberPattern", method, StringComparison.Ordinal);
+            Assert.Contains("ORDER BY Timestamp DESC", method, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-activity-log-checkout-history-id-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-activity-log-checkout-history-id-guard.md
@@ -1,0 +1,10 @@
+# Activity Log Checkout History ID Guard
+
+## Completed
+- Tightened the new checkout-history activity-log query so non-positive item IDs fail clearly at the service boundary.
+- Kept legacy `Toggled item <id> check-out status` activity searches and newer `Checked out/in item <number> (<id>)` searches intact for valid items.
+- Added source-contract coverage to keep the invalid-ID guard ahead of SQL work and to preserve both supported activity-log search formats.
+
+## Validation Notes
+- This scheduled Linux container does not have a local repository checkout, `dotnet`, PowerShell/`pwsh`, `gh`, or a Windows WPF runtime, so local build/test/full validation and WPF screenshots were not run here.
+- GitHub connector readback/compare should be used for this pass, followed by the next Windows/.NET-capable full validation run.

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -93,7 +93,7 @@ namespace InventoryManagementApp.Services.Users
             try
             {
                 if (itemID < 1)
-                    return new Result<List<ActivityLog>>(new List<ActivityLog>(), true);
+                    return new Result<List<ActivityLog>>(null, false, "Item ID must be positive.");
 
                 var itemIdPattern = $"%item {itemID} check-out status%";
                 var itemNumberPattern = string.IsNullOrWhiteSpace(itemNumber)


### PR DESCRIPTION
## Summary

- Make `ActivityLogService.GetCheckoutHistoryForItemAsync` reject non-positive item IDs with a clear failure result before SQL work begins.
- Keep valid checkout-history searches covering both legacy toggle activity rows and newer checked-out/checked-in item-number rows.
- Add focused source-contract coverage and a progress note for the new guard.

## Why This Matters

A recent direct print/details update added checkout-history lookup from item details. Unlike the reservation, rental, kit, maintenance, and calibration service hardening completed today, this new query still treated invalid item IDs as successful empty history. This keeps the new activity-log API aligned with the current service-boundary guard pattern and makes bad call sites visible instead of silently indistinguishable from a real no-history result.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `ActivityLogService`, one focused source-contract test, and a progress note.
- GitHub connector readback confirmed invalid item IDs now return `new Result<List<ActivityLog>>(null, false, "Item ID must be positive.")` before connection creation, while the legacy and item-number activity search patterns remain intact.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local checkout is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata shows `master` is active.