### PR TITLE
Guard key-value print table polish

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/PrintPreviewWindowXamlTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/PrintPreviewWindowXamlTests.cs
@@ -45,6 +45,7 @@ namespace InventoryManagementApp.Tests.ViewModels
             Assert.Contains("ApplyTablePolish", codeBehind, StringComparison.Ordinal);
             Assert.Contains("isKeyValueTable", codeBehind, StringComparison.Ordinal);
             Assert.Contains("table.Tag as string, \"KeyValue\"", codeBehind, StringComparison.Ordinal);
+            Assert.Contains("else if (!isKeyValueTable && rowIndex % 2 == 0)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("foreach (var rowGroup in table.RowGroups)", codeBehind, StringComparison.Ordinal);
             Assert.Contains("Generated from InventoryManagementApp print preview", codeBehind, StringComparison.Ordinal);
         }

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-key-value-print-polish-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-key-value-print-polish-guard.md
@@ -1,0 +1,12 @@
+# Key-Value Print Polish Guard - 2026-06-27
+
+## Completed
+
+- Kept shared print-preview table polishing from applying alternating row backgrounds to key-value tables tagged by item detail print sections.
+- Preserved normal header and alternating-row polish for standard tabular print outputs.
+- Extended `PrintPreviewWindowXamlTests` source-contract coverage so the key-value table guard remains explicit.
+
+## Validation Notes
+
+- GitHub connector readback/compare should be used for this scheduled pass because the Linux container cannot clone the repository directly.
+- Local `dotnet` test execution, PowerShell validation, WPF runtime screenshots, and local banned-word checks remain unavailable in this scheduled environment.

--- a/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml.cs
+++ b/InventoryManagementApp/Views/Windows/PrintPreviewWindow.xaml.cs
@@ -198,7 +198,7 @@ namespace InventoryManagementApp.Views.Windows
                         row.Foreground = PrintDocumentTheme.HeaderForegroundBrush;
                         row.FontWeight = FontWeights.SemiBold;
                     }
-                    else if (rowIndex % 2 == 0)
+                    else if (!isKeyValueTable && rowIndex % 2 == 0)
                     {
                         row.Background = PrintDocumentTheme.AlternatingRowBackgroundBrush;
                     }


### PR DESCRIPTION
## Summary

- Keep shared print-preview table polishing from applying alternating row backgrounds to key-value tables tagged by item detail print sections.
- Preserve existing header and alternating-row polish for standard tabular print outputs.
- Extend focused source-contract coverage and add a progress note for the key-value print polish guard.

## Why This Matters

A recent item details print update introduced key-value section tables so printed item details include more complete handoff context. Those tables are intentionally not header tables, but the shared print polish still treated their first row as an alternating table row. This keeps item detail key-value sections visually plain and readable while leaving normal report tables unchanged.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `PrintPreviewWindow.xaml.cs`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed key-value tables now skip both header styling and alternating row background styling through `!isKeyValueTable` guards.
- GitHub connector readback confirmed `PrintPreviewWindowXamlTests` now covers the key-value alternating-row guard marker.
- Direct local checkout/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata shows `master` is active.