### PR TITLE
Add empty state to generated reports

### DIFF
--- a/InventoryManagementApp.Tests/ReportServiceUserFacingLabelContractTests.cs
+++ b/InventoryManagementApp.Tests/ReportServiceUserFacingLabelContractTests.cs
@@ -97,6 +97,25 @@ namespace InventoryManagementApp.Tests
             Assert.DoesNotContain("Items: {itemCount}", kitReport, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void BuildReportAddsReadableEmptyStateWhenNoRowsExist()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Items", "ReportService.cs");
+
+            var buildReport = ExtractMethod(
+                source,
+                "FlowDocument BuildReport(string title, IEnumerable<string> lines)",
+                "    }\n}");
+
+            Assert.Contains("var reportLines = lines as IReadOnlyCollection<string> ?? lines.ToList();", buildReport, StringComparison.Ordinal);
+            Assert.Contains("if (reportLines.Count == 0)", buildReport, StringComparison.Ordinal);
+            Assert.Contains("No report records found.", buildReport, StringComparison.Ordinal);
+            Assert.True(
+                buildReport.IndexOf("if (reportLines.Count == 0)", StringComparison.Ordinal) <
+                buildReport.IndexOf("foreach (var line in reportLines)", StringComparison.Ordinal),
+                "Expected empty report output to be filled before report paragraphs are rendered.");
+        }
+
         private static string ExtractMethod(string source, string startMarker, string endMarker)
         {
             var start = source.IndexOf(startMarker, StringComparison.Ordinal);

--- a/InventoryManagementApp/ProgressNotes/2026-06-28-report-empty-state.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-28-report-empty-state.md
@@ -1,0 +1,16 @@
+# Report Empty State Polish - 2026-06-28
+
+## What Changed
+
+- Updated the shared generated-report builder to render a clear `No report records found.` line when a report has no data rows.
+- Kept existing service-unavailable messages intact because those report paths already pass explicit explanatory lines.
+- Added source-contract coverage so empty generated reports keep a readable body instead of rendering only a report title.
+
+## Why It Matters
+
+Generated reports are operator-facing and printable. A report with only a title can look broken or incomplete when the underlying query legitimately has no rows. The shared empty-state line makes empty inventory, rental, activity log, customer, user, maintenance, calibration, reservation, and kit reports self-explanatory.
+
+## Validation
+
+- GitHub connector readback/compare should confirm the focused report-service, test, and progress-note diff.
+- Local restore/build/test, WPF screenshots, PowerShell validation runner, local banned-word checks, and full validation were not run in the scheduled Linux environment because direct local clone/raw access is blocked and `dotnet`, PowerShell/`pwsh`, and `gh` are unavailable.

--- a/InventoryManagementApp/Services/Items/ReportService.cs
+++ b/InventoryManagementApp/Services/Items/ReportService.cs
@@ -283,7 +283,11 @@ namespace InventoryManagementApp.Services.Items
             };
             doc.Blocks.Add(header);
 
-            foreach (var line in lines)
+            var reportLines = lines as IReadOnlyCollection<string> ?? lines.ToList();
+            if (reportLines.Count == 0)
+                reportLines = new[] { "No report records found." };
+
+            foreach (var line in reportLines)
             {
                 var p = new Paragraph(new Run(line)) { Margin = new Thickness(0, 0, 0, 10) };
                 doc.Blocks.Add(p);


### PR DESCRIPTION
## Summary

- Add a shared empty-state line to generated reports when a report has no data rows.
- Preserve existing explicit service-unavailable messages for optional report services.
- Extend `ReportServiceUserFacingLabelContractTests` so empty generated reports do not regress to title-only output.

## Why This Matters

Recent reporting work made report labels more readable, but an empty generated report could still render only a title. That looks incomplete when a query legitimately has no rows. This gives inventory, rental, activity log, customer, user, maintenance, calibration, reservation, and kit reports a clear printable body without adding another Admin Settings theme layer.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `ReportService`, `ReportServiceUserFacingLabelContractTests`, and one progress note.
- GitHub connector readback confirmed `BuildReport` materializes report lines, adds `No report records found.` before paragraph rendering when there are no rows, and leaves explicit service-unavailable lines untouched.
- GitHub connector readback confirmed `ReportServiceUserFacingLabelContractTests` guards the empty-report fallback and ordering before paragraph rendering.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.