### PR TITLE
Align active rental count with visible rentals

### DIFF
--- a/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
@@ -84,6 +84,28 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void ActiveRentalCountUsesVisibleRentalProjectionJoins()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+
+            var countMethod = ExtractMethod(
+                source,
+                "public async Task<int> CountActiveRentalsAsync()",
+                "public async Task<List<Rental>> GetActiveRentalsAsync()");
+            AssertContainsAll(
+                countMethod,
+                "SELECT COUNT(r.RentalID)",
+                "FROM Rentals r",
+                "JOIN Items t ON r.ItemID = t.ItemID",
+                "JOIN Customers c ON r.CustomerID = c.CustomerID",
+                "WHERE r.Status='Rented'");
+            Assert.DoesNotContain(
+                "SELECT COUNT(*) FROM Rentals WHERE Status='Rented'",
+                countMethod,
+                StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void RentalFrequencyValidatesPositiveLimitBeforeSqlWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-active-rental-count-projection.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-active-rental-count-projection.md
@@ -1,0 +1,15 @@
+# Active Rental Count Projection Alignment
+
+Date: 2026-06-27
+
+## Summary
+
+- Aligned `RentalService.CountActiveRentalsAsync` with the same item/customer projection used by visible rental list queries.
+- Active rental counts now exclude legacy orphan rows that cannot appear in `GetActiveRentalsAsync`, preventing dashboard count/list drift.
+- Added focused source-contract coverage so the count query keeps the visible rental joins instead of regressing to a raw `Rentals` table count.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
+- GitHub connector readback/compare should be used for branch validation in this environment.

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -324,7 +324,12 @@ namespace InventoryManagementApp.Services.Rentals
         public async Task<int> CountActiveRentalsAsync()
         {
             using var conn = _dbService.CreateConnection();
-            const string sql = "SELECT COUNT(*) FROM Rentals WHERE Status='Rented'";
+            const string sql = @"
+                SELECT COUNT(r.RentalID)
+                FROM Rentals r
+                JOIN Items t ON r.ItemID = t.ItemID
+                JOIN Customers c ON r.CustomerID = c.CustomerID
+                WHERE r.Status='Rented'";
             return Convert.ToInt32(await SqliteHelper.ExecuteScalarAsync(conn, sql).ConfigureAwait(false) ?? 0);
         }
 


### PR DESCRIPTION
## Summary

- Align `RentalService.CountActiveRentalsAsync` with the same item/customer joins used by visible rental list queries.
- Prevent active rental counts from including legacy orphan rental rows that cannot appear in `GetActiveRentalsAsync`.
- Add focused source-contract coverage and a progress note for the active-rental count projection.

## Why This Matters

The dashboard and other summaries can use `CountActiveRentalsAsync`, while visible active rental lists use the shared joined rental projection. A raw `Rentals` count could include stale legacy rows whose item or customer no longer exists, creating count/list drift. This keeps the count aligned with the rows operators can actually see, without extending Admin Settings theme customization.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `RentalService`, `RentalServiceQueryGuardContractTests`, and one progress note.
- GitHub connector readback confirmed `CountActiveRentalsAsync` now counts `r.RentalID` from `Rentals r` joined to `Items` and `Customers`, with `WHERE r.Status='Rented'`.
- GitHub connector readback confirmed `ActiveRentalCountUsesVisibleRentalProjectionJoins` guards the join-based count and rejects the old raw `SELECT COUNT(*) FROM Rentals WHERE Status='Rented'` query.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.