### PR TITLE
Guard kit item listings for missing parent kits

### DIFF
--- a/InventoryManagementApp.Tests/KitServiceTests.cs
+++ b/InventoryManagementApp.Tests/KitServiceTests.cs
@@ -172,6 +172,12 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task GetKitItems_WithMissingKit_ShouldThrow()
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _kitService.GetKitItemsAsync(999));
+        }
+
+        [Fact]
         public async Task RemoveKitItem_ShouldSucceed()
         {
             var kit = new Kit

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-kit-items-parent-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-kit-items-parent-guard.md
@@ -1,0 +1,9 @@
+# Kit Item Listing Parent Guard
+
+## Summary
+- Guarded `KitService.GetKitItemsAsync` so positive kit IDs must still reference an existing kit row before membership SQL is prepared or executed.
+- Missing kit item-list requests now fail with the existing `InvalidOperationException("Kit not found.")` service contract instead of returning an empty list that looks like a real kit with no items.
+- Added focused `KitServiceTests` coverage for the missing-kit item-list contract.
+
+## Validation
+- GitHub connector readback/compare should be used for this scheduled run because direct local checkout/raw access, `dotnet`, PowerShell/`pwsh`, `gh`, WPF screenshots, and local banned-word checks are unavailable in the Linux scheduled environment.

--- a/InventoryManagementApp/Services/Kits/KitService.cs
+++ b/InventoryManagementApp/Services/Kits/KitService.cs
@@ -114,6 +114,8 @@ namespace InventoryManagementApp.Services.Kits
             {
                 var items = new List<KitItem>();
                 using var conn = _databaseService.CreateConnection();
+                EnsureKitExists(conn, kitID);
+
                 var sql = @"
                     SELECT ki.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM KitItems ki


### PR DESCRIPTION
## Summary

- Confirm positive kit IDs still reference an existing kit row before running kit item membership SQL.
- Preserve the existing `Kit not found.` service contract for stale or missing kit item listing requests.
- Add focused `KitServiceTests` coverage for the missing-kit item listing case plus a short progress note.

## Why This Matters

`GetKitItemsAsync` rejected non-positive kit IDs, but a positive missing kit ID returned an empty list. That made a stale kit reference look the same as a real kit with no items. This keeps kit item listing behavior aligned with the recent kit availability parent guard without extending Admin Settings theme customization.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `KitService`, `KitServiceTests`, and a progress note.
- GitHub connector readback confirmed `GetKitItemsAsync` opens the database connection, calls `EnsureKitExists(conn, kitID)`, and only then prepares the kit membership SQL and `@KitID` parameter.
- GitHub connector readback confirmed `KitServiceTests.GetKitItems_WithMissingKit_ShouldThrow` covers the missing positive kit ID contract.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.