### PR TITLE
Guard blank activity log user names

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
@@ -30,6 +30,34 @@ namespace InventoryManagementApp.Tests
         }
 
         [Fact]
+        public void LogActionRejectsBlankUserNamesBeforeSqlWork()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");
+            var method = ExtractMethod(
+                source,
+                "public virtual async Task<Result> LogActionAsync",
+                "public virtual async Task<Result<List<ActivityLog>>> GetRecentLogsAsync");
+
+            Assert.Contains("if (string.IsNullOrWhiteSpace(userName))", method, StringComparison.Ordinal);
+            Assert.Contains("return new Result(false, \"User name is required.\");", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("cancellationToken.ThrowIfCancellationRequested();", StringComparison.Ordinal) < method.IndexOf("if (string.IsNullOrWhiteSpace(userName))", StringComparison.Ordinal),
+                "Cancellation should still be honored before blank-user validation.");
+            Assert.True(
+                method.IndexOf("if (string.IsNullOrWhiteSpace(userName))", StringComparison.Ordinal) < method.IndexOf("if (string.IsNullOrWhiteSpace(action))", StringComparison.Ordinal),
+                "The blank-user guard should run before blank-action validation.");
+            Assert.True(
+                method.IndexOf("if (string.IsNullOrWhiteSpace(userName))", StringComparison.Ordinal) < method.IndexOf("const string sql =", StringComparison.Ordinal),
+                "The blank-user guard should run before activity-log SQL text is prepared.");
+            Assert.True(
+                method.IndexOf("if (string.IsNullOrWhiteSpace(userName))", StringComparison.Ordinal) < method.IndexOf("new SqliteParameter(\"@UserName\", userName)", StringComparison.Ordinal),
+                "The blank-user guard should run before user-name parameters are prepared.");
+            Assert.True(
+                method.IndexOf("if (string.IsNullOrWhiteSpace(userName))", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection()", StringComparison.Ordinal),
+                "The blank-user guard should run before opening a database connection.");
+        }
+
+        [Fact]
         public void LogActionRejectsBlankActionsBeforeSqlWork()
         {
             var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-activity-log-user-name-guard.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-activity-log-user-name-guard.md
@@ -1,0 +1,19 @@
+# Activity Log User Name Guard
+
+Date: 2026-06-29
+
+## Completed
+
+- Tightened `ActivityLogService.LogActionAsync` so blank audit user names are rejected before SQL, parameter preparation, or database connection work begins.
+- Preserved the existing cancellation-first behavior and kept blank-action validation after the user-name guard.
+- Extended activity-log source-contract coverage to keep the guard ordering explicit and prevent anonymous audit rows from being persisted by accident.
+
+## Why This Matters
+
+Activity Logs are the app's audit trail. Recent work blocked blank action text from reaching persistence, but a blank user name could still create an entry that is difficult to attribute later. Guarding user names at the same boundary keeps audit rows useful without extending the Admin Settings theme system or adding speculative feature surface.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
+- Validation for this pass is limited to GitHub connector compare/readback plus status/workflow readback.

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -30,6 +30,9 @@ namespace InventoryManagementApp.Services.Users
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
+                if (string.IsNullOrWhiteSpace(userName))
+                    return new Result(false, "User name is required.");
+
                 if (string.IsNullOrWhiteSpace(action))
                     return new Result(false, "Action is required.");
 


### PR DESCRIPTION
## Summary

- Reject blank `ActivityLogService.LogActionAsync` user names before SQL work starts.
- Preserve cancellation-first behavior and keep blank-action validation after the user-name guard.
- Extend `ActivityLogCheckoutHistoryContractTests` so the audit user-name guard remains before SQL text, parameter preparation, and database connection creation.

## Why This Matters

Activity Logs are the app's audit trail. Recent work blocked blank action text from being persisted, but blank user names could still create audit rows that are hard to attribute later. This closes the adjacent service-boundary gap without extending the Admin Settings theme system or adding speculative feature surface.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `ActivityLogService`, `ActivityLogCheckoutHistoryContractTests`, and one progress note.
- GitHub connector readback confirmed `LogActionAsync` checks `string.IsNullOrWhiteSpace(userName)` after cancellation and before blank-action validation, SQL text, `@UserName` parameter creation, and `_dbService.CreateConnection()`.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.