### PR TITLE
Guard user service entrypoints

### DIFF
--- a/InventoryManagementApp.Tests/UserServiceEntryPointContractTests.cs
+++ b/InventoryManagementApp.Tests/UserServiceEntryPointContractTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class UserServiceEntryPointContractTests
+    {
+        [Fact]
+        public void UserQueriesHonorCancellationBeforeSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+
+            AssertCancellationGuardBeforeConnection(
+                source,
+                "public async Task<List<User>> GetAllUsersAsync",
+                "public async Task<int> CountUsersAsync");
+            AssertCancellationGuardBeforeConnection(
+                source,
+                "public async Task<int> CountUsersAsync",
+                "public async Task<User?> GetUserByIDAsync");
+            AssertCancellationGuardBeforeConnection(
+                source,
+                "public async Task<User?> GetUserByIDAsync",
+                "public async Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync");
+        }
+
+        [Fact]
+        public void GetUserByIdRejectsInvalidIdsBeforeCancellationAndConnectionWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<User?> GetUserByIDAsync",
+                "public async Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync");
+
+            Assert.Contains("if (userID < 1)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentOutOfRangeException(nameof(userID), \"User ID must be greater than 0.\");", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (userID < 1)", StringComparison.Ordinal) < method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal),
+                "Invalid user IDs should fail before cancellation and query work.");
+            Assert.True(
+                method.IndexOf("if (userID < 1)", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection();", StringComparison.Ordinal),
+                "Invalid user IDs should fail before opening a database connection.");
+        }
+
+        [Fact]
+        public void ChangePasswordRejectsInvalidUserIdsBeforeAuthorizationPasswordAndSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<bool> ChangeUserPasswordAsync",
+                "async Task DeleteUserInternalAsync");
+
+            Assert.Contains("if (userID < 1)", method, StringComparison.Ordinal);
+            Assert.Contains("throw new ArgumentOutOfRangeException(nameof(userID), \"User ID must be greater than 0.\");", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (userID < 1)", StringComparison.Ordinal) < method.IndexOf("_context.CurrentUser?.UserID", StringComparison.Ordinal),
+                "Invalid password-change user IDs should fail before authorization work.");
+            Assert.True(
+                method.IndexOf("if (userID < 1)", StringComparison.Ordinal) < method.IndexOf("PasswordValidator.IsValid", StringComparison.Ordinal),
+                "Invalid password-change user IDs should fail before password validation work.");
+            Assert.True(
+                method.IndexOf("if (userID < 1)", StringComparison.Ordinal) < method.IndexOf("SecurityHelper.HashPasswordAsync", StringComparison.Ordinal),
+                "Invalid password-change user IDs should fail before password hashing work.");
+            Assert.True(
+                method.IndexOf("if (userID < 1)", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection();", StringComparison.Ordinal),
+                "Invalid password-change user IDs should fail before opening a database connection.");
+        }
+
+        [Fact]
+        public void TryDeleteUserReturnsFalseForInvalidUserIdsBeforeAuthorizationAndLookup()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<bool> TryDeleteUserAsync",
+                "    }\n}");
+
+            Assert.Contains("if (userID < 1)", method, StringComparison.Ordinal);
+            Assert.Contains("return false;", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (userID < 1)", StringComparison.Ordinal) < method.IndexOf("_auth.EnsurePermission", StringComparison.Ordinal),
+                "Invalid delete user IDs should fail before authorization work.");
+            Assert.True(
+                method.IndexOf("if (userID < 1)", StringComparison.Ordinal) < method.IndexOf("GetUserByIDAsync", StringComparison.Ordinal),
+                "Invalid delete user IDs should fail before user lookup work.");
+            Assert.True(
+                method.IndexOf("if (userID < 1)", StringComparison.Ordinal) < method.IndexOf("DeleteUserInternalAsync", StringComparison.Ordinal),
+                "Invalid delete user IDs should fail before delete work.");
+        }
+
+        private static void AssertCancellationGuardBeforeConnection(string source, string startMarker, string endMarker)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+
+            Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection();", StringComparison.Ordinal),
+                $"Expected {startMarker} to honor cancellation before opening a database connection.");
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-user-service-entrypoint-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-user-service-entrypoint-guards.md
@@ -1,0 +1,13 @@
+# User Service Entrypoint Guards - 2026-06-27
+
+## Completed
+- Added early cancellation checks to user listing/count/detail query entrypoints before SQLite connection work begins.
+- Added an explicit positive-user-id guard to `GetUserByIDAsync` before cancellation, SQL parameter, or connection work.
+- Added an explicit positive-user-id guard to `ChangeUserPasswordAsync` before authorization, password validation, password hashing, or database update work.
+- Kept `TryDeleteUserAsync`'s boolean contract while returning `false` for non-positive user IDs before authorization, lookup, or delete work.
+- Added focused source-contract coverage in `UserServiceEntryPointContractTests` for guard presence and ordering.
+
+## Validation Notes
+- Local checkout and direct raw access are blocked in this scheduled Linux environment by `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
+- Use GitHub connector readback/compare as fallback validation for this pass.

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -112,6 +112,8 @@ namespace InventoryManagementApp.Services.Users
 
         public async Task<List<User>> GetAllUsersAsync(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             using var conn = _dbService.CreateConnection();
             const string sql = "SELECT UserID, UserName, UserPhotoPath, IsAdmin, Email, Phone, Mobile, Address, Role, IsActive, CreatedAt, PasswordExpired, FailedLoginAttempts, LockoutEndUtc, Permissions FROM Users";
             return await SqliteHelper.ExecuteReaderAsync(conn, sql, MapUser, cancellationToken: cancellationToken);
@@ -119,6 +121,8 @@ namespace InventoryManagementApp.Services.Users
 
         public async Task<int> CountUsersAsync(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             using var conn = _dbService.CreateConnection();
             const string sql = "SELECT COUNT(*) FROM Users";
             var result = await SqliteHelper.ExecuteScalarAsync(conn, sql, cancellationToken: cancellationToken);
@@ -127,6 +131,10 @@ namespace InventoryManagementApp.Services.Users
 
         public async Task<User?> GetUserByIDAsync(int userID, CancellationToken cancellationToken = default)
         {
+            if (userID < 1)
+                throw new ArgumentOutOfRangeException(nameof(userID), "User ID must be greater than 0.");
+            cancellationToken.ThrowIfCancellationRequested();
+
             using var conn = _dbService.CreateConnection();
             var list = await SqliteHelper.ExecuteReaderAsync(conn, "SELECT * FROM Users WHERE UserID=@ID",
                 MapUser,
@@ -389,6 +397,9 @@ namespace InventoryManagementApp.Services.Users
 
         public async Task<bool> ChangeUserPasswordAsync(int userID, string newPassword)
         {
+            if (userID < 1)
+                throw new ArgumentOutOfRangeException(nameof(userID), "User ID must be greater than 0.");
+
             if (_context.CurrentUser?.UserID != userID)
                 _auth.EnsurePermission(User.PermissionManageUsers);
 
@@ -426,6 +437,9 @@ namespace InventoryManagementApp.Services.Users
 
         public async Task<bool> TryDeleteUserAsync(int userID)
         {
+            if (userID < 1)
+                return false;
+
             _auth.EnsurePermission(User.PermissionManageUsers);
             var user = await GetUserByIDAsync(userID, CancellationToken.None);
             if (user == null) return false;


### PR DESCRIPTION
## Summary

- Honor cancellation before user list/count/detail query entrypoints open SQLite work.
- Reject non-positive user IDs in direct user lookup and password-change entrypoints before SQL, password hashing, or authorization work.
- Keep `TryDeleteUserAsync`'s boolean contract while returning `false` for invalid user IDs before lookup/delete work.
- Add focused source-contract coverage and a progress note for the guard ordering.

## Why This Matters

Recent reliability work has moved invalid inputs, stale rows, and cancellation handling to explicit service boundaries across rentals, items, maintenance, calibration, and activity logs. User account management still let invalid or cancelled direct entrypoint calls reach database/password work in a few places. This keeps the user-management workflow aligned with the broader defensive pattern without changing UI behavior or extending the Admin Settings theme system.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `UserService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed user query methods call `cancellationToken.ThrowIfCancellationRequested()` before `CreateConnection`.
- GitHub connector readback confirmed `GetUserByIDAsync` and `ChangeUserPasswordAsync` reject non-positive user IDs before database/password work, and `TryDeleteUserAsync` returns `false` for invalid IDs before lookup/delete work.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.