### PR TITLE
Align reservation read projections with visible references

### DIFF
--- a/InventoryManagementApp.Tests/ReservationServiceQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationServiceQueryGuardContractTests.cs
@@ -7,6 +7,30 @@ namespace InventoryManagementApp.Tests
     public class ReservationServiceQueryGuardContractTests
     {
         [Fact]
+        public void ReservationReadModelsRequireExistingItemAndCustomerRows()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
+
+            AssertContainsAll(
+                source,
+                "FROM Reservations r\n                    JOIN Items i ON r.ItemID = i.ItemID\n                    JOIN Customers c ON r.CustomerID = c.CustomerID",
+                "public async Task<List<Reservation>> GetAllReservationsAsync()",
+                "public async Task<List<Reservation>> GetActiveReservationsAsync()",
+                "public async Task<List<Reservation>> GetReservationsByItemAsync(int itemID)",
+                "public async Task<List<Reservation>> GetReservationsByCustomerAsync(int customerID)",
+                "public async Task<List<Reservation>> GetUpcomingReservationsAsync(int days = 7)",
+                "public async Task<Reservation?> GetReservationByIdAsync(int reservationID)");
+            Assert.DoesNotContain(
+                "FROM Reservations r\n                    LEFT JOIN Items i ON r.ItemID = i.ItemID",
+                source,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                "LEFT JOIN Customers c ON r.CustomerID = c.CustomerID",
+                source,
+                StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void ReservationHistoryQueriesValidateParentRowsBeforeExecutingHistoryQueries()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-27-reservation-visible-projection-joins.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-27-reservation-visible-projection-joins.md
@@ -1,0 +1,12 @@
+# Reservation Visible Projection Joins
+
+Date: 2026-06-27
+
+## Summary
+- Aligned visible reservation read projections with existing item and customer rows by changing reservation `Items` and `Customers` joins from optional to required joins.
+- Kept the reservation availability overlap query's `LEFT JOIN Reservations` behavior intact so items with no overlapping reservations still evaluate as available.
+- Added source-contract coverage to prevent reservation list, active, item-history, customer-history, upcoming, and by-id reads from returning rows with blank item or customer identity after legacy referenced rows disappear.
+
+## Validation
+- Connector readback/compare should confirm the branch only changes reservation service projection SQL, reservation query-guard coverage, and this progress note.
+- Local .NET test execution remains unavailable in the scheduled Linux environment when `dotnet` is not installed and direct checkout is blocked.

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -40,8 +40,8 @@ namespace InventoryManagementApp.Services.Reservations
                 var sql = @"
                     SELECT r.*, i.ItemNumber, i.NameDescription as ItemName, i.ImagePath, c.Company as CustomerName
                     FROM Reservations r
-                    LEFT JOIN Items i ON r.ItemID = i.ItemID
-                    LEFT JOIN Customers c ON r.CustomerID = c.CustomerID
+                    JOIN Items i ON r.ItemID = i.ItemID
+                    JOIN Customers c ON r.CustomerID = c.CustomerID
                     ORDER BY r.StartDate DESC";
                 using var cmd = new SqliteCommand(sql, conn);
                 using var reader = cmd.ExecuteReader();
@@ -66,8 +66,8 @@ namespace InventoryManagementApp.Services.Reservations
                 var sql = @"
                     SELECT r.*, i.ItemNumber, i.NameDescription as ItemName, i.ImagePath, c.Company as CustomerName
                     FROM Reservations r
-                    LEFT JOIN Items i ON r.ItemID = i.ItemID
-                    LEFT JOIN Customers c ON r.CustomerID = c.CustomerID
+                    JOIN Items i ON r.ItemID = i.ItemID
+                    JOIN Customers c ON r.CustomerID = c.CustomerID
                     WHERE r.Status IN ('Pending', 'Confirmed')
                     ORDER BY r.StartDate ASC";
                 using var cmd = new SqliteCommand(sql, conn);
@@ -98,8 +98,8 @@ namespace InventoryManagementApp.Services.Reservations
                 var sql = @"
                     SELECT r.*, i.ItemNumber, i.NameDescription as ItemName, i.ImagePath, c.Company as CustomerName
                     FROM Reservations r
-                    LEFT JOIN Items i ON r.ItemID = i.ItemID
-                    LEFT JOIN Customers c ON r.CustomerID = c.CustomerID
+                    JOIN Items i ON r.ItemID = i.ItemID
+                    JOIN Customers c ON r.CustomerID = c.CustomerID
                     WHERE r.ItemID = @ItemID
                     ORDER BY r.StartDate DESC";
                 using var cmd = new SqliteCommand(sql, conn);
@@ -126,8 +126,8 @@ namespace InventoryManagementApp.Services.Reservations
                 var sql = @"
                     SELECT r.*, i.ItemNumber, i.NameDescription as ItemName, i.ImagePath, c.Company as CustomerName
                     FROM Reservations r
-                    LEFT JOIN Items i ON r.ItemID = i.ItemID
-                    LEFT JOIN Customers c ON r.CustomerID = c.CustomerID
+                    JOIN Items i ON r.ItemID = i.ItemID
+                    JOIN Customers c ON r.CustomerID = c.CustomerID
                     WHERE r.CustomerID = @CustomerID
                     ORDER BY r.StartDate DESC";
                 using var cmd = new SqliteCommand(sql, conn);
@@ -153,8 +153,8 @@ namespace InventoryManagementApp.Services.Reservations
                 var sql = @"
                     SELECT r.*, i.ItemNumber, i.NameDescription as ItemName, i.ImagePath, c.Company as CustomerName
                     FROM Reservations r
-                    LEFT JOIN Items i ON r.ItemID = i.ItemID
-                    LEFT JOIN Customers c ON r.CustomerID = c.CustomerID
+                    JOIN Items i ON r.ItemID = i.ItemID
+                    JOIN Customers c ON r.CustomerID = c.CustomerID
                     WHERE r.Status IN ('Pending', 'Confirmed')
                     AND r.StartDate <= @FutureDate
                     ORDER BY r.StartDate ASC";
@@ -180,8 +180,8 @@ namespace InventoryManagementApp.Services.Reservations
                 var sql = @"
                     SELECT r.*, i.ItemNumber, i.NameDescription as ItemName, i.ImagePath, c.Company as CustomerName
                     FROM Reservations r
-                    LEFT JOIN Items i ON r.ItemID = i.ItemID
-                    LEFT JOIN Customers c ON r.CustomerID = c.CustomerID
+                    JOIN Items i ON r.ItemID = i.ItemID
+                    JOIN Customers c ON r.CustomerID = c.CustomerID
                     WHERE r.ReservationID = @ReservationID";
                 using var cmd = new SqliteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@ReservationID", reservationID);


### PR DESCRIPTION
## Summary

- Change visible reservation read projections from optional item/customer joins to required joins.
- Keep reservation list, active, item-history, customer-history, upcoming, and by-id rows aligned with reservations that still have real item and customer identity.
- Add source-contract coverage plus a progress note for the reservation projection contract.

## Why This Matters

Recent service work has tightened stale-row behavior across rentals, maintenance, calibration, kits, and reservation parent lookups. Reservation visible reads could still surface legacy rows whose item or customer row had disappeared, mapping missing identity fields to blank strings. This keeps operator-facing reservation rows consistent with the parent-row validation already used by reservation history and write paths, without extending Admin Settings theme customization.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `ReservationService`, one reservation query-guard test file, and one progress note.
- GitHub connector readback confirmed `GetAllReservationsAsync`, `GetActiveReservationsAsync`, `GetReservationsByItemAsync`, `GetReservationsByCustomerAsync`, `GetUpcomingReservationsAsync`, and `GetReservationByIdAsync` now use `JOIN Items` and `JOIN Customers` for visible reservation projections.
- GitHub connector readback confirmed the availability overlap query still keeps its intentional `LEFT JOIN Reservations` behavior.
- GitHub connector readback confirmed `ReservationReadModelsRequireExistingItemAndCustomerRows` guards the required projection joins and rejects the old `LEFT JOIN Items` / `LEFT JOIN Customers` reservation read contract.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.