### PR TITLE
[codex] Guard item repository helper query cancellation

### DIFF
--- a/InventoryManagementApp.Tests/ItemRepositoryBulkSaveContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryBulkSaveContractTests.cs
@@ -85,6 +85,47 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void InsertItemRejectsNullBeforeCancellationAndSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Data", "ItemRepository.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<int> InsertAsync(Item item, CancellationToken ct)",
+                "public async Task UpdateAsync");
+
+            Assert.Contains("if (item is null)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(item));", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (item is null)", StringComparison.Ordinal) < method.IndexOf("ct.ThrowIfCancellationRequested();", StringComparison.Ordinal),
+                "Null item inserts should fail before cancellation and SQL work can dereference the item.");
+            Assert.True(
+                method.IndexOf("ct.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("const string sql =", StringComparison.Ordinal),
+                "Item inserts should honor cancellation before SQL work starts.");
+            Assert.True(
+                method.IndexOf("ct.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("await using var conn", StringComparison.Ordinal),
+                "Item inserts should honor cancellation before opening a database connection.");
+        }
+
+        [Fact]
+        public void ItemRepositoryHelperQueriesHonorCancellationBeforeConnectionWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Data", "ItemRepository.cs");
+
+            AssertCancellationGuardBeforeConnection(
+                source,
+                "public async Task<List<Item>> GetItemsCheckedOutByAsync(string userName, CancellationToken ct)",
+                "public async Task<List<Item>> GetCheckedOutItemsAsync(CancellationToken ct)");
+            AssertCancellationGuardBeforeConnection(
+                source,
+                "public async Task<List<Item>> GetCheckedOutItemsAsync(CancellationToken ct)",
+                "public async Task UpdateItemImageAsync");
+            AssertCancellationGuardBeforeConnection(
+                source,
+                "public async Task<List<Item>> GetIncompleteItemsAsync(CancellationToken ct)",
+                "private static (string WhereClause, DynamicParameters Parameters) BuildFilter");
+        }
+
+        [Fact]
         public void MostCommonlyUsedItemsRejectsInvalidLimitsBeforeSqlWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Data", "ItemRepository.cs");
@@ -129,6 +170,19 @@ namespace InventoryManagementApp.Tests
             Assert.True(
                 method.IndexOf(guardSnippet, StringComparison.Ordinal) < method.IndexOf("await using var conn", StringComparison.Ordinal),
                 $"Expected {startMarker} to reject invalid item IDs before opening a database connection.");
+        }
+
+        private static void AssertCancellationGuardBeforeConnection(string source, string startMarker, string endMarker)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+
+            Assert.Contains("ct.ThrowIfCancellationRequested();", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("ct.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("var sql =", StringComparison.Ordinal),
+                $"Expected {startMarker} to honor cancellation before SQL work starts.");
+            Assert.True(
+                method.IndexOf("ct.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("await using var conn", StringComparison.Ordinal),
+                $"Expected {startMarker} to honor cancellation before opening a database connection.");
         }
 
         private static string ExtractMethod(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -90,6 +90,10 @@ public sealed class ItemRepository : IItemRepository
 
     public async Task<int> InsertAsync(Item item, CancellationToken ct)
     {
+        if (item is null)
+            throw new ArgumentNullException(nameof(item));
+        ct.ThrowIfCancellationRequested();
+
         const string sql = @"INSERT INTO Items (ItemNumber, NameDescription, Location, Brand, PartNumber, Supplier, PurchasedDate, Notes, Keywords, AvailableQuantity, RentedQuantity, IsRentalItem, Price, ImagePath, IsCheckedOut, IsPowered, IsIncomplete, MissingComponentsNotes, IssuesNotes, CheckoutCount)
                              VALUES (@ItemNumber,@Name,@Location,@Brand,@PartNumber,@Supplier,@PurchasedDate,@Notes,@Keywords,@QuantityOnHand,@RentedQuantity,@IsRentalItem,@Price,@ImagePath,0,@IsPowered,0,'','',0);
                              SELECT last_insert_rowid();";
@@ -245,6 +249,7 @@ public sealed class ItemRepository : IItemRepository
 
     public async Task<List<Item>> GetItemsCheckedOutByAsync(string userName, CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
         var sql = $@"SELECT {ItemProjection} FROM Items WHERE CheckedOutBy=@User AND IsCheckedOut=1 AND IFNULL(IsRentalItem,0)=0";
         await using var conn = (DbConnection)_factory.Create();
         var items = await conn.QueryAsync<Item>(new CommandDefinition(sql, new { User = userName }, cancellationToken: ct)).ConfigureAwait(false);
@@ -253,6 +258,7 @@ public sealed class ItemRepository : IItemRepository
 
     public async Task<List<Item>> GetCheckedOutItemsAsync(CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
         var sql = $@"SELECT {ItemProjection} FROM Items WHERE IsCheckedOut=1 AND IFNULL(IsRentalItem,0)=0";
         await using var conn = (DbConnection)_factory.Create();
         var items = await conn.QueryAsync<Item>(new CommandDefinition(sql, cancellationToken: ct)).ConfigureAwait(false);
@@ -289,6 +295,7 @@ public sealed class ItemRepository : IItemRepository
 
     public async Task<List<Item>> GetIncompleteItemsAsync(CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
         var sql = $@"SELECT {ItemProjection}
             FROM Items
             WHERE IsIncomplete = 1";

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-item-repository-query-cancellation-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-item-repository-query-cancellation-guards.md
@@ -1,0 +1,16 @@
+# Item Repository Query Cancellation Guards - 2026-06-27
+
+## Completed
+
+- Guarded `ItemRepository.InsertAsync` against null item models before cancellation or SQL work can dereference the item.
+- Added early cancellation checks to direct item repository helper query paths before SQL construction and database connection work:
+  - `GetItemsCheckedOutByAsync`
+  - `GetCheckedOutItemsAsync`
+  - `GetIncompleteItemsAsync`
+- Extended `ItemRepositoryBulkSaveContractTests` with source-contract coverage for insert null/cancellation ordering and helper-query cancellation ordering.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in the scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and the full validation runner are unavailable here.
+- Use GitHub connector readback/compare as fallback validation for this scheduled pass.


### PR DESCRIPTION
## Summary

- Add an early null guard to `ItemRepository.InsertAsync` before cancellation or SQL work can dereference the item model.
- Add early cancellation checks to direct item repository helper queries before SQL construction and database connection work.
- Extend focused source-contract coverage and add a progress note for the repository helper query guards.

## Why This Matters

Recent reliability work guarded stale and invalid item repository write paths. A few helper query paths still opened database connections without first honoring cancellation, and item inserts could dereference a null model while building SQL parameters. This keeps direct item repository entrypoints aligned with the current defensive boundary pattern while staying behaviorally narrow.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `ItemRepository`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed `InsertAsync` now checks `item is null` before cancellation/SQL work, and `GetItemsCheckedOutByAsync`, `GetCheckedOutItemsAsync`, and `GetIncompleteItemsAsync` call `ct.ThrowIfCancellationRequested()` before SQL construction and connection creation.
- GitHub connector status readback found no commit statuses attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.