### PR TITLE
Normalize activity log inputs

### DIFF
--- a/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
+++ b/InventoryManagementApp.Tests/ActivityLogCheckoutHistoryContractTests.cs
@@ -50,7 +50,7 @@ namespace InventoryManagementApp.Tests
                 method.IndexOf("if (string.IsNullOrWhiteSpace(userName))", StringComparison.Ordinal) < method.IndexOf("const string sql =", StringComparison.Ordinal),
                 "The blank-user guard should run before activity-log SQL text is prepared.");
             Assert.True(
-                method.IndexOf("if (string.IsNullOrWhiteSpace(userName))", StringComparison.Ordinal) < method.IndexOf("new SqliteParameter(\"@UserName\", userName)", StringComparison.Ordinal),
+                method.IndexOf("if (string.IsNullOrWhiteSpace(userName))", StringComparison.Ordinal) < method.IndexOf("new SqliteParameter(\"@UserName\", normalizedUserName)", StringComparison.Ordinal),
                 "The blank-user guard should run before user-name parameters are prepared.");
             Assert.True(
                 method.IndexOf("if (string.IsNullOrWhiteSpace(userName))", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection()", StringComparison.Ordinal),
@@ -75,11 +75,34 @@ namespace InventoryManagementApp.Tests
                 method.IndexOf("if (string.IsNullOrWhiteSpace(action))", StringComparison.Ordinal) < method.IndexOf("const string sql =", StringComparison.Ordinal),
                 "The blank-action guard should run before activity-log SQL text is prepared.");
             Assert.True(
-                method.IndexOf("if (string.IsNullOrWhiteSpace(action))", StringComparison.Ordinal) < method.IndexOf("new SqliteParameter(\"@Action\",   action)", StringComparison.Ordinal),
+                method.IndexOf("if (string.IsNullOrWhiteSpace(action))", StringComparison.Ordinal) < method.IndexOf("new SqliteParameter(\"@Action\",   normalizedAction)", StringComparison.Ordinal),
                 "The blank-action guard should run before action parameters are prepared.");
             Assert.True(
                 method.IndexOf("if (string.IsNullOrWhiteSpace(action))", StringComparison.Ordinal) < method.IndexOf("using var conn = _dbService.CreateConnection()", StringComparison.Ordinal),
                 "The blank-action guard should run before opening a database connection.");
+        }
+
+        [Fact]
+        public void LogActionNormalizesAuditFieldsBeforePersisting()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "ActivityLogService.cs");
+            var method = ExtractMethod(
+                source,
+                "public virtual async Task<Result> LogActionAsync",
+                "public virtual async Task<Result<List<ActivityLog>>> GetRecentLogsAsync");
+
+            Assert.Contains("var normalizedUserName = userName.Trim();", method, StringComparison.Ordinal);
+            Assert.Contains("var normalizedAction = action.Trim();", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@UserName\", normalizedUserName)", method, StringComparison.Ordinal);
+            Assert.Contains("new SqliteParameter(\"@Action\",   normalizedAction)", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("new SqliteParameter(\"@UserName\", userName)", method, StringComparison.Ordinal);
+            Assert.DoesNotContain("new SqliteParameter(\"@Action\",   action)", method, StringComparison.Ordinal);
+            Assert.True(
+                method.IndexOf("if (string.IsNullOrWhiteSpace(action))", StringComparison.Ordinal) < method.IndexOf("var normalizedUserName = userName.Trim();", StringComparison.Ordinal),
+                "Audit fields should be normalized only after the blank-input guards pass.");
+            Assert.True(
+                method.IndexOf("var normalizedAction = action.Trim();", StringComparison.Ordinal) < method.IndexOf("const string sql =", StringComparison.Ordinal),
+                "Audit fields should be normalized before activity-log SQL work starts.");
         }
 
         [Fact]

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-activity-log-input-normalization.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-activity-log-input-normalization.md
@@ -1,0 +1,19 @@
+# Activity Log Input Normalization
+
+Date: 2026-06-29
+
+## Completed
+
+- Tightened `ActivityLogService.LogActionAsync` so accepted audit user names and actions are trimmed before persistence.
+- Preserved cancellation-first behavior and the existing blank user-name/action guards before normalization or SQL work starts.
+- Extended activity-log source-contract coverage to keep normalized values flowing into the `@UserName` and `@Action` parameters instead of raw padded input.
+
+## Why This Matters
+
+Activity Logs are the app's audit trail. Recent work rejects blank audit fields; trimming accepted values closes the adjacent data-quality gap so padded UI or service inputs do not create visually duplicated user names or action text in reports, filters, and history views.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
+- Validation for this pass is limited to GitHub connector compare/readback plus status/workflow readback.

--- a/InventoryManagementApp/Services/Users/ActivityLogService.cs
+++ b/InventoryManagementApp/Services/Users/ActivityLogService.cs
@@ -36,14 +36,17 @@ namespace InventoryManagementApp.Services.Users
                 if (string.IsNullOrWhiteSpace(action))
                     return new Result(false, "Action is required.");
 
+                var normalizedUserName = userName.Trim();
+                var normalizedAction = action.Trim();
+
                 const string sql = @"
                     INSERT INTO ActivityLogs (UserID, UserName, Action)
                     VALUES (@UserID, @UserName, @Action)";
                 var p = new[]
                 {
                     new SqliteParameter("@UserID",   userID),
-                    new SqliteParameter("@UserName", userName),
-                    new SqliteParameter("@Action",   action)
+                    new SqliteParameter("@UserName", normalizedUserName),
+                    new SqliteParameter("@Action",   normalizedAction)
                 };
                 using var conn = _dbService.CreateConnection();
                 await SqliteHelper.ExecuteNonQueryAsync(conn, sql, p, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary

- Trim accepted `ActivityLogService.LogActionAsync` user names and actions before persistence.
- Preserve cancellation-first behavior and existing blank user-name/action guards before normalization or SQL work starts.
- Extend `ActivityLogCheckoutHistoryContractTests` so audit fields continue flowing into SQLite parameters as normalized values instead of raw padded input.

## Why This Matters

Activity Logs are the app's audit trail. Recent work rejected blank audit fields; this closes the adjacent data-quality gap so padded UI or service inputs do not create visually duplicated names/actions in reports, filters, and history views.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, three commits ahead, and changes only `ActivityLogService`, `ActivityLogCheckoutHistoryContractTests`, and one progress note.
- GitHub connector readback confirmed `LogActionAsync` runs cancellation, blank user-name validation, and blank action validation before assigning `normalizedUserName = userName.Trim()` and `normalizedAction = action.Trim()`.
- GitHub connector readback confirmed the `@UserName` and `@Action` parameters now use the normalized values, and the contract test rejects the old raw parameter bindings.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.