### PR TITLE
Guard rental returns against stale active rows

### DIFF
--- a/InventoryManagementApp.Tests/RentalServiceReferenceGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceReferenceGuardContractTests.cs
@@ -30,6 +30,29 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("Convert.ToInt32(await availCmd.ExecuteScalarAsync() ?? 0)", source, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void ReturnItemGuardsActiveRentalWriteBeforeInventorySync()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+
+            AssertContainsAll(
+                source,
+                "SELECT ItemID FROM Rentals WHERE RentalID=@RentalID AND Status='Rented'",
+                "var returnedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, tx,",
+                "UPDATE Rentals SET ReturnDate=@ReturnDate,Status='Returned' WHERE RentalID=@RentalID AND Status='Rented'",
+                "if (returnedRows == 0)",
+                "throw new InvalidOperationException(\"Rental not found or already returned.\");",
+                "await _itemService.UpdateItemQuantitiesAsync(itemID, 1, false, conn, tx);");
+            Assert.True(
+                source.IndexOf("UPDATE Rentals SET ReturnDate=@ReturnDate,Status='Returned' WHERE RentalID=@RentalID AND Status='Rented'", StringComparison.Ordinal) <
+                source.IndexOf("await _itemService.UpdateItemQuantitiesAsync(itemID, 1, false, conn, tx);", StringComparison.Ordinal),
+                "Expected rental return persistence to prove the active rental row was updated before inventory sync.");
+            Assert.True(
+                source.IndexOf("if (returnedRows == 0)", StringComparison.Ordinal) <
+                source.IndexOf("await _itemService.UpdateItemQuantitiesAsync(itemID, 1, false, conn, tx);", StringComparison.Ordinal),
+                "Expected stale return writes to fail before returning item quantity to stock.");
+        }
+
         private static void AssertContainsAll(string source, params string[] expectedSnippets)
         {
             foreach (var snippet in expectedSnippets)

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-rental-return-active-row-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-rental-return-active-row-guard.md
@@ -1,0 +1,13 @@
+# Rental Return Active Row Guard
+
+## Completed
+
+- Tightened rental returns so the return update is constrained to active `Rented` rows, matching the existing active-rental lookup.
+- Added an affected-row check after the return update so stale or already-returned rows fail clearly before item quantities are returned to stock.
+- Added source-contract coverage that keeps the active-row predicate, affected-row guard, and inventory-sync ordering intact.
+
+## Validation Notes
+
+- Direct local checkout/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and the full validation runner are unavailable here, so local build/test/full validation was not run.
+- GitHub connector readback/compare should be used for this pass, followed by the next Windows/.NET-capable full validation run.

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -223,13 +223,15 @@ namespace InventoryManagementApp.Services.Rentals
                 if (result == null) throw new InvalidOperationException("Rental not found or already returned.");
                 var itemID = Convert.ToInt32(result);
 
-                await SqliteHelper.ExecuteNonQueryAsync(conn, tx,
-                    "UPDATE Rentals SET ReturnDate=@ReturnDate,Status='Returned' WHERE RentalID=@RentalID",
+                var returnedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, tx,
+                    "UPDATE Rentals SET ReturnDate=@ReturnDate,Status='Returned' WHERE RentalID=@RentalID AND Status='Rented'",
                     new[]
                     {
                         new SqliteParameter("@ReturnDate", returnDate),
                         new SqliteParameter("@RentalID", rentalID)
                     });
+                if (returnedRows == 0)
+                    throw new InvalidOperationException("Rental not found or already returned.");
 
                 if (_itemService != null)
                     await _itemService.UpdateItemQuantitiesAsync(itemID, 1, false, conn, tx);


### PR DESCRIPTION
## Summary

- Constrain `RentalService.ReturnItemAsync`'s return update to active `Rented` rows, matching the active-rental lookup that precedes it.
- Check the affected-row count before returning item quantity to stock so stale or already-returned rows fail clearly.
- Add focused source-contract coverage and a progress note for the return-write guard.

## Why This Matters

Recent service hardening has moved stale IDs and invalid references to explicit service-boundary failures across rentals, reservations, kits, maintenance, calibration, customers, users, categories, and reports. Rental return already selected an active rental before updating, but the update itself was less tightly guarded than extend/delete and did not inspect the affected row count. This keeps the return workflow aligned with the current reliability pattern and prevents stock from being returned after a stale return write.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `RentalService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed `ReturnItemAsync` now updates only `Status='Rented'` rows, checks `returnedRows == 0`, and fails before `_itemService.UpdateItemQuantitiesAsync` when no active row was updated.
- GitHub connector readback confirmed `RentalServiceReferenceGuardContractTests` now covers the active-row update predicate, affected-row guard, and inventory-sync ordering.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local checkout/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata shows `master` is active.