### PR TITLE
Polish generated report ID labels

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceUserFacingLabelContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceUserFacingLabelContractTests.cs
@@ -22,11 +22,64 @@ namespace InventoryManagementApp.Tests
 
             Assert.Contains("BuildReport(\"Inventory Report\", lines)", inventoryReport, StringComparison.Ordinal);
             Assert.Contains("Item ID: {t.ItemID}", inventoryReport, StringComparison.Ordinal);
+            Assert.Contains("Item Number: {t.ItemNumber}", inventoryReport, StringComparison.Ordinal);
             Assert.Contains("Item ID: {r.ItemID}", rentalReport, StringComparison.Ordinal);
 
             Assert.DoesNotContain("ItemModel Inventory Report", inventoryReport, StringComparison.Ordinal);
             Assert.DoesNotContain("ItemModel ID:", inventoryReport, StringComparison.Ordinal);
             Assert.DoesNotContain("ItemModel ID:", rentalReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("ItemNumber:", inventoryReport, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void GeneratedReportsUseReadableIdLabels()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
+
+            var activityLogReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateActivityLogReport()",
+                "public async Task<FlowDocument> GenerateCustomerReport()");
+            var customerReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateCustomerReport()",
+                "public async Task<FlowDocument> GenerateUserReport()");
+            var userReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateUserReport()",
+                "public async Task<FlowDocument> GenerateSummaryReport()");
+            var maintenanceReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateMaintenanceReport(bool overdueOnly = false)",
+                "public async Task<FlowDocument> GenerateCalibrationReport(bool overdueOnly = false)");
+            var calibrationReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateCalibrationReport(bool overdueOnly = false)",
+                "public async Task<FlowDocument> GenerateReservationReport(bool activeOnly = true)");
+            var reservationReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateReservationReport(bool activeOnly = true)",
+                "public async Task<FlowDocument> GenerateKitReport()");
+
+            Assert.Contains("Log ID: {l.LogID}", activityLogReport, StringComparison.Ordinal);
+            Assert.Contains("User ID: {l.UserID}", activityLogReport, StringComparison.Ordinal);
+            Assert.Contains("Customer ID: {c.CustomerID}", customerReport, StringComparison.Ordinal);
+            Assert.Contains("User ID: {u.UserID}", userReport, StringComparison.Ordinal);
+            Assert.Contains("User Name: {u.UserName}", userReport, StringComparison.Ordinal);
+            Assert.Contains("Admin: {u.IsAdmin}", userReport, StringComparison.Ordinal);
+            Assert.Contains("Maintenance ID: {m.MaintenanceID}", maintenanceReport, StringComparison.Ordinal);
+            Assert.Contains("Calibration ID: {c.CalibrationID}", calibrationReport, StringComparison.Ordinal);
+            Assert.Contains("Reservation ID: {r.ReservationID}", reservationReport, StringComparison.Ordinal);
+
+            Assert.DoesNotContain("LogID:", activityLogReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("UserID:", activityLogReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("CustomerID:", customerReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("UserID:", userReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("UserName:", userReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("IsAdmin:", userReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("ID: {m.MaintenanceID}", maintenanceReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("ID: {c.CalibrationID}", calibrationReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("ID: {r.ReservationID}", reservationReport, StringComparison.Ordinal);
         }
 
         private static string ExtractMethod(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp/ProgressNotes/2026-06-28-report-readable-id-labels.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-28-report-readable-id-labels.md
@@ -1,0 +1,14 @@
+# Report Readable ID Labels
+
+## Summary
+- Polished generated report lines so operator-facing output uses spaced ID labels such as `Log ID`, `Customer ID`, `User ID`, `Maintenance ID`, `Calibration ID`, and `Reservation ID`.
+- Updated inventory report item numbering from `ItemNumber` to `Item Number` and user report role output from `IsAdmin` to `Admin`.
+- Extended report source-contract coverage so generated report labels do not drift back to compact property-style wording.
+
+## Why
+Generated reports are printable and operator-facing. Compact model/property labels such as `CustomerID`, `UserID`, and `IsAdmin` make report output feel like source code rather than user documentation. This keeps the reporting polish moving without adding more Admin Settings theme layers.
+
+## Validation Notes
+- Direct local clone/raw/API access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403` / HTTP 403.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
+- Validation for this pass is limited to GitHub connector readback/compare and PR status/workflow readback.

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -61,7 +61,7 @@ namespace InventoryManagementApp.Services.Items
                 .WithCancellation(CancellationToken.None).ConfigureAwait(false))
                 items.Add(item);
             var lines = items.Select(t =>
-                $"Item ID: {t.ItemID} | ItemNumber: {t.ItemNumber} | Qty: {t.QuantityOnHand} | Location: {t.Location} | Supplier: {t.Supplier}");
+                $"Item ID: {t.ItemID} | Item Number: {t.ItemNumber} | Qty: {t.QuantityOnHand} | Location: {t.Location} | Supplier: {t.Supplier}");
             return BuildReport("Inventory Report", lines);
         }
 
@@ -94,7 +94,7 @@ namespace InventoryManagementApp.Services.Items
                 ? result.Value
                 : new List<ActivityLog>();
             var lines = logs.Select(l =>
-                $"LogID: {l.LogID} | UserID: {l.UserID} | User: {l.UserName} | Action: {l.Action} | Timestamp: {l.Timestamp:yyyy-MM-dd HH:mm:ss}");
+                $"Log ID: {l.LogID} | User ID: {l.UserID} | User: {l.UserName} | Action: {l.Action} | Timestamp: {l.Timestamp:yyyy-MM-dd HH:mm:ss}");
             return BuildReport("Activity Log Report", lines);
         }
 
@@ -102,7 +102,7 @@ namespace InventoryManagementApp.Services.Items
         {
             var customers = await _customerService.GetAllCustomersAsync().ConfigureAwait(false);
             var lines = customers.Select(c =>
-                $"CustomerID: {c.CustomerID} | Company: {c.Company} | Email: {c.Email} | Contact: {c.Contact} | Phone: {c.Phone} | Mobile: {c.Mobile} | Address: {c.Address}");
+                $"Customer ID: {c.CustomerID} | Company: {c.Company} | Email: {c.Email} | Contact: {c.Contact} | Phone: {c.Phone} | Mobile: {c.Mobile} | Address: {c.Address}");
             return BuildReport("Customer Report", lines);
         }
 
@@ -110,7 +110,7 @@ namespace InventoryManagementApp.Services.Items
         {
             var users = await _userService.GetAllUsersAsync(CancellationToken.None).ConfigureAwait(false);
             var lines = users.Select(u =>
-                $"UserID: {u.UserID} | UserName: {u.UserName} | IsAdmin: {u.IsAdmin}");
+                $"User ID: {u.UserID} | User Name: {u.UserName} | Admin: {u.IsAdmin}");
             return BuildReport("User Report", lines);
         }
 
@@ -198,7 +198,7 @@ namespace InventoryManagementApp.Services.Items
             var title = overdueOnly ? "Overdue Maintenance Report" : "Maintenance Schedule Report";
 
             var lines = records.Select(m =>
-                $"ID: {m.MaintenanceID} | Item: {m.ItemNumber} - {m.ItemName} | Type: {m.MaintenanceType} | Scheduled: {m.ScheduledDate:yyyy-MM-dd} | Status: {m.StatusDisplay} | Cost: ${m.Cost:F2}");
+                $"Maintenance ID: {m.MaintenanceID} | Item: {m.ItemNumber} - {m.ItemName} | Type: {m.MaintenanceType} | Scheduled: {m.ScheduledDate:yyyy-MM-dd} | Status: {m.StatusDisplay} | Cost: ${m.Cost:F2}");
 
             return BuildReport(title, lines);
         }
@@ -215,7 +215,7 @@ namespace InventoryManagementApp.Services.Items
             var title = overdueOnly ? "Overdue Calibration Report" : "Calibration Records Report";
 
             var lines = records.Select(c =>
-                $"ID: {c.CalibrationID} | Item: {c.ItemNumber} - {c.ItemName} | Date: {c.CalibrationDate:yyyy-MM-dd} | Next Due: {c.NextCalibrationDue:yyyy-MM-dd} | Status: {c.StatusDisplay} | Cert#: {c.CertificateNumber}");
+                $"Calibration ID: {c.CalibrationID} | Item: {c.ItemNumber} - {c.ItemName} | Date: {c.CalibrationDate:yyyy-MM-dd} | Next Due: {c.NextCalibrationDue:yyyy-MM-dd} | Status: {c.StatusDisplay} | Cert#: {c.CertificateNumber}");
 
             return BuildReport(title, lines);
         }
@@ -232,7 +232,7 @@ namespace InventoryManagementApp.Services.Items
             var title = activeOnly ? "Active Reservations Report" : "All Reservations Report";
 
             var lines = reservations.Select(r =>
-                $"ID: {r.ReservationID} | Item: {r.ItemNumber} - {r.ItemName} | Customer: {r.CustomerName} | Start: {r.StartDate:yyyy-MM-dd} | End: {r.EndDate:yyyy-MM-dd} | Qty: {r.Quantity} | Status: {r.StatusDisplay}");
+                $"Reservation ID: {r.ReservationID} | Item: {r.ItemNumber} - {r.ItemName} | Customer: {r.CustomerName} | Start: {r.StartDate:yyyy-MM-dd} | End: {r.EndDate:yyyy-MM-dd} | Qty: {r.Quantity} | Status: {r.StatusDisplay}");
 
             return BuildReport(title, lines);
         }


### PR DESCRIPTION
## Summary

- Update generated report lines to use readable ID labels such as `Log ID`, `Customer ID`, `User ID`, `Maintenance ID`, `Calibration ID`, and `Reservation ID`.
- Rename inventory report `ItemNumber` output to `Item Number` and user report `IsAdmin` output to `Admin`.
- Extend report source-contract coverage so printable report labels do not drift back to compact property-style wording.

## Why This Matters

Reports are printable, operator-facing output. Compact property labels like `CustomerID`, `UserID`, and `IsAdmin` make the report output feel like source code instead of plain user documentation. This is a focused follow-up to the recent report label polish and avoids further Admin Settings theme expansion.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `ReportService`, one source-contract test, and one progress note.
- GitHub connector readback confirmed generated inventory, activity log, customer, user, maintenance, calibration, and reservation report labels now use readable user-facing wording.
- GitHub connector readback confirmed `ReportServiceUserFacingLabelContractTests` guards the updated labels and rejects the prior compact property-style labels.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw/API access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403` / HTTP 403.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.