### PR TITLE
Cover maintenance and calibration missing item lookups

### DIFF
--- a/InventoryManagementApp.Tests/CalibrationServiceTests.cs
+++ b/InventoryManagementApp.Tests/CalibrationServiceTests.cs
@@ -86,6 +86,22 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task GetCalibrationRecordsByItem_WithMissingItem_ShouldThrow()
+        {
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _calibrationService.GetCalibrationRecordsByItemAsync(999));
+
+            Assert.Equal("Item not found.", ex.Message);
+        }
+
+        [Fact]
+        public async Task GetLatestCalibrationForItem_WithMissingItem_ShouldThrow()
+        {
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _calibrationService.GetLatestCalibrationForItemAsync(999));
+
+            Assert.Equal("Item not found.", ex.Message);
+        }
+
+        [Fact]
         public async Task GetAllCalibrationRecords_ShouldReturnList()
         {
             var record = new CalibrationRecord

--- a/InventoryManagementApp.Tests/MaintenanceServiceTests.cs
+++ b/InventoryManagementApp.Tests/MaintenanceServiceTests.cs
@@ -86,6 +86,14 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public async Task GetMaintenanceRecordsByItem_WithMissingItem_ShouldThrow()
+        {
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _maintenanceService.GetMaintenanceRecordsByItemAsync(999));
+
+            Assert.Equal("Item not found.", ex.Message);
+        }
+
+        [Fact]
         public async Task GetAllMaintenanceRecords_ShouldReturnList()
         {
             var record = new MaintenanceRecord

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-maintenance-calibration-parent-item-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-maintenance-calibration-parent-item-coverage.md
@@ -1,0 +1,15 @@
+# Maintenance And Calibration Parent Item Coverage
+
+Date: 2026-06-27
+
+## Summary
+
+- Added focused service coverage for maintenance item-history lookups when the requested parent item row is missing.
+- Added focused service coverage for calibration item-history and latest-calibration lookups when the requested parent item row is missing.
+- Confirmed these read paths preserve the existing `Item not found.` contract instead of making stale parent selections look like valid empty histories.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
+- GitHub connector readback/compare should be used for branch validation in this environment.


### PR DESCRIPTION
## Summary

- Add behavioral coverage for maintenance item-history lookups when the requested parent item row is missing.
- Add behavioral coverage for calibration item-history and latest-calibration lookups when the requested parent item row is missing.
- Confirm these paths preserve the existing `Item not found.` contract instead of making stale item selections look like valid empty histories.

## Why This Matters

Recent service-boundary work has tightened stale parent-row behavior across reservations, rentals, kits, customers, users, and imports. Maintenance and calibration already perform the right parent-item guard for these read paths; this PR locks that contract down without adding more Admin Settings theme layers.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `MaintenanceServiceTests`, `CalibrationServiceTests`, and one progress note.
- GitHub connector readback confirmed `GetMaintenanceRecordsByItem_WithMissingItem_ShouldThrow` asserts the existing `Item not found.` contract.
- GitHub connector readback confirmed `GetCalibrationRecordsByItem_WithMissingItem_ShouldThrow` and `GetLatestCalibrationForItem_WithMissingItem_ShouldThrow` assert the existing `Item not found.` contract.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.