### PR TITLE
Tighten maintenance and calibration orphan read coverage

### DIFF
--- a/InventoryManagementApp.Tests/MaintenanceCalibrationOrphanReadBehaviorTests.cs
+++ b/InventoryManagementApp.Tests/MaintenanceCalibrationOrphanReadBehaviorTests.cs
@@ -14,20 +14,30 @@ namespace InventoryManagementApp.Tests
     public class MaintenanceCalibrationOrphanReadBehaviorTests
     {
         [Fact]
-        public async Task MaintenanceReadModels_WithLegacyMissingItemReference_ShouldHideOrphanRecords()
+        public async Task MaintenanceReadModels_WithLegacyMissingItemReference_ShouldReturnValidRowsAndHideOrphanRecords()
         {
             using var databaseService = CreateDatabaseService("maintenance_orphan_reads");
             SeedRequiredData(databaseService);
             var maintenanceService = new MaintenanceService(databaseService, CreateUserContext());
-            var overdueOrphanId = InsertLegacyMaintenanceRecord(databaseService, 999, DateTime.Now.AddDays(-7), "Scheduled");
-            var upcomingOrphanId = InsertLegacyMaintenanceRecord(databaseService, 999, DateTime.Now.AddDays(7), "Scheduled");
+            var now = DateTime.Now;
+            var validOverdueId = InsertLegacyMaintenanceRecord(databaseService, 1, now.AddDays(-3), "Scheduled");
+            var validUpcomingId = InsertLegacyMaintenanceRecord(databaseService, 1, now.AddDays(3), "Scheduled");
+            var overdueOrphanId = InsertLegacyMaintenanceRecord(databaseService, 999, now.AddDays(-7), "Scheduled");
+            var upcomingOrphanId = InsertLegacyMaintenanceRecord(databaseService, 999, now.AddDays(7), "Scheduled");
 
             var allRecords = await maintenanceService.GetAllMaintenanceRecordsAsync();
             var overdueRecords = await maintenanceService.GetOverdueMaintenanceAsync();
             var upcomingRecords = await maintenanceService.GetUpcomingMaintenanceAsync(30);
+            var validById = await maintenanceService.GetMaintenanceRecordByIdAsync(validOverdueId);
             var overdueById = await maintenanceService.GetMaintenanceRecordByIdAsync(overdueOrphanId);
             var upcomingById = await maintenanceService.GetMaintenanceRecordByIdAsync(upcomingOrphanId);
 
+            Assert.Contains(allRecords, record => record.MaintenanceID == validOverdueId);
+            Assert.Contains(allRecords, record => record.MaintenanceID == validUpcomingId);
+            Assert.Contains(overdueRecords, record => record.MaintenanceID == validOverdueId);
+            Assert.Contains(upcomingRecords, record => record.MaintenanceID == validUpcomingId);
+            Assert.NotNull(validById);
+            Assert.Equal("ITEM-001", validById!.ItemNumber);
             Assert.DoesNotContain(allRecords, record => record.ItemID == 999);
             Assert.DoesNotContain(overdueRecords, record => record.ItemID == 999);
             Assert.DoesNotContain(upcomingRecords, record => record.ItemID == 999);
@@ -36,20 +46,30 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
-        public async Task CalibrationReadModels_WithLegacyMissingItemReference_ShouldHideOrphanRecords()
+        public async Task CalibrationReadModels_WithLegacyMissingItemReference_ShouldReturnValidRowsAndHideOrphanRecords()
         {
             using var databaseService = CreateDatabaseService("calibration_orphan_reads");
             SeedRequiredData(databaseService);
             var calibrationService = new CalibrationService(databaseService, CreateUserContext());
-            var overdueOrphanId = InsertLegacyCalibrationRecord(databaseService, 999, DateTime.Now.AddYears(-2), DateTime.Now.AddDays(-7));
-            var upcomingOrphanId = InsertLegacyCalibrationRecord(databaseService, 999, DateTime.Now.AddDays(-7), DateTime.Now.AddDays(7));
+            var now = DateTime.Now;
+            var validOverdueId = InsertLegacyCalibrationRecord(databaseService, 1, now.AddYears(-2), now.AddDays(-3));
+            var validUpcomingId = InsertLegacyCalibrationRecord(databaseService, 1, now.AddDays(-7), now.AddDays(3));
+            var overdueOrphanId = InsertLegacyCalibrationRecord(databaseService, 999, now.AddYears(-2), now.AddDays(-7));
+            var upcomingOrphanId = InsertLegacyCalibrationRecord(databaseService, 999, now.AddDays(-7), now.AddDays(7));
 
             var allRecords = await calibrationService.GetAllCalibrationRecordsAsync();
             var overdueRecords = await calibrationService.GetOverdueCalibrationAsync();
             var upcomingRecords = await calibrationService.GetUpcomingCalibrationAsync(30);
+            var validById = await calibrationService.GetCalibrationRecordByIdAsync(validOverdueId);
             var overdueById = await calibrationService.GetCalibrationRecordByIdAsync(overdueOrphanId);
             var upcomingById = await calibrationService.GetCalibrationRecordByIdAsync(upcomingOrphanId);
 
+            Assert.Contains(allRecords, record => record.CalibrationID == validOverdueId);
+            Assert.Contains(allRecords, record => record.CalibrationID == validUpcomingId);
+            Assert.Contains(overdueRecords, record => record.CalibrationID == validOverdueId);
+            Assert.Contains(upcomingRecords, record => record.CalibrationID == validUpcomingId);
+            Assert.NotNull(validById);
+            Assert.Equal("ITEM-001", validById!.ItemNumber);
             Assert.DoesNotContain(allRecords, record => record.ItemID == 999);
             Assert.DoesNotContain(overdueRecords, record => record.ItemID == 999);
             Assert.DoesNotContain(upcomingRecords, record => record.ItemID == 999);

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-maintenance-calibration-positive-orphan-coverage.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-maintenance-calibration-positive-orphan-coverage.md
@@ -1,0 +1,11 @@
+# Maintenance and Calibration Positive Orphan Coverage
+
+## Completed
+- Tightened the maintenance orphan-read behavioral test so it now verifies valid joined maintenance rows still appear in all, overdue, upcoming, and by-id read paths while legacy missing-item rows stay hidden.
+- Tightened the calibration orphan-read behavioral test the same way for all, overdue, upcoming, and by-id read paths.
+- Kept the change focused on recent maintenance/calibration validation instead of extending Admin Settings theme customization.
+
+## Validation Notes
+- The scheduled Linux environment still cannot clone the repository directly because GitHub HTTPS access fails with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and the full validation script are unavailable in this container.
+- GitHub connector readback/compare should be used as fallback validation for this branch.


### PR DESCRIPTION
## Summary

- Strengthen the maintenance orphan-read behavior test so it proves valid joined maintenance rows still appear in all, overdue, upcoming, and by-id reads.
- Strengthen the calibration orphan-read behavior test the same way for valid joined calibration rows.
- Keep the existing orphan exclusions in place so legacy missing-item rows remain hidden from visible workbench projections.

## Why This Matters

PR #1370 added behavioral coverage for hiding legacy orphan maintenance/calibration rows after the join cleanup. Those tests could still pass if a future regression made the read paths return no rows at all. This closes that test gap by asserting both sides of the contract: real item-backed records are visible, while stale missing-item records are not.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, two commits ahead, and changes only `MaintenanceCalibrationOrphanReadBehaviorTests` plus one progress note.
- GitHub connector readback confirmed maintenance coverage now inserts valid overdue/upcoming records for `ITEM-001`, asserts all/overdue/upcoming/by-id reads return them, and still excludes orphan `ItemID = 999` rows.
- GitHub connector readback confirmed calibration coverage now inserts valid overdue/upcoming records for `ITEM-001`, asserts all/overdue/upcoming/by-id reads return them, and still excludes orphan `ItemID = 999` rows.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.