### PR TITLE
Guard customer writes against stale rows

### DIFF
--- a/InventoryManagementApp.Tests/CustomerServiceStaleRowContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomerServiceStaleRowContractTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class CustomerServiceStaleRowContractTests
+    {
+        [Fact]
+        public void UpdateCustomerRejectsInvalidIdsBeforeAuthorizationAndSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var method = ExtractMethod(
+                source,
+                "public Task UpdateCustomerAsync(CustomerModel customer",
+                "public Task DeleteCustomerAsync(int customerID");
+
+            Assert.Contains("if (customer.CustomerID < 1)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentOutOfRangeException(nameof(customer), \"Customer ID must be greater than 0.\");", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (customer.CustomerID < 1)", StringComparison.Ordinal) < method.IndexOf("_auth.EnsureAdmin()", StringComparison.Ordinal),
+                "Invalid customer IDs should be rejected before update authorization and SQL work are reached.");
+        }
+
+        [Fact]
+        public void UpdateCustomerChecksTargetRowBeforeExecutingUpdate()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var method = ExtractMethod(
+                source,
+                "async Task UpdateCustomerInternalAsync",
+                "async Task DeleteCustomerInternalAsync");
+
+            Assert.Contains("await EnsureCustomerRowExistsAsync(conn, customer.CustomerID, cancellationToken);", method, StringComparison.Ordinal);
+            Assert.Contains("await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("EnsureCustomerRowExistsAsync", StringComparison.Ordinal) < method.IndexOf("ExecuteNonQueryAsync", StringComparison.Ordinal),
+                "The stale customer-row guard should run before the update statement executes.");
+        }
+
+        [Fact]
+        public void DeleteCustomerChecksTargetRowBeforeExecutingDelete()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var method = ExtractMethod(
+                source,
+                "async Task DeleteCustomerInternalAsync",
+                "async Task<CustomerModel?> GetCustomerByIDInternalAsync");
+
+            Assert.Contains("await EnsureCustomerRowExistsAsync(conn, customerID, cancellationToken);", method, StringComparison.Ordinal);
+            Assert.Contains("await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("EnsureCustomerRowExistsAsync", StringComparison.Ordinal) < method.IndexOf("ExecuteNonQueryAsync", StringComparison.Ordinal),
+                "The stale customer-row guard should run before the delete statement executes.");
+        }
+
+        [Fact]
+        public void CustomerRowGuardCountsByCustomerIdAndThrowsClearMissingRowFailure()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+            var method = ExtractMethod(
+                source,
+                "static async Task EnsureCustomerRowExistsAsync",
+                "static string? GetSkipReason");
+
+            Assert.Contains("SELECT COUNT(*) FROM Customers WHERE CustomerID = @CustomerID", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@CustomerID\", customerID)", method, StringComparison.Ordinal);
+            Assert.Contains("if (count == 0)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new KeyNotFoundException($\"Customer {customerID} not found.\");", method, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-customer-stale-row-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-customer-stale-row-guards.md
@@ -1,0 +1,11 @@
+# Customer Stale Row Guards
+
+## Completed
+- Tightened customer update and delete writes so stale customer IDs are checked before mutating the `Customers` table.
+- Added positive ID validation to customer updates, aligning them with delete and get-by-id boundaries.
+- Added source-contract coverage to keep stale-row checks ahead of update/delete SQL execution.
+
+## Validation Notes
+- Direct local checkout/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and the full validation runner are unavailable here, so local build/test/full validation was not run.
+- GitHub connector readback/compare should be used for this pass, followed by the next Windows/.NET-capable full validation run.

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -61,11 +61,14 @@ namespace InventoryManagementApp.Services.Customers
         /// <param name="customer">The customer with updated information.</param>
         /// <param name="cancellationToken">Cancellation token for the operation.</param>
         /// <exception cref="ArgumentNullException">Thrown if customer is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if customer ID is less than 1.</exception>
         /// <exception cref="UnauthorizedAccessException">Thrown if user lacks admin privileges.</exception>
         public Task UpdateCustomerAsync(CustomerModel customer, CancellationToken cancellationToken = default)
         {
             if (customer is null)
                 throw new ArgumentNullException(nameof(customer));
+            if (customer.CustomerID < 1)
+                throw new ArgumentOutOfRangeException(nameof(customer), "Customer ID must be greater than 0.");
             
             _auth.EnsureAdmin();
             return UpdateCustomerInternalAsync(customer, cancellationToken);
@@ -195,6 +198,7 @@ namespace InventoryManagementApp.Services.Customers
             using var conn = _dbService.CreateConnection();
             try
             {
+                await EnsureCustomerRowExistsAsync(conn, customer.CustomerID, cancellationToken);
                 await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);
             }
             catch (Exception ex)
@@ -211,6 +215,7 @@ namespace InventoryManagementApp.Services.Customers
             using var conn = _dbService.CreateConnection();
             try
             {
+                await EnsureCustomerRowExistsAsync(conn, customerID, cancellationToken);
                 await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);
             }
             catch (Exception ex)
@@ -391,6 +396,18 @@ namespace InventoryManagementApp.Services.Customers
                 _logger.LogError(ex, "Failed to check if customer exists");
                 throw;
             }
+        }
+
+        static async Task EnsureCustomerRowExistsAsync(SqliteConnection conn, int customerID, CancellationToken cancellationToken)
+        {
+            const string sql = "SELECT COUNT(*) FROM Customers WHERE CustomerID = @CustomerID";
+            var count = Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql, new[]
+            {
+                new SqliteParameter("@CustomerID", customerID)
+            }, cancellationToken) ?? 0);
+
+            if (count == 0)
+                throw new KeyNotFoundException($"Customer {customerID} not found.");
         }
 
         static string? GetSkipReason(CustomerModel c)


### PR DESCRIPTION
## Summary

- Add positive ID validation to customer updates so invalid update targets fail at the service boundary.
- Confirm customer rows exist before update/delete writes execute, making stale customer actions fail clearly instead of looking like successful no-ops.
- Add focused source-contract coverage and a progress note for the customer stale-row guards.

## Why This Matters

Recent service hardening moved stale IDs and invalid references to explicit boundary failures across reservations, kits, rentals, maintenance, calibration, and activity-log paths. Customer update/delete still only validated positive IDs before issuing SQL, so stale UI actions targeting deleted customer rows could complete without a clear failure. This keeps customer directory writes aligned with the current reliability pattern.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `CustomerService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed customer update rejects non-positive IDs before authorization/SQL work, and update/delete now call `EnsureCustomerRowExistsAsync` before `ExecuteNonQueryAsync`.
- GitHub connector readback confirmed the shared customer row guard counts by `CustomerID` and throws `Customer {customerID} not found.` when the target row is missing.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local checkout/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata shows `master` is active.