### PR TITLE
Guard item common usage limits

### DIFF
--- a/InventoryManagementApp.Tests/ItemRepositoryBulkSaveContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryBulkSaveContractTests.cs
@@ -31,6 +31,41 @@ namespace InventoryManagementApp.Tests
                 "Bulk item saves should fail before committing when a stale item row is encountered.");
         }
 
+        [Fact]
+        public void MostCommonlyUsedItemsRejectsInvalidLimitsBeforeSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Data", "ItemRepository.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<List<Item>> GetMostCommonlyUsedItemsAsync(int limit, CancellationToken ct)",
+                "public async Task<List<Item>> GetIncompleteItemsAsync(CancellationToken ct)");
+
+            Assert.Contains("ct.ThrowIfCancellationRequested();", method, StringComparison.Ordinal);
+            Assert.Contains("if (limit < 1)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentOutOfRangeException(nameof(limit), \"Limit must be positive.\");", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (limit < 1)", StringComparison.Ordinal) < method.IndexOf("var sql =", StringComparison.Ordinal),
+                "The invalid limit guard should run before most-common item SQL work starts.");
+            Assert.True(
+                method.IndexOf("if (limit < 1)", StringComparison.Ordinal) < method.IndexOf("await using var conn", StringComparison.Ordinal),
+                "The invalid limit guard should run before opening a database connection.");
+        }
+
+        [Fact]
+        public void MostCommonlyUsedItemsStillOrdersByCheckoutCountAndAppliesTheRequestedLimit()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Data", "ItemRepository.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<List<Item>> GetMostCommonlyUsedItemsAsync(int limit, CancellationToken ct)",
+                "public async Task<List<Item>> GetIncompleteItemsAsync(CancellationToken ct)");
+
+            Assert.Contains("WHERE CheckoutCount > 0", method, StringComparison.Ordinal);
+            Assert.Contains("ORDER BY CheckoutCount DESC", method, StringComparison.Ordinal);
+            Assert.Contains("LIMIT @Limit", method, StringComparison.Ordinal);
+            Assert.Contains("new { Limit = limit }", method, StringComparison.Ordinal);
+        }
+
         private static string ExtractMethod(string source, string startMarker, string endMarker)
         {
             var start = source.IndexOf(startMarker, StringComparison.Ordinal);

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -252,6 +252,10 @@ public sealed class ItemRepository : IItemRepository
 
     public async Task<List<Item>> GetMostCommonlyUsedItemsAsync(int limit, CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
+        if (limit < 1)
+            throw new ArgumentOutOfRangeException(nameof(limit), "Limit must be positive.");
+
         var sql = $@"SELECT {ItemProjection}
             FROM Items
             WHERE CheckoutCount > 0 

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-item-common-use-limit-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-item-common-use-limit-guard.md
@@ -1,0 +1,12 @@
+# Item Common Usage Limit Guard - 2026-06-27
+
+## Completed
+
+- Added an explicit non-positive limit guard to `ItemRepository.GetMostCommonlyUsedItemsAsync` before SQL construction or database connection work begins.
+- Preserved the existing valid-query behavior that returns checked-out usage rows ordered by `CheckoutCount DESC` using the requested `LIMIT @Limit` parameter.
+- Extended `ItemRepositoryBulkSaveContractTests` with focused source-contract coverage for the invalid-limit guard and the valid limit/order query contract.
+
+## Validation Notes
+
+- GitHub connector readback/compare should be used for this scheduled pass because the Linux container cannot clone the repository directly.
+- Local `dotnet` test execution, PowerShell validation, WPF runtime screenshots, and local banned-word checks remain unavailable in this scheduled environment.


### PR DESCRIPTION
## Summary

- Make `ItemRepository.GetMostCommonlyUsedItemsAsync` reject non-positive limits before SQL construction or database connection work begins.
- Preserve the valid most-common item query contract: checkout-count filtering, descending usage ordering, and caller-supplied `LIMIT @Limit` parameter binding.
- Extend focused source-contract coverage and add a progress note for the limit guard.

## Why This Matters

Recent service hardening moved invalid query inputs and stale write targets to explicit service-boundary failures. The most-common item usage query still passed non-positive limits straight to SQLite, which could make invalid dashboard/report callers depend on provider-specific `LIMIT` behavior. This keeps the item usage summary path aligned with the current reliability pattern.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `ItemRepository`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed `GetMostCommonlyUsedItemsAsync` now checks cancellation, rejects `limit < 1` with `ArgumentOutOfRangeException(nameof(limit), "Limit must be positive.")`, and does so before SQL construction or connection creation.
- GitHub connector readback confirmed the valid query still filters `CheckoutCount > 0`, orders by `CheckoutCount DESC`, and binds `new { Limit = limit }` to `LIMIT @Limit`.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local checkout/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata shows `master` is active.