### PR TITLE
Polish report quantity and certificate labels

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceUserFacingLabelContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceUserFacingLabelContractTests.cs
@@ -23,12 +23,14 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("BuildReport(\"Inventory Report\", lines)", inventoryReport, StringComparison.Ordinal);
             Assert.Contains("Item ID: {t.ItemID}", inventoryReport, StringComparison.Ordinal);
             Assert.Contains("Item Number: {t.ItemNumber}", inventoryReport, StringComparison.Ordinal);
+            Assert.Contains("Quantity: {t.QuantityOnHand}", inventoryReport, StringComparison.Ordinal);
             Assert.Contains("Item ID: {r.ItemID}", rentalReport, StringComparison.Ordinal);
 
             Assert.DoesNotContain("ItemModel Inventory Report", inventoryReport, StringComparison.Ordinal);
             Assert.DoesNotContain("ItemModel ID:", inventoryReport, StringComparison.Ordinal);
             Assert.DoesNotContain("ItemModel ID:", rentalReport, StringComparison.Ordinal);
             Assert.DoesNotContain("ItemNumber:", inventoryReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("Qty:", inventoryReport, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -69,7 +71,9 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("Admin: {u.IsAdmin}", userReport, StringComparison.Ordinal);
             Assert.Contains("Maintenance ID: {m.MaintenanceID}", maintenanceReport, StringComparison.Ordinal);
             Assert.Contains("Calibration ID: {c.CalibrationID}", calibrationReport, StringComparison.Ordinal);
+            Assert.Contains("Certificate Number: {c.CertificateNumber}", calibrationReport, StringComparison.Ordinal);
             Assert.Contains("Reservation ID: {r.ReservationID}", reservationReport, StringComparison.Ordinal);
+            Assert.Contains("Quantity: {r.Quantity}", reservationReport, StringComparison.Ordinal);
 
             Assert.DoesNotContain("LogID:", activityLogReport, StringComparison.Ordinal);
             Assert.DoesNotContain("UserID:", activityLogReport, StringComparison.Ordinal);
@@ -80,6 +84,8 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("$\"ID: {m.MaintenanceID}", maintenanceReport, StringComparison.Ordinal);
             Assert.DoesNotContain("$\"ID: {c.CalibrationID}", calibrationReport, StringComparison.Ordinal);
             Assert.DoesNotContain("$\"ID: {r.ReservationID}", reservationReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("Cert#:", calibrationReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("Qty:", reservationReport, StringComparison.Ordinal);
         }
 
         private static string ExtractMethod(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp/ProgressNotes/2026-06-28-report-readable-quantity-cert-labels.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-28-report-readable-quantity-cert-labels.md
@@ -1,0 +1,16 @@
+# Report Quantity and Certificate Label Polish - 2026-06-28
+
+## Summary
+- Replaced the remaining abbreviated printable report labels `Qty` and `Cert#` with readable `Quantity` and `Certificate Number` labels.
+- Updated inventory and reservation report quantity output so printed/exported report text reads consistently with the recently polished ID labels.
+- Extended `ReportServiceUserFacingLabelContractTests` so the readable quantity and certificate labels stay covered by source-contract checks.
+
+## Why This Matters
+- The report workflow is operator-facing and often printed or exported.
+- Abbreviations beside the newly polished ID labels made the output feel less consistent and less readable.
+- This keeps the current work focused on app-completion polish and validation instead of adding more Admin Settings theme layers.
+
+## Validation
+- GitHub connector readback should confirm only `ReportService`, `ReportServiceUserFacingLabelContractTests`, and this progress note changed.
+- GitHub connector readback should confirm generated report strings now use `Quantity` and `Certificate Number` instead of `Qty` and `Cert#`.
+- Local clone/raw access, `dotnet`, PowerShell/`pwsh`, WPF screenshots/runtime checks, local banned-word checks, and `scripts/run-full-validation.ps1` are unavailable in this scheduled Linux environment, so local build/test/full validation was not run.

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -61,7 +61,7 @@ namespace InventoryManagementApp.Services.Items
                 .WithCancellation(CancellationToken.None).ConfigureAwait(false))
                 items.Add(item);
             var lines = items.Select(t =>
-                $"Item ID: {t.ItemID} | Item Number: {t.ItemNumber} | Qty: {t.QuantityOnHand} | Location: {t.Location} | Supplier: {t.Supplier}");
+                $"Item ID: {t.ItemID} | Item Number: {t.ItemNumber} | Quantity: {t.QuantityOnHand} | Location: {t.Location} | Supplier: {t.Supplier}");
             return BuildReport("Inventory Report", lines);
         }
 
@@ -215,7 +215,7 @@ namespace InventoryManagementApp.Services.Items
             var title = overdueOnly ? "Overdue Calibration Report" : "Calibration Records Report";
 
             var lines = records.Select(c =>
-                $"Calibration ID: {c.CalibrationID} | Item: {c.ItemNumber} - {c.ItemName} | Date: {c.CalibrationDate:yyyy-MM-dd} | Next Due: {c.NextCalibrationDue:yyyy-MM-dd} | Status: {c.StatusDisplay} | Cert#: {c.CertificateNumber}");
+                $"Calibration ID: {c.CalibrationID} | Item: {c.ItemNumber} - {c.ItemName} | Date: {c.CalibrationDate:yyyy-MM-dd} | Next Due: {c.NextCalibrationDue:yyyy-MM-dd} | Status: {c.StatusDisplay} | Certificate Number: {c.CertificateNumber}");
 
             return BuildReport(title, lines);
         }
@@ -232,7 +232,7 @@ namespace InventoryManagementApp.Services.Items
             var title = activeOnly ? "Active Reservations Report" : "All Reservations Report";
 
             var lines = reservations.Select(r =>
-                $"Reservation ID: {r.ReservationID} | Item: {r.ItemNumber} - {r.ItemName} | Customer: {r.CustomerName} | Start: {r.StartDate:yyyy-MM-dd} | End: {r.EndDate:yyyy-MM-dd} | Qty: {r.Quantity} | Status: {r.StatusDisplay}");
+                $"Reservation ID: {r.ReservationID} | Item: {r.ItemNumber} - {r.ItemName} | Customer: {r.CustomerName} | Start: {r.StartDate:yyyy-MM-dd} | End: {r.EndDate:yyyy-MM-dd} | Quantity: {r.Quantity} | Status: {r.StatusDisplay}");
 
             return BuildReport(title, lines);
         }


### PR DESCRIPTION
## Summary

- Replace remaining abbreviated printable report labels `Qty` and `Cert#` with readable `Quantity` and `Certificate Number` wording.
- Keep inventory and reservation quantity output aligned with the recent report ID label polish.
- Extend `ReportServiceUserFacingLabelContractTests` so the readable report labels are guarded against regression.

## Why This Matters

Generated reports are operator-facing and often printed or exported. The recent report polish removed internal model/property wording, but a couple of abbreviated labels still made the output less readable. This is a focused app-completion polish pass, not another Admin Settings theme expansion.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `ReportService`, `ReportServiceUserFacingLabelContractTests`, and one progress note.
- GitHub connector readback confirmed generated inventory, calibration, and reservation report strings now use `Quantity` and `Certificate Number` labels.
- GitHub connector readback confirmed `ReportServiceUserFacingLabelContractTests` requires the readable labels and rejects the old `Qty:` and `Cert#:` abbreviations.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw/API access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403` / HTTP 403.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.