### PR TITLE
Guard reservation writes against stale rows

### DIFF
--- a/InventoryManagementApp.Tests/ReservationServiceWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationServiceWriteGuardContractTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ReservationServiceWriteGuardContractTests
+    {
+        [Fact]
+        public void ReservationWritesThrowWhenNoRowsAreAffected()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
+
+            AssertWriteGuard(
+                source,
+                "public async Task<bool> UpdateReservationAsync",
+                "public async Task<bool> ConfirmReservationAsync",
+                "var updatedRows = cmd.ExecuteNonQuery();",
+                "EnsureReservationWriteSucceeded(updatedRows);");
+            AssertWriteGuard(
+                source,
+                "public async Task<bool> ConfirmReservationAsync",
+                "public async Task<bool> CancelReservationAsync",
+                "var confirmedRows = cmd.ExecuteNonQuery();",
+                "EnsureReservationWriteSucceeded(confirmedRows);");
+            AssertWriteGuard(
+                source,
+                "public async Task<bool> CancelReservationAsync",
+                "public async Task<bool> FulfillReservationAsync",
+                "var cancelledRows = cmd.ExecuteNonQuery();",
+                "EnsureReservationWriteSucceeded(cancelledRows);");
+            AssertWriteGuard(
+                source,
+                "public async Task<bool> FulfillReservationAsync",
+                "public async Task<bool> DeleteReservationAsync",
+                "var fulfilledRows = cmd.ExecuteNonQuery();",
+                "EnsureReservationWriteSucceeded(fulfilledRows);");
+            AssertWriteGuard(
+                source,
+                "public async Task<bool> DeleteReservationAsync",
+                "public async Task<bool> CheckAvailabilityAsync",
+                "var deletedRows = cmd.ExecuteNonQuery();",
+                "EnsureReservationWriteSucceeded(deletedRows);");
+
+            Assert.Contains("private static void EnsureReservationWriteSucceeded(int affectedRows)", source, StringComparison.Ordinal);
+            Assert.Contains("if (affectedRows == 0)", source, StringComparison.Ordinal);
+            Assert.Contains("throw new InvalidOperationException(\"Reservation not found.\");", source, StringComparison.Ordinal);
+        }
+
+        private static void AssertWriteGuard(
+            string source,
+            string startMarker,
+            string endMarker,
+            string executeSnippet,
+            string guardSnippet)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+
+            Assert.Contains(executeSnippet, method, StringComparison.Ordinal);
+            Assert.Contains(guardSnippet, method, StringComparison.Ordinal);
+            Assert.Contains("return true;", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("return cmd.ExecuteNonQuery() > 0;", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf(executeSnippet, StringComparison.Ordinal) < method.IndexOf(guardSnippet, StringComparison.Ordinal),
+                $"Expected {startMarker} to check affected rows after executing the write.");
+            Assert.True(
+                method.IndexOf(guardSnippet, StringComparison.Ordinal) < method.IndexOf("return true;", StringComparison.Ordinal),
+                $"Expected {startMarker} to fail stale writes before reporting success.");
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-reservation-write-stale-row-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-reservation-write-stale-row-guards.md
@@ -1,0 +1,13 @@
+# Reservation write stale-row guards
+
+## Date
+2026-06-27
+
+## Summary
+- Updated reservation update, confirm, cancel, fulfill, and delete writes to check the affected row count after the SQL write executes.
+- Stale reservation writes now throw the existing `InvalidOperationException("Reservation not found.")` contract instead of returning `false` after a pre-write existence check had already succeeded.
+- Added source-contract coverage in `InventoryManagementApp.Tests/ReservationServiceWriteGuardContractTests.cs` so future reservation write changes keep affected-row checks before reporting success.
+
+## Validation
+- GitHub connector readback/compare was used because the scheduled Linux container cannot clone the repository directly.
+- Local `dotnet` build/test, PowerShell validation, WPF screenshots, and local banned-word checks were not run in this environment.

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -257,7 +257,9 @@ namespace InventoryManagementApp.Services.Reservations
                 cmd.Parameters.AddWithValue("@Status", NormalizeStatus(reservation.Status));
                 cmd.Parameters.AddWithValue("@Notes", ToDbNullableText(reservation.Notes));
                 cmd.Parameters.AddWithValue("@RentalID", reservation.RentalID.HasValue ? (object)reservation.RentalID.Value : DBNull.Value);
-                return cmd.ExecuteNonQuery() > 0;
+                var updatedRows = cmd.ExecuteNonQuery();
+                EnsureReservationWriteSucceeded(updatedRows);
+                return true;
             });
         }
 
@@ -274,7 +276,9 @@ namespace InventoryManagementApp.Services.Reservations
                 var sql = "UPDATE Reservations SET Status = 'Confirmed' WHERE ReservationID = @ReservationID";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@ReservationID", reservationID);
-                return cmd.ExecuteNonQuery() > 0;
+                var confirmedRows = cmd.ExecuteNonQuery();
+                EnsureReservationWriteSucceeded(confirmedRows);
+                return true;
             });
         }
 
@@ -291,7 +295,9 @@ namespace InventoryManagementApp.Services.Reservations
                 var sql = "UPDATE Reservations SET Status = 'Cancelled' WHERE ReservationID = @ReservationID";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@ReservationID", reservationID);
-                return cmd.ExecuteNonQuery() > 0;
+                var cancelledRows = cmd.ExecuteNonQuery();
+                EnsureReservationWriteSucceeded(cancelledRows);
+                return true;
             });
         }
 
@@ -313,7 +319,9 @@ namespace InventoryManagementApp.Services.Reservations
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@ReservationID", reservationID);
                 cmd.Parameters.AddWithValue("@RentalID", rentalID);
-                return cmd.ExecuteNonQuery() > 0;
+                var fulfilledRows = cmd.ExecuteNonQuery();
+                EnsureReservationWriteSucceeded(fulfilledRows);
+                return true;
             });
         }
 
@@ -330,7 +338,9 @@ namespace InventoryManagementApp.Services.Reservations
                 var sql = "DELETE FROM Reservations WHERE ReservationID = @ReservationID";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@ReservationID", reservationID);
-                return cmd.ExecuteNonQuery() > 0;
+                var deletedRows = cmd.ExecuteNonQuery();
+                EnsureReservationWriteSucceeded(deletedRows);
+                return true;
             });
         }
 
@@ -412,6 +422,12 @@ namespace InventoryManagementApp.Services.Reservations
         private static void EnsureReservationExists(SqliteConnection conn, int reservationID)
         {
             if (!RecordExists(conn, "SELECT COUNT(*) FROM Reservations WHERE ReservationID = @ID", reservationID))
+                throw new InvalidOperationException("Reservation not found.");
+        }
+
+        private static void EnsureReservationWriteSucceeded(int affectedRows)
+        {
+            if (affectedRows == 0)
                 throw new InvalidOperationException("Reservation not found.");
         }
 


### PR DESCRIPTION
## Summary

- Check affected row counts for reservation update, confirm, cancel, fulfill, and delete writes.
- Throw the existing `InvalidOperationException("Reservation not found.")` contract when a reservation row disappears after the pre-write existence check but before the write succeeds.
- Add focused source-contract coverage and a progress note for the stale-write guard pattern.

## Why This Matters

Recent reliability work has made stale service writes fail clearly across rentals, categories, users, customers, maintenance, calibration, and item repository paths. Reservation writes already validated the target row before issuing SQL, but they could still return `false` after a raced or stale write. This keeps the reservation workflow aligned with the broader service-boundary contract without touching Admin Settings theme customization.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `ReservationService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed update, confirm, cancel, fulfill, and delete write paths capture `ExecuteNonQuery()` results, call `EnsureReservationWriteSucceeded(...)`, and return success only after that guard.
- GitHub connector readback confirmed `ReservationServiceWriteGuardContractTests` covers all five write paths and the shared stale-write helper.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.