### PR TITLE
Cover item checkout toggle write guard

### DIFF
--- a/InventoryManagementApp.Tests/ItemRepositoryWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/ItemRepositoryWriteGuardContractTests.cs
@@ -53,6 +53,24 @@ namespace InventoryManagementApp.Tests
                 deleteMethod.IndexOf("if (rows == 0)", StringComparison.Ordinal),
                 "Expected item deletes to inspect affected rows after executing the delete.");
 
+            var toggleMethod = ExtractMethod(
+                source,
+                "public async Task<bool> ToggleCheckOutStatusAsync",
+                "public async Task<List<Item>> GetItemsCheckedOutByAsync");
+            AssertContainsAll(
+                toggleMethod,
+                "var rows = await conn.ExecuteAsync(new CommandDefinition(@\"UPDATE Items SET",
+                "if (rows == 0)",
+                "throw new InvalidOperationException(\"Check-out status update failed.\");");
+            Assert.True(
+                toggleMethod.IndexOf("var rows = await conn.ExecuteAsync", StringComparison.Ordinal) <
+                toggleMethod.IndexOf("if (rows == 0)", StringComparison.Ordinal),
+                "Expected checkout toggles to inspect affected rows after executing the status update.");
+            Assert.True(
+                toggleMethod.IndexOf("if (rows == 0)", StringComparison.Ordinal) <
+                toggleMethod.IndexOf("return true;", StringComparison.Ordinal),
+                "Expected checkout toggles to fail stale writes before reporting success.");
+
             var imageMethod = ExtractMethod(
                 source,
                 "public async Task UpdateItemImageAsync(int itemID, string imagePath, CancellationToken ct)",

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-item-checkout-toggle-write-guard-contract.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-item-checkout-toggle-write-guard-contract.md
@@ -1,0 +1,19 @@
+# Item Checkout Toggle Write Guard Contract
+
+Date: 2026-06-29
+
+## Completed
+
+- Extended item repository source-contract coverage to include checkout status toggles.
+- Guarded the expectation that `ToggleCheckOutStatusAsync` inspects affected rows after the status update and before returning success.
+- Kept the existing stale-write failure message, `Check-out status update failed.`, under contract coverage.
+
+## Why This Matters
+
+Recent item repository write guard coverage protected bulk saves, single item updates, deletes, and image updates. Checkout toggles are another central inventory write path, and they already fail stale zero-row updates in production code. Covering that path keeps checkout/check-in workflows aligned with the broader stale-write hardening work without extending the Admin Settings theme system or adding speculative product surface.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
+- Validation for this pass is limited to GitHub connector compare/readback plus status/workflow readback.


### PR DESCRIPTION
## Summary

- Extend item repository source-contract coverage to include checkout status toggles.
- Guard that `ToggleCheckOutStatusAsync` checks affected rows after the status update and before returning success.
- Add a progress note documenting the checkout/check-in stale-write coverage gap.

## Why This Matters

Recent item repository write guard coverage protected bulk saves, updates, deletes, and image writes, but the checkout toggle path is also a central inventory write. The production code already fails zero-row toggle updates; this keeps that checkout/check-in stale-write guard from silently regressing without extending the Admin Settings theme system or adding speculative feature surface.

## Validation

- GitHub connector compare confirmed the branch is current with `master`, two commits ahead, and changes only `ItemRepositoryWriteGuardContractTests` plus one progress note.
- GitHub connector readback confirmed the test now extracts `ToggleCheckOutStatusAsync`, requires the checkout status `UPDATE Items SET` write, requires `if (rows == 0)`, requires `Check-out status update failed.`, and verifies the guard runs before `return true;`.
- GitHub connector readback confirmed the production checkout toggle still checks affected rows after executing the status update and before returning success.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.