### PR TITLE
Guard customer writes against stale rows

### DIFF
--- a/InventoryManagementApp.Tests/CustomerServiceWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomerServiceWriteGuardContractTests.cs
@@ -40,7 +40,7 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains(executeSnippet, method, StringComparison.Ordinal);
             Assert.Contains(guardSnippet, method, StringComparison.Ordinal);
-            Assert.DoesNotContain("await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("                await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);", method, StringComparison.Ordinal);
             Assert.True(
                 method.IndexOf(executeSnippet, StringComparison.Ordinal) < method.IndexOf(guardSnippet, StringComparison.Ordinal),
                 $"Expected {startMarker} to check affected rows after executing the write.");

--- a/InventoryManagementApp.Tests/CustomerServiceWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/CustomerServiceWriteGuardContractTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class CustomerServiceWriteGuardContractTests
+    {
+        [Fact]
+        public void CustomerWritesThrowWhenNoRowsAreAffected()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Customers", "CustomerService.cs");
+
+            AssertWriteGuard(
+                source,
+                "async Task UpdateCustomerInternalAsync",
+                "async Task DeleteCustomerInternalAsync",
+                "var updatedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);",
+                "EnsureCustomerWriteSucceeded(updatedRows, customer.CustomerID);");
+            AssertWriteGuard(
+                source,
+                "async Task DeleteCustomerInternalAsync",
+                "async Task<CustomerModel?> GetCustomerByIDInternalAsync",
+                "var deletedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);",
+                "EnsureCustomerWriteSucceeded(deletedRows, customerID);");
+
+            Assert.Contains("static void EnsureCustomerWriteSucceeded(int affectedRows, int customerID)", source, StringComparison.Ordinal);
+            Assert.Contains("if (affectedRows == 0)", source, StringComparison.Ordinal);
+            Assert.Contains("throw new KeyNotFoundException($\"Customer {customerID} not found.\");", source, StringComparison.Ordinal);
+        }
+
+        private static void AssertWriteGuard(
+            string source,
+            string startMarker,
+            string endMarker,
+            string executeSnippet,
+            string guardSnippet)
+        {
+            var method = ExtractMethod(source, startMarker, endMarker);
+
+            Assert.Contains(executeSnippet, method, StringComparison.Ordinal);
+            Assert.Contains(guardSnippet, method, StringComparison.Ordinal);
+            Assert.DoesNotContain("await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf(executeSnippet, StringComparison.Ordinal) < method.IndexOf(guardSnippet, StringComparison.Ordinal),
+                $"Expected {startMarker} to check affected rows after executing the write.");
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-customer-write-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-customer-write-guards.md
@@ -1,0 +1,13 @@
+# Customer Write Guard Stale Row Protection - 2026-06-27
+
+## Summary
+
+- Guarded customer update writes by checking the affected row count after the pre-write existence check.
+- Guarded customer delete writes with the same affected-row check.
+- Routed stale update/delete races through the existing `KeyNotFoundException($"Customer {customerID} not found.")` customer-not-found contract instead of allowing a no-op write to look successful.
+- Added `CustomerServiceWriteGuardContractTests` source-contract coverage for the update/delete guard ordering.
+
+## Validation Notes
+
+- Connector readback/compare was used because direct local clone/raw access is blocked in the scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable in this environment, so local build/test/full validation was not run.

--- a/InventoryManagementApp/Services/Customers/CustomerService.cs
+++ b/InventoryManagementApp/Services/Customers/CustomerService.cs
@@ -203,7 +203,8 @@ namespace InventoryManagementApp.Services.Customers
             try
             {
                 await EnsureCustomerRowExistsAsync(conn, customer.CustomerID, cancellationToken);
-                await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);
+                var updatedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);
+                EnsureCustomerWriteSucceeded(updatedRows, customer.CustomerID);
             }
             catch (Exception ex)
             {
@@ -222,7 +223,8 @@ namespace InventoryManagementApp.Services.Customers
             try
             {
                 await EnsureCustomerRowExistsAsync(conn, customerID, cancellationToken);
-                await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);
+                var deletedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken);
+                EnsureCustomerWriteSucceeded(deletedRows, customerID);
             }
             catch (Exception ex)
             {
@@ -433,6 +435,12 @@ namespace InventoryManagementApp.Services.Customers
             }, cancellationToken) ?? 0);
 
             if (count == 0)
+                throw new KeyNotFoundException($"Customer {customerID} not found.");
+        }
+
+        static void EnsureCustomerWriteSucceeded(int affectedRows, int customerID)
+        {
+            if (affectedRows == 0)
                 throw new KeyNotFoundException($"Customer {customerID} not found.");
         }
 


### PR DESCRIPTION
## Summary

- Check affected row counts for customer update and delete writes after the existing pre-write row-existence check.
- Throw the existing `KeyNotFoundException($"Customer {customerID} not found.")` contract when a customer row disappears before the write reports success.
- Add focused source-contract coverage and a progress note for the stale-write guard ordering.

## Why This Matters

Recent reliability work has made stale service writes fail clearly across reservations, kits, users, maintenance, calibration, rentals, and item repository paths. Customer update/delete already validated the target row before issuing SQL, but a raced or stale write could still complete as a no-op. This keeps customer management aligned with the broader service-boundary hardening without extending Admin Settings theme customization.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `CustomerService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed customer update/delete paths capture `ExecuteNonQueryAsync(...)` results and call `EnsureCustomerWriteSucceeded(...)` after the write.
- GitHub connector readback confirmed `CustomerServiceWriteGuardContractTests` covers update/delete write guard ordering and the shared customer-not-found stale-write helper.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.