### PR TITLE
Guard kit writes against stale rows

### DIFF
--- a/InventoryManagementApp.Tests/KitServiceWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/KitServiceWriteGuardContractTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class KitServiceWriteGuardContractTests
+    {
+        [Fact]
+        public void KitWritesThrowWhenNoRowsAreAffected()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Kits", "KitService.cs");
+
+            AssertWriteGuard(
+                source,
+                "public async Task<bool> UpdateKitAsync",
+                "public async Task<bool> DeleteKitAsync",
+                "var updatedRows = cmd.ExecuteNonQuery();",
+                "EnsureKitWriteSucceeded(updatedRows);");
+            AssertWriteGuard(
+                source,
+                "public async Task<bool> DeleteKitAsync",
+                "public async Task<int> AddKitItemAsync",
+                "var deletedRows = deleteKitCmd.ExecuteNonQuery();",
+                "EnsureKitWriteSucceeded(deletedRows);");
+
+            Assert.Contains("private static void EnsureKitWriteSucceeded(int affectedRows)", source, StringComparison.Ordinal);
+            Assert.Contains("throw new InvalidOperationException(\"Kit not found.\");", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void KitItemWritesThrowWhenNoRowsAreAffected()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Kits", "KitService.cs");
+
+            AssertWriteGuard(
+                source,
+                "public async Task<bool> UpdateKitItemAsync",
+                "public async Task<bool> RemoveKitItemAsync",
+                "var updatedRows = cmd.ExecuteNonQuery();",
+                "EnsureKitItemWriteSucceeded(updatedRows);");
+            AssertWriteGuard(
+                source,
+                "public async Task<bool> RemoveKitItemAsync",
+                "public async Task<bool> CheckKitAvailabilityAsync",
+                "var removedRows = cmd.ExecuteNonQuery();",
+                "EnsureKitItemWriteSucceeded(removedRows);");
+
+            Assert.Contains("private static void EnsureKitItemWriteSucceeded(int affectedRows)", source, StringComparison.Ordinal);
+            Assert.Contains("throw new InvalidOperationException(\"Kit item not found.\");", source, StringComparison.Ordinal);
+        }
+
+        private static void AssertWriteGuard(
+            string source,
+            string startMarker,
+            string endMarker,
+            string executeSnippet,
+            string guardSnippet)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+
+            Assert.Contains(executeSnippet, method, StringComparison.Ordinal);
+            Assert.Contains(guardSnippet, method, StringComparison.Ordinal);
+            Assert.Contains("return true;", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("return cmd.ExecuteNonQuery() > 0;", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf(executeSnippet, StringComparison.Ordinal) < method.IndexOf(guardSnippet, StringComparison.Ordinal),
+                $"Expected {startMarker} to check affected rows after executing the write.");
+            Assert.True(
+                method.IndexOf(guardSnippet, StringComparison.Ordinal) < method.IndexOf("return true;", StringComparison.Ordinal),
+                $"Expected {startMarker} to fail stale writes before reporting success.");
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-kit-write-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-kit-write-guards.md
@@ -1,0 +1,14 @@
+# Kit Write Guard Progress - 2026-06-27
+
+## Completed
+
+- Guarded `KitService.UpdateKitAsync` so a stale update that affects zero kit rows throws `InvalidOperationException("Kit not found.")` instead of returning `false`.
+- Guarded `KitService.DeleteKitAsync` so a raced kit delete that affects zero kit rows rolls back the transaction and throws the existing kit-not-found contract.
+- Guarded `KitService.UpdateKitItemAsync` and `KitService.RemoveKitItemAsync` so stale kit item writes throw `InvalidOperationException("Kit item not found.")` instead of returning `false`.
+- Added `KitServiceWriteGuardContractTests` to keep kit and kit-item write paths checking affected row counts before reporting success.
+
+## Validation Notes
+
+- Local clone/raw access is blocked in the scheduled Linux environment with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable in this environment.
+- Use GitHub connector readback/compare for this pass, then run the full validation runner from a Windows/.NET-capable checkout.

--- a/InventoryManagementApp/Services/Kits/KitService.cs
+++ b/InventoryManagementApp/Services/Kits/KitService.cs
@@ -184,7 +184,9 @@ namespace InventoryManagementApp.Services.Kits
                 cmd.Parameters.AddWithValue("@Category", ToDbNullableText(kit.Category));
                 cmd.Parameters.AddWithValue("@IsActive", kit.IsActive ? 1 : 0);
                 cmd.Parameters.AddWithValue("@UpdatedAt", DateTime.Now);
-                return cmd.ExecuteNonQuery() > 0;
+                var updatedRows = cmd.ExecuteNonQuery();
+                EnsureKitWriteSucceeded(updatedRows);
+                return true;
             });
         }
 
@@ -208,10 +210,11 @@ namespace InventoryManagementApp.Services.Kits
                     var deleteKitSql = "DELETE FROM Kits WHERE KitID = @KitID";
                     using var deleteKitCmd = new SqliteCommand(deleteKitSql, conn, transaction);
                     deleteKitCmd.Parameters.AddWithValue("@KitID", kitID);
-                    var result = deleteKitCmd.ExecuteNonQuery() > 0;
+                    var deletedRows = deleteKitCmd.ExecuteNonQuery();
+                    EnsureKitWriteSucceeded(deletedRows);
 
                     transaction.Commit();
-                    return result;
+                    return true;
                 }
                 catch
                 {
@@ -267,7 +270,9 @@ namespace InventoryManagementApp.Services.Kits
                 cmd.Parameters.AddWithValue("@ItemID", kitItem.ItemID);
                 cmd.Parameters.AddWithValue("@Quantity", kitItem.Quantity);
                 cmd.Parameters.AddWithValue("@IsOptional", kitItem.IsOptional ? 1 : 0);
-                return cmd.ExecuteNonQuery() > 0;
+                var updatedRows = cmd.ExecuteNonQuery();
+                EnsureKitItemWriteSucceeded(updatedRows);
+                return true;
             });
         }
 
@@ -284,7 +289,9 @@ namespace InventoryManagementApp.Services.Kits
                 var sql = "DELETE FROM KitItems WHERE KitItemID = @KitItemID";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@KitItemID", kitItemID);
-                return cmd.ExecuteNonQuery() > 0;
+                var removedRows = cmd.ExecuteNonQuery();
+                EnsureKitItemWriteSucceeded(removedRows);
+                return true;
             });
         }
 
@@ -375,6 +382,18 @@ namespace InventoryManagementApp.Services.Kits
         private static void EnsureKitItemExists(SqliteConnection conn, int kitItemID)
         {
             if (!RecordExists(conn, "SELECT COUNT(*) FROM KitItems WHERE KitItemID = @ID", kitItemID))
+                throw new InvalidOperationException("Kit item not found.");
+        }
+
+        private static void EnsureKitWriteSucceeded(int affectedRows)
+        {
+            if (affectedRows == 0)
+                throw new InvalidOperationException("Kit not found.");
+        }
+
+        private static void EnsureKitItemWriteSucceeded(int affectedRows)
+        {
+            if (affectedRows == 0)
                 throw new InvalidOperationException("Kit item not found.");
         }
 


### PR DESCRIPTION
## Summary

- Check affected row counts for kit update/delete writes before reporting success.
- Check affected row counts for kit-item update/remove writes before reporting success.
- Throw the existing `InvalidOperationException("Kit not found.")` or `InvalidOperationException("Kit item not found.")` contracts when a row disappears after the pre-write existence check.
- Add focused source-contract coverage and a progress note for the stale-write guard pattern.

## Why This Matters

Recent reliability work has made stale service writes fail clearly across rentals, reservations, users, customers, maintenance, calibration, and item repository paths. Kit writes already validated the target row before issuing SQL, but several paths could still return `false` after a raced or stale write. This keeps kit management aligned with the broader service-boundary contract without touching Admin Settings theme customization.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `KitService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed kit update/delete and kit-item update/remove paths capture `ExecuteNonQuery()` results, call stale-write guards, and return success only after those guards.
- GitHub connector readback confirmed `KitServiceWriteGuardContractTests` covers all four write paths plus the shared kit and kit-item stale-write helpers.
- GitHub connector status readback found no commit statuses attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.