### PR TITLE
Guard last-admin user deletes at write time

### DIFF
--- a/InventoryManagementApp.Tests/UserServiceDeleteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/UserServiceDeleteGuardContractTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class UserServiceDeleteGuardContractTests
+    {
+        [Fact]
+        public void DeleteUserInternalKeepsLastAdminGuardInFinalDeleteStatement()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+            var method = ExtractMethod(
+                source,
+                "async Task<bool> DeleteUserInternalAsync",
+                "public async Task<bool> TryDeleteUserAsync");
+
+            Assert.Contains("DELETE FROM Users", method, StringComparison.Ordinal);
+            Assert.Contains("WHERE UserID=@ID", method, StringComparison.Ordinal);
+            Assert.Contains("AND (IsAdmin = 0 OR (SELECT COUNT(*) FROM Users WHERE IsAdmin = 1) > 1)", method, StringComparison.Ordinal);
+            Assert.Contains("var deletedRows = await SqliteHelper.ExecuteNonQueryAsync", method, StringComparison.Ordinal);
+            Assert.Contains("return deletedRows > 0;", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("AND (IsAdmin = 0 OR (SELECT COUNT(*) FROM Users WHERE IsAdmin = 1) > 1)", StringComparison.Ordinal) <
+                method.IndexOf("var deletedRows = await SqliteHelper.ExecuteNonQueryAsync", StringComparison.Ordinal),
+                "The last-admin guard should be part of the final delete command, not only the caller pre-check.");
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-user-delete-last-admin-write-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-user-delete-last-admin-write-guard.md
@@ -1,0 +1,12 @@
+# User Delete Last Admin Write Guard - 2026-06-27
+
+## Completed
+
+- Tightened `UserService.DeleteUserInternalAsync` so the final `DELETE` statement refuses to delete an admin row unless more than one admin still exists at write time.
+- Preserved the existing `TryDeleteUserAsync` caller pre-check and affected-row boolean result, so raced or stale delete attempts return `false` instead of removing the final admin account.
+- Added focused source-contract coverage in `UserServiceDeleteGuardContractTests` to keep the last-admin rule inside the final delete command.
+
+## Validation Notes
+
+- GitHub connector readback/compare should be used for this scheduled pass because the Linux container cannot clone the repository directly.
+- Local `dotnet` test execution, PowerShell validation, WPF runtime screenshots, and local banned-word checks remain unavailable in this scheduled environment.

--- a/InventoryManagementApp/Services/Users/UserService.cs
+++ b/InventoryManagementApp/Services/Users/UserService.cs
@@ -446,7 +446,10 @@ namespace InventoryManagementApp.Services.Users
 
         async Task<bool> DeleteUserInternalAsync(int userID)
         {
-            var sql = "DELETE FROM Users WHERE UserID=@ID";
+            var sql = @"
+                DELETE FROM Users
+                WHERE UserID=@ID
+                AND (IsAdmin = 0 OR (SELECT COUNT(*) FROM Users WHERE IsAdmin = 1) > 1)";
             using var conn = _dbService.CreateConnection();
             var deletedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, sql, new[] { new SqliteParameter("@ID", userID) });
             return deletedRows > 0;


### PR DESCRIPTION
## Summary

- Keep the existing user-delete pre-check, but also make the final `DELETE` statement refuse to remove an admin row unless more than one admin still exists at write time.
- Preserve the affected-row boolean result from the recent user-delete hardening so raced or stale deletes return `false`.
- Add focused source-contract coverage and a progress note for the final delete guard.

## Why This Matters

The recent user-service reliability sweep made deletion report the actual affected-row result, but the last-admin safety rule was still enforced only before the write. If admin rows changed between the pre-check and delete statement, the final delete could still remove the last admin account. This keeps the invariant enforced at the write boundary without extending the Admin Settings theme system.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `UserService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed `DeleteUserInternalAsync` includes `AND (IsAdmin = 0 OR (SELECT COUNT(*) FROM Users WHERE IsAdmin = 1) > 1)` in the final `DELETE` statement and still returns `deletedRows > 0`.
- GitHub connector readback confirmed `UserServiceDeleteGuardContractTests.DeleteUserInternalKeepsLastAdminGuardInFinalDeleteStatement` covers the final delete guard ordering.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.