### PR TITLE
Guard maintenance and calibration item query parents

### DIFF
--- a/InventoryManagementApp.Tests/MaintenanceCalibrationQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/MaintenanceCalibrationQueryGuardContractTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class MaintenanceCalibrationQueryGuardContractTests
+    {
+        [Fact]
+        public void MaintenanceItemHistoryValidatesParentItemBeforeHistoryQuery()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Maintenance", "MaintenanceService.cs");
+
+            AssertContainsAll(
+                source,
+                "private static void EnsureItemExists(SqliteConnection conn, int itemID)",
+                "SELECT COUNT(*) FROM Items WHERE ItemID = @ItemID",
+                "throw new InvalidOperationException(\"Item not found.\");");
+
+            var method = ExtractMethod(
+                source,
+                "public async Task<List<MaintenanceRecord>> GetMaintenanceRecordsByItemAsync(int itemID)",
+                "public async Task<List<MaintenanceRecord>> GetOverdueMaintenanceAsync()");
+
+            AssertContainsAll(
+                method,
+                "if (itemID < 1)",
+                "throw new ArgumentOutOfRangeException(nameof(itemID), \"Item ID must be greater than 0.\");",
+                "using var conn = _databaseService.CreateConnection();",
+                "EnsureItemExists(conn, itemID);",
+                "WHERE m.ItemID = @ItemID");
+            Assert.True(
+                method.IndexOf("EnsureItemExists(conn, itemID);", StringComparison.Ordinal) <
+                method.IndexOf("var sql = @\"", StringComparison.Ordinal),
+                "Expected maintenance item history to confirm the item row exists before building/executing the history query.");
+        }
+
+        [Fact]
+        public void CalibrationItemQueriesValidateParentItemBeforeItemQueries()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Calibration", "CalibrationService.cs");
+
+            AssertContainsAll(
+                source,
+                "private static void EnsureItemExists(SqliteConnection conn, int itemID)",
+                "SELECT COUNT(*) FROM Items WHERE ItemID = @ItemID",
+                "throw new InvalidOperationException(\"Item not found.\");");
+
+            var historyMethod = ExtractMethod(
+                source,
+                "public async Task<List<CalibrationRecord>> GetCalibrationRecordsByItemAsync(int itemID)",
+                "public async Task<List<CalibrationRecord>> GetOverdueCalibrationAsync()");
+            AssertContainsAll(
+                historyMethod,
+                "if (itemID < 1)",
+                "throw new ArgumentOutOfRangeException(nameof(itemID), \"Item ID must be greater than 0.\");",
+                "using var conn = _databaseService.CreateConnection();",
+                "EnsureItemExists(conn, itemID);",
+                "WHERE c.ItemID = @ItemID");
+            Assert.True(
+                historyMethod.IndexOf("EnsureItemExists(conn, itemID);", StringComparison.Ordinal) <
+                historyMethod.IndexOf("var sql = @\"", StringComparison.Ordinal),
+                "Expected calibration item history to confirm the item row exists before building/executing the history query.");
+
+            var latestMethod = ExtractMethod(
+                source,
+                "public async Task<CalibrationRecord?> GetLatestCalibrationForItemAsync(int itemID)",
+                "public async Task<CalibrationRecord?> GetCalibrationRecordByIdAsync(int calibrationID)");
+            AssertContainsAll(
+                latestMethod,
+                "if (itemID < 1)",
+                "throw new ArgumentOutOfRangeException(nameof(itemID), \"Item ID must be greater than 0.\");",
+                "using var conn = _databaseService.CreateConnection();",
+                "EnsureItemExists(conn, itemID);",
+                "WHERE c.ItemID = @ItemID",
+                "LIMIT 1");
+            Assert.True(
+                latestMethod.IndexOf("EnsureItemExists(conn, itemID);", StringComparison.Ordinal) <
+                latestMethod.IndexOf("var sql = @\"", StringComparison.Ordinal),
+                "Expected latest calibration lookup to confirm the item row exists before building/executing the lookup query.");
+        }
+
+        private static void AssertContainsAll(string source, params string[] expectedSnippets)
+        {
+            foreach (var snippet in expectedSnippets)
+            {
+                Assert.Contains(snippet, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-maintenance-calibration-item-query-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-maintenance-calibration-item-query-guards.md
@@ -1,0 +1,16 @@
+# Maintenance and Calibration Item Query Guards - 2026-06-27
+
+## Completed
+
+- Guarded `MaintenanceService.GetMaintenanceRecordsByItemAsync` so positive item IDs must still reference an existing `Items` row before maintenance history queries run.
+- Guarded `CalibrationService.GetCalibrationRecordsByItemAsync` and `GetLatestCalibrationForItemAsync` so missing positive item IDs fail clearly instead of returning an ordinary empty history or `null` latest calibration result.
+- Added source-contract coverage in `MaintenanceCalibrationQueryGuardContractTests` to preserve the item-existence check before each per-item SQL query is built or executed.
+
+## Why
+
+Rental and reservation item-history paths now distinguish between real parent rows with no history and stale or missing parent rows. Maintenance and calibration item-history lookups still collapsed those cases together for positive missing item IDs. These guards keep technician scheduling history behavior aligned with the broader service-boundary reliability work.
+
+## Validation Notes
+
+- GitHub connector readback/compare should be used for this pass because the scheduled Linux environment cannot directly clone the repository.
+- Local `dotnet` build/test, PowerShell validation, WPF screenshots, and local banned-word checks were not run in this environment.

--- a/InventoryManagementApp/Services/Calibration/CalibrationService.cs
+++ b/InventoryManagementApp/Services/Calibration/CalibrationService.cs
@@ -66,6 +66,7 @@ namespace InventoryManagementApp.Services.Calibration
             {
                 var records = new List<CalibrationRecord>();
                 using var conn = _databaseService.CreateConnection();
+                EnsureItemExists(conn, itemID);
                 var sql = @"
                     SELECT c.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM CalibrationRecords c
@@ -142,6 +143,7 @@ namespace InventoryManagementApp.Services.Calibration
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureItemExists(conn, itemID);
                 var sql = @"
                     SELECT c.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM CalibrationRecords c

--- a/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
+++ b/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
@@ -66,6 +66,7 @@ namespace InventoryManagementApp.Services.Maintenance
             {
                 var records = new List<MaintenanceRecord>();
                 using var conn = _databaseService.CreateConnection();
+                EnsureItemExists(conn, itemID);
                 var sql = @"
                     SELECT m.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM MaintenanceRecords m


### PR DESCRIPTION
## Summary

- Confirm item rows exist before running maintenance item-history queries.
- Confirm item rows exist before running calibration item-history and latest-calibration lookups.
- Add source-contract coverage and a progress note for the parent-row guard ordering.

## Why This Matters

Rental and reservation history lookups now distinguish between a real parent row with no history and a stale/missing parent row. Maintenance and calibration item-specific queries still returned ordinary empty/null results for positive missing item IDs. These guards keep scheduling history behavior aligned with the broader service-boundary reliability work without extending Admin Settings theme customization.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only maintenance/calibration services, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed `MaintenanceService.GetMaintenanceRecordsByItemAsync` calls `EnsureItemExists(conn, itemID)` before its per-item SQL query is built/executed.
- GitHub connector readback confirmed `CalibrationService.GetCalibrationRecordsByItemAsync` and `GetLatestCalibrationForItemAsync` call `EnsureItemExists(conn, itemID)` before their per-item SQL queries are built/executed.
- GitHub connector readback confirmed `MaintenanceCalibrationQueryGuardContractTests` covers the maintenance history, calibration history, and latest-calibration query guard ordering.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.