### PR TITLE
Align maintenance and calibration item projections

### DIFF
--- a/InventoryManagementApp.Tests/MaintenanceCalibrationProjectionContractTests.cs
+++ b/InventoryManagementApp.Tests/MaintenanceCalibrationProjectionContractTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class MaintenanceCalibrationProjectionContractTests
+    {
+        [Fact]
+        public void MaintenanceReadModelsRequireExistingItemRows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Maintenance", "MaintenanceService.cs");
+
+            AssertContainsAll(
+                source,
+                "FROM MaintenanceRecords m\n                    JOIN Items i ON m.ItemID = i.ItemID",
+                "public async Task<List<MaintenanceRecord>> GetAllMaintenanceRecordsAsync()",
+                "public async Task<List<MaintenanceRecord>> GetMaintenanceRecordsByItemAsync(int itemID)",
+                "public async Task<List<MaintenanceRecord>> GetOverdueMaintenanceAsync()",
+                "public async Task<List<MaintenanceRecord>> GetUpcomingMaintenanceAsync(int days = 30)",
+                "public async Task<MaintenanceRecord?> GetMaintenanceRecordByIdAsync(int maintenanceID)");
+            Assert.DoesNotContain(
+                "FROM MaintenanceRecords m\n                    LEFT JOIN Items i ON m.ItemID = i.ItemID",
+                source,
+                StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CalibrationReadModelsRequireExistingItemRows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Calibration", "CalibrationService.cs");
+
+            AssertContainsAll(
+                source,
+                "FROM CalibrationRecords c\n                    JOIN Items i ON c.ItemID = i.ItemID",
+                "public async Task<List<CalibrationRecord>> GetAllCalibrationRecordsAsync()",
+                "public async Task<List<CalibrationRecord>> GetCalibrationRecordsByItemAsync(int itemID)",
+                "public async Task<List<CalibrationRecord>> GetOverdueCalibrationAsync()",
+                "public async Task<List<CalibrationRecord>> GetUpcomingCalibrationAsync(int days = 30)",
+                "public async Task<CalibrationRecord?> GetLatestCalibrationForItemAsync(int itemID)",
+                "public async Task<CalibrationRecord?> GetCalibrationRecordByIdAsync(int calibrationID)");
+            Assert.DoesNotContain(
+                "FROM CalibrationRecords c\n                    LEFT JOIN Items i ON c.ItemID = i.ItemID",
+                source,
+                StringComparison.Ordinal);
+        }
+
+        private static void AssertContainsAll(string source, params string[] expectedSnippets)
+        {
+            foreach (var snippet in expectedSnippets)
+            {
+                Assert.Contains(snippet, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-28-maintenance-calibration-item-projections.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-28-maintenance-calibration-item-projections.md
@@ -1,0 +1,13 @@
+# Maintenance and Calibration Item Projection Alignment
+
+## Completed
+
+- Updated maintenance record read projections to require matching item rows instead of returning rows with blank item identity after stale item references.
+- Updated calibration record read projections to require matching item rows for list, item-history, overdue, upcoming, latest, and by-id lookups.
+- Added source-contract coverage so maintenance and calibration read models keep using item joins and do not regress to orphan-visible left joins.
+
+## Validation
+
+- GitHub connector readback/compare should confirm this branch changes only the two services, one focused contract test, and this progress note.
+- Local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.

--- a/InventoryManagementApp/Services/Calibration/CalibrationService.cs
+++ b/InventoryManagementApp/Services/Calibration/CalibrationService.cs
@@ -40,7 +40,7 @@ namespace InventoryManagementApp.Services.Calibration
                 var sql = @"
                     SELECT c.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM CalibrationRecords c
-                    LEFT JOIN Items i ON c.ItemID = i.ItemID
+                    JOIN Items i ON c.ItemID = i.ItemID
                     ORDER BY c.CalibrationDate DESC";
                 using var cmd = new SqliteCommand(sql, conn);
                 using var reader = cmd.ExecuteReader();
@@ -70,7 +70,7 @@ namespace InventoryManagementApp.Services.Calibration
                 var sql = @"
                     SELECT c.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM CalibrationRecords c
-                    LEFT JOIN Items i ON c.ItemID = i.ItemID
+                    JOIN Items i ON c.ItemID = i.ItemID
                     WHERE c.ItemID = @ItemID
                     ORDER BY c.CalibrationDate DESC";
                 using var cmd = new SqliteCommand(sql, conn);
@@ -93,7 +93,7 @@ namespace InventoryManagementApp.Services.Calibration
                 var sql = @"
                     SELECT c.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM CalibrationRecords c
-                    LEFT JOIN Items i ON c.ItemID = i.ItemID
+                    JOIN Items i ON c.ItemID = i.ItemID
                     WHERE c.NextCalibrationDue < @Now
                     ORDER BY c.NextCalibrationDue ASC";
                 using var cmd = new SqliteCommand(sql, conn);
@@ -119,7 +119,7 @@ namespace InventoryManagementApp.Services.Calibration
                 var sql = @"
                     SELECT c.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM CalibrationRecords c
-                    LEFT JOIN Items i ON c.ItemID = i.ItemID
+                    JOIN Items i ON c.ItemID = i.ItemID
                     WHERE c.NextCalibrationDue >= @Now 
                     AND c.NextCalibrationDue <= @FutureDate
                     ORDER BY c.NextCalibrationDue ASC";
@@ -147,7 +147,7 @@ namespace InventoryManagementApp.Services.Calibration
                 var sql = @"
                     SELECT c.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM CalibrationRecords c
-                    LEFT JOIN Items i ON c.ItemID = i.ItemID
+                    JOIN Items i ON c.ItemID = i.ItemID
                     WHERE c.ItemID = @ItemID
                     ORDER BY c.CalibrationDate DESC
                     LIMIT 1";
@@ -173,7 +173,7 @@ namespace InventoryManagementApp.Services.Calibration
                 var sql = @"
                     SELECT c.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM CalibrationRecords c
-                    LEFT JOIN Items i ON c.ItemID = i.ItemID
+                    JOIN Items i ON c.ItemID = i.ItemID
                     WHERE c.CalibrationID = @CalibrationID";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@CalibrationID", calibrationID);

--- a/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
+++ b/InventoryManagementApp/Services/Maintenance/MaintenanceService.cs
@@ -40,7 +40,7 @@ namespace InventoryManagementApp.Services.Maintenance
                 var sql = @"
                     SELECT m.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM MaintenanceRecords m
-                    LEFT JOIN Items i ON m.ItemID = i.ItemID
+                    JOIN Items i ON m.ItemID = i.ItemID
                     ORDER BY m.ScheduledDate DESC";
                 using var cmd = new SqliteCommand(sql, conn);
                 using var reader = cmd.ExecuteReader();
@@ -70,7 +70,7 @@ namespace InventoryManagementApp.Services.Maintenance
                 var sql = @"
                     SELECT m.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM MaintenanceRecords m
-                    LEFT JOIN Items i ON m.ItemID = i.ItemID
+                    JOIN Items i ON m.ItemID = i.ItemID
                     WHERE m.ItemID = @ItemID
                     ORDER BY m.ScheduledDate DESC";
                 using var cmd = new SqliteCommand(sql, conn);
@@ -97,7 +97,7 @@ namespace InventoryManagementApp.Services.Maintenance
                 var sql = @"
                     SELECT m.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM MaintenanceRecords m
-                    LEFT JOIN Items i ON m.ItemID = i.ItemID
+                    JOIN Items i ON m.ItemID = i.ItemID
                     WHERE m.Status = 'Scheduled' AND m.ScheduledDate < @Now
                     ORDER BY m.ScheduledDate ASC";
                 using var cmd = new SqliteCommand(sql, conn);
@@ -123,7 +123,7 @@ namespace InventoryManagementApp.Services.Maintenance
                 var sql = @"
                     SELECT m.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM MaintenanceRecords m
-                    LEFT JOIN Items i ON m.ItemID = i.ItemID
+                    JOIN Items i ON m.ItemID = i.ItemID
                     WHERE m.Status = 'Scheduled' 
                     AND m.ScheduledDate >= @Now 
                     AND m.ScheduledDate <= @FutureDate
@@ -151,7 +151,7 @@ namespace InventoryManagementApp.Services.Maintenance
                 var sql = @"
                     SELECT m.*, i.ItemNumber, i.NameDescription as ItemName
                     FROM MaintenanceRecords m
-                    LEFT JOIN Items i ON m.ItemID = i.ItemID
+                    JOIN Items i ON m.ItemID = i.ItemID
                     WHERE m.MaintenanceID = @MaintenanceID";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@MaintenanceID", maintenanceID);


### PR DESCRIPTION
## Summary

- Change maintenance record read projections from item `LEFT JOIN`s to item `JOIN`s so stale orphan maintenance rows do not appear with blank item identity.
- Change calibration record read projections the same way across list, item-history, overdue, upcoming, latest, and by-id lookups.
- Add focused source-contract coverage and a progress note for the maintenance/calibration item projection contract.

## Why This Matters

Recent service-boundary work made item-specific maintenance and calibration lookups preserve the clear `Item not found.` contract for stale item selections. The broader read models could still surface records whose item row had disappeared, mapping the missing item number/name to blank strings. This keeps visible maintenance and calibration workbench rows aligned with rows that still have a real item identity, without extending Admin Settings theme customization.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and changes only `MaintenanceService`, `CalibrationService`, one focused source-contract test, and one progress note.
- GitHub connector readback confirmed maintenance read projections now use `JOIN Items i ON m.ItemID = i.ItemID` for all/item/overdue/upcoming/by-id read models.
- GitHub connector readback confirmed calibration read projections now use `JOIN Items i ON c.ItemID = i.ItemID` for all/item/overdue/upcoming/latest/by-id read models.
- GitHub connector readback confirmed `MaintenanceCalibrationProjectionContractTests` rejects the old item `LEFT JOIN` projection strings.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.