### PR TITLE
Polish generated report item labels

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceUserFacingLabelContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceUserFacingLabelContractTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ReportServiceUserFacingLabelContractTests
+    {
+        [Fact]
+        public void InventoryAndRentalReportsUseUserFacingItemLabels()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
+
+            var inventoryReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateInventoryReport()",
+                "public async Task<FlowDocument> GenerateRentalReport(bool activeOnly = true)");
+            var rentalReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateRentalReport(bool activeOnly = true)",
+                "public async Task<FlowDocument> GenerateRentalFrequencyReport(int topN = 20)");
+
+            Assert.Contains("BuildReport(\"Inventory Report\", lines)", inventoryReport, StringComparison.Ordinal);
+            Assert.Contains("Item ID: {t.ItemID}", inventoryReport, StringComparison.Ordinal);
+            Assert.Contains("Item ID: {r.ItemID}", rentalReport, StringComparison.Ordinal);
+
+            Assert.DoesNotContain("ItemModel Inventory Report", inventoryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("ItemModel ID:", inventoryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("ItemModel ID:", rentalReport, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-28-report-item-label-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-28-report-item-label-polish.md
@@ -1,0 +1,14 @@
+# Report Item Label Polish
+
+## Summary
+- Updated generated inventory and rental report lines to use user-facing `Item ID` wording instead of the internal `ItemModel ID` label.
+- Renamed the inventory report title from `ItemModel Inventory Report` to `Inventory Report`.
+- Added source-contract coverage so printable report labels do not leak the internal model type name again.
+
+## Why
+Reports are operator-facing and printable. Keeping internal model names in report titles and row labels makes the output feel less polished and less clear for users who only need item identity, quantity, location, customer, and rental status details.
+
+## Validation Notes
+- Direct local clone/raw/API access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403` / HTTP 403.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
+- Validation for this pass is limited to GitHub connector readback/compare and PR status/workflow readback.

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -61,8 +61,8 @@ namespace InventoryManagementApp.Services.Items
                 .WithCancellation(CancellationToken.None).ConfigureAwait(false))
                 items.Add(item);
             var lines = items.Select(t =>
-                $"ItemModel ID: {t.ItemID} | ItemNumber: {t.ItemNumber} | Qty: {t.QuantityOnHand} | Location: {t.Location} | Supplier: {t.Supplier}");
-            return BuildReport("ItemModel Inventory Report", lines);
+                $"Item ID: {t.ItemID} | ItemNumber: {t.ItemNumber} | Qty: {t.QuantityOnHand} | Location: {t.Location} | Supplier: {t.Supplier}");
+            return BuildReport("Inventory Report", lines);
         }
 
         public async Task<FlowDocument> GenerateRentalReport(bool activeOnly = true)
@@ -74,7 +74,7 @@ namespace InventoryManagementApp.Services.Items
             var title = activeOnly ? "Active Rental Report" : "Full Rental History Report";
 
             var lines = rentals.Select(r =>
-                $"Rental ID: {r.RentalID} | ItemModel ID: {r.ItemID} | Customer ID: {r.CustomerID} | Rental Date: {r.RentalDate:yyyy-MM-dd} | Due Date: {r.DueDate:yyyy-MM-dd} | Return Date: {(r.ReturnDate.HasValue ? r.ReturnDate.Value.ToString("yyyy-MM-dd") : "N/A")} | Status: {r.Status}");
+                $"Rental ID: {r.RentalID} | Item ID: {r.ItemID} | Customer ID: {r.CustomerID} | Rental Date: {r.RentalDate:yyyy-MM-dd} | Due Date: {r.DueDate:yyyy-MM-dd} | Return Date: {(r.ReturnDate.HasValue ? r.ReturnDate.Value.ToString("yyyy-MM-dd") : "N/A")} | Status: {r.Status}");
 
             return BuildReport(title, lines);
         }


### PR DESCRIPTION
## Summary

- Update generated inventory and rental reports to show user-facing `Item ID` labels instead of internal `ItemModel ID` wording.
- Rename the inventory report title from `ItemModel Inventory Report` to `Inventory Report`.
- Add source-contract coverage so printable report labels do not leak the internal model type name again.

## Why This Matters

Reports are operator-facing and printable. Removing internal model names makes exported/printed inventory and rental report text clearer for users and keeps the report workflow polished without extending the Admin Settings theme system.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `ReportService`, one source-contract test, and one progress note.
- GitHub connector readback confirmed inventory and rental reports now use `Item ID` labels, and the inventory report title is `Inventory Report`.
- GitHub connector readback confirmed `ReportServiceUserFacingLabelContractTests` guards the user-facing labels and rejects the prior `ItemModel` report wording.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw/API access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403` / HTTP 403.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.