### PR TITLE
Guard maintenance and calibration null records

### DIFF
--- a/InventoryManagementApp.Tests/CalibrationServiceTests.cs
+++ b/InventoryManagementApp.Tests/CalibrationServiceTests.cs
@@ -60,6 +60,14 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task CreateCalibrationRecord_WithNullRecord_ShouldThrow()
+        {
+            var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => _calibrationService.CreateCalibrationRecordAsync(null));
+
+            Assert.Equal("record", ex.ParamName);
+        }
+
+        [Fact]
         public async Task CreateCalibrationRecord_WithMissingItem_ShouldThrow()
         {
             var record = new CalibrationRecord
@@ -137,6 +145,14 @@ namespace InventoryManagementApp.Tests
             var result = await _calibrationService.UpdateCalibrationRecordAsync(record);
 
             Assert.True(result);
+        }
+
+        [Fact]
+        public async Task UpdateCalibrationRecord_WithNullRecord_ShouldThrow()
+        {
+            var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => _calibrationService.UpdateCalibrationRecordAsync(null));
+
+            Assert.Equal("record", ex.ParamName);
         }
 
         [Fact]

--- a/InventoryManagementApp.Tests/MaintenanceServiceTests.cs
+++ b/InventoryManagementApp.Tests/MaintenanceServiceTests.cs
@@ -60,6 +60,14 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task CreateMaintenanceRecord_WithNullRecord_ShouldThrow()
+        {
+            var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => _maintenanceService.CreateMaintenanceRecordAsync(null));
+
+            Assert.Equal("record", ex.ParamName);
+        }
+
+        [Fact]
         public async Task CreateMaintenanceRecord_WithMissingItem_ShouldThrow()
         {
             var record = new MaintenanceRecord
@@ -137,6 +145,14 @@ namespace InventoryManagementApp.Tests
             var result = await _maintenanceService.UpdateMaintenanceRecordAsync(record);
 
             Assert.True(result);
+        }
+
+        [Fact]
+        public async Task UpdateMaintenanceRecord_WithNullRecord_ShouldThrow()
+        {
+            var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => _maintenanceService.UpdateMaintenanceRecordAsync(null));
+
+            Assert.Equal("record", ex.ParamName);
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-maintenance-calibration-null-record-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-maintenance-calibration-null-record-guards.md
@@ -1,0 +1,12 @@
+# Maintenance and Calibration Null Record Guards - 2026-06-27
+
+## Completed
+
+- Added explicit `ArgumentNullException(nameof(record))` guards to maintenance record create and update entrypoints before any record fields are dereferenced.
+- Added explicit `ArgumentNullException(nameof(record))` guards to calibration record create and update entrypoints before any record fields are dereferenced.
+- Added focused service tests for null maintenance and calibration create/update calls so the service-boundary contract is covered alongside the existing missing-item and missing-record tests.
+
+## Validation
+
+- Local build and test execution were not available in the scheduled Linux container because direct checkout is blocked and the .NET SDK is unavailable.
+- GitHub connector readback and compare should be used as the validation fallback for this pass.

--- a/InventoryManagementApp/Services/Calibration/CalibrationService.cs
+++ b/InventoryManagementApp/Services/Calibration/CalibrationService.cs
@@ -186,6 +186,8 @@ namespace InventoryManagementApp.Services.Calibration
 
         public async Task<int> CreateCalibrationRecordAsync(CalibrationRecord record)
         {
+            if (record is null)
+                throw new ArgumentNullException(nameof(record));
             if (record.ItemID < 1)
                 throw new ArgumentOutOfRangeException(nameof(record.ItemID), "Item ID must be greater than 0.");
 
@@ -221,6 +223,8 @@ namespace InventoryManagementApp.Services.Calibration
 
         public async Task<bool> UpdateCalibrationRecordAsync(CalibrationRecord record)
         {
+            if (record is null)
+                throw new ArgumentNullException(nameof(record));
             if (record.CalibrationID < 1)
                 throw new ArgumentOutOfRangeException(nameof(record.CalibrationID), "Calibration ID must be greater than 0.");
             if (record.ItemID < 1)

--- a/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
+++ b/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
@@ -165,6 +165,8 @@ namespace InventoryManagementApp.Services.Maintenance
 
         public async Task<int> CreateMaintenanceRecordAsync(MaintenanceRecord record)
         {
+            if (record is null)
+                throw new ArgumentNullException(nameof(record));
             if (record.ItemID < 1)
                 throw new ArgumentOutOfRangeException(nameof(record.ItemID), "Item ID must be greater than 0.");
 
@@ -200,6 +202,8 @@ namespace InventoryManagementApp.Services.Maintenance
 
         public async Task<bool> UpdateMaintenanceRecordAsync(MaintenanceRecord record)
         {
+            if (record is null)
+                throw new ArgumentNullException(nameof(record));
             if (record.MaintenanceID < 1)
                 throw new ArgumentOutOfRangeException(nameof(record.MaintenanceID), "Maintenance ID must be greater than 0.");
             if (record.ItemID < 1)


### PR DESCRIPTION
## Summary

- Add explicit null record guards to maintenance create/update entrypoints before record fields are dereferenced.
- Add explicit null record guards to calibration create/update entrypoints before record fields are dereferenced.
- Cover all four null-record paths with focused service tests and record the pass in a progress note.

## Why This Matters

Recent service hardening has moved invalid IDs, stale rows, and invalid planning windows to clear service-boundary failures. Maintenance and calibration create/update paths still dereferenced the supplied record before validating it, which made null callers fail as incidental null-reference crashes instead of a clear `ArgumentNullException(nameof(record))` contract. This keeps these scheduling services aligned with the current reliability pattern.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only the two scheduling services, their focused service tests, and a progress note.
- GitHub connector readback confirmed maintenance and calibration create/update methods throw `ArgumentNullException(nameof(record))` before reading record IDs or opening database work.
- GitHub connector readback confirmed the maintenance and calibration service tests cover null create/update calls and preserve nearby missing-item/missing-record coverage.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.