### PR TITLE
Guard activity log view model result contract

### DIFF
--- a/InventoryManagementApp.Tests/ViewModels/ActivityLogsViewModelResultContractTests.cs
+++ b/InventoryManagementApp.Tests/ViewModels/ActivityLogsViewModelResultContractTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests.ViewModels
+{
+    public class ActivityLogsViewModelResultContractTests
+    {
+        [Fact]
+        public void LoadLogsUsesCanonicalResultValueCollection()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "ViewModels", "ActivityLogsViewModel.cs");
+
+            var method = ExtractMethod(source, "public async Task<bool> LoadLogsAsync()", "private void ClearActivityLogRowsAfterLoadFailure");
+
+            Assert.Contains("var result = await _service.GetRecentLogsAsync();", method, StringComparison.Ordinal);
+            Assert.Contains("if (!result.Success || result.Value == null)", method, StringComparison.Ordinal);
+            Assert.Contains("foreach (var log in result.Value)", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("result.Data", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("result?.Data", method, StringComparison.Ordinal);
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-28-activity-log-viewmodel-result-value-contract.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-28-activity-log-viewmodel-result-value-contract.md
@@ -1,0 +1,14 @@
+# Activity Log ViewModel Result Value Contract
+
+## Summary
+- Added source-contract coverage for `ActivityLogsViewModel.LoadLogsAsync`.
+- Guarded the Activity Logs workbench so recent logs are read from the canonical `Result<T>.Value` collection.
+- Rejected the removed activity-log-specific `Data` result contract in the view-model load path.
+
+## Why
+Recent cleanup removed the legacy `Result<T>.Data` escape hatch and aligned report generation with `Value`, but the Activity Logs workbench is the other central consumer of recent activity logs. Guarding it keeps the UI load path aligned with the shared result model and prevents the old activity-log-specific contract from creeping back in.
+
+## Validation Notes
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here.
+- Validation for this pass is limited to GitHub connector readback/compare and PR status/workflow readback.


### PR DESCRIPTION
## Summary

- Add source-contract coverage for `ActivityLogsViewModel.LoadLogsAsync`.
- Guard the Activity Logs workbench so recent logs continue reading from the canonical `Result<T>.Value` collection.
- Reject the removed activity-log-specific `Data` result contract in the view-model load path.

## Why This Matters

Recent cleanup removed the legacy `Result<T>.Data` escape hatch and aligned activity-log report generation with `Value`. The Activity Logs workbench is the other central recent-log consumer, so this closes the matching test gap without extending the Admin Settings theme system or adding more report-label polish.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, two commits ahead, and changes only one new source-contract test plus one progress note.
- GitHub connector readback confirmed `ActivityLogsViewModelResultContractTests` requires `LoadLogsAsync` to call `GetRecentLogsAsync`, guard `result.Value == null`, enumerate `result.Value`, and reject `result.Data` / `result?.Data` usage.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.