### PR TITLE
Guard item repository write contracts

### DIFF
--- a/InventoryManagementApp.Tests/ItemRepositoryWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryWriteGuardContractTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class ItemRepositoryWriteGuardContractTests
+    {
+        [Fact]
+        public void ItemRepositoryWritesThrowWhenNoRowsAreAffected()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Data", "ItemRepository.cs");
+
+            var saveChangesMethod = ExtractMethod(
+                source,
+                "public async Task SaveChangesAsync(IEnumerable<Item> changes, CancellationToken ct)",
+                "public async Task<int> InsertAsync(Item item, CancellationToken ct)");
+            AssertContainsAll(
+                saveChangesMethod,
+                "var rows = await conn.ExecuteAsync(new CommandDefinition(sql, new",
+                "if (rows == 0)",
+                "throw new InvalidOperationException($\"Failed to save item {item.ItemID}.\");");
+            Assert.True(
+                saveChangesMethod.IndexOf("var rows = await conn.ExecuteAsync(new CommandDefinition(sql, new", StringComparison.Ordinal) <
+                saveChangesMethod.IndexOf("if (rows == 0)", StringComparison.Ordinal),
+                "Expected bulk item saves to inspect affected rows after executing each update.");
+
+            var updateMethod = ExtractMethod(
+                source,
+                "public async Task UpdateAsync(Item item, CancellationToken ct)",
+                "public async Task DeleteAsync(int itemID, CancellationToken ct)");
+            AssertContainsAll(
+                updateMethod,
+                "var rows = await conn.ExecuteAsync(new CommandDefinition(sql, new",
+                "if (rows == 0)",
+                "throw new InvalidOperationException($\"Failed to update item {item.ItemID}.\");");
+            Assert.True(
+                updateMethod.IndexOf("var rows = await conn.ExecuteAsync(new CommandDefinition(sql, new", StringComparison.Ordinal) <
+                updateMethod.IndexOf("if (rows == 0)", StringComparison.Ordinal),
+                "Expected item updates to inspect affected rows after executing the update.");
+
+            var deleteMethod = ExtractMethod(
+                source,
+                "public async Task DeleteAsync(int itemID, CancellationToken ct)",
+                "public async Task<bool> ToggleCheckOutStatusAsync");
+            AssertContainsAll(
+                deleteMethod,
+                "var rows = await conn.ExecuteAsync(new CommandDefinition(\"DELETE FROM Items WHERE ItemID=@ID\"",
+                "if (rows == 0)",
+                "throw new InvalidOperationException($\"Failed to delete item {itemID}.\");");
+            Assert.True(
+                deleteMethod.IndexOf("var rows = await conn.ExecuteAsync", StringComparison.Ordinal) <
+                deleteMethod.IndexOf("if (rows == 0)", StringComparison.Ordinal),
+                "Expected item deletes to inspect affected rows after executing the delete.");
+
+            var imageMethod = ExtractMethod(
+                source,
+                "public async Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken ct)",
+                "public async Task<List<Item>> GetMostCommonlyUsedItemsAsync");
+            AssertContainsAll(
+                imageMethod,
+                "var rows = await conn.ExecuteAsync(new CommandDefinition(\"UPDATE Items SET ImagePath=@Img WHERE ItemID=@ID\"",
+                "if (rows == 0)",
+                "throw new InvalidOperationException($\"Failed to update image for item {itemID}.\");");
+            Assert.True(
+                imageMethod.IndexOf("var rows = await conn.ExecuteAsync", StringComparison.Ordinal) <
+                imageMethod.IndexOf("if (rows == 0)", StringComparison.Ordinal),
+                "Expected item image writes to inspect affected rows after executing the update.");
+        }
+
+        private static void AssertContainsAll(string source, params string[] expectedSnippets)
+        {
+            foreach (var snippet in expectedSnippets)
+            {
+                Assert.Contains(snippet, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-28-item-repository-write-guard-contracts.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-28-item-repository-write-guard-contracts.md
@@ -1,0 +1,18 @@
+# Item Repository Write Guard Contract Coverage
+
+Date: 2026-06-28
+
+## Completed
+
+- Added focused source-contract coverage for item repository write guards.
+- Guarded bulk item saves, single item updates, item deletes, and item image updates so each write continues to inspect affected row counts.
+- Confirmed the contracts preserve explicit failures when a stale or missing item row causes a write to affect zero rows.
+
+## Why This Matters
+
+Recent service-boundary work hardened stale-row behavior across rentals, reservations, kits, customers, and users. Item repository writes already had affected-row checks, but there was no focused contract preventing those central inventory safeguards from regressing. The new coverage keeps item edit/delete/image workflows aligned with the broader stale-write guard direction without adding more Admin Settings theme or report-label surface area.
+
+## Validation Notes
+
+- GitHub connector readback should confirm the new contract test scans `ItemRepository.cs` for affected-row checks after write execution and explicit stale-write exceptions.
+- Local checkout/raw access, `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable in this scheduled Linux container, so local build/test/full validation was not run here.


### PR DESCRIPTION
## Summary

- Add focused source-contract coverage for item repository write guards.
- Guard bulk item saves, single item updates, item deletes, and item image updates so each write continues checking affected row counts.
- Record a progress note tying the coverage to the recent stale-row/service-boundary hardening work.

## Why This Matters

Recent work hardened stale-write behavior across rentals, reservations, kits, customers, and users. `ItemRepository` already has affected-row checks for central inventory writes, but there was no focused contract preventing those safeguards from being softened later. This closes that test gap without extending the Admin Settings theme system or adding another report-label polish pass.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, two commits ahead, and changes only one new test file plus one progress note.
- GitHub connector readback confirmed `ItemRepositoryWriteGuardContractTests` scans `ItemRepository.cs` for affected-row checks after write execution and explicit stale-write exceptions for bulk save, update, delete, and image update writes.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.