### PR TITLE
Guard password changes for missing users before hashing

### DIFF
--- a/InventoryManagementApp.Tests/UserServiceEntryPointContractTests.cs
+++ b/InventoryManagementApp.Tests/UserServiceEntryPointContractTests.cs
@@ -70,6 +70,35 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ChangePasswordChecksUserExistsBeforePasswordValidationAndHashing()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "public async Task<bool> ChangeUserPasswordAsync",
+                "async Task DeleteUserInternalAsync");
+
+            const string lookupSnippet = "var existing = await GetUserByIDAsync(userID, CancellationToken.None);";
+            const string missingSnippet = "if (existing is null)";
+
+            Assert.Contains(lookupSnippet, method, StringComparison.Ordinal);
+            Assert.Contains(missingSnippet, method, StringComparison.Ordinal);
+            Assert.Contains("return false;", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf(lookupSnippet, StringComparison.Ordinal) < method.IndexOf(missingSnippet, StringComparison.Ordinal),
+                "Password changes should inspect the target user before handling a missing account.");
+            Assert.True(
+                method.IndexOf(missingSnippet, StringComparison.Ordinal) < method.IndexOf("PasswordValidator.IsValid", StringComparison.Ordinal),
+                "Missing password-change users should fail before password validation work.");
+            Assert.True(
+                method.IndexOf(missingSnippet, StringComparison.Ordinal) < method.IndexOf("SecurityHelper.HashPasswordAsync", StringComparison.Ordinal),
+                "Missing password-change users should fail before password hashing work.");
+            Assert.True(
+                method.IndexOf(missingSnippet, StringComparison.Ordinal) < method.IndexOf("var sql = \"UPDATE Users SET PasswordHash=@Pwd", StringComparison.Ordinal),
+                "Missing password-change users should fail before update SQL is prepared.");
+        }
+
+        [Fact]
         public void TryDeleteUserReturnsFalseForInvalidUserIdsBeforeAuthorizationAndLookup()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-user-password-missing-row-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-user-password-missing-row-guard.md
@@ -1,0 +1,13 @@
+# User Password Missing Row Guard
+
+## Completed
+
+- `UserService.ChangeUserPasswordAsync` now checks that the target user still exists before password validation, password hashing, or update SQL preparation.
+- Missing positive user IDs keep the existing boolean password-change surface by logging the missing target and returning `false`, while avoiding unnecessary password work for a stale account row.
+- `UserServiceEntryPointContractTests` now guards the missing-user lookup ordering so future edits keep password validation, hashing, and update SQL behind the target-user check.
+
+## Validation
+
+- Source-contract coverage was added for the password-change missing-user guard ordering.
+- Local restore/build/test, WPF runtime checks, screenshots, banned-word checks, and the full validation runner were not run in the scheduled Linux environment because direct local checkout/raw access, `dotnet`, PowerShell/`pwsh`, and `gh` are unavailable here.
+- GitHub connector readback/compare should be used as fallback validation for this pass.

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -403,6 +403,13 @@ namespace InventoryManagementApp.Services.Users
             if (_context.CurrentUser?.UserID != userID)
                 _auth.EnsurePermission(User.PermissionManageUsers);
 
+            var existing = await GetUserByIDAsync(userID, CancellationToken.None);
+            if (existing is null)
+            {
+                _logger.LogWarning("Password update requested for missing UserID {UserID}", userID);
+                return false;
+            }
+
             newPassword = (newPassword ?? string.Empty).Trim();
             if (!PasswordValidator.IsValid(newPassword, out var error))
                 throw new ArgumentException(error, nameof(newPassword));


### PR DESCRIPTION
## Summary

- Check that the target user still exists before password validation, password hashing, or update SQL preparation in `ChangeUserPasswordAsync`.
- Preserve the existing boolean password-change surface by logging and returning `false` for missing positive user IDs.
- Add source-contract coverage and a progress note for the guard ordering.

## Why This Matters

Recent service-boundary hardening has moved invalid or stale user operations earlier, before unnecessary database or password work. `ChangeUserPasswordAsync` already rejected non-positive user IDs before password work, but a deleted or missing positive user row still validated and hashed the new password before the update returned zero affected rows. This keeps the password-change path aligned with the broader reliability work without changing Admin Settings theme customization.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `UserService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed `ChangeUserPasswordAsync` calls `GetUserByIDAsync(userID, CancellationToken.None)` and returns `false` for a missing target before password validation, password hashing, or update SQL preparation.
- GitHub connector readback confirmed `UserServiceEntryPointContractTests.ChangePasswordChecksUserExistsBeforePasswordValidationAndHashing` guards the lookup and missing-user ordering.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.