### PR TITLE
Cover rental extension write guard ordering

### DIFF
--- a/InventoryManagementApp.Tests/RentalServiceWriteGuardContractTests.cs
+++ b/InventoryManagementApp.Tests/RentalServiceWriteGuardContractTests.cs
@@ -36,8 +36,19 @@ namespace InventoryManagementApp.Tests
                 "public async Task DeleteRentalAsync");
             AssertContainsAll(
                 extendMethod,
+                "var updateCmd = new SqliteCommand(",
+                "UPDATE Rentals SET DueDate=@NewDueDate WHERE RentalID=@RentalID AND Status='Rented'",
                 "if (await updateCmd.ExecuteNonQueryAsync() == 0)",
-                "throw new InvalidOperationException(\"Unable to extend rental. Rental not found or already returned.\");");
+                "throw new InvalidOperationException(\"Unable to extend rental. Rental not found or already returned.\");",
+                "await _activityLog.LogActionAsync(user?.UserID ?? 0, user?.UserName ?? string.Empty, $\"Extended rental {rentalID}\").ConfigureAwait(false);");
+            Assert.True(
+                extendMethod.IndexOf("var updateCmd = new SqliteCommand(", StringComparison.Ordinal) <
+                extendMethod.IndexOf("if (await updateCmd.ExecuteNonQueryAsync() == 0)", StringComparison.Ordinal),
+                "Expected extension writes to inspect affected rows after preparing and executing the due-date update.");
+            Assert.True(
+                extendMethod.IndexOf("if (await updateCmd.ExecuteNonQueryAsync() == 0)", StringComparison.Ordinal) <
+                extendMethod.IndexOf("await _activityLog.LogActionAsync(user?.UserID ?? 0, user?.UserName ?? string.Empty, $\"Extended rental {rentalID}\").ConfigureAwait(false);", StringComparison.Ordinal),
+                "Expected stale extension writes to fail before activity logging can report success.");
 
             var deleteMethod = ExtractMethod(
                 source,

--- a/InventoryManagementApp/ProgressNotes/2026-06-29-rental-extension-write-guard-contract.md
+++ b/InventoryManagementApp/ProgressNotes/2026-06-29-rental-extension-write-guard-contract.md
@@ -1,0 +1,9 @@
+# Rental Extension Write Guard Contract
+
+- Added focused source-contract coverage for `RentalService.ExtendRentalAsync` alongside the existing return/delete stale-write coverage.
+- The contract now pins the active-rental due-date update shape, the zero-row stale-write failure, and the ordering that keeps stale extension attempts from logging a successful extension.
+- This keeps the rental extension workflow aligned with the recent rental write-guard hardening without changing production behavior or extending Admin Settings theme customization.
+
+Validation notes:
+- Direct local clone/raw access is blocked in the scheduled Linux container with `CONNECT tunnel failed, response 403`.
+- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and full validation are unavailable here, so validation uses GitHub connector readback and compare.


### PR DESCRIPTION
## Summary

- Tighten `RentalServiceWriteGuardContractTests` around `ExtendRentalAsync`.
- Guard the active-rental due-date update shape, zero-row stale-write failure, and ordering before success activity logging.
- Add a progress note documenting the rental extension write-guard coverage.

## Why This Matters

Recent rental hardening covered stale return/delete writes and other service-boundary edge cases. Rental extension is another central active-rental write path; this pins down the existing production guard so stale extension attempts cannot regress into logged success.

## Validation

- GitHub connector compare confirmed this branch is current with `master`, two commits ahead, and changes only `RentalServiceWriteGuardContractTests` plus one progress note.
- GitHub connector readback confirmed the test now requires the `ExtendRentalAsync` due-date update SQL, the zero-row `ExecuteNonQueryAsync` guard, the existing stale-rental failure message, and ordering before the extension activity log.
- GitHub connector status/workflow readback found no commit statuses or workflow runs attached to the branch head before PR creation.
- Direct local clone/raw access is blocked in this scheduled Linux container with `CONNECT tunnel failed, response 403`.
- `dotnet`, PowerShell/`pwsh`, `gh`, WPF runtime/screenshots, local banned-word checks, and `pwsh -File scripts/run-full-validation.ps1` are unavailable here, so local build/test/full validation was not run.
- The repository default branch reports as `master`; the prompt mentioned `main`, but GitHub metadata and recent history show `master` is active.