### PR TITLE
Guard rental history lookups against missing parent rows

### DIFF
--- a/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
@@ -31,7 +31,7 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void RentalHistoryQueriesValidateParentRowsBeforeHistorySqlWork()
+        public void RentalHistoryQueriesValidateParentRowsBeforeExecutingHistoryQueries()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
 
@@ -48,12 +48,12 @@ namespace InventoryManagementApp.Tests
 
             Assert.True(
                 source.IndexOf("await EnsureItemExistsAsync(conn, itemID).ConfigureAwait(false);", StringComparison.Ordinal) <
-                source.IndexOf("WHERE r.ItemID = @ItemID", StringComparison.Ordinal),
-                "Expected item rental history to confirm the item row exists before running the history query.");
+                source.IndexOf("var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);", StringComparison.Ordinal),
+                "Expected item rental history to confirm the item row exists before executing the history query.");
             Assert.True(
                 source.IndexOf("await EnsureCustomerExistsAsync(conn, customerID).ConfigureAwait(false);", StringComparison.Ordinal) <
-                source.IndexOf("WHERE r.CustomerID = @CustomerID", StringComparison.Ordinal),
-                "Expected customer rental history to confirm the customer row exists before running the history query.");
+                source.LastIndexOf("var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);", StringComparison.Ordinal),
+                "Expected customer rental history to confirm the customer row exists before executing the history query.");
         }
 
         [Fact]

--- a/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
@@ -31,6 +31,32 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void RentalHistoryQueriesValidateParentRowsBeforeHistorySqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+
+            AssertContainsAll(
+                source,
+                "private static async Task EnsureItemExistsAsync(SqliteConnection conn, int itemID)",
+                "SELECT COUNT(*) FROM Items WHERE ItemID=@ItemID",
+                "throw new InvalidOperationException(\"Item not found.\");",
+                "private static async Task EnsureCustomerExistsAsync(SqliteConnection conn, int customerID)",
+                "SELECT COUNT(*) FROM Customers WHERE CustomerID=@CustomerID",
+                "throw new InvalidOperationException(\"Customer not found.\");",
+                "await EnsureItemExistsAsync(conn, itemID).ConfigureAwait(false);",
+                "await EnsureCustomerExistsAsync(conn, customerID).ConfigureAwait(false);");
+
+            Assert.True(
+                source.IndexOf("await EnsureItemExistsAsync(conn, itemID).ConfigureAwait(false);", StringComparison.Ordinal) <
+                source.IndexOf("WHERE r.ItemID = @ItemID", StringComparison.Ordinal),
+                "Expected item rental history to confirm the item row exists before running the history query.");
+            Assert.True(
+                source.IndexOf("await EnsureCustomerExistsAsync(conn, customerID).ConfigureAwait(false);", StringComparison.Ordinal) <
+                source.IndexOf("WHERE r.CustomerID = @CustomerID", StringComparison.Ordinal),
+                "Expected customer rental history to confirm the customer row exists before running the history query.");
+        }
+
+        [Fact]
         public void RentalFrequencyValidatesPositiveLimitBeforeSqlWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-26-rental-history-parent-row-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-26-rental-history-parent-row-guards.md
@@ -1,0 +1,11 @@
+# Rental History Parent Row Guards
+
+## Completed
+- Tightened rental history lookups so item and customer history requests confirm the referenced parent row still exists before executing the history query.
+- Preserved valid existing item/customer history behavior, including empty history results for real rows with no rentals.
+- Added source-contract coverage for the new parent-row guards and their ordering before history query execution.
+
+## Validation Notes
+- Direct local checkout/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and the full validation runner are unavailable here, so local build/test/full validation was not run.
+- GitHub connector readback/compare should be used for this pass, followed by the next Windows/.NET-capable full validation run.

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -357,6 +357,7 @@ namespace InventoryManagementApp.Services.Rentals
             const string sql = BaseSelect + @" WHERE r.ItemID = @ItemID ORDER BY r.RentalDate DESC";
             var p = new[] { new SqliteParameter("@ItemID", itemID) };
             using var conn = _dbService.CreateConnection();
+            await EnsureItemExistsAsync(conn, itemID).ConfigureAwait(false);
             var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);
             return list.Where(r => r != null).Select(r => r!).ToList();
         }
@@ -369,6 +370,7 @@ namespace InventoryManagementApp.Services.Rentals
             const string sql = BaseSelect + @" WHERE r.CustomerID = @CustomerID ORDER BY r.RentalDate DESC";
             var p = new[] { new SqliteParameter("@CustomerID", customerID) };
             using var conn = _dbService.CreateConnection();
+            await EnsureCustomerExistsAsync(conn, customerID).ConfigureAwait(false);
             var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);
             return list.Where(r => r != null).Select(r => r!).ToList();
         }
@@ -420,6 +422,28 @@ namespace InventoryManagementApp.Services.Rentals
                 throw new InvalidOperationException("Item not found.");
 
             return Convert.ToInt32(result);
+        }
+
+        private static async Task EnsureItemExistsAsync(SqliteConnection conn, int itemID)
+        {
+            var itemCmd = new SqliteCommand(
+                "SELECT COUNT(*) FROM Items WHERE ItemID=@ItemID",
+                conn);
+            itemCmd.Parameters.AddWithValue("@ItemID", itemID);
+            var itemCount = Convert.ToInt32(await itemCmd.ExecuteScalarAsync() ?? 0);
+            if (itemCount < 1)
+                throw new InvalidOperationException("Item not found.");
+        }
+
+        private static async Task EnsureCustomerExistsAsync(SqliteConnection conn, int customerID)
+        {
+            var customerCmd = new SqliteCommand(
+                "SELECT COUNT(*) FROM Customers WHERE CustomerID=@CustomerID",
+                conn);
+            customerCmd.Parameters.AddWithValue("@CustomerID", customerID);
+            var customerCount = Convert.ToInt32(await customerCmd.ExecuteScalarAsync() ?? 0);
+            if (customerCount < 1)
+                throw new InvalidOperationException("Customer not found.");
         }
 
         private static async Task EnsureCustomerExistsAsync(SqliteConnection conn, SqliteTransaction tx, int customerID)


### PR DESCRIPTION
## Summary

- Add item/customer parent-row existence checks before rental history lookups execute their history queries.
- Preserve valid existing item/customer history behavior, including empty histories for real rows with no rentals.
- Extend focused source-contract coverage and add a progress note for the rental history parent-row guard.

## Why This Matters

Recent service hardening moved invalid IDs and stale write targets to explicit boundary failures. Rental history lookups now reject non-positive IDs, but a stale item or customer selection could still return an empty history that looks the same as a real existing row with no rentals. These checks make missing parent rows visible before the history query runs.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `RentalService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed item/customer rental history calls now run parent-row guards before `SqliteHelper.ExecuteReaderAsync`, while valid query SQL remains unchanged.
- GitHub connector status readback found no commit statuses attached to the branch head before PR creation.
- Direct local checkout/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata shows `master` is active.