### PR TITLE
Honor category service cancellation before database work

### DIFF
--- a/InventoryManagementApp.Tests/CategoriesServiceTests.cs
+++ b/InventoryManagementApp.Tests/CategoriesServiceTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
 using InventoryManagementApp.Services.Categories;
@@ -34,5 +36,92 @@ public class CategoriesServiceTests
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             svc.LinkCategoryToInventoryAsync(categoryId, 1));
     }
-}
 
+    [Fact]
+    public async Task EnsureCategoryAsync_HonorsCancellationBeforeCreatingCategory()
+    {
+        await using var db = new DatabaseService(":memory:");
+        var svc = new CategoriesService(db);
+        await svc.EnsureSchemaAsync();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => svc.EnsureCategoryAsync("Tools", cts.Token));
+
+        await using var conn = db.CreateConnection();
+        var count = await conn.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM Categories");
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void CategoryServiceHonorsCancellationBeforeConnectionWork()
+    {
+        var source = ReadRepoFile("InventoryManagementApp", "Services", "Categories", "CategoriesService.cs");
+
+        AssertCancellationGuardBeforeConnection(
+            source,
+            "public async Task EnsureSchemaAsync(CancellationToken ct = default)",
+            "public async Task<int> EnsureCategoryAsync");
+        AssertCancellationGuardBeforeConnection(
+            source,
+            "public async Task<int> EnsureCategoryAsync(string name, CancellationToken ct = default)",
+            "public async Task LinkCategoryToInventoryAsync");
+        AssertCancellationGuardBeforeConnection(
+            source,
+            "public async Task LinkCategoryToInventoryAsync(int categoryId, int inventoryId, CancellationToken ct = default)",
+            "public async Task<List<CategoryDto>> GetCategoriesForInventoryAsync");
+        AssertCancellationGuardBeforeConnection(
+            source,
+            "public async Task<List<CategoryDto>> GetCategoriesForInventoryAsync(int inventoryId, CancellationToken ct = default)",
+            "public async Task<bool> RenameCategoryAsync");
+        AssertCancellationGuardBeforeConnection(
+            source,
+            "public async Task<bool> RenameCategoryAsync(int categoryId, string newName, CancellationToken ct = default)",
+            "public async Task<bool> DeleteCategoryAsync");
+        AssertCancellationGuardBeforeConnection(
+            source,
+            "public async Task<bool> DeleteCategoryAsync(int categoryId, CancellationToken ct = default)",
+            "private static async Task EnsureInventoryExistsAsync");
+    }
+
+    private static void AssertCancellationGuardBeforeConnection(string source, string startMarker, string endMarker)
+    {
+        var method = ExtractMethod(source, startMarker, endMarker);
+
+        Assert.Contains("ct.ThrowIfCancellationRequested();", method, StringComparison.Ordinal);
+        Assert.True(
+            method.IndexOf("ct.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("_db.CreateConnection()", StringComparison.Ordinal),
+            $"Expected {startMarker} to honor cancellation before opening a database connection.");
+    }
+
+    private static string ExtractMethod(string source, string startMarker, string endMarker)
+    {
+        var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+        var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+        Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+        return source[start..end];
+    }
+
+    private static string ReadRepoFile(params string[] parts)
+    {
+        var directory = AppContext.BaseDirectory;
+
+        while (!string.IsNullOrEmpty(directory))
+        {
+            var candidate = Path.Combine(directory, Path.Combine(parts));
+            if (File.Exists(candidate))
+                return File.ReadAllText(candidate);
+
+            var parent = Directory.GetParent(directory);
+            if (parent is null)
+                break;
+
+            directory = parent.FullName;
+        }
+
+        throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-category-service-cancellation-guards.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-category-service-cancellation-guards.md
@@ -1,0 +1,13 @@
+# Category Service Cancellation Guards
+
+## Summary
+
+- Added early `CancellationToken.ThrowIfCancellationRequested()` checks to `CategoriesService` public async operations before database connections or Dapper work begin.
+- Preserved existing argument validation order so invalid IDs or empty category names still return the established validation errors before cancellation is checked.
+- Added focused category service coverage for canceled category creation and source-contract coverage that keeps cancellation guards before `_db.CreateConnection()` across the category service surface.
+
+## Validation Notes
+
+- Source readback should confirm every public `CategoriesService` method that accepts `CancellationToken ct` checks `ct.ThrowIfCancellationRequested()` before `_db.CreateConnection()`.
+- Source readback should confirm `CategoriesServiceTests.EnsureCategoryAsync_HonorsCancellationBeforeCreatingCategory` verifies canceled category creation does not add a category row.
+- Local build/test validation still needs a Windows/.NET-capable checkout because this scheduled Linux environment cannot clone the repository and does not provide `dotnet` or PowerShell.

--- a/InventoryManagementApp/Services/Categories/CategoriesService.cs
+++ b/InventoryManagementApp/Services/Categories/CategoriesService.cs
@@ -30,6 +30,8 @@ namespace InventoryManagementApp.Services.Categories
         /// <param name="ct">Cancellation token for the operation.</param>
         public async Task EnsureSchemaAsync(CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
+
             await using var conn = _db.CreateConnection();
             var sql = @"
 CREATE TABLE IF NOT EXISTS Categories (
@@ -62,6 +64,8 @@ CREATE TABLE IF NOT EXISTS InventoryCategories (
         {
             name = (name ?? string.Empty).Trim();
             if (name.Length == 0) throw new ArgumentException("Category name cannot be empty.", nameof(name));
+            ct.ThrowIfCancellationRequested();
+
             await using var conn = _db.CreateConnection();
             var tx = conn.BeginTransaction();
             try
@@ -101,6 +105,7 @@ CREATE TABLE IF NOT EXISTS InventoryCategories (
                 throw new ArgumentOutOfRangeException(nameof(categoryId), "Category ID must be greater than 0.");
             if (inventoryId < 1)
                 throw new ArgumentOutOfRangeException(nameof(inventoryId), "Inventory ID must be greater than 0.");
+            ct.ThrowIfCancellationRequested();
             
             await using var conn = _db.CreateConnection();
             await EnsureInventoryExistsAsync(conn, inventoryId);
@@ -122,6 +127,8 @@ CREATE TABLE IF NOT EXISTS InventoryCategories (
         {
             if (inventoryId < 1)
                 throw new ArgumentOutOfRangeException(nameof(inventoryId), "Inventory ID must be greater than 0.");
+            ct.ThrowIfCancellationRequested();
+
             await using var conn = _db.CreateConnection();
             await EnsureInventoryExistsAsync(conn, inventoryId);
             var list = await conn.QueryAsync<CategoryDto>(
@@ -151,6 +158,8 @@ CREATE TABLE IF NOT EXISTS InventoryCategories (
             
             newName = (newName ?? string.Empty).Trim();
             if (newName.Length == 0) throw new ArgumentException("Category name cannot be empty.", nameof(newName));
+            ct.ThrowIfCancellationRequested();
+
             await using var conn = _db.CreateConnection();
             await EnsureCategoryExistsAsync(conn, categoryId);
             var exists = await conn.ExecuteScalarAsync<long>(
@@ -177,6 +186,8 @@ CREATE TABLE IF NOT EXISTS InventoryCategories (
         {
             if (categoryId < 1)
                 throw new ArgumentOutOfRangeException(nameof(categoryId), "Category ID must be greater than 0.");
+            ct.ThrowIfCancellationRequested();
+
             await using var conn = _db.CreateConnection();
             var tx = conn.BeginTransaction();
             try


### PR DESCRIPTION
## Summary

- Add early cancellation checks to all public `CategoriesService` operations that accept a `CancellationToken` before opening SQLite connections or starting Dapper work.
- Preserve the existing argument-validation order so invalid category/inventory IDs and empty names keep returning their established validation errors before cancellation is considered.
- Add focused category service coverage for canceled category creation plus source-contract coverage that keeps the cancellation guards ahead of `_db.CreateConnection()`.

## Why This Matters

The category service already exposed cancellation tokens but ignored them at the service boundary. A canceled category workflow could still open a database connection and start category work before noticing cancellation, unlike recently hardened item repository paths. This makes category operations cheaper and more predictable when view-model refreshes or user actions are canceled, without extending the Admin Settings theme system.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `CategoriesService`, `CategoriesServiceTests`, and one progress note.
- GitHub connector readback confirmed each public `CategoriesService` method accepting `CancellationToken ct` now calls `ct.ThrowIfCancellationRequested()` before `_db.CreateConnection()`.
- GitHub connector readback confirmed `CategoriesServiceTests.EnsureCategoryAsync_HonorsCancellationBeforeCreatingCategory` verifies canceled category creation throws and leaves the `Categories` table empty.
- GitHub connector readback confirmed `CategoriesServiceTests.CategoryServiceHonorsCancellationBeforeConnectionWork` covers guard ordering for the category service surface.
- GitHub connector workflow readback found no workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.