### PR TITLE
Guard blank activity log actions

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
@@ -30,6 +30,31 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void LogActionRejectsBlankActionsBeforeSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");
+            var method = ExtractMethod(
+                source,
+                "public virtual async Task<Result> LogActionAsync",
+                "public virtual async Task<Result<List<ActivityLog>>> GetRecentLogsAsync");
+
+            Assert.Contains("if (string.IsNullOrWhiteSpace(action))", method, StringComparison.Ordinal);
+            Assert.Contains("return new Result(false, \"Action is required.\");", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("if (string.IsNullOrWhiteSpace(action))", StringComparison.Ordinal),
+                "Cancellation should still be honored before blank-action validation.");
+            Assert.True(
+                method.IndexOf("if (string.IsNullOrWhiteSpace(action))", StringComparison.Ordinal) < method.IndexOf("const string sql =", StringComparison.Ordinal),
+                "The blank-action guard should run before activity-log SQL text is prepared.");
+            Assert.True(
+                method.IndexOf("if (string.IsNullOrWhiteSpace(action))", StringComparison.Ordinal) < method.IndexOf("new SqliteParameter(\"@Action\",   action)", StringComparison.Ordinal),
+                "The blank-action guard should run before action parameters are prepared.");
+            Assert.True(
+                method.IndexOf("if (string.IsNullOrWhiteSpace(action))", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection()", StringComparison.Ordinal),
+                "The blank-action guard should run before opening a database connection.");
+        }
+
+        [Fact]
         public void RecentLogsRejectsInvalidCountsBeforeSqlWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-activity-log-action-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-activity-log-action-guard.md
@@ -1,0 +1,11 @@
+# Activity Log Action Guard
+
+## Completed
+- Tightened `ActivityLogService.LogActionAsync` so blank activity text is rejected before SQL, parameter preparation, or database connection work begins.
+- Preserved the existing cancellation-first behavior before the new blank-action validation.
+- Extended activity-log source-contract coverage to keep the guard ordering explicit and prevent empty audit rows from returning.
+
+## Validation Notes
+- This scheduled Linux container cannot perform direct local checkout/raw access because GitHub network access fails with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
+- Use GitHub connector readback/compare for this pass, followed by the next Windows/.NET-capable full validation run.

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -30,6 +30,9 @@ namespace InventoryManagementApp.Services.Users
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
+                if (string.IsNullOrWhiteSpace(action))
+                    return new Result(false, "Action is required.");
+
                 const string sql = @"
                     INSERT INTO ActivityLogs (UserID, UserName, Action)
                     VALUES (@UserID, @UserName, @Action)";


### PR DESCRIPTION
## Summary

- Reject blank `ActivityLogService.LogActionAsync` action text before SQL work starts.
- Preserve cancellation-first behavior before blank-action validation.
- Extend `ActivityLogCheckoutHistoryContractTests` so the action guard remains before SQL text, parameter preparation, and database connection creation.

## Why This Matters

Activity logs are the app's audit trail. Letting a blank action reach persistence can create rows that are technically valid but operationally useless. This is a focused service-boundary hardening pass outside the Admin Settings theme loop and report-label polish.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `ActivityLogService`, `ActivityLogCheckoutHistoryContractTests`, and one progress note.
- GitHub connector readback confirmed `LogActionAsync` checks `string.IsNullOrWhiteSpace(action)` after cancellation and before SQL text, `@Action` parameter creation, and `_dbService.CreateConnection()`.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.