### PR TITLE
Guard bulk item save entrypoint inputs

### DIFF
--- a/InventoryManagementApp.Tests/ItemRepositoryBulkSaveContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryBulkSaveContractTests.cs
@@ -32,6 +32,35 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void BulkItemSaveRejectsInvalidEntrypointInputsBeforeConnectionWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Data", "ItemRepository.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task SaveChangesAsync(IEnumerable<Item> changes, CancellationToken ct)",
+                "public async Task<int> InsertAsync(Item item, CancellationToken ct)");
+
+            Assert.Contains("if (changes is null)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentNullException(nameof(changes));", method, StringComparison.Ordinal);
+            Assert.Contains("ct.ThrowIfCancellationRequested();", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (changes is null)", StringComparison.Ordinal) < method.IndexOf("ct.ThrowIfCancellationRequested();", StringComparison.Ordinal),
+                "Null bulk item change collections should fail before cancellation and connection work.");
+            Assert.True(
+                method.IndexOf("ct.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("await using var conn", StringComparison.Ordinal),
+                "Bulk item saves should honor cancellation before opening a database connection.");
+            Assert.True(
+                method.IndexOf("ct.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("const string sql =", StringComparison.Ordinal),
+                "Bulk item saves should honor cancellation before SQL work starts.");
+
+            Assert.Contains("if (item is null)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentException(\"Bulk item changes cannot contain null items.\", nameof(changes));", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (item is null)", StringComparison.Ordinal) < method.IndexOf("var rows = await conn.ExecuteAsync", StringComparison.Ordinal),
+                "Null rows inside a bulk item change collection should fail before an update command is built.");
+        }
+
+        [Fact]
         public void ItemRepositoryRejectsInvalidItemIdsBeforeConnectionWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Data", "ItemRepository.cs");

--- a/InventoryManagementApp/Data/ItemRepository.cs
+++ b/InventoryManagementApp/Data/ItemRepository.cs
@@ -68,11 +68,17 @@ public sealed class ItemRepository : IItemRepository
 
     public async Task SaveChangesAsync(IEnumerable<Item> changes, CancellationToken ct)
     {
+        if (changes is null)
+            throw new ArgumentNullException(nameof(changes));
+        ct.ThrowIfCancellationRequested();
+
         await using var conn = (DbConnection)_factory.Create();
         using var tx = conn.BeginTransaction();
         const string sql = "UPDATE Items SET NameDescription=@Name, Location=@Location, AvailableQuantity=@QuantityOnHand, Price=@Price WHERE ItemID=@ItemID";
         foreach (var item in changes)
         {
+            if (item is null)
+                throw new ArgumentException("Bulk item changes cannot contain null items.", nameof(changes));
             ct.ThrowIfCancellationRequested();
             var rows = await conn.ExecuteAsync(new CommandDefinition(sql, new
             {

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-item-bulk-save-entrypoint-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-item-bulk-save-entrypoint-guards.md
@@ -1,0 +1,16 @@
+# Item Bulk Save Entrypoint Guards
+
+Date: 2026-06-27
+
+## Summary
+
+- Guarded `ItemRepository.SaveChangesAsync` so a null bulk-change collection fails before cancellation, SQL, transaction, or connection work can start.
+- Moved the initial cancellation check ahead of database connection creation for bulk item saves.
+- Added a per-row null-item guard so malformed bulk-save collections fail clearly before update command construction.
+- Extended `ItemRepositoryBulkSaveContractTests` source-contract coverage for the new entrypoint and per-row guard ordering.
+
+## Validation Notes
+
+- GitHub connector readback and compare were used to validate the focused source changes.
+- Direct local clone/raw access is blocked in the scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and the full validation runner are unavailable in this environment, so local build/test/full validation was not run.


### PR DESCRIPTION
## Summary

- Guard `ItemRepository.SaveChangesAsync` so null bulk-change collections fail before cancellation, SQL, transaction, or database connection work.
- Honor cancellation before opening the bulk-save database connection.
- Reject null rows inside a bulk-change collection before update command construction.
- Extend focused source-contract coverage and add a progress note for the new guard ordering.

## Why This Matters

Recent item repository work guarded stale-row, invalid-ID, null single-item, and helper-query cancellation paths. Bulk item saves still opened a database connection before validating the change collection or honoring an already-cancelled token. This keeps the bulk-save entrypoint aligned with the current repository boundary pattern and avoids unnecessary database work for invalid or cancelled calls.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `ItemRepository`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed `SaveChangesAsync` now rejects null `changes`, checks cancellation before connection creation, and rejects null per-row items before update command construction.
- GitHub connector readback confirmed `ItemRepositoryBulkSaveContractTests` now covers the entrypoint null/cancellation ordering and per-row null guard.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.