### PR TITLE
Guard reservation availability item lookups

### DIFF
--- a/InventoryManagementApp.Tests/ReservationServiceQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationServiceQueryGuardContractTests.cs
@@ -53,6 +53,30 @@ namespace InventoryManagementApp.Tests
                 "Expected customer reservation history to confirm the customer row exists before building/executing the history query.");
         }
 
+        [Fact]
+        public void ReservationAvailabilityValidatesItemRowBeforeAvailabilityQuery()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
+
+            var availabilityMethod = ExtractMethod(
+                source,
+                "public async Task<bool> CheckAvailabilityAsync(int itemID, DateTime startDate, DateTime endDate, int quantity)",
+                "private Reservation MapReservation");
+
+            AssertContainsAll(
+                availabilityMethod,
+                "if (itemID < 1)",
+                "throw new ArgumentOutOfRangeException(nameof(itemID), \"Item ID must be greater than 0.\");",
+                "using var conn = _databaseService.CreateConnection();",
+                "EnsureReservationItemExists(conn, itemID);",
+                "SELECT i.AvailableQuantity",
+                "WHERE i.ItemID = @ItemID");
+            Assert.True(
+                availabilityMethod.IndexOf("EnsureReservationItemExists(conn, itemID);", StringComparison.Ordinal) <
+                availabilityMethod.IndexOf("var sql = @\"", StringComparison.Ordinal),
+                "Expected reservation availability checks to confirm the item row exists before building/executing the availability query.");
+        }
+
         private static void AssertContainsAll(string source, params string[] expectedSnippets)
         {
             foreach (var snippet in expectedSnippets)

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-reservation-availability-item-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-reservation-availability-item-guard.md
@@ -1,0 +1,13 @@
+# Reservation Availability Item Guard
+
+## Summary
+
+- Updated `ReservationService.CheckAvailabilityAsync` to confirm the requested positive item ID still exists before running the reservation availability query.
+- Reused the existing `EnsureReservationItemExists` helper so missing item rows now fail with the same clear `InvalidOperationException("Item not found.")` contract as reservation item-history lookups.
+- Added source-contract coverage that keeps the item-row guard ahead of availability SQL construction and execution.
+
+## Validation Notes
+
+- Source readback should confirm `CheckAvailabilityAsync` calls `EnsureReservationItemExists(conn, itemID)` immediately after opening the database connection and before `var sql = @"`.
+- Source readback should confirm `ReservationServiceQueryGuardContractTests.ReservationAvailabilityValidatesItemRowBeforeAvailabilityQuery` guards the availability ordering.
+- Local build/test validation still needs a Windows/.NET-capable checkout because this scheduled Linux environment cannot clone the repository and does not provide `dotnet`, PowerShell, or WPF runtime support.

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -358,6 +358,7 @@ namespace InventoryManagementApp.Services.Reservations
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureReservationItemExists(conn, itemID);
                 var sql = @"
                     SELECT i.AvailableQuantity,
                     COALESCE(SUM(r.Quantity), 0) as ReservedQuantity


### PR DESCRIPTION
## Summary

- Confirm positive item IDs still reference an existing item row before running reservation availability SQL.
- Reuse the existing reservation item guard so missing availability items fail with the same clear `Item not found.` contract as item reservation-history lookups.
- Add source-contract coverage and a progress note for the availability guard ordering.

## Why This Matters

Recent reservation hardening made item/customer history lookups distinguish a real parent row with no data from a missing parent row. `CheckAvailabilityAsync` still returned `false` for a positive missing item ID, which could look like ordinary unavailability instead of stale or invalid item data. This keeps availability checks aligned with the broader service-boundary reliability work without extending Admin Settings theme customization.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `ReservationService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed `CheckAvailabilityAsync` calls `EnsureReservationItemExists(conn, itemID)` immediately after opening the database connection and before availability SQL construction.
- GitHub connector readback confirmed `ReservationServiceQueryGuardContractTests.ReservationAvailabilityValidatesItemRowBeforeAvailabilityQuery` covers the guard ordering.
- GitHub connector status readback found no commit statuses attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.