### PR TITLE
Guard activity log cancellation before SQL work

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
@@ -7,6 +7,29 @@ namespace InventoryManagementApp.Tests
     public class ActivityLogCheckoutHistoryContractTests
     {
         [Fact]
+        public void ActivityLogEntrypointsHonorCancellationBeforeSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");
+
+            AssertCancellationGuardBeforeSqlWork(
+                source,
+                "public virtual async Task<Result> LogActionAsync",
+                "public virtual async Task<Result<List<ActivityLog>>> GetRecentLogsAsync");
+            AssertCancellationGuardBeforeSqlWork(
+                source,
+                "public virtual async Task<Result<List<ActivityLog>>> GetRecentLogsAsync",
+                "public virtual async Task<Result<List<ActivityLog>>> GetCheckoutHistoryForItemAsync");
+            AssertCancellationGuardBeforeSqlWork(
+                source,
+                "public virtual async Task<Result<List<ActivityLog>>> GetCheckoutHistoryForItemAsync",
+                "public virtual async Task<Result> PurgeOldLogsAsync");
+            AssertCancellationGuardBeforeSqlWork(
+                source,
+                "public virtual async Task<Result> PurgeOldLogsAsync",
+                "ActivityLog MapLog");
+        }
+
+        [Fact]
         public void RecentLogsRejectsInvalidCountsBeforeSqlWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");
@@ -67,6 +90,19 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("Action LIKE @LegacyTogglePattern", method, StringComparison.Ordinal);
             Assert.Contains("OR Action LIKE @ItemNumberPattern", method, StringComparison.Ordinal);
             Assert.Contains("ORDER BY Timestamp DESC", method, StringComparison.Ordinal);
+        }
+
+        private static void AssertCancellationGuardBeforeSqlWork(string source, string startMarker, string endMarker)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+
+            Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("const string sql =", StringComparison.Ordinal),
+                $"Expected {startMarker} to honor cancellation before SQL work starts.");
+            Assert.True(
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection()", StringComparison.Ordinal),
+                $"Expected {startMarker} to honor cancellation before opening a database connection.");
         }
 
         private static string ExtractMethod(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
@@ -98,7 +98,7 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", method, StringComparison.Ordinal);
             Assert.True(
-                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("const string sql =", StringComparison.Ordinal),
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("sql =", StringComparison.Ordinal),
                 $"Expected {startMarker} to honor cancellation before SQL work starts.");
             Assert.True(
                 method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection()", StringComparison.Ordinal),

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-activity-log-cancellation-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-activity-log-cancellation-guards.md
@@ -1,0 +1,9 @@
+# Activity Log Cancellation Guards
+
+## Completed
+- Added early cancellation checks to `ActivityLogService` entrypoints before SQL, parameter, or database connection work begins.
+- Covered `LogActionAsync`, `GetRecentLogsAsync`, `GetCheckoutHistoryForItemAsync`, and `PurgeOldLogsAsync` with source-contract assertions that keep cancellation at the service boundary.
+
+## Validation
+- GitHub connector readback and compare were used because this scheduled Linux environment cannot clone the repository directly or run local .NET/WPF validation.
+- Local build, test, PowerShell validation, WPF screenshots, and local banned-word checks still need a capable Windows/.NET environment.

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -28,6 +28,8 @@ namespace InventoryManagementApp.Services.Users
         {
             try
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 const string sql = @"
                     INSERT INTO ActivityLogs (UserID, UserName, Action)
                     VALUES (@UserID, @UserName, @Action)";
@@ -62,6 +64,8 @@ namespace InventoryManagementApp.Services.Users
         {
             try
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (count < 1)
                     return new Result<List<ActivityLog>>(null, false, "Count must be positive.");
 
@@ -95,6 +99,8 @@ namespace InventoryManagementApp.Services.Users
         {
             try
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (itemID < 1)
                     return new Result<List<ActivityLog>>(null, false, "Item ID must be positive.");
 
@@ -144,6 +150,8 @@ namespace InventoryManagementApp.Services.Users
         {
             try
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 const string sql = @"
                     DELETE FROM ActivityLogs
                      WHERE Timestamp < @Threshold";


### PR DESCRIPTION
## Summary

- Add early cancellation checks to `ActivityLogService` entrypoints before SQL, parameter, or database connection work begins.
- Cover `LogActionAsync`, `GetRecentLogsAsync`, `GetCheckoutHistoryForItemAsync`, and `PurgeOldLogsAsync` with focused source-contract assertions.
- Add a progress note for the activity log cancellation guard pass.

## Why This Matters

Recent reliability work has been moving invalid input and stale-row behavior to explicit service boundaries. Activity log paths already passed cancellation tokens into lower-level SQLite helpers, but they still built SQL/parameters and opened connections before honoring an already-cancelled caller. This keeps the audit-log service aligned with the current boundary pattern while preserving the existing successful query/write contracts.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `ActivityLogService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed all four activity-log entrypoints call `cancellationToken.ThrowIfCancellationRequested()` before SQL/connection work.
- GitHub connector readback confirmed `ActivityLogCheckoutHistoryContractTests` covers cancellation guard ordering while preserving the recent-log limit and checkout-history search contracts.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.