### PR TITLE
Align activity log reports with result value contract

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceActivityLogContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceActivityLogContractTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ReportServiceActivityLogContractTests
+    {
+        [Fact]
+        public void ActivityLogReportUsesCanonicalResultValueCollection()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
+
+            var method = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateActivityLogReport()",
+                "public async Task<FlowDocument> GenerateCustomerReport()");
+
+            Assert.Contains("var result = await _activityLogService.GetRecentLogsAsync(100).ConfigureAwait(false);", method, StringComparison.Ordinal);
+            Assert.Contains("result?.Success == true && result.Value != null", method, StringComparison.Ordinal);
+            Assert.Contains("? result.Value", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("result?.Data", method, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-28-activity-log-report-result-value.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-28-activity-log-report-result-value.md
@@ -1,0 +1,14 @@
+# Activity Log Report Result Contract
+
+## Summary
+- Updated `ReportService.GenerateActivityLogReport` to read recent activity from the canonical `Result<T>.Value` collection instead of the legacy activity-log-specific `Data` property.
+- Kept failed or empty activity-log reads safe by falling back to an empty report line collection.
+- Added source-contract coverage so the activity-log report stays aligned with the same result contract used by the dashboard.
+
+## Why
+The dashboard already reads recent activity from `Result<T>.Value`, while the activity-log report used `Data`. Keeping reports on the canonical result contract reduces the chance that activity-log reports silently render empty output when service callers only populate `Value`.
+
+## Validation Notes
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
+- Validation for this pass is limited to GitHub connector readback/compare and PR status/workflow readback.

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -90,7 +90,9 @@ namespace InventoryManagementApp.Services.Items
         public async Task<FlowDocument> GenerateActivityLogReport()
         {
             var result = await _activityLogService.GetRecentLogsAsync(100).ConfigureAwait(false);
-            var logs = result?.Data ?? new List<ActivityLog>();
+            var logs = result?.Success == true && result.Value != null
+                ? result.Value
+                : new List<ActivityLog>();
             var lines = logs.Select(l =>
                 $"LogID: {l.LogID} | UserID: {l.UserID} | User: {l.UserName} | Action: {l.Action} | Timestamp: {l.Timestamp:yyyy-MM-dd HH:mm:ss}");
             return BuildReport("Activity Log Report", lines);


### PR DESCRIPTION
## Summary

- Update `ReportService.GenerateActivityLogReport` to read recent activity from the canonical `Result<T>.Value` collection.
- Preserve a safe empty report when the recent-activity read fails or returns no value.
- Add source-contract coverage guarding the report against falling back to the legacy activity-log-specific `Data` property.

## Why This Matters

The dashboard already consumes recent activity through `Result<T>.Value`, while the activity-log report was still reading `Data`. Aligning the report with the canonical result contract reduces the chance that activity-log reports silently render empty output when the service result only populates `Value`.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `ReportService`, one source-contract test, and one progress note.
- GitHub connector readback confirmed `GenerateActivityLogReport` now gates on `result?.Success == true && result.Value != null`, then renders from `result.Value`.
- GitHub connector readback confirmed `ReportServiceActivityLogContractTests` guards the canonical `Value` usage and rejects `result?.Data` in the report method.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.