### PR TITLE
Guard bulk item saves against stale rows

### DIFF
--- a/InventoryManagementApp.Tests/ItemRepositoryBulkSaveContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryBulkSaveContractTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ItemRepositoryBulkSaveContractTests
+    {
+        [Fact]
+        public void BulkItemSaveChecksAffectedRowsAndFailsForStaleItems()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Data", "ItemRepository.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task SaveChangesAsync(IEnumerable<Item> changes, CancellationToken ct)",
+                "public async Task<int> InsertAsync(Item item, CancellationToken ct)");
+
+            Assert.Contains("var rows = await conn.ExecuteAsync(new CommandDefinition(sql, new", method, StringComparison.Ordinal);
+            Assert.Contains("}, tx, cancellationToken: ct)).ConfigureAwait(false);", method, StringComparison.Ordinal);
+            Assert.Contains("if (rows == 0)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new InvalidOperationException($\"Failed to save item {item.ItemID}.\");", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("await conn.ExecuteAsync(sql, new", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("var rows = await conn.ExecuteAsync", StringComparison.Ordinal) <
+                method.IndexOf("if (rows == 0)", StringComparison.Ordinal),
+                "Bulk item saves should inspect the affected-row count immediately after each row update.");
+            Assert.True(
+                method.IndexOf("if (rows == 0)", StringComparison.Ordinal) <
+                method.IndexOf("tx.Commit();", StringComparison.Ordinal),
+                "Bulk item saves should fail before committing when a stale item row is encountered.");
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -71,14 +71,16 @@ public sealed class ItemRepository : IItemRepository
         foreach (var item in changes)
         {
             ct.ThrowIfCancellationRequested();
-            await conn.ExecuteAsync(sql, new
+            var rows = await conn.ExecuteAsync(new CommandDefinition(sql, new
             {
                 item.Name,
                 item.Location,
                 QuantityOnHand = item.QuantityOnHand,
                 item.Price,
                 item.ItemID
-            }, tx);
+            }, tx, cancellationToken: ct)).ConfigureAwait(false);
+            if (rows == 0)
+                throw new InvalidOperationException($"Failed to save item {item.ItemID}.");
         }
         tx.Commit();
     }

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-item-bulk-save-stale-row-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-item-bulk-save-stale-row-guard.md
@@ -1,0 +1,15 @@
+# Item Bulk Save Stale Row Guard - 2026-06-27
+
+## Summary
+- Updated `ItemRepository.SaveChangesAsync` to execute each bulk item update through a cancellation-aware `CommandDefinition`.
+- Added affected-row validation for each item row saved in the bulk edit transaction.
+- Changed stale bulk item saves from silent no-op updates to clear `InvalidOperationException` failures before the transaction commits.
+
+## Why This Matters
+- Incremental item editing can submit multiple saved rows at once, and a stale row should not look like a successful save.
+- The rest of the recently hardened services now fail clearly when update/delete targets no longer exist; bulk item saves now follow that same reliability pattern.
+- Keeping the failure inside the transaction prevents a mixed commit where earlier edits are saved while a later stale item is silently skipped.
+
+## Validation
+- Added `ItemRepositoryBulkSaveContractTests` source-contract coverage for cancellation-aware update commands, affected-row checks, stale-row failure messages, and failure-before-commit ordering.
+- Local build/test execution was not available in the scheduled Linux environment because direct checkout/raw access, `dotnet`, PowerShell/`pwsh`, `gh`, WPF screenshots, local banned-word checks, and full validation runner access were unavailable.


### PR DESCRIPTION
## Summary

- Make `ItemRepository.SaveChangesAsync` execute each bulk item update through a cancellation-aware `CommandDefinition`.
- Check the affected-row count for every bulk item save and fail clearly when a stale item row is encountered.
- Add focused source-contract coverage and a progress note for the bulk item stale-row guard.

## Why This Matters

Recent service hardening moved stale update/delete targets to explicit failures across reservations, kits, rentals, maintenance, calibration, customers, users, categories, and activity logs. Bulk item edits still allowed an update for a missing item row to affect zero rows and then commit as if the save succeeded. This keeps item editing aligned with the current reliability pattern and prevents silent partial saves when one edited row is stale.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `ItemRepository`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed bulk item saves now use a cancellation-aware `CommandDefinition`, inspect `rows`, throw `InvalidOperationException($"Failed to save item {item.ItemID}.")` on zero affected rows, and fail before `tx.Commit()`.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local checkout/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata shows `master` is active.