### PR TITLE
Cover kit availability with legacy item references

### DIFF
--- a/InventoryManagementApp.Tests/KitServiceTests.cs
+++ b/InventoryManagementApp.Tests/KitServiceTests.cs
@@ -227,20 +227,7 @@ namespace InventoryManagementApp.Tests
         [Fact]
         public async Task DeleteKit_WithMissingKit_ShouldThrowWithoutDeletingLegacyKitItems()
         {
-            var builder = new SqliteConnectionStringBuilder(_databaseService.ConnectionString)
-            {
-                ForeignKeys = false
-            };
-
-            using (var conn = new SqliteConnection(builder.ToString()))
-            using (var cmd = conn.CreateCommand())
-            {
-                conn.Open();
-                cmd.CommandText = @"
-                    INSERT INTO KitItems (KitID, ItemID, Quantity, IsOptional)
-                    VALUES (999, 1, 1, 0);";
-                cmd.ExecuteNonQuery();
-            }
+            InsertLegacyKitItem(999, itemID: 1, quantity: 1, isOptional: false);
 
             await Assert.ThrowsAsync<InvalidOperationException>(() => _kitService.DeleteKitAsync(999));
 
@@ -411,6 +398,60 @@ namespace InventoryManagementApp.Tests
             var isAvailable = await _kitService.CheckKitAvailabilityAsync(kitId);
 
             Assert.False(isAvailable);
+        }
+
+        [Fact]
+        public async Task CheckKitAvailability_WithMissingRequiredItemReference_ShouldReturnFalse()
+        {
+            var kit = new Kit
+            {
+                KitNumber = "KIT-015",
+                Name = "Kit with Missing Required Item",
+                IsActive = true
+            };
+            var kitId = await _kitService.CreateKitAsync(kit);
+            InsertLegacyKitItem(kitId, itemID: 999, quantity: 1, isOptional: false);
+
+            var isAvailable = await _kitService.CheckKitAvailabilityAsync(kitId);
+
+            Assert.False(isAvailable);
+        }
+
+        [Fact]
+        public async Task CheckKitAvailability_WithMissingOptionalItemReference_ShouldReturnTrue()
+        {
+            var kit = new Kit
+            {
+                KitNumber = "KIT-016",
+                Name = "Kit with Missing Optional Item",
+                IsActive = true
+            };
+            var kitId = await _kitService.CreateKitAsync(kit);
+            InsertLegacyKitItem(kitId, itemID: 999, quantity: 1, isOptional: true);
+
+            var isAvailable = await _kitService.CheckKitAvailabilityAsync(kitId);
+
+            Assert.True(isAvailable);
+        }
+
+        private void InsertLegacyKitItem(int kitID, int itemID, int quantity, bool isOptional)
+        {
+            var builder = new SqliteConnectionStringBuilder(_databaseService.ConnectionString)
+            {
+                ForeignKeys = false
+            };
+
+            using var conn = new SqliteConnection(builder.ToString());
+            using var cmd = conn.CreateCommand();
+            conn.Open();
+            cmd.CommandText = @"
+                INSERT INTO KitItems (KitID, ItemID, Quantity, IsOptional)
+                VALUES (@KitID, @ItemID, @Quantity, @IsOptional);";
+            cmd.Parameters.AddWithValue("@KitID", kitID);
+            cmd.Parameters.AddWithValue("@ItemID", itemID);
+            cmd.Parameters.AddWithValue("@Quantity", quantity);
+            cmd.Parameters.AddWithValue("@IsOptional", isOptional ? 1 : 0);
+            cmd.ExecuteNonQuery();
         }
 
         private int CountKitItemsForKit(int kitID)

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-kit-availability-legacy-item-tests.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-kit-availability-legacy-item-tests.md
@@ -1,0 +1,10 @@
+# Kit Availability Legacy Item Coverage
+
+## Summary
+- Added focused `KitServiceTests` coverage for legacy kit membership rows whose item references no longer exist.
+- Required missing item references now have behavioral coverage proving `CheckKitAvailabilityAsync` returns `false`.
+- Optional missing item references now have behavioral coverage proving they do not block kit availability.
+- Reused the existing SQLite foreign-key-disabled test setup through a small helper so stale membership rows are created consistently.
+
+## Validation
+- GitHub connector readback/compare should be used for this scheduled run because direct local checkout/raw access, `dotnet`, PowerShell/`pwsh`, `gh`, WPF screenshots, and local banned-word checks are unavailable in the Linux scheduled environment.


### PR DESCRIPTION
## Summary

- Add behavioral coverage for kit availability when legacy kit membership rows reference deleted or missing items.
- Confirm missing required item references make `CheckKitAvailabilityAsync` return `false`.
- Confirm missing optional item references do not block kit availability.
- Reuse a small SQLite foreign-key-disabled helper for stale kit membership setup.

## Why This Matters

Recent kit work guarded missing parent kits before availability and item-listing queries. This follow-up does not extend Admin Settings theme customization; it tightens coverage around the existing kit availability SQL so future changes preserve the required-vs-optional behavior for legacy membership rows.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `KitServiceTests` plus one progress note.
- GitHub connector readback confirmed `CheckKitAvailability_WithMissingRequiredItemReference_ShouldReturnFalse` inserts a stale required kit item and asserts availability is `false`.
- GitHub connector readback confirmed `CheckKitAvailability_WithMissingOptionalItemReference_ShouldReturnTrue` inserts a stale optional kit item and asserts availability remains `true`.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.