### PR TITLE
Polish kit report labels

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceUserFacingLabelContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceUserFacingLabelContractTests.cs
@@ -62,6 +62,10 @@ namespace InventoryManagementApp.Tests
                 source,
                 "public async Task<FlowDocument> GenerateReservationReport(bool activeOnly = true)",
                 "public async Task<FlowDocument> GenerateKitReport()");
+            var kitReport = ExtractMethod(
+                source,
+                "public async Task<FlowDocument> GenerateKitReport()",
+                "private async Task<int> CountItemsAsync()");
 
             Assert.Contains("Log ID: {l.LogID}", activityLogReport, StringComparison.Ordinal);
             Assert.Contains("User ID: {l.UserID}", activityLogReport, StringComparison.Ordinal);
@@ -74,6 +78,9 @@ namespace InventoryManagementApp.Tests
             Assert.Contains("Certificate Number: {c.CertificateNumber}", calibrationReport, StringComparison.Ordinal);
             Assert.Contains("Reservation ID: {r.ReservationID}", reservationReport, StringComparison.Ordinal);
             Assert.Contains("Quantity: {r.Quantity}", reservationReport, StringComparison.Ordinal);
+            Assert.Contains("Kit Number: {kit.KitNumber}", kitReport, StringComparison.Ordinal);
+            Assert.Contains("Kit Name: {kit.Name}", kitReport, StringComparison.Ordinal);
+            Assert.Contains("Item Count: {itemCount}", kitReport, StringComparison.Ordinal);
 
             Assert.DoesNotContain("LogID:", activityLogReport, StringComparison.Ordinal);
             Assert.DoesNotContain("UserID:", activityLogReport, StringComparison.Ordinal);
@@ -86,6 +93,8 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("$\"ID: {r.ReservationID}", reservationReport, StringComparison.Ordinal);
             Assert.DoesNotContain("Cert#:", calibrationReport, StringComparison.Ordinal);
             Assert.DoesNotContain("Qty:", reservationReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("Kit: {kit.KitNumber}", kitReport, StringComparison.Ordinal);
+            Assert.DoesNotContain("Items: {itemCount}", kitReport, StringComparison.Ordinal);
         }
 
         private static string ExtractMethod(string source, string startMarker, string endMarker)

--- a/InventoryManagementApp/ProgressNotes/2026-06-28-kit-report-label-polish.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-28-kit-report-label-polish.md
@@ -1,0 +1,16 @@
+# Kit Report Label Polish - 2026-06-28
+
+## What Changed
+
+- Updated generated kit report rows to use explicit printable labels for kit number, kit name, and item count.
+- Replaced the older `Kit: number - name` and `Items: count` shorthand with `Kit Number`, `Kit Name`, and `Item Count` wording that matches the rest of the recent report label polish.
+- Extended `ReportServiceUserFacingLabelContractTests` so the kit report remains covered alongside inventory, rental, activity log, customer, user, maintenance, calibration, and reservation report labels.
+
+## Why It Matters
+
+The kit report is operator-facing printable output. Making its labels explicit keeps it aligned with the rest of the report workflow and avoids shorthand that can be less clear in exported or printed reports.
+
+## Validation
+
+- GitHub connector readback/compare should confirm the focused report-service, test, and progress-note diff.
+- Local restore/build/test, WPF screenshots, PowerShell validation runner, local banned-word checks, and full validation were not run in the scheduled Linux environment because direct local clone/raw access is blocked and `dotnet`, PowerShell/`pwsh`, and `gh` are unavailable.

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -249,7 +249,7 @@ namespace InventoryManagementApp.Services.Items
             {
                 var items = await _kitService.GetKitItemsAsync(kit.KitID).ConfigureAwait(false);
                 var itemCount = items.Count;
-                lines.Add($"Kit: {kit.KitNumber} - {kit.Name} | Category: {kit.Category} | Items: {itemCount} | Status: {(kit.IsActive ? "Active" : "Inactive")}");
+                lines.Add($"Kit Number: {kit.KitNumber} | Kit Name: {kit.Name} | Category: {kit.Category} | Item Count: {itemCount} | Status: {(kit.IsActive ? "Active" : "Inactive")}");
             }
 
             return BuildReport("Active Kits Report", lines);


### PR DESCRIPTION
## Summary

- Update generated kit report rows to use explicit `Kit Number`, `Kit Name`, and `Item Count` labels.
- Align the kit report with the recent report-output polish across inventory, rental, activity log, customer, user, maintenance, calibration, and reservation reports.
- Extend `ReportServiceUserFacingLabelContractTests` so kit report labels are guarded against the older shorthand returning.

## Why This Matters

Generated kit reports are printable, operator-facing output. The recent report polish made other reports read less like source-code fields, but the kit report still used `Kit: number - name` and `Items: count` shorthand. This keeps the report workflow consistent without adding another Admin Settings theme layer.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `ReportService`, `ReportServiceUserFacingLabelContractTests`, and one progress note.
- GitHub connector readback confirmed `GenerateKitReport` now emits `Kit Number`, `Kit Name`, and `Item Count` labels.
- GitHub connector readback confirmed `ReportServiceUserFacingLabelContractTests` requires the readable kit labels and rejects the older `Kit:` and `Items:` shorthand.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.