### PR TITLE
Guard user authentication state writes

### DIFF
--- a/InventoryManagementApp.Tests/UserServiceEntryPointContractTests.cs
+++ b/InventoryManagementApp.Tests/UserServiceEntryPointContractTests.cs
@@ -45,6 +45,42 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void AuthenticationStateWritesGuardAffectedRowsBeforeInMemoryMutation()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var authenticate = ExtractMethod(
+                source,
+                "public async Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync",
+                "static bool IsLockoutActive");
+            var helpers = ExtractMethod(
+                source,
+                "async Task<bool> RecordFailedLoginAsync",
+                "public async Task<User?> GetCurrentUserAsync");
+
+            const string upgradeWrite = "var upgradedRows = await SqliteHelper.ExecuteNonQueryAsync";
+            const string upgradeGuard = "EnsureUserWriteSucceeded(upgradedRows, u.UserID);";
+            Assert.Contains(upgradeWrite, authenticate, StringComparison.Ordinal);
+            Assert.Contains(upgradeGuard, authenticate, StringComparison.Ordinal);
+            Assert.True(
+                authenticate.IndexOf(upgradeWrite, StringComparison.Ordinal) < authenticate.IndexOf(upgradeGuard, StringComparison.Ordinal),
+                "Legacy password upgrades should capture affected rows before checking the write result.");
+            Assert.True(
+                authenticate.IndexOf(upgradeGuard, StringComparison.Ordinal) < authenticate.IndexOf("u.PasswordHash = upgradedResult.hash;", StringComparison.Ordinal),
+                "Legacy password upgrades should guard stale rows before mutating the in-memory user.");
+
+            Assert.Contains("var recordedRows = await SqliteHelper.ExecuteNonQueryAsync", helpers, StringComparison.Ordinal);
+            Assert.Contains("EnsureUserWriteSucceeded(recordedRows, user.UserID);", helpers, StringComparison.Ordinal);
+            Assert.True(
+                helpers.IndexOf("EnsureUserWriteSucceeded(recordedRows, user.UserID);", StringComparison.Ordinal) < helpers.IndexOf("user.FailedLoginAttempts = failedAttempts;", StringComparison.Ordinal),
+                "Failed-login state should guard stale rows before mutating the in-memory user.");
+
+            Assert.Contains("var clearedRows = await SqliteHelper.ExecuteNonQueryAsync", helpers, StringComparison.Ordinal);
+            Assert.Contains("EnsureUserWriteSucceeded(clearedRows, userID);", helpers, StringComparison.Ordinal);
+            Assert.Contains("static void EnsureUserWriteSucceeded(int rows, int userID)", helpers, StringComparison.Ordinal);
+            Assert.Contains("throw new KeyNotFoundException($\"User {userID} not found.\");", helpers, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ChangePasswordRejectsInvalidUserIdsBeforeAuthorizationPasswordAndSqlWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-user-auth-state-write-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-user-auth-state-write-guards.md
@@ -1,0 +1,14 @@
+# User Authentication State Write Guards
+
+## Completed
+
+- `UserService.AuthenticateUserAsync` now checks affected row counts when upgrading legacy password hashes during login before mutating the in-memory user password fields.
+- Failed-login recording now checks the `Users` update result before mutating `FailedLoginAttempts` or `LockoutEndUtc` on the in-memory user.
+- Login failure-state clearing now checks the `Users` update result and throws the existing `KeyNotFoundException($"User {userID} not found.")` contract when a stale account row disappears mid-authentication.
+- `UserServiceEntryPointContractTests` now guards the authentication state write ordering and shared stale-write helper.
+
+## Validation
+
+- Source-contract coverage was added for authentication state write guard ordering.
+- Local restore/build/test, WPF runtime checks, screenshots, banned-word checks, and the full validation runner were not run in the scheduled Linux environment because direct local checkout/raw access, `dotnet`, PowerShell/`pwsh`, and `gh` are unavailable here.
+- GitHub connector readback/compare should be used as fallback validation for this pass.

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -186,7 +186,8 @@ namespace InventoryManagementApp.Services.Users
                         new SqliteParameter("@Salt", upgradedResult.salt),
                         new SqliteParameter("@ID", u.UserID)
                     };
-                    await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET PasswordHash=@Pwd, PasswordSalt=@Salt WHERE UserID=@ID", p);
+                    var upgradedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, "UPDATE Users SET PasswordHash=@Pwd, PasswordSalt=@Salt WHERE UserID=@ID", p).ConfigureAwait(false);
+                    EnsureUserWriteSucceeded(upgradedRows, u.UserID);
                     u.PasswordHash = upgradedResult.hash;
                     u.PasswordSalt = upgradedResult.salt;
                 }
@@ -229,9 +230,10 @@ namespace InventoryManagementApp.Services.Users
                 new SqliteParameter("@LockoutEndUtc", (object?)lockoutEndUtc ?? DBNull.Value),
                 new SqliteParameter("@ID", user.UserID)
             };
-            await SqliteHelper.ExecuteNonQueryAsync(conn,
+            var recordedRows = await SqliteHelper.ExecuteNonQueryAsync(conn,
                 "UPDATE Users SET FailedLoginAttempts=@Attempts, LockoutEndUtc=@LockoutEndUtc WHERE UserID=@ID",
                 p).ConfigureAwait(false);
+            EnsureUserWriteSucceeded(recordedRows, user.UserID);
 
             user.FailedLoginAttempts = failedAttempts;
             user.LockoutEndUtc = lockoutEndUtc;
@@ -246,12 +248,19 @@ namespace InventoryManagementApp.Services.Users
             return lockoutEndUtc.HasValue;
         }
 
-        static Task ClearLoginFailureStateAsync(SqliteConnection conn, int userID)
+        static async Task ClearLoginFailureStateAsync(SqliteConnection conn, int userID)
         {
             var p = new[] { new SqliteParameter("@ID", userID) };
-            return SqliteHelper.ExecuteNonQueryAsync(conn,
+            var clearedRows = await SqliteHelper.ExecuteNonQueryAsync(conn,
                 "UPDATE Users SET FailedLoginAttempts=0, LockoutEndUtc=NULL WHERE UserID=@ID",
-                p);
+                p).ConfigureAwait(false);
+            EnsureUserWriteSucceeded(clearedRows, userID);
+        }
+
+        static void EnsureUserWriteSucceeded(int rows, int userID)
+        {
+            if (rows == 0)
+                throw new KeyNotFoundException($"User {userID} not found.");
         }
 
         public async Task<User?> GetCurrentUserAsync()


### PR DESCRIPTION
## Summary

- Check affected row counts when legacy password hashes are upgraded during login before mutating the in-memory user password fields.
- Check affected row counts when recording failed-login state before mutating `FailedLoginAttempts` or `LockoutEndUtc` on the in-memory user.
- Check affected row counts when clearing login failure state and throw the existing `KeyNotFoundException($"User {userID} not found.")` contract if the account row disappears mid-authentication.
- Add source-contract coverage and a progress note for the authentication state write ordering.

## Why This Matters

Recent service-boundary hardening has made stale user writes fail clearly across password changes, update paths, and deletion paths. Authentication still had several write paths after the initial user lookup where a concurrently deleted user row could make the database update affect zero rows while the in-memory user object was treated as updated. This keeps login bookkeeping aligned with the broader stale-row reliability work without extending Admin Settings theme customization.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `UserService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed legacy password upgrades capture `upgradedRows`, call `EnsureUserWriteSucceeded(upgradedRows, u.UserID)`, and only then mutate `u.PasswordHash` / `u.PasswordSalt`.
- GitHub connector readback confirmed failed-login recording captures `recordedRows`, calls `EnsureUserWriteSucceeded(recordedRows, user.UserID)`, and only then mutates `FailedLoginAttempts` / `LockoutEndUtc`.
- GitHub connector readback confirmed login failure-state clearing captures `clearedRows` and calls `EnsureUserWriteSucceeded(clearedRows, userID)`.
- GitHub connector readback confirmed `UserServiceEntryPointContractTests.AuthenticationStateWritesGuardAffectedRowsBeforeInMemoryMutation` covers the guard ordering and shared stale-write helper.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.