### PR TITLE
Guard user delete result against stale rows

### DIFF
--- a/InventoryManagementApp.Tests/UserServiceEntryPointContractTests.cs
+++ b/InventoryManagementApp.Tests/UserServiceEntryPointContractTests.cs
@@ -87,7 +87,7 @@ namespace InventoryManagementApp.Tests
             var method = ExtractMethod(
                 source,
                 "public async Task<bool> ChangeUserPasswordAsync",
-                "async Task DeleteUserInternalAsync");
+                "async Task<bool> DeleteUserInternalAsync");
 
             Assert.Contains("if (userID < 1)", method, StringComparison.Ordinal);
             Assert.Contains("throw new ArgumentOutOfRangeException(nameof(userID), \"User ID must be greater than 0.\");", method, StringComparison.Ordinal);
@@ -112,7 +112,7 @@ namespace InventoryManagementApp.Tests
             var method = ExtractMethod(
                 source,
                 "public async Task<bool> ChangeUserPasswordAsync",
-                "async Task DeleteUserInternalAsync");
+                "async Task<bool> DeleteUserInternalAsync");
 
             const string lookupSnippet = "var existing = await GetUserByIDAsync(userID, CancellationToken.None);";
             const string missingSnippet = "if (existing is null)";
@@ -154,6 +154,28 @@ namespace InventoryManagementApp.Tests
             Assert.True(
                 method.IndexOf("if (userID < 1)", StringComparison.Ordinal) < method.IndexOf("DeleteUserInternalAsync", StringComparison.Ordinal),
                 "Invalid delete user IDs should fail before delete work.");
+        }
+
+        [Fact]
+        public void TryDeleteUserReturnsActualDeleteResultAfterPrecheck()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var deleteHelper = ExtractMethod(
+                source,
+                "async Task<bool> DeleteUserInternalAsync",
+                "public async Task<bool> TryDeleteUserAsync");
+            var tryDelete = ExtractMethod(
+                source,
+                "public async Task<bool> TryDeleteUserAsync",
+                "    }\n}");
+
+            Assert.Contains("var deletedRows = await SqliteHelper.ExecuteNonQueryAsync", deleteHelper, StringComparison.Ordinal);
+            Assert.Contains("return deletedRows > 0;", deleteHelper, StringComparison.Ordinal);
+            Assert.True(
+                deleteHelper.IndexOf("var deletedRows = await SqliteHelper.ExecuteNonQueryAsync", StringComparison.Ordinal) < deleteHelper.IndexOf("return deletedRows > 0;", StringComparison.Ordinal),
+                "User delete should derive its boolean result from the affected row count.");
+            Assert.Contains("return await DeleteUserInternalAsync(userID);", tryDelete, StringComparison.Ordinal);
+            Assert.DoesNotContain("await DeleteUserInternalAsync(userID);\n            return true;", tryDelete, StringComparison.Ordinal);
         }
 
         private static void AssertCancellationGuardBeforeConnection(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-user-delete-stale-row-result.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-user-delete-stale-row-result.md
@@ -1,0 +1,13 @@
+# User Delete Stale Row Result Guard
+
+## Completed
+
+- `UserService.DeleteUserInternalAsync` now captures the affected row count from the user delete statement.
+- `TryDeleteUserAsync` now returns the delete helper's boolean result instead of always returning `true` after the pre-delete lookup/admin checks.
+- `UserServiceEntryPointContractTests` now guards that user deletes derive their result from affected rows and do not reintroduce the unconditional success path.
+
+## Validation
+
+- Source-contract coverage was added for the user delete affected-row result.
+- Local restore/build/test, WPF runtime checks, screenshots, banned-word checks, and the full validation runner were not run in the scheduled Linux environment because direct local checkout/raw access, `dotnet`, PowerShell/`pwsh`, and `gh` are unavailable here.
+- GitHub connector readback/compare should be used as fallback validation for this pass.

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -444,11 +444,12 @@ namespace InventoryManagementApp.Services.Users
             return rows > 0;
         }
 
-        async Task DeleteUserInternalAsync(int userID)
+        async Task<bool> DeleteUserInternalAsync(int userID)
         {
             var sql = "DELETE FROM Users WHERE UserID=@ID";
             using var conn = _dbService.CreateConnection();
-            await SqliteHelper.ExecuteNonQueryAsync(conn, sql, new[] { new SqliteParameter("@ID", userID) });
+            var deletedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, new[] { new SqliteParameter("@ID", userID) });
+            return deletedRows > 0;
         }
 
         public async Task<bool> TryDeleteUserAsync(int userID)
@@ -466,8 +467,7 @@ namespace InventoryManagementApp.Services.Users
                 var adminCount = Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql) ?? 0);
                 if (adminCount <= 1) return false;
             }
-            await DeleteUserInternalAsync(userID);
-            return true;
+            return await DeleteUserInternalAsync(userID);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Capture the affected row count from the user delete statement in `DeleteUserInternalAsync`.
- Return that delete helper result from `TryDeleteUserAsync` instead of always returning `true` after the pre-delete lookup/admin checks.
- Add source-contract coverage and a progress note for the stale delete result behavior.

## Why This Matters

Recent user-service hardening aligned password updates and authentication state writes with affected-row results, but user deletion still had a small stale-row gap: if a user disappeared after the pre-delete lookup, `TryDeleteUserAsync` could still report success. This keeps the delete workflow's boolean contract honest without extending Admin Settings theme customization.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `UserService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed `DeleteUserInternalAsync` captures `deletedRows` from `SqliteHelper.ExecuteNonQueryAsync(...)` and returns `deletedRows > 0`.
- GitHub connector readback confirmed `TryDeleteUserAsync` now returns `await DeleteUserInternalAsync(userID)` instead of calling the helper and unconditionally returning `true`.
- GitHub connector readback confirmed `UserServiceEntryPointContractTests.TryDeleteUserReturnsActualDeleteResultAfterPrecheck` covers the affected-row result and prevents the unconditional success path from returning.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.