### PR TITLE
Guard item repository invalid IDs

### DIFF
--- a/InventoryManagementApp.Tests/ItemRepositoryBulkSaveContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryBulkSaveContractTests.cs
@@ -32,6 +32,59 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ItemRepositoryRejectsInvalidItemIdsBeforeConnectionWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Data", "ItemRepository.cs");
+
+            AssertInvalidIdGuardBeforeConnection(
+                source,
+                "public async Task<Item?> GetByIdAsync(int id, CancellationToken ct)",
+                "public async Task SaveChangesAsync",
+                "if (id < 1)",
+                "throw new ArgumentOutOfRangeException(nameof(id), \"Item ID must be greater than 0.\");");
+            AssertInvalidIdGuardBeforeConnection(
+                source,
+                "public async Task UpdateAsync(Item item, CancellationToken ct)",
+                "public async Task DeleteAsync",
+                "if (item.ItemID < 1)",
+                "throw new ArgumentOutOfRangeException(nameof(item), \"Item ID must be greater than 0.\");");
+            AssertInvalidIdGuardBeforeConnection(
+                source,
+                "public async Task DeleteAsync(int itemID, CancellationToken ct)",
+                "public async Task<bool> ToggleCheckOutStatusAsync",
+                "if (itemID < 1)",
+                "throw new ArgumentOutOfRangeException(nameof(itemID), \"Item ID must be greater than 0.\");");
+            AssertInvalidIdGuardBeforeConnection(
+                source,
+                "public async Task<bool> ToggleCheckOutStatusAsync(int itemID",
+                "public async Task<List<Item>> GetItemsCheckedOutByAsync",
+                "if (itemID < 1)",
+                "throw new ArgumentOutOfRangeException(nameof(itemID), \"Item ID must be greater than 0.\");");
+            AssertInvalidIdGuardBeforeConnection(
+                source,
+                "public async Task UpdateItemImageAsync(int itemID",
+                "public async Task<List<Item>> GetMostCommonlyUsedItemsAsync",
+                "if (itemID < 1)",
+                "throw new ArgumentOutOfRangeException(nameof(itemID), \"Item ID must be greater than 0.\");");
+        }
+
+        [Fact]
+        public void UpdateItemRejectsNullBeforeCancellationAndSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Data", "ItemRepository.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task UpdateAsync(Item item, CancellationToken ct)",
+                "public async Task DeleteAsync");
+
+            Assert.Contains("if (item is null)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(item));", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (item is null)", StringComparison.Ordinal) < method.IndexOf("ct.ThrowIfCancellationRequested();", StringComparison.Ordinal),
+                "Null item updates should fail before cancellation and SQL work can dereference the item.");
+        }
+
+        [Fact]
         public void MostCommonlyUsedItemsRejectsInvalidLimitsBeforeSqlWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Data", "ItemRepository.cs");
@@ -64,6 +117,18 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("ORDER BY CheckoutCount DESC", method, StringComparison.Ordinal);
             Assert.Contains("LIMIT @Limit", method, StringComparison.Ordinal);
             Assert.Contains("new { Limit = limit }", method, StringComparison.Ordinal);
+        }
+
+        private static void AssertInvalidIdGuardBeforeConnection(string source, string startMarker, string endMarker, string guardSnippet, string exceptionSnippet)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+
+            Assert.Contains("ct.ThrowIfCancellationRequested();", method, StringComparison.Ordinal);
+            Assert.Contains(guardSnippet, method, StringComparison.Ordinal);
+            Assert.Contains(exceptionSnippet, method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf(guardSnippet, StringComparison.Ordinal) < method.IndexOf("await using var conn", StringComparison.Ordinal),
+                $"Expected {startMarker} to reject invalid item IDs before opening a database connection.");
         }
 
         private static string ExtractMethod(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -58,6 +58,9 @@ public sealed class ItemRepository : IItemRepository
     public async Task<Item?> GetByIdAsync(int id, CancellationToken ct)
     {
         ct.ThrowIfCancellationRequested();
+        if (id < 1)
+            throw new ArgumentOutOfRangeException(nameof(id), "Item ID must be greater than 0.");
+
         var sql = $@"SELECT {ItemProjection} FROM Items WHERE ItemID=@ID";
         await using var conn = (DbConnection)_factory.Create();
         return await conn.QueryFirstOrDefaultAsync<Item>(new CommandDefinition(sql, new { ID = id }, cancellationToken: ct)).ConfigureAwait(false);
@@ -114,6 +117,12 @@ public sealed class ItemRepository : IItemRepository
 
     public async Task UpdateAsync(Item item, CancellationToken ct)
     {
+        if (item is null)
+            throw new ArgumentNullException(nameof(item));
+        ct.ThrowIfCancellationRequested();
+        if (item.ItemID < 1)
+            throw new ArgumentOutOfRangeException(nameof(item), "Item ID must be greater than 0.");
+
         const string sql = @"UPDATE Items SET
                   ItemNumber = @ItemNumber,
                   NameDescription = @Name,
@@ -173,6 +182,10 @@ public sealed class ItemRepository : IItemRepository
 
     public async Task DeleteAsync(int itemID, CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
+        if (itemID < 1)
+            throw new ArgumentOutOfRangeException(nameof(itemID), "Item ID must be greater than 0.");
+
         await using var conn = (DbConnection)_factory.Create();
         var rows = await conn.ExecuteAsync(new CommandDefinition("DELETE FROM Items WHERE ItemID=@ID", new { ID = itemID }, cancellationToken: ct));
         if (rows == 0)
@@ -181,6 +194,10 @@ public sealed class ItemRepository : IItemRepository
 
     public async Task<bool> ToggleCheckOutStatusAsync(int itemID, string currentUser, bool isAdmin, CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
+        if (itemID < 1)
+            throw new ArgumentOutOfRangeException(nameof(itemID), "Item ID must be greater than 0.");
+
         await using var conn = (DbConnection)_factory.Create();
         var record = await conn.QueryFirstOrDefaultAsync<(bool Rental, bool Out, int Qty, string? By)>(new CommandDefinition(
             "SELECT IsRentalItem as Rental, IsCheckedOut as Out, AvailableQuantity as Qty, CheckedOutBy as By FROM Items WHERE ItemID=@ID",
@@ -244,6 +261,10 @@ public sealed class ItemRepository : IItemRepository
 
     public async Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
+        if (itemID < 1)
+            throw new ArgumentOutOfRangeException(nameof(itemID), "Item ID must be greater than 0.");
+
         await using var conn = (DbConnection)_factory.Create();
         var rows = await conn.ExecuteAsync(new CommandDefinition("UPDATE Items SET ImagePath=@Img WHERE ItemID=@ID", new { Img = imagePath, ID = itemID }, cancellationToken: ct));
         if (rows == 0)

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-item-repository-invalid-id-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-item-repository-invalid-id-guards.md
@@ -1,0 +1,14 @@
+# Item Repository Invalid ID Guards
+
+Date: 2026-06-27
+
+## Summary
+
+- Added early invalid item ID guards to direct `ItemRepository` item lookups and write paths before database connections are opened.
+- Added a null-item guard to `UpdateAsync` so invalid update calls fail before cancellation or SQL work can dereference the item.
+- Extended focused source-contract coverage to keep the invalid ID guards ahead of connection work while preserving the recent stale-row update/delete protections.
+
+## Validation
+
+- GitHub connector readback/compare was used in the scheduled environment.
+- Local clone/raw access, `dotnet`, PowerShell/`pwsh`, `gh`, WPF screenshots, banned-word checks, and the full validation runner were unavailable in this environment, so local build/test/full validation was not run.


### PR DESCRIPTION
## Summary
- Reject non-positive item IDs in direct `ItemRepository` lookup/write paths before opening database connections.
- Add a null guard to `UpdateAsync` before cancellation or SQL work can dereference the item.
- Extend focused source-contract coverage and add a progress note for the repository invalid-ID guard.

## Why This Matters
Recent reliability work has made stale item rows fail clearly, but several direct repository entrypoints still let invalid item IDs reach database work before failing as generic missing-row writes. This keeps item repository behavior aligned with the current service-boundary guard pattern and avoids unnecessary database work for invalid calls.

## Validation
- GitHub connector compare confirmed a focused three-file diff against `master` and branch readback confirmed the invalid-ID guards, null-update guard, source-contract coverage, and progress note.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and current repo history show `master` is active.