### PR TITLE
Remove legacy result data contract

### DIFF
--- a/InventoryManagementApp.Tests/ResultModelContractTests.cs
+++ b/InventoryManagementApp.Tests/ResultModelContractTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ResultModelContractTests
+    {
+        [Fact]
+        public void GenericResultUsesCanonicalValueOnly()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Models", "Result.cs");
+
+            Assert.Contains("public record Result<T>(T? Value, bool Success, string? ErrorMessage = null)", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("List<ActivityLog>", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("Data {", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("using InventoryManagementApp.Models.Domain;", source, StringComparison.Ordinal);
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/Models/Result.cs
+++ b/InventoryManagementApp/Models/Result.cs
@@ -1,12 +1,7 @@
-using InventoryManagementApp.Models.Domain;
-
 namespace InventoryManagementApp.Models
 {
     public record Result(bool Success, string? ErrorMessage = null);
 
     public record Result<T>(T? Value, bool Success, string? ErrorMessage = null)
-        : Result(Success, ErrorMessage)
-    {
-        public List<ActivityLog>? Data { get; internal set; }
-    }
+        : Result(Success, ErrorMessage);
 }

--- a/InventoryManagementApp/ProgressNotes/2026-06-28-result-value-contract-cleanup.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-28-result-value-contract-cleanup.md
@@ -1,0 +1,14 @@
+# Result Value Contract Cleanup
+
+## Summary
+- Removed the legacy activity-log-specific `Data` property from the generic `Result<T>` model.
+- Kept `Result<T>` focused on the canonical `Value`, `Success`, and `ErrorMessage` contract used by current service callers.
+- Added source-contract coverage so the shared result model does not regain activity-log-specific coupling.
+
+## Why
+The activity-log report now reads recent logs through `Result<T>.Value`, and `ActivityLogService.GetRecentLogsAsync` returns that canonical value directly. Leaving an unused `Data` escape hatch in the shared result type kept a misleading second contract alive and tied every generic result to `ActivityLog`.
+
+## Validation Notes
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
+- Validation for this pass is limited to GitHub connector readback/compare and PR status/workflow readback.


### PR DESCRIPTION
## Summary

- Remove the legacy activity-log-specific `Data` property from the shared `Result<T>` model.
- Keep generic results focused on the canonical `Value`, `Success`, and `ErrorMessage` contract now used by activity-log reports and service callers.
- Add source-contract coverage plus a progress note so activity-log-specific coupling does not return to the shared result model.

## Why This Matters

PR #1379 moved activity-log report generation to the canonical `Result<T>.Value` collection, and `ActivityLogService.GetRecentLogsAsync` already returns recent logs through `Value`. Keeping an activity-log-only `Data` property in every generic result kept a misleading second contract alive and tied the shared result model to `ActivityLog` unnecessarily.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `Result.cs`, one source-contract test, and one progress note.
- GitHub connector readback confirmed `Result<T>` now exposes the canonical positional `Value`, `Success`, and `ErrorMessage` contract without the activity-log-specific `Data` property or domain-model using.
- GitHub connector readback confirmed `ResultModelContractTests` guards the canonical result contract and rejects `List<ActivityLog>`, `Data {`, and the activity-log domain using in `Result.cs`.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw/API access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403` / HTTP 403.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.