### PR TITLE
Guard kit availability parent lookups

### DIFF
--- a/InventoryManagementApp.Tests/KitServiceTests.cs
+++ b/InventoryManagementApp.Tests/KitServiceTests.cs
@@ -373,6 +373,12 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task CheckKitAvailability_WithMissingKit_ShouldThrow()
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _kitService.CheckKitAvailabilityAsync(999));
+        }
+
+        [Fact]
         public async Task CheckKitAvailability_WithInsufficientRequiredItemQuantity_ShouldReturnFalse()
         {
             var kit = new Kit

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-kit-availability-parent-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-kit-availability-parent-guard.md
@@ -1,0 +1,9 @@
+# Kit Availability Parent Guard
+
+## Summary
+- Guarded `KitService.CheckKitAvailabilityAsync` so positive kit IDs must still reference an existing kit row before availability SQL is prepared or executed.
+- Missing kit availability checks now fail with the existing `InvalidOperationException("Kit not found.")` service contract instead of returning `true` because no required kit items were counted as missing.
+- Added focused `KitServiceTests` coverage for the missing-kit availability contract.
+
+## Validation
+- GitHub connector readback/compare should be used for this scheduled run because direct local checkout/raw access, `dotnet`, PowerShell/`pwsh`, `gh`, WPF screenshots, and local banned-word checks are unavailable in the Linux scheduled environment.

--- a/InventoryManagementApp/Services/Kits/KitService.cs
+++ b/InventoryManagementApp/Services/Kits/KitService.cs
@@ -303,6 +303,8 @@ namespace InventoryManagementApp.Services.Kits
             return await Task.Run(() =>
             {
                 using var conn = _databaseService.CreateConnection();
+                EnsureKitExists(conn, kitID);
+
                 var sql = @"
                     SELECT COUNT(*) as MissingItems
                     FROM KitItems ki


### PR DESCRIPTION
## Summary

- Confirm positive kit IDs still reference an existing kit row before running kit availability SQL.
- Preserve the existing `Kit not found.` service contract for stale or missing kit availability checks.
- Add focused `KitServiceTests` coverage for the missing-kit availability case plus a short progress note.

## Why This Matters

`CheckKitAvailabilityAsync` rejected non-positive kit IDs, but a positive missing kit ID could return `true` because no required kit items were counted as missing. That made a stale kit reference look available instead of clearly invalid. This aligns kit availability with the recent reservation, rental, and kit write guard work without extending Admin Settings theme customization.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `KitService`, `KitServiceTests`, and a progress note.
- GitHub connector readback confirmed `CheckKitAvailabilityAsync` opens the database connection, calls `EnsureKitExists(conn, kitID)`, and only then prepares the availability SQL and `@KitID` parameter.
- GitHub connector readback confirmed `KitServiceTests.CheckKitAvailability_WithMissingKit_ShouldThrow` covers the missing positive kit ID contract.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.