### PR TITLE
Cover maintenance and calibration orphan read behavior

### DIFF
--- a/InventoryManagementApp.Tests/MaintenanceCalibrationOrphanReadBehaviorTests.cs
+++ b/InventoryManagementApp.Tests/MaintenanceCalibrationOrphanReadBehaviorTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using InventoryManagementApp.Interfaces;
+using InventoryManagementApp.Models.Domain;
+using InventoryManagementApp.Services.Calibration;
+using InventoryManagementApp.Services.Core;
+using InventoryManagementApp.Services.Maintenance;
+using Microsoft.Data.Sqlite;
+using Moq;
+
+namespace InventoryManagementApp.Tests
+{
+    public class MaintenanceCalibrationOrphanReadBehaviorTests
+    {
+        [Fact]
+        public async Task MaintenanceReadModels_WithLegacyMissingItemReference_ShouldHideOrphanRecords()
+        {
+            using var databaseService = CreateDatabaseService("maintenance_orphan_reads");
+            SeedRequiredData(databaseService);
+            var maintenanceService = new MaintenanceService(databaseService, CreateUserContext());
+            var overdueOrphanId = InsertLegacyMaintenanceRecord(databaseService, 999, DateTime.Now.AddDays(-7), "Scheduled");
+            var upcomingOrphanId = InsertLegacyMaintenanceRecord(databaseService, 999, DateTime.Now.AddDays(7), "Scheduled");
+
+            var allRecords = await maintenanceService.GetAllMaintenanceRecordsAsync();
+            var overdueRecords = await maintenanceService.GetOverdueMaintenanceAsync();
+            var upcomingRecords = await maintenanceService.GetUpcomingMaintenanceAsync(30);
+            var overdueById = await maintenanceService.GetMaintenanceRecordByIdAsync(overdueOrphanId);
+            var upcomingById = await maintenanceService.GetMaintenanceRecordByIdAsync(upcomingOrphanId);
+
+            Assert.DoesNotContain(allRecords, record => record.ItemID == 999);
+            Assert.DoesNotContain(overdueRecords, record => record.ItemID == 999);
+            Assert.DoesNotContain(upcomingRecords, record => record.ItemID == 999);
+            Assert.Null(overdueById);
+            Assert.Null(upcomingById);
+        }
+
+        [Fact]
+        public async Task CalibrationReadModels_WithLegacyMissingItemReference_ShouldHideOrphanRecords()
+        {
+            using var databaseService = CreateDatabaseService("calibration_orphan_reads");
+            SeedRequiredData(databaseService);
+            var calibrationService = new CalibrationService(databaseService, CreateUserContext());
+            var overdueOrphanId = InsertLegacyCalibrationRecord(databaseService, 999, DateTime.Now.AddYears(-2), DateTime.Now.AddDays(-7));
+            var upcomingOrphanId = InsertLegacyCalibrationRecord(databaseService, 999, DateTime.Now.AddDays(-7), DateTime.Now.AddDays(7));
+
+            var allRecords = await calibrationService.GetAllCalibrationRecordsAsync();
+            var overdueRecords = await calibrationService.GetOverdueCalibrationAsync();
+            var upcomingRecords = await calibrationService.GetUpcomingCalibrationAsync(30);
+            var overdueById = await calibrationService.GetCalibrationRecordByIdAsync(overdueOrphanId);
+            var upcomingById = await calibrationService.GetCalibrationRecordByIdAsync(upcomingOrphanId);
+
+            Assert.DoesNotContain(allRecords, record => record.ItemID == 999);
+            Assert.DoesNotContain(overdueRecords, record => record.ItemID == 999);
+            Assert.DoesNotContain(upcomingRecords, record => record.ItemID == 999);
+            Assert.Null(overdueById);
+            Assert.Null(upcomingById);
+        }
+
+        private static DatabaseService CreateDatabaseService(string prefix)
+        {
+            return new DatabaseService($"test_{prefix}_{Guid.NewGuid()}.db");
+        }
+
+        private static IUserContext CreateUserContext()
+        {
+            var userContextMock = new Mock<IUserContext>();
+            userContextMock.Setup(x => x.CurrentUser).Returns(new User { UserID = 1, UserName = "TestUser" });
+            return userContextMock.Object;
+        }
+
+        private static void SeedRequiredData(DatabaseService databaseService)
+        {
+            using var conn = databaseService.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"
+                INSERT INTO Users (UserID, UserName, IsAdmin, IsActive) VALUES (1, 'TestUser', 0, 1);
+                INSERT INTO Items (ItemID, ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, IsPowered) VALUES (1, 'ITEM-001', 'Seed Item', 1, 0, 0, 0);";
+            cmd.ExecuteNonQuery();
+        }
+
+        private static int InsertLegacyMaintenanceRecord(DatabaseService databaseService, int itemID, DateTime scheduledDate, string status)
+        {
+            var builder = CreateLegacyConnectionStringBuilder(databaseService);
+
+            using var conn = new SqliteConnection(builder.ToString());
+            using var cmd = conn.CreateCommand();
+            conn.Open();
+            cmd.CommandText = @"
+                INSERT INTO MaintenanceRecords
+                    (ItemID, ScheduledDate, MaintenanceType, Status, Cost, UserID, CreatedAt)
+                VALUES
+                    (@ItemID, @ScheduledDate, @MaintenanceType, @Status, @Cost, @UserID, @CreatedAt);
+                SELECT last_insert_rowid();";
+            cmd.Parameters.AddWithValue("@ItemID", itemID);
+            cmd.Parameters.AddWithValue("@ScheduledDate", scheduledDate);
+            cmd.Parameters.AddWithValue("@MaintenanceType", "Legacy orphan");
+            cmd.Parameters.AddWithValue("@Status", status);
+            cmd.Parameters.AddWithValue("@Cost", 0m);
+            cmd.Parameters.AddWithValue("@UserID", 1);
+            cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now);
+            return Convert.ToInt32(cmd.ExecuteScalar());
+        }
+
+        private static int InsertLegacyCalibrationRecord(DatabaseService databaseService, int itemID, DateTime calibrationDate, DateTime nextCalibrationDue)
+        {
+            var builder = CreateLegacyConnectionStringBuilder(databaseService);
+
+            using var conn = new SqliteConnection(builder.ToString());
+            using var cmd = conn.CreateCommand();
+            conn.Open();
+            cmd.CommandText = @"
+                INSERT INTO CalibrationRecords
+                    (ItemID, CalibrationDate, NextCalibrationDue, Result, Cost, UserID, CreatedAt)
+                VALUES
+                    (@ItemID, @CalibrationDate, @NextCalibrationDue, @Result, @Cost, @UserID, @CreatedAt);
+                SELECT last_insert_rowid();";
+            cmd.Parameters.AddWithValue("@ItemID", itemID);
+            cmd.Parameters.AddWithValue("@CalibrationDate", calibrationDate);
+            cmd.Parameters.AddWithValue("@NextCalibrationDue", nextCalibrationDue);
+            cmd.Parameters.AddWithValue("@Result", "Pass");
+            cmd.Parameters.AddWithValue("@Cost", 0m);
+            cmd.Parameters.AddWithValue("@UserID", 1);
+            cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now);
+            return Convert.ToInt32(cmd.ExecuteScalar());
+        }
+
+        private static SqliteConnectionStringBuilder CreateLegacyConnectionStringBuilder(DatabaseService databaseService)
+        {
+            return new SqliteConnectionStringBuilder(databaseService.ConnectionString)
+            {
+                ForeignKeys = false
+            };
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-maintenance-calibration-orphan-read-tests.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-maintenance-calibration-orphan-read-tests.md
@@ -1,0 +1,11 @@
+# Maintenance and Calibration Orphan Read Coverage
+
+## Completed
+- Added behavioral coverage for legacy maintenance records whose `ItemID` no longer points at an existing item row.
+- Added behavioral coverage for legacy calibration records with missing item references.
+- Covered all, overdue, upcoming, and by-id read paths so orphan maintenance/calibration rows stay hidden from visible workbench projections after the join cleanup.
+
+## Validation Notes
+- The scheduled Linux environment still cannot clone the repository directly because GitHub HTTPS access fails with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and the full validation script are unavailable in this container.
+- GitHub connector readback/compare should be used as fallback validation for this branch.


### PR DESCRIPTION
## Summary

- Add behavioral coverage for legacy maintenance records whose item reference no longer exists.
- Add behavioral coverage for legacy calibration records with missing item references.
- Confirm all, overdue, upcoming, and by-id read paths keep those orphan rows out of visible workbench projections after the recent join cleanup.

## Why This Matters

PR #1369 aligned maintenance and calibration read projections with existing item rows, but the coverage was source-contract only. These tests exercise the legacy-data behavior directly by inserting rows with foreign keys disabled and verifying the operator-facing reads hide those stale records, without extending Admin Settings theme customization.

## Validation

- GitHub connector compare confirmed this branch is current with `master` and adds only `MaintenanceCalibrationOrphanReadBehaviorTests` plus one progress note.
- GitHub connector readback confirmed the maintenance test inserts overdue/upcoming legacy maintenance records with missing `ItemID` references and verifies all, overdue, upcoming, and by-id reads exclude them.
- GitHub connector readback confirmed the calibration test inserts overdue/upcoming legacy calibration records with missing `ItemID` references and verifies all, overdue, upcoming, and by-id reads exclude them.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.