### PR TITLE
Cover user authentication write guards

### DIFF
--- a/InventoryManagementApp.Tests/UserServiceAuthenticationWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/UserServiceAuthenticationWriteGuardContractTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace InventoryManagementApp.Tests
+{
+    public class UserServiceAuthenticationWriteGuardContractTests
+    {
+        [Fact]
+        public void AuthenticationStateWritesCheckAffectedRowsBeforeReportingSuccess()
+        {
+            var source = ReadRepoFile("InventoryManagementApp", "Services", "Users", "UserService.cs");
+
+            var authenticateMethod = ExtractMethod(
+                source,
+                "public async Task<(AuthenticationResult Result, User? User)> AuthenticateUserAsync",
+                "static bool IsLockoutActive");
+            AssertContainsAll(
+                authenticateMethod,
+                "var upgradedRows = await SqliteHelper.ExecuteNonQueryAsync(conn, \"UPDATE Users SET PasswordHash=@Pwd, PasswordSalt=@Salt WHERE UserID=@ID\", p).ConfigureAwait(false);",
+                "EnsureUserWriteSucceeded(upgradedRows, u.UserID);",
+                "u.PasswordHash = upgradedResult.hash;",
+                "u.PasswordSalt = upgradedResult.salt;");
+            Assert.True(
+                authenticateMethod.IndexOf("EnsureUserWriteSucceeded(upgradedRows, u.UserID);", StringComparison.Ordinal) <
+                authenticateMethod.IndexOf("u.PasswordHash = upgradedResult.hash;", StringComparison.Ordinal),
+                "Legacy password upgrades should verify the database write before mutating the in-memory user.");
+
+            var failedLoginMethod = ExtractMethod(
+                source,
+                "async Task<bool> RecordFailedLoginAsync",
+                "static async Task ClearLoginFailureStateAsync");
+            AssertContainsAll(
+                failedLoginMethod,
+                "var recordedRows = await SqliteHelper.ExecuteNonQueryAsync(conn,",
+                "EnsureUserWriteSucceeded(recordedRows, user.UserID);",
+                "user.FailedLoginAttempts = failedAttempts;",
+                "user.LockoutEndUtc = lockoutEndUtc;");
+            Assert.True(
+                failedLoginMethod.IndexOf("EnsureUserWriteSucceeded(recordedRows, user.UserID);", StringComparison.Ordinal) <
+                failedLoginMethod.IndexOf("user.FailedLoginAttempts = failedAttempts;", StringComparison.Ordinal),
+                "Failed-login recording should verify the database write before mutating in-memory failure state.");
+
+            var clearFailureMethod = ExtractMethod(
+                source,
+                "static async Task ClearLoginFailureStateAsync",
+                "static void EnsureUserWriteSucceeded");
+            AssertContainsAll(
+                clearFailureMethod,
+                "var clearedRows = await SqliteHelper.ExecuteNonQueryAsync(conn,",
+                "UPDATE Users SET FailedLoginAttempts=0, LockoutEndUtc=NULL WHERE UserID=@ID",
+                "EnsureUserWriteSucceeded(clearedRows, userID);");
+            Assert.True(
+                clearFailureMethod.IndexOf("var clearedRows = await SqliteHelper.ExecuteNonQueryAsync", StringComparison.Ordinal) <
+                clearFailureMethod.IndexOf("EnsureUserWriteSucceeded(clearedRows, userID);", StringComparison.Ordinal),
+                "Login failure clears should inspect affected rows after executing the database write.");
+        }
+
+        private static void AssertContainsAll(string source, params string[] expectedSnippets)
+        {
+            foreach (var snippet in expectedSnippets)
+            {
+                Assert.Contains(snippet, source, StringComparison.Ordinal);
+            }
+        }
+
+        private static string ExtractMethod(string source, string startMarker, string endMarker)
+        {
+            var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Could not find method start marker: {startMarker}");
+
+            var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+            Assert.True(end > start, $"Could not find method end marker: {endMarker}");
+
+            return source[start..end];
+        }
+
+        private static string ReadRepoFile(params string[] parts)
+        {
+            var directory = AppContext.BaseDirectory;
+
+            while (!string.IsNullOrEmpty(directory))
+            {
+                var candidate = Path.Combine(directory, Path.Combine(parts));
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+
+                var parent = Directory.GetParent(directory);
+                if (parent is null)
+                    break;
+
+                directory = parent.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find repository file: {Path.Combine(parts)}");
+        }
+    }
+}

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-user-authentication-write-guard-contract.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-user-authentication-write-guard-contract.md
@@ -1,0 +1,20 @@
+# User Authentication Write Guard Contract Coverage
+
+Date: 2026-06-29
+
+## Completed
+
+- Added source-contract coverage for `UserService` authentication state writes.
+- Guarded the legacy password-hash upgrade path so affected rows are checked before mutating the in-memory user hash/salt.
+- Guarded failed-login recording so affected rows are checked before mutating in-memory failed-attempt and lockout state.
+- Guarded login failure-state clearing so the reset write continues checking affected rows after the database update.
+
+## Why This Matters
+
+Authentication state writes drive login reliability, account lockout behavior, and legacy password migration. The production code already checks affected rows in these paths; this contract keeps those stale-row guards from being softened during future user-management changes.
+
+## Validation Notes
+
+- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
+- Validation for this pass is limited to GitHub connector compare/readback plus status/workflow readback.


### PR DESCRIPTION
## Summary

- Add focused source-contract coverage for `UserService` authentication state writes.
- Guard that legacy password-hash upgrades verify affected rows before mutating the in-memory user hash/salt.
- Guard that failed-login recording and login failure-state clearing continue checking affected rows after database writes.

## Why This Matters

Authentication state writes drive login reliability, lockout behavior, and legacy password migration. The production code already has stale-row checks in these paths; this pins those safeguards down without extending the Admin Settings theme system or adding speculative feature work.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, two commits ahead, and changes only one new source-contract test plus one progress note.
- GitHub connector readback confirmed the contract scans `UserService.cs` for affected-row checks in legacy password upgrades, failed-login recording, and login failure clearing, and verifies the checks happen before in-memory state mutation where applicable.
- GitHub connector status readback found no commit statuses attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.