### PR TITLE
Guard CSV item import quantities

### DIFF
--- a/InventoryManagementApp.Tests/ItemServiceImportTransactionTests.cs
+++ b/InventoryManagementApp.Tests/ItemServiceImportTransactionTests.cs
@@ -49,6 +49,36 @@ namespace InventoryManagementApp.Tests
             }
         }
 
+        [Fact]
+        public void CsvImportRejectsOutOfRangeQuantitiesBeforeInsert()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ItemService.cs");
+            var method = ExtractMethod(
+                source,
+                "private async Task<List<int>> ImportItemsFromCsvInternalAsync",
+                "protected virtual async Task<int> InsertItemAsync");
+
+            Assert.Contains("var parsedQuantity = TryParseInt(quantity);", method, StringComparison.Ordinal);
+            Assert.Contains("if (!skip && (parsedQuantity < 0 || parsedQuantity > MaxQuantityOnHand))", method, StringComparison.Ordinal);
+            Assert.Contains("_logger.LogWarning(\"Skipping row {Row}: AvailableQuantity {Quantity} is outside the allowed range.\", row, parsedQuantity);", method, StringComparison.Ordinal);
+            Assert.Contains("invalidRows.Add(row);", method, StringComparison.Ordinal);
+            Assert.Contains("QuantityOnHand = parsedQuantity", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("QuantityOnHand = TryParseInt(quantity)", method, StringComparison.Ordinal);
+
+            Assert.True(
+                method.IndexOf("var parsedQuantity = TryParseInt(quantity);", StringComparison.Ordinal) <
+                method.IndexOf("var item = new ItemModel", StringComparison.Ordinal),
+                "CSV import should parse quantity before building the item row.");
+            Assert.True(
+                method.IndexOf("if (!skip && (parsedQuantity < 0 || parsedQuantity > MaxQuantityOnHand))", StringComparison.Ordinal) <
+                method.IndexOf("var item = new ItemModel", StringComparison.Ordinal),
+                "CSV import should reject out-of-range quantities before building the item row.");
+            Assert.True(
+                method.IndexOf("if (!skip && (parsedQuantity < 0 || parsedQuantity > MaxQuantityOnHand))", StringComparison.Ordinal) <
+                method.IndexOf("await InsertItemAsync", StringComparison.Ordinal),
+                "CSV import should reject out-of-range quantities before direct insert work.");
+        }
+
         private static ItemModel CreateItem(string itemNumber, string name) => new()
         {
             ItemNumber = itemNumber,
@@ -95,6 +125,37 @@ namespace InventoryManagementApp.Tests
             {
                 return Task.FromResult((_items, new List<int>()));
             }
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
         }
     }
 }

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-item-csv-import-quantity-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-item-csv-import-quantity-guard.md
@@ -1,0 +1,12 @@
+# Item CSV Import Quantity Guard - 2026-06-27
+
+## Completed
+
+- Tightened the CSV item import path so parsed `AvailableQuantity` values must stay within the same `0` to `10000` range used by normal item add/update saves.
+- Out-of-range CSV quantities now mark the row invalid, log a clear row warning, and skip direct insert work instead of persisting impossible inventory counts.
+- Added focused source-contract coverage in `ItemServiceImportTransactionTests` to keep the CSV quantity guard before item model construction and `InsertItemAsync`.
+
+## Validation Notes
+
+- GitHub connector readback/compare should be used for this scheduled pass because the Linux container cannot clone the repository directly.
+- Local `dotnet` test execution, PowerShell validation, WPF runtime screenshots, and local banned-word checks remain unavailable in this scheduled environment.

--- a/InventoryManagementApp/Services/Items/ItemService.cs
+++ b/InventoryManagementApp/Services/Items/ItemService.cs
@@ -485,6 +485,13 @@ namespace InventoryManagementApp.Services.Items
                         }
                     }
 
+                    var parsedQuantity = TryParseInt(quantity);
+                    if (!skip && (parsedQuantity < 0 || parsedQuantity > MaxQuantityOnHand))
+                    {
+                        _logger.LogWarning("Skipping row {Row}: AvailableQuantity {Quantity} is outside the allowed range.", row, parsedQuantity);
+                        skip = true;
+                    }
+
                     if (skip)
                     {
                         invalidRows.Add(row);
@@ -502,7 +509,7 @@ namespace InventoryManagementApp.Services.Items
                         PurchasedDate = TryParseDate(purchased),
                         Notes = notes ?? string.Empty,
                         Keywords = keywords ?? string.Empty,
-                        QuantityOnHand = TryParseInt(quantity),
+                        QuantityOnHand = parsedQuantity,
                         IsPowered = TryParseBool(powered),
                         IsRentalItem = TryParseBool(rental)
                     };


### PR DESCRIPTION
## Summary

- Validate parsed CSV `AvailableQuantity` values against the existing item quantity range before creating imported item rows.
- Mark out-of-range CSV rows invalid and skip direct insert work instead of persisting negative or oversized inventory counts.
- Add focused source-contract coverage and a progress note for the CSV import guard ordering.

## Why This Matters

Normal item add/update paths already reject quantities outside `0` to `10000`, and the generic importer validates quantities before direct insert. The CSV-specific import path parsed `AvailableQuantity` and inserted directly, so a CSV could bypass that service invariant. This keeps imported item rows aligned with the rest of item management without extending Admin Settings theme customization.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `ItemService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed `ImportItemsFromCsvInternalAsync` parses `AvailableQuantity`, skips rows when `parsedQuantity < 0 || parsedQuantity > MaxQuantityOnHand`, records the row in `invalidRows`, and assigns `QuantityOnHand = parsedQuantity` before direct insert work.
- GitHub connector readback confirmed `ItemServiceImportTransactionTests.CsvImportRejectsOutOfRangeQuantitiesBeforeInsert` covers the CSV guard and verifies it remains before item model construction and `InsertItemAsync`.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.