### PR TITLE
Guard upcoming maintenance and calibration windows

### DIFF
--- a/InventoryManagementApp.Tests/CalibrationServiceTests.cs
+++ b/InventoryManagementApp.Tests/CalibrationServiceTests.cs
@@ -112,6 +112,15 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task GetUpcomingCalibration_WithNegativeDays_ShouldThrow()
+        {
+            var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => _calibrationService.GetUpcomingCalibrationAsync(-1));
+
+            Assert.Equal("days", ex.ParamName);
+            Assert.Contains("Days must be greater than or equal to 0.", ex.Message);
+        }
+
+        [Fact]
         public async Task UpdateCalibrationRecord_ShouldSucceed()
         {
             var record = new CalibrationRecord

--- a/InventoryManagementApp.Tests/MaintenanceServiceTests.cs
+++ b/InventoryManagementApp.Tests/MaintenanceServiceTests.cs
@@ -112,6 +112,15 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task GetUpcomingMaintenance_WithNegativeDays_ShouldThrow()
+        {
+            var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => _maintenanceService.GetUpcomingMaintenanceAsync(-1));
+
+            Assert.Equal("days", ex.ParamName);
+            Assert.Contains("Days must be greater than or equal to 0.", ex.Message);
+        }
+
+        [Fact]
         public async Task UpdateMaintenanceRecord_ShouldSucceed()
         {
             var record = new MaintenanceRecord

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-upcoming-window-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-upcoming-window-guards.md
@@ -1,0 +1,12 @@
+# Upcoming Maintenance and Calibration Window Guards
+
+## Summary
+
+- Added negative-day guard clauses to `MaintenanceService.GetUpcomingMaintenanceAsync` and `CalibrationService.GetUpcomingCalibrationAsync`.
+- Aligned maintenance and calibration upcoming-window behavior with the existing reservation upcoming-window validation contract.
+- Added focused service tests that verify negative windows throw `ArgumentOutOfRangeException` before query work can run.
+
+## Validation
+
+- GitHub connector readback/compare was used for source validation in the scheduled Linux environment.
+- Local `dotnet` build/test and WPF runtime validation were not run because this environment cannot clone the repository and does not provide `dotnet`, PowerShell/`pwsh`, or `gh`.

--- a/InventoryManagementApp/Services/Calibration/CalibrationService.cs
+++ b/InventoryManagementApp/Services/Calibration/CalibrationService.cs
@@ -108,6 +108,9 @@ namespace InventoryManagementApp.Services.Calibration
 
         public async Task<List<CalibrationRecord>> GetUpcomingCalibrationAsync(int days = 30)
         {
+            if (days < 0)
+                throw new ArgumentOutOfRangeException(nameof(days), "Days must be greater than or equal to 0.");
+
             return await Task.Run(() =>
             {
                 var records = new List<CalibrationRecord>();

--- a/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
+++ b/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
@@ -112,6 +112,9 @@ namespace InventoryManagementApp.Services.Maintenance
 
         public async Task<List<MaintenanceRecord>> GetUpcomingMaintenanceAsync(int days = 30)
         {
+            if (days < 0)
+                throw new ArgumentOutOfRangeException(nameof(days), "Days must be greater than or equal to 0.");
+
             return await Task.Run(() =>
             {
                 var records = new List<MaintenanceRecord>();


### PR DESCRIPTION
## Summary

- Reject negative `days` windows in `MaintenanceService.GetUpcomingMaintenanceAsync` and `CalibrationService.GetUpcomingCalibrationAsync` before query work starts.
- Align maintenance and calibration upcoming-window validation with the existing reservation upcoming-window contract.
- Add focused service tests for both negative-window guards and record the pass in a progress note.

## Why This Matters

Upcoming maintenance and calibration views should not quietly convert a negative planning window into a past-date query. Reservations already reject that input, so this keeps the scheduling services consistent and makes invalid workflow inputs fail clearly at the service boundary.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only the two scheduling services, their focused test files, and a progress note.
- GitHub connector readback confirmed both services throw `ArgumentOutOfRangeException(nameof(days), "Days must be greater than or equal to 0.")` before `Task.Run`, connection creation, or SQL query work.
- GitHub connector status readback found no commit statuses attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.