### PR TITLE
Guard rental delete inventory sync ordering

### DIFF
--- a/InventoryManagementApp.Tests/RentalServiceReferenceGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceReferenceGuardContractTests.cs
@@ -53,6 +53,33 @@ namespace InventoryManagementApp.Tests
                 "Expected stale return writes to fail before returning item quantity to stock.");
         }
 
+        [Fact]
+        public void DeleteRentalGuardsDeleteWriteBeforeInventorySync()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+
+            AssertContainsAll(
+                source,
+                "public async Task DeleteRentalAsync(int rentalID)",
+                "SELECT ItemID, Status, ReturnDate FROM Rentals WHERE RentalID=@RentalID",
+                "var deletedRows = await deleteCmd.ExecuteNonQueryAsync();",
+                "if (deletedRows == 0)",
+                "throw new InvalidOperationException(\"Rental not found.\");",
+                "await _itemService.UpdateItemQuantitiesAsync(itemID, 1, false, conn, tx);");
+
+            var deleteMethodIndex = source.IndexOf("public async Task DeleteRentalAsync(int rentalID)", StringComparison.Ordinal);
+            var deletedRowsIndex = source.IndexOf("var deletedRows = await deleteCmd.ExecuteNonQueryAsync();", deleteMethodIndex, StringComparison.Ordinal);
+            var staleGuardIndex = source.IndexOf("if (deletedRows == 0)", deleteMethodIndex, StringComparison.Ordinal);
+            var deleteInventorySyncIndex = source.LastIndexOf("await _itemService.UpdateItemQuantitiesAsync(itemID, 1, false, conn, tx);", StringComparison.Ordinal);
+
+            Assert.True(
+                deletedRowsIndex < deleteInventorySyncIndex,
+                "Expected rental delete persistence to prove the row was removed before inventory sync.");
+            Assert.True(
+                staleGuardIndex < deleteInventorySyncIndex,
+                "Expected stale rental delete writes to fail before returning item quantity to stock.");
+        }
+
         private static void AssertContainsAll(string source, params string[] expectedSnippets)
         {
             foreach (var snippet in expectedSnippets)

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-rental-delete-inventory-sync-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-rental-delete-inventory-sync-guard.md
@@ -1,0 +1,13 @@
+# Rental Delete Inventory Sync Guard
+
+## Completed
+
+- Tightened rental deletion so the rental row delete executes and proves it removed a row before active-rental item quantity is returned to stock.
+- Preserved existing active-rental detection from the selected rental row so returned rentals can still be deleted without changing item quantity.
+- Added source-contract coverage that keeps the delete affected-row guard and inventory-sync ordering intact.
+
+## Validation Notes
+
+- Direct local checkout/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and the full validation runner are unavailable here, so local build/test/full validation was not run.
+- GitHub connector readback/compare should be used for this pass, followed by the next Windows/.NET-capable full validation run.

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -303,15 +303,16 @@ namespace InventoryManagementApp.Services.Rentals
                 var isActive = string.Equals(status, "Rented", StringComparison.OrdinalIgnoreCase) && reader["ReturnDate"] is DBNull;
                 await reader.DisposeAsync();
 
-                if (isActive && _itemService != null)
-                    await _itemService.UpdateItemQuantitiesAsync(itemID, 1, false, conn, tx);
-
                 var deleteCmd = new SqliteCommand(
                     "DELETE FROM Rentals WHERE RentalID=@RentalID",
                     conn, tx);
                 deleteCmd.Parameters.AddWithValue("@RentalID", rentalID);
-                if (await deleteCmd.ExecuteNonQueryAsync() == 0)
+                var deletedRows = await deleteCmd.ExecuteNonQueryAsync();
+                if (deletedRows == 0)
                     throw new InvalidOperationException("Rental not found.");
+
+                if (isActive && _itemService != null)
+                    await _itemService.UpdateItemQuantitiesAsync(itemID, 1, false, conn, tx);
             });
             if (_activityLog != null)
             {


### PR DESCRIPTION
## Summary
- Move active-rental inventory restoration in `DeleteRentalAsync` after the rental row delete has executed and proven it affected a row.
- Keep returned-rental deletion behavior unchanged: only active rentals restore item quantity.
- Add source-contract coverage and a progress note for the delete/write ordering guard.

## Validation
- GitHub connector compare confirmed a focused three-file diff against `master` and branch readback confirmed the updated delete ordering, contract test, and progress note.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and the full validation runner are unavailable here, so local build/test/full validation was not run.