### PR TITLE
Guard reservation history parent rows

### DIFF
--- a/InventoryManagementApp.Tests/ReservationServiceQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationServiceQueryGuardContractTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ReservationServiceQueryGuardContractTests
+    {
+        [Fact]
+        public void ReservationHistoryQueriesValidateParentRowsBeforeExecutingHistoryQueries()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
+
+            AssertContainsAll(
+                source,
+                "private static void EnsureReservationItemExists(SqliteConnection conn, int itemID)",
+                "SELECT COUNT(*) FROM Items WHERE ItemID = @ID",
+                "throw new InvalidOperationException(\"Item not found.\");",
+                "private static void EnsureReservationCustomerExists(SqliteConnection conn, int customerID)",
+                "SELECT COUNT(*) FROM Customers WHERE CustomerID = @ID",
+                "throw new InvalidOperationException(\"Customer not found.\");");
+
+            var itemMethod = ExtractMethod(
+                source,
+                "public async Task<List<Reservation>> GetReservationsByItemAsync(int itemID)",
+                "public async Task<List<Reservation>> GetReservationsByCustomerAsync(int customerID)");
+            AssertContainsAll(
+                itemMethod,
+                "if (itemID < 1)",
+                "throw new ArgumentOutOfRangeException(nameof(itemID), \"Item ID must be greater than 0.\");",
+                "using var conn = _databaseService.CreateConnection();",
+                "EnsureReservationItemExists(conn, itemID);",
+                "WHERE r.ItemID = @ItemID");
+            Assert.True(
+                itemMethod.IndexOf("EnsureReservationItemExists(conn, itemID);", StringComparison.Ordinal) <
+                itemMethod.IndexOf("var sql = @\"", StringComparison.Ordinal),
+                "Expected item reservation history to confirm the item row exists before building/executing the history query.");
+
+            var customerMethod = ExtractMethod(
+                source,
+                "public async Task<List<Reservation>> GetReservationsByCustomerAsync(int customerID)",
+                "public async Task<List<Reservation>> GetUpcomingReservationsAsync");
+            AssertContainsAll(
+                customerMethod,
+                "if (customerID < 1)",
+                "throw new ArgumentOutOfRangeException(nameof(customerID), \"Customer ID must be greater than 0.\");",
+                "using var conn = _databaseService.CreateConnection();",
+                "EnsureReservationCustomerExists(conn, customerID);",
+                "WHERE r.CustomerID = @CustomerID");
+            Assert.True(
+                customerMethod.IndexOf("EnsureReservationCustomerExists(conn, customerID);", StringComparison.Ordinal) <
+                customerMethod.IndexOf("var sql = @\"", StringComparison.Ordinal),
+                "Expected customer reservation history to confirm the customer row exists before building/executing the history query.");
+        }
+
+        private static void AssertContainsAll(string source, params string[] expectedSnippets)
+        {
+            foreach (var snippet in expectedSnippets)
+            {
+                Assert.Contains(snippet, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-reservation-history-parent-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-reservation-history-parent-guards.md
@@ -1,0 +1,13 @@
+# Reservation History Parent Guard Progress - 2026-06-27
+
+## Completed
+
+- Guarded `ReservationService.GetReservationsByItemAsync` so a positive but missing item ID now fails with `InvalidOperationException("Item not found.")` before running the reservation history query.
+- Guarded `ReservationService.GetReservationsByCustomerAsync` so a positive but missing customer ID now fails with `InvalidOperationException("Customer not found.")` before running the reservation history query.
+- Added `ReservationServiceQueryGuardContractTests` to keep the positive-ID validation and parent-row checks ahead of SQL history query construction/execution.
+
+## Validation Notes
+
+- Local clone/raw access is blocked in the scheduled Linux environment with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable in this environment.
+- Use GitHub connector readback/compare for this pass, then run the full validation runner from a Windows/.NET-capable checkout.

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -94,6 +94,7 @@ namespace InventoryManagementApp.Services.Reservations
             {
                 var reservations = new List<Reservation>();
                 using var conn = _databaseService.CreateConnection();
+                EnsureReservationItemExists(conn, itemID);
                 var sql = @"
                     SELECT r.*, i.ItemNumber, i.NameDescription as ItemName, i.ImagePath, c.Company as CustomerName
                     FROM Reservations r
@@ -121,6 +122,7 @@ namespace InventoryManagementApp.Services.Reservations
             {
                 var reservations = new List<Reservation>();
                 using var conn = _databaseService.CreateConnection();
+                EnsureReservationCustomerExists(conn, customerID);
                 var sql = @"
                     SELECT r.*, i.ItemNumber, i.NameDescription as ItemName, i.ImagePath, c.Company as CustomerName
                     FROM Reservations r
@@ -429,6 +431,18 @@ namespace InventoryManagementApp.Services.Reservations
         {
             if (affectedRows == 0)
                 throw new InvalidOperationException("Reservation not found.");
+        }
+
+        private static void EnsureReservationItemExists(SqliteConnection conn, int itemID)
+        {
+            if (!RecordExists(conn, "SELECT COUNT(*) FROM Items WHERE ItemID = @ID", itemID))
+                throw new InvalidOperationException("Item not found.");
+        }
+
+        private static void EnsureReservationCustomerExists(SqliteConnection conn, int customerID)
+        {
+            if (!RecordExists(conn, "SELECT COUNT(*) FROM Customers WHERE CustomerID = @ID", customerID))
+                throw new InvalidOperationException("Customer not found.");
         }
 
         private static void EnsureReservationReferencesExist(SqliteConnection conn, Reservation reservation)


### PR DESCRIPTION
## Summary

- Confirm item rows exist before running item reservation history queries.
- Confirm customer rows exist before running customer reservation history queries.
- Add focused source-contract coverage and a progress note for the parent-row guard ordering.

## Why This Matters

Recent reliability work aligned rental history lookups so missing parent rows fail clearly instead of looking like valid parents with empty histories. Reservation history queries already rejected non-positive IDs, but positive IDs for deleted or missing item/customer rows could still produce an ordinary empty result. This keeps reservation history behavior consistent with the broader service-boundary hardening without adding more Admin Settings theme layers.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `ReservationService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed `GetReservationsByItemAsync` calls `EnsureReservationItemExists(conn, itemID)` before SQL construction/execution.
- GitHub connector readback confirmed `GetReservationsByCustomerAsync` calls `EnsureReservationCustomerExists(conn, customerID)` before SQL construction/execution.
- GitHub connector readback confirmed `ReservationServiceQueryGuardContractTests` covers both parent-row helpers and the guard ordering for item/customer reservation history queries.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.