### PR TITLE
Guard customer service cancellation before database work

### DIFF
--- a/InventoryManagementApp.Tests/CustomerServiceEntryPointContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomerServiceEntryPointContractTests.cs
@@ -1,0 +1,178 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class CustomerServiceEntryPointContractTests
+    {
+        [Fact]
+        public void CustomerCrudAndQueryHelpersHonorCancellationBeforeSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+
+            AssertCancellationGuardBeforeConnection(
+                source,
+                "async Task AddCustomerInternalAsync",
+                "async Task UpdateCustomerInternalAsync");
+            AssertCancellationGuardBeforeSqlAndConnection(
+                source,
+                "async Task UpdateCustomerInternalAsync",
+                "async Task DeleteCustomerInternalAsync");
+            AssertCancellationGuardBeforeSqlAndConnection(
+                source,
+                "async Task DeleteCustomerInternalAsync",
+                "async Task<CustomerModel?> GetCustomerByIDInternalAsync");
+            AssertCancellationGuardBeforeSqlAndConnection(
+                source,
+                "async Task<CustomerModel?> GetCustomerByIDInternalAsync",
+                "async Task<List<CustomerModel>> GetAllCustomersInternalAsync");
+            AssertCancellationGuardBeforeSqlAndConnection(
+                source,
+                "async Task<List<CustomerModel>> GetAllCustomersInternalAsync",
+                "async Task<int> CountCustomersInternalAsync");
+            AssertCancellationGuardBeforeSqlAndConnection(
+                source,
+                "async Task<int> CountCustomersInternalAsync",
+                "async Task<List<CustomerModel>> SearchCustomersInternalAsync");
+            AssertCancellationGuardBeforeSqlAndConnection(
+                source,
+                "async Task<List<CustomerModel>> SearchCustomersInternalAsync",
+                "async Task<CustomerImportResult> ImportCustomersFromCsvInternalAsync");
+        }
+
+        [Fact]
+        public void CustomerImportAndExportHelpersHonorCancellationBeforeDatabaseWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+
+            var csvImportMethod = ExtractMethod(
+                source,
+                "async Task<CustomerImportResult> ImportCustomersFromCsvInternalAsync",
+                "async Task ExportCustomersToCsvInternalAsync");
+            Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", csvImportMethod, StringComparison.Ordinal);
+            Assert.True(
+                csvImportMethod.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < csvImportMethod.IndexOf("CsvHelperUtil.LoadCustomersFromCsvAsync", StringComparison.Ordinal),
+                "CSV import should honor already-cancelled callers before file or database work begins.");
+            Assert.True(
+                csvImportMethod.LastIndexOf("cancellationToken.ThrowIfCancellationRequested();", csvImportMethod.IndexOf("using var conn = _dbService.CreateConnection();", StringComparison.Ordinal), StringComparison.Ordinal) >= 0,
+                "CSV import should re-check cancellation before opening the import transaction connection.");
+
+            AssertCancellationGuardBeforeMethodCall(
+                source,
+                "async Task ExportCustomersToCsvInternalAsync",
+                "async Task InsertCustomerAsync",
+                "GetAllCustomersInternalAsync");
+            AssertCancellationGuardBeforeSqlAndConnection(
+                source,
+                "async Task InsertCustomerAsync",
+                "async Task<bool> CustomerExistsAsync");
+            AssertCancellationGuardBeforeSqlAndConnection(
+                source,
+                "async Task<bool> CustomerExistsAsync",
+                "static async Task EnsureCustomerRowExistsAsync");
+            AssertCancellationGuardBeforeSql(
+                source,
+                "static async Task EnsureCustomerRowExistsAsync",
+                "static string? GetSkipReason");
+        }
+
+        [Fact]
+        public void AlternateCustomerImportExportEntrypointsHonorCancellationBeforeConnectionOrExporterWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+
+            var importMethod = ExtractMethod(
+                source,
+                "public async Task<int> ImportCustomersAsync",
+                "public async Task ExportCustomersAsync");
+            Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", importMethod, StringComparison.Ordinal);
+            Assert.True(
+                importMethod.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < importMethod.IndexOf("importer.ImportAsync", StringComparison.Ordinal),
+                "Generic customer import should honor already-cancelled callers before importer work begins.");
+            Assert.True(
+                importMethod.LastIndexOf("cancellationToken.ThrowIfCancellationRequested();", importMethod.IndexOf("using var conn = _dbService.CreateConnection();", StringComparison.Ordinal), StringComparison.Ordinal) >= 0,
+                "Generic customer import should re-check cancellation before opening the database connection.");
+
+            AssertCancellationGuardBeforeMethodCall(
+                source,
+                "public async Task ExportCustomersAsync",
+                "    }\n}",
+                "GetAllCustomersAsync");
+        }
+
+        private static void AssertCancellationGuardBeforeSqlAndConnection(string source, string startMarker, string endMarker)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+
+            Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("const string sql", StringComparison.Ordinal),
+                $"Expected {startMarker} to honor cancellation before SQL construction.");
+            Assert.True(
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("CreateConnection", StringComparison.Ordinal),
+                $"Expected {startMarker} to honor cancellation before opening a database connection.");
+        }
+
+        private static void AssertCancellationGuardBeforeConnection(string source, string startMarker, string endMarker)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+
+            Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("CreateConnection", StringComparison.Ordinal),
+                $"Expected {startMarker} to honor cancellation before opening a database connection.");
+        }
+
+        private static void AssertCancellationGuardBeforeSql(string source, string startMarker, string endMarker)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+
+            Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("const string sql", StringComparison.Ordinal),
+                $"Expected {startMarker} to honor cancellation before SQL construction.");
+        }
+
+        private static void AssertCancellationGuardBeforeMethodCall(string source, string startMarker, string endMarker, string methodCall)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+
+            Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf(methodCall, StringComparison.Ordinal),
+                $"Expected {startMarker} to honor cancellation before {methodCall}.");
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp.Tests/CustomerServiceEntryPointContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomerServiceEntryPointContractTests.cs
@@ -63,7 +63,7 @@ namespace InventoryManagementApp.Tests
                 "async Task ExportCustomersToCsvInternalAsync",
                 "async Task InsertCustomerAsync",
                 "GetAllCustomersInternalAsync");
-            AssertCancellationGuardBeforeSqlAndConnection(
+            AssertCancellationGuardBeforeSql(
                 source,
                 "async Task InsertCustomerAsync",
                 "async Task<bool> CustomerExistsAsync");

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-customer-service-cancellation-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-customer-service-cancellation-guards.md
@@ -1,0 +1,13 @@
+# Customer service cancellation guards
+
+## Date
+2026-06-27
+
+## Summary
+- Added early cancellation checks to customer service database helpers before SQL, parameter, transaction, or SQLite connection work begins.
+- Guarded customer list/count/detail/search, add/update/delete, CSV import/export helpers, duplicate checks, row-existence checks, and generic importer/exporter entrypoints.
+- Added source-contract coverage in `InventoryManagementApp.Tests/CustomerServiceEntryPointContractTests.cs` so future changes keep cancellation ahead of customer database work.
+
+## Validation
+- GitHub connector readback/compare was used because the scheduled Linux container cannot clone the repository directly.
+- Local `dotnet` build/test, PowerShell validation, WPF screenshots, and local banned-word checks were not run in this environment.

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -166,6 +166,8 @@ namespace InventoryManagementApp.Services.Customers
 
         async Task AddCustomerInternalAsync(CustomerModel customer, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             using var conn = _dbService.CreateConnection();
             try
             {
@@ -180,6 +182,8 @@ namespace InventoryManagementApp.Services.Customers
 
         async Task UpdateCustomerInternalAsync(CustomerModel customer, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             const string sql = @"
                 UPDATE Customers
                 SET Company = @Company, Email = @Email, Contact = @Contact,
@@ -210,6 +214,8 @@ namespace InventoryManagementApp.Services.Customers
 
         async Task DeleteCustomerInternalAsync(int customerID, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             const string sql = "DELETE FROM Customers WHERE CustomerID = @CustomerID";
             var p = new[] { new SqliteParameter("@CustomerID", customerID) };
             using var conn = _dbService.CreateConnection();
@@ -227,6 +233,8 @@ namespace InventoryManagementApp.Services.Customers
 
         async Task<CustomerModel?> GetCustomerByIDInternalAsync(int customerID, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             const string sql = "SELECT * FROM Customers WHERE CustomerID = @id";
             var p = new[] { new SqliteParameter("@id", customerID) };
             using var conn = _dbService.CreateConnection();
@@ -248,6 +256,8 @@ namespace InventoryManagementApp.Services.Customers
 
         async Task<List<CustomerModel>> GetAllCustomersInternalAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             const string sql = "SELECT * FROM Customers";
             using var conn = _dbService.CreateConnection();
             try
@@ -263,6 +273,8 @@ namespace InventoryManagementApp.Services.Customers
 
         async Task<int> CountCustomersInternalAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             const string sql = "SELECT COUNT(*) FROM Customers";
             using var conn = _dbService.CreateConnection();
             try
@@ -279,6 +291,8 @@ namespace InventoryManagementApp.Services.Customers
 
         async Task<List<CustomerModel>> SearchCustomersInternalAsync(string searchTerm, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             const string sql = @"
                 SELECT * FROM Customers
                 WHERE Company LIKE @t OR Contact LIKE @t OR Email LIKE @t OR Phone LIKE @t OR Mobile LIKE @t OR Address LIKE @t";
@@ -297,7 +311,11 @@ namespace InventoryManagementApp.Services.Customers
 
         async Task<CustomerImportResult> ImportCustomersFromCsvInternalAsync(string filePath, IDictionary<string, string> map, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var customers = await CsvHelperUtil.LoadCustomersFromCsvAsync(filePath, map, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+
             var result = new CustomerImportResult();
             using var conn = _dbService.CreateConnection();
             using var tran = conn.BeginTransaction();
@@ -341,12 +359,16 @@ namespace InventoryManagementApp.Services.Customers
 
         async Task ExportCustomersToCsvInternalAsync(string filePath, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var all = await GetAllCustomersInternalAsync(cancellationToken);
             await Task.Run(() => CsvHelperUtil.ExportCustomersToCsv(filePath, all), cancellationToken);
         }
 
         async Task InsertCustomerAsync(SqliteConnection conn, SqliteTransaction? tran, CustomerModel customer, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             const string sql = @"
         INSERT INTO Customers (Company, Email, Contact, Phone, Mobile, Address)
         VALUES (@Company, @Email, @Contact, @Phone, @Mobile, @Address);
@@ -377,6 +399,8 @@ namespace InventoryManagementApp.Services.Customers
 
         async Task<bool> CustomerExistsAsync(string contact, string phone, string mobile, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             const string sql = @"
         SELECT COUNT(*) FROM Customers
          WHERE Contact = @Contact AND (Phone = @Phone OR Mobile = @Mobile)";
@@ -400,6 +424,8 @@ namespace InventoryManagementApp.Services.Customers
 
         static async Task EnsureCustomerRowExistsAsync(SqliteConnection conn, int customerID, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             const string sql = "SELECT COUNT(*) FROM Customers WHERE CustomerID = @CustomerID";
             var count = Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql, new[]
             {
@@ -433,14 +459,18 @@ namespace InventoryManagementApp.Services.Customers
         public async Task<int> ImportCustomersAsync(string filePath, IDataImporter<Customer> importer, CancellationToken cancellationToken = default)
         {
             _auth.EnsureAdmin();
+            cancellationToken.ThrowIfCancellationRequested();
             
             var (customers, skippedRows) = await importer.ImportAsync(filePath, cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
             
             int importedCount = 0;
             using var conn = _dbService.CreateConnection();
             
             foreach (var customer in customers)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 var customerModel = new CustomerModel
                 {
                     Company = customer.Company ?? string.Empty,
@@ -468,6 +498,8 @@ namespace InventoryManagementApp.Services.Customers
 
         public async Task ExportCustomersAsync(string filePath, IDataExporter<Customer> exporter, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var all = await GetAllCustomersAsync(cancellationToken).ConfigureAwait(false);
             await exporter.ExportAsync(filePath, all, cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
## Summary

- Add early cancellation checks to customer service CRUD/query helpers before SQL, parameter, transaction, or SQLite connection work begins.
- Guard CSV import/export helpers, duplicate checks, row-existence checks, and generic importer/exporter entrypoints so already-cancelled callers stop before customer database work.
- Add focused source-contract coverage and a progress note for the guard ordering.

## Why This Matters

Recent reliability work has moved cancellation and invalid input behavior to explicit service boundaries across users, items, rentals, activity logs, maintenance, and calibration. Customer management still accepted cancelled calls deep enough to build SQL/parameters or open SQLite work in several paths. This keeps customer workflows aligned with the broader defensive pattern without extending the Admin Settings theme system.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `CustomerService`, one source-contract test file, and a progress note.
- GitHub connector readback confirmed customer CRUD/query helpers call `cancellationToken.ThrowIfCancellationRequested()` before SQL/parameter/connection work.
- GitHub connector readback confirmed customer CSV import/export, duplicate checks, row-existence checks, and generic import/export paths now honor cancellation before database/exporter work as applicable.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.