### PR TITLE
Guard rental history parent checks before query setup

### DIFF
--- a/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
@@ -31,7 +31,7 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public void RentalHistoryQueriesValidateParentRowsBeforeExecutingHistoryQueries()
+        public void RentalHistoryQueriesValidateParentRowsBeforePreparingHistoryQueries()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
 
@@ -42,18 +42,45 @@ namespace InventoryManagementApp.Tests
                 "throw new InvalidOperationException(\"Item not found.\");",
                 "private static async Task EnsureCustomerExistsAsync(SqliteConnection conn, int customerID)",
                 "SELECT COUNT(*) FROM Customers WHERE CustomerID=@CustomerID",
-                "throw new InvalidOperationException(\"Customer not found.\");",
-                "await EnsureItemExistsAsync(conn, itemID).ConfigureAwait(false);",
-                "await EnsureCustomerExistsAsync(conn, customerID).ConfigureAwait(false);");
+                "throw new InvalidOperationException(\"Customer not found.\");");
 
+            var itemMethod = ExtractMethod(
+                source,
+                "public async Task<List<Rental>> GetRentalHistoryForItemAsync(int itemID)",
+                "public async Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID)");
+            AssertContainsAll(
+                itemMethod,
+                "using var conn = _dbService.CreateConnection();",
+                "await EnsureItemExistsAsync(conn, itemID).ConfigureAwait(false);",
+                "const string sql = BaseSelect + @\" WHERE r.ItemID = @ItemID ORDER BY r.RentalDate DESC\";",
+                "var p = new[] { new SqliteParameter(\"@ItemID\", itemID) };");
             Assert.True(
-                source.IndexOf("await EnsureItemExistsAsync(conn, itemID).ConfigureAwait(false);", StringComparison.Ordinal) <
-                source.IndexOf("var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);", StringComparison.Ordinal),
-                "Expected item rental history to confirm the item row exists before executing the history query.");
+                itemMethod.IndexOf("await EnsureItemExistsAsync(conn, itemID).ConfigureAwait(false);", StringComparison.Ordinal) <
+                itemMethod.IndexOf("const string sql = BaseSelect", StringComparison.Ordinal),
+                "Expected item rental history to confirm the item row exists before preparing the history query.");
             Assert.True(
-                source.IndexOf("await EnsureCustomerExistsAsync(conn, customerID).ConfigureAwait(false);", StringComparison.Ordinal) <
-                source.LastIndexOf("var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);", StringComparison.Ordinal),
-                "Expected customer rental history to confirm the customer row exists before executing the history query.");
+                itemMethod.IndexOf("await EnsureItemExistsAsync(conn, itemID).ConfigureAwait(false);", StringComparison.Ordinal) <
+                itemMethod.IndexOf("new SqliteParameter(\"@ItemID\", itemID)", StringComparison.Ordinal),
+                "Expected item rental history to confirm the item row exists before preparing query parameters.");
+
+            var customerMethod = ExtractMethod(
+                source,
+                "public async Task<List<Rental>> GetRentalHistoryForCustomerAsync(int customerID)",
+                "public async Task<List<ItemRentalFrequency>> GetRentalFrequencyAsync");
+            AssertContainsAll(
+                customerMethod,
+                "using var conn = _dbService.CreateConnection();",
+                "await EnsureCustomerExistsAsync(conn, customerID).ConfigureAwait(false);",
+                "const string sql = BaseSelect + @\" WHERE r.CustomerID = @CustomerID ORDER BY r.RentalDate DESC\";",
+                "var p = new[] { new SqliteParameter(\"@CustomerID\", customerID) };");
+            Assert.True(
+                customerMethod.IndexOf("await EnsureCustomerExistsAsync(conn, customerID).ConfigureAwait(false);", StringComparison.Ordinal) <
+                customerMethod.IndexOf("const string sql = BaseSelect", StringComparison.Ordinal),
+                "Expected customer rental history to confirm the customer row exists before preparing the history query.");
+            Assert.True(
+                customerMethod.IndexOf("await EnsureCustomerExistsAsync(conn, customerID).ConfigureAwait(false);", StringComparison.Ordinal) <
+                customerMethod.IndexOf("new SqliteParameter(\"@CustomerID\", customerID)", StringComparison.Ordinal),
+                "Expected customer rental history to confirm the customer row exists before preparing query parameters.");
         }
 
         [Fact]
@@ -80,6 +107,17 @@ namespace InventoryManagementApp.Tests
             {
                 Assert.Contains(snippet, source, StringComparison.Ordinal);
             }
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
         }
 
         private static string ReadRepoFile(params string[] parts)

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-rental-history-parent-guard-order.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-rental-history-parent-guard-order.md
@@ -1,0 +1,13 @@
+# Rental History Parent Guard Ordering
+
+## Summary
+
+- Updated `RentalService.GetRentalHistoryForItemAsync` and `GetRentalHistoryForCustomerAsync` so they confirm the requested positive item or customer row exists before preparing the history SQL or query parameters.
+- Kept the existing `InvalidOperationException("Item not found.")` and `InvalidOperationException("Customer not found.")` contracts for stale parent rows.
+- Added focused source-contract coverage that checks the parent-row guards stay ahead of history query and parameter setup.
+
+## Validation Notes
+
+- Source readback should confirm both rental history methods open the database connection, call the matching parent-row guard, and only then prepare `const string sql = BaseSelect + ...` plus `SqliteParameter` values.
+- Source readback should confirm `RentalServiceQueryGuardContractTests.RentalHistoryQueriesValidateParentRowsBeforePreparingHistoryQueries` guards item and customer history ordering.
+- Local build/test validation still needs a Windows/.NET-capable checkout because this scheduled Linux environment cannot clone the repository and does not provide `dotnet`, PowerShell/`pwsh`, `gh`, or WPF runtime support.

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -357,10 +357,11 @@ namespace InventoryManagementApp.Services.Rentals
             if (itemID < 1)
                 throw new ArgumentOutOfRangeException(nameof(itemID), "Item ID must be greater than 0.");
 
-            const string sql = BaseSelect + @" WHERE r.ItemID = @ItemID ORDER BY r.RentalDate DESC";
-            var p = new[] { new SqliteParameter("@ItemID", itemID) };
             using var conn = _dbService.CreateConnection();
             await EnsureItemExistsAsync(conn, itemID).ConfigureAwait(false);
+
+            const string sql = BaseSelect + @" WHERE r.ItemID = @ItemID ORDER BY r.RentalDate DESC";
+            var p = new[] { new SqliteParameter("@ItemID", itemID) };
             var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);
             return list.Where(r => r != null).Select(r => r!).ToList();
         }
@@ -370,10 +371,11 @@ namespace InventoryManagementApp.Services.Rentals
             if (customerID < 1)
                 throw new ArgumentOutOfRangeException(nameof(customerID), "Customer ID must be greater than 0.");
 
-            const string sql = BaseSelect + @" WHERE r.CustomerID = @CustomerID ORDER BY r.RentalDate DESC";
-            var p = new[] { new SqliteParameter("@CustomerID", customerID) };
             using var conn = _dbService.CreateConnection();
             await EnsureCustomerExistsAsync(conn, customerID).ConfigureAwait(false);
+
+            const string sql = BaseSelect + @" WHERE r.CustomerID = @CustomerID ORDER BY r.RentalDate DESC";
+            var p = new[] { new SqliteParameter("@CustomerID", customerID) };
             var list = await SqliteHelper.ExecuteReaderAsync(conn, sql, MapRental, p);
             return list.Where(r => r != null).Select(r => r!).ToList();
         }


### PR DESCRIPTION
## Summary

- Move rental item-history and customer-history SQL/parameter setup until after the requested parent item or customer row has been confirmed to exist.
- Preserve the existing `Item not found.` and `Customer not found.` contracts for positive stale parent IDs.
- Tighten `RentalServiceQueryGuardContractTests` so the source contract guards parent-row checks before history query and parameter preparation, plus add a short progress note.

## Why This Matters

Recent reservation and rental reliability work has made stale parent IDs fail clearly before query execution. The rental history methods already checked the parent rows before executing their history queries, but they still prepared the SQL and parameters first. This keeps rental history ordering aligned with the newer reservation availability guard and avoids doing avoidable query setup for stale item/customer references, without extending Admin Settings theme customization.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `RentalService`, one focused source-contract test file, and a progress note.
- GitHub connector readback confirmed `GetRentalHistoryForItemAsync` opens the database connection, calls `EnsureItemExistsAsync(conn, itemID)`, and only then prepares the item-history SQL and `@ItemID` parameter.
- GitHub connector readback confirmed `GetRentalHistoryForCustomerAsync` opens the database connection, calls `EnsureCustomerExistsAsync(conn, customerID)`, and only then prepares the customer-history SQL and `@CustomerID` parameter.
- GitHub connector readback confirmed `RentalServiceQueryGuardContractTests.RentalHistoryQueriesValidateParentRowsBeforePreparingHistoryQueries` guards the item and customer ordering.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.