### PR TITLE
Cover rental write guard contracts

### DIFF
--- a/InventoryManagementApp.Tests/RentalServiceWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceWriteGuardContractTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class RentalServiceWriteGuardContractTests
+    {
+        [Fact]
+        public void RentalWritesThrowWhenNoRowsAreAffected()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Rentals", "RentalService.cs");
+
+            var returnMethod = ExtractMethod(
+                source,
+                "public async Task ReturnItemAsync(int rentalID, DateTime returnDate)",
+                "public async Task ExtendRentalAsync");
+            AssertContainsAll(
+                returnMethod,
+                "var returnedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, tx,",
+                "if (returnedRows == 0)",
+                "throw new InvalidOperationException(\"Rental not found or already returned.\");",
+                "await _itemService.UpdateItemQuantitiesAsync(itemID, 1, false, conn, tx);");
+            Assert.True(
+                returnMethod.IndexOf("var returnedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, tx,", StringComparison.Ordinal) <
+                returnMethod.IndexOf("if (returnedRows == 0)", StringComparison.Ordinal),
+                "Expected return writes to inspect affected rows after executing the update.");
+            Assert.True(
+                returnMethod.IndexOf("if (returnedRows == 0)", StringComparison.Ordinal) <
+                returnMethod.IndexOf("await _itemService.UpdateItemQuantitiesAsync(itemID, 1, false, conn, tx);", StringComparison.Ordinal),
+                "Expected stale return writes to fail before inventory quantity sync.");
+
+            var extendMethod = ExtractMethod(
+                source,
+                "public async Task ExtendRentalAsync",
+                "public async Task DeleteRentalAsync");
+            AssertContainsAll(
+                extendMethod,
+                "if (await updateCmd.ExecuteNonQueryAsync() == 0)",
+                "throw new InvalidOperationException(\"Unable to extend rental. Rental not found or already returned.\");");
+
+            var deleteMethod = ExtractMethod(
+                source,
+                "public async Task DeleteRentalAsync",
+                "public async Task<int> CountActiveRentalsAsync");
+            AssertContainsAll(
+                deleteMethod,
+                "var deletedRows = await deleteCmd.ExecuteNonQueryAsync();",
+                "if (deletedRows == 0)",
+                "throw new InvalidOperationException(\"Rental not found.\");",
+                "await _itemService.UpdateItemQuantitiesAsync(itemID, 1, false, conn, tx);");
+            Assert.True(
+                deleteMethod.IndexOf("var deletedRows = await deleteCmd.ExecuteNonQueryAsync();", StringComparison.Ordinal) <
+                deleteMethod.IndexOf("if (deletedRows == 0)", StringComparison.Ordinal),
+                "Expected delete writes to inspect affected rows after executing the delete.");
+            Assert.True(
+                deleteMethod.IndexOf("if (deletedRows == 0)", StringComparison.Ordinal) <
+                deleteMethod.IndexOf("await _itemService.UpdateItemQuantitiesAsync(itemID, 1, false, conn, tx);", StringComparison.Ordinal),
+                "Expected stale delete writes to fail before inventory quantity sync.");
+        }
+
+        private static void AssertContainsAll(string source, params string[] expectedSnippets)
+        {
+            foreach (var snippet in expectedSnippets)
+            {
+                Assert.Contains(snippet, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-28-rental-write-guard-contracts.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-28-rental-write-guard-contracts.md
@@ -1,0 +1,14 @@
+# Rental Write Guard Contract Coverage
+
+## Completed
+- Added source-contract coverage for `RentalService` return, extend, and delete write guards.
+- Locked in the existing stale-write behavior so no-op return and delete writes throw before inventory quantity synchronization can run.
+- Locked in the existing extend behavior so stale or already-returned rentals fail instead of silently reporting success.
+
+## Why
+Recent service-boundary work has added affected-row guard coverage for reservations, kits, customers, and users. Rental writes already contain the same important stale-row checks, but they were not covered by a focused source contract. This closes that regression gap without adding another Admin Settings theme customization layer.
+
+## Validation Notes
+- Local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
+- Validation for this pass is limited to GitHub connector readback/compare and source review.


### PR DESCRIPTION
## Summary

- Add source-contract coverage for `RentalService` return, extend, and delete stale-write guards.
- Confirm return/delete no-op writes throw before item quantity synchronization can run.
- Record the focused service-boundary coverage pass in progress notes.

## Why This Matters

Recent service-boundary work added affected-row guard coverage for reservations, kits, customers, and users. Rental writes already contain the same important stale-write checks, but they lacked a focused contract test. This closes a regression gap around recently reviewed code without extending the Admin Settings theme system.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, two commits ahead, and changes only `RentalServiceWriteGuardContractTests` plus one progress note.
- GitHub connector readback confirmed the new contract test checks return, extend, and delete no-op write guards.
- GitHub connector readback confirmed return/delete stale-write guards are asserted before `_itemService.UpdateItemQuantitiesAsync(...)` inventory synchronization.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.