### PR TITLE
Guard user updates against stale rows

### DIFF
--- a/InventoryManagementApp.Tests/UserServiceStaleRowContractTests.cs
+++ b/InventoryManagementApp.Tests/UserServiceStaleRowContractTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class UserServiceStaleRowContractTests
+    {
+        [Fact]
+        public void UpdateUserRejectsNullAndInvalidIdsBeforeAuthorizationAndSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task UpdateUserAsync(User user)",
+                "public async Task<bool> ChangeUserPasswordAsync");
+
+            Assert.Contains("if (user is null)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(user));", method, StringComparison.Ordinal);
+            Assert.Contains("if (user.UserID < 1)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentOutOfRangeException(nameof(user), \"User ID must be greater than 0.\");", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (user.UserID < 1)", StringComparison.Ordinal) < method.IndexOf("_auth.EnsurePermission(User.PermissionManageUsers)", StringComparison.Ordinal),
+                "Invalid user IDs should be rejected before authorization and SQL work are reached.");
+        }
+
+        [Fact]
+        public void UpdateUserChecksTargetRowBeforePasswordFallbackAndSqlUpdate()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task UpdateUserAsync(User user)",
+                "public async Task<bool> ChangeUserPasswordAsync");
+
+            Assert.Contains("var existing = await GetUserByIDAsync(user.UserID, CancellationToken.None);", method, StringComparison.Ordinal);
+            Assert.Contains("if (existing is null)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new KeyNotFoundException($\"User {user.UserID} not found.\");", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("var existing = await GetUserByIDAsync", StringComparison.Ordinal) < method.IndexOf("string hashed = user.PasswordHash;", StringComparison.Ordinal),
+                "The stale user-row guard should run before password fallback values are copied.");
+            Assert.True(
+                method.IndexOf("if (existing is null)", StringComparison.Ordinal) < method.IndexOf("ExecuteNonQueryAsync", StringComparison.Ordinal),
+                "The missing-user guard should run before the update statement executes.");
+        }
+
+        [Fact]
+        public void UpdateUserThrowsOnZeroRowsBeforeMutatingCallerPasswordFields()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task UpdateUserAsync(User user)",
+                "public async Task<bool> ChangeUserPasswordAsync");
+
+            Assert.Contains("int rows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);", method, StringComparison.Ordinal);
+            Assert.Contains("if (rows == 0)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new KeyNotFoundException($\"User {user.UserID} not found.\");", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (rows == 0)", StringComparison.Ordinal) < method.IndexOf("user.PasswordHash = hashed;", StringComparison.Ordinal),
+                "A stale zero-row update should fail before the caller's password fields are rewritten.");
+        }
+
+        [Fact]
+        public void UserServiceImportsGenericCollectionsForMissingRowFailures()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+
+            Assert.Contains("using System.Collections.Generic;", source, StringComparison.Ordinal);
+            Assert.Contains("throw new KeyNotFoundException($\"User {user.UserID} not found.\");", source, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-user-update-stale-row-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-user-update-stale-row-guard.md
@@ -1,0 +1,12 @@
+# User Update Stale Row Guard
+
+## Completed
+- Tightened admin user profile updates so null users and non-positive user IDs fail before authorization or SQL work.
+- Added an explicit target-user lookup before password fallback handling and update SQL execution, making stale admin-user edit actions fail clearly.
+- Added a zero-row update guard before rewriting the caller's password hash and salt fields.
+- Added source-contract coverage for the user update stale-row behavior.
+
+## Validation Notes
+- Direct local checkout/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and the full validation runner are unavailable here, so local build/test/full validation was not run.
+- GitHub connector readback/compare should be used for this pass, followed by the next Windows/.NET-capable full validation run.

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.Data.Sqlite;
 using System.Data;
 using System.Threading;
@@ -319,6 +320,11 @@ namespace InventoryManagementApp.Services.Users
 
         public async Task UpdateUserAsync(User user)
         {
+            if (user is null)
+                throw new ArgumentNullException(nameof(user));
+            if (user.UserID < 1)
+                throw new ArgumentOutOfRangeException(nameof(user), "User ID must be greater than 0.");
+
             _auth.EnsurePermission(User.PermissionManageUsers);
             const string sql = @"
                 UPDATE Users SET
@@ -336,20 +342,17 @@ namespace InventoryManagementApp.Services.Users
                   Permissions   = @Permissions
                 WHERE UserID = @UserID";
 
+            var existing = await GetUserByIDAsync(user.UserID, CancellationToken.None);
+            if (existing is null)
+                throw new KeyNotFoundException($"User {user.UserID} not found.");
+
             string hashed = user.PasswordHash;
             string salt = user.PasswordSalt;
 
-            if (string.IsNullOrWhiteSpace(user.PasswordHash) || string.IsNullOrWhiteSpace(user.PasswordSalt))
-            {
-                var existing = await GetUserByIDAsync(user.UserID, CancellationToken.None);
-                if (existing != null)
-                {
-                    if (string.IsNullOrWhiteSpace(user.PasswordHash))
-                        hashed = existing.PasswordHash;
-                    if (string.IsNullOrWhiteSpace(user.PasswordSalt))
-                        salt = existing.PasswordSalt;
-                }
-            }
+            if (string.IsNullOrWhiteSpace(user.PasswordHash))
+                hashed = existing.PasswordHash;
+            if (string.IsNullOrWhiteSpace(user.PasswordSalt))
+                salt = existing.PasswordSalt;
 
             if (!string.IsNullOrWhiteSpace(user.PasswordHash) && string.IsNullOrWhiteSpace(user.PasswordSalt))
             {
@@ -376,7 +379,10 @@ namespace InventoryManagementApp.Services.Users
             };
 
             using var conn = _dbService.CreateConnection();
-            await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+            int rows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p);
+            if (rows == 0)
+                throw new KeyNotFoundException($"User {user.UserID} not found.");
+
             user.PasswordHash = hashed;
             user.PasswordSalt = salt;
         }


### PR DESCRIPTION
## Summary

- Add null and positive-ID validation to admin user updates before authorization or SQL work begins.
- Confirm the target user row exists before password fallback handling and update SQL execution.
- Treat zero-row user updates as stale-row failures before rewriting the caller's password hash/salt fields.
- Add focused source-contract coverage and a progress note for the user update stale-row guard.

## Why This Matters

Recent service hardening moved stale IDs and invalid references to explicit boundary failures across reservations, kits, rentals, maintenance, calibration, activity logs, and customers. `UserService.UpdateUserAsync` still allowed stale admin-user edit actions to execute an update that could affect zero rows, then rewrite the caller's password fields as if the save succeeded. This keeps user administration aligned with the current reliability pattern and avoids misleading post-save state after stale selections.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `UserService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed `UpdateUserAsync` now rejects null users and non-positive IDs before authorization/SQL work, looks up the target user before password fallback handling and update SQL execution, and throws on zero affected rows before mutating caller password fields.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local checkout/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata shows `master` is active.