### PR TITLE
Align reservation availability with visible holds

### DIFF
--- a/InventoryManagementApp.Tests/ReservationOrphanReadBehaviorTests.cs
+++ b/InventoryManagementApp.Tests/ReservationOrphanReadBehaviorTests.cs
@@ -53,6 +53,24 @@ namespace InventoryManagementApp.Tests
             Assert.Null(missingCustomerById);
         }
 
+        [Fact]
+        public async Task CheckAvailability_WithLegacyMissingCustomerHold_ShouldIgnoreInvisibleReservationAndCountValidHold()
+        {
+            using var databaseService = CreateDatabaseService("reservation_availability_orphan_customer");
+            SeedRequiredData(databaseService);
+            var reservationService = new ReservationService(databaseService, CreateUserContext());
+            var startDate = DateTime.Today.AddDays(1);
+            var endDate = DateTime.Today.AddDays(3);
+            InsertLegacyReservation(databaseService, 1, 999, startDate, endDate, "Pending");
+
+            var availableWithOnlyInvisibleHold = await reservationService.CheckAvailabilityAsync(1, startDate, endDate, 1);
+            InsertLegacyReservation(databaseService, 1, 1, startDate, endDate, "Confirmed");
+            var availableWithValidHold = await reservationService.CheckAvailabilityAsync(1, startDate, endDate, 1);
+
+            Assert.True(availableWithOnlyInvisibleHold);
+            Assert.False(availableWithValidHold);
+        }
+
         private static DatabaseService CreateDatabaseService(string prefix)
         {
             return new DatabaseService($"test_{prefix}_{Guid.NewGuid()}.db");

--- a/InventoryManagementApp.Tests/ReservationServiceQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/ReservationServiceQueryGuardContractTests.cs
@@ -101,6 +101,24 @@ namespace InventoryManagementApp.Tests
                 "Expected reservation availability checks to confirm the item row exists before building/executing the availability query.");
         }
 
+        [Fact]
+        public void ReservationAvailabilityCountsOnlyVisibleCustomerBackedHolds()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Reservations", "ReservationService.cs");
+
+            var availabilityMethod = ExtractMethod(
+                source,
+                "public async Task<bool> CheckAvailabilityAsync(int itemID, DateTime startDate, DateTime endDate, int quantity)",
+                "private Reservation MapReservation");
+
+            AssertContainsAll(
+                availabilityMethod,
+                "LEFT JOIN Reservations r ON i.ItemID = r.ItemID",
+                "AND r.Status IN ('Pending', 'Confirmed')",
+                "AND EXISTS (SELECT 1 FROM Customers c WHERE c.CustomerID = r.CustomerID)",
+                "COALESCE(SUM(r.Quantity), 0) as ReservedQuantity");
+        }
+
         private static void AssertContainsAll(string source, params string[] expectedSnippets)
         {
             foreach (var snippet in expectedSnippets)

--- a/InventoryManagementApp/ProgressNotes/2026-06-28-reservation-availability-visible-holds.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-28-reservation-availability-visible-holds.md
@@ -1,0 +1,15 @@
+# Reservation Availability Visible Hold Alignment
+
+## Completed
+- Updated `ReservationService.CheckAvailabilityAsync` so the reservation overlap calculation only counts pending or confirmed reservations that still have an existing customer row.
+- Preserved the item-side availability guard and the intentional `LEFT JOIN Reservations` shape so items with no holds can still return available stock.
+- Added database-backed coverage proving a legacy missing-customer reservation no longer blocks availability, while a valid customer-backed hold still blocks the same quantity.
+- Added source-contract coverage for the customer-backed hold filter in the availability query.
+
+## Why
+Visible reservation reads now require both item and customer rows. Without this follow-up, a legacy reservation whose customer was deleted could stay invisible to operators but still consume availability in `CheckAvailabilityAsync`. This keeps availability decisions aligned with the reservations the app can actually show and manage.
+
+## Validation Notes
+- Local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
+- Validation for this pass is limited to GitHub connector readback/compare and source review.

--- a/InventoryManagementApp/Services/Reservations/ReservationService.cs
+++ b/InventoryManagementApp/Services/Reservations/ReservationService.cs
@@ -366,6 +366,7 @@ namespace InventoryManagementApp.Services.Reservations
                     LEFT JOIN Reservations r ON i.ItemID = r.ItemID
                         AND r.Status IN ('Pending', 'Confirmed')
                         AND ((r.StartDate <= @EndDate AND r.EndDate >= @StartDate))
+                        AND EXISTS (SELECT 1 FROM Customers c WHERE c.CustomerID = r.CustomerID)
                     WHERE i.ItemID = @ItemID
                     GROUP BY i.ItemID, i.AvailableQuantity";
                 using var cmd = new SqliteCommand(sql, conn);


### PR DESCRIPTION
## Summary

- Update `ReservationService.CheckAvailabilityAsync` so overlap counts only include pending/confirmed reservations whose customer row still exists.
- Keep the item-side availability guard and intentional `LEFT JOIN Reservations` behavior for items with no holds.
- Add database-backed coverage for missing-customer legacy holds plus source-contract coverage for the customer-backed availability filter.

## Why This Matters

Recent reservation read work now hides legacy reservations whose item or customer reference no longer exists. Availability could still count an invisible missing-customer reservation against stock, creating a mismatch where operators cannot see or manage the hold that blocks availability. This keeps availability decisions aligned with visible reservation records without extending the Admin Settings theme system.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, four commits ahead, and changes only `ReservationService`, reservation orphan behavior tests, reservation query-guard tests, and one progress note.
- GitHub connector readback confirmed `CheckAvailabilityAsync` now keeps the `LEFT JOIN Reservations` overlap query but adds an existing-customer filter for counted holds.
- GitHub connector readback confirmed the behavioral test asserts a missing-customer legacy hold does not block availability, while a valid customer-backed hold does block the same quantity.
- GitHub connector readback confirmed source-contract coverage guards the visible customer-backed hold filter.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.