### PR TITLE
Align rental frequency with visible rentals

### DIFF
--- a/InventoryManagementApp.Tests/RentalFrequencyOrphanBehaviorTests.cs
+++ b/InventoryManagementApp.Tests/RentalFrequencyOrphanBehaviorTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading.Tasks;
+using InventoryManagementApp.Services.Core;
+using InventoryManagementApp.Services.Rentals;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class RentalFrequencyOrphanBehaviorTests
+    {
+        [Fact]
+        public async Task RentalFrequency_WithLegacyMissingReferences_ShouldCountOnlyVisibleCustomerBackedRentals()
+        {
+            using var databaseService = CreateDatabaseService("rental_frequency_orphan_reads");
+            SeedRequiredData(databaseService);
+            var rentalService = new RentalService(databaseService);
+            var rentalDate = DateTime.Today.AddDays(-7);
+            var dueDate = DateTime.Today.AddDays(-1);
+
+            InsertLegacyRental(databaseService, 1, 1, rentalDate, dueDate, "Returned");
+            InsertLegacyRental(databaseService, 1, 999, rentalDate, dueDate, "Returned");
+            InsertLegacyRental(databaseService, 999, 1, rentalDate, dueDate, "Returned");
+
+            var frequencies = await rentalService.GetRentalFrequencyAsync(10);
+
+            var frequency = Assert.Single(frequencies);
+            Assert.Equal(1, frequency.ItemID);
+            Assert.Equal("ITEM-001", frequency.ItemNumber);
+            Assert.Equal(1, frequency.RentalCount);
+        }
+
+        private static DatabaseService CreateDatabaseService(string prefix)
+        {
+            return new DatabaseService($"test_{prefix}_{Guid.NewGuid()}.db");
+        }
+
+        private static void SeedRequiredData(DatabaseService databaseService)
+        {
+            using var conn = databaseService.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"
+                INSERT INTO Items (ItemID, ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, ImagePath, IsPowered) VALUES (1, 'ITEM-001', 'Seed Item', 1, 0, 1, 'Assets/ItemImages/ITEM-001.png', 0);
+                INSERT INTO Customers (CustomerID, Company, Contact) VALUES (1, 'Seed Customer', 'Primary Contact');";
+            cmd.ExecuteNonQuery();
+        }
+
+        private static int InsertLegacyRental(
+            DatabaseService databaseService,
+            int itemID,
+            int customerID,
+            DateTime rentalDate,
+            DateTime dueDate,
+            string status)
+        {
+            var builder = new SqliteConnectionStringBuilder(databaseService.ConnectionString)
+            {
+                ForeignKeys = false
+            };
+
+            using var conn = new SqliteConnection(builder.ToString());
+            using var cmd = conn.CreateCommand();
+            conn.Open();
+            cmd.CommandText = @"
+                INSERT INTO Rentals
+                    (ItemID, CustomerID, RentalDate, DueDate, Status)
+                VALUES
+                    (@ItemID, @CustomerID, @RentalDate, @DueDate, @Status);
+                SELECT last_insert_rowid();";
+            cmd.Parameters.AddWithValue("@ItemID", itemID);
+            cmd.Parameters.AddWithValue("@CustomerID", customerID);
+            cmd.Parameters.AddWithValue("@RentalDate", rentalDate);
+            cmd.Parameters.AddWithValue("@DueDate", dueDate);
+            cmd.Parameters.AddWithValue("@Status", status);
+            return Convert.ToInt32(cmd.ExecuteScalar());
+        }
+    }
+}

--- a/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceQueryGuardContractTests.cs
@@ -123,6 +123,24 @@ namespace InventoryManagementApp.Tests
                 "Expected rental frequency to validate the limit before building/executing SQL.");
         }
 
+        [Fact]
+        public void RentalFrequencyCountsOnlyCustomerBackedVisibleRentals()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+
+            var frequencyMethod = ExtractMethod(
+                source,
+                "public async Task<List<ItemRentalFrequency>> GetRentalFrequencyAsync(int topN = 10)",
+                "private static async Task<int> GetAvailableQuantityForExistingItemAsync");
+            AssertContainsAll(
+                frequencyMethod,
+                "SELECT t.ItemID, t.ItemNumber, t.NameDescription, COUNT(r.RentalID) AS RentalCount",
+                "FROM Items t",
+                "LEFT JOIN Rentals r ON t.ItemID = r.ItemID",
+                "AND EXISTS (SELECT 1 FROM Customers c WHERE c.CustomerID = r.CustomerID)",
+                "HAVING RentalCount > 0");
+        }
+
         private static void AssertContainsAll(string source, params string[] expectedSnippets)
         {
             foreach (var snippet in expectedSnippets)

--- a/InventoryManagementApp/ProgressNotes/2026-06-28-rental-frequency-visible-counts.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-28-rental-frequency-visible-counts.md
@@ -1,0 +1,15 @@
+# Rental Frequency Visible Count Alignment
+
+## Completed
+- Updated `RentalService.GetRentalFrequencyAsync` so rental frequency counts only include rentals whose customer row still exists.
+- Preserved the item-side `LEFT JOIN Rentals` shape so frequency rows still start from real items and exclude items with no counted rental history.
+- Added source-contract coverage for the customer-backed rental frequency filter.
+- Added database-backed coverage proving legacy missing-customer and missing-item rental rows do not inflate visible item frequency counts.
+
+## Why
+Visible rental reads now require both item and customer rows. Without this follow-up, rental frequency reporting could count a legacy rental whose customer was deleted even though operators cannot see that rental in the rental lists or histories. This keeps reporting counts aligned with the rentals the app can display and manage.
+
+## Validation Notes
+- Local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
+- Validation for this pass is limited to GitHub connector readback/compare and source review.

--- a/InventoryManagementApp/Services/Rentals/RentalService.cs
+++ b/InventoryManagementApp/Services/Rentals/RentalService.cs
@@ -394,6 +394,7 @@ namespace InventoryManagementApp.Services.Rentals
                 SELECT t.ItemID, t.ItemNumber, t.NameDescription, COUNT(r.RentalID) AS RentalCount
                 FROM Items t
                 LEFT JOIN Rentals r ON t.ItemID = r.ItemID
+                    AND EXISTS (SELECT 1 FROM Customers c WHERE c.CustomerID = r.CustomerID)
                 GROUP BY t.ItemID, t.ItemNumber, t.NameDescription
                 HAVING RentalCount > 0
                 ORDER BY RentalCount DESC


### PR DESCRIPTION
## Summary

- Update `RentalService.GetRentalFrequencyAsync` so rental counts ignore legacy rental rows whose customer row no longer exists.
- Preserve the item-side `LEFT JOIN Rentals` frequency shape while adding the customer-backed visibility filter.
- Add source-contract coverage plus database-backed coverage for missing-customer and missing-item legacy rental rows.

## Why This Matters

Recent rental read and count work now requires both item and customer rows for visible rental projections. Rental frequency could still count a legacy rental whose customer was deleted, inflating demand reporting for records operators cannot see in rental lists or histories. This keeps frequency reporting aligned with visible/manageable rental records without extending the Admin Settings theme system.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, four commits ahead, and changes only `RentalService`, rental query-guard coverage, one rental frequency orphan behavior test, and one progress note.
- GitHub connector readback confirmed `GetRentalFrequencyAsync` keeps the item-side `LEFT JOIN Rentals` query while adding an existing-customer filter to counted rental rows.
- GitHub connector readback confirmed source-contract coverage guards the customer-backed rental frequency filter.
- GitHub connector readback confirmed the database-backed test seeds a valid rental, a missing-customer rental, and a missing-item rental, then asserts only the visible customer-backed rental contributes to item frequency.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.