### PR TITLE
Fix report ID label contract assertions

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceUserFacingLabelContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceUserFacingLabelContractTests.cs
@@ -77,9 +77,9 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("UserID:", userReport, StringComparison.Ordinal);
             Assert.DoesNotContain("UserName:", userReport, StringComparison.Ordinal);
             Assert.DoesNotContain("IsAdmin:", userReport, StringComparison.Ordinal);
-            Assert.DoesNotContain("ID: {m.MaintenanceID}", maintenanceReport, StringComparison.Ordinal);
-            Assert.DoesNotContain("ID: {c.CalibrationID}", calibrationReport, StringComparison.Ordinal);
-            Assert.DoesNotContain("ID: {r.ReservationID}", reservationReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"ID: {m.MaintenanceID}", maintenanceReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"ID: {c.CalibrationID}", calibrationReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("$\"ID: {r.ReservationID}", reservationReport, StringComparison.Ordinal);
         }
 
         private static string ExtractMethod(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp/ProgressNotes/2026-06-28-report-id-label-contract-fix.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-28-report-id-label-contract-fix.md
@@ -1,0 +1,13 @@
+# Report ID Label Contract Fix
+
+## Summary
+- Repaired the generated report label source-contract test so readable `Maintenance ID`, `Calibration ID`, and `Reservation ID` labels are not rejected by the same test that requires them.
+- Narrowed the negative assertions to the legacy whole-line template that started with `ID:` instead of matching the shared `ID:` substring inside the corrected readable labels.
+
+## Why
+The latest report label polish intentionally changed generated reports to use readable labels. The source-contract test had a false-failure risk because `ID: {m.MaintenanceID}` is a substring of the desired `Maintenance ID: {m.MaintenanceID}` text. Fixing the assertion keeps validation useful without changing product behavior.
+
+## Validation Notes
+- Direct local clone/raw/API access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403` / HTTP 403.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
+- Validation for this pass is limited to GitHub connector readback/compare and PR status/workflow readback.


### PR DESCRIPTION
## Summary

- Fix the generated report label source-contract test so readable `Maintenance ID`, `Calibration ID`, and `Reservation ID` labels are not rejected by their own negative assertions.
- Narrow the legacy-label checks to the old whole-line template that started with `ID:` rather than the shared `ID:` substring inside the corrected readable labels.
- Add a progress note documenting the false-failure risk and validation limits.

## Why This Matters

PR #1382 polished generated report labels, but the added test contained a self-contradictory substring assertion. `ID: {m.MaintenanceID}` appears inside the desired `Maintenance ID: {m.MaintenanceID}` text, so the test could fail even though the product output is correct. This is a focused validation repair, not another Admin Settings theme expansion.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, two commits ahead, and changes only `ReportServiceUserFacingLabelContractTests` plus one progress note.
- GitHub connector readback confirmed the test still requires readable `Maintenance ID`, `Calibration ID`, and `Reservation ID` labels, while the negative assertions now target `$"ID: ...` legacy line templates.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw/API access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403` / HTTP 403.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.