### PR TITLE
Guard recent activity log count inputs

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
@@ -7,6 +7,36 @@ namespace InventoryManagementApp.Tests
     public class ActivityLogCheckoutHistoryContractTests
     {
         [Fact]
+        public void RecentLogsRejectsInvalidCountsBeforeSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");
+            var method = ExtractMethod(
+                source,
+                "public virtual async Task<Result<List<ActivityLog>>> GetRecentLogsAsync",
+                "public virtual async Task<Result<List<ActivityLog>>> GetCheckoutHistoryForItemAsync");
+
+            Assert.Contains("if (count < 1)", method, StringComparison.Ordinal);
+            Assert.Contains("return new Result<List<ActivityLog>>(null, false, \"Count must be positive.\");", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (count < 1)", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection()", StringComparison.Ordinal),
+                "The invalid count guard should run before recent-log SQL work starts.");
+        }
+
+        [Fact]
+        public void RecentLogsStillOrdersByTimestampAndAppliesTheRequestedLimit()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");
+            var method = ExtractMethod(
+                source,
+                "public virtual async Task<Result<List<ActivityLog>>> GetRecentLogsAsync",
+                "public virtual async Task<Result<List<ActivityLog>>> GetCheckoutHistoryForItemAsync");
+
+            Assert.Contains("ORDER BY Timestamp DESC", method, StringComparison.Ordinal);
+            Assert.Contains("LIMIT @Count", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Count\", count)", method, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void CheckoutHistoryRejectsInvalidItemIdsBeforeSqlWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-activity-log-recent-count-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-activity-log-recent-count-guard.md
@@ -1,0 +1,10 @@
+# Activity Log Recent Count Guard
+
+## Completed
+- Tightened recent activity-log retrieval so non-positive `count` values fail clearly at the service boundary.
+- Kept valid recent-log queries ordered by latest timestamp and limited by the requested count.
+- Extended activity-log source-contract coverage to keep the invalid-count guard ahead of SQL work.
+
+## Validation Notes
+- This scheduled Linux container does not have a local repository checkout, `dotnet`, PowerShell/`pwsh`, `gh`, or a Windows WPF runtime, so local build/test/full validation, WPF screenshots, and local banned-word checks were not run here.
+- GitHub connector readback/compare should be used for this pass, followed by the next Windows/.NET-capable full validation run.

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -62,6 +62,9 @@ namespace InventoryManagementApp.Services.Users
         {
             try
             {
+                if (count < 1)
+                    return new Result<List<ActivityLog>>(null, false, "Count must be positive.");
+
                 const string sql = @"
                     SELECT * FROM ActivityLogs
                      ORDER BY Timestamp DESC


### PR DESCRIPTION
## Summary

- Make `ActivityLogService.GetRecentLogsAsync` reject non-positive `count` values with a clear failure result before SQL work begins.
- Preserve valid recent-log behavior: newest-first ordering and the requested SQLite limit parameter.
- Extend focused activity-log source-contract coverage and add a progress note for the new guard.

## Why This Matters

Recent service hardening moved invalid IDs and query limits to explicit service-boundary failures. `GetRecentLogsAsync` still passed non-positive counts directly into SQLite `LIMIT @Count`, which can make invalid callers look like legitimate empty or provider-specific queries. This keeps activity-log query behavior consistent and makes bad count inputs visible before any database work starts.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `ActivityLogService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed invalid counts now return `new Result<List<ActivityLog>>(null, false, "Count must be positive.")` before connection creation, while valid queries still use `ORDER BY Timestamp DESC`, `LIMIT @Count`, and the requested `count` parameter.
- GitHub connector status readback found no commit statuses attached to the branch head before PR creation.
- Direct local checkout/raw clone is blocked in this scheduled Linux container; only the memory folder is locally present for this run.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata shows `master` is active.