### PR TITLE
[codex] Cover active rental count orphan behavior

### DIFF
--- a/InventoryManagementApp.Tests/ActiveRentalCountOrphanBehaviorTests.cs
+++ b/InventoryManagementApp.Tests/ActiveRentalCountOrphanBehaviorTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Threading.Tasks;
+using InventoryManagementApp.Services.Core;
+using InventoryManagementApp.Services.Rentals;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ActiveRentalCountOrphanBehaviorTests
+    {
+        [Fact]
+        public async Task CountActiveRentals_WithLegacyMissingReferences_ShouldCountOnlyVisibleActiveRentals()
+        {
+            using var databaseService = CreateDatabaseService("active_rental_count_orphan_reads");
+            SeedRequiredData(databaseService);
+            var rentalService = new RentalService(databaseService);
+            var rentalDate = DateTime.Today.AddDays(-7);
+            var dueDate = DateTime.Today.AddDays(7);
+
+            InsertLegacyRental(databaseService, 1, 1, rentalDate, dueDate, "Rented");
+            InsertLegacyRental(databaseService, 1, 999, rentalDate, dueDate, "Rented");
+            InsertLegacyRental(databaseService, 999, 1, rentalDate, dueDate, "Rented");
+            InsertLegacyRental(databaseService, 1, 1, rentalDate, dueDate, "Returned");
+
+            var activeRentalCount = await rentalService.CountActiveRentalsAsync();
+
+            Assert.Equal(1, activeRentalCount);
+        }
+
+        private static DatabaseService CreateDatabaseService(string prefix)
+        {
+            return new DatabaseService($"test_{prefix}_{Guid.NewGuid()}.db");
+        }
+
+        private static void SeedRequiredData(DatabaseService databaseService)
+        {
+            using var conn = databaseService.CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"
+                INSERT INTO Items (ItemID, ItemNumber, NameDescription, AvailableQuantity, RentedQuantity, IsRentalItem, ImagePath, IsPowered) VALUES (1, 'ITEM-001', 'Seed Item', 1, 0, 1, 'Assets/ItemImages/ITEM-001.png', 0);
+                INSERT INTO Customers (CustomerID, Company, Contact) VALUES (1, 'Seed Customer', 'Primary Contact');";
+            cmd.ExecuteNonQuery();
+        }
+
+        private static int InsertLegacyRental(
+            DatabaseService databaseService,
+            int itemID,
+            int customerID,
+            DateTime rentalDate,
+            DateTime dueDate,
+            string status)
+        {
+            var builder = new SqliteConnectionStringBuilder(databaseService.ConnectionString)
+            {
+                ForeignKeys = false
+            };
+
+            using var conn = new SqliteConnection(builder.ToString());
+            using var cmd = conn.CreateCommand();
+            conn.Open();
+            cmd.CommandText = @"
+                INSERT INTO Rentals
+                    (ItemID, CustomerID, RentalDate, DueDate, Status)
+                VALUES
+                    (@ItemID, @CustomerID, @RentalDate, @DueDate, @Status);
+                SELECT last_insert_rowid();";
+            cmd.Parameters.AddWithValue("@ItemID", itemID);
+            cmd.Parameters.AddWithValue("@CustomerID", customerID);
+            cmd.Parameters.AddWithValue("@RentalDate", rentalDate);
+            cmd.Parameters.AddWithValue("@DueDate", dueDate);
+            cmd.Parameters.AddWithValue("@Status", status);
+            return Convert.ToInt32(cmd.ExecuteScalar());
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-28-active-rental-count-orphan-behavior.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-28-active-rental-count-orphan-behavior.md
@@ -1,0 +1,11 @@
+# Active Rental Count Orphan Behavior Coverage
+
+## Summary
+- Added database-backed coverage for active rental counts when legacy rental rows reference deleted or missing items/customers.
+- Confirmed `CountActiveRentalsAsync` counts only active rentals that still have visible item and customer rows.
+- Confirmed returned rentals remain excluded from the active count while orphan active rows do not inflate dashboard/summary totals.
+
+## Validation
+- Direct local clone/raw access is blocked in the scheduled environment with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF screenshots, local banned-word checks, and the full validation runner are unavailable here.
+- Intended validation is GitHub connector readback/compare plus PR status/workflow readback before merge.


### PR DESCRIPTION
## Summary

- Add database-backed coverage for `RentalService.CountActiveRentalsAsync` with legacy missing item/customer rental rows.
- Confirm only active rentals that still have visible item and customer rows contribute to the active rental count.
- Record the focused coverage pass in progress notes.

## Why This Matters

PR #1368 aligned active rental counts with visible rental projections using item/customer joins, but the coverage was source-contract only. This adds behavioral coverage with seeded legacy data so future changes cannot accidentally inflate dashboard/summary active counts with rental rows operators cannot see or manage.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, two commits ahead, and changes only `ActiveRentalCountOrphanBehaviorTests` plus one progress note.
- GitHub connector readback confirmed the test seeds one valid active rental, missing-customer and missing-item active rentals, plus a returned rental, then expects `CountActiveRentalsAsync()` to return `1`.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.